### PR TITLE
docs(governance): NENE2 系ワークフロー規約を継承する (#2)

### DIFF
--- a/.cursor/rules/00-project-always.mdc
+++ b/.cursor/rules/00-project-always.mdc
@@ -1,0 +1,15 @@
+---
+description: NeNe Records 全作業共通の正本と安全方針
+alwaysApply: true
+---
+
+# Project Rules
+
+- 正本は `README.md`、`AGENTS.md`、`docs/CONTRIBUTING.md`、`docs/inheritance-from-nene2.md`、`docs/development/`、`docs/workflow.md`。
+- AI/エージェントは作業前に `AGENTS.md` と関連 docs を確認する。
+- フレームワーク挙動は NENE2 upstream（`vendor/hideyukimori/nene2/docs/`）を参照する。製品ルールはこのリポジトリの docs を優先する。
+- 秘密情報、トークン、パスワード、ローカル `.env`、生成物をコミットしない。
+- 変更は依頼範囲と Issue の目的に留め、無関係な整形やリファクタを混ぜない。
+- NeNe Records は API first、型付きエンティティ、管理フロント optional、MCP 対応のプラットフォームとして育てる。
+- 実装は疎結合、型安全、テスト容易性、OpenAPI/MCP 境界の明確さを優先する（NENE2 継承）。
+- Cursor ルールと docs が食い違う場合は docs を先に更新し、このルールは短く保つ。

--- a/.cursor/rules/10-issue-driven-workflow.mdc
+++ b/.cursor/rules/10-issue-driven-workflow.mdc
@@ -1,0 +1,15 @@
+---
+description: Issue ベース開発と branch / PR / merge 運用
+alwaysApply: true
+---
+
+# Issue Driven Workflow
+
+- コード、ドキュメント、設定変更は GitHub Issue ベースで進める。
+- 作業開始時に `docs/roadmap.md`、`docs/milestones/`、`docs/todo/current.md`、関連 Issue/PR を確認する。
+- `main` へ直接コミットしない。ブランチ名は `type/issue-number-summary` を基本にする。
+- 作業完了時は通常、commit、push、PR 作成、チェック確認、merge、Issue close/update、`main` 同期まで進める。
+- PR には目的、変更点、検証結果、関連 Issue または `Closes #番号`、使用したセルフレビューチェックリスト名を書く。
+- コミットは Conventional Commits。description/body は日本語、type/scope は英語。Issue 番号を subject に含める。
+- ユーザーが「調査だけ」「コミットしない」「PR まで」など範囲を明示した場合は、その指示を優先する。
+- 正本は `docs/workflow.md` と `docs/development/commit-conventions.md`。

--- a/.cursor/rules/20-modern-php.mdc
+++ b/.cursor/rules/20-modern-php.mdc
@@ -1,0 +1,17 @@
+---
+description: NeNe Records PHP 実装時のモダン PHP / API 契約ルール
+globs: "**/*.php"
+alwaysApply: false
+---
+
+# Modern PHP
+
+- 新規 PHP ファイルは `declare(strict_types=1);` を付け、PSR-12 を基本にする（NENE2 継承）。
+- Controller は薄く保ち、入力解釈、UseCase 呼び出し、Response 生成に集中する。
+- UseCase / Domain は HTTP、DB、テンプレート、CLI、frontend build から独立させる。
+- 配列のまま境界を越えず、DTO、value object、enum、readonly property を優先する。
+- エンティティスキーマとフィールド型は API 境界で検証する。フロントのみのスキーマ定義に依存しない。
+- OpenAPI で表現する public API 契約と実装のズレを避ける。
+- MCP 連携は DB 直結ではなく、OpenAPI 経由の HTTP API を通す。
+- アプリ固有 Problem Details の type は `https://nene-records.dev/problems/{problem-name}` を使う。
+- 正本は `docs/development/coding-standards.md` と NENE2 `docs/development/coding-standards.md`。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Agent / AI Guide
+
+This file is the entry point for AI agents working on NeNe Records.
+
+## Read First
+
+- Inheritance map: `docs/inheritance-from-nene2.md`
+- Human and AI collaboration: `docs/CONTRIBUTING.md`
+- Workflow: `docs/workflow.md`
+- Coding standards: `docs/development/coding-standards.md`
+- Commit messages: `docs/development/commit-conventions.md`
+- AI tool policy: `docs/integrations/ai-tools.md`
+- Roadmap: `docs/roadmap.md`
+- Current work: `docs/todo/current.md`
+
+## Operating Rules
+
+- Work from GitHub Issues. Create an Issue before implementation or doc changes that lack one.
+- Do not commit directly to `main`. Use branches named like `type/issue-number-summary`.
+- Read NENE2 upstream docs for framework behavior; read local docs for product rules.
+- Keep `docs/todo/current.md` and milestones aligned with Issues and PRs.
+- Keep changes focused. Do not mix governance, feature work, and unrelated cleanup in one PR.
+- Do not commit secrets, credentials, local `.env` files, or generated build outputs.
+- Prefer explicit, typed, testable code over hidden framework behavior.
+- When docs and Cursor rules conflict, update the docs first and keep `.cursor/rules/` concise.
+
+## Project Direction
+
+NeNe Records is an API-first flexible entity platform on NENE2:
+
+- JSON APIs first, with OpenAPI as the contract.
+- Typed entity fields and schema registry — not WordPress-style untyped meta.
+- Admin frontend owns most configuration UX; API enforces validation and auth.
+- MCP tools expose the same API boundary to AI clients.
+- Consumer views are replaceable presentation layers.
+
+## Framework Reference
+
+Install `hideyukimori/nene2` via Composer. For HTTP runtime, middleware, Problem Details, and MCP patterns, NENE2 upstream documentation is authoritative unless a local ADR says otherwise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md — NeNe Records
+
+Claude Code / AI agent guide for this repository. Cursor summaries live in `.cursor/rules/`.
+
+## Source of Truth
+
+| Purpose | Document |
+| --- | --- |
+| NENE2 inheritance | `docs/inheritance-from-nene2.md` |
+| Agent entry | `AGENTS.md` |
+| Workflow | `docs/workflow.md` |
+| Commits | `docs/development/commit-conventions.md` |
+| Coding | `docs/development/coding-standards.md` |
+| Current tasks | `docs/todo/current.md` |
+| Roadmap | `docs/roadmap.md` |
+
+## Quick Rules
+
+- **Issue-driven**: no Issue, no code/doc change (except explicit user scope limits).
+- **Branch**: `type/issue-number-summary` from `main`; never commit directly to `main`.
+- **Commits**: Conventional Commits; type/scope English, description/body Japanese, include `(#issue)`.
+- **PR**: purpose, changes, verification, checklist name, `Closes #n`.
+- **Secrets**: never commit `.env`, tokens, or credentials.
+- **Framework**: NENE2 via Composer — read `vendor/hideyukimori/nene2/docs/` for runtime patterns.
+- **MCP**: tools go through OpenAPI HTTP boundary only.
+
+## Product Direction
+
+Flexible entity platform — lighter and more typed than WordPress post meta. Admin frontend for schema UX; API for persistence, auth, and contracts; MCP for AI operations.
+
+## Verification (when scaffolded)
+
+```bash
+composer check
+composer openapi
+composer mcp
+```
+
+Until then: `git diff --check` for doc-only changes.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,27 @@ Consumer views          ──┼──→  NeNe Records API (NENE2)  ──→ 
 AI clients (MCP)        ──┘
 ```
 
+## Contributing
+
+NeNe Records inherits NENE2 engineering discipline:
+
+| Topic | Document |
+| --- | --- |
+| **Start here (agents)** | [`AGENTS.md`](./AGENTS.md) |
+| NENE2 inheritance map | [`docs/inheritance-from-nene2.md`](./docs/inheritance-from-nene2.md) |
+| Workflow | [`docs/workflow.md`](./docs/workflow.md) |
+| Commit conventions | [`docs/development/commit-conventions.md`](./docs/development/commit-conventions.md) |
+| Coding standards | [`docs/development/coding-standards.md`](./docs/development/coding-standards.md) |
+| Full contributing guide | [`docs/CONTRIBUTING.md`](./docs/CONTRIBUTING.md) |
+
+**Rules in brief:** GitHub Issue-driven work, `type/issue-number-summary` branches, Conventional Commits (Japanese description, English type), PR with verification and self-review checklist, no direct commits to `main`.
+
 ## Status
 
-Early planning. See [Issues](https://github.com/hideyukiMORI/nene-records/issues) for roadmap.
+Early planning. See [Issues](https://github.com/hideyukiMORI/nene-records/issues).
+
+- [#1](https://github.com/hideyukiMORI/nene-records/issues/1) — MVP entity CRUD vertical slice
+- [#2](https://github.com/hideyukiMORI/nene-records/issues/2) — NENE2 governance inheritance
 
 ## Related
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+NeNe Records is built through small, Issue-driven changes. This document is the shared entry point for humans and AI agents.
+
+## Required Reading
+
+| Topic | Document |
+| --- | --- |
+| NENE2 inheritance map | `docs/inheritance-from-nene2.md` |
+| Workflow | `docs/workflow.md` |
+| Coding standards | `docs/development/coding-standards.md` |
+| Commit messages | `docs/development/commit-conventions.md` |
+| AI tools | `docs/integrations/ai-tools.md` |
+| Agent entry point | `AGENTS.md` |
+| Roadmap | `docs/roadmap.md` |
+| Current work | `docs/todo/current.md` |
+
+## Collaboration Policy
+
+- Start work from a GitHub Issue.
+- Use one branch and one PR per focused work unit.
+- Do not commit directly to `main`.
+- Keep `docs/milestones/`, `docs/roadmap.md`, and `docs/todo/current.md` updated when direction changes.
+- Explain intent, impact, verification, and remaining risk in PRs.
+- Prefer documentation that helps the next developer or AI agent decide what to do without rereading chat history.
+
+## Secrets
+
+Do not commit passwords, tokens, private URLs, production credentials, or local `.env` files. Commit only non-secret examples such as `.env.example` when needed.
+
+## Engineering Theme
+
+NeNe Records should stay readable, secure, and replaceable:
+
+- strict, typed, explicit boundaries (inherited from NENE2)
+- decoupled use cases and infrastructure
+- OpenAPI contracts before client assumptions
+- MCP and AI access only through documented API boundaries
+- admin frontend and consumer views kept independent from core persistence rules
+
+## Upstream Framework
+
+Runtime HTTP, middleware, and DI patterns come from [NENE2](https://github.com/hideyukiMORI/NENE2). When framework behavior is unclear, read NENE2 docs under `vendor/hideyukimori/nene2/docs/` after `composer install`.

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,24 @@
+# ADR 0000: Title
+
+## Status
+
+proposed
+
+## Context
+
+Describe the problem, constraints, and trade-offs that make this decision necessary.
+
+## Decision
+
+Describe the decision in clear, direct language.
+
+## Consequences
+
+Describe the expected benefits, costs, and follow-up work.
+
+## Related
+
+- Issue: `#000`
+- PR: `#000`
+- Supersedes: none
+- Superseded by: none

--- a/docs/adr/0001-inherit-nene2-governance.md
+++ b/docs/adr/0001-inherit-nene2-governance.md
@@ -1,0 +1,52 @@
+# ADR 0001: Inherit NENE2 Governance and Workflow
+
+## Status
+
+accepted
+
+## Context
+
+NeNe Records is a consumer application built on [NENE2](https://github.com/hideyukiMORI/NENE2). The maintainer wants the same strict engineering discipline as NENE2 — Issue-driven workflow, Conventional Commits, self-review checklists, and AI-readable documentation — without copying the entire NENE2 documentation tree into this repository.
+
+Alternatives considered:
+
+1. **Link-only**: point all contributors to NENE2 docs — rejected because product-specific rules and agent entry points would be unclear.
+2. **Full copy**: duplicate all NENE2 policy docs — rejected because upstream drift would be hard to track.
+3. **Hybrid inheritance** (chosen): local source-of-truth for workflow and product rules; reference NENE2 upstream for framework runtime behavior.
+
+## Decision
+
+Adopt NENE2 governance patterns locally:
+
+- Issue-driven development with `type/issue-number-summary` branches
+- Conventional Commits (English type/scope, Japanese description/body, Issue number in subject)
+- Self-review checklists under `docs/review/`
+- ADR policy under `docs/development/adr.md`
+- AI agent entry via `AGENTS.md`, `CLAUDE.md`, and `.cursor/rules/`
+- Inheritance map in `docs/inheritance-from-nene2.md` as the canonical split between local and upstream rules
+
+Framework HTTP, middleware, validation, and MCP behavior remain defined by NENE2 unless this repository records an explicit deviation in a later ADR.
+
+## Consequences
+
+**Benefits**
+
+- Contributors and AI agents have a single local entry point.
+- Product rules (entity schema, Problem Details base URL) stay separate from framework rules.
+- NENE2 upstream improvements remain consumable via Composer and linked docs.
+
+**Costs**
+
+- Two documentation layers must be kept mentally in sync when NENE2 workflow policy changes materially.
+- Some NENE2 docs must be read from `vendor/` or GitHub during implementation work.
+
+**Follow-up**
+
+- Scaffold runtime (`composer.json`, checks) in a subsequent Issue.
+- Add NeNe Records–specific ADRs when entity schema and auth model stabilize.
+
+## Related
+
+- Issue: `#2`
+- NENE2 workflow: https://github.com/hideyukiMORI/NENE2/blob/main/docs/workflow.md
+- Inheritance map: `docs/inheritance-from-nene2.md`

--- a/docs/development/adr.md
+++ b/docs/development/adr.md
@@ -1,0 +1,45 @@
+# ADR Policy
+
+NeNe Records uses lightweight Architecture Decision Records, inherited from [NENE2 ADR policy](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/adr.md).
+
+## When to write an ADR
+
+Write an ADR when a decision affects:
+
+- entity schema architecture or public API contracts
+- dependency or framework integration choices
+- authentication, authorization, or MCP safety boundaries
+- release, versioning, or compatibility policy
+- long-term maintenance cost
+
+Do **not** use ADRs for routine task detail — use Issues, PRs, and `docs/todo/current.md`.
+
+## Directory and naming
+
+```text
+docs/adr/
+├── 0000-template.md
+├── 0001-inherit-nene2-governance.md
+└── NNNN-short-title.md
+```
+
+Use a stable four-digit sequence. Do not renumber after publication.
+
+## Status values
+
+- `proposed`
+- `accepted`
+- `deprecated`
+- `superseded`
+
+Supersede old ADRs instead of silently rewriting history.
+
+## Template
+
+Use `docs/adr/0000-template.md`.
+
+## Relationship to NENE2 ADRs
+
+- NENE2 ADRs describe **framework** decisions.
+- NeNe Records ADRs describe **product** decisions.
+- When consuming NENE2, prefer upstream ADRs for framework behavior; record local deviations here.

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -1,0 +1,50 @@
+# Coding Standards
+
+NeNe Records follows NENE2 coding standards for PHP, HTTP, and API design, with additions for the flexible entity platform.
+
+**Framework baseline:** [NENE2 coding standards](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/coding-standards.md)
+
+**Inheritance map:** `docs/inheritance-from-nene2.md`
+
+## PHP Baseline (inherited)
+
+- Target PHP `>=8.4.1 <9.0`
+- `declare(strict_types=1);` on all new PHP files
+- PSR-12 style
+- Readonly DTOs, value objects, and enums at boundaries
+- Thin controllers; use cases independent from HTTP and persistence
+- Constructor injection; no service locator in domain code
+- RFC 9457 Problem Details for public JSON errors
+
+## NeNe Records Additions
+
+### Entity platform boundaries
+
+- **Entity types and field definitions** are persisted and validated at the API layer using a schema registry — do not rely on frontend-only schema knowledge for writes.
+- **Typed field values** live in type-specific tables or documented storage adapters; avoid a single untyped key/value blob for all field types.
+- **Soft delete** (`is_deleted`, `deleted_at`) should be consistent across entity tables unless an ADR documents an exception.
+- **SQL stays in repositories**; use cases express business rules, not query text.
+
+### API surface
+
+- JSON APIs are the primary product surface.
+- OpenAPI describes public request, response, and error shapes.
+- MCP tools map to the same OpenAPI operations; no direct database access from MCP.
+- Application-specific Problem Details `type` values use `https://nene-records.dev/problems/{problem-name}`.
+
+### Frontend layers (future)
+
+- **Admin frontend** owns schema editing UI and most configuration workflows.
+- **Consumer views** are replaceable presentation layers over the same API.
+- Backend domain logic must not depend on React or admin-specific assumptions.
+
+### Language
+
+- Public docs, OpenAPI text, Problem Details titles, and validation codes: **English**
+- Issues, PR descriptions, commit messages, and `.cursor/rules/`: **Japanese allowed**
+
+## Testing (inherited intent)
+
+- Unit-test use cases without a database when practical.
+- Add HTTP or contract tests for public API behavior.
+- Keep tests deterministic and small.

--- a/docs/development/commit-conventions.md
+++ b/docs/development/commit-conventions.md
@@ -1,0 +1,48 @@
+# Commit Message Conventions
+
+NeNe Records uses Conventional Commits, inherited from [NENE2](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/commit-conventions.md).
+
+## Format
+
+```text
+<type>(<optional scope>): <description> (#<issue>)
+
+[optional body]
+
+[optional footer]
+```
+
+## Language
+
+- Keep `type`, `scope`, `BREAKING CHANGE`, and other Conventional Commits keywords in **English**.
+- Write the **description and body in Japanese**.
+- Include the related GitHub Issue number in the subject when practical.
+
+Example:
+
+```text
+docs(governance): NENE2 系ワークフロー規約を継承する (#2)
+```
+
+## Common Types
+
+| Type | Use |
+| --- | --- |
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `refactor` | Code change without feature or bug fix |
+| `test` | Test additions or changes |
+| `build` | Dependency or build setup |
+| `ci` | CI configuration |
+| `chore` | Maintenance |
+
+## Body
+
+Use the body when the reason is not obvious from the subject. Explain why the change exists, what trade-off was chosen, and whether follow-up work remains.
+
+## Breaking Changes
+
+Use `!` or a `BREAKING CHANGE:` footer when public API, configuration, CLI, or documented behavior changes incompatibly.
+
+Public API changes must also update OpenAPI and, when applicable, `docs/mcp/tools.json`.

--- a/docs/development/self-review.md
+++ b/docs/development/self-review.md
@@ -1,0 +1,36 @@
+# Self-Review Checklist Policy
+
+NeNe Records uses self-review checklists before push or PR, inherited from [NENE2](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/self-review.md).
+
+## How to use
+
+1. Identify the work type.
+2. Open the matching checklist in `docs/review/`.
+3. Review every applicable item.
+4. Run the narrowest useful verification.
+5. Mention the checklist in the PR body.
+
+Example:
+
+```text
+Self-review: backend-api, openapi-contract
+```
+
+If an item is not applicable, mark it mentally as `N/A`. Do not delete checklist items to pass review.
+
+## Checklist files
+
+| File | Use for |
+| --- | --- |
+| `backend-api.md` | Endpoints, handlers, validation, HTTP behavior |
+| `openapi-contract.md` | OpenAPI schemas, examples, contract tests |
+| `database.md` | Migrations, repositories, soft delete |
+| `middleware-security.md` | Auth, CORS, logging, rate limits |
+| `frontend.md` | Admin or consumer React/TypeScript |
+| `docs-policy.md` | Workflow, ADRs, roadmap, Cursor rules |
+
+## AI agents
+
+Pick relevant checklists before finalizing changes. Do not claim an item passed if it was not checked.
+
+If no checklist matches, use `docs/workflow.md`, `docs/development/coding-standards.md`, and `docs/inheritance-from-nene2.md` directly.

--- a/docs/inheritance-from-nene2.md
+++ b/docs/inheritance-from-nene2.md
@@ -1,0 +1,83 @@
+# Inheritance from NENE2
+
+NeNe Records inherits engineering governance from [NENE2](https://github.com/hideyukiMORI/NENE2). This document is the source of truth for what is inherited, what is adapted, and what is NeNe Records–specific.
+
+## Relationship
+
+| Layer | Repository | Role |
+| --- | --- | --- |
+| Framework runtime | [NENE2](https://github.com/hideyukiMORI/NENE2) | HTTP runtime, DI, middleware, Problem Details, OpenAPI/MCP patterns |
+| Application platform | **NeNe Records** (this repo) | Flexible entity schema, CRUD API, admin/consumer layers |
+| Reference trials | [NENE2-FT](https://github.com/hideyukiMORI/NENE2-FT) | Patterns and friction notes from field trials |
+
+NeNe Records is a **consumer project**, not a fork of NENE2. Framework code stays in NENE2; product code stays here.
+
+## Inherited by policy (same rules)
+
+These policies are adopted with the same intent as NENE2. Local copies live in this repository so agents and contributors do not need to guess.
+
+| Topic | Local document |
+| --- | --- |
+| Issue-driven workflow | `docs/workflow.md` |
+| Conventional Commits | `docs/development/commit-conventions.md` |
+| Self-review before PR | `docs/development/self-review.md` |
+| ADR operation | `docs/development/adr.md` |
+| AI agent workflow | `docs/integrations/ai-tools.md`, `AGENTS.md` |
+| Cursor summaries | `.cursor/rules/` |
+
+## Inherited by reference (framework behavior)
+
+When implementing HTTP, middleware, validation, or error responses, follow NENE2 upstream docs unless NeNe Records records an explicit deviation in an ADR.
+
+| Topic | NENE2 upstream |
+| --- | --- |
+| HTTP runtime (PSR-7/15/17) | `docs/development/http-runtime.md` |
+| Middleware order and security | `docs/development/middleware-security.md` |
+| Request validation layers | `docs/development/request-validation.md` |
+| Problem Details errors | `docs/development/api-error-responses.md` |
+| Authentication boundaries | `docs/development/authentication-boundary.md` |
+| OpenAPI conventions | `docs/integrations/openapi.md` |
+| MCP tool policy | `docs/integrations/mcp-tools.md`, `docs/explanation/why-mcp.md` |
+| Database adapter boundaries | `docs/development/database-migrations.md` |
+| Domain / use case layering | `docs/development/domain-layer.md` |
+
+Install NENE2 as a Composer dependency and treat `vendor/hideyukimori/nene2/docs/` as the framework reference during development.
+
+## Adapted for NeNe Records
+
+| Topic | NeNe Records choice |
+| --- | --- |
+| Product goal | API-first flexible entity platform (not a general PHP framework) |
+| Public Problem Details base URL | `https://nene-records.dev/problems/` (application errors) |
+| NENE2 framework errors | Keep NENE2 canonical types when surfaced by the runtime |
+| Coding standards | `docs/development/coding-standards.md` — NENE2 baseline + entity-platform additions |
+| Language policy | English for public docs, OpenAPI, and API error metadata; Japanese allowed in Issues, PRs, commits, and `.cursor/rules/` |
+| Review checklists | `docs/review/` — task-specific lists for this product |
+
+## NeNe Records–specific (not inherited)
+
+Record these in ADRs or product docs when they stabilize:
+
+- Entity type / field schema model
+- Typed value tables and soft-delete conventions
+- Admin frontend vs consumer view boundaries
+- Analytics and MCP tool catalog for entity operations
+- Release versioning of the NeNe Records product (`v0.x` until first stable API)
+
+## When upstream and local docs conflict
+
+1. Update the **local source-of-truth doc** in this repository first.
+2. If the conflict is about **framework behavior**, prefer NENE2 upstream unless an ADR documents a deliberate deviation.
+3. Keep `.cursor/rules/` as a short summary; do not duplicate full policy text there.
+
+## Verification commands (once runtime is scaffolded)
+
+NeNe Records should expose the same quality gates as NENE2 consumer projects:
+
+```bash
+composer check
+composer openapi
+composer mcp
+```
+
+Until `composer.json` exists, governance changes are verified by doc review and `git diff --check`.

--- a/docs/integrations/ai-tools.md
+++ b/docs/integrations/ai-tools.md
@@ -1,0 +1,52 @@
+# AI Tooling Policy
+
+NeNe Records inherits AI workflow policy from [NENE2](https://github.com/hideyukiMORI/NENE2/blob/main/docs/integrations/ai-tools.md) with product-specific notes below.
+
+## Source of Truth (this repo)
+
+- Product direction: `README.md`, `docs/roadmap.md`
+- Inheritance map: `docs/inheritance-from-nene2.md`
+- Workflow: `docs/workflow.md`
+- Coding rules: `docs/development/coding-standards.md`
+- Current state: `docs/todo/current.md`
+- Agent entry: `AGENTS.md`
+- Cursor summaries: `.cursor/rules/`
+
+## Agent Workflow
+
+For normal code or documentation work:
+
+1. Confirm or create a GitHub Issue.
+2. Check roadmap, milestone, and TODO state.
+3. Create an Issue-numbered branch from `main`.
+4. Make focused changes only.
+5. Update documentation when behavior or policy changes.
+6. Run the narrowest useful verification.
+7. Commit, push, open a PR, merge, and sync `main` unless the user narrowed scope.
+
+## Design for AI Readability
+
+- Use predictable directory names (`src/Entity/`, `database/migrations/`, `docs/openapi/`).
+- Keep entity schema and field types explicit in code and OpenAPI.
+- Prefer typed DTOs over ambiguous arrays at API boundaries.
+- Document MCP tools in `docs/mcp/tools.json` once the API exists.
+
+## Safety Boundaries
+
+- AI tools must not commit secrets.
+- MCP tools interact through documented HTTP APIs, not direct database access.
+- Write/admin MCP tools require authentication consistent with NENE2 JWT/API-key policy.
+- Destructive operations require explicit user approval.
+- Production credentials must not appear in agent context or commits.
+
+## NENE2 Upstream References
+
+When implementing runtime behavior, also read:
+
+- `vendor/hideyukimori/nene2/docs/integrations/mcp-tools.md`
+- `vendor/hideyukimori/nene2/docs/explanation/why-mcp.md`
+- `vendor/hideyukimori/nene2/docs/howto/add-mcp-tools.md`
+
+## Cursor GitHub MCP
+
+Cursor GitHub MCP uses its own PAT, not `gh auth login`. For private repo MCP operations, configure token scopes in Cursor MCP settings. Do not commit PAT values.

--- a/docs/milestones/2026-05-governance-and-foundation.md
+++ b/docs/milestones/2026-05-governance-and-foundation.md
@@ -1,0 +1,22 @@
+# Milestone: Governance and Foundation (2026-05)
+
+Goal: establish NeNe Records engineering discipline inherited from NENE2 before runtime code grows.
+
+## Acceptance Criteria
+
+- [x] GitHub repository created (`hideyukiMORI/nene-records`)
+- [x] `docs/inheritance-from-nene2.md` documents local vs upstream rules
+- [x] `docs/workflow.md` and commit conventions in place
+- [x] `AGENTS.md`, `CLAUDE.md`, `docs/CONTRIBUTING.md` exist
+- [x] `.cursor/rules/` summaries for always-on agent guidance
+- [x] `docs/review/` initial self-review checklists
+- [x] ADR 0001 accepted
+- [x] `docs/roadmap.md` and `docs/todo/current.md` initialized
+
+## Issues
+
+- #2 — governance inheritance documentation and Cursor rules
+
+## Follow-up Milestone
+
+Phase 1 MVP entity CRUD — Issue #1

--- a/docs/review/backend-api.md
+++ b/docs/review/backend-api.md
@@ -1,0 +1,26 @@
+# Backend API Self-Review
+
+Use for API endpoints, handlers, request validation, responses, and HTTP-facing behavior.
+
+Source policies:
+
+- `docs/development/coding-standards.md`
+- `docs/inheritance-from-nene2.md`
+- NENE2: `docs/development/http-runtime.md`, `request-validation.md`, `api-error-responses.md`, `domain-layer.md`
+
+## Checklist
+
+- [ ] Public request or response behavior is reflected in OpenAPI when stable.
+- [ ] Handlers map request data to readonly DTOs before calling use cases.
+- [ ] Use cases do not receive raw PSR-7 requests or unstructured request arrays.
+- [ ] Business rules (ownership, state, schema invariants) live in use cases, not handlers or middleware.
+- [ ] Repositories are injected through interfaces; use cases do not use PDO directly.
+- [ ] SQL is confined to repository adapters.
+- [ ] Validation failures use Problem Details `validation-failed` with structured `errors`.
+- [ ] Application Problem Details `type` values use `https://nene-records.dev/problems/{problem-name}`.
+- [ ] Public API text and error metadata are in English.
+- [ ] Public errors do not expose stack traces, SQL, paths, or secrets.
+- [ ] Entity writes validate against registered field schema when applicable.
+- [ ] Soft-deleted records are excluded from public list/get unless explicitly documented.
+- [ ] Narrowest useful verification was run (usually `composer check`).
+- [ ] PR notes mention this checklist when API-facing.

--- a/docs/review/database.md
+++ b/docs/review/database.md
@@ -1,0 +1,19 @@
+# Database Self-Review
+
+Use for migrations, schema docs, repositories, and soft-delete behavior.
+
+Source policies:
+
+- `docs/development/coding-standards.md`
+- NENE2: `docs/development/database-migrations.md`
+
+## Checklist
+
+- [ ] Migrations are reversible or rollback strategy is documented.
+- [ ] Schema docs or migration comments explain entity/field table relationships.
+- [ ] Soft delete columns (`is_deleted`, `deleted_at`) are used consistently when required.
+- [ ] Repository queries default to excluding soft-deleted rows unless admin API documented otherwise.
+- [ ] Indexes exist for common filter columns (entity_type_id, foreign keys).
+- [ ] No secrets or environment-specific values in migration files.
+- [ ] SQLite tests cover important repository contracts.
+- [ ] PR notes mention this checklist when database-facing.

--- a/docs/review/docs-policy.md
+++ b/docs/review/docs-policy.md
@@ -1,0 +1,23 @@
+# Documentation and Policy Self-Review
+
+Use for policy docs, workflow docs, ADRs, roadmap updates, TODO updates, and Cursor rules.
+
+Source policies:
+
+- `docs/workflow.md`
+- `docs/development/adr.md`
+- `docs/inheritance-from-nene2.md`
+- `docs/todo/current.md`
+- `docs/roadmap.md`
+
+## Checklist
+
+- [ ] The source-of-truth policy doc was updated instead of only adding a summary elsewhere.
+- [ ] `docs/roadmap.md` or `docs/todo/current.md` updated when project state changed.
+- [ ] Major architecture decisions considered whether an ADR is needed.
+- [ ] NENE2 inheritance changes reflected in `docs/inheritance-from-nene2.md`.
+- [ ] Public source-of-truth docs and OpenAPI text remain English unless policy allows otherwise.
+- [ ] Cursor rules stay concise; full policy not duplicated in `.cursor/rules/`.
+- [ ] Issue and PR references included where useful.
+- [ ] Wording is concrete enough for humans and AI agents to follow.
+- [ ] `git diff --check` reviewed for whitespace errors.

--- a/docs/review/frontend.md
+++ b/docs/review/frontend.md
@@ -1,0 +1,17 @@
+# Frontend Self-Review
+
+Use for admin or consumer React/TypeScript changes.
+
+Source policies:
+
+- `docs/development/coding-standards.md`
+- NENE2: `docs/development/frontend-integration.md`
+
+## Checklist
+
+- [ ] API calls go through typed fetch wrappers, not ad-hoc URLs scattered in components.
+- [ ] Admin UI does not bypass API validation assumptions (schema edits still POST to API).
+- [ ] No secrets or API keys embedded in frontend source.
+- [ ] Build output goes to `public_html/assets/` when integrated; `node_modules/` is not committed.
+- [ ] `npm run check --prefix frontend` passes when frontend exists.
+- [ ] PR notes mention this checklist when frontend-facing.

--- a/docs/review/middleware-security.md
+++ b/docs/review/middleware-security.md
@@ -1,0 +1,18 @@
+# Middleware and Security Self-Review
+
+Use for auth, CORS, logging, rate limits, and request pipeline changes.
+
+Source policies:
+
+- `docs/inheritance-from-nene2.md`
+- NENE2: `docs/development/middleware-security.md`, `authentication-boundary.md`, `observability.md`
+
+## Checklist
+
+- [ ] Middleware order matches NENE2 documented baseline unless ADR documents a deviation.
+- [ ] Auth failures return documented Problem Details, not ad-hoc JSON.
+- [ ] Logs do not include tokens, passwords, Authorization headers, or raw bodies.
+- [ ] CORS allowlist is config-driven; production origins are explicit.
+- [ ] Machine client paths use API key or documented auth mechanism.
+- [ ] Write MCP tools require authentication when JWT/API key is configured.
+- [ ] PR notes mention this checklist when security-facing.

--- a/docs/review/openapi-contract.md
+++ b/docs/review/openapi-contract.md
@@ -1,0 +1,18 @@
+# OpenAPI Contract Self-Review
+
+Use when changing `docs/openapi/openapi.yaml` or API response shapes.
+
+Source policies:
+
+- `docs/development/coding-standards.md`
+- NENE2: `docs/integrations/openapi.md`
+
+## Checklist
+
+- [ ] Every shipped JSON endpoint has an OpenAPI path with `operationId`.
+- [ ] Success and error responses reference shared Problem Details schemas where applicable.
+- [ ] Request bodies and query parameters match handler DTO validation rules.
+- [ ] Examples are realistic (`ok` examples for success paths).
+- [ ] `composer openapi` passes after runtime scaffold exists.
+- [ ] MCP tool entries in `docs/mcp/tools.json` align with OpenAPI when tools are added.
+- [ ] Public text in OpenAPI descriptions is English.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,81 @@
+# Roadmap
+
+NeNe Records is an API-first flexible entity platform on NENE2 — lighter, typed, and MCP-ready compared to WordPress-style CMS monoliths.
+
+## North Star
+
+Developers and AI agents can:
+
+- define entity types and typed fields through an admin frontend
+- persist and query records through a documented JSON API
+- operate the same data through MCP tools in natural language
+- swap admin UI, consumer views, or API hosting independently
+
+## Phase 0: Governance and Foundation
+
+Goal: make contribution, AI operation, and NENE2 inheritance unambiguous.
+
+- README and contribution guide
+- Issue-driven workflow and commit conventions
+- inheritance map from NENE2
+- ADR 0001 (governance inheritance)
+- Cursor rules for agents
+- self-review checklist policy
+
+Tracked by `docs/milestones/2026-05-governance-and-foundation.md`.
+
+## Phase 1: MVP Entity CRUD
+
+Goal: smallest vertical slice proving the entity model.
+
+- `entity_types`, `entities`, `text_fields` tables and migrations
+- CRUD API + OpenAPI
+- PHPUnit + SQLite tests
+- NENE2 consumer project scaffold (`composer.json`, check scripts)
+
+Issue: `#1`
+
+## Phase 2: Additional Field Types
+
+Goal: expand typed storage beyond text.
+
+- int, enum, bool, datetime field tables or unified adapter
+- schema registry API (`field_defs`)
+- validation against registered schema on write
+
+## Phase 3: Relations, Tags, and Query
+
+Goal: support real CMS/app patterns.
+
+- tag or relation model
+- filtered list/search API
+- pagination helpers (NENE2 patterns)
+
+## Phase 4: Admin Frontend
+
+Goal: schema and record management UI.
+
+- React + TypeScript admin starter
+- entity type editor
+- record CRUD screens
+
+## Phase 5: MCP and Analytics
+
+Goal: AI-native operations and basic reporting.
+
+- MCP tool catalog for entity CRUD and queries
+- access log + date-based aggregation API
+- semantic MCP tools (`listEntitiesByTag`, `getAccessStatsByDate`, etc.)
+
+## Phase 6: Consumer Views
+
+Goal: replaceable public presentation patterns.
+
+- list/detail view templates or SPA shells
+- API-only consumer examples
+
+## Non-Goals
+
+- Rebuilding Laravel/Symfony-style full-stack framework features in this repo
+- WordPress plugin/theme compatibility
+- Direct database access from MCP or admin frontend

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,0 +1,37 @@
+# Current Work
+
+Last updated: 2026-05-24
+
+## In Progress
+
+| Issue | Branch | Summary |
+| --- | --- | --- |
+| #2 | `docs/2-inherit-nene2-governance` | NENE2 系ガバナンス・ワークフロー規約の継承 |
+
+## Up Next
+
+| Issue | Summary |
+| --- | --- |
+| #1 | MVP: `entity_types` + `entities` + `text_fields` CRUD vertical slice |
+
+## Recently Completed
+
+| Issue | Summary |
+| --- | --- |
+| — | Repository bootstrap (`README`, MIT license) |
+
+## Handoff Notes
+
+- Governance docs and Cursor rules land in PR for #2.
+- Runtime scaffold (`composer.json`, Docker, migrations) starts in #1 after #2 merges.
+- Framework reference: `hideyukimori/nene2` via Composer; see `docs/inheritance-from-nene2.md`.
+
+## Verification Commands
+
+Not yet available — add after Phase 1 scaffold:
+
+```bash
+composer check
+composer openapi
+composer mcp
+```

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,70 @@
+# Workflow
+
+NeNe Records uses GitHub Issues for work tracking and local Markdown for project memory. This workflow inherits [NENE2 `docs/workflow.md`](https://github.com/hideyukiMORI/NENE2/blob/main/docs/workflow.md) with the substitutions below.
+
+See also: `docs/inheritance-from-nene2.md`.
+
+## Standard Flow
+
+1. Create or reuse a focused GitHub Issue.
+2. Confirm context in `docs/roadmap.md`, `docs/milestones/`, and `docs/todo/current.md`.
+3. Create a branch from `main` named like `type/issue-number-summary`.
+4. Implement the smallest useful change.
+5. Update docs, roadmap, milestone, or TODO files when the decision or state changes.
+6. Review the relevant self-review checklist in `docs/review/`.
+7. Run the narrowest meaningful verification available.
+8. Commit with Conventional Commits and include the Issue number.
+9. Push the branch and create a PR linked to the Issue.
+10. Merge after review and checks.
+11. Return local `main` to the merged, clean state.
+
+## Branch Names
+
+Use Conventional Commit style as the prefix:
+
+- `docs/2-inherit-nene2-governance`
+- `feat/1-entity-types-crud`
+- `fix/12-soft-delete-filter`
+- `test/8-field-value-validation`
+
+## PR Requirements
+
+Every PR should include:
+
+- purpose
+- change summary
+- verification results
+- self-review checklist used, when applicable
+- related Issue, preferably `Closes #number`
+- remaining risks or follow-up work
+
+Do not commit directly to `main`.
+
+## Local Project Memory
+
+- `docs/roadmap.md`: long-lived direction and phases
+- `docs/milestones/`: medium-sized goals and acceptance criteria
+- `docs/todo/current.md`: current task board and handoff notes
+- `docs/adr/`: major architecture decisions
+- `docs/inheritance-from-nene2.md`: NENE2 governance inheritance map
+
+Do not leave important decisions only in chat. If it changes how the project should be built, record it in `docs/`.
+
+Use ADRs for decisions that affect architecture, public contracts, dependency choices, or long-term maintenance. See `docs/development/adr.md`.
+
+Use self-review checklists before push or PR. See `docs/development/self-review.md`.
+
+## AI Agent Responsibilities
+
+AI agents should manage the normal lifecycle when asked to complete work:
+
+- create or reuse the Issue
+- create the Issue branch
+- read `AGENTS.md` and relevant docs before editing
+- edit only relevant files
+- review relevant self-review checklists
+- verify the change
+- commit, push, open PR, merge, and sync `main`
+- update local docs that describe project state
+
+If a user explicitly says investigation only, no commit, no PR, or another narrower scope, follow that instruction.


### PR DESCRIPTION
## Summary

- NENE2 の Issue 駆動開発、Conventional Commits、セルフレビュー、AI エージェント規約を NeNe Records に継承
- 正本 `docs/inheritance-from-nene2.md` でローカル規約と NENE2 upstream 参照の境界を明文化
- ADR 0001 でガバナンス継承方針を accepted として記録
- Cursor ルール 3 件、review チェックリスト 6 件、roadmap / todo / milestone を初期化

## 主な追加ファイル

| カテゴリ | ファイル |
|---------|---------|
| エージェント入口 | `AGENTS.md`, `CLAUDE.md` |
| 継承マップ | `docs/inheritance-from-nene2.md` |
| ワークフロー | `docs/workflow.md`, `docs/development/commit-conventions.md` |
| コーディング | `docs/development/coding-standards.md` |
| ADR | `docs/adr/0001-inherit-nene2-governance.md` |
| Cursor | `.cursor/rules/00`, `10`, `20` |
| レビュー | `docs/review/*.md` (6 files) |

## Test plan

- [x] `git diff --check` — whitespace clean
- [x] 全 doc リンクと README Contributing セクション確認
- [x] ADR 0001 status = accepted
- [x] milestone acceptance criteria 全項目チェック済み

## Self-review

`docs-policy`

Closes #2

Made with [Cursor](https://cursor.com)