### PR TITLE
docs(handoff): ワークスペース切替引き継ぎとプロダクトビジョン (#4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ This file is the entry point for AI agents working on NeNe Records.
 
 ## Read First
 
+- **Workspace handoff (2026-05-24):** `docs/todo/handoff-2026-05-24-workspace-switch.md`
+- **Product vision:** `docs/explanation/product-vision.md`
 - Inheritance map: `docs/inheritance-from-nene2.md`
 - Human and AI collaboration: `docs/CONTRIBUTING.md`
 - Workflow: `docs/workflow.md`

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ NeNe Records inherits NENE2 engineering discipline:
 
 | Topic | Document |
 | --- | --- |
+| **Product vision** | [`docs/explanation/product-vision.md`](./docs/explanation/product-vision.md) |
+| **Workspace handoff** | [`docs/todo/handoff-2026-05-24-workspace-switch.md`](./docs/todo/handoff-2026-05-24-workspace-switch.md) |
 | **Start here (agents)** | [`AGENTS.md`](./AGENTS.md) |
 | NENE2 inheritance map | [`docs/inheritance-from-nene2.md`](./docs/inheritance-from-nene2.md) |
 | Workflow | [`docs/workflow.md`](./docs/workflow.md) |

--- a/docs/explanation/product-vision.md
+++ b/docs/explanation/product-vision.md
@@ -1,0 +1,135 @@
+# Product Vision
+
+NeNe Records is a flexible entity platform built on [NENE2](https://github.com/hideyukiMORI/NENE2). This document records why the product exists, what it optimizes for, and how it relates to WordPress and the NENE2 ecosystem.
+
+## Origin
+
+The idea started from a simple question: **can we build something as useful as a CMS, but lighter, more readable, and more secure than WordPress?**
+
+WordPress proved that a generic `posts` table plus extensible metadata can power blogs, shops, and arbitrary applications. It also showed the cost: untyped `postmeta`, hook-driven control flow, theme/plugin coupling, and security surface that grows with every extension.
+
+NeNe Records keeps the **flexibility** while rejecting the **monolith**. The API layer (NENE2) owns persistence, auth, validation, and contracts. The admin frontend owns schema UX and most configuration workflows. Consumer views own public presentation. AI clients (MCP) use the same HTTP boundary as every other client.
+
+## North Star
+
+Developers and AI agents can:
+
+- define entity types and typed fields from an admin frontend
+- persist and query records through a documented JSON API
+- operate records in natural language via MCP tools
+- replace the admin UI, consumer views, or API host without rewriting core data rules
+
+NeNe Records is **not** a PHP framework. It is a **product** that consumes NENE2.
+
+## Philosophy
+
+### 1. API first, always
+
+JSON APIs and OpenAPI are the primary contract. HTML admin and consumer views are clients, not the source of truth.
+
+Inherited from NENE2: `README.md`, `docs/integrations/openapi.md`, `docs/explanation/why-mcp.md`.
+
+### 2. Typed data, not meta chaos
+
+Flexible storage without WordPress-style string-only meta blobs.
+
+- **Entity types** define what can exist (article, product, event, …).
+- **Field definitions** register keys, types, and validation rules in a schema registry persisted at the API layer.
+- **Typed value storage** uses type-specific tables or documented adapters (text, int, enum, image, file, …).
+- **Soft delete** is consistent (`is_deleted`, `deleted_at`) unless an ADR says otherwise.
+
+The frontend may edit schema UX, but **writes must be validated against API-side schema** — otherwise the WordPress plugin/meta problem returns.
+
+### 3. Extreme responsibility separation
+
+| Layer | Responsibility |
+| --- | --- |
+| **NENE2 runtime** | HTTP, DI, middleware, Problem Details, OpenAPI/MCP plumbing |
+| **NeNe Records API** | Entity CRUD, schema registry, auth enforcement, file adapters, analytics endpoints |
+| **Admin frontend** | Schema editing UI, management workflows, most configuration UX |
+| **Consumer views** | Public list/detail/card patterns over the same API |
+| **MCP tools** | AI-facing operations mapped to OpenAPI — never direct database access |
+
+Each layer should be swappable: API host, admin SPA, consumer theme, or MCP catalog can change independently when contracts stay stable.
+
+### 4. AI-native by contract, not by bolt-on
+
+MCP tools expose the same endpoints humans use. Examples the product should eventually support:
+
+- “Show access stats for 05/24”
+- “Change the title of that article”
+- “List articles tagged `php`”
+
+This works when OpenAPI is complete and MCP tools have clear descriptions — not when agents query SQL directly.
+
+### 5. Readable to humans and agents
+
+Explicit directories, small use cases, typed DTOs, documented ADRs, Issue-driven workflow. Inherited from NENE2 governance (ADR 0001).
+
+## WordPress comparison
+
+| Aspect | WordPress | NeNe Records |
+| --- | --- | --- |
+| Runtime | Monolithic PHP core + hooks | Thin NENE2 JSON API |
+| Metadata | Untyped `postmeta` strings | Typed fields + schema registry |
+| Business logic | PHP hooks/filters everywhere | Admin frontend + API validation |
+| Public site | Theme-coupled PHP templates | Replaceable consumer views |
+| AI access | Ad hoc, plugin-dependent | OpenAPI + MCP catalog |
+| Extension model | Plugins touch everything | Contract-bound API clients |
+
+NeNe Records is **not** WordPress-compatible and should not try to be.
+
+## Scope beyond CMS
+
+With schema registry, relations, tags, and query APIs, the same platform can support:
+
+- **Headless CMS** (articles, pages, media)
+- **Lightweight app backend** (forms, inventories, simple CRM)
+- **AI-operated admin** (natural language CRUD and reporting)
+
+It becomes an app framework only when Phase 3+ features exist (relations, workflow, webhooks, computed fields). Until then, treat it as a **typed entity platform**.
+
+## Performance expectations
+
+Architecture alone does not guarantee speed.
+
+**Likely faster than WordPress when:**
+
+- comparing lean JSON API vs heavy plugin stacks
+- querying indexed typed columns instead of generic meta joins
+- avoiding hook/bootstrap overhead per request
+
+**Can be slower when:**
+
+- naive EAV joins across many typed tables
+- N+1 field loads on list endpoints
+- uncached SPA public pages vs fully cached WordPress HTML
+
+Design rules from day one:
+
+- repository queries should eager-load fields in 1–2 SQL round-trips
+- consider denormalized read models for hot list endpoints
+- cache schema registry and popular entities when needed
+
+## Relationship to NENE2
+
+```
+NENE2          → framework (Packagist: hideyukimori/nene2)
+NeNe Records   → product (this repository)
+NENE2-FT       → reference trials and pattern catalog
+```
+
+- Framework changes belong in NENE2.
+- Entity model, admin UX, and product MCP tools belong here.
+- See `docs/inheritance-from-nene2.md` for governance and doc boundaries.
+
+## Non-goals
+
+- Rebuilding Laravel/Symfony in this repository
+- WordPress plugin, theme, or database compatibility
+- MCP or admin clients bypassing the HTTP API
+- Putting all business logic in PHP when the admin frontend is the intended owner
+
+## Naming note
+
+The working name **NeNe Records** avoids WordPress `posts` baggage. Prefer `entities`, `entity_types`, and `field_defs` in schema design over `posts` / `postmeta`.

--- a/docs/milestones/2026-05-governance-and-foundation.md
+++ b/docs/milestones/2026-05-governance-and-foundation.md
@@ -12,6 +12,7 @@ Goal: establish NeNe Records engineering discipline inherited from NENE2 before 
 - [x] `docs/review/` initial self-review checklists
 - [x] ADR 0001 accepted
 - [x] `docs/roadmap.md` and `docs/todo/current.md` initialized
+- [x] Workspace handoff and product vision documented (Issue #4)
 
 ## Issues
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -2,11 +2,17 @@
 
 Last updated: 2026-05-24
 
+## Workspace
+
+**Main Cursor workspace:** `/home/xi/docker/nene-records`
+
+New contributors and AI agents: read [`handoff-2026-05-24-workspace-switch.md`](./handoff-2026-05-24-workspace-switch.md) and [`docs/explanation/product-vision.md`](../explanation/product-vision.md) first.
+
 ## In Progress
 
 | Issue | Branch | Summary |
 | --- | --- | --- |
-| #2 | `docs/2-inherit-nene2-governance` | NENE2 系ガバナンス・ワークフロー規約の継承 |
+| #4 | `docs/4-workspace-handoff` | Workspace switch handoff and product vision |
 
 ## Up Next
 
@@ -18,13 +24,14 @@ Last updated: 2026-05-24
 
 | Issue | Summary |
 | --- | --- |
+| #2 | NENE2 governance inheritance (merged PR #3) |
 | — | Repository bootstrap (`README`, MIT license) |
 
 ## Handoff Notes
 
-- Governance docs and Cursor rules land in PR for #2.
-- Runtime scaffold (`composer.json`, Docker, migrations) starts in #1 after #2 merges.
+- Phase 0 governance complete. Phase 1 runtime scaffold starts in Issue #1.
 - Framework reference: `hideyukimori/nene2` via Composer; see `docs/inheritance-from-nene2.md`.
+- NENE2 sibling in workspace is optional; see handoff §1.
 
 ## Verification Commands
 

--- a/docs/todo/handoff-2026-05-24-workspace-switch.md
+++ b/docs/todo/handoff-2026-05-24-workspace-switch.md
@@ -1,0 +1,210 @@
+# Handoff: Workspace Switch and Project Kickoff (2026-05-24)
+
+この文書は、**NENE2 ワークスペースから NeNe Records をメイン Cursor ワークスペースに切り替える**ための引き継ぎである。  
+構想の経緯・ゴール・哲学の durable 版は [`docs/explanation/product-vision.md`](../explanation/product-vision.md) を正本とする。
+
+---
+
+## 1. ワークスペース切替
+
+### 推奨設定
+
+| 項目 | 値 |
+| --- | --- |
+| **メイン WS** | `/home/xi/docker/nene-records` |
+| **リポジトリ** | https://github.com/hideyukiMORI/nene-records |
+| **NENE2 を WS に追加** | 任意（未リリース機能・本体 PR 並行時のみ） |
+| **NENE2-FT** | 通常は WS 外。パターン参照時だけ |
+
+### NENE2 は composer だけで足りるか
+
+**通常は足りる。** `composer require hideyukimori/nene2` で `vendor/hideyukimori/nene2/` にコードと docs が入る。  
+実装・テスト・MCP 検証は vendor 参照で可能。
+
+**NENE2 を sibling で WS に足すケース:**
+
+- NENE2 未リリース HEAD を path repository で試す
+- フレームワーク本体に並行 PR を出す
+- `src/` 定義ジャンプを IDE で横断したい
+
+```json
+"repositories": [{ "type": "path", "url": "../NENE2" }],
+"require": { "hideyukimori/nene2": "@dev" }
+```
+
+### AI / 人間が最初に読むファイル
+
+1. [`AGENTS.md`](../../AGENTS.md)
+2. [`docs/explanation/product-vision.md`](../explanation/product-vision.md) — **なぜ作るか**
+3. [`docs/inheritance-from-nene2.md`](../inheritance-from-nene2.md) — **NENE2 継承境界**
+4. [`docs/todo/current.md`](./current.md) — **今何をするか**
+5. [`docs/roadmap.md`](../roadmap.md) — **フェーズ全体**
+
+---
+
+## 2. 構想の経緯（2026-05-24 対話サマリー）
+
+### 出発点
+
+hide が NENE2 で「有用でそこそこな規模のもの」を作れないかと検討。  
+WordPress の `wp_posts` + `wp_postmeta` に似た **汎用エンティティ + 型付きデータ** モデルを提案:
+
+- `entities`（旧 posts 相当）
+- `data`（フィールド定義 + data_type）
+- `int_data`, `text_data`, `enum_data`, …（型別 value テーブル）
+- 全表共通の soft delete（`is_deleted`, `deleted_at`）
+
+フロントから仮想テーブルを CRUD できれば、**DB っぽいものを自由に管理できるのでは** という発想。
+
+### WordPress との距離
+
+WordPress は似た柔軟性を実証したが、`postmeta` の string 化・フック地獄・テーマ/プラグイン密結合で **カオスになりやすい**。
+
+NeNe Records は:
+
+- **API（NENE2）** = 認証・ファイル・CRUD・契約
+- **管理フロント** = スキーマ定義 UI + 主なビジネスロジック
+- **Consumer View** = 公開表現（差し替え可能）
+
+→ **API もフロントも差し替え可能** な責務分離。
+
+### CMS を超える可能性
+
+CRUD + スキーマレジストリ + 認可 + クエリ + リレーションまで行けば、CMS だけでなく **軽量アプリ基盤** になりうる。  
+Level 3（ワークフロー・Webhook・マルチテナント等）は別プロダクト域 — Phase ごとに [`docs/roadmap.md`](../roadmap.md) 参照。
+
+### MCP 構想
+
+OpenAPI ベース MCP を充実させれば:
+
+- 「5/24 のアクセス集計」
+- 「あの記事のタイトル変更」
+- 「php タグの記事一覧」
+
+など **自然言語 → MCP ツール → HTTP API → DB** で実現可能。  
+NENE2 の Note/Tag CRUD + MCP write パターンが原型。
+
+### 命名・リポジトリ
+
+- プロダクト名: **NeNe Records**（`posts` baggage を避ける）
+- リポジトリ: https://github.com/hideyukiMORI/nene-records
+- NENE2 **本体には入れない**（consumer project として独立）
+
+---
+
+## 3. ゴール
+
+### 短期（Phase 0–1）
+
+- [x] ガバナンス継承（Issue #2, ADR 0001, Cursor rules）
+- [ ] MVP vertical slice（Issue #1）  
+  `entity_types` + `entities` + `text_fields` CRUD + OpenAPI + SQLite tests + `composer.json`
+
+### 中期
+
+- 型追加（int, enum, image, file）
+- スキーマレジストリ API（`field_defs`）
+- タグ・リレーション・フィルタクエリ
+- 管理フロント React
+
+### 長期
+
+- MCP セマンティックツール + アクセス集計
+- Consumer View パターン
+- 必要なら read model / キャッシュ最適化
+
+---
+
+## 4. 哲学（要約）
+
+詳細は [`product-vision.md`](../explanation/product-vision.md)。
+
+| 原則 | 意味 |
+| --- | --- |
+| API first | OpenAPI が契約の中心 |
+| Typed, not meta | WP 型 `postmeta` 地獄を避ける |
+| 責務分離 | API / Admin / Consumer / MCP を独立 |
+| AI-native | MCP は DB 直結禁止、HTTP 契約のみ |
+| NENE2 上に載せる | フレームワーク再発明しない |
+| Issue 駆動 | NENE2 と同じ厳格運用を継承 |
+
+---
+
+## 5. NENE2 からの文脈
+
+### NENE2 が既に提供するもの
+
+- PSR-7/15/17 HTTP runtime、明示ルーティング、ミドルウェア
+- OpenAPI + Swagger UI + contract tests
+- RFC 9457 Problem Details
+- Bearer JWT / API key / CompositeAuth
+- PDO + Phinx migrations + repository パターン
+- Local MCP server + `docs/mcp/tools.json`
+- Note/Tag CRUD 参照実装（Phase 1 のテンプレート）
+
+### NeNe Records が追加するもの
+
+- 汎用エンティティモデルと型付きフィールド永続化
+- スキーマレジストリ（API 側検証）
+- 管理フロント・Consumer View（将来）
+- プロダクト固有 MCP ツール（entity CRUD, analytics 等）
+- Problem Details base: `https://nene-records.dev/problems/`
+
+### 参照実装の場所
+
+| 用途 | 参照先 |
+| --- | --- |
+| CRUD + UseCase パターン | NENE2 `src/Example/Note/`, `Tag/` |
+| Consumer project 構成 | NENE2-FT（例: `noteslog/`） |
+| フレームワーク docs | `vendor/hideyukimori/nene2/docs/` |
+| ガバナンス継承 | [`docs/inheritance-from-nene2.md`](../inheritance-from-nene2.md) |
+
+---
+
+## 6. 設計上の注意（対話で合意した論点）
+
+### スキーマはフロントだけにしない
+
+`field_defs` を API で永続化し、write 時に API が検証する。
+
+### 型テーブルはハイブリッド
+
+全部 typed テーブル分割しすぎない。コア型は typed、拡張 escape hatch に JSON カラムも検討。
+
+### パフォーマンス
+
+API は WP プラグイン地獄より速くなりやすいが、EAV JOIN / N+1 を放置すると遅くなる。  
+repository で eager load、必要なら read model。
+
+### 命名
+
+テーブル・API では `entities` / `entity_types` / `field_defs` を優先。`posts` は使わない。
+
+---
+
+## 7. 完了済み作業
+
+| 日付 | 内容 |
+| --- | --- |
+| 2026-05-24 | リポジトリ bootstrap、Issue #1 MVP 計画 |
+| 2026-05-24 | Issue #2 ガバナンス継承 → PR #3 merge |
+| 2026-05-24 | 本 handoff + product-vision 作成（Issue #4） |
+
+---
+
+## 8. 次のアクション
+
+1. **Cursor WS を `/home/xi/docker/nene-records` に切替**
+2. **Issue #1** — `feat/1-entity-types-crud` ブランチで runtime スキャフォールド
+3. Phase 1 着手前に entity ER 図を `docs/` に固定（ADR 0002 候補）
+4. NENE2 は composer require のみで開始。path repo は必要になってから
+
+---
+
+## 9. 関連リンク
+
+- Product vision: [`docs/explanation/product-vision.md`](../explanation/product-vision.md)
+- Roadmap: [`docs/roadmap.md`](../roadmap.md)
+- Inheritance: [`docs/inheritance-from-nene2.md`](../inheritance-from-nene2.md)
+- ADR 0001: [`docs/adr/0001-inherit-nene2-governance.md`](../adr/0001-inherit-nene2-governance.md)
+- Issue #1: https://github.com/hideyukiMORI/nene-records/issues/1


### PR DESCRIPTION
## Summary

- `docs/todo/handoff-2026-05-24-workspace-switch.md` — WS 切替手順、構想経緯、次アクション
- `docs/explanation/product-vision.md` — ゴール、哲学、WP 比較、NENE2 関係、性能論点（durable 正本）
- `AGENTS.md`, `README.md`, `docs/todo/current.md` を handoff 参照付きに更新

## Test plan

- [x] handoff から product-vision / inheritance / roadmap へリンク確認
- [x] `git diff --check`

## Self-review

`docs-policy`

Closes #4

Made with [Cursor](https://cursor.com)