### PR TITLE
docs(standards): フロント/バックエンド厳格コーディング規約 (#6)

### DIFF
--- a/.cursor/rules/20-modern-php.mdc
+++ b/.cursor/rules/20-modern-php.mdc
@@ -1,17 +1,45 @@
 ---
-description: NeNe Records PHP 実装時のモダン PHP / API 契約ルール
+description: NeNe Records PHP/API 実装時の厳格ルール — NENE2 consumer
 globs: "**/*.php"
 alwaysApply: false
 ---
 
-# Modern PHP
+# Backend PHP / API
 
-- 新規 PHP ファイルは `declare(strict_types=1);` を付け、PSR-12 を基本にする（NENE2 継承）。
-- Controller は薄く保ち、入力解釈、UseCase 呼び出し、Response 生成に集中する。
-- UseCase / Domain は HTTP、DB、テンプレート、CLI、frontend build から独立させる。
-- 配列のまま境界を越えず、DTO、value object、enum、readonly property を優先する。
-- エンティティスキーマとフィールド型は API 境界で検証する。フロントのみのスキーマ定義に依存しない。
-- OpenAPI で表現する public API 契約と実装のズレを避ける。
-- MCP 連携は DB 直結ではなく、OpenAPI 経由の HTTP API を通す。
-- アプリ固有 Problem Details の type は `https://nene-records.dev/problems/{problem-name}` を使う。
-- 正本は `docs/development/coding-standards.md` と NENE2 `docs/development/coding-standards.md`。
+正本: **`docs/development/backend-standards.md`**（配置・レイヤー違反はマージ不可）
+
+## NENE2 継承
+
+- フレームワークは `vendor/hideyukimori/nene2`。参照実装: `../NENE2/src/Example/Note/`
+- Runtime / Middleware / DI / Problem Details / DatabaseQueryExecutor は NENE2 を使用
+- `Nene2\Example\` は本番 NeNe Records に載せない
+
+## 配置（zero tolerance）
+
+- ドメイン単位フォルダ: `src/EntityType/`, `src/Entity/` 等。**`src/Controllers/` 等のレイヤー分割禁止**
+- Handler / UseCase / DTO / Repository / RouteRegistrar / ServiceProvider は同一ドメインフォルダ内
+- SQL は `Pdo*Repository.php` のみ。Migration は `database/migrations/`
+
+## レイヤー
+
+- Handler: PSR-7 解析 + format validation → Input DTO → UseCase → JSON
+- UseCase: ビジネス不変条件。`execute(Input): Output` のみ。PDO/HTTP 禁止
+- Repository: interface + `Pdo*` adapter。`DatabaseQueryExecutorInterface` 経由
+- 依存は下向きのみ。Handler が Repository を直接呼ばない
+
+## 型・命名
+
+- 全ファイル `declare(strict_types=1);`。PHP >=8.4.1。DTO/handler は `final readonly` 優先
+- Namespace: `NeNeRecords\{Domain}\`
+- Path param は `Router::PARAMETERS_ATTRIBUTE` から取得
+
+## 契約
+
+- 公開 API は `docs/openapi/openapi.yaml` と一致。endpoint 追加 = OpenAPI + テスト
+- Problem Details type: `https://nene-records.dev/problems/{problem-name}`
+- MCP は HTTP/OpenAPI 経由のみ
+
+## テスト・CI
+
+- UseCase: InMemory repository。Repository: SQLite `:memory:`
+- マージ前 `composer check` 必須

--- a/.cursor/rules/30-frontend-react.mdc
+++ b/.cursor/rules/30-frontend-react.mdc
@@ -1,0 +1,49 @@
+---
+description: NeNe Records フロント（React/TS）— 厳格アーキテクチャ・データフロー・テスト規約（Phase 4+）
+globs: "frontend/**/*.{ts,tsx}"
+alwaysApply: false
+---
+
+# Frontend React / TypeScript
+
+正本: **`docs/development/frontend-standards.md`**（違反はマージ不可）
+
+## アーキテクチャ
+
+- レイヤー: `app → pages → features → entities → shared`。上向き・feature 横断 import 禁止。
+- 公開面: `entities/{resource}/index.ts` と `features/{feature}/index.ts` のみから import。
+- Phase 1（Issue #1）ではフロント実装しない。
+
+## 配置（zero tolerance）
+
+- model / enum / ids / api-types / mapper / query-keys / queries / mutations は `entities/{resource}/` の規定ファイルのみ。
+- generated 型は `shared/api/generated/` のみ。features / pages / `*.tsx` から DTO を import しない。
+- HTTP は `shared/api/client.ts` のみ。
+
+## データフロー
+
+- Read: API → client → mapper → entity query → feature hook → UI（UI は model のみ）。
+- Write: UI → mutation hook → client → API → 明示的 invalidation。
+- `useEffect` + fetch 禁止。Query cache を useState に複製しない。
+- loading / empty / error / success を明示。
+
+## デザインパターン
+
+- Hook + View（`features/*/hooks` + `features/*/ui`）。`shared/ui` にドメインロジックなし。
+- TanStack Query v5。query key は factory のみ。
+- Form: React Hook Form + Zod（UX 用）。破壊的操作は confirm dialog。
+- named export のみ。class component / default export 禁止。
+
+## 型・セキュリティ
+
+- TS strict + `noUncheckedIndexedAccess`。`any` / 無理由 `@ts-ignore` / `!` 禁止。
+- 401/403 fail closed。秘密情報をソースに埋め込まない。
+
+## テスト
+
+- Vitest + Testing Library + MSW。mapper / feature の happy + error path 必須。
+- factories は model 用。MSW は OpenAPI 準拠。
+
+## CI
+
+- `npm run check --prefix frontend` 必須。ESLint boundary 違反は fail。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ This file is the entry point for AI agents working on NeNe Records.
 - Human and AI collaboration: `docs/CONTRIBUTING.md`
 - Workflow: `docs/workflow.md`
 - Coding standards: `docs/development/coding-standards.md`
+- Backend standards: `docs/development/backend-standards.md`
+- Frontend standards (Phase 4+; policy now): `docs/development/frontend-standards.md`
 - Commit messages: `docs/development/commit-conventions.md`
 - AI tool policy: `docs/integrations/ai-tools.md`
 - Roadmap: `docs/roadmap.md`

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,6 +9,8 @@ NeNe Records is built through small, Issue-driven changes. This document is the 
 | NENE2 inheritance map | `docs/inheritance-from-nene2.md` |
 | Workflow | `docs/workflow.md` |
 | Coding standards | `docs/development/coding-standards.md` |
+| Backend standards (PHP/API) | `docs/development/backend-standards.md` |
+| Frontend standards (Phase 4+) | `docs/development/frontend-standards.md` |
 | Commit messages | `docs/development/commit-conventions.md` |
 | AI tools | `docs/integrations/ai-tools.md` |
 | Agent entry point | `AGENTS.md` |

--- a/docs/development/backend-standards.md
+++ b/docs/development/backend-standards.md
@@ -1,0 +1,569 @@
+# Backend Standards
+
+NeNe Records backend is a **NENE2 consumer application**: framework runtime, middleware, DI, and database adapters come from [NENE2](https://github.com/hideyukiMORI/NENE2); product logic (entity model, CRUD, schema rules) lives in this repository.
+
+**Status:** Phase 1 (Issue `#1`) implements the first vertical slice — `entity_types`, `entities`, `text_fields` — following these rules from the first commit.
+
+**Framework reference:** `vendor/hideyukimori/nene2/docs/` after `composer install`; sibling checkout at `../NENE2` for IDE jump and upstream PRs.
+
+**Reference implementation:** NENE2 `src/Example/Note/` and `src/Example/Tag/` — same patterns, NeNe Records namespaces and routes.
+
+**Inheritance map:** `docs/inheritance-from-nene2.md`
+
+**Enforcement level:** violations of placement, layering, dependency direction, OpenAPI sync, or security rules **block merge to `main`**. No temporary exceptions without an ADR.
+
+---
+
+## Document map
+
+| Section | Covers |
+| --- | --- |
+| [Principles](#principles) | Non-negotiable values |
+| [NENE2 boundary](#nene2-boundary) | Framework vs application ownership |
+| [Repository layout](#repository-layout) | Project tree |
+| [Architecture](#architecture) | Request flow, layers, dependencies |
+| [Module placement](#module-placement-zero-tolerance) | Domain folders — zero tolerance |
+| [Naming](#naming-conventions) | Classes, files, routes, migrations |
+| [Handlers](#http-handlers) | Thin HTTP boundary |
+| [Use cases](#use-cases) | Application logic |
+| [Repositories](#repositories-and-database) | Persistence |
+| [DI and routing](#dependency-injection-and-routing) | Wiring |
+| [Validation](#validation-layers) | Where rules live |
+| [Errors](#errors-and-problem-details) | RFC 9457 |
+| [OpenAPI](#openapi-and-mcp) | Contract-first |
+| [Testing](#testing) | Pyramid and placement |
+| [Security](#security) | API boundary |
+| [CI](#commands-and-ci) | Quality gates |
+
+---
+
+## Principles
+
+| Principle | Meaning |
+| --- | --- |
+| **API first** | OpenAPI describes public behavior; runtime must match. |
+| **Domain-grouped modules** | Code grouped by **aggregate** (`EntityType/`, `Entity/`), not by technical layer (`Controllers/`, `Repositories/`). |
+| **Thin HTTP** | Handlers parse/validate format → DTO → use case → JSON response. No business rules in handlers. |
+| **Use case centric** | Business invariants live in use cases; one `execute()` per operation. |
+| **Interface at boundaries** | Repositories and use cases exposed as interfaces; wired explicitly in service providers. |
+| **No raw persistence in domain** | Use cases never touch PDO; SQL only in `Pdo*Repository` adapters via NENE2 executors. |
+| **Typed boundaries** | Readonly DTOs, domain objects, enums — not unstructured arrays across layers. |
+| **Fixed placement** | Handlers, use cases, repositories, and tests live in mandated paths — **violations block merge**. |
+| **Test by layer** | In-memory repos for use cases; SQLite for repositories; HTTP + OpenAPI for contracts. |
+| **Secure by default** | Fail closed on auth; no secrets in repo; errors do not leak internals. |
+
+---
+
+## NENE2 boundary
+
+| Owns | Layer |
+| --- | --- |
+| **NENE2** (`vendor/…/nene2`) | HTTP runtime, Router, middleware pipeline, DI container builder, PDO adapters, Problem Details factory, OpenAPI tooling, MCP plumbing |
+| **NeNe Records** (`src/`) | Entity platform domains, migrations for product tables, OpenAPI paths for product API, application service providers, contract tests for product routes |
+| **Not shipped** | NENE2 `src/Example/Note|Tag` — reference only; do not expose `/examples/notes` in production NeNe Records |
+
+Consumer wiring replaces Example providers with NeNe Records providers. See NENE2 `docs/development/client-project-start.md`.
+
+---
+
+## Repository layout
+
+```text
+nene-records/
+  composer.json                 # require hideyukimori/nene2; PSR-4 NeNeRecords\ → src/
+  phinx.php                     # reads NENE2 ConfigLoader / DatabaseConfig
+  phpunit.xml.dist
+  phpstan.neon.dist
+  .php-cs-fixer.php
+  public_html/
+    index.php                   # front controller → project container factory
+    openapi.php                 # serves docs/openapi/openapi.yaml
+  src/
+    EntityType/                 # domain module (Issue #1)
+    Entity/
+    TextField/
+    ApplicationServiceProvider.php
+    Http/
+      RuntimeContainerFactory.php   # project container; registers app providers
+  tests/
+    EntityType/
+    Entity/
+    TextField/
+    OpenApi/                    # contract tests vs docs/openapi/openapi.yaml
+    Database/                   # optional shared DB test helpers
+  database/
+    migrations/
+    schema/                     # SQL snapshots per table
+  docs/
+    openapi/openapi.yaml        # public contract source of truth
+    mcp/tools.json              # when MCP tools exist
+  tools/                        # optional; or reuse NENE2 validate scripts via composer
+```
+
+Do **not** mirror NENE2 framework directories inside `src/` (`Middleware/`, `Routing/`, …) — consume them from the package.
+
+---
+
+## Architecture
+
+### Request flow
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant MW as NENE2 Middleware
+  participant Router
+  participant Handler
+  participant UC as UseCase
+  participant Repo as Repository
+  participant DB as DatabaseQueryExecutor
+
+  Client->>MW: HTTP request
+  MW->>Router: PSR-7 request
+  Router->>Handler: matched route
+  Handler->>Handler: format validation → Input DTO
+  Handler->>UC: execute(input)
+  UC->>Repo: domain operations
+  Repo->>DB: parameterized SQL
+  DB-->>Repo: rows
+  Repo-->>UC: domain objects
+  UC-->>Handler: Output DTO
+  Handler-->>Client: JSON response
+```
+
+### Layer dependency graph
+
+```text
+Handler → UseCaseInterface → RepositoryInterface → PdoRepository → DatabaseQueryExecutorInterface (NENE2)
+         ↓
+    Input/Output DTOs, Domain entity, Domain exceptions
+```
+
+**Hard rules:**
+
+- **Downward only** — repositories never call use cases; handlers never call repositories directly.
+- **No sideways** — `EntityType/` must not import `Entity/` internals; cross-aggregate orchestration uses application-level use cases or explicit ADR.
+- **Framework up** — application code imports `Nene2\…` infrastructure; NENE2 never imports `NeNeRecords\…`.
+
+### Validation split
+
+| Layer | Validates |
+| --- | --- |
+| **Middleware** | Auth, size limits, CORS, rate limits (NENE2) |
+| **Handler** | JSON shape, required fields, formats → `ValidationException` |
+| **Use case** | Business invariants: existence, uniqueness, state, soft-delete rules, schema registry (future) |
+| **Repository** | Nothing — persists and retrieves only |
+
+---
+
+## Module placement (zero tolerance)
+
+Each **aggregate or API resource** gets one folder under `src/` in **PascalCase** matching the domain name (`EntityType`, `Entity`, `TextField`).
+
+**Do not** create `src/UseCases/`, `src/Handlers/`, or `src/Repositories/` layer roots.
+
+### Canonical domain tree
+
+```text
+src/EntityType/
+  EntityType.php                      # domain entity (final readonly) — optional until needed
+  EntityTypeNotFoundException.php
+  CreateEntityTypeInput.php
+  CreateEntityTypeOutput.php
+  ListEntityTypesInput.php
+  ListEntityTypesOutput.php
+  ListEntityTypeItem.php
+  GetEntityTypeByIdInput.php          # when input non-trivial; omit for id-only gets
+  GetEntityTypeByIdOutput.php
+  UpdateEntityTypeInput.php
+  UpdateEntityTypeOutput.php
+  DeleteEntityTypeInput.php
+  DeleteEntityTypeOutput.php          # or void pattern via empty output DTO
+  CreateEntityTypeUseCaseInterface.php
+  CreateEntityTypeUseCase.php
+  GetEntityTypeByIdUseCaseInterface.php
+  GetEntityTypeByIdUseCase.php
+  ListEntityTypesUseCaseInterface.php
+  ListEntityTypesUseCase.php
+  UpdateEntityTypeUseCaseInterface.php
+  UpdateEntityTypeUseCase.php
+  DeleteEntityTypeUseCaseInterface.php
+  DeleteEntityTypeUseCase.php
+  EntityTypeRepositoryInterface.php
+  PdoEntityTypeRepository.php
+  CreateEntityTypeHandler.php
+  GetEntityTypeByIdHandler.php
+  ListEntityTypesHandler.php
+  UpdateEntityTypeHandler.php
+  DeleteEntityTypeHandler.php
+  EntityTypeNotFoundExceptionHandler.php
+  EntityTypeRouteRegistrar.php
+  EntityTypeServiceProvider.php
+```
+
+List operations use `List{Entity}Item` inside `List{Entity}sOutput` — same as NENE2 Note pattern.
+
+### Placement matrix (mandatory)
+
+| Artifact | Required path | May depend on |
+| --- | --- | --- |
+| Domain entity | `src/{Domain}/{Entity}.php` | same domain value types only |
+| Domain exception | `src/{Domain}/{Entity}NotFoundException.php` | — |
+| Input DTO | `src/{Domain}/{Operation}Input.php` | primitives, enums, ids from same domain |
+| Output DTO | `src/{Domain}/{Operation}Output.php` | same |
+| List item DTO | `src/{Domain}/List{Entity}Item.php` | same |
+| Use case interface | `src/{Domain}/{Operation}UseCaseInterface.php` | Input/Output DTOs |
+| Use case impl | `src/{Domain}/{Operation}UseCase.php` | repository interface, domain |
+| Repository interface | `src/{Domain}/{Entity}RepositoryInterface.php` | domain entity |
+| PDO repository | `src/{Domain}/Pdo{Entity}Repository.php` | `DatabaseQueryExecutorInterface`, domain |
+| HTTP handler | `src/{Domain}/{Operation}Handler.php` | use case interface, NENE2 HTTP helpers |
+| Exception → HTTP | `src/{Domain}/{Exception}Handler.php` | NENE2 Problem Details factory |
+| Route registrar | `src/{Domain}/{Entity}RouteRegistrar.php` | handlers only |
+| Service provider | `src/{Domain}/{Entity}ServiceProvider.php` | NENE2 DI interfaces |
+| Migrations | `database/migrations/` | Phinx API only |
+| Schema snapshot | `database/schema/{table}.sql` | matches migration end state |
+| OpenAPI | `docs/openapi/openapi.yaml` | — |
+| Use case unit test | `tests/{Domain}/{Operation}UseCaseTest.php` | in-memory repository double |
+| Repository test | `tests/{Domain}/Pdo{Entity}RepositoryTest.php` | SQLite `:memory:` |
+| HTTP test | `tests/{Domain}/{Entity}HttpTest.php` | wired handlers or full runtime |
+| In-memory double | `tests/{Domain}/InMemory{Entity}Repository.php` | implements production interface |
+
+### Cross-domain rules
+
+- **No imports of another domain's `Pdo*Repository`, handlers, or internal DTOs.**
+- Shared kernel (future): `src/Shared/` with ADR — not a dumping ground for convenience helpers.
+- **ApplicationServiceProvider** aggregates domain providers and exposes route registrar list — it does not contain business logic.
+
+### Forbidden placements (automatic PR reject)
+
+- Business logic in handlers beyond format validation
+- SQL outside `Pdo*Repository.php`
+- PDO / `DatabaseQueryExecutorInterface` in use cases or handlers
+- Use cases accepting `ServerRequestInterface` or raw request body arrays
+- Domain code under `vendor/` or copied NENE2 framework trees in `src/`
+- Public routes without OpenAPI path (when endpoint is shipped)
+- Layer-grouped directories (`src/Controllers/`, `src/UseCases/`)
+- Generic `src/Util/` with domain rules
+
+---
+
+## Naming conventions
+
+| Artifact | Pattern | Example |
+| --- | --- | --- |
+| Namespace | `NeNeRecords\{Domain}\` | `NeNeRecords\EntityType\CreateEntityTypeHandler` |
+| Test namespace | `NeNeRecords\Tests\{Domain}\` | `NeNeRecords\Tests\EntityType\CreateEntityTypeUseCaseTest` |
+| Use case | `{Verb}{Entity}UseCase` + `Interface` | `GetEntityTypeByIdUseCaseInterface` |
+| Handler | `{Verb}{Entity}Handler` or `List{Entity}sHandler` | `ListEntityTypesHandler` |
+| Input / Output | `{Operation}Input` / `{Operation}Output` | `UpdateEntityTypeInput` |
+| Repository IF | `{Entity}RepositoryInterface` | `EntityTypeRepositoryInterface` |
+| PDO adapter | `Pdo{Entity}Repository` | `PdoEntityTypeRepository` |
+| Route registrar | `{Entity}RouteRegistrar` | `EntityTypeRouteRegistrar` |
+| Service provider | `{Entity}ServiceProvider` | `EntityTypeServiceProvider` |
+| Migration file | `YYYYMMDDHHMMSS_snake_description.php` | `20260524000000_create_entity_types_table.php` |
+| Migration class | PascalCase matching purpose | `CreateEntityTypesTable` |
+| API path | plural kebab or snake per OpenAPI | `/entity-types`, `/entity-types/{id}` |
+| `operationId` | camelCase verb + entity | `listEntityTypes`, `createEntityType` |
+
+### PHP defaults (inherited from NENE2)
+
+- `declare(strict_types=1);` on **every** PHP file
+- PHP `>=8.4.1 <9.0`
+- `final readonly class` for DTOs, handlers, domain entities, service providers where applicable
+- PSR-12 via PHP-CS-Fixer
+- Constructor injection only — **no service locator** in domain code
+- One class per file; filename matches class name
+
+---
+
+## HTTP handlers
+
+Handlers are the **only** layer that touches PSR-7.
+
+### Responsibilities
+
+1. Parse JSON body (`JsonRequestBodyParser`) or read path params from `Router::PARAMETERS_ATTRIBUTE`
+2. **Format validation** → collect `ValidationError[]` → throw `ValidationException`
+3. Map to Input DTO
+4. Call `$useCase->execute($input)`
+5. Map Output DTO to JSON via `JsonResponseFactory`
+6. Set correct status (`200`, `201` + `Location`, `204`)
+
+### Forbidden in handlers
+
+- Repository calls
+- Business rules (uniqueness, soft-delete policy, schema invariants)
+- Direct SQL or transaction control
+- Reading path params via `$request->getAttribute('id')` — use `Router::PARAMETERS_ATTRIBUTE` (NENE2 router stores params as a named array)
+
+Reference: `../NENE2/src/Example/Note/CreateNoteHandler.php`
+
+---
+
+## Use cases
+
+One application operation = one use case interface with single method:
+
+```php
+interface CreateEntityTypeUseCaseInterface
+{
+    public function execute(CreateEntityTypeInput $input): CreateEntityTypeOutput;
+}
+```
+
+### Rules
+
+- `final readonly class` implementation
+- Constructor-injected repository **interfaces** only
+- Input carries format-validated data; use case enforces **business invariants**
+- Throw domain exceptions (`EntityTypeNotFoundException`) for caller-actionable failures
+- Return typed Output DTO — callers must not re-query repository for the same data
+- **No** HTTP, **no** PDO, **no** container, **no** `$_ENV`
+
+### NeNe Records domain rules (Issue #1+)
+
+- **Soft delete:** list/get default excludes `is_deleted = true` unless admin API documented otherwise
+- **Typed fields:** text values in `text_fields` — not generic untyped meta blobs
+- **Schema registry (future):** field definition validation on write happens in use cases, not handlers alone
+
+Reference: `../NENE2/docs/development/domain-layer.md`
+
+---
+
+## Repositories and database
+
+### Access pattern
+
+- Inject `DatabaseQueryExecutorInterface` (NENE2) into `Pdo*Repository` only
+- **Parameterized queries only** — no string concatenation of user input
+- Map rows to domain objects inside repository — return domain types, not `array` rows to use cases
+- Transactions via `DatabaseTransactionManagerInterface` when use case spans multiple writes — coordinate at use case or dedicated application service with ADR
+
+### Migrations (Phinx)
+
+- Config: `phinx.php` at project root (NENE2 pattern)
+- Paths: `database/migrations/`, `database/seeds/`
+- Every new table: migration + snapshot in `database/schema/{table}.sql`
+- Reversible migrations or documented rollback strategy
+- Consistent soft-delete columns: `is_deleted` (bool), `deleted_at` (nullable datetime) where applicable
+- Indexes on foreign keys and common filters (`entity_type_id`, etc.)
+
+### Issue #1 tables
+
+| Table | Purpose |
+| --- | --- |
+| `entity_types` | name, slug |
+| `entities` | `entity_type_id`, soft delete |
+| `text_fields` | `entity_id`, key, value, soft delete |
+
+Reference: NENE2 `docs/development/database-migrations.md`, `docs/development/test-database-strategy.md`
+
+---
+
+## Dependency injection and routing
+
+### Service providers
+
+Each domain implements `ServiceProviderInterface` (NENE2):
+
+- Bind `{Entity}RepositoryInterface` → `Pdo{Entity}Repository`
+- Bind each `{Operation}UseCaseInterface` → implementation
+- Bind each `{Operation}Handler`
+- Bind `{Entity}NotFoundExceptionHandler`
+- Register string key `'nene-records.route_registrar.{entity}'` → `{Entity}RouteRegistrar`
+
+Wire with **explicit factory closures** and runtime `instanceof` checks — same as NENE2 Note provider. **No autowiring.**
+
+`ApplicationServiceProvider` registers all domain providers and collects route registrars for `RuntimeApplicationFactory`.
+
+### Project container
+
+`src/Http/RuntimeContainerFactory.php`:
+
+1. Creates NENE2 `ContainerBuilder` with project root
+2. Adds `RuntimeServiceProvider` (NENE2)
+3. Adds `ApplicationServiceProvider` (NeNe Records) — **not** NENE2 Example providers in production
+4. Builds PSR-11 container
+
+`public_html/index.php` — front controller only; no business logic.
+
+### Routing
+
+- Domain `{Entity}RouteRegistrar` receives `Router` and registers REST routes
+- Path prefix for product API: **`/api/v1/`** (ADR may adjust — use consistently once chosen)
+- Handlers resolved from container in registrar constructor — registrars do not contain request logic
+
+Reference: `../NENE2/src/Example/Note/NoteRouteRegistrar.php`, `docs/development/http-runtime.md`
+
+---
+
+## Validation layers
+
+| Concern | Where | Mechanism |
+| --- | --- | --- |
+| Missing JSON field | Handler | `ValidationError` + `ValidationException` |
+| Invalid slug format | Handler | format rule |
+| Duplicate slug | Use case | repository check → domain exception or conflict Problem Details |
+| Referenced entity missing | Use case | `NotFoundException` |
+| Field key not in schema | Use case | future schema registry |
+
+Public validation metadata and Problem Details titles: **English**.
+
+Reference: NENE2 `docs/development/request-validation.md`
+
+---
+
+## Errors and Problem Details
+
+- All public JSON errors: **RFC 9457** via NENE2 `ProblemDetailsResponseFactory`
+- Application error `type`: `https://nene-records.dev/problems/{problem-name}`
+- Validation failures: `validation-failed` with structured `errors` array
+- Register domain exception handlers in domain service provider
+- **Never** expose stack traces, SQL, file paths, or secrets in responses
+- Log details server-side (NENE2 PSR-3 + request ID)
+
+Reference: NENE2 `docs/development/api-error-responses.md`
+
+---
+
+## OpenAPI and MCP
+
+### OpenAPI
+
+- **Source of truth:** `docs/openapi/openapi.yaml` (OpenAPI 3.1.0)
+- Every shipped JSON endpoint includes:
+  - stable `operationId`
+  - success schema + realistic example
+  - Problem Details responses (`401`, `404`, `422`, `500`, … as applicable)
+- Served via `public_html/openapi.php`
+- Validate: `composer openapi`
+
+### Endpoint completion checklist
+
+An endpoint is **not done** until:
+
+1. Route + handler + use case + repository (if persistent)
+2. OpenAPI path updated
+3. Unit test (use case) + integration test (repository and/or HTTP)
+4. Contract test entry if part of public surface
+5. Migration + schema snapshot when table changes
+
+Reference: NENE2 `docs/development/endpoint-scaffold.md`
+
+### MCP
+
+- Catalog: `docs/mcp/tools.json`
+- Each tool maps to OpenAPI `method` + `path` + `operationId`
+- Validate: `composer mcp`
+- MCP never accesses database directly — HTTP only
+
+---
+
+## Testing
+
+### Pyramid
+
+| Level | Tool | Scope | Required when |
+| --- | --- | --- | --- |
+| **Use case unit** | PHPUnit | `{Operation}UseCaseTest` with `InMemory*Repository` | Every use case |
+| **Repository** | PHPUnit + SQLite `:memory:` | `Pdo*RepositoryTest`; schema in `setUp()` | Every PDO repository |
+| **HTTP** | PHPUnit + PSR-7 | `{Entity}HttpTest` or runtime factory | Every handler group |
+| **OpenAPI contract** | PHPUnit | `tests/OpenApi/` vs YAML examples | Public JSON endpoints |
+| **Static analysis** | PHPStan level 8 | `src/` | All PRs |
+
+### Test placement
+
+| Artifact | Location |
+| --- | --- |
+| In-memory repository | `tests/{Domain}/InMemory{Entity}Repository.php` |
+| Use case tests | `tests/{Domain}/{Operation}UseCaseTest.php` |
+| Repository tests | `tests/{Domain}/Pdo{Entity}RepositoryTest.php` |
+| HTTP tests | `tests/{Domain}/{Entity}HttpTest.php` |
+| Contract tests | `tests/OpenApi/` |
+
+### Rules
+
+- Use cases tested **without** database when possible
+- Repository tests use SQLite — schema created per test class; do not depend on migration runner in unit tests
+- No network in unit tests
+- Test doubles implement **production interfaces** from `src/`
+- Bug fixes include regression test unless Issue waives
+
+Reference: NENE2 `docs/development/test-database-strategy.md`, `tests/Example/Note/`
+
+---
+
+## Security
+
+| Topic | Rule |
+| --- | --- |
+| **Secrets** | Never in repo; `.env` gitignored; `.env.example` only non-secret keys |
+| **Auth** | NENE2 middleware (Bearer, API key, composite) — handlers assume auth already enforced when route requires it |
+| **Input** | Validate at handler; never trust client for schema authority |
+| **SQL** | Parameterized only; no dynamic identifier injection without allowlist |
+| **Errors** | Fail closed; no internal detail in JSON |
+| **Dependencies** | `composer audit` in CI; block high/critical on `main` |
+| **Debug** | `APP_DEBUG` controls verbosity — never enable in production deploy docs by default |
+
+Reference: NENE2 `docs/development/middleware-security.md`, `authentication-boundary.md`
+
+---
+
+## Commands and CI
+
+Once `composer.json` exists:
+
+```bash
+composer install
+composer check          # test + phpstan + cs + openapi + mcp (+ version when applicable)
+composer test
+composer analyse
+composer cs
+composer openapi
+composer migrations:migrate
+```
+
+### Required before merge (API PRs)
+
+1. `composer check` green
+2. OpenAPI updated for changed endpoints
+3. Tests for touched use cases and repositories
+4. `git diff --check` clean for doc-only; CS-Fixer clean for PHP
+
+### PHPStan
+
+- Level **8** minimum on `src/`
+- No `@phpstan-ignore` without Issue/ADR comment
+
+### PHP-CS-Fixer
+
+- PSR-12 based NENE2 config
+- `composer cs` must pass — no manual style arguments in PR
+
+---
+
+## Admin vs API consumers
+
+The JSON API is the only persistence boundary for admin frontend, consumer views, and MCP. No special "admin bypass" repositories — authorization differs by middleware/policy, not duplicate data paths.
+
+---
+
+## Non-goals
+
+- Forking NENE2 framework code into `src/`
+- Laravel/Symfony-style full stack in this repo
+- WordPress compatibility
+- Direct DB access from MCP or frontend
+- Generic EAV blob storage for all field types (Issue #1 uses typed `text_fields`)
+
+---
+
+## Related documents
+
+- Summary index: `docs/development/coding-standards.md`
+- Frontend: `docs/development/frontend-standards.md`
+- Self-review: `docs/review/backend-api.md`, `database.md`, `openapi-contract.md`
+- NENE2 domain layer: `../NENE2/docs/development/domain-layer.md`
+- NENE2 client start: `../NENE2/docs/development/client-project-start.md`
+- Product: `docs/explanation/product-vision.md`
+- Issue #1: MVP entity CRUD vertical slice

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -1,50 +1,60 @@
 # Coding Standards
 
-NeNe Records follows NENE2 coding standards for PHP, HTTP, and API design, with additions for the flexible entity platform.
+NeNe Records coding standards split by surface. **Full policies live in the dedicated documents below** — this file is the index.
 
-**Framework baseline:** [NENE2 coding standards](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/coding-standards.md)
+| Surface | Source of truth |
+| --- | --- |
+| **PHP / API / database** | [`backend-standards.md`](./backend-standards.md) |
+| **React / TypeScript admin & consumer** | [`frontend-standards.md`](./frontend-standards.md) |
+| **NENE2 inheritance map** | [`../inheritance-from-nene2.md`](../inheritance-from-nene2.md) |
 
-**Inheritance map:** `docs/inheritance-from-nene2.md`
+**Framework baseline:** [NENE2 coding standards](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/coding-standards.md) — NeNe Records deviates only where local docs or ADRs say so.
 
-## PHP Baseline (inherited)
+---
 
-- Target PHP `>=8.4.1 <9.0`
-- `declare(strict_types=1);` on all new PHP files
-- PSR-12 style
-- Readonly DTOs, value objects, and enums at boundaries
-- Thin controllers; use cases independent from HTTP and persistence
-- Constructor injection; no service locator in domain code
-- RFC 9457 Problem Details for public JSON errors
+## Shared rules (all surfaces)
 
-## NeNe Records Additions
+- GitHub Issue-driven work; focused PRs; no direct commits to `main`
+- **Strict typing** at boundaries — PHP readonly DTOs; TypeScript strict mode
+- **OpenAPI** is the public API contract; MCP maps to the same HTTP operations
+- Application Problem Details `type`: `https://nene-records.dev/problems/{problem-name}`
+- **Placement violations block merge** — see backend and frontend standards
+- Public docs, OpenAPI text, and API error metadata: **English**
+- Issues, PRs, commits, `.cursor/rules/`: **Japanese allowed**
 
-### Entity platform boundaries
+---
 
-- **Entity types and field definitions** are persisted and validated at the API layer using a schema registry — do not rely on frontend-only schema knowledge for writes.
-- **Typed field values** live in type-specific tables or documented storage adapters; avoid a single untyped key/value blob for all field types.
-- **Soft delete** (`is_deleted`, `deleted_at`) should be consistent across entity tables unless an ADR documents an exception.
-- **SQL stays in repositories**; use cases express business rules, not query text.
+## Backend (summary)
 
-### API surface
+Full policy: **`docs/development/backend-standards.md`**.
 
-- JSON APIs are the primary product surface.
-- OpenAPI describes public request, response, and error shapes.
-- MCP tools map to the same OpenAPI operations; no direct database access from MCP.
-- Application-specific Problem Details `type` values use `https://nene-records.dev/problems/{problem-name}`.
+- NENE2 consumer — framework in `vendor/`, product in `src/`
+- Domain-grouped modules (`EntityType/`, `Entity/`, …) — not layer folders
+- Handler → UseCase → RepositoryInterface → PdoRepository
+- No PDO/SQL outside `Pdo*Repository`; no business logic in handlers
+- Phinx migrations + `database/schema/` snapshots; soft delete conventions
+- PHPUnit: in-memory use cases, SQLite repositories, OpenAPI contract tests
+- `composer check` before merge
 
-### Frontend layers (future)
+---
 
-- **Admin frontend** owns schema editing UI and most configuration workflows.
-- **Consumer views** are replaceable presentation layers over the same API.
-- Backend domain logic must not depend on React or admin-specific assumptions.
+## Frontend (summary)
 
-### Language
+Full policy: **`docs/development/frontend-standards.md`**.
 
-- Public docs, OpenAPI text, Problem Details titles, and validation codes: **English**
-- Issues, PR descriptions, commit messages, and `.cursor/rules/`: **Japanese allowed**
+- Phase 4+ implementation; Issue `#1` is API-only
+- React + TypeScript strict + TanStack Query + zero-tolerance module placement
+- API first — schema validation at API, not browser alone
 
-## Testing (inherited intent)
+---
 
-- Unit-test use cases without a database when practical.
-- Add HTTP or contract tests for public API behavior.
-- Keep tests deterministic and small.
+## Verification (once scaffolded)
+
+```bash
+composer check
+composer openapi
+composer mcp
+npm run check --prefix frontend   # when frontend/ exists
+```
+
+Until `composer.json` exists, governance and standards docs are verified by review and `git diff --check`.

--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -1,0 +1,682 @@
+# Frontend Standards
+
+NeNe Records admin and consumer frontends are **React + TypeScript** clients of the JSON API. They are not the source of truth for schema, validation, or persistence.
+
+**Status:** policy only — **Phase 4** implementation. Issue `#1` (Phase 1 MVP) is API-only; do not add `frontend/` until the OpenAPI contract for entity CRUD is stable enough to build against.
+
+**Framework baseline:** [NENE2 frontend integration](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/frontend-integration.md) — directory layout, npm, lockfile, build output, and dev proxy.
+
+**Inheritance map:** `docs/inheritance-from-nene2.md`
+
+**Enforcement level:** violations of placement, dependency direction, data flow, security, or testing rules in this document **block merge to `main`**. No temporary exceptions without an ADR.
+
+---
+
+## Document map
+
+| Section | Covers |
+| --- | --- |
+| [Principles](#principles) | Non-negotiable values |
+| [Architecture](#architecture) | Layers, dependency graph, design boundaries |
+| [Repository layout](#repository-layout) | Top-level tree |
+| [Type and module placement](#type-and-module-placement-zero-tolerance) | Models, enums, API types — zero tolerance |
+| [Data flow](#data-flow) | Read/write paths, cache, URL state |
+| [Design patterns](#design-patterns) | Mandatory React/TS patterns and forbidden anti-patterns |
+| [TypeScript](#typescript-strictness) | Compiler and type rules |
+| [Components](#component-conventions) | UI structure and styling |
+| [API access](#api-and-data-access) | HTTP, TanStack Query, errors |
+| [State](#state-management) | What state lives where |
+| [Security](#security) | Client-side security baseline |
+| [Testing](#testing) | Pyramid, tools, placement, required coverage |
+| [A11y / perf / observability](#accessibility) | Quality bars beyond correctness |
+| [CI](#commands-and-ci) | Commands and automated gates |
+
+---
+
+## Principles
+
+| Principle | Meaning |
+| --- | --- |
+| **API first** | OpenAPI is the contract; UI reflects API types and errors, never replaces validation. |
+| **Unidirectional flow** | Data flows **down** (API → entity → feature → UI); events flow **up** (UI → feature hook → mutation → API). No sideways shortcuts. |
+| **Strict TypeScript** | `strict` mode and additional compiler guards; no untyped escape hatches by default. |
+| **Fixed placement** | Models, enums, hooks, and tests live in mandated paths — **placement violations block merge**. |
+| **Explicit dependencies** | Import graph encodes architecture; ESLint enforces it. |
+| **Loose coupling** | Layers communicate through public surfaces (`index.ts`, props, hooks) — not internals. |
+| **Secure by default** | Fail closed on auth errors; minimal trust of client input and third-party markup. |
+| **Test by behavior** | Tests assert user-observable outcomes; MSW mirrors OpenAPI at boundaries. |
+| **Replaceable** | Admin SPA and consumer views swap independently when contracts stay stable. |
+
+---
+
+## When to implement
+
+| Phase | Frontend work |
+| --- | --- |
+| Phase 1 (`#1`) | **None** — PHP API, migrations, OpenAPI, PHPUnit only |
+| Phase 2–3 | Optional read-only prototypes only if explicitly tracked by an Issue |
+| Phase 4 | Admin React app — entity type editor, record CRUD screens |
+| Phase 6 | Consumer views — replaceable presentation over the same API |
+
+Conventions apply **now** to frontend policy PRs. Application code waits until Phase 4 unless an Issue says otherwise.
+
+---
+
+## Stack (NeNe Records default)
+
+Adopt current stable majors at scaffold time; keep them current with Dependabot or Renovate.
+
+| Layer | Choice | Notes |
+| --- | --- | --- |
+| UI | **React** (latest stable major) | Function components and hooks only — no class components |
+| Language | **TypeScript** (latest stable major) | All app source in `.ts` / `.tsx` |
+| Bundler | **Vite** | Dev server + production build |
+| Package manager | **npm** | Commit `frontend/package-lock.json`; CI uses `npm ci` |
+| Node.js | **Active LTS** | `engines` + `packageManager` in `frontend/package.json` |
+| Routing | **React Router** | Data APIs / loaders optional; URL is shareable state |
+| Server state | **TanStack Query v5** | Queries, mutations, cache, invalidation |
+| Forms | **React Hook Form** + **Zod** | Client UX validation only — API remains authoritative |
+| Lint | **ESLint** flat config: `typescript-eslint` strict-type-checked, `react-hooks`, `jsx-a11y`, `import/no-restricted-paths` or `eslint-plugin-boundaries` | `--max-warnings 0` |
+| Format | **Prettier** | Single formatter |
+| Unit / integration | **Vitest** + **Testing Library** + **MSW** | jsdom environment |
+| E2E | **Playwright** | Critical admin flows after Phase 4 stabilizes |
+| Dead code | **knip** (recommended) | Fail CI on unused exports in `entities/` and `features/` |
+
+Alternate UI frameworks, state libraries, or package managers require an ADR.
+
+---
+
+## Architecture
+
+NeNe Records frontend uses a **strict layered architecture** adjacent to [Feature-Sliced Design](https://feature-sliced.design/): `app → pages → features → entities → shared`.
+
+It is **not** a generic FSD repo — entity modules and API boundaries are **NeNe-specific** and stricter than generic FSD guidance.
+
+### Layer responsibilities
+
+| Layer | Owns | Must not own |
+| --- | --- | --- |
+| **`shared/`** | Transport, design tokens, pure utils, env | Routes, features, resource models, business workflows |
+| **`entities/`** | One API resource: DTO mapping, query keys, TanStack hooks | JSX, cross-resource orchestration, feature copy |
+| **`features/`** | User workflows composing entities + UI | Raw HTTP, DTO types, direct TanStack key strings |
+| **`pages/`** | Route wiring, lazy loading, layout slots | Business rules, API calls |
+| **`app/`** | Providers, router, global error boundary, auth gate shell | Feature-specific screens |
+
+### Dependency graph
+
+```mermaid
+flowchart TB
+  subgraph ui [UI layers]
+    app[app]
+    pages[pages]
+    features[features]
+  end
+  subgraph data [Data layers]
+    entities[entities]
+    shared_api[shared/api]
+    shared_ui[shared/ui]
+    shared_lib[shared/lib]
+  end
+  api[(NeNe Records API)]
+
+  app --> pages
+  pages --> features
+  features --> entities
+  features --> shared_ui
+  entities --> shared_api
+  entities --> shared_lib
+  shared_api --> api
+  shared_ui --> shared_lib
+
+  app --> shared_api
+  app --> shared_ui
+```
+
+**Hard rule:** no arrow may point **upward** (e.g. `entities → features`, `shared → entities`).
+
+### Import matrix (mandatory)
+
+| From ↓ / To → | `shared/ui` | `shared/api` | `shared/lib` | `entities/*` | `features/*` | `pages/*` | `app/*` |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `shared/ui` | ✓ internal | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ |
+| `shared/api` | ✗ | ✓ internal | ✓ | ✗ | ✗ | ✗ | ✗ |
+| `shared/lib` | ✗ | ✗ | ✓ internal | ✗ | ✗ | ✗ | ✗ |
+| `entities/{r}` | ✗ | ✓ client only | ✓ | ✗ sibling | ✗ | ✗ | ✗ |
+| `features/{f}` | ✓ | ✗ | ✓ | ✓ via `index.ts` | ✗ cross-feature | ✗ | ✗ |
+| `pages/` | ✓ | ✗ | ✓ | ✗ direct | ✓ via `index.ts` | ✗ | ✗ |
+| `app/` | ✓ | ✓ providers | ✓ | ✗ | ✗ | ✓ | ✓ internal |
+
+Cross-feature sharing: extract to `entities/` (if resource-level) or `shared/` (if generic with ADR) — **never** import `features/foo` from `features/bar`.
+
+### Public surfaces
+
+Every `entities/{resource}/` and `features/{feature}/` folder exposes **`index.ts` only** to upper layers. Internals (`mapper.ts`, `api-types.ts`, `ui/*.tsx`) are private to the slice.
+
+---
+
+## Repository layout
+
+Follow NENE2 placement: source under `frontend/`, built assets under `public_html/assets/` when integrated.
+
+```text
+frontend/
+  package.json
+  package-lock.json
+  tsconfig.json
+  tsconfig.app.json
+  vite.config.ts
+  eslint.config.js
+  vitest.config.ts
+  README.md                   # links to this document
+  src/
+    app/
+      providers.tsx           # QueryClientProvider, Router, theme
+      router.tsx
+      root-error-boundary.tsx
+      auth-gate.tsx           # fail-closed session check
+    pages/
+      entity-types/
+        EntityTypesPage.tsx
+    features/
+    entities/
+    shared/
+  tests/
+    setup/                    # vitest setup, MSW server bootstrap
+    msw/                      # shared MSW handlers (or per-entity __msw__)
+    factories/                # test data builders (models, not raw DTOs)
+    render/                   # renderWithProviders(), createTestQueryClient()
+```
+
+**Admin** and **consumer** may later split to `frontend/admin/` and `frontend/consumer/` with duplicated `shared/` extracted to `packages/shared/` — requires ADR.
+
+---
+
+## Type and module placement (zero tolerance)
+
+**Placement violations are never accepted on `main`.**
+
+Enforcement:
+
+- ESLint `import/no-restricted-paths` / `eslint-plugin-boundaries` — **`npm run lint` fails**
+- Reviewers reject structural drift; no “fix later” PRs
+
+### Canonical entity tree
+
+Each API resource → one `entities/{resource}/` folder (**kebab-case**, matches OpenAPI tag).
+
+```text
+entities/entity-type/
+  index.ts              # ONLY public import surface
+  ids.ts                # branded IDs
+  enum.ts               # resource-scoped enums (optional)
+  api-types.ts          # DTOs pre-codegen; aliases post-codegen
+  model.ts              # UI read models
+  mapper.ts             # DTO ↔ model (pure)
+  query-keys.ts         # TanStack key factory
+  queries.ts            # useQuery hooks
+  mutations.ts          # useMutation hooks
+  mapper.test.ts
+  query-keys.test.ts    # when non-trivial
+```
+
+### Placement matrix
+
+| Artifact | Required path |
+| --- | --- |
+| OpenAPI-generated types | `shared/api/generated/` |
+| Hand-written API DTOs | `entities/{resource}/api-types.ts` |
+| Branded IDs | `entities/{resource}/ids.ts` |
+| Enums | `entities/{resource}/enum.ts` or `shared/lib/enums/{name}.ts` (ADR) |
+| UI models | `entities/{resource}/model.ts` |
+| Mappers | `entities/{resource}/mapper.ts` |
+| Query keys | `entities/{resource}/query-keys.ts` |
+| `useQuery` | `entities/{resource}/queries.ts` |
+| `useMutation` | `entities/{resource}/mutations.ts` |
+| HTTP transport | `shared/api/client.ts` |
+| Problem Details | `shared/api/errors.ts` |
+| Cross-resource API helpers | `shared/api/types/` |
+| Component props | same `.tsx` file as component |
+| Feature orchestration hooks | `features/{feature}/hooks/` |
+| Test render helpers | `tests/render/` |
+| MSW handlers | `tests/msw/{resource}.ts` or `entities/{resource}/__msw__/handlers.ts` |
+| Test factories | `tests/factories/{resource}.ts` |
+
+### Import surface rules
+
+- Upper layers import entities **only** via `entities/{resource}/index.ts`.
+- **`features/` must not import** `shared/api/generated/` or `entities/*/api-types.ts`.
+- **`shared/ui/` must not import** `entities/`, `features/`, or generated types.
+- **Sibling entities never import each other.**
+- **`index.ts` does not re-export** `api-types`, `mapper`, or generated DTOs.
+
+Example public surface:
+
+```typescript
+export type { EntityTypeId } from "./ids";
+export type { EntityType } from "./model";
+export { EntityTypeStatus } from "./enum";
+export { entityTypeKeys } from "./query-keys";
+export { useEntityType, useEntityTypeList } from "./queries";
+export { useCreateEntityType, useUpdateEntityType, useDeleteEntityType } from "./mutations";
+```
+
+### Forbidden placements (automatic reject)
+
+- DTOs / API shapes in `features/`, `pages/`, `shared/ui/`, or `.tsx` (except `*Props`)
+- Models, enums, mappers outside `entities/{resource}/`
+- TanStack logic outside `query-keys.ts` / `queries.ts` / `mutations.ts`
+- `fetch` outside `shared/api/client.ts`
+- `shared/api/generated/` imported from any `.tsx`
+- Deep entity imports from features
+- Root-level `src/types/`, `src/utils/` type dumps
+
+---
+
+## Data flow
+
+### Read path (server → UI)
+
+```text
+API JSON
+  → shared/api/client.ts          (transport, auth headers, status parse)
+  → entities/{r}/api-types.ts     (wire shape)
+  → entities/{r}/mapper.ts        (map to model)
+  → entities/{r}/queries.ts       (TanStack Query cache)
+  → features/{f}/hooks/*.ts         (compose queries, derive view state)
+  → features/{f}/ui/*.tsx           (render props)
+```
+
+Rules:
+
+- **Mappers run inside entity hooks**, not in components.
+- Components receive **`model` types** and plain callbacks — never raw `Response`, never DTOs.
+- List screens use **stable query keys** from `query-keys.ts` only.
+
+### Write path (UI → server)
+
+```text
+UI event
+  → features/{f}/hooks              (or entity mutation hook directly)
+  → entities/{r}/mutations.ts       (useMutation)
+  → shared/api/client.ts
+  → API
+  → onSuccess: invalidate query-keys  (explicit, documented)
+  → onError: map Problem Details → AppError → UI feedback
+```
+
+Rules:
+
+- **Mutations live in `mutations.ts`** — features call exported hooks, not `useMutation` inline.
+- **Invalidation lists** are colocated with the entity (`mutations.ts` or `query-keys.ts` helpers).
+- **Optimistic updates** require rollback on failure and a test proving rollback behavior.
+
+### URL and shareable state
+
+| State | Location |
+| --- | --- |
+| Resource id in detail view | route param (`/entity-types/:id`) |
+| Filters, sort, page | `searchParams` (serializable) |
+| Modal open, tab, hover | local `useState` in feature |
+| Server data | TanStack Query cache — **not** duplicated in global store |
+
+Do not mirror Query cache into Context without an ADR.
+
+### Error and async UI flow
+
+Every data screen implements **four explicit UI states**:
+
+| State | UI responsibility |
+| --- | --- |
+| **Loading** | Skeleton or spinner from `shared/ui`; Suspense boundary at page level where lazy |
+| **Empty** | Intentional empty state copy — not a blank page |
+| **Error** | Safe message + retry action; Problem Details `type` logged in dev only |
+| **Success** | Primary content |
+
+Feature hooks return **narrowed view-model** (`{ status, data, error, retry }`) or components use TanStack `isPending` / `isError` / `isSuccess` explicitly — no ambiguous combined flags.
+
+---
+
+## Design patterns
+
+### Mandatory patterns
+
+| Pattern | Where | Purpose |
+| --- | --- | --- |
+| **Hook + View** | `features/{f}/hooks` + `features/{f}/ui` | Logic in hooks; UI is prop-driven |
+| **Entity module** | `entities/{r}/` | Single resource: types, map, cache, API |
+| **Query key factory** | `query-keys.ts` | Hierarchical, typed keys — no string literals in features |
+| **Mapper purity** | `mapper.ts` | Pure functions; unit-tested; no side effects |
+| **Barrel public API** | `index.ts` | Encapsulation and ESLint boundary targets |
+| **Problem Details mapping** | `shared/api/errors.ts` | Single parse path for `application/problem+json` |
+| **Provider stack** | `app/providers.tsx` | QueryClient, Router, theme, auth — one composition root |
+| **Route error boundary** | `app/root-error-boundary.tsx` | Uncaught render errors — safe fallback |
+| **Fail-closed auth gate** | `app/auth-gate.tsx` | 401 → login; 403 → forbidden — no silent writes |
+
+### Feature module pattern
+
+```text
+features/entity-type-editor/
+  index.ts                    # exports page-ready feature component or hook
+  hooks/
+    use-entity-type-editor.ts # composes entity mutations/queries
+  ui/
+    EntityTypeEditor.tsx      # presentational
+    EntityTypeEditor.test.tsx
+  lib/                        # optional pure helpers scoped to this feature
+```
+
+- **`index.ts` exports one primary entry** (e.g. `EntityTypeEditorFeature`).
+- Feature hooks **orchestrate**; they do not call `fetch` or define DTO types.
+
+### Presentational component rules
+
+- Zero data fetching; zero `useQuery` / `useMutation` in `shared/ui/**`.
+- Accept **`model` types** and callbacks (`onSave`, `onCancel`).
+- Use **`shared/ui`** primitives — no duplicate Button/Input per feature.
+
+### Forms pattern
+
+- **React Hook Form** + **Zod resolver** for client-side UX validation (required fields, format hints).
+- Submit calls **entity mutation hook** — not inline fetch.
+- Server validation errors map from Problem Details **`errors` field** to form field errors when API provides them.
+- Destructive submits (delete) require **explicit confirm dialog** component from `shared/ui`.
+
+### Compound components (design system)
+
+`shared/ui` may use compound pattern (e.g. `Dialog`, `Dialog.Header`, `Dialog.Body`) for flexible, typed composition — still no business logic.
+
+### Forbidden anti-patterns
+
+| Anti-pattern | Why forbidden |
+| --- | --- |
+| `useEffect` + `fetch` for server data | Use TanStack Query in `entities/` |
+| Prop drilling server data through 3+ layers | Feature hook or composition |
+| Global EventEmitter / custom pub-sub | Breaks traceability |
+| Storing API responses in `useState` | Duplicates Query cache |
+| Class components | Legacy — inconsistent with stack |
+| Default exports | Breaks refactor and boundary tooling |
+| Business rules in `shared/ui` | Couples design system to domain |
+| String query keys in features | Untyped invalidation bugs |
+| `dangerouslySetInnerHTML` without policy | XSS risk |
+| Auth token in `localStorage` without ADR | XSS exfiltration risk |
+
+---
+
+## TypeScript strictness
+
+`frontend/tsconfig.json` minimum:
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "exactOptionalPropertyTypes": true,
+    "verbatimModuleSyntax": true,
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "isolatedModules": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}
+```
+
+### Hard rules
+
+- **`any` forbidden** — use `unknown` and narrow.
+- **`@ts-expect-error` / `@ts-ignore`** — Issue or ADR id in comment.
+- **No `!` non-null assertion** without invariant comment.
+- **`interface` for component props**; `type` for unions and mapped types.
+- **`satisfies`** for const config objects (query defaults, route maps).
+- **Branded IDs** in `ids.ts` — no bare `string` for resource ids across layers.
+- **Exhaustive `switch`** on discriminated unions (`eslint` enforced).
+- **Env vars** validated once in `shared/config/env.ts` (Zod).
+
+### API types
+
+1. **Generated:** `shared/api/generated/` only; regenerate when OpenAPI changes.
+2. **Pre-codegen:** `entities/{resource}/api-types.ts` synced with contract tests.
+3. **UI consumes `model` via `index.ts`** — never raw DTOs in features.
+
+Frontend validation is UX-only; API owns authoritative schema validation.
+
+---
+
+## Component conventions
+
+### Files and exports
+
+- One primary component per file; named exports only.
+- Components: `PascalCase.tsx`; hooks: `use-kebab-case.ts`; utils: `kebab-case.ts`.
+- Props: `{ComponentName}Props` in the same file.
+
+### Styling
+
+Pick **CSS Modules** or **Tailwind** at scaffold (ADR). Design tokens in `shared/ui/theme` or equivalent — no magic values scattered in features.
+
+### React rules
+
+- Function components + hooks only.
+- Prefer **`useMemo` / `useCallback` only when measured or required for ref stability** — do not blanket-wrap.
+- **`useEffect` for external sync only** — not for derived state (compute inline or use Query).
+- Lazy routes: `React.lazy` + Suspense fallback from `shared/ui`.
+- Keys on lists: stable resource ids.
+
+---
+
+## API and data access
+
+```text
+UI → feature hook → entity query/mutation → shared/api/client → API
+```
+
+### HTTP client (`shared/api/client.ts`)
+
+- Single `apiClient` with typed methods (`get`, `post`, `patch`, `delete`).
+- Attaches auth per API policy (cookie credentials or bearer from secure context).
+- Parses JSON; throws **`AppError`** from Problem Details on 4xx/5xx.
+- **No domain logic** — only transport.
+
+### TanStack Query standards
+
+Configure defaults in `app/providers.tsx`:
+
+```typescript
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      retry: (failureCount, error) =>
+        failureCount < 2 && error instanceof AppError && error.isRetryable,
+      refetchOnWindowFocus: import.meta.env.PROD,
+    },
+    mutations: {
+      retry: false,
+    },
+  },
+});
+```
+
+Per entity in `queries.ts` / `mutations.ts`:
+
+- Export hooks with **explicit generic return types** (`UseQueryResult<EntityType, AppError>`).
+- **`queryFn` calls mapper** before returning to cache.
+- Document **`staleTime` overrides** in file header comment when not default.
+
+---
+
+## State management
+
+| State | Tool | Location |
+| --- | --- | --- |
+| Remote server data | TanStack Query | `entities/*/queries.ts` |
+| Writes | TanStack mutations | `entities/*/mutations.ts` |
+| URL / shareable | React Router | `pages/` + feature hooks reading `searchParams` |
+| Form draft | React Hook Form | feature ui + hooks |
+| Ephemeral UI | `useState` | feature ui |
+| Auth session flag | Context in `app/` only | minimal — details from API |
+
+No Redux, Zustand, or Jotai unless ADR.
+
+---
+
+## Security
+
+### Trust model
+
+The browser is **hostile context**. Treat all rendered user content and all client storage as potentially compromised.
+
+| Topic | Rule |
+| --- | --- |
+| **Secrets** | Never in repo. Only public `VITE_*` in frontend env. |
+| **Auth tokens** | Prefer httpOnly cookies; no refresh token in `localStorage` without ADR. |
+| **XSS** | No `dangerouslySetInnerHTML` without DOMPurify + Issue. Rich text is Phase 2+ with ADR. |
+| **CSRF** | Cookie auth → CSRF token or SameSite per API docs. |
+| **Links** | `rel="noopener noreferrer"` on `target="_blank"`. |
+| **Open redirects** | Validate post-login redirect paths against allowlist. |
+| **Dependencies** | `npm audit` in CI; block high/critical on `main`. Lockfile required. |
+| **CSP** | No inline scripts in prod build; coordinate with API middleware. |
+| **PII in logs** | Client logs never include tokens, passwords, or full Problem Details in production. |
+| **RBAC UI** | Hide/disable actions based on API-exposed permissions — UI gating is UX only; API enforces auth. |
+| **Fail closed** | 401 → login; 403 → forbidden; never silent unauthenticated mutations. |
+
+---
+
+## Testing
+
+### Pyramid
+
+| Level | Tool | Scope | Required when |
+| --- | --- | --- | --- |
+| **Unit** | Vitest | `mapper.ts`, `query-keys.ts`, pure `lib/` | Every entity module |
+| **Integration** | Vitest + Testing Library + MSW | Feature UI + hooks | Every feature PR |
+| **Contract** | MSW handlers vs OpenAPI | `tests/msw/` | Endpoint touched |
+| **E2E** | Playwright | Critical admin journeys | Phase 4 stable + Issue |
+
+### Test placement
+
+| Artifact | Location |
+| --- | --- |
+| Mapper / query-key tests | colocated `*.test.ts` in entity folder |
+| Component tests | `FeatureName.test.tsx` next to component |
+| MSW handlers | `tests/msw/{resource}.ts` |
+| Factories | `tests/factories/{resource}.ts` — build **models**, not DTOs |
+| `renderWithProviders` | `tests/render/render-with-providers.tsx` |
+
+### Testing rules
+
+- Query by **role / label / accessible name** — never by class or `data-testid` unless no a11y hook exists.
+- Use **`userEvent.setup()`** for interactions.
+- Wrap with **`createTestQueryClient()`** — disable retries, predictable cache.
+- MSW handlers **match OpenAPI** shapes; share fixtures with factories.
+- **No mocking child components** to skip integration — mock API boundary only.
+- **No snapshot tests** for full pages.
+- Bug fixes include **regression test** unless Issue waives.
+
+### Required before merge
+
+- Entity: mapper tests + query-key tests (if non-trivial) + hook test with MSW for primary query/mutation.
+- Feature: component test — happy path + primary error path (Problem Details).
+- `npm run test` green in CI.
+
+---
+
+## Accessibility
+
+- **WCAG 2.2 Level AA** for admin UI.
+- Focus management on route change and modal open/close.
+- `eslint-plugin-jsx-a11y` — errors fail CI.
+- Form errors linked via `aria-describedby`.
+
+---
+
+## Performance
+
+- Route-level code splitting (`React.lazy`).
+- Virtualize long lists (e.g. `@tanstack/react-virtual`) when >100 rows — Issue may track.
+- Images via API URLs; `loading="lazy"` on consumer views.
+- Avoid loading entire entity graphs when list endpoint exists.
+
+---
+
+## Observability
+
+- Dev-only structured logging behind `import.meta.env.DEV`.
+- Production: optional error reporting (Sentry etc.) via ADR — scrub PII and tokens.
+- TanStack Query Devtools **dev only**, never bundled in production entry.
+
+---
+
+## Commands and CI
+
+```bash
+npm install --prefix frontend
+npm run dev --prefix frontend
+npm run build --prefix frontend
+npm run check --prefix frontend
+```
+
+Recommended scripts:
+
+```json
+{
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint . --max-warnings 0",
+    "format": "prettier --check .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "knip": "knip",
+    "check": "npm run type-check && npm run lint && npm run format && npm run test"
+  }
+}
+```
+
+CI on frontend PRs:
+
+1. `npm ci --prefix frontend`
+2. `npm run check --prefix frontend`
+3. `npm run knip --prefix frontend` (when configured)
+4. `npm audit --audit-level=high` (fail on high/critical)
+
+Encode boundary rules in `eslint.config.js`:
+
+- `features/**` → no `shared/api/generated/**`, no deep `entities/**` except `index.ts`
+- `shared/ui/**` → no `entities/**`, `features/**`
+- `entities/*/**` → no sibling `entities/*/**`
+
+---
+
+## Admin vs consumer
+
+| App | Purpose | Shared |
+| --- | --- | --- |
+| **Admin** | Schema editing, record CRUD | `shared/api`, `entities/`, optional `shared/ui` |
+| **Consumer** | Public list/detail views | API client, entities; **not** admin features |
+
+Consumer must not import admin feature modules.
+
+---
+
+## Non-goals
+
+- Frontend in Phase 1 (Issue `#1`).
+- Duplicating API validation in the browser as source of truth.
+- DB or MCP access from the browser.
+- Committing `node_modules/` or generated assets.
+- Alternate UI stack without ADR.
+
+---
+
+## Related documents
+
+- Self-review: `docs/review/frontend.md`
+- PHP / API: `docs/development/coding-standards.md`
+- Product: `docs/explanation/product-vision.md`
+- Roadmap Phase 4: `docs/roadmap.md`

--- a/docs/inheritance-from-nene2.md
+++ b/docs/inheritance-from-nene2.md
@@ -51,6 +51,8 @@ Install NENE2 as a Composer dependency and treat `vendor/hideyukimori/nene2/docs
 | Public Problem Details base URL | `https://nene-records.dev/problems/` (application errors) |
 | NENE2 framework errors | Keep NENE2 canonical types when surfaced by the runtime |
 | Coding standards | `docs/development/coding-standards.md` — NENE2 baseline + entity-platform additions |
+| Backend standards | `docs/development/backend-standards.md` — PHP/API strict policy (NENE2 consumer) |
+| Frontend standards | `docs/development/frontend-standards.md` — React + TypeScript strict policy (Phase 4+ implementation) |
 | Language policy | English for public docs, OpenAPI, and API error metadata; Japanese allowed in Issues, PRs, commits, and `.cursor/rules/` |
 | Review checklists | `docs/review/` — task-specific lists for this product |
 

--- a/docs/review/backend-api.md
+++ b/docs/review/backend-api.md
@@ -1,26 +1,56 @@
 # Backend API Self-Review
 
-Use for API endpoints, handlers, request validation, responses, and HTTP-facing behavior.
+Use for API endpoints, handlers, use cases, validation, and HTTP behavior. Policy source: **`docs/development/backend-standards.md`**.
 
-Source policies:
+Also read:
 
 - `docs/development/coding-standards.md`
 - `docs/inheritance-from-nene2.md`
-- NENE2: `docs/development/http-runtime.md`, `request-validation.md`, `api-error-responses.md`, `domain-layer.md`
+- NENE2: `docs/development/domain-layer.md`, `http-runtime.md`, `request-validation.md`, `api-error-responses.md`, `endpoint-scaffold.md`
 
-## Checklist
+## Module placement (zero tolerance)
 
-- [ ] Public request or response behavior is reflected in OpenAPI when stable.
-- [ ] Handlers map request data to readonly DTOs before calling use cases.
-- [ ] Use cases do not receive raw PSR-7 requests or unstructured request arrays.
-- [ ] Business rules (ownership, state, schema invariants) live in use cases, not handlers or middleware.
-- [ ] Repositories are injected through interfaces; use cases do not use PDO directly.
-- [ ] SQL is confined to repository adapters.
-- [ ] Validation failures use Problem Details `validation-failed` with structured `errors`.
-- [ ] Application Problem Details `type` values use `https://nene-records.dev/problems/{problem-name}`.
-- [ ] Public API text and error metadata are in English.
-- [ ] Public errors do not expose stack traces, SQL, paths, or secrets.
-- [ ] Entity writes validate against registered field schema when applicable.
-- [ ] Soft-deleted records are excluded from public list/get unless explicitly documented.
-- [ ] Narrowest useful verification was run (usually `composer check`).
-- [ ] PR notes mention this checklist when API-facing.
+- [ ] Domain code lives under `src/{Domain}/` — no layer-grouped roots (`Controllers/`, `UseCases/`, `Repositories/`).
+- [ ] Each operation has Handler, UseCase (+ Interface), Input/Output DTOs in the correct domain folder.
+- [ ] SQL exists only in `Pdo{Entity}Repository.php`; no PDO in handlers or use cases.
+- [ ] Route registrar and service provider in the same domain folder.
+- [ ] No imports of another domain's repositories, handlers, or internal DTOs without ADR.
+
+## Request flow
+
+- [ ] Handler: JSON/path parse → format validation → Input DTO → use case → JSON response.
+- [ ] Path parameters read from `Router::PARAMETERS_ATTRIBUTE`, not `$request->getAttribute('id')`.
+- [ ] Business rules (uniqueness, soft delete, schema invariants) in use cases, not handlers or middleware.
+- [ ] Use cases do not receive PSR-7 requests or unstructured body arrays.
+
+## Dependencies and typing
+
+- [ ] Repositories injected via interfaces; explicit service provider wiring (no autowiring).
+- [ ] DTOs and domain objects are `final readonly` where applicable.
+- [ ] `declare(strict_types=1);` on all new PHP files.
+
+## OpenAPI and errors
+
+- [ ] Shipped endpoints have OpenAPI paths with stable `operationId`, examples, Problem Details responses.
+- [ ] Application Problem Details `type` uses `https://nene-records.dev/problems/{problem-name}`.
+- [ ] Validation failures use structured `errors`; public text in English.
+- [ ] Responses do not expose stack traces, SQL, paths, or secrets.
+
+## Entity platform (when applicable)
+
+- [ ] Writes validate against API-side schema when schema registry applies.
+- [ ] Soft-deleted rows excluded from list/get unless explicitly documented.
+- [ ] Typed field storage — not generic untyped meta blobs.
+
+## Testing and CI
+
+- [ ] Use case unit tests with in-memory repository doubles.
+- [ ] PDO repository tests with SQLite where repository changed.
+- [ ] HTTP or contract tests for public behavior when endpoints change.
+- [ ] `composer check` passes (or narrowest useful subset noted with reason).
+- [ ] PHPStan level 8 clean for touched `src/` code.
+
+## PR
+
+- [ ] PR body includes `Self-review: backend-api` (+ `openapi-contract`, `database` when applicable).
+- [ ] Reviewer rejects merge on placement or layer violations — no deferrals.

--- a/docs/review/database.md
+++ b/docs/review/database.md
@@ -1,19 +1,39 @@
 # Database Self-Review
 
-Use for migrations, schema docs, repositories, and soft-delete behavior.
+Use for migrations, schema docs, repositories, and soft-delete behavior. Policy source: **`docs/development/backend-standards.md`**.
 
-Source policies:
+Also read:
 
-- `docs/development/coding-standards.md`
-- NENE2: `docs/development/database-migrations.md`
+- NENE2: `docs/development/database-migrations.md`, `test-database-strategy.md`
 
-## Checklist
+## Schema and migrations
 
-- [ ] Migrations are reversible or rollback strategy is documented.
-- [ ] Schema docs or migration comments explain entity/field table relationships.
-- [ ] Soft delete columns (`is_deleted`, `deleted_at`) are used consistently when required.
-- [ ] Repository queries default to excluding soft-deleted rows unless admin API documented otherwise.
-- [ ] Indexes exist for common filter columns (entity_type_id, foreign keys).
+- [ ] New/changed tables have Phinx migration in `database/migrations/`.
+- [ ] Schema snapshot updated in `database/schema/{table}.sql`.
+- [ ] Migrations reversible or rollback strategy documented.
+- [ ] Migration class/file naming follows `YYYYMMDDHHMMSS_snake_description.php` convention.
 - [ ] No secrets or environment-specific values in migration files.
-- [ ] SQLite tests cover important repository contracts.
-- [ ] PR notes mention this checklist when database-facing.
+- [ ] Indexes on foreign keys and common filter columns (`entity_type_id`, etc.).
+
+## Soft delete and data model
+
+- [ ] Soft delete columns (`is_deleted`, `deleted_at`) consistent with product rules.
+- [ ] Repository queries exclude soft-deleted rows by default unless admin API documented otherwise.
+- [ ] Entity / field table relationships documented in migration comments or schema docs.
+
+## Repository layer
+
+- [ ] SQL confined to `src/{Domain}/Pdo{Entity}Repository.php` only.
+- [ ] Parameterized queries only — no concatenated user input in SQL.
+- [ ] Repositories use `DatabaseQueryExecutorInterface` — not raw PDO in use cases.
+- [ ] Row mapping to domain objects inside repository; use cases receive domain types.
+
+## Testing
+
+- [ ] `Pdo{Entity}RepositoryTest` with SQLite `:memory:` covers important contracts.
+- [ ] Schema created in test `setUp()` — tests do not depend on migration runner state.
+
+## PR
+
+- [ ] PR notes mention `Self-review: database` when database-facing.
+- [ ] `composer test` (database suite) passes for touched repositories.

--- a/docs/review/frontend.md
+++ b/docs/review/frontend.md
@@ -1,17 +1,73 @@
 # Frontend Self-Review
 
-Use for admin or consumer React/TypeScript changes.
+Use for admin or consumer React/TypeScript changes (Phase 4+). Policy source: **`docs/development/frontend-standards.md`**.
 
-Source policies:
+Also read:
 
 - `docs/development/coding-standards.md`
 - NENE2: `docs/development/frontend-integration.md`
 
-## Checklist
+## Architecture and dependencies
 
-- [ ] API calls go through typed fetch wrappers, not ad-hoc URLs scattered in components.
-- [ ] Admin UI does not bypass API validation assumptions (schema edits still POST to API).
-- [ ] No secrets or API keys embedded in frontend source.
-- [ ] Build output goes to `public_html/assets/` when integrated; `node_modules/` is not committed.
-- [ ] `npm run check --prefix frontend` passes when frontend exists.
-- [ ] PR notes mention this checklist when frontend-facing.
+- [ ] Layer imports follow `app → pages → features → entities → shared` only (no upward or cross-feature imports).
+- [ ] Entities and features imported only via their `index.ts` public surface.
+- [ ] ESLint boundary / `import/no-restricted-paths` passes — violations are merge blockers.
+- [ ] No sibling `entities/*` imports; orchestration lives in `features/`.
+
+## Placement (zero tolerance)
+
+- [ ] Entity folders match canonical tree (`ids`, `model`, `mapper`, `query-keys`, `queries`, `mutations`, `index.ts`; `enum` / `api-types` when needed).
+- [ ] No models, enums, DTOs, TanStack hooks, or MSW handlers outside mandated paths.
+- [ ] No `shared/api/generated/` or `api-types` imports from `features/`, `pages/`, or `*.tsx` (except colocated `*Props`).
+- [ ] No root `src/types/` or ad-hoc type dumps in `utils.ts` / `helpers.ts`.
+- [ ] Generated OpenAPI types only in `shared/api/generated/`; not hand-edited.
+
+## Data flow
+
+- [ ] Read path: API → client → mapper → entity query → feature hook → UI (models only in UI).
+- [ ] Write path: UI → mutation hook → client → API; explicit query invalidation on success.
+- [ ] No `useEffect` + `fetch` for server data; no API responses duplicated in `useState`.
+- [ ] Screens implement loading, empty, error, and success states explicitly.
+- [ ] Optimistic updates (if any) roll back on Problem Details failure and have a test.
+
+## Design patterns
+
+- [ ] Feature split: `hooks/` (logic) + `ui/` (presentational); no fetch/query in `shared/ui`.
+- [ ] Query keys only from `entities/{resource}/query-keys.ts` — no string literals in features.
+- [ ] Forms use React Hook Form + Zod (UX); server errors mapped from Problem Details.
+- [ ] Destructive actions use confirm dialog from `shared/ui`.
+- [ ] Named exports only; no class components or default exports.
+
+## TypeScript
+
+- [ ] No `any`, unjustified `@ts-ignore`, or `!` without invariant comment.
+- [ ] Branded IDs in `entities/{resource}/ids.ts`.
+- [ ] Env vars read only through `shared/config/env.ts`.
+
+## API and security
+
+- [ ] HTTP only in `shared/api/client.ts`; Problem Details parsed in `shared/api/errors.ts`.
+- [ ] Schema writes go to API; UI does not treat client validation as authoritative.
+- [ ] No secrets or tokens in source; auth storage matches API policy.
+- [ ] 401/403 fail closed; no silent unauthenticated writes.
+- [ ] No `dangerouslySetInnerHTML` without sanitization policy and Issue reference.
+
+## Testing
+
+- [ ] Entity: mapper tests (+ query-key tests if non-trivial); hook tests with MSW for primary query/mutation.
+- [ ] Feature: component tests — happy path + primary error path.
+- [ ] MSW handlers match OpenAPI; live in `tests/msw/` or mandated `__msw__/` path.
+- [ ] Factories build **models**, not raw DTOs, in `tests/factories/`.
+- [ ] Tests use role/label/text queries and `userEvent`; no shallow child mocks.
+- [ ] Bug fixes include regression test unless Issue waives.
+
+## Build, a11y, CI
+
+- [ ] `npm run check --prefix frontend` passes (type-check, lint, format, test).
+- [ ] Keyboard accessible primary flows; controls have accessible names.
+- [ ] `node_modules/` and generated assets not committed; lockfile updated if deps changed.
+
+## PR
+
+- [ ] PR body includes `Self-review: frontend` and verification commands run.
+- [ ] Reviewer rejects merge on placement, dependency, data-flow, or security violations — no deferrals.

--- a/docs/review/openapi-contract.md
+++ b/docs/review/openapi-contract.md
@@ -1,18 +1,37 @@
 # OpenAPI Contract Self-Review
 
-Use when changing `docs/openapi/openapi.yaml` or API response shapes.
+Use when changing `docs/openapi/openapi.yaml` or API response shapes. Policy source: **`docs/development/backend-standards.md`**.
 
-Source policies:
+Also read:
 
-- `docs/development/coding-standards.md`
-- NENE2: `docs/integrations/openapi.md`
+- NENE2: `docs/integrations/openapi.md`, `docs/development/endpoint-scaffold.md`
 
-## Checklist
+## Contract completeness
 
-- [ ] Every shipped JSON endpoint has an OpenAPI path with `operationId`.
-- [ ] Success and error responses reference shared Problem Details schemas where applicable.
-- [ ] Request bodies and query parameters match handler DTO validation rules.
-- [ ] Examples are realistic (`ok` examples for success paths).
-- [ ] `composer openapi` passes after runtime scaffold exists.
-- [ ] MCP tool entries in `docs/mcp/tools.json` align with OpenAPI when tools are added.
-- [ ] Public text in OpenAPI descriptions is English.
+- [ ] Every shipped JSON endpoint has an OpenAPI path with stable `operationId`.
+- [ ] Summary, description, request body, query params match handler format validation.
+- [ ] Success response has schema and realistic `ok` example.
+- [ ] Problem Details responses documented (`401`, `404`, `422`, `500`, … as applicable).
+- [ ] Public OpenAPI text is English.
+
+## Runtime alignment
+
+- [ ] Handler response shapes match OpenAPI success schema.
+- [ ] Request DTO rules align with documented required fields and formats.
+- [ ] `composer openapi` passes.
+- [ ] Contract tests in `tests/OpenApi/` updated when public examples change.
+
+## MCP (when applicable)
+
+- [ ] `docs/mcp/tools.json` entries reference valid OpenAPI `method`, `path`, `operationId`.
+- [ ] `composer mcp` passes when catalog changed.
+
+## Endpoint completion
+
+- [ ] Route + handler + use case + repository (if persistent) land together or same PR series.
+- [ ] Migration + schema snapshot included when new tables introduced.
+
+## PR
+
+- [ ] PR notes mention `Self-review: openapi-contract` when contract-facing.
+- [ ] No merge with OpenAPI drift from runtime behavior.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,6 +28,8 @@ Tracked by `docs/milestones/2026-05-governance-and-foundation.md`.
 
 Goal: smallest vertical slice proving the entity model.
 
+Policy (now): `docs/development/backend-standards.md` — NENE2 consumer, domain-grouped modules, zero-tolerance placement.
+
 - `entity_types`, `entities`, `text_fields` tables and migrations
 - CRUD API + OpenAPI
 - PHPUnit + SQLite tests
@@ -54,6 +56,8 @@ Goal: support real CMS/app patterns.
 ## Phase 4: Admin Frontend
 
 Goal: schema and record management UI.
+
+Policy (now): `docs/development/frontend-standards.md` — React + TypeScript strict, layered architecture, MSW tests.
 
 - React + TypeScript admin starter
 - entity type editor


### PR DESCRIPTION
## Summary

- **`docs/development/frontend-standards.md`** を新設 — React + TypeScript strict、TanStack Query、レイヤー/配置 zero tolerance、データフロー、デザインパターン、テスト、セキュリティ
- **`docs/development/backend-standards.md`** を新設 — NENE2 consumer 準拠、ドメイン単位モジュール（`EntityType/` 等）、Handler→UseCase→Repository、OpenAPI/Phinx/PHPUnit 規約
- **`docs/development/coding-standards.md`** を索引化し、review checklist・Cursor rules・AGENTS/CONTRIBUTING/roadmap/inheritance をリンク整合

## Test plan

- [x] `git diff --check` — whitespace clean
- [x] 正本間の相互リンク確認（backend ↔ frontend ↔ coding-standards ↔ review）
- [x] NENE2 参照パス（`../NENE2/src/Example/Note/`）が handoff 方針と矛盾しないこと

## Self-review

`Self-review: docs-policy, frontend, backend-api, openapi-contract, database`

Closes #6


Made with [Cursor](https://cursor.com)