### PR TITLE
feat(api): field_defs スキーマレジストリ (#9)

### DIFF
--- a/database/migrations/20260524000003_create_field_defs_table.php
+++ b/database/migrations/20260524000003_create_field_defs_table.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateFieldDefsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('field_defs')
+            ->addColumn('entity_type_id', 'integer', ['null' => false, 'signed' => false])
+            ->addColumn('field_key', 'string', ['null' => false])
+            ->addColumn('data_type', 'string', ['null' => false])
+            ->addColumn('is_deleted', 'boolean', ['default' => false, 'null' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true, 'default' => null])
+            ->addIndex(['entity_type_id'])
+            ->addForeignKey('entity_type_id', 'entity_types', 'id', ['delete' => 'RESTRICT', 'update' => 'NO_ACTION'])
+            ->create();
+    }
+}

--- a/database/schema/field_defs.sql
+++ b/database/schema/field_defs.sql
@@ -1,0 +1,11 @@
+CREATE TABLE field_defs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type_id INTEGER NOT NULL,
+    field_key TEXT NOT NULL,
+    data_type TEXT NOT NULL,
+    is_deleted BOOLEAN NOT NULL DEFAULT 0,
+    deleted_at DATETIME NULL,
+    FOREIGN KEY (entity_type_id) REFERENCES entity_types (id) ON DELETE RESTRICT ON UPDATE NO ACTION
+);
+CREATE INDEX field_defs_entity_type_id ON field_defs (entity_type_id);
+CREATE UNIQUE INDEX field_defs_entity_type_id_field_key_active ON field_defs (entity_type_id, field_key) WHERE is_deleted = 0;

--- a/docs/adr/0002-entity-model-and-field-defs.md
+++ b/docs/adr/0002-entity-model-and-field-defs.md
@@ -1,0 +1,93 @@
+# ADR 0002: Entity Model and Field Definitions Registry
+
+## Status
+
+accepted
+
+## Context
+
+Phase 1 (Issue #1) introduced `entity_types`, `entities`, and `text_fields` with CRUD APIs but **no schema registry**. Writes to `text_fields` accept any `field_key`, which recreates WordPress-style untyped meta risk.
+
+Phase 2 requires API-side field definitions so admin frontend and MCP clients cannot bypass validation.
+
+Constraints:
+
+- Typed value storage remains in type-specific tables (`text_fields` today; `int_fields`, etc. later).
+- Domain modules stay grouped under `src/{Domain}/` per `backend-standards.md`.
+- Cross-domain reads for validation must remain explicit and testable.
+
+## Decision
+
+### Entity relationship (Phase 1–2)
+
+```text
+entity_types (1) ──< entities (N)
+entity_types (1) ──< field_defs (N)
+entities (1) ──< text_fields (N)
+```
+
+| Table | Purpose |
+| --- | --- |
+| `entity_types` | Named kind of record (name, slug) |
+| `entities` | Record instance; FK `entity_type_id`; soft delete |
+| `field_defs` | Registered field key + `data_type` per entity type; soft delete |
+| `text_fields` | Text value for `(entity_id, field_key)`; soft delete |
+
+### `field_defs` columns
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | integer PK | |
+| `entity_type_id` | FK → `entity_types.id` | |
+| `field_key` | string | Unique per `entity_type_id` among active rows |
+| `data_type` | string | Phase 2: `text` only enforced; future: `int`, `enum`, … |
+| `is_deleted` | boolean | default false |
+| `deleted_at` | datetime nullable | |
+
+### API surface
+
+- CRUD at `/api/v1/field-defs` (same Handler → UseCase → Repository pattern as Phase 1).
+- `entity_type_id`, `field_key`, `data_type` on create/update; list supports filter by `entity_type_id`.
+
+### Write validation (text_fields)
+
+On **create** and **update** of `text_fields`:
+
+1. Resolve parent `entity` → `entity_type_id`.
+2. Load active `field_def` for `(entity_type_id, field_key)`.
+3. If absent → reject with domain exception → **422** Problem Details (`field-key-not-registered`).
+4. If present and `data_type !== 'text'` → **422** (`field-type-mismatch`).
+
+**Cross-domain rule (explicit exception to sibling import ban):** TextField use cases may depend on **repository interfaces** of `Entity` and `FieldDef` for read-only validation. No handler or repository SQL cross-imports.
+
+### Problem Details types (application)
+
+- `https://nene-records.dev/problems/field-key-not-registered`
+- `https://nene-records.dev/problems/field-type-mismatch`
+- `https://nene-records.dev/problems/field-def-not-found`
+- `https://nene-records.dev/problems/field-def-conflict` (duplicate key per entity type)
+
+## Consequences
+
+**Benefits**
+
+- Schema authority moves to API; frontend becomes an editor only.
+- Foundation for int/enum/bool tables in Phase 2 follow-up issues.
+- Clear ER for contributors and AI agents.
+
+**Costs**
+
+- TextField use cases gain dependencies on Entity + FieldDef repositories.
+- Additional CRUD surface and tests to maintain.
+
+**Follow-up**
+
+- Issue #9: implement `field_defs` CRUD + text_fields validation.
+- Later Phase 2: additional typed tables; `data_type` routes writes to correct table.
+
+## Related
+
+- Issue: `#9`
+- Supersedes: none
+- Superseded by: none
+- Documents: `docs/development/backend-standards.md`, `docs/explanation/product-vision.md`

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: NeNe Records API
   version: 0.1.0
   description: >
-    NeNe Records public API contract — entity_types, entities, and text_fields CRUD (MVP).
+    NeNe Records public API contract — entity_types, field_defs, entities, and text_fields CRUD (MVP + Phase 2 registry).
 servers:
   - url: http://localhost:8080
     description: Local development server
@@ -14,6 +14,8 @@ tags:
     description: Entity type schema definitions.
   - name: Entities
     description: Entity instances bound to an entity type.
+  - name: FieldDefs
+    description: Registered field definitions per entity type.
   - name: TextFields
     description: Typed text field values on entities.
 paths:
@@ -322,6 +324,156 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/field-defs:
+    get:
+      tags:
+        - FieldDefs
+      summary: List field definitions
+      description: Returns non-deleted field definitions, optionally filtered by entity type.
+      operationId: listFieldDefs
+      parameters:
+        - $ref: '#/components/parameters/LimitQuery'
+        - $ref: '#/components/parameters/OffsetQuery'
+        - $ref: '#/components/parameters/EntityTypeIdQuery'
+      responses:
+        '200':
+          description: Paginated field definition list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FieldDefListResponse'
+              examples:
+                ok:
+                  summary: Empty list
+                  value:
+                    items: []
+                    limit: 20
+                    offset: 0
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - FieldDefs
+      summary: Create field definition
+      description: Registers a field key and data type for an entity type.
+      operationId: createFieldDef
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateFieldDefRequest'
+            examples:
+              ok:
+                value:
+                  entity_type_id: 1
+                  field_key: title
+                  data_type: text
+      responses:
+        '201':
+          description: Field definition created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FieldDefResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_type_id: 1
+                    field_key: title
+                    data_type: text
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/FieldDefConflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/field-defs/{id}:
+    get:
+      tags:
+        - FieldDefs
+      summary: Get field definition by id
+      operationId: getFieldDefById
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      responses:
+        '200':
+          description: Field definition found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FieldDefResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_type_id: 1
+                    field_key: title
+                    data_type: text
+        '404':
+          $ref: '#/components/responses/FieldDefNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      tags:
+        - FieldDefs
+      summary: Update field definition
+      operationId: updateFieldDef
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateFieldDefRequest'
+            examples:
+              ok:
+                value:
+                  entity_type_id: 1
+                  field_key: headline
+                  data_type: text
+      responses:
+        '200':
+          description: Field definition updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FieldDefResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_type_id: 1
+                    field_key: headline
+                    data_type: text
+        '404':
+          $ref: '#/components/responses/FieldDefNotFound'
+        '409':
+          $ref: '#/components/responses/FieldDefConflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - FieldDefs
+      summary: Soft delete field definition
+      operationId: deleteFieldDef
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      responses:
+        '204':
+          description: Field definition soft-deleted.
+        '404':
+          $ref: '#/components/responses/FieldDefNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /api/v1/text-fields:
     get:
       tags:
@@ -384,7 +536,13 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '422':
-          $ref: '#/components/responses/ValidationFailed'
+          description: Validation failed, unregistered field key, or field type mismatch.
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ValidationProblemDetails'
+                  - $ref: '#/components/schemas/ProblemDetails'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /api/v1/text-fields/{id}:
@@ -448,7 +606,13 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '422':
-          $ref: '#/components/responses/ValidationFailed'
+          description: Validation failed, unregistered field key, or field type mismatch.
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ValidationProblemDetails'
+                  - $ref: '#/components/schemas/ProblemDetails'
         '500':
           $ref: '#/components/responses/InternalServerError'
     delete:
@@ -495,6 +659,15 @@ components:
         minimum: 0
         default: 0
       example: 0
+    EntityTypeIdQuery:
+      name: entity_type_id
+      in: query
+      required: false
+      schema:
+        type: integer
+        format: int64
+        minimum: 1
+      example: 1
   responses:
     NotFound:
       description: Resource not found.
@@ -524,6 +697,62 @@ components:
                 status: 409
                 detail: The slug is already in use.
                 instance: /api/v1/entity-types
+    FieldDefNotFound:
+      description: Field definition not found.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          examples:
+            fieldDefNotFound:
+              value:
+                type: https://nene-records.dev/problems/field-def-not-found
+                title: Field Definition Not Found
+                status: 404
+                detail: The requested field definition was not found.
+                instance: /api/v1/field-defs/99
+    FieldDefConflict:
+      description: Duplicate field key for entity type.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          examples:
+            fieldDefConflict:
+              value:
+                type: https://nene-records.dev/problems/field-def-conflict
+                title: Conflict
+                status: 409
+                detail: A field definition with this key already exists for the entity type.
+                instance: /api/v1/field-defs
+    FieldKeyNotRegistered:
+      description: Field key is not registered for the entity type.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          examples:
+            fieldKeyNotRegistered:
+              value:
+                type: https://nene-records.dev/problems/field-key-not-registered
+                title: Field Key Not Registered
+                status: 422
+                detail: The field key is not registered for this entity type.
+                instance: /api/v1/text-fields
+    FieldTypeMismatch:
+      description: Field key is registered with a non-text data type.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          examples:
+            fieldTypeMismatch:
+              value:
+                type: https://nene-records.dev/problems/field-type-mismatch
+                title: Field Type Mismatch
+                status: 422
+                detail: The field key is registered with a different data type.
+                instance: /api/v1/text-fields
     ValidationFailed:
       description: Validation failed.
       content:
@@ -709,6 +938,62 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EntityResponse'
+        limit:
+          type: integer
+        offset:
+          type: integer
+    FieldDefResponse:
+      type: object
+      required:
+        - id
+        - entity_type_id
+        - field_key
+        - data_type
+      properties:
+        id:
+          type: integer
+          format: int64
+        entity_type_id:
+          type: integer
+          format: int64
+        field_key:
+          type: string
+        data_type:
+          type: string
+          enum:
+            - text
+    CreateFieldDefRequest:
+      type: object
+      required:
+        - entity_type_id
+        - field_key
+        - data_type
+      properties:
+        entity_type_id:
+          type: integer
+          format: int64
+          minimum: 1
+        field_key:
+          type: string
+          minLength: 1
+        data_type:
+          type: string
+          enum:
+            - text
+      additionalProperties: false
+    UpdateFieldDefRequest:
+      $ref: '#/components/schemas/CreateFieldDefRequest'
+    FieldDefListResponse:
+      type: object
+      required:
+        - items
+        - limit
+        - offset
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/FieldDefResponse'
         limit:
           type: integer
         offset:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -12,33 +12,34 @@ New contributors and AI agents: read [`handoff-2026-05-24-workspace-switch.md`](
 
 | Issue | Branch | Summary |
 | --- | --- | --- |
-| #4 | `docs/4-workspace-handoff` | Workspace switch handoff and product vision |
+| #9 | `feat/9-field-defs-registry` | Phase 2: `field_defs` schema registry API |
 
 ## Up Next
 
 | Issue | Summary |
 | --- | --- |
-| #1 | MVP: `entity_types` + `entities` + `text_fields` CRUD vertical slice |
+| — | Phase 2 follow-up: int / enum / bool / datetime field types |
 
 ## Recently Completed
 
 | Issue | Summary |
 | --- | --- |
+| #1 | MVP entity CRUD vertical slice (merged PR #8) |
+| #6 | Frontend/backend coding standards (merged PR #7) |
+| #4 | Workspace handoff + product vision (merged PR #5) |
 | #2 | NENE2 governance inheritance (merged PR #3) |
 | — | Repository bootstrap (`README`, MIT license) |
 
 ## Handoff Notes
 
-- Phase 0 governance complete. Phase 1 runtime scaffold starts in Issue #1.
-- Framework reference: `hideyukimori/nene2` via Composer; see `docs/inheritance-from-nene2.md`.
-- NENE2 sibling in workspace is optional; see handoff §1.
+- **Phase 1 complete.** `composer check`, `composer openapi` available.
+- Phase 2 starts with ADR 0002 + `field_defs` registry (Issue #9).
+- Framework reference: `hideyukimori/nene2` via Composer path `../NENE2`; see `docs/inheritance-from-nene2.md`.
 
 ## Verification Commands
-
-Not yet available — add after Phase 1 scaffold:
 
 ```bash
 composer check
 composer openapi
-composer mcp
+composer migrations:migrate   # requires .env with SQLite
 ```

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -13,6 +13,11 @@ use NeNeRecords\Entity\EntityServiceProvider;
 use NeNeRecords\EntityType\EntityTypeNotFoundExceptionHandler;
 use NeNeRecords\EntityType\EntityTypeServiceProvider;
 use NeNeRecords\EntityType\EntityTypeSlugConflictExceptionHandler;
+use NeNeRecords\FieldDef\FieldDefConflictExceptionHandler;
+use NeNeRecords\FieldDef\FieldDefNotFoundExceptionHandler;
+use NeNeRecords\FieldDef\FieldDefServiceProvider;
+use NeNeRecords\TextField\FieldKeyNotRegisteredExceptionHandler;
+use NeNeRecords\TextField\FieldTypeMismatchExceptionHandler;
 use NeNeRecords\TextField\TextFieldNotFoundExceptionHandler;
 use NeNeRecords\TextField\TextFieldServiceProvider;
 use Psr\Container\ContainerInterface;
@@ -27,6 +32,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
     {
         $builder
             ->addProvider(new EntityTypeServiceProvider())
+            ->addProvider(new FieldDefServiceProvider())
             ->addProvider(new EntityServiceProvider())
             ->addProvider(new TextFieldServiceProvider());
 
@@ -35,14 +41,20 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                 self::ROUTE_REGISTRARS,
                 static function (ContainerInterface $container): array {
                     $entityType = $container->get('nene-records.route_registrar.entity_type');
+                    $fieldDef = $container->get('nene-records.route_registrar.field_def');
                     $entity = $container->get('nene-records.route_registrar.entity');
                     $textField = $container->get('nene-records.route_registrar.text_field');
 
-                    if (!is_callable($entityType) || !is_callable($entity) || !is_callable($textField)) {
+                    if (
+                        !is_callable($entityType)
+                        || !is_callable($fieldDef)
+                        || !is_callable($entity)
+                        || !is_callable($textField)
+                    ) {
                         throw new LogicException('Route registrar service is invalid.');
                     }
 
-                    return [$entityType, $entity, $textField];
+                    return [$entityType, $fieldDef, $entity, $textField];
                 },
             )
             ->set(
@@ -50,14 +62,22 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                 static function (ContainerInterface $container): array {
                     $entityTypeNotFound = $container->get(EntityTypeNotFoundExceptionHandler::class);
                     $entityTypeSlugConflict = $container->get(EntityTypeSlugConflictExceptionHandler::class);
+                    $fieldDefNotFound = $container->get(FieldDefNotFoundExceptionHandler::class);
+                    $fieldDefConflict = $container->get(FieldDefConflictExceptionHandler::class);
                     $entityNotFound = $container->get(EntityNotFoundExceptionHandler::class);
                     $textFieldNotFound = $container->get(TextFieldNotFoundExceptionHandler::class);
+                    $fieldKeyNotRegistered = $container->get(FieldKeyNotRegisteredExceptionHandler::class);
+                    $fieldTypeMismatch = $container->get(FieldTypeMismatchExceptionHandler::class);
 
                     foreach ([
                         $entityTypeNotFound,
                         $entityTypeSlugConflict,
+                        $fieldDefNotFound,
+                        $fieldDefConflict,
                         $entityNotFound,
                         $textFieldNotFound,
+                        $fieldKeyNotRegistered,
+                        $fieldTypeMismatch,
                     ] as $handler) {
                         if (!$handler instanceof DomainExceptionHandlerInterface) {
                             throw new LogicException('Exception handler service is invalid.');
@@ -67,8 +87,12 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     return [
                         $entityTypeNotFound,
                         $entityTypeSlugConflict,
+                        $fieldDefNotFound,
+                        $fieldDefConflict,
                         $entityNotFound,
                         $textFieldNotFound,
+                        $fieldKeyNotRegistered,
+                        $fieldTypeMismatch,
                     ];
                 },
             );

--- a/src/FieldDef/CreateFieldDefHandler.php
+++ b/src/FieldDef/CreateFieldDefHandler.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateFieldDefHandler
+{
+    /** @var list<string> */
+    private const ALLOWED_DATA_TYPES = ['text'];
+
+    public function __construct(
+        private CreateFieldDefUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+
+        $entityTypeId = (int) ($body['entity_type_id'] ?? 0);
+        $fieldKey = trim((string) ($body['field_key'] ?? ''));
+        $dataType = trim((string) ($body['data_type'] ?? ''));
+
+        if ($entityTypeId <= 0) {
+            $errors[] = new ValidationError('entity_type_id', 'Entity type id must be a positive integer.', 'invalid');
+        }
+
+        if ($fieldKey === '') {
+            $errors[] = new ValidationError('field_key', 'Field key is required.', 'required');
+        }
+
+        if ($dataType === '') {
+            $errors[] = new ValidationError('data_type', 'Data type is required.', 'required');
+        } elseif (!in_array($dataType, self::ALLOWED_DATA_TYPES, true)) {
+            $errors[] = new ValidationError('data_type', 'Data type must be one of: text.', 'invalid');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new CreateFieldDefInput(
+            entityTypeId: $entityTypeId,
+            fieldKey: $fieldKey,
+            dataType: $dataType,
+        ));
+
+        return $this->response->create(
+            [
+                'id' => $output->id,
+                'entity_type_id' => $output->entityTypeId,
+                'field_key' => $output->fieldKey,
+                'data_type' => $output->dataType,
+            ],
+            201,
+            ['Location' => '/api/v1/field-defs/' . $output->id],
+        );
+    }
+}

--- a/src/FieldDef/CreateFieldDefInput.php
+++ b/src/FieldDef/CreateFieldDefInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+final readonly class CreateFieldDefInput
+{
+    public function __construct(
+        public int $entityTypeId,
+        public string $fieldKey,
+        public string $dataType,
+    ) {
+    }
+}

--- a/src/FieldDef/CreateFieldDefOutput.php
+++ b/src/FieldDef/CreateFieldDefOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+final readonly class CreateFieldDefOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityTypeId,
+        public string $fieldKey,
+        public string $dataType,
+    ) {
+    }
+}

--- a/src/FieldDef/CreateFieldDefUseCase.php
+++ b/src/FieldDef/CreateFieldDefUseCase.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use NeNeRecords\EntityType\EntityTypeNotFoundException;
+use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
+
+final readonly class CreateFieldDefUseCase implements CreateFieldDefUseCaseInterface
+{
+    public function __construct(
+        private FieldDefRepositoryInterface $fieldDefs,
+        private EntityTypeRepositoryInterface $entityTypes,
+    ) {
+    }
+
+    public function execute(CreateFieldDefInput $input): CreateFieldDefOutput
+    {
+        if ($this->entityTypes->findById($input->entityTypeId) === null) {
+            throw new EntityTypeNotFoundException($input->entityTypeId);
+        }
+
+        $existing = $this->fieldDefs->findByEntityTypeIdAndFieldKey($input->entityTypeId, $input->fieldKey);
+
+        if ($existing !== null) {
+            throw new FieldDefConflictException($input->entityTypeId, $input->fieldKey);
+        }
+
+        $id = $this->fieldDefs->save(new FieldDef(
+            entityTypeId: $input->entityTypeId,
+            fieldKey: $input->fieldKey,
+            dataType: $input->dataType,
+        ));
+
+        return new CreateFieldDefOutput(
+            id: $id,
+            entityTypeId: $input->entityTypeId,
+            fieldKey: $input->fieldKey,
+            dataType: $input->dataType,
+        );
+    }
+}

--- a/src/FieldDef/CreateFieldDefUseCaseInterface.php
+++ b/src/FieldDef/CreateFieldDefUseCaseInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use NeNeRecords\EntityType\EntityTypeNotFoundException;
+
+interface CreateFieldDefUseCaseInterface
+{
+    /**
+     * @throws EntityTypeNotFoundException when the entity type does not exist.
+     * @throws FieldDefConflictException when the field key is taken for the entity type.
+     */
+    public function execute(CreateFieldDefInput $input): CreateFieldDefOutput;
+}

--- a/src/FieldDef/DeleteFieldDefHandler.php
+++ b/src/FieldDef/DeleteFieldDefHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteFieldDefHandler
+{
+    public function __construct(
+        private DeleteFieldDefUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new FieldDefNotFoundException($id);
+        }
+
+        $this->useCase->execute(new DeleteFieldDefInput($id));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/FieldDef/DeleteFieldDefInput.php
+++ b/src/FieldDef/DeleteFieldDefInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+final readonly class DeleteFieldDefInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/FieldDef/DeleteFieldDefUseCase.php
+++ b/src/FieldDef/DeleteFieldDefUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+final readonly class DeleteFieldDefUseCase implements DeleteFieldDefUseCaseInterface
+{
+    public function __construct(
+        private FieldDefRepositoryInterface $fieldDefs,
+    ) {
+    }
+
+    public function execute(DeleteFieldDefInput $input): void
+    {
+        $fieldDef = $this->fieldDefs->findById($input->id);
+
+        if ($fieldDef === null) {
+            throw new FieldDefNotFoundException($input->id);
+        }
+
+        $this->fieldDefs->softDelete($input->id);
+    }
+}

--- a/src/FieldDef/DeleteFieldDefUseCaseInterface.php
+++ b/src/FieldDef/DeleteFieldDefUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+interface DeleteFieldDefUseCaseInterface
+{
+    /**
+     * @throws FieldDefNotFoundException when the field definition does not exist.
+     */
+    public function execute(DeleteFieldDefInput $input): void;
+}

--- a/src/FieldDef/FieldDef.php
+++ b/src/FieldDef/FieldDef.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use DateTimeImmutable;
+
+final readonly class FieldDef
+{
+    public function __construct(
+        public int $entityTypeId,
+        public string $fieldKey,
+        public string $dataType,
+        public ?int $id = null,
+        public bool $isDeleted = false,
+        public ?DateTimeImmutable $deletedAt = null,
+    ) {
+    }
+}

--- a/src/FieldDef/FieldDefConflictException.php
+++ b/src/FieldDef/FieldDefConflictException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use RuntimeException;
+
+final class FieldDefConflictException extends RuntimeException
+{
+    public function __construct(
+        public int $entityTypeId,
+        public string $fieldKey,
+    ) {
+        parent::__construct("A field definition with key {$fieldKey} already exists for entity type {$entityTypeId}.");
+    }
+}

--- a/src/FieldDef/FieldDefConflictExceptionHandler.php
+++ b/src/FieldDef/FieldDefConflictExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class FieldDefConflictExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof FieldDefConflictException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'field-def-conflict',
+            'Conflict',
+            409,
+            'A field definition with this key already exists for the entity type.',
+        );
+    }
+}

--- a/src/FieldDef/FieldDefNotFoundException.php
+++ b/src/FieldDef/FieldDefNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use RuntimeException;
+
+final class FieldDefNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("Field definition with id {$id} was not found.");
+    }
+}

--- a/src/FieldDef/FieldDefNotFoundExceptionHandler.php
+++ b/src/FieldDef/FieldDefNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class FieldDefNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof FieldDefNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'field-def-not-found',
+            'Field Definition Not Found',
+            404,
+            'The requested field definition was not found.',
+        );
+    }
+}

--- a/src/FieldDef/FieldDefRepositoryInterface.php
+++ b/src/FieldDef/FieldDefRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+interface FieldDefRepositoryInterface
+{
+    public function findById(int $id): ?FieldDef;
+
+    public function findByEntityTypeIdAndFieldKey(int $entityTypeId, string $fieldKey): ?FieldDef;
+
+    /** @return list<FieldDef> */
+    public function findAll(?int $entityTypeId, int $limit, int $offset): array;
+
+    public function save(FieldDef $fieldDef): int;
+
+    public function update(FieldDef $fieldDef): void;
+
+    public function softDelete(int $id): void;
+}

--- a/src/FieldDef/FieldDefRouteRegistrar.php
+++ b/src/FieldDef/FieldDefRouteRegistrar.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class FieldDefRouteRegistrar
+{
+    public function __construct(
+        private GetFieldDefByIdHandler $getHandler,
+        private CreateFieldDefHandler $createHandler,
+        private UpdateFieldDefHandler $updateHandler,
+        private DeleteFieldDefHandler $deleteHandler,
+        private ListFieldDefsHandler $listHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $getHandler = $this->getHandler;
+        $createHandler = $this->createHandler;
+        $updateHandler = $this->updateHandler;
+        $deleteHandler = $this->deleteHandler;
+        $listHandler = $this->listHandler;
+
+        $router->get('/api/v1/field-defs', static fn (ServerRequestInterface $request) => $listHandler->handle($request));
+        $router->get('/api/v1/field-defs/{id}', static fn (ServerRequestInterface $request) => $getHandler->handle($request));
+        $router->post('/api/v1/field-defs', static fn (ServerRequestInterface $request) => $createHandler->handle($request));
+        $router->put('/api/v1/field-defs/{id}', static fn (ServerRequestInterface $request) => $updateHandler->handle($request));
+        $router->delete('/api/v1/field-defs/{id}', static fn (ServerRequestInterface $request) => $deleteHandler->handle($request));
+    }
+}

--- a/src/FieldDef/FieldDefServiceProvider.php
+++ b/src/FieldDef/FieldDefServiceProvider.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class FieldDefServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                FieldDefRepositoryInterface::class,
+                static function (ContainerInterface $c): FieldDefRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoFieldDefRepository($query);
+                },
+            )
+            ->set(
+                GetFieldDefByIdUseCaseInterface::class,
+                static function (ContainerInterface $c): GetFieldDefByIdUseCaseInterface {
+                    $repository = $c->get(FieldDefRepositoryInterface::class);
+
+                    if (!$repository instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field definition repository service is invalid.');
+                    }
+
+                    return new GetFieldDefByIdUseCase($repository);
+                },
+            )
+            ->set(
+                GetFieldDefByIdHandler::class,
+                static function (ContainerInterface $c): GetFieldDefByIdHandler {
+                    $useCase = $c->get(GetFieldDefByIdUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof GetFieldDefByIdUseCaseInterface) {
+                        throw new LogicException('GetFieldDefById use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new GetFieldDefByIdHandler($useCase, $response);
+                },
+            )
+            ->set(
+                CreateFieldDefUseCaseInterface::class,
+                static function (ContainerInterface $c): CreateFieldDefUseCaseInterface {
+                    $fieldDefs = $c->get(FieldDefRepositoryInterface::class);
+                    $entityTypes = $c->get(EntityTypeRepositoryInterface::class);
+
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field definition repository service is invalid.');
+                    }
+
+                    if (!$entityTypes instanceof EntityTypeRepositoryInterface) {
+                        throw new LogicException('Entity type repository service is invalid.');
+                    }
+
+                    return new CreateFieldDefUseCase($fieldDefs, $entityTypes);
+                },
+            )
+            ->set(
+                CreateFieldDefHandler::class,
+                static function (ContainerInterface $c): CreateFieldDefHandler {
+                    $useCase = $c->get(CreateFieldDefUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof CreateFieldDefUseCaseInterface) {
+                        throw new LogicException('CreateFieldDef use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new CreateFieldDefHandler($useCase, $response);
+                },
+            )
+            ->set(
+                DeleteFieldDefUseCaseInterface::class,
+                static function (ContainerInterface $c): DeleteFieldDefUseCaseInterface {
+                    $repository = $c->get(FieldDefRepositoryInterface::class);
+
+                    if (!$repository instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field definition repository service is invalid.');
+                    }
+
+                    return new DeleteFieldDefUseCase($repository);
+                },
+            )
+            ->set(
+                DeleteFieldDefHandler::class,
+                static function (ContainerInterface $c): DeleteFieldDefHandler {
+                    $useCase = $c->get(DeleteFieldDefUseCaseInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof DeleteFieldDefUseCaseInterface) {
+                        throw new LogicException('DeleteFieldDef use case service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    return new DeleteFieldDefHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
+                ListFieldDefsUseCaseInterface::class,
+                static function (ContainerInterface $c): ListFieldDefsUseCaseInterface {
+                    $repository = $c->get(FieldDefRepositoryInterface::class);
+
+                    if (!$repository instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field definition repository service is invalid.');
+                    }
+
+                    return new ListFieldDefsUseCase($repository);
+                },
+            )
+            ->set(
+                ListFieldDefsHandler::class,
+                static function (ContainerInterface $c): ListFieldDefsHandler {
+                    $useCase = $c->get(ListFieldDefsUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListFieldDefsUseCaseInterface) {
+                        throw new LogicException('ListFieldDefs use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListFieldDefsHandler($useCase, $response);
+                },
+            )
+            ->set(
+                UpdateFieldDefUseCaseInterface::class,
+                static function (ContainerInterface $c): UpdateFieldDefUseCaseInterface {
+                    $fieldDefs = $c->get(FieldDefRepositoryInterface::class);
+                    $entityTypes = $c->get(EntityTypeRepositoryInterface::class);
+
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field definition repository service is invalid.');
+                    }
+
+                    if (!$entityTypes instanceof EntityTypeRepositoryInterface) {
+                        throw new LogicException('Entity type repository service is invalid.');
+                    }
+
+                    return new UpdateFieldDefUseCase($fieldDefs, $entityTypes);
+                },
+            )
+            ->set(
+                UpdateFieldDefHandler::class,
+                static function (ContainerInterface $c): UpdateFieldDefHandler {
+                    $useCase = $c->get(UpdateFieldDefUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof UpdateFieldDefUseCaseInterface) {
+                        throw new LogicException('UpdateFieldDef use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new UpdateFieldDefHandler($useCase, $response);
+                },
+            )
+            ->set(
+                FieldDefNotFoundExceptionHandler::class,
+                static function (ContainerInterface $c): FieldDefNotFoundExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new FieldDefNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                FieldDefConflictExceptionHandler::class,
+                static function (ContainerInterface $c): FieldDefConflictExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new FieldDefConflictExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.field_def',
+                static function (ContainerInterface $c): FieldDefRouteRegistrar {
+                    $get = $c->get(GetFieldDefByIdHandler::class);
+                    $create = $c->get(CreateFieldDefHandler::class);
+                    $update = $c->get(UpdateFieldDefHandler::class);
+                    $delete = $c->get(DeleteFieldDefHandler::class);
+                    $list = $c->get(ListFieldDefsHandler::class);
+
+                    if (!$get instanceof GetFieldDefByIdHandler) {
+                        throw new LogicException('GetFieldDefById handler service is invalid.');
+                    }
+
+                    if (!$create instanceof CreateFieldDefHandler) {
+                        throw new LogicException('CreateFieldDef handler service is invalid.');
+                    }
+
+                    if (!$update instanceof UpdateFieldDefHandler) {
+                        throw new LogicException('UpdateFieldDef handler service is invalid.');
+                    }
+
+                    if (!$delete instanceof DeleteFieldDefHandler) {
+                        throw new LogicException('DeleteFieldDef handler service is invalid.');
+                    }
+
+                    if (!$list instanceof ListFieldDefsHandler) {
+                        throw new LogicException('ListFieldDefs handler service is invalid.');
+                    }
+
+                    return new FieldDefRouteRegistrar($get, $create, $update, $delete, $list);
+                },
+            );
+    }
+}

--- a/src/FieldDef/GetFieldDefByIdHandler.php
+++ b/src/FieldDef/GetFieldDefByIdHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetFieldDefByIdHandler
+{
+    public function __construct(
+        private GetFieldDefByIdUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new FieldDefNotFoundException($id);
+        }
+
+        $output = $this->useCase->execute(new GetFieldDefByIdInput($id));
+
+        return $this->response->create([
+            'id' => $output->id,
+            'entity_type_id' => $output->entityTypeId,
+            'field_key' => $output->fieldKey,
+            'data_type' => $output->dataType,
+        ]);
+    }
+}

--- a/src/FieldDef/GetFieldDefByIdInput.php
+++ b/src/FieldDef/GetFieldDefByIdInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+final readonly class GetFieldDefByIdInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/FieldDef/GetFieldDefByIdOutput.php
+++ b/src/FieldDef/GetFieldDefByIdOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+final readonly class GetFieldDefByIdOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityTypeId,
+        public string $fieldKey,
+        public string $dataType,
+    ) {
+    }
+}

--- a/src/FieldDef/GetFieldDefByIdUseCase.php
+++ b/src/FieldDef/GetFieldDefByIdUseCase.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+final readonly class GetFieldDefByIdUseCase implements GetFieldDefByIdUseCaseInterface
+{
+    public function __construct(
+        private FieldDefRepositoryInterface $fieldDefs,
+    ) {
+    }
+
+    public function execute(GetFieldDefByIdInput $input): GetFieldDefByIdOutput
+    {
+        $fieldDef = $this->fieldDefs->findById($input->id);
+
+        if ($fieldDef === null) {
+            throw new FieldDefNotFoundException($input->id);
+        }
+
+        return new GetFieldDefByIdOutput(
+            id: $fieldDef->id ?? $input->id,
+            entityTypeId: $fieldDef->entityTypeId,
+            fieldKey: $fieldDef->fieldKey,
+            dataType: $fieldDef->dataType,
+        );
+    }
+}

--- a/src/FieldDef/GetFieldDefByIdUseCaseInterface.php
+++ b/src/FieldDef/GetFieldDefByIdUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+interface GetFieldDefByIdUseCaseInterface
+{
+    /**
+     * @throws FieldDefNotFoundException when the field definition does not exist.
+     */
+    public function execute(GetFieldDefByIdInput $input): GetFieldDefByIdOutput;
+}

--- a/src/FieldDef/ListFieldDefItem.php
+++ b/src/FieldDef/ListFieldDefItem.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+final readonly class ListFieldDefItem
+{
+    public function __construct(
+        public int $id,
+        public int $entityTypeId,
+        public string $fieldKey,
+        public string $dataType,
+    ) {
+    }
+}

--- a/src/FieldDef/ListFieldDefsHandler.php
+++ b/src/FieldDef/ListFieldDefsHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListFieldDefsHandler
+{
+    public function __construct(
+        private ListFieldDefsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $pagination = PaginationQueryParser::parse($request);
+        $query = $request->getQueryParams();
+
+        $entityTypeId = null;
+        if (isset($query['entity_type_id'])) {
+            $raw = (int) $query['entity_type_id'];
+            if ($raw > 0) {
+                $entityTypeId = $raw;
+            }
+        }
+
+        $output = $this->useCase->execute(new ListFieldDefsInput(
+            entityTypeId: $entityTypeId,
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+        ));
+
+        return $this->response->create(
+            (new PaginationResponse(
+                items: array_map(
+                    static fn (ListFieldDefItem $item) => [
+                        'id' => $item->id,
+                        'entity_type_id' => $item->entityTypeId,
+                        'field_key' => $item->fieldKey,
+                        'data_type' => $item->dataType,
+                    ],
+                    $output->items,
+                ),
+                limit: $output->limit,
+                offset: $output->offset,
+            ))->toArray(),
+        );
+    }
+}

--- a/src/FieldDef/ListFieldDefsInput.php
+++ b/src/FieldDef/ListFieldDefsInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+final readonly class ListFieldDefsInput
+{
+    public function __construct(
+        public ?int $entityTypeId,
+        public int $limit = 20,
+        public int $offset = 0,
+    ) {
+    }
+}

--- a/src/FieldDef/ListFieldDefsOutput.php
+++ b/src/FieldDef/ListFieldDefsOutput.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+final readonly class ListFieldDefsOutput
+{
+    /**
+     * @param list<ListFieldDefItem> $items
+     */
+    public function __construct(
+        public array $items,
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/FieldDef/ListFieldDefsUseCase.php
+++ b/src/FieldDef/ListFieldDefsUseCase.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+final readonly class ListFieldDefsUseCase implements ListFieldDefsUseCaseInterface
+{
+    public function __construct(
+        private FieldDefRepositoryInterface $fieldDefs,
+    ) {
+    }
+
+    public function execute(ListFieldDefsInput $input): ListFieldDefsOutput
+    {
+        $rows = $this->fieldDefs->findAll($input->entityTypeId, $input->limit, $input->offset);
+
+        $items = array_map(
+            static fn (FieldDef $fieldDef) => new ListFieldDefItem(
+                id: (int) $fieldDef->id,
+                entityTypeId: $fieldDef->entityTypeId,
+                fieldKey: $fieldDef->fieldKey,
+                dataType: $fieldDef->dataType,
+            ),
+            $rows,
+        );
+
+        return new ListFieldDefsOutput(
+            items: $items,
+            limit: $input->limit,
+            offset: $input->offset,
+        );
+    }
+}

--- a/src/FieldDef/ListFieldDefsUseCaseInterface.php
+++ b/src/FieldDef/ListFieldDefsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+interface ListFieldDefsUseCaseInterface
+{
+    public function execute(ListFieldDefsInput $input): ListFieldDefsOutput;
+}

--- a/src/FieldDef/PdoFieldDefRepository.php
+++ b/src/FieldDef/PdoFieldDefRepository.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use DateTimeImmutable;
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoFieldDefRepository implements FieldDefRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?FieldDef
+    {
+        $row = $this->query->fetchOne(
+            <<<'SQL'
+                SELECT id, entity_type_id, field_key, data_type, is_deleted, deleted_at
+                FROM field_defs
+                WHERE id = ? AND is_deleted = 0
+                SQL,
+            [$id],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return $this->mapRow($row);
+    }
+
+    public function findByEntityTypeIdAndFieldKey(int $entityTypeId, string $fieldKey): ?FieldDef
+    {
+        $row = $this->query->fetchOne(
+            <<<'SQL'
+                SELECT id, entity_type_id, field_key, data_type, is_deleted, deleted_at
+                FROM field_defs
+                WHERE entity_type_id = ? AND field_key = ? AND is_deleted = 0
+                SQL,
+            [$entityTypeId, $fieldKey],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return $this->mapRow($row);
+    }
+
+    /** @return list<FieldDef> */
+    public function findAll(?int $entityTypeId, int $limit, int $offset): array
+    {
+        if ($entityTypeId !== null) {
+            $rows = $this->query->fetchAll(
+                <<<'SQL'
+                    SELECT id, entity_type_id, field_key, data_type, is_deleted, deleted_at
+                    FROM field_defs
+                    WHERE is_deleted = 0 AND entity_type_id = ?
+                    ORDER BY id ASC
+                    LIMIT ? OFFSET ?
+                    SQL,
+                [$entityTypeId, $limit, $offset],
+            );
+        } else {
+            $rows = $this->query->fetchAll(
+                <<<'SQL'
+                    SELECT id, entity_type_id, field_key, data_type, is_deleted, deleted_at
+                    FROM field_defs
+                    WHERE is_deleted = 0
+                    ORDER BY id ASC
+                    LIMIT ? OFFSET ?
+                    SQL,
+                [$limit, $offset],
+            );
+        }
+
+        return array_map(fn (array $row) => $this->mapRow($row), $rows);
+    }
+
+    public function save(FieldDef $fieldDef): int
+    {
+        $this->query->execute(
+            'INSERT INTO field_defs (entity_type_id, field_key, data_type) VALUES (?, ?, ?)',
+            [$fieldDef->entityTypeId, $fieldDef->fieldKey, $fieldDef->dataType],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function update(FieldDef $fieldDef): void
+    {
+        $id = $fieldDef->id;
+
+        if ($id === null) {
+            throw new LogicException('FieldDef id must be set before update.');
+        }
+
+        $this->query->execute(
+            <<<'SQL'
+                UPDATE field_defs
+                SET entity_type_id = ?, field_key = ?, data_type = ?
+                WHERE id = ? AND is_deleted = 0
+                SQL,
+            [$fieldDef->entityTypeId, $fieldDef->fieldKey, $fieldDef->dataType, $id],
+        );
+    }
+
+    public function softDelete(int $id): void
+    {
+        $this->query->execute(
+            <<<'SQL'
+                UPDATE field_defs
+                SET is_deleted = 1, deleted_at = CURRENT_TIMESTAMP
+                WHERE id = ? AND is_deleted = 0
+                SQL,
+            [$id],
+        );
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): FieldDef
+    {
+        $deletedRaw = $row['deleted_at'] ?? null;
+        $deletedAt = ($deletedRaw !== null && $deletedRaw !== '') ? new DateTimeImmutable((string) $deletedRaw) : null;
+
+        return new FieldDef(
+            entityTypeId: (int) $row['entity_type_id'],
+            fieldKey: (string) $row['field_key'],
+            dataType: (string) $row['data_type'],
+            id: (int) $row['id'],
+            isDeleted: (bool) (int) $row['is_deleted'],
+            deletedAt: $deletedAt,
+        );
+    }
+}

--- a/src/FieldDef/UpdateFieldDefHandler.php
+++ b/src/FieldDef/UpdateFieldDefHandler.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateFieldDefHandler
+{
+    /** @var list<string> */
+    private const ALLOWED_DATA_TYPES = ['text'];
+
+    public function __construct(
+        private UpdateFieldDefUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new FieldDefNotFoundException($id);
+        }
+
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+
+        $entityTypeId = (int) ($body['entity_type_id'] ?? 0);
+        $fieldKey = trim((string) ($body['field_key'] ?? ''));
+        $dataType = trim((string) ($body['data_type'] ?? ''));
+
+        if ($entityTypeId <= 0) {
+            $errors[] = new ValidationError('entity_type_id', 'Entity type id must be a positive integer.', 'invalid');
+        }
+
+        if ($fieldKey === '') {
+            $errors[] = new ValidationError('field_key', 'Field key is required.', 'required');
+        }
+
+        if ($dataType === '') {
+            $errors[] = new ValidationError('data_type', 'Data type is required.', 'required');
+        } elseif (!in_array($dataType, self::ALLOWED_DATA_TYPES, true)) {
+            $errors[] = new ValidationError('data_type', 'Data type must be one of: text.', 'invalid');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new UpdateFieldDefInput(
+            id: $id,
+            entityTypeId: $entityTypeId,
+            fieldKey: $fieldKey,
+            dataType: $dataType,
+        ));
+
+        return $this->response->create([
+            'id' => $output->id,
+            'entity_type_id' => $output->entityTypeId,
+            'field_key' => $output->fieldKey,
+            'data_type' => $output->dataType,
+        ]);
+    }
+}

--- a/src/FieldDef/UpdateFieldDefInput.php
+++ b/src/FieldDef/UpdateFieldDefInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+final readonly class UpdateFieldDefInput
+{
+    public function __construct(
+        public int $id,
+        public int $entityTypeId,
+        public string $fieldKey,
+        public string $dataType,
+    ) {
+    }
+}

--- a/src/FieldDef/UpdateFieldDefOutput.php
+++ b/src/FieldDef/UpdateFieldDefOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+final readonly class UpdateFieldDefOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityTypeId,
+        public string $fieldKey,
+        public string $dataType,
+    ) {
+    }
+}

--- a/src/FieldDef/UpdateFieldDefUseCase.php
+++ b/src/FieldDef/UpdateFieldDefUseCase.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use NeNeRecords\EntityType\EntityTypeNotFoundException;
+use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
+
+final readonly class UpdateFieldDefUseCase implements UpdateFieldDefUseCaseInterface
+{
+    public function __construct(
+        private FieldDefRepositoryInterface $fieldDefs,
+        private EntityTypeRepositoryInterface $entityTypes,
+    ) {
+    }
+
+    public function execute(UpdateFieldDefInput $input): UpdateFieldDefOutput
+    {
+        $fieldDef = $this->fieldDefs->findById($input->id);
+
+        if ($fieldDef === null) {
+            throw new FieldDefNotFoundException($input->id);
+        }
+
+        if ($this->entityTypes->findById($input->entityTypeId) === null) {
+            throw new EntityTypeNotFoundException($input->entityTypeId);
+        }
+
+        $existing = $this->fieldDefs->findByEntityTypeIdAndFieldKey($input->entityTypeId, $input->fieldKey);
+
+        if ($existing !== null && $existing->id !== $input->id) {
+            throw new FieldDefConflictException($input->entityTypeId, $input->fieldKey);
+        }
+
+        $updated = new FieldDef(
+            entityTypeId: $input->entityTypeId,
+            fieldKey: $input->fieldKey,
+            dataType: $input->dataType,
+            id: $input->id,
+        );
+        $this->fieldDefs->update($updated);
+
+        return new UpdateFieldDefOutput(
+            id: $input->id,
+            entityTypeId: $input->entityTypeId,
+            fieldKey: $input->fieldKey,
+            dataType: $input->dataType,
+        );
+    }
+}

--- a/src/FieldDef/UpdateFieldDefUseCaseInterface.php
+++ b/src/FieldDef/UpdateFieldDefUseCaseInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use NeNeRecords\EntityType\EntityTypeNotFoundException;
+
+interface UpdateFieldDefUseCaseInterface
+{
+    /**
+     * @throws FieldDefNotFoundException when the field definition does not exist.
+     * @throws EntityTypeNotFoundException when the entity type does not exist.
+     * @throws FieldDefConflictException when the field key is taken for the entity type.
+     */
+    public function execute(UpdateFieldDefInput $input): UpdateFieldDefOutput;
+}

--- a/src/TextField/CreateTextFieldUseCase.php
+++ b/src/TextField/CreateTextFieldUseCase.php
@@ -6,20 +6,28 @@ namespace NeNeRecords\TextField;
 
 use NeNeRecords\Entity\EntityNotFoundException;
 use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
 
 final readonly class CreateTextFieldUseCase implements CreateTextFieldUseCaseInterface
 {
+    private const TEXT_DATA_TYPE = 'text';
+
     public function __construct(
         private TextFieldRepositoryInterface $textFields,
         private EntityRepositoryInterface $entities,
+        private FieldDefRepositoryInterface $fieldDefs,
     ) {
     }
 
     public function execute(CreateTextFieldInput $input): CreateTextFieldOutput
     {
-        if ($this->entities->findById($input->entityId) === null) {
+        $entity = $this->entities->findById($input->entityId);
+
+        if ($entity === null) {
             throw new EntityNotFoundException($input->entityId);
         }
+
+        $this->assertTextFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
 
         $id = $this->textFields->save(new TextField(
             entityId: $input->entityId,
@@ -33,5 +41,18 @@ final readonly class CreateTextFieldUseCase implements CreateTextFieldUseCaseInt
             fieldKey: $input->fieldKey,
             value: $input->value,
         );
+    }
+
+    private function assertTextFieldKeyRegistered(int $entityTypeId, string $fieldKey): void
+    {
+        $fieldDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($entityTypeId, $fieldKey);
+
+        if ($fieldDef === null) {
+            throw new FieldKeyNotRegisteredException($entityTypeId, $fieldKey);
+        }
+
+        if ($fieldDef->dataType !== self::TEXT_DATA_TYPE) {
+            throw new FieldTypeMismatchException($fieldKey, self::TEXT_DATA_TYPE, $fieldDef->dataType);
+        }
     }
 }

--- a/src/TextField/FieldKeyNotRegisteredException.php
+++ b/src/TextField/FieldKeyNotRegisteredException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\TextField;
+
+use RuntimeException;
+
+final class FieldKeyNotRegisteredException extends RuntimeException
+{
+    public function __construct(
+        public int $entityTypeId,
+        public string $fieldKey,
+    ) {
+        parent::__construct("Field key {$fieldKey} is not registered for entity type {$entityTypeId}.");
+    }
+}

--- a/src/TextField/FieldKeyNotRegisteredExceptionHandler.php
+++ b/src/TextField/FieldKeyNotRegisteredExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\TextField;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class FieldKeyNotRegisteredExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof FieldKeyNotRegisteredException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'field-key-not-registered',
+            'Field Key Not Registered',
+            422,
+            'The field key is not registered for this entity type.',
+        );
+    }
+}

--- a/src/TextField/FieldTypeMismatchException.php
+++ b/src/TextField/FieldTypeMismatchException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\TextField;
+
+use RuntimeException;
+
+final class FieldTypeMismatchException extends RuntimeException
+{
+    public function __construct(
+        public string $fieldKey,
+        public string $expectedDataType,
+        public string $actualDataType,
+    ) {
+        parent::__construct("Field key {$fieldKey} has data type {$actualDataType}, expected {$expectedDataType}.");
+    }
+}

--- a/src/TextField/FieldTypeMismatchExceptionHandler.php
+++ b/src/TextField/FieldTypeMismatchExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\TextField;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class FieldTypeMismatchExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof FieldTypeMismatchException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'field-type-mismatch',
+            'Field Type Mismatch',
+            422,
+            'The field key is registered with a different data type.',
+        );
+    }
+}

--- a/src/TextField/TextFieldServiceProvider.php
+++ b/src/TextField/TextFieldServiceProvider.php
@@ -11,6 +11,7 @@ use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 
@@ -36,6 +37,7 @@ final readonly class TextFieldServiceProvider implements ServiceProviderInterfac
                 static function (ContainerInterface $container): CreateTextFieldUseCaseInterface {
                     $textFields = $container->get(TextFieldRepositoryInterface::class);
                     $entities = $container->get(EntityRepositoryInterface::class);
+                    $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
 
                     if (!$textFields instanceof TextFieldRepositoryInterface) {
                         throw new LogicException('Text field repository service is invalid.');
@@ -45,7 +47,11 @@ final readonly class TextFieldServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('Entity repository service is invalid.');
                     }
 
-                    return new CreateTextFieldUseCase($textFields, $entities);
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field definition repository service is invalid.');
+                    }
+
+                    return new CreateTextFieldUseCase($textFields, $entities, $fieldDefs);
                 },
             )
             ->set(
@@ -155,13 +161,23 @@ final readonly class TextFieldServiceProvider implements ServiceProviderInterfac
             ->set(
                 UpdateTextFieldUseCaseInterface::class,
                 static function (ContainerInterface $container): UpdateTextFieldUseCaseInterface {
-                    $repository = $container->get(TextFieldRepositoryInterface::class);
+                    $textFields = $container->get(TextFieldRepositoryInterface::class);
+                    $entities = $container->get(EntityRepositoryInterface::class);
+                    $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
 
-                    if (!$repository instanceof TextFieldRepositoryInterface) {
+                    if (!$textFields instanceof TextFieldRepositoryInterface) {
                         throw new LogicException('Text field repository service is invalid.');
                     }
 
-                    return new UpdateTextFieldUseCase($repository);
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field definition repository service is invalid.');
+                    }
+
+                    return new UpdateTextFieldUseCase($textFields, $entities, $fieldDefs);
                 },
             )
             ->set(
@@ -191,6 +207,30 @@ final readonly class TextFieldServiceProvider implements ServiceProviderInterfac
                     }
 
                     return new TextFieldNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                FieldKeyNotRegisteredExceptionHandler::class,
+                static function (ContainerInterface $container): FieldKeyNotRegisteredExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new FieldKeyNotRegisteredExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                FieldTypeMismatchExceptionHandler::class,
+                static function (ContainerInterface $container): FieldTypeMismatchExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new FieldTypeMismatchExceptionHandler($problemDetails);
                 },
             )
             ->set(

--- a/src/TextField/UpdateTextFieldUseCase.php
+++ b/src/TextField/UpdateTextFieldUseCase.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 
 namespace NeNeRecords\TextField;
 
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+
 final readonly class UpdateTextFieldUseCase implements UpdateTextFieldUseCaseInterface
 {
+    private const TEXT_DATA_TYPE = 'text';
+
     public function __construct(
         private TextFieldRepositoryInterface $textFields,
+        private EntityRepositoryInterface $entities,
+        private FieldDefRepositoryInterface $fieldDefs,
     ) {
     }
 
@@ -18,6 +26,14 @@ final readonly class UpdateTextFieldUseCase implements UpdateTextFieldUseCaseInt
         if ($existing === null) {
             throw new TextFieldNotFoundException($input->id);
         }
+
+        $entity = $this->entities->findById($existing->entityId);
+
+        if ($entity === null) {
+            throw new EntityNotFoundException($existing->entityId);
+        }
+
+        $this->assertTextFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
 
         $updated = new TextField(
             entityId: $existing->entityId,
@@ -33,5 +49,18 @@ final readonly class UpdateTextFieldUseCase implements UpdateTextFieldUseCaseInt
             fieldKey: $input->fieldKey,
             value: $input->value,
         );
+    }
+
+    private function assertTextFieldKeyRegistered(int $entityTypeId, string $fieldKey): void
+    {
+        $fieldDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($entityTypeId, $fieldKey);
+
+        if ($fieldDef === null) {
+            throw new FieldKeyNotRegisteredException($entityTypeId, $fieldKey);
+        }
+
+        if ($fieldDef->dataType !== self::TEXT_DATA_TYPE) {
+            throw new FieldTypeMismatchException($fieldKey, self::TEXT_DATA_TYPE, $fieldDef->dataType);
+        }
     }
 }

--- a/tests/FieldDef/CreateFieldDefUseCaseTest.php
+++ b/tests/FieldDef/CreateFieldDefUseCaseTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\FieldDef;
+
+use NeNeRecords\EntityType\EntityType;
+use NeNeRecords\EntityType\EntityTypeNotFoundException;
+use NeNeRecords\FieldDef\CreateFieldDefInput;
+use NeNeRecords\FieldDef\CreateFieldDefUseCase;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\FieldDef\FieldDefConflictException;
+use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use PHPUnit\Framework\TestCase;
+
+final class CreateFieldDefUseCaseTest extends TestCase
+{
+    public function testReturnsOutputWithNewId(): void
+    {
+        $entityTypes = new InMemoryEntityTypeRepository([]);
+        $entityTypes->save(new EntityType(name: 'Article', slug: 'article'));
+
+        $fieldDefs = new InMemoryFieldDefRepository([]);
+        $useCase = new CreateFieldDefUseCase($fieldDefs, $entityTypes);
+
+        $output = $useCase->execute(new CreateFieldDefInput(
+            entityTypeId: 1,
+            fieldKey: 'title',
+            dataType: 'text',
+        ));
+
+        self::assertSame(1, $output->id);
+        self::assertSame(1, $output->entityTypeId);
+        self::assertSame('title', $output->fieldKey);
+        self::assertSame('text', $output->dataType);
+    }
+
+    public function testThrowsEntityTypeNotFoundExceptionWhenEntityTypeAbsent(): void
+    {
+        $entityTypes = new InMemoryEntityTypeRepository([]);
+        $fieldDefs = new InMemoryFieldDefRepository([]);
+        $useCase = new CreateFieldDefUseCase($fieldDefs, $entityTypes);
+
+        $this->expectException(EntityTypeNotFoundException::class);
+
+        $useCase->execute(new CreateFieldDefInput(entityTypeId: 99, fieldKey: 'title', dataType: 'text'));
+    }
+
+    public function testThrowsFieldDefConflictExceptionOnDuplicateKey(): void
+    {
+        $entityTypes = new InMemoryEntityTypeRepository([]);
+        $entityTypes->save(new EntityType(name: 'Article', slug: 'article'));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'title', dataType: 'text', id: 1),
+        ]);
+        $useCase = new CreateFieldDefUseCase($fieldDefs, $entityTypes);
+
+        $this->expectException(FieldDefConflictException::class);
+
+        $useCase->execute(new CreateFieldDefInput(entityTypeId: 1, fieldKey: 'title', dataType: 'text'));
+    }
+}

--- a/tests/FieldDef/FieldDefHttpTest.php
+++ b/tests/FieldDef/FieldDefHttpTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\FieldDef;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\EntityType\EntityType;
+use NeNeRecords\EntityType\EntityTypeNotFoundExceptionHandler;
+use NeNeRecords\FieldDef\CreateFieldDefHandler;
+use NeNeRecords\FieldDef\CreateFieldDefUseCase;
+use NeNeRecords\FieldDef\DeleteFieldDefHandler;
+use NeNeRecords\FieldDef\DeleteFieldDefUseCase;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\FieldDef\FieldDefConflictExceptionHandler;
+use NeNeRecords\FieldDef\FieldDefNotFoundExceptionHandler;
+use NeNeRecords\FieldDef\FieldDefRouteRegistrar;
+use NeNeRecords\FieldDef\GetFieldDefByIdHandler;
+use NeNeRecords\FieldDef\GetFieldDefByIdUseCase;
+use NeNeRecords\FieldDef\ListFieldDefsHandler;
+use NeNeRecords\FieldDef\ListFieldDefsUseCase;
+use NeNeRecords\FieldDef\UpdateFieldDefHandler;
+use NeNeRecords\FieldDef\UpdateFieldDefUseCase;
+use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class FieldDefHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryEntityTypeRepository $entityTypes;
+    private InMemoryFieldDefRepository $fieldDefs;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->entityTypes = new InMemoryEntityTypeRepository();
+        $this->fieldDefs = new InMemoryFieldDefRepository();
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+
+        $registrar = new FieldDefRouteRegistrar(
+            new GetFieldDefByIdHandler(new GetFieldDefByIdUseCase($this->fieldDefs), $jsonResponse),
+            new CreateFieldDefHandler(new CreateFieldDefUseCase($this->fieldDefs, $this->entityTypes), $jsonResponse),
+            new UpdateFieldDefHandler(new UpdateFieldDefUseCase($this->fieldDefs, $this->entityTypes), $jsonResponse),
+            new DeleteFieldDefHandler(new DeleteFieldDefUseCase($this->fieldDefs), $this->factory),
+            new ListFieldDefsHandler(new ListFieldDefsUseCase($this->fieldDefs), $jsonResponse),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [
+                new EntityTypeNotFoundExceptionHandler($problemDetails),
+                new FieldDefNotFoundExceptionHandler($problemDetails),
+                new FieldDefConflictExceptionHandler($problemDetails),
+            ],
+            routeRegistrars: [$registrar],
+        ))->create();
+    }
+
+    public function testPostFieldDefCreatesDefinitionAndReturns201WithLocation(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Article', slug: 'article'));
+
+        $body = $this->factory->createStream(json_encode([
+            'entity_type_id' => $typeId,
+            'field_key' => 'title',
+            'data_type' => 'text',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/field-defs')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertStringStartsWith('/api/v1/field-defs/', $response->getHeaderLine('Location'));
+        self::assertSame($typeId, $payload['entity_type_id']);
+        self::assertSame('title', $payload['field_key']);
+        self::assertSame('text', $payload['data_type']);
+        self::assertIsInt($payload['id']);
+    }
+
+    public function testPostDuplicateKeyReturns409WithConflictProblemType(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Article', slug: 'article'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'title', dataType: 'text'));
+
+        $body = $this->factory->createStream(json_encode([
+            'entity_type_id' => $typeId,
+            'field_key' => 'title',
+            'data_type' => 'text',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/field-defs')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(409, $response->getStatusCode());
+        self::assertStringEndsWith('field-def-conflict', (string) $payload['type']);
+    }
+
+    public function testPostUnknownEntityTypeReturns404(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'entity_type_id' => 99,
+            'field_key' => 'title',
+            'data_type' => 'text',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/field-defs')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertStringEndsWith('not-found', (string) $payload['type']);
+    }
+
+    public function testGetFieldDefByIdReturnsDefinition(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Article', slug: 'article'));
+        $id = $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'title', dataType: 'text'));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/field-defs/{$id}"),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame($id, $payload['id']);
+        self::assertSame('title', $payload['field_key']);
+    }
+
+    public function testDeleteFieldDefReturns204AndSoftDeletes(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Article', slug: 'article'));
+        $id = $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'title', dataType: 'text'));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', "https://example.test/api/v1/field-defs/{$id}"),
+        );
+
+        self::assertSame(204, $response->getStatusCode());
+        self::assertNull($this->fieldDefs->findById($id));
+    }
+
+    public function testListFieldDefsFiltersByEntityTypeId(): void
+    {
+        $typeA = $this->entityTypes->save(new EntityType(name: 'A', slug: 'a'));
+        $typeB = $this->entityTypes->save(new EntityType(name: 'B', slug: 'b'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeA, fieldKey: 'title', dataType: 'text'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeB, fieldKey: 'body', dataType: 'text'));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/field-defs?entity_type_id={$typeA}"),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertCount(1, $payload['items']);
+        self::assertSame('title', $payload['items'][0]['field_key']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/tests/FieldDef/InMemoryFieldDefRepository.php
+++ b/tests/FieldDef/InMemoryFieldDefRepository.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\FieldDef;
+
+use DateTimeImmutable;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+
+final class InMemoryFieldDefRepository implements FieldDefRepositoryInterface
+{
+    /** @var array<int, FieldDef> */
+    private array $byId;
+
+    /** @var array<string, int> */
+    private array $entityTypeFieldKeyToId;
+
+    private int $nextId;
+
+    /** @param list<FieldDef> $seed */
+    public function __construct(array $seed = [])
+    {
+        $this->byId = [];
+        $this->entityTypeFieldKeyToId = [];
+        $this->nextId = 1;
+
+        foreach ($seed as $fieldDef) {
+            if ($fieldDef->id !== null) {
+                $id = $fieldDef->id;
+                $stored = new FieldDef(
+                    entityTypeId: $fieldDef->entityTypeId,
+                    fieldKey: $fieldDef->fieldKey,
+                    dataType: $fieldDef->dataType,
+                    id: $id,
+                    isDeleted: $fieldDef->isDeleted,
+                    deletedAt: $fieldDef->deletedAt,
+                );
+                $this->byId[$id] = $stored;
+                if (!$stored->isDeleted) {
+                    $this->entityTypeFieldKeyToId[$this->compositeKey($stored->entityTypeId, $stored->fieldKey)] = $id;
+                }
+                $this->nextId = max($this->nextId, $id + 1);
+            }
+        }
+    }
+
+    public function findById(int $id): ?FieldDef
+    {
+        $fieldDef = $this->byId[$id] ?? null;
+
+        if ($fieldDef === null || $fieldDef->isDeleted) {
+            return null;
+        }
+
+        return $fieldDef;
+    }
+
+    public function findByEntityTypeIdAndFieldKey(int $entityTypeId, string $fieldKey): ?FieldDef
+    {
+        $id = $this->entityTypeFieldKeyToId[$this->compositeKey($entityTypeId, $fieldKey)] ?? null;
+
+        if ($id === null) {
+            return null;
+        }
+
+        return $this->findById($id);
+    }
+
+    /** @return list<FieldDef> */
+    public function findAll(?int $entityTypeId, int $limit, int $offset): array
+    {
+        $defs = array_values(array_filter(
+            $this->byId,
+            static fn (FieldDef $fieldDef): bool => !$fieldDef->isDeleted
+                && ($entityTypeId === null || $fieldDef->entityTypeId === $entityTypeId),
+        ));
+        usort($defs, static fn (FieldDef $a, FieldDef $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
+
+        return array_slice($defs, $offset, $limit);
+    }
+
+    public function save(FieldDef $fieldDef): int
+    {
+        $id = $this->nextId++;
+        $stored = new FieldDef(
+            entityTypeId: $fieldDef->entityTypeId,
+            fieldKey: $fieldDef->fieldKey,
+            dataType: $fieldDef->dataType,
+            id: $id,
+        );
+        $this->byId[$id] = $stored;
+        $this->entityTypeFieldKeyToId[$this->compositeKey($stored->entityTypeId, $stored->fieldKey)] = $id;
+
+        return $id;
+    }
+
+    public function update(FieldDef $fieldDef): void
+    {
+        $id = $fieldDef->id;
+
+        if ($id === null || !isset($this->byId[$id])) {
+            return;
+        }
+
+        $old = $this->byId[$id];
+        unset($this->entityTypeFieldKeyToId[$this->compositeKey($old->entityTypeId, $old->fieldKey)]);
+
+        $this->entityTypeFieldKeyToId[$this->compositeKey($fieldDef->entityTypeId, $fieldDef->fieldKey)] = $id;
+        $this->byId[$id] = $fieldDef;
+    }
+
+    public function softDelete(int $id): void
+    {
+        $fieldDef = $this->byId[$id] ?? null;
+
+        if ($fieldDef === null || $fieldDef->isDeleted) {
+            return;
+        }
+
+        unset($this->entityTypeFieldKeyToId[$this->compositeKey($fieldDef->entityTypeId, $fieldDef->fieldKey)]);
+
+        $this->byId[$id] = new FieldDef(
+            entityTypeId: $fieldDef->entityTypeId,
+            fieldKey: $fieldDef->fieldKey,
+            dataType: $fieldDef->dataType,
+            id: $id,
+            isDeleted: true,
+            deletedAt: new DateTimeImmutable(),
+        );
+    }
+
+    private function compositeKey(int $entityTypeId, string $fieldKey): string
+    {
+        return $entityTypeId . ':' . $fieldKey;
+    }
+}

--- a/tests/FieldDef/PdoFieldDefRepositoryTest.php
+++ b/tests/FieldDef/PdoFieldDefRepositoryTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\FieldDef;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\FieldDef\PdoFieldDefRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PdoFieldDefRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene-records-test',
+            '',
+            'utf8',
+        )));
+
+        $this->executor->execute('PRAGMA foreign_keys = ON');
+
+        foreach ($this->schemaStatements() as $statement) {
+            $this->executor->execute($statement);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function schemaStatements(): array
+    {
+        $projectRoot = dirname(__DIR__, 2);
+        $paths = [
+            $projectRoot . '/database/schema/entity_types.sql',
+            $projectRoot . '/database/schema/entities.sql',
+            $projectRoot . '/database/schema/text_fields.sql',
+            $projectRoot . '/database/schema/field_defs.sql',
+        ];
+
+        $statements = [];
+
+        foreach ($paths as $path) {
+            self::assertFileExists($path);
+            $raw = trim((string) file_get_contents($path));
+            foreach (preg_split('/;\R/s', $raw) ?: [] as $chunk) {
+                $statement = trim($chunk);
+                if ($statement !== '') {
+                    $statements[] = $statement;
+                }
+            }
+        }
+
+        return $statements;
+    }
+
+    public function testFindByIdReturnsFieldDef(): void
+    {
+        $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('Article', 'article')");
+        $this->executor->execute("INSERT INTO field_defs (entity_type_id, field_key, data_type) VALUES (1, 'title', 'text')");
+
+        $repository = new PdoFieldDefRepository($this->executor);
+        $fieldDef = $repository->findById(1);
+
+        self::assertNotNull($fieldDef);
+        self::assertSame(1, $fieldDef->id);
+        self::assertSame(1, $fieldDef->entityTypeId);
+        self::assertSame('title', $fieldDef->fieldKey);
+        self::assertSame('text', $fieldDef->dataType);
+    }
+
+    public function testFindByEntityTypeIdAndFieldKeyReturnsActiveDefinition(): void
+    {
+        $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('Article', 'article')");
+        $this->executor->execute("INSERT INTO field_defs (entity_type_id, field_key, data_type) VALUES (1, 'title', 'text')");
+
+        $repository = new PdoFieldDefRepository($this->executor);
+        $fieldDef = $repository->findByEntityTypeIdAndFieldKey(1, 'title');
+
+        self::assertNotNull($fieldDef);
+        self::assertSame('title', $fieldDef->fieldKey);
+    }
+
+    public function testSoftDeleteHidesFromFindById(): void
+    {
+        $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('Article', 'article')");
+        $this->executor->execute("INSERT INTO field_defs (entity_type_id, field_key, data_type) VALUES (1, 'title', 'text')");
+
+        $repository = new PdoFieldDefRepository($this->executor);
+        $repository->softDelete(1);
+
+        self::assertNull($repository->findById(1));
+        self::assertNull($repository->findByEntityTypeIdAndFieldKey(1, 'title'));
+    }
+
+    public function testFindAllFiltersByEntityTypeId(): void
+    {
+        $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('A', 'a')");
+        $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('B', 'b')");
+        $this->executor->execute("INSERT INTO field_defs (entity_type_id, field_key, data_type) VALUES (1, 'title', 'text')");
+        $this->executor->execute("INSERT INTO field_defs (entity_type_id, field_key, data_type) VALUES (2, 'body', 'text')");
+
+        $repository = new PdoFieldDefRepository($this->executor);
+        $list = $repository->findAll(1, 10, 0);
+
+        self::assertCount(1, $list);
+        self::assertSame('title', $list[0]->fieldKey);
+    }
+
+    public function testSaveReturnsNewId(): void
+    {
+        $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('Article', 'article')");
+
+        $repository = new PdoFieldDefRepository($this->executor);
+        $id = $repository->save(new FieldDef(entityTypeId: 1, fieldKey: 'summary', dataType: 'text'));
+
+        self::assertSame(1, $id);
+    }
+
+    public function testUpdateChangesFields(): void
+    {
+        $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('Article', 'article')");
+        $this->executor->execute("INSERT INTO field_defs (entity_type_id, field_key, data_type) VALUES (1, 'title', 'text')");
+
+        $repository = new PdoFieldDefRepository($this->executor);
+        $repository->update(new FieldDef(entityTypeId: 1, fieldKey: 'headline', dataType: 'text', id: 1));
+        $fieldDef = $repository->findById(1);
+
+        self::assertNotNull($fieldDef);
+        self::assertSame('headline', $fieldDef->fieldKey);
+    }
+}

--- a/tests/TextField/CreateTextFieldUseCaseTest.php
+++ b/tests/TextField/CreateTextFieldUseCaseTest.php
@@ -5,9 +5,16 @@ declare(strict_types=1);
 namespace NeNeRecords\Tests\TextField;
 
 use NeNeRecords\Entity\Entity;
+use NeNeRecords\FieldDef\FieldDef;
 use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
 use NeNeRecords\TextField\CreateTextFieldInput;
 use NeNeRecords\TextField\CreateTextFieldUseCase;
+use NeNeRecords\TextField\FieldKeyNotRegisteredException;
+use NeNeRecords\TextField\FieldTypeMismatchException;
+use NeNeRecords\TextField\TextField;
+use NeNeRecords\TextField\UpdateTextFieldInput;
+use NeNeRecords\TextField\UpdateTextFieldUseCase;
 use PHPUnit\Framework\TestCase;
 
 final class CreateTextFieldUseCaseTest extends TestCase
@@ -17,8 +24,12 @@ final class CreateTextFieldUseCaseTest extends TestCase
         $entities = new InMemoryEntityRepository([]);
         $entityId = $entities->save(new Entity(id: null, entityTypeId: 99));
 
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 99, fieldKey: 'title', dataType: 'text', id: 1),
+        ]);
+
         $textFields = new InMemoryTextFieldRepository([]);
-        $useCase = new CreateTextFieldUseCase($textFields, $entities);
+        $useCase = new CreateTextFieldUseCase($textFields, $entities, $fieldDefs);
 
         $output = $useCase->execute(new CreateTextFieldInput(entityId: $entityId, fieldKey: 'title', value: 'Hello'));
 
@@ -33,13 +44,71 @@ final class CreateTextFieldUseCaseTest extends TestCase
         $entities = new InMemoryEntityRepository([]);
         $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
 
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'a', dataType: 'text', id: 1),
+            new FieldDef(entityTypeId: 1, fieldKey: 'b', dataType: 'text', id: 2),
+        ]);
+
         $textFields = new InMemoryTextFieldRepository([]);
-        $useCase = new CreateTextFieldUseCase($textFields, $entities);
+        $useCase = new CreateTextFieldUseCase($textFields, $entities, $fieldDefs);
 
         $first = $useCase->execute(new CreateTextFieldInput(entityId: $entityId, fieldKey: 'a', value: '1'));
         $second = $useCase->execute(new CreateTextFieldInput(entityId: $entityId, fieldKey: 'b', value: '2'));
 
         self::assertSame(1, $first->id);
         self::assertSame(2, $second->id);
+    }
+
+    public function testThrowsFieldKeyNotRegisteredExceptionWhenFieldDefAbsent(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([]);
+        $textFields = new InMemoryTextFieldRepository([]);
+        $useCase = new CreateTextFieldUseCase($textFields, $entities, $fieldDefs);
+
+        $this->expectException(FieldKeyNotRegisteredException::class);
+
+        $useCase->execute(new CreateTextFieldInput(entityId: $entityId, fieldKey: 'title', value: 'Hello'));
+    }
+
+    public function testThrowsFieldTypeMismatchExceptionWhenDataTypeIsNotText(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'count', dataType: 'int', id: 1),
+        ]);
+
+        $textFields = new InMemoryTextFieldRepository([]);
+        $useCase = new CreateTextFieldUseCase($textFields, $entities, $fieldDefs);
+
+        $this->expectException(FieldTypeMismatchException::class);
+
+        $useCase->execute(new CreateTextFieldInput(entityId: $entityId, fieldKey: 'count', value: '1'));
+    }
+}
+
+final class UpdateTextFieldUseCaseTest extends TestCase
+{
+    public function testThrowsFieldKeyNotRegisteredExceptionWhenUpdatedKeyIsUnregistered(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'title', dataType: 'text', id: 1),
+        ]);
+
+        $textFields = new InMemoryTextFieldRepository([]);
+        $textFields->save(new TextField(entityId: $entityId, fieldKey: 'title', value: 'Old', id: null));
+
+        $useCase = new UpdateTextFieldUseCase($textFields, $entities, $fieldDefs);
+
+        $this->expectException(FieldKeyNotRegisteredException::class);
+
+        $useCase->execute(new UpdateTextFieldInput(id: 1, fieldKey: 'body', value: 'New'));
     }
 }

--- a/tests/TextField/TextFieldHttpTest.php
+++ b/tests/TextField/TextFieldHttpTest.php
@@ -21,12 +21,16 @@ use NeNeRecords\Entity\UpdateEntityHandler;
 use NeNeRecords\Entity\UpdateEntityUseCase;
 use NeNeRecords\EntityType\EntityType;
 use NeNeRecords\EntityType\EntityTypeNotFoundExceptionHandler;
+use NeNeRecords\FieldDef\FieldDef;
 use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
 use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
 use NeNeRecords\TextField\CreateTextFieldHandler;
 use NeNeRecords\TextField\CreateTextFieldUseCase;
 use NeNeRecords\TextField\DeleteTextFieldHandler;
 use NeNeRecords\TextField\DeleteTextFieldUseCase;
+use NeNeRecords\TextField\FieldKeyNotRegisteredExceptionHandler;
+use NeNeRecords\TextField\FieldTypeMismatchExceptionHandler;
 use NeNeRecords\TextField\GetTextFieldByIdHandler;
 use NeNeRecords\TextField\GetTextFieldByIdUseCase;
 use NeNeRecords\TextField\ListTextFieldsHandler;
@@ -45,6 +49,7 @@ final class TextFieldHttpTest extends TestCase
     private Psr17Factory $factory;
     private InMemoryEntityTypeRepository $entityTypes;
     private InMemoryEntityRepository $entities;
+    private InMemoryFieldDefRepository $fieldDefs;
     private InMemoryTextFieldRepository $textFields;
     private RequestHandlerInterface $application;
 
@@ -55,6 +60,7 @@ final class TextFieldHttpTest extends TestCase
         $this->factory = new Psr17Factory();
         $this->entityTypes = new InMemoryEntityTypeRepository();
         $this->entities = new InMemoryEntityRepository();
+        $this->fieldDefs = new InMemoryFieldDefRepository();
         $this->textFields = new InMemoryTextFieldRepository();
 
         $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
@@ -71,8 +77,8 @@ final class TextFieldHttpTest extends TestCase
         $textFieldRegistrar = new TextFieldRouteRegistrar(
             new ListTextFieldsHandler(new ListTextFieldsUseCase($this->textFields), $jsonResponse),
             new GetTextFieldByIdHandler(new GetTextFieldByIdUseCase($this->textFields), $jsonResponse),
-            new CreateTextFieldHandler(new CreateTextFieldUseCase($this->textFields, $this->entities), $jsonResponse),
-            new UpdateTextFieldHandler(new UpdateTextFieldUseCase($this->textFields), $jsonResponse),
+            new CreateTextFieldHandler(new CreateTextFieldUseCase($this->textFields, $this->entities, $this->fieldDefs), $jsonResponse),
+            new UpdateTextFieldHandler(new UpdateTextFieldUseCase($this->textFields, $this->entities, $this->fieldDefs), $jsonResponse),
             new DeleteTextFieldHandler(new DeleteTextFieldUseCase($this->textFields), $this->factory),
         );
 
@@ -83,6 +89,8 @@ final class TextFieldHttpTest extends TestCase
                 new EntityTypeNotFoundExceptionHandler($problemDetails),
                 new EntityNotFoundExceptionHandler($problemDetails),
                 new TextFieldNotFoundExceptionHandler($problemDetails),
+                new FieldKeyNotRegisteredExceptionHandler($problemDetails),
+                new FieldTypeMismatchExceptionHandler($problemDetails),
             ],
             routeRegistrars: [$entityRegistrar, $textFieldRegistrar],
         ))->create();
@@ -91,6 +99,8 @@ final class TextFieldHttpTest extends TestCase
     public function testPostTextFieldCreatesFieldAndReturns201WithLocation(): void
     {
         $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'title', dataType: 'text'));
+
         $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
 
         $entityResponse = $this->application->handle(
@@ -118,9 +128,63 @@ final class TextFieldHttpTest extends TestCase
         self::assertSame('Hello Field', $payload['value']);
     }
 
+    public function testPostUnregisteredFieldKeyReturns422(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        $entityId = (int) $this->decodeJson($entityResponse)['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'title',
+            'value' => 'Hello Field',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/text-fields')->withBody($bodyTf),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringEndsWith('field-key-not-registered', (string) $payload['type']);
+    }
+
+    public function testPostMismatchedFieldTypeReturns422(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'count', dataType: 'int'));
+
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        $entityId = (int) $this->decodeJson($entityResponse)['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'count',
+            'value' => '1',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/text-fields')->withBody($bodyTf),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringEndsWith('field-type-mismatch', (string) $payload['type']);
+    }
+
     public function testAfterDeleteGetTextFieldReturns404(): void
     {
         $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'body', dataType: 'text'));
+
         $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
 
         $entityResponse = $this->application->handle(


### PR DESCRIPTION
## Summary

- **ADR 0002** — entity model ER + `field_defs` registry design
- **`field_defs` CRUD** at `/api/v1/field-defs` (soft delete, conflict 409)
- **TextField validation** — create/update require registered `field_key` with `data_type=text` (422)
- OpenAPI + tests updated (**58 tests**)

## Test plan

- [x] `composer check` — 58/58, PHPStan L8, CS, OpenAPI valid
- [ ] Manual: create entity_type → field_def → entity → text_field with valid key
- [ ] Manual: text_field with unregistered key returns 422

## Self-review

`Self-review: backend-api, openapi-contract, database, docs-policy`

Closes #9


Made with [Cursor](https://cursor.com)