### PR TITLE
feat(api): int_fields CRUD (#11)

### DIFF
--- a/database/migrations/20260524000004_create_int_fields_table.php
+++ b/database/migrations/20260524000004_create_int_fields_table.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateIntFieldsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('int_fields')
+            ->addColumn('entity_id', 'integer', ['null' => false, 'signed' => false])
+            ->addColumn('field_key', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('value', 'integer', ['null' => false])
+            ->addColumn('is_deleted', 'boolean', ['default' => false, 'null' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true, 'default' => null])
+            ->addIndex(['entity_id'])
+            ->addForeignKey('entity_id', 'entities', 'id', ['delete' => 'RESTRICT', 'update' => 'NO_ACTION'])
+            ->create();
+    }
+}

--- a/database/schema/int_fields.sql
+++ b/database/schema/int_fields.sql
@@ -1,0 +1,10 @@
+CREATE TABLE int_fields (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_id INTEGER UNSIGNED NOT NULL,
+    field_key VARCHAR(255) NOT NULL,
+    value INTEGER NOT NULL,
+    is_deleted BOOLEAN NOT NULL DEFAULT 0,
+    deleted_at DATETIME NULL,
+    FOREIGN KEY (entity_id) REFERENCES entities (id) ON DELETE RESTRICT ON UPDATE NO ACTION
+);
+CREATE INDEX int_fields_entity_id ON int_fields (entity_id);

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: NeNe Records API
   version: 0.1.0
   description: >
-    NeNe Records public API contract — entity_types, field_defs, entities, and text_fields CRUD (MVP + Phase 2 registry).
+    NeNe Records public API contract — entity_types, field_defs, entities, text_fields, and int_fields CRUD (MVP + Phase 2 registry).
 servers:
   - url: http://localhost:8080
     description: Local development server
@@ -18,6 +18,8 @@ tags:
     description: Registered field definitions per entity type.
   - name: TextFields
     description: Typed text field values on entities.
+  - name: IntFields
+    description: Typed integer field values on entities.
 paths:
   /health:
     get:
@@ -629,6 +631,161 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/int-fields:
+    get:
+      tags:
+        - IntFields
+      summary: List int fields
+      description: Returns non-deleted int fields.
+      operationId: listIntFields
+      parameters:
+        - $ref: '#/components/parameters/LimitQuery'
+        - $ref: '#/components/parameters/OffsetQuery'
+      responses:
+        '200':
+          description: Paginated int field list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntFieldListResponse'
+              examples:
+                ok:
+                  summary: Empty list
+                  value:
+                    items: []
+                    limit: 20
+                    offset: 0
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - IntFields
+      summary: Create int field
+      operationId: createIntField
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateIntFieldRequest'
+            examples:
+              ok:
+                value:
+                  entity_id: 1
+                  field_key: count
+                  value: 42
+      responses:
+        '201':
+          description: Int field created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntFieldResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_id: 1
+                    field_key: count
+                    value: 42
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: Validation failed, unregistered field key, or field type mismatch.
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ValidationProblemDetails'
+                  - $ref: '#/components/schemas/ProblemDetails'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/int-fields/{id}:
+    get:
+      tags:
+        - IntFields
+      summary: Get int field by id
+      operationId: getIntFieldById
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      responses:
+        '200':
+          description: Int field found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntFieldResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_id: 1
+                    field_key: count
+                    value: 42
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      tags:
+        - IntFields
+      summary: Update int field
+      operationId: updateIntField
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateIntFieldRequest'
+            examples:
+              ok:
+                value:
+                  field_key: count
+                  value: 99
+      responses:
+        '200':
+          description: Int field updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntFieldResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_id: 1
+                    field_key: count
+                    value: 99
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: Validation failed, unregistered field key, or field type mismatch.
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ValidationProblemDetails'
+                  - $ref: '#/components/schemas/ProblemDetails'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - IntFields
+      summary: Soft delete int field
+      operationId: deleteIntField
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      responses:
+        '204':
+          description: Int field soft-deleted.
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   parameters:
     IdPath:
@@ -740,7 +897,7 @@ components:
                 detail: The field key is not registered for this entity type.
                 instance: /api/v1/text-fields
     FieldTypeMismatch:
-      description: Field key is registered with a non-text data type.
+      description: Field key is registered with a different data type.
       content:
         application/problem+json:
           schema:
@@ -962,6 +1119,7 @@ components:
           type: string
           enum:
             - text
+            - int
     CreateFieldDefRequest:
       type: object
       required:
@@ -980,6 +1138,7 @@ components:
           type: string
           enum:
             - text
+            - int
       additionalProperties: false
     UpdateFieldDefRequest:
       $ref: '#/components/schemas/CreateFieldDefRequest'
@@ -1056,6 +1215,71 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TextFieldResponse'
+        limit:
+          type: integer
+        offset:
+          type: integer
+    IntFieldResponse:
+      type: object
+      required:
+        - id
+        - entity_id
+        - field_key
+        - value
+      properties:
+        id:
+          type: integer
+          format: int64
+        entity_id:
+          type: integer
+          format: int64
+        field_key:
+          type: string
+        value:
+          type: integer
+          format: int64
+    CreateIntFieldRequest:
+      type: object
+      required:
+        - entity_id
+        - field_key
+        - value
+      properties:
+        entity_id:
+          type: integer
+          format: int64
+          minimum: 1
+        field_key:
+          type: string
+          minLength: 1
+        value:
+          type: integer
+          format: int64
+      additionalProperties: false
+    UpdateIntFieldRequest:
+      type: object
+      required:
+        - field_key
+        - value
+      properties:
+        field_key:
+          type: string
+          minLength: 1
+        value:
+          type: integer
+          format: int64
+      additionalProperties: false
+    IntFieldListResponse:
+      type: object
+      required:
+        - items
+        - limit
+        - offset
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/IntFieldResponse'
         limit:
           type: integer
         offset:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -12,29 +12,29 @@ New contributors and AI agents: read [`handoff-2026-05-24-workspace-switch.md`](
 
 | Issue | Branch | Summary |
 | --- | --- | --- |
-| #9 | `feat/9-field-defs-registry` | Phase 2: `field_defs` schema registry API |
+| #11 | `feat/11-int-fields` | Phase 2: `int_fields` CRUD + `data_type=int` |
 
 ## Up Next
 
 | Issue | Summary |
 | --- | --- |
-| — | Phase 2 follow-up: int / enum / bool / datetime field types |
+| — | Phase 2: enum / bool / datetime field types |
 
 ## Recently Completed
 
 | Issue | Summary |
 | --- | --- |
+| #9 | field_defs schema registry (merged PR #10, ADR 0002) |
 | #1 | MVP entity CRUD vertical slice (merged PR #8) |
 | #6 | Frontend/backend coding standards (merged PR #7) |
 | #4 | Workspace handoff + product vision (merged PR #5) |
 | #2 | NENE2 governance inheritance (merged PR #3) |
-| — | Repository bootstrap (`README`, MIT license) |
 
 ## Handoff Notes
 
-- **Phase 1 complete.** `composer check`, `composer openapi` available.
-- Phase 2 starts with ADR 0002 + `field_defs` registry (Issue #9).
-- Framework reference: `hideyukimori/nene2` via Composer path `../NENE2`; see `docs/inheritance-from-nene2.md`.
+- Phase 1 complete. Phase 2 in progress — registry (#9) done; typed field tables expanding.
+- ADR 0002: `docs/adr/0002-entity-model-and-field-defs.md`
+- Framework: `hideyukimori/nene2` via Composer path `../NENE2`
 
 ## Verification Commands
 

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -16,8 +16,12 @@ use NeNeRecords\EntityType\EntityTypeSlugConflictExceptionHandler;
 use NeNeRecords\FieldDef\FieldDefConflictExceptionHandler;
 use NeNeRecords\FieldDef\FieldDefNotFoundExceptionHandler;
 use NeNeRecords\FieldDef\FieldDefServiceProvider;
-use NeNeRecords\TextField\FieldKeyNotRegisteredExceptionHandler;
-use NeNeRecords\TextField\FieldTypeMismatchExceptionHandler;
+use NeNeRecords\IntField\FieldKeyNotRegisteredExceptionHandler as IntFieldKeyNotRegisteredExceptionHandler;
+use NeNeRecords\IntField\FieldTypeMismatchExceptionHandler as IntFieldTypeMismatchExceptionHandler;
+use NeNeRecords\IntField\IntFieldNotFoundExceptionHandler;
+use NeNeRecords\IntField\IntFieldServiceProvider;
+use NeNeRecords\TextField\FieldKeyNotRegisteredExceptionHandler as TextFieldKeyNotRegisteredExceptionHandler;
+use NeNeRecords\TextField\FieldTypeMismatchExceptionHandler as TextFieldTypeMismatchExceptionHandler;
 use NeNeRecords\TextField\TextFieldNotFoundExceptionHandler;
 use NeNeRecords\TextField\TextFieldServiceProvider;
 use Psr\Container\ContainerInterface;
@@ -34,7 +38,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new EntityTypeServiceProvider())
             ->addProvider(new FieldDefServiceProvider())
             ->addProvider(new EntityServiceProvider())
-            ->addProvider(new TextFieldServiceProvider());
+            ->addProvider(new TextFieldServiceProvider())
+            ->addProvider(new IntFieldServiceProvider());
 
         $builder
             ->set(
@@ -44,17 +49,19 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $fieldDef = $container->get('nene-records.route_registrar.field_def');
                     $entity = $container->get('nene-records.route_registrar.entity');
                     $textField = $container->get('nene-records.route_registrar.text_field');
+                    $intField = $container->get('nene-records.route_registrar.int_field');
 
                     if (
                         !is_callable($entityType)
                         || !is_callable($fieldDef)
                         || !is_callable($entity)
                         || !is_callable($textField)
+                        || !is_callable($intField)
                     ) {
                         throw new LogicException('Route registrar service is invalid.');
                     }
 
-                    return [$entityType, $fieldDef, $entity, $textField];
+                    return [$entityType, $fieldDef, $entity, $textField, $intField];
                 },
             )
             ->set(
@@ -66,8 +73,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $fieldDefConflict = $container->get(FieldDefConflictExceptionHandler::class);
                     $entityNotFound = $container->get(EntityNotFoundExceptionHandler::class);
                     $textFieldNotFound = $container->get(TextFieldNotFoundExceptionHandler::class);
-                    $fieldKeyNotRegistered = $container->get(FieldKeyNotRegisteredExceptionHandler::class);
-                    $fieldTypeMismatch = $container->get(FieldTypeMismatchExceptionHandler::class);
+                    $textFieldKeyNotRegistered = $container->get(TextFieldKeyNotRegisteredExceptionHandler::class);
+                    $textFieldTypeMismatch = $container->get(TextFieldTypeMismatchExceptionHandler::class);
+                    $intFieldNotFound = $container->get(IntFieldNotFoundExceptionHandler::class);
+                    $intFieldKeyNotRegistered = $container->get(IntFieldKeyNotRegisteredExceptionHandler::class);
+                    $intFieldTypeMismatch = $container->get(IntFieldTypeMismatchExceptionHandler::class);
 
                     foreach ([
                         $entityTypeNotFound,
@@ -76,8 +86,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $fieldDefConflict,
                         $entityNotFound,
                         $textFieldNotFound,
-                        $fieldKeyNotRegistered,
-                        $fieldTypeMismatch,
+                        $textFieldKeyNotRegistered,
+                        $textFieldTypeMismatch,
+                        $intFieldNotFound,
+                        $intFieldKeyNotRegistered,
+                        $intFieldTypeMismatch,
                     ] as $handler) {
                         if (!$handler instanceof DomainExceptionHandlerInterface) {
                             throw new LogicException('Exception handler service is invalid.');
@@ -91,8 +104,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $fieldDefConflict,
                         $entityNotFound,
                         $textFieldNotFound,
-                        $fieldKeyNotRegistered,
-                        $fieldTypeMismatch,
+                        $textFieldKeyNotRegistered,
+                        $textFieldTypeMismatch,
+                        $intFieldNotFound,
+                        $intFieldKeyNotRegistered,
+                        $intFieldTypeMismatch,
                     ];
                 },
             );

--- a/src/FieldDef/CreateFieldDefHandler.php
+++ b/src/FieldDef/CreateFieldDefHandler.php
@@ -14,7 +14,7 @@ use Psr\Http\Message\ServerRequestInterface;
 final readonly class CreateFieldDefHandler
 {
     /** @var list<string> */
-    private const ALLOWED_DATA_TYPES = ['text'];
+    private const ALLOWED_DATA_TYPES = ['text', 'int'];
 
     public function __construct(
         private CreateFieldDefUseCaseInterface $useCase,
@@ -43,7 +43,7 @@ final readonly class CreateFieldDefHandler
         if ($dataType === '') {
             $errors[] = new ValidationError('data_type', 'Data type is required.', 'required');
         } elseif (!in_array($dataType, self::ALLOWED_DATA_TYPES, true)) {
-            $errors[] = new ValidationError('data_type', 'Data type must be one of: text.', 'invalid');
+            $errors[] = new ValidationError('data_type', 'Data type must be one of: text, int.', 'invalid');
         }
 
         if ($errors !== []) {

--- a/src/FieldDef/UpdateFieldDefHandler.php
+++ b/src/FieldDef/UpdateFieldDefHandler.php
@@ -15,7 +15,7 @@ use Psr\Http\Message\ServerRequestInterface;
 final readonly class UpdateFieldDefHandler
 {
     /** @var list<string> */
-    private const ALLOWED_DATA_TYPES = ['text'];
+    private const ALLOWED_DATA_TYPES = ['text', 'int'];
 
     public function __construct(
         private UpdateFieldDefUseCaseInterface $useCase,
@@ -51,7 +51,7 @@ final readonly class UpdateFieldDefHandler
         if ($dataType === '') {
             $errors[] = new ValidationError('data_type', 'Data type is required.', 'required');
         } elseif (!in_array($dataType, self::ALLOWED_DATA_TYPES, true)) {
-            $errors[] = new ValidationError('data_type', 'Data type must be one of: text.', 'invalid');
+            $errors[] = new ValidationError('data_type', 'Data type must be one of: text, int.', 'invalid');
         }
 
         if ($errors !== []) {

--- a/src/IntField/CreateIntFieldHandler.php
+++ b/src/IntField/CreateIntFieldHandler.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateIntFieldHandler
+{
+    public function __construct(
+        private CreateIntFieldUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+
+        $entityId = (int) ($body['entity_id'] ?? 0);
+        $fieldKey = trim((string) ($body['field_key'] ?? ''));
+
+        if ($entityId <= 0) {
+            $errors[] = new ValidationError('entity_id', 'Entity id must be a positive integer.', 'invalid');
+        }
+
+        if ($fieldKey === '') {
+            $errors[] = new ValidationError('field_key', 'Field key is required.', 'required');
+        }
+
+        if (!array_key_exists('value', $body)) {
+            $errors[] = new ValidationError('value', 'Value is required.', 'required');
+        } elseif (!is_int($body['value'])) {
+            $errors[] = new ValidationError('value', 'Value must be an integer.', 'invalid');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        /** @var int $value */
+        $value = $body['value'];
+
+        $output = $this->useCase->execute(new CreateIntFieldInput(
+            entityId: $entityId,
+            fieldKey: $fieldKey,
+            value: $value,
+        ));
+
+        return $this->response->create(
+            [
+                'id'         => $output->id,
+                'entity_id'  => $output->entityId,
+                'field_key'  => $output->fieldKey,
+                'value'      => $output->value,
+            ],
+            201,
+            ['Location' => '/api/v1/int-fields/' . $output->id],
+        );
+    }
+}

--- a/src/IntField/CreateIntFieldInput.php
+++ b/src/IntField/CreateIntFieldInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+final readonly class CreateIntFieldInput
+{
+    public function __construct(
+        public int $entityId,
+        public string $fieldKey,
+        public int $value,
+    ) {
+    }
+}

--- a/src/IntField/CreateIntFieldOutput.php
+++ b/src/IntField/CreateIntFieldOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+final readonly class CreateIntFieldOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public int $value,
+    ) {
+    }
+}

--- a/src/IntField/CreateIntFieldUseCase.php
+++ b/src/IntField/CreateIntFieldUseCase.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+
+final readonly class CreateIntFieldUseCase implements CreateIntFieldUseCaseInterface
+{
+    private const INT_DATA_TYPE = 'int';
+
+    public function __construct(
+        private IntFieldRepositoryInterface $intFields,
+        private EntityRepositoryInterface $entities,
+        private FieldDefRepositoryInterface $fieldDefs,
+    ) {
+    }
+
+    public function execute(CreateIntFieldInput $input): CreateIntFieldOutput
+    {
+        $entity = $this->entities->findById($input->entityId);
+
+        if ($entity === null) {
+            throw new EntityNotFoundException($input->entityId);
+        }
+
+        $this->assertIntFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
+
+        $id = $this->intFields->save(new IntField(
+            entityId: $input->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+        ));
+
+        return new CreateIntFieldOutput(
+            id: $id,
+            entityId: $input->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+        );
+    }
+
+    private function assertIntFieldKeyRegistered(int $entityTypeId, string $fieldKey): void
+    {
+        $fieldDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($entityTypeId, $fieldKey);
+
+        if ($fieldDef === null) {
+            throw new FieldKeyNotRegisteredException($entityTypeId, $fieldKey);
+        }
+
+        if ($fieldDef->dataType !== self::INT_DATA_TYPE) {
+            throw new FieldTypeMismatchException($fieldKey, self::INT_DATA_TYPE, $fieldDef->dataType);
+        }
+    }
+}

--- a/src/IntField/CreateIntFieldUseCaseInterface.php
+++ b/src/IntField/CreateIntFieldUseCaseInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+
+interface CreateIntFieldUseCaseInterface
+{
+    /**
+     * @throws EntityNotFoundException When {@see CreateIntFieldInput::$entityId} does not exist.
+     */
+    public function execute(CreateIntFieldInput $input): CreateIntFieldOutput;
+}

--- a/src/IntField/DeleteIntFieldByIdInput.php
+++ b/src/IntField/DeleteIntFieldByIdInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+final readonly class DeleteIntFieldByIdInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/IntField/DeleteIntFieldHandler.php
+++ b/src/IntField/DeleteIntFieldHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteIntFieldHandler
+{
+    public function __construct(
+        private DeleteIntFieldUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new IntFieldNotFoundException($id);
+        }
+
+        $this->useCase->execute(new DeleteIntFieldByIdInput($id));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/IntField/DeleteIntFieldUseCase.php
+++ b/src/IntField/DeleteIntFieldUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+final readonly class DeleteIntFieldUseCase implements DeleteIntFieldUseCaseInterface
+{
+    public function __construct(
+        private IntFieldRepositoryInterface $intFields,
+    ) {
+    }
+
+    public function execute(DeleteIntFieldByIdInput $input): void
+    {
+        $intField = $this->intFields->findById($input->id);
+
+        if ($intField === null) {
+            throw new IntFieldNotFoundException($input->id);
+        }
+
+        $this->intFields->delete($input->id);
+    }
+}

--- a/src/IntField/DeleteIntFieldUseCaseInterface.php
+++ b/src/IntField/DeleteIntFieldUseCaseInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+interface DeleteIntFieldUseCaseInterface
+{
+    /**
+     * Soft-deletes the int field.
+     *
+     * @throws IntFieldNotFoundException when no int field matches the given id.
+     */
+    public function execute(DeleteIntFieldByIdInput $input): void;
+}

--- a/src/IntField/FieldKeyNotRegisteredException.php
+++ b/src/IntField/FieldKeyNotRegisteredException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+use RuntimeException;
+
+final class FieldKeyNotRegisteredException extends RuntimeException
+{
+    public function __construct(
+        public int $entityTypeId,
+        public string $fieldKey,
+    ) {
+        parent::__construct("Field key {$fieldKey} is not registered for entity type {$entityTypeId}.");
+    }
+}

--- a/src/IntField/FieldKeyNotRegisteredExceptionHandler.php
+++ b/src/IntField/FieldKeyNotRegisteredExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class FieldKeyNotRegisteredExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof FieldKeyNotRegisteredException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'field-key-not-registered',
+            'Field Key Not Registered',
+            422,
+            'The field key is not registered for this entity type.',
+        );
+    }
+}

--- a/src/IntField/FieldTypeMismatchException.php
+++ b/src/IntField/FieldTypeMismatchException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+use RuntimeException;
+
+final class FieldTypeMismatchException extends RuntimeException
+{
+    public function __construct(
+        public string $fieldKey,
+        public string $expectedDataType,
+        public string $actualDataType,
+    ) {
+        parent::__construct("Field key {$fieldKey} has data type {$actualDataType}, expected {$expectedDataType}.");
+    }
+}

--- a/src/IntField/FieldTypeMismatchExceptionHandler.php
+++ b/src/IntField/FieldTypeMismatchExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class FieldTypeMismatchExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof FieldTypeMismatchException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'field-type-mismatch',
+            'Field Type Mismatch',
+            422,
+            'The field key is registered with a different data type.',
+        );
+    }
+}

--- a/src/IntField/GetIntFieldByIdHandler.php
+++ b/src/IntField/GetIntFieldByIdHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetIntFieldByIdHandler
+{
+    public function __construct(
+        private GetIntFieldByIdUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new IntFieldNotFoundException($id);
+        }
+
+        $output = $this->useCase->execute(new GetIntFieldByIdInput($id));
+
+        return $this->response->create([
+            'id'        => $output->id,
+            'entity_id' => $output->entityId,
+            'field_key' => $output->fieldKey,
+            'value'     => $output->value,
+        ]);
+    }
+}

--- a/src/IntField/GetIntFieldByIdInput.php
+++ b/src/IntField/GetIntFieldByIdInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+final readonly class GetIntFieldByIdInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/IntField/GetIntFieldByIdOutput.php
+++ b/src/IntField/GetIntFieldByIdOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+final readonly class GetIntFieldByIdOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public int $value,
+    ) {
+    }
+}

--- a/src/IntField/GetIntFieldByIdUseCase.php
+++ b/src/IntField/GetIntFieldByIdUseCase.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+final readonly class GetIntFieldByIdUseCase implements GetIntFieldByIdUseCaseInterface
+{
+    public function __construct(
+        private IntFieldRepositoryInterface $intFields,
+    ) {
+    }
+
+    public function execute(GetIntFieldByIdInput $input): GetIntFieldByIdOutput
+    {
+        $intField = $this->intFields->findById($input->id);
+
+        if ($intField === null) {
+            throw new IntFieldNotFoundException($input->id);
+        }
+
+        return new GetIntFieldByIdOutput(
+            id: (int) $intField->id,
+            entityId: $intField->entityId,
+            fieldKey: $intField->fieldKey,
+            value: $intField->value,
+        );
+    }
+}

--- a/src/IntField/GetIntFieldByIdUseCaseInterface.php
+++ b/src/IntField/GetIntFieldByIdUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+interface GetIntFieldByIdUseCaseInterface
+{
+    /**
+     * @throws IntFieldNotFoundException when no int field matches the given id.
+     */
+    public function execute(GetIntFieldByIdInput $input): GetIntFieldByIdOutput;
+}

--- a/src/IntField/IntField.php
+++ b/src/IntField/IntField.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+final readonly class IntField
+{
+    public function __construct(
+        public int $entityId,
+        public string $fieldKey,
+        public int $value,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/IntField/IntFieldNotFoundException.php
+++ b/src/IntField/IntFieldNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+use RuntimeException;
+
+final class IntFieldNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("Int field with id {$id} was not found.");
+    }
+}

--- a/src/IntField/IntFieldNotFoundExceptionHandler.php
+++ b/src/IntField/IntFieldNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class IntFieldNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof IntFieldNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'not-found',
+            'Not Found',
+            404,
+            'The requested int field was not found.',
+        );
+    }
+}

--- a/src/IntField/IntFieldRepositoryInterface.php
+++ b/src/IntField/IntFieldRepositoryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+interface IntFieldRepositoryInterface
+{
+    public function findById(int $id): ?IntField;
+
+    /**
+     * Active (non-soft-deleted) rows only.
+     *
+     * @return list<IntField>
+     */
+    public function findAll(int $limit, int $offset): array;
+
+    public function save(IntField $intField): int;
+
+    public function update(IntField $intField): void;
+
+    /**
+     * Soft delete: sets is_deleted and deleted_at.
+     *
+     * @throws IntFieldNotFoundException When the id does not refer to an active row.
+     */
+    public function delete(int $id): void;
+}

--- a/src/IntField/IntFieldRouteRegistrar.php
+++ b/src/IntField/IntFieldRouteRegistrar.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class IntFieldRouteRegistrar
+{
+    public function __construct(
+        private ListIntFieldsHandler $listHandler,
+        private GetIntFieldByIdHandler $getHandler,
+        private CreateIntFieldHandler $createHandler,
+        private UpdateIntFieldHandler $updateHandler,
+        private DeleteIntFieldHandler $deleteHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $listHandler = $this->listHandler;
+        $getHandler = $this->getHandler;
+        $createHandler = $this->createHandler;
+        $updateHandler = $this->updateHandler;
+        $deleteHandler = $this->deleteHandler;
+
+        $router->get('/api/v1/int-fields', static fn (ServerRequestInterface $request) => $listHandler->handle($request));
+        $router->get('/api/v1/int-fields/{id}', static fn (ServerRequestInterface $request) => $getHandler->handle($request));
+        $router->post('/api/v1/int-fields', static fn (ServerRequestInterface $request) => $createHandler->handle($request));
+        $router->put('/api/v1/int-fields/{id}', static fn (ServerRequestInterface $request) => $updateHandler->handle($request));
+        $router->delete('/api/v1/int-fields/{id}', static fn (ServerRequestInterface $request) => $deleteHandler->handle($request));
+    }
+}

--- a/src/IntField/IntFieldServiceProvider.php
+++ b/src/IntField/IntFieldServiceProvider.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class IntFieldServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                IntFieldRepositoryInterface::class,
+                static function (ContainerInterface $container): IntFieldRepositoryInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoIntFieldRepository($query);
+                },
+            )
+            ->set(
+                CreateIntFieldUseCaseInterface::class,
+                static function (ContainerInterface $container): CreateIntFieldUseCaseInterface {
+                    $intFields = $container->get(IntFieldRepositoryInterface::class);
+                    $entities = $container->get(EntityRepositoryInterface::class);
+                    $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
+
+                    if (!$intFields instanceof IntFieldRepositoryInterface) {
+                        throw new LogicException('Int field repository service is invalid.');
+                    }
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field definition repository service is invalid.');
+                    }
+
+                    return new CreateIntFieldUseCase($intFields, $entities, $fieldDefs);
+                },
+            )
+            ->set(
+                CreateIntFieldHandler::class,
+                static function (ContainerInterface $container): CreateIntFieldHandler {
+                    $useCase = $container->get(CreateIntFieldUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof CreateIntFieldUseCaseInterface) {
+                        throw new LogicException('CreateIntField use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new CreateIntFieldHandler($useCase, $response);
+                },
+            )
+            ->set(
+                DeleteIntFieldUseCaseInterface::class,
+                static function (ContainerInterface $container): DeleteIntFieldUseCaseInterface {
+                    $repository = $container->get(IntFieldRepositoryInterface::class);
+
+                    if (!$repository instanceof IntFieldRepositoryInterface) {
+                        throw new LogicException('Int field repository service is invalid.');
+                    }
+
+                    return new DeleteIntFieldUseCase($repository);
+                },
+            )
+            ->set(
+                DeleteIntFieldHandler::class,
+                static function (ContainerInterface $container): DeleteIntFieldHandler {
+                    $useCase = $container->get(DeleteIntFieldUseCaseInterface::class);
+                    $responseFactory = $container->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof DeleteIntFieldUseCaseInterface) {
+                        throw new LogicException('DeleteIntField use case service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    return new DeleteIntFieldHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
+                GetIntFieldByIdUseCaseInterface::class,
+                static function (ContainerInterface $container): GetIntFieldByIdUseCaseInterface {
+                    $repository = $container->get(IntFieldRepositoryInterface::class);
+
+                    if (!$repository instanceof IntFieldRepositoryInterface) {
+                        throw new LogicException('Int field repository service is invalid.');
+                    }
+
+                    return new GetIntFieldByIdUseCase($repository);
+                },
+            )
+            ->set(
+                GetIntFieldByIdHandler::class,
+                static function (ContainerInterface $container): GetIntFieldByIdHandler {
+                    $useCase = $container->get(GetIntFieldByIdUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof GetIntFieldByIdUseCaseInterface) {
+                        throw new LogicException('GetIntFieldById use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new GetIntFieldByIdHandler($useCase, $response);
+                },
+            )
+            ->set(
+                ListIntFieldsUseCaseInterface::class,
+                static function (ContainerInterface $container): ListIntFieldsUseCaseInterface {
+                    $repository = $container->get(IntFieldRepositoryInterface::class);
+
+                    if (!$repository instanceof IntFieldRepositoryInterface) {
+                        throw new LogicException('Int field repository service is invalid.');
+                    }
+
+                    return new ListIntFieldsUseCase($repository);
+                },
+            )
+            ->set(
+                ListIntFieldsHandler::class,
+                static function (ContainerInterface $container): ListIntFieldsHandler {
+                    $useCase = $container->get(ListIntFieldsUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListIntFieldsUseCaseInterface) {
+                        throw new LogicException('ListIntFields use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListIntFieldsHandler($useCase, $response);
+                },
+            )
+            ->set(
+                UpdateIntFieldUseCaseInterface::class,
+                static function (ContainerInterface $container): UpdateIntFieldUseCaseInterface {
+                    $intFields = $container->get(IntFieldRepositoryInterface::class);
+                    $entities = $container->get(EntityRepositoryInterface::class);
+                    $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
+
+                    if (!$intFields instanceof IntFieldRepositoryInterface) {
+                        throw new LogicException('Int field repository service is invalid.');
+                    }
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field definition repository service is invalid.');
+                    }
+
+                    return new UpdateIntFieldUseCase($intFields, $entities, $fieldDefs);
+                },
+            )
+            ->set(
+                UpdateIntFieldHandler::class,
+                static function (ContainerInterface $container): UpdateIntFieldHandler {
+                    $useCase = $container->get(UpdateIntFieldUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof UpdateIntFieldUseCaseInterface) {
+                        throw new LogicException('UpdateIntField use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new UpdateIntFieldHandler($useCase, $response);
+                },
+            )
+            ->set(
+                IntFieldNotFoundExceptionHandler::class,
+                static function (ContainerInterface $container): IntFieldNotFoundExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new IntFieldNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                FieldKeyNotRegisteredExceptionHandler::class,
+                static function (ContainerInterface $container): FieldKeyNotRegisteredExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new FieldKeyNotRegisteredExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                FieldTypeMismatchExceptionHandler::class,
+                static function (ContainerInterface $container): FieldTypeMismatchExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new FieldTypeMismatchExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.int_field',
+                static function (ContainerInterface $container): IntFieldRouteRegistrar {
+                    $list = $container->get(ListIntFieldsHandler::class);
+                    $get = $container->get(GetIntFieldByIdHandler::class);
+                    $create = $container->get(CreateIntFieldHandler::class);
+                    $update = $container->get(UpdateIntFieldHandler::class);
+                    $delete = $container->get(DeleteIntFieldHandler::class);
+
+                    if (!$list instanceof ListIntFieldsHandler) {
+                        throw new LogicException('ListIntFields handler service is invalid.');
+                    }
+
+                    if (!$get instanceof GetIntFieldByIdHandler) {
+                        throw new LogicException('GetIntFieldById handler service is invalid.');
+                    }
+
+                    if (!$create instanceof CreateIntFieldHandler) {
+                        throw new LogicException('CreateIntField handler service is invalid.');
+                    }
+
+                    if (!$update instanceof UpdateIntFieldHandler) {
+                        throw new LogicException('UpdateIntField handler service is invalid.');
+                    }
+
+                    if (!$delete instanceof DeleteIntFieldHandler) {
+                        throw new LogicException('DeleteIntField handler service is invalid.');
+                    }
+
+                    return new IntFieldRouteRegistrar($list, $get, $create, $update, $delete);
+                },
+            );
+    }
+}

--- a/src/IntField/ListIntFieldItem.php
+++ b/src/IntField/ListIntFieldItem.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+final readonly class ListIntFieldItem
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public int $value,
+    ) {
+    }
+}

--- a/src/IntField/ListIntFieldsHandler.php
+++ b/src/IntField/ListIntFieldsHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListIntFieldsHandler
+{
+    public function __construct(
+        private ListIntFieldsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $pagination = PaginationQueryParser::parse($request);
+
+        $output = $this->useCase->execute(new ListIntFieldsInput($pagination->limit, $pagination->offset));
+
+        return $this->response->create(
+            (new PaginationResponse(
+                items: array_map(
+                    static fn (ListIntFieldItem $item) => [
+                        'id'        => $item->id,
+                        'entity_id' => $item->entityId,
+                        'field_key' => $item->fieldKey,
+                        'value'     => $item->value,
+                    ],
+                    $output->items,
+                ),
+                limit:  $output->limit,
+                offset: $output->offset,
+            ))->toArray(),
+        );
+    }
+}

--- a/src/IntField/ListIntFieldsInput.php
+++ b/src/IntField/ListIntFieldsInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+final readonly class ListIntFieldsInput
+{
+    public function __construct(
+        public int $limit = 20,
+        public int $offset = 0,
+    ) {
+    }
+}

--- a/src/IntField/ListIntFieldsOutput.php
+++ b/src/IntField/ListIntFieldsOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+final readonly class ListIntFieldsOutput
+{
+    /** @param list<ListIntFieldItem> $items */
+    public function __construct(
+        public array $items,
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/IntField/ListIntFieldsUseCase.php
+++ b/src/IntField/ListIntFieldsUseCase.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+final readonly class ListIntFieldsUseCase implements ListIntFieldsUseCaseInterface
+{
+    public function __construct(
+        private IntFieldRepositoryInterface $intFields,
+    ) {
+    }
+
+    public function execute(ListIntFieldsInput $input): ListIntFieldsOutput
+    {
+        $rows = $this->intFields->findAll($input->limit, $input->offset);
+
+        $items = array_map(
+            static fn (IntField $field) => new ListIntFieldItem(
+                id: (int) $field->id,
+                entityId: $field->entityId,
+                fieldKey: $field->fieldKey,
+                value: $field->value,
+            ),
+            $rows,
+        );
+
+        return new ListIntFieldsOutput(
+            items: $items,
+            limit: $input->limit,
+            offset: $input->offset,
+        );
+    }
+}

--- a/src/IntField/ListIntFieldsUseCaseInterface.php
+++ b/src/IntField/ListIntFieldsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+interface ListIntFieldsUseCaseInterface
+{
+    public function execute(ListIntFieldsInput $input): ListIntFieldsOutput;
+}

--- a/src/IntField/PdoIntFieldRepository.php
+++ b/src/IntField/PdoIntFieldRepository.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoIntFieldRepository implements IntFieldRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?IntField
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, entity_id, field_key, value FROM int_fields WHERE id = ? AND is_deleted = 0',
+            [$id],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return new IntField(
+            entityId: (int) $row['entity_id'],
+            fieldKey: (string) $row['field_key'],
+            value: (int) $row['value'],
+            id: (int) $row['id'],
+        );
+    }
+
+    /** @return list<IntField> */
+    public function findAll(int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, entity_id, field_key, value FROM int_fields WHERE is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$limit, $offset],
+        );
+
+        return array_map(
+            static fn (array $row) => new IntField(
+                entityId: (int) $row['entity_id'],
+                fieldKey: (string) $row['field_key'],
+                value: (int) $row['value'],
+                id: (int) $row['id'],
+            ),
+            $rows,
+        );
+    }
+
+    public function save(IntField $intField): int
+    {
+        $this->query->execute(
+            'INSERT INTO int_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$intField->entityId, $intField->fieldKey, $intField->value],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function update(IntField $intField): void
+    {
+        if ($intField->id === null) {
+            throw new LogicException('IntField id is required when updating.');
+        }
+
+        $affected = $this->query->execute(
+            'UPDATE int_fields SET field_key = ?, value = ? WHERE id = ? AND is_deleted = 0',
+            [$intField->fieldKey, $intField->value, $intField->id],
+        );
+
+        if ($affected === 0) {
+            throw new IntFieldNotFoundException($intField->id);
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        $affected = $this->query->execute(
+            'UPDATE int_fields SET is_deleted = 1, deleted_at = CURRENT_TIMESTAMP WHERE id = ? AND is_deleted = 0',
+            [$id],
+        );
+
+        if ($affected === 0) {
+            throw new IntFieldNotFoundException($id);
+        }
+    }
+}

--- a/src/IntField/UpdateIntFieldHandler.php
+++ b/src/IntField/UpdateIntFieldHandler.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateIntFieldHandler
+{
+    public function __construct(
+        private UpdateIntFieldUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new IntFieldNotFoundException($id);
+        }
+
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+
+        $fieldKey = trim((string) ($body['field_key'] ?? ''));
+
+        if ($fieldKey === '') {
+            $errors[] = new ValidationError('field_key', 'Field key is required.', 'required');
+        }
+
+        if (!array_key_exists('value', $body)) {
+            $errors[] = new ValidationError('value', 'Value is required.', 'required');
+        } elseif (!is_int($body['value'])) {
+            $errors[] = new ValidationError('value', 'Value must be an integer.', 'invalid');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        /** @var int $value */
+        $value = $body['value'];
+
+        $output = $this->useCase->execute(new UpdateIntFieldInput(id: $id, fieldKey: $fieldKey, value: $value));
+
+        return $this->response->create([
+            'id'        => $output->id,
+            'entity_id' => $output->entityId,
+            'field_key' => $output->fieldKey,
+            'value'     => $output->value,
+        ]);
+    }
+}

--- a/src/IntField/UpdateIntFieldInput.php
+++ b/src/IntField/UpdateIntFieldInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+final readonly class UpdateIntFieldInput
+{
+    public function __construct(
+        public int $id,
+        public string $fieldKey,
+        public int $value,
+    ) {
+    }
+}

--- a/src/IntField/UpdateIntFieldOutput.php
+++ b/src/IntField/UpdateIntFieldOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+final readonly class UpdateIntFieldOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public int $value,
+    ) {
+    }
+}

--- a/src/IntField/UpdateIntFieldUseCase.php
+++ b/src/IntField/UpdateIntFieldUseCase.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+
+final readonly class UpdateIntFieldUseCase implements UpdateIntFieldUseCaseInterface
+{
+    private const INT_DATA_TYPE = 'int';
+
+    public function __construct(
+        private IntFieldRepositoryInterface $intFields,
+        private EntityRepositoryInterface $entities,
+        private FieldDefRepositoryInterface $fieldDefs,
+    ) {
+    }
+
+    public function execute(UpdateIntFieldInput $input): UpdateIntFieldOutput
+    {
+        $existing = $this->intFields->findById($input->id);
+
+        if ($existing === null) {
+            throw new IntFieldNotFoundException($input->id);
+        }
+
+        $entity = $this->entities->findById($existing->entityId);
+
+        if ($entity === null) {
+            throw new EntityNotFoundException($existing->entityId);
+        }
+
+        $this->assertIntFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
+
+        $updated = new IntField(
+            entityId: $existing->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+            id: $input->id,
+        );
+        $this->intFields->update($updated);
+
+        return new UpdateIntFieldOutput(
+            id: $input->id,
+            entityId: $existing->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+        );
+    }
+
+    private function assertIntFieldKeyRegistered(int $entityTypeId, string $fieldKey): void
+    {
+        $fieldDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($entityTypeId, $fieldKey);
+
+        if ($fieldDef === null) {
+            throw new FieldKeyNotRegisteredException($entityTypeId, $fieldKey);
+        }
+
+        if ($fieldDef->dataType !== self::INT_DATA_TYPE) {
+            throw new FieldTypeMismatchException($fieldKey, self::INT_DATA_TYPE, $fieldDef->dataType);
+        }
+    }
+}

--- a/src/IntField/UpdateIntFieldUseCaseInterface.php
+++ b/src/IntField/UpdateIntFieldUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\IntField;
+
+interface UpdateIntFieldUseCaseInterface
+{
+    /**
+     * @throws IntFieldNotFoundException when no int field matches the given id.
+     */
+    public function execute(UpdateIntFieldInput $input): UpdateIntFieldOutput;
+}

--- a/tests/FieldDef/FieldDefHttpTest.php
+++ b/tests/FieldDef/FieldDefHttpTest.php
@@ -127,6 +127,45 @@ final class FieldDefHttpTest extends TestCase
         self::assertStringEndsWith('not-found', (string) $payload['type']);
     }
 
+    public function testPostFieldDefWithIntDataTypeCreatesDefinition(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Article', slug: 'article'));
+
+        $body = $this->factory->createStream(json_encode([
+            'entity_type_id' => $typeId,
+            'field_key' => 'count',
+            'data_type' => 'int',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/field-defs')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame('count', $payload['field_key']);
+        self::assertSame('int', $payload['data_type']);
+    }
+
+    public function testPostInvalidDataTypeReturns422(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Article', slug: 'article'));
+
+        $body = $this->factory->createStream(json_encode([
+            'entity_type_id' => $typeId,
+            'field_key' => 'score',
+            'data_type' => 'float',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/field-defs')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringEndsWith('validation-failed', (string) $payload['type']);
+    }
+
     public function testGetFieldDefByIdReturnsDefinition(): void
     {
         $typeId = $this->entityTypes->save(new EntityType(name: 'Article', slug: 'article'));

--- a/tests/IntField/CreateIntFieldUseCaseTest.php
+++ b/tests/IntField/CreateIntFieldUseCaseTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\IntField;
+
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\IntField\CreateIntFieldInput;
+use NeNeRecords\IntField\CreateIntFieldUseCase;
+use NeNeRecords\IntField\FieldKeyNotRegisteredException;
+use NeNeRecords\IntField\FieldTypeMismatchException;
+use NeNeRecords\IntField\IntField;
+use NeNeRecords\IntField\UpdateIntFieldInput;
+use NeNeRecords\IntField\UpdateIntFieldUseCase;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use PHPUnit\Framework\TestCase;
+
+final class CreateIntFieldUseCaseTest extends TestCase
+{
+    public function testReturnsOutputWithNewId(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 99));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 99, fieldKey: 'count', dataType: 'int', id: 1),
+        ]);
+
+        $intFields = new InMemoryIntFieldRepository([]);
+        $useCase = new CreateIntFieldUseCase($intFields, $entities, $fieldDefs);
+
+        $output = $useCase->execute(new CreateIntFieldInput(entityId: $entityId, fieldKey: 'count', value: 42));
+
+        self::assertSame(1, $output->id);
+        self::assertSame($entityId, $output->entityId);
+        self::assertSame('count', $output->fieldKey);
+        self::assertSame(42, $output->value);
+    }
+
+    public function testAssignsSequentialIds(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'a', dataType: 'int', id: 1),
+            new FieldDef(entityTypeId: 1, fieldKey: 'b', dataType: 'int', id: 2),
+        ]);
+
+        $intFields = new InMemoryIntFieldRepository([]);
+        $useCase = new CreateIntFieldUseCase($intFields, $entities, $fieldDefs);
+
+        $first = $useCase->execute(new CreateIntFieldInput(entityId: $entityId, fieldKey: 'a', value: 1));
+        $second = $useCase->execute(new CreateIntFieldInput(entityId: $entityId, fieldKey: 'b', value: 2));
+
+        self::assertSame(1, $first->id);
+        self::assertSame(2, $second->id);
+    }
+
+    public function testThrowsFieldKeyNotRegisteredExceptionWhenFieldDefAbsent(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([]);
+        $intFields = new InMemoryIntFieldRepository([]);
+        $useCase = new CreateIntFieldUseCase($intFields, $entities, $fieldDefs);
+
+        $this->expectException(FieldKeyNotRegisteredException::class);
+
+        $useCase->execute(new CreateIntFieldInput(entityId: $entityId, fieldKey: 'count', value: 1));
+    }
+
+    public function testThrowsFieldTypeMismatchExceptionWhenDataTypeIsNotInt(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'title', dataType: 'text', id: 1),
+        ]);
+
+        $intFields = new InMemoryIntFieldRepository([]);
+        $useCase = new CreateIntFieldUseCase($intFields, $entities, $fieldDefs);
+
+        $this->expectException(FieldTypeMismatchException::class);
+
+        $useCase->execute(new CreateIntFieldInput(entityId: $entityId, fieldKey: 'title', value: 1));
+    }
+}
+
+final class UpdateIntFieldUseCaseTest extends TestCase
+{
+    public function testThrowsFieldKeyNotRegisteredExceptionWhenUpdatedKeyIsUnregistered(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'count', dataType: 'int', id: 1),
+        ]);
+
+        $intFields = new InMemoryIntFieldRepository([]);
+        $intFields->save(new IntField(entityId: $entityId, fieldKey: 'count', value: 10, id: null));
+
+        $useCase = new UpdateIntFieldUseCase($intFields, $entities, $fieldDefs);
+
+        $this->expectException(FieldKeyNotRegisteredException::class);
+
+        $useCase->execute(new UpdateIntFieldInput(id: 1, fieldKey: 'body', value: 20));
+    }
+}

--- a/tests/IntField/InMemoryIntFieldRepository.php
+++ b/tests/IntField/InMemoryIntFieldRepository.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\IntField;
+
+use NeNeRecords\IntField\IntField;
+use NeNeRecords\IntField\IntFieldNotFoundException;
+use NeNeRecords\IntField\IntFieldRepositoryInterface;
+
+final class InMemoryIntFieldRepository implements IntFieldRepositoryInterface
+{
+    /** @var array<int, IntField> */
+    private array $fields;
+
+    /** @var array<int, true> */
+    private array $deletedIds;
+
+    private int $nextId;
+
+    /** @param list<IntField> $seed */
+    public function __construct(array $seed = [])
+    {
+        $this->fields = [];
+        $this->deletedIds = [];
+        $this->nextId = 1;
+
+        foreach ($seed as $textField) {
+            $id = $textField->id;
+            if ($id !== null) {
+                $this->fields[$id] = $textField;
+                $this->nextId = max($this->nextId, $id + 1);
+            }
+        }
+    }
+
+    public function findById(int $id): ?IntField
+    {
+        if (isset($this->deletedIds[$id])) {
+            return null;
+        }
+
+        return $this->fields[$id] ?? null;
+    }
+
+    /** @return list<IntField> */
+    public function findAll(int $limit, int $offset): array
+    {
+        $active = [];
+
+        foreach ($this->fields as $id => $textField) {
+            if (!isset($this->deletedIds[$id])) {
+                $active[] = $textField;
+            }
+        }
+
+        usort($active, static fn (IntField $a, IntField $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
+
+        return array_slice($active, $offset, $limit);
+    }
+
+    public function save(IntField $intField): int
+    {
+        $id = $this->nextId++;
+        $this->fields[$id] = new IntField(
+            entityId: $intField->entityId,
+            fieldKey: $intField->fieldKey,
+            value: $intField->value,
+            id: $id,
+        );
+
+        return $id;
+    }
+
+    public function update(IntField $intField): void
+    {
+        $id = $intField->id;
+
+        if ($id === null) {
+            return;
+        }
+
+        if ($this->findById($id) === null) {
+            throw new IntFieldNotFoundException($id);
+        }
+
+        $this->fields[$id] = $intField;
+    }
+
+    public function delete(int $id): void
+    {
+        if (!isset($this->fields[$id]) || isset($this->deletedIds[$id])) {
+            throw new IntFieldNotFoundException($id);
+        }
+
+        unset($this->fields[$id]);
+        $this->deletedIds[$id] = true;
+    }
+}

--- a/tests/IntField/IntFieldHttpTest.php
+++ b/tests/IntField/IntFieldHttpTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\IntField;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Entity\CreateEntityHandler;
+use NeNeRecords\Entity\CreateEntityUseCase;
+use NeNeRecords\Entity\DeleteEntityHandler;
+use NeNeRecords\Entity\DeleteEntityUseCase;
+use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
+use NeNeRecords\Entity\EntityRouteRegistrar;
+use NeNeRecords\Entity\GetEntityByIdHandler;
+use NeNeRecords\Entity\GetEntityByIdUseCase;
+use NeNeRecords\Entity\ListEntitiesHandler;
+use NeNeRecords\Entity\ListEntitiesUseCase;
+use NeNeRecords\Entity\UpdateEntityHandler;
+use NeNeRecords\Entity\UpdateEntityUseCase;
+use NeNeRecords\EntityType\EntityType;
+use NeNeRecords\EntityType\EntityTypeNotFoundExceptionHandler;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\IntField\CreateIntFieldHandler;
+use NeNeRecords\IntField\CreateIntFieldUseCase;
+use NeNeRecords\IntField\DeleteIntFieldHandler;
+use NeNeRecords\IntField\DeleteIntFieldUseCase;
+use NeNeRecords\IntField\FieldKeyNotRegisteredExceptionHandler;
+use NeNeRecords\IntField\FieldTypeMismatchExceptionHandler;
+use NeNeRecords\IntField\GetIntFieldByIdHandler;
+use NeNeRecords\IntField\GetIntFieldByIdUseCase;
+use NeNeRecords\IntField\IntFieldNotFoundExceptionHandler;
+use NeNeRecords\IntField\IntFieldRouteRegistrar;
+use NeNeRecords\IntField\ListIntFieldsHandler;
+use NeNeRecords\IntField\ListIntFieldsUseCase;
+use NeNeRecords\IntField\UpdateIntFieldHandler;
+use NeNeRecords\IntField\UpdateIntFieldUseCase;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class IntFieldHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryEntityTypeRepository $entityTypes;
+    private InMemoryEntityRepository $entities;
+    private InMemoryFieldDefRepository $fieldDefs;
+    private InMemoryIntFieldRepository $intFields;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->entityTypes = new InMemoryEntityTypeRepository();
+        $this->entities = new InMemoryEntityRepository();
+        $this->fieldDefs = new InMemoryFieldDefRepository();
+        $this->intFields = new InMemoryIntFieldRepository();
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+
+        $entityRegistrar = new EntityRouteRegistrar(
+            new GetEntityByIdHandler(new GetEntityByIdUseCase($this->entities), $jsonResponse),
+            new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
+            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
+            new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse),
+        );
+
+        $intFieldRegistrar = new IntFieldRouteRegistrar(
+            new ListIntFieldsHandler(new ListIntFieldsUseCase($this->intFields), $jsonResponse),
+            new GetIntFieldByIdHandler(new GetIntFieldByIdUseCase($this->intFields), $jsonResponse),
+            new CreateIntFieldHandler(new CreateIntFieldUseCase($this->intFields, $this->entities, $this->fieldDefs), $jsonResponse),
+            new UpdateIntFieldHandler(new UpdateIntFieldUseCase($this->intFields, $this->entities, $this->fieldDefs), $jsonResponse),
+            new DeleteIntFieldHandler(new DeleteIntFieldUseCase($this->intFields), $this->factory),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [
+                new EntityTypeNotFoundExceptionHandler($problemDetails),
+                new EntityNotFoundExceptionHandler($problemDetails),
+                new IntFieldNotFoundExceptionHandler($problemDetails),
+                new FieldKeyNotRegisteredExceptionHandler($problemDetails),
+                new FieldTypeMismatchExceptionHandler($problemDetails),
+            ],
+            routeRegistrars: [$entityRegistrar, $intFieldRegistrar],
+        ))->create();
+    }
+
+    public function testPostIntFieldCreatesFieldAndReturns201WithLocation(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'title', dataType: 'int'));
+
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        self::assertSame(201, $entityResponse->getStatusCode());
+        $createdEntity = $this->decodeJson($entityResponse);
+        $entityId = (int) $createdEntity['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'title',
+            'value' => 42,
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/int-fields')->withBody($bodyTf),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertStringStartsWith('/api/v1/int-fields/', $response->getHeaderLine('Location'));
+        self::assertSame($entityId, $payload['entity_id']);
+        self::assertSame('title', $payload['field_key']);
+        self::assertSame(42, $payload['value']);
+    }
+
+    public function testPostUnregisteredFieldKeyReturns422(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        $entityId = (int) $this->decodeJson($entityResponse)['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'title',
+            'value' => 42,
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/int-fields')->withBody($bodyTf),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringEndsWith('field-key-not-registered', (string) $payload['type']);
+    }
+
+    public function testPostMismatchedFieldTypeReturns422(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'count', dataType: 'text'));
+
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        $entityId = (int) $this->decodeJson($entityResponse)['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'count',
+            'value' => 1,
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/int-fields')->withBody($bodyTf),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringEndsWith('field-type-mismatch', (string) $payload['type']);
+    }
+
+    public function testAfterDeleteGetIntFieldReturns404(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'body', dataType: 'int'));
+
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        $entityId = (int) $this->decodeJson($entityResponse)['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'body',
+            'value' => 99,
+        ], JSON_THROW_ON_ERROR));
+
+        $createTf = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/int-fields')->withBody($bodyTf),
+        );
+        self::assertSame(201, $createTf->getStatusCode());
+        $id = (int) $this->decodeJson($createTf)['id'];
+
+        $getBefore = $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/int-fields/{$id}"),
+        );
+        self::assertSame(200, $getBefore->getStatusCode());
+
+        $del = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', "https://example.test/api/v1/int-fields/{$id}"),
+        );
+        self::assertSame(204, $del->getStatusCode());
+
+        $getAfter = $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/int-fields/{$id}"),
+        );
+        $payload = $this->decodeJson($getAfter);
+
+        self::assertSame(404, $getAfter->getStatusCode());
+        self::assertStringEndsWith('not-found', (string) $payload['type']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/tests/IntField/PdoIntFieldRepositoryTest.php
+++ b/tests/IntField/PdoIntFieldRepositoryTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\IntField;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeNeRecords\IntField\IntField;
+use NeNeRecords\IntField\IntFieldNotFoundException;
+use NeNeRecords\IntField\PdoIntFieldRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PdoIntFieldRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene-records-test',
+            '',
+            'utf8',
+        )));
+
+        $this->executor->execute('PRAGMA foreign_keys = ON');
+
+        foreach ($this->schemaStatements() as $statement) {
+            $this->executor->execute($statement);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function schemaStatements(): array
+    {
+        $projectRoot = dirname(__DIR__, 2);
+        $paths = [
+            $projectRoot . '/database/schema/entity_types.sql',
+            $projectRoot . '/database/schema/entities.sql',
+            $projectRoot . '/database/schema/int_fields.sql',
+        ];
+
+        $statements = [];
+
+        foreach ($paths as $path) {
+            self::assertFileExists($path);
+            $raw = trim((string) file_get_contents($path));
+            foreach (preg_split('/;\R/s', $raw) ?: [] as $chunk) {
+                $statement = trim($chunk);
+                if ($statement !== '') {
+                    $statements[] = $statement;
+                }
+            }
+        }
+
+        return $statements;
+    }
+
+    /** @return array{entityTypeId: int, entityId: int} */
+    private function insertEntityHierarchy(): array
+    {
+        $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('Base', 'base')");
+        $entityTypeId = $this->executor->lastInsertId();
+
+        $this->executor->execute('INSERT INTO entities (entity_type_id) VALUES (?)', [$entityTypeId]);
+        $entityId = $this->executor->lastInsertId();
+
+        return ['entityTypeId' => $entityTypeId, 'entityId' => $entityId];
+    }
+
+    public function testFindByIdReturnsIntField(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $this->executor->execute(
+            'INSERT INTO int_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$ids['entityId'], 'count', 42],
+        );
+
+        $repository = new PdoIntFieldRepository($this->executor);
+        $intField = $repository->findById(1);
+
+        self::assertNotNull($intField);
+        self::assertSame(1, $intField->id);
+        self::assertSame($ids['entityId'], $intField->entityId);
+        self::assertSame('count', $intField->fieldKey);
+        self::assertSame(42, $intField->value);
+    }
+
+    public function testFindByIdReturnsNullAfterSoftDelete(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $this->executor->execute(
+            'INSERT INTO int_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$ids['entityId'], 'count', 7],
+        );
+
+        $repository = new PdoIntFieldRepository($this->executor);
+        $repository->delete(1);
+
+        self::assertNull($repository->findById(1));
+    }
+
+    public function testSaveReturnsNewId(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $repository = new PdoIntFieldRepository($this->executor);
+        $id = $repository->save(new IntField(entityId: $ids['entityId'], fieldKey: 'k', value: 3));
+
+        self::assertSame(1, $id);
+    }
+
+    public function testUpdateThrowsWhenRowIsSoftDeleted(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $this->executor->execute(
+            'INSERT INTO int_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$ids['entityId'], 'count', 1],
+        );
+
+        $repository = new PdoIntFieldRepository($this->executor);
+        $repository->delete(1);
+
+        $this->expectException(IntFieldNotFoundException::class);
+
+        $repository->update(new IntField(entityId: $ids['entityId'], fieldKey: 'count', value: 2, id: 1));
+    }
+
+    public function testFindAllExcludesDeleted(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $repository = new PdoIntFieldRepository($this->executor);
+
+        $repository->save(new IntField(entityId: $ids['entityId'], fieldKey: 'a', value: 1));
+        $b = $repository->save(new IntField(entityId: $ids['entityId'], fieldKey: 'b', value: 2));
+
+        $repository->delete($b);
+
+        $list = $repository->findAll(10, 0);
+
+        self::assertCount(1, $list);
+        self::assertSame('a', $list[0]->fieldKey);
+    }
+}


### PR DESCRIPTION
## Summary

- **`int_fields`** テーブル + CRUD at `/api/v1/int-fields`
- **FieldDef** — `data_type` に `int` を追加
- IntField create/update で field_defs 検証（ADR 0002 同様）
- OpenAPI + tests（**73 tests**）

## Test plan

- [x] `composer check` green

## Self-review

`Self-review: backend-api, openapi-contract, database`

Closes #11


Made with [Cursor](https://cursor.com)