### PR TITLE
feat(api): enum/bool/datetime フィールド CRUD (#14)

### DIFF
--- a/database/migrations/20260524000005_create_enum_fields_table.php
+++ b/database/migrations/20260524000005_create_enum_fields_table.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateEnumFieldsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('enum_fields')
+            ->addColumn('entity_id', 'integer', ['null' => false, 'signed' => false])
+            ->addColumn('field_key', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('value', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('is_deleted', 'boolean', ['default' => false, 'null' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true, 'default' => null])
+            ->addIndex(['entity_id'])
+            ->addForeignKey('entity_id', 'entities', 'id', ['delete' => 'RESTRICT', 'update' => 'NO_ACTION'])
+            ->create();
+    }
+}

--- a/database/migrations/20260524000006_create_bool_fields_table.php
+++ b/database/migrations/20260524000006_create_bool_fields_table.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateBoolFieldsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('bool_fields')
+            ->addColumn('entity_id', 'integer', ['null' => false, 'signed' => false])
+            ->addColumn('field_key', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('value', 'boolean', ['null' => false])
+            ->addColumn('is_deleted', 'boolean', ['default' => false, 'null' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true, 'default' => null])
+            ->addIndex(['entity_id'])
+            ->addForeignKey('entity_id', 'entities', 'id', ['delete' => 'RESTRICT', 'update' => 'NO_ACTION'])
+            ->create();
+    }
+}

--- a/database/migrations/20260524000007_create_datetime_fields_table.php
+++ b/database/migrations/20260524000007_create_datetime_fields_table.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateDateTimeFieldsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('datetime_fields')
+            ->addColumn('entity_id', 'integer', ['null' => false, 'signed' => false])
+            ->addColumn('field_key', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('value', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('is_deleted', 'boolean', ['default' => false, 'null' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true, 'default' => null])
+            ->addIndex(['entity_id'])
+            ->addForeignKey('entity_id', 'entities', 'id', ['delete' => 'RESTRICT', 'update' => 'NO_ACTION'])
+            ->create();
+    }
+}

--- a/database/schema/bool_fields.sql
+++ b/database/schema/bool_fields.sql
@@ -1,0 +1,10 @@
+CREATE TABLE bool_fields (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_id INTEGER UNSIGNED NOT NULL,
+    field_key VARCHAR(255) NOT NULL,
+    value BOOLEAN NOT NULL,
+    is_deleted BOOLEAN NOT NULL DEFAULT 0,
+    deleted_at DATETIME NULL,
+    FOREIGN KEY (entity_id) REFERENCES entities (id) ON DELETE RESTRICT ON UPDATE NO ACTION
+);
+CREATE INDEX bool_fields_entity_id ON bool_fields (entity_id);

--- a/database/schema/datetime_fields.sql
+++ b/database/schema/datetime_fields.sql
@@ -1,0 +1,10 @@
+CREATE TABLE datetime_fields (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_id INTEGER UNSIGNED NOT NULL,
+    field_key VARCHAR(255) NOT NULL,
+    value VARCHAR(64) NOT NULL,
+    is_deleted BOOLEAN NOT NULL DEFAULT 0,
+    deleted_at DATETIME NULL,
+    FOREIGN KEY (entity_id) REFERENCES entities (id) ON DELETE RESTRICT ON UPDATE NO ACTION
+);
+CREATE INDEX datetime_fields_entity_id ON datetime_fields (entity_id);

--- a/database/schema/enum_fields.sql
+++ b/database/schema/enum_fields.sql
@@ -1,0 +1,10 @@
+CREATE TABLE enum_fields (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_id INTEGER UNSIGNED NOT NULL,
+    field_key VARCHAR(255) NOT NULL,
+    value VARCHAR(255) NOT NULL,
+    is_deleted BOOLEAN NOT NULL DEFAULT 0,
+    deleted_at DATETIME NULL,
+    FOREIGN KEY (entity_id) REFERENCES entities (id) ON DELETE RESTRICT ON UPDATE NO ACTION
+);
+CREATE INDEX enum_fields_entity_id ON enum_fields (entity_id);

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: NeNe Records API
   version: 0.1.0
   description: >
-    NeNe Records public API contract — entity_types, field_defs, entities, text_fields, and int_fields CRUD (MVP + Phase 2 registry).
+    NeNe Records public API contract — entity_types, field_defs, entities, text_fields, int_fields, enum_fields, bool_fields, and datetime_fields CRUD (MVP + Phase 2 registry).
 servers:
   - url: http://localhost:8080
     description: Local development server
@@ -20,6 +20,12 @@ tags:
     description: Typed text field values on entities.
   - name: IntFields
     description: Typed integer field values on entities.
+  - name: EnumFields
+    description: Typed enum field values on entities.
+  - name: BoolFields
+    description: Typed boolean field values on entities.
+  - name: DateTimeFields
+    description: Typed datetime field values on entities.
 paths:
   /health:
     get:
@@ -786,6 +792,471 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/enum-fields:
+    get:
+      tags:
+        - EnumFields
+      summary: List enum fields
+      description: Returns non-deleted enum fields.
+      operationId: listEnumFields
+      parameters:
+        - $ref: '#/components/parameters/LimitQuery'
+        - $ref: '#/components/parameters/OffsetQuery'
+      responses:
+        '200':
+          description: Paginated enum field list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnumFieldListResponse'
+              examples:
+                ok:
+                  summary: Empty list
+                  value:
+                    items: []
+                    limit: 20
+                    offset: 0
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - EnumFields
+      summary: Create enum field
+      operationId: createEnumField
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateEnumFieldRequest'
+            examples:
+              ok:
+                value:
+                  entity_id: 1
+                  field_key: status
+                  value: active
+      responses:
+        '201':
+          description: Enum field created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnumFieldResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_id: 1
+                    field_key: status
+                    value: active
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: Validation failed, unregistered field key, or field type mismatch.
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ValidationProblemDetails'
+                  - $ref: '#/components/schemas/ProblemDetails'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/enum-fields/{id}:
+    get:
+      tags:
+        - EnumFields
+      summary: Get enum field by id
+      operationId: getEnumFieldById
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      responses:
+        '200':
+          description: Enum field found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnumFieldResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_id: 1
+                    field_key: status
+                    value: active
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      tags:
+        - EnumFields
+      summary: Update enum field
+      operationId: updateEnumField
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateEnumFieldRequest'
+            examples:
+              ok:
+                value:
+                  field_key: status
+                  value: inactive
+      responses:
+        '200':
+          description: Enum field updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnumFieldResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_id: 1
+                    field_key: status
+                    value: inactive
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: Validation failed, unregistered field key, or field type mismatch.
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ValidationProblemDetails'
+                  - $ref: '#/components/schemas/ProblemDetails'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - EnumFields
+      summary: Soft delete enum field
+      operationId: deleteEnumField
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      responses:
+        '204':
+          description: Enum field soft-deleted.
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/bool-fields:
+    get:
+      tags:
+        - BoolFields
+      summary: List bool fields
+      description: Returns non-deleted bool fields.
+      operationId: listBoolFields
+      parameters:
+        - $ref: '#/components/parameters/LimitQuery'
+        - $ref: '#/components/parameters/OffsetQuery'
+      responses:
+        '200':
+          description: Paginated bool field list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BoolFieldListResponse'
+              examples:
+                ok:
+                  summary: Empty list
+                  value:
+                    items: []
+                    limit: 20
+                    offset: 0
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - BoolFields
+      summary: Create bool field
+      operationId: createBoolField
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateBoolFieldRequest'
+            examples:
+              ok:
+                value:
+                  entity_id: 1
+                  field_key: enabled
+                  value: true
+      responses:
+        '201':
+          description: Bool field created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BoolFieldResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_id: 1
+                    field_key: enabled
+                    value: true
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: Validation failed, unregistered field key, or field type mismatch.
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ValidationProblemDetails'
+                  - $ref: '#/components/schemas/ProblemDetails'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/bool-fields/{id}:
+    get:
+      tags:
+        - BoolFields
+      summary: Get bool field by id
+      operationId: getBoolFieldById
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      responses:
+        '200':
+          description: Bool field found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BoolFieldResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_id: 1
+                    field_key: enabled
+                    value: true
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      tags:
+        - BoolFields
+      summary: Update bool field
+      operationId: updateBoolField
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateBoolFieldRequest'
+            examples:
+              ok:
+                value:
+                  field_key: enabled
+                  value: false
+      responses:
+        '200':
+          description: Bool field updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BoolFieldResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_id: 1
+                    field_key: enabled
+                    value: false
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: Validation failed, unregistered field key, or field type mismatch.
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ValidationProblemDetails'
+                  - $ref: '#/components/schemas/ProblemDetails'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - BoolFields
+      summary: Soft delete bool field
+      operationId: deleteBoolField
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      responses:
+        '204':
+          description: Bool field soft-deleted.
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/datetime-fields:
+    get:
+      tags:
+        - DateTimeFields
+      summary: List datetime fields
+      description: Returns non-deleted datetime fields.
+      operationId: listDateTimeFields
+      parameters:
+        - $ref: '#/components/parameters/LimitQuery'
+        - $ref: '#/components/parameters/OffsetQuery'
+      responses:
+        '200':
+          description: Paginated datetime field list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DateTimeFieldListResponse'
+              examples:
+                ok:
+                  summary: Empty list
+                  value:
+                    items: []
+                    limit: 20
+                    offset: 0
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - DateTimeFields
+      summary: Create datetime field
+      operationId: createDateTimeField
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDateTimeFieldRequest'
+            examples:
+              ok:
+                value:
+                  entity_id: 1
+                  field_key: published_at
+                  value: 2026-05-24T12:00:00+00:00
+      responses:
+        '201':
+          description: Datetime field created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DateTimeFieldResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_id: 1
+                    field_key: published_at
+                    value: 2026-05-24T12:00:00+00:00
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: Validation failed, unregistered field key, or field type mismatch.
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ValidationProblemDetails'
+                  - $ref: '#/components/schemas/ProblemDetails'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/datetime-fields/{id}:
+    get:
+      tags:
+        - DateTimeFields
+      summary: Get datetime field by id
+      operationId: getDateTimeFieldById
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      responses:
+        '200':
+          description: Datetime field found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DateTimeFieldResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_id: 1
+                    field_key: published_at
+                    value: 2026-05-24T12:00:00+00:00
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      tags:
+        - DateTimeFields
+      summary: Update datetime field
+      operationId: updateDateTimeField
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateDateTimeFieldRequest'
+            examples:
+              ok:
+                value:
+                  field_key: published_at
+                  value: 2026-05-25T12:00:00+00:00
+      responses:
+        '200':
+          description: Datetime field updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DateTimeFieldResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_id: 1
+                    field_key: published_at
+                    value: 2026-05-25T12:00:00+00:00
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: Validation failed, unregistered field key, or field type mismatch.
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ValidationProblemDetails'
+                  - $ref: '#/components/schemas/ProblemDetails'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - DateTimeFields
+      summary: Soft delete datetime field
+      operationId: deleteDateTimeField
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      responses:
+        '204':
+          description: Datetime field soft-deleted.
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   parameters:
     IdPath:
@@ -1120,6 +1591,9 @@ components:
           enum:
             - text
             - int
+            - enum
+            - bool
+            - datetime
     CreateFieldDefRequest:
       type: object
       required:
@@ -1139,6 +1613,9 @@ components:
           enum:
             - text
             - int
+            - enum
+            - bool
+            - datetime
       additionalProperties: false
     UpdateFieldDefRequest:
       $ref: '#/components/schemas/CreateFieldDefRequest'
@@ -1280,6 +1757,198 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/IntFieldResponse'
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    EnumFieldResponse:
+      type: object
+      required:
+        - id
+        - entity_id
+        - field_key
+        - value
+      properties:
+        id:
+          type: integer
+          format: int64
+        entity_id:
+          type: integer
+          format: int64
+        field_key:
+          type: string
+        value:
+          type: string
+    CreateEnumFieldRequest:
+      type: object
+      required:
+        - entity_id
+        - field_key
+        - value
+      properties:
+        entity_id:
+          type: integer
+          format: int64
+          minimum: 1
+        field_key:
+          type: string
+          minLength: 1
+        value:
+          type: string
+      additionalProperties: false
+    UpdateEnumFieldRequest:
+      type: object
+      required:
+        - field_key
+        - value
+      properties:
+        field_key:
+          type: string
+          minLength: 1
+        value:
+          type: string
+      additionalProperties: false
+    EnumFieldListResponse:
+      type: object
+      required:
+        - items
+        - limit
+        - offset
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/EnumFieldResponse'
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    BoolFieldResponse:
+      type: object
+      required:
+        - id
+        - entity_id
+        - field_key
+        - value
+      properties:
+        id:
+          type: integer
+          format: int64
+        entity_id:
+          type: integer
+          format: int64
+        field_key:
+          type: string
+        value:
+          type: boolean
+    CreateBoolFieldRequest:
+      type: object
+      required:
+        - entity_id
+        - field_key
+        - value
+      properties:
+        entity_id:
+          type: integer
+          format: int64
+          minimum: 1
+        field_key:
+          type: string
+          minLength: 1
+        value:
+          type: boolean
+      additionalProperties: false
+    UpdateBoolFieldRequest:
+      type: object
+      required:
+        - field_key
+        - value
+      properties:
+        field_key:
+          type: string
+          minLength: 1
+        value:
+          type: boolean
+      additionalProperties: false
+    BoolFieldListResponse:
+      type: object
+      required:
+        - items
+        - limit
+        - offset
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/BoolFieldResponse'
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    DateTimeFieldResponse:
+      type: object
+      required:
+        - id
+        - entity_id
+        - field_key
+        - value
+      properties:
+        id:
+          type: integer
+          format: int64
+        entity_id:
+          type: integer
+          format: int64
+        field_key:
+          type: string
+        value:
+          type: string
+          format: date-time
+    CreateDateTimeFieldRequest:
+      type: object
+      required:
+        - entity_id
+        - field_key
+        - value
+      properties:
+        entity_id:
+          type: integer
+          format: int64
+          minimum: 1
+        field_key:
+          type: string
+          minLength: 1
+        value:
+          type: string
+          format: date-time
+      additionalProperties: false
+    UpdateDateTimeFieldRequest:
+      type: object
+      required:
+        - field_key
+        - value
+      properties:
+        field_key:
+          type: string
+          minLength: 1
+        value:
+          type: string
+          format: date-time
+      additionalProperties: false
+    DateTimeFieldListResponse:
+      type: object
+      required:
+        - items
+        - limit
+        - offset
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/DateTimeFieldResponse'
         limit:
           type: integer
         offset:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -12,13 +12,13 @@ New contributors and AI agents: read [`handoff-2026-05-24-workspace-switch.md`](
 
 | Issue | Branch | Summary |
 | --- | --- | --- |
-| — | — | _(none — pick next Phase 2 item)_ |
+| #14 | `feat/14-enum-bool-datetime-fields` | enum_fields / bool_fields / datetime_fields CRUD + field_defs data_type expansion |
 
 ## Up Next
 
 | Issue | Summary |
 | --- | --- |
-| TBD | Phase 2: enum / bool / datetime field types |
+| TBD | Phase 2: next typed field or registry follow-up |
 
 ## Recently Completed
 

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -8,11 +8,23 @@ use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\DomainExceptionHandlerInterface;
+use NeNeRecords\BoolField\BoolFieldNotFoundExceptionHandler;
+use NeNeRecords\BoolField\BoolFieldServiceProvider;
+use NeNeRecords\BoolField\FieldKeyNotRegisteredExceptionHandler as BoolFieldKeyNotRegisteredExceptionHandler;
+use NeNeRecords\BoolField\FieldTypeMismatchExceptionHandler as BoolFieldTypeMismatchExceptionHandler;
+use NeNeRecords\DateTimeField\DateTimeFieldNotFoundExceptionHandler;
+use NeNeRecords\DateTimeField\DateTimeFieldServiceProvider;
+use NeNeRecords\DateTimeField\FieldKeyNotRegisteredExceptionHandler as DateTimeFieldKeyNotRegisteredExceptionHandler;
+use NeNeRecords\DateTimeField\FieldTypeMismatchExceptionHandler as DateTimeFieldTypeMismatchExceptionHandler;
 use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
 use NeNeRecords\Entity\EntityServiceProvider;
 use NeNeRecords\EntityType\EntityTypeNotFoundExceptionHandler;
 use NeNeRecords\EntityType\EntityTypeServiceProvider;
 use NeNeRecords\EntityType\EntityTypeSlugConflictExceptionHandler;
+use NeNeRecords\EnumField\EnumFieldNotFoundExceptionHandler;
+use NeNeRecords\EnumField\EnumFieldServiceProvider;
+use NeNeRecords\EnumField\FieldKeyNotRegisteredExceptionHandler as EnumFieldKeyNotRegisteredExceptionHandler;
+use NeNeRecords\EnumField\FieldTypeMismatchExceptionHandler as EnumFieldTypeMismatchExceptionHandler;
 use NeNeRecords\FieldDef\FieldDefConflictExceptionHandler;
 use NeNeRecords\FieldDef\FieldDefNotFoundExceptionHandler;
 use NeNeRecords\FieldDef\FieldDefServiceProvider;
@@ -39,7 +51,10 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new FieldDefServiceProvider())
             ->addProvider(new EntityServiceProvider())
             ->addProvider(new TextFieldServiceProvider())
-            ->addProvider(new IntFieldServiceProvider());
+            ->addProvider(new IntFieldServiceProvider())
+            ->addProvider(new EnumFieldServiceProvider())
+            ->addProvider(new BoolFieldServiceProvider())
+            ->addProvider(new DateTimeFieldServiceProvider());
 
         $builder
             ->set(
@@ -50,6 +65,9 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $entity = $container->get('nene-records.route_registrar.entity');
                     $textField = $container->get('nene-records.route_registrar.text_field');
                     $intField = $container->get('nene-records.route_registrar.int_field');
+                    $enumField = $container->get('nene-records.route_registrar.enum_field');
+                    $boolField = $container->get('nene-records.route_registrar.bool_field');
+                    $datetimeField = $container->get('nene-records.route_registrar.datetime_field');
 
                     if (
                         !is_callable($entityType)
@@ -57,11 +75,23 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !is_callable($entity)
                         || !is_callable($textField)
                         || !is_callable($intField)
+                        || !is_callable($enumField)
+                        || !is_callable($boolField)
+                        || !is_callable($datetimeField)
                     ) {
                         throw new LogicException('Route registrar service is invalid.');
                     }
 
-                    return [$entityType, $fieldDef, $entity, $textField, $intField];
+                    return [
+                        $entityType,
+                        $fieldDef,
+                        $entity,
+                        $textField,
+                        $intField,
+                        $enumField,
+                        $boolField,
+                        $datetimeField,
+                    ];
                 },
             )
             ->set(
@@ -78,6 +108,15 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $intFieldNotFound = $container->get(IntFieldNotFoundExceptionHandler::class);
                     $intFieldKeyNotRegistered = $container->get(IntFieldKeyNotRegisteredExceptionHandler::class);
                     $intFieldTypeMismatch = $container->get(IntFieldTypeMismatchExceptionHandler::class);
+                    $enumFieldNotFound = $container->get(EnumFieldNotFoundExceptionHandler::class);
+                    $enumFieldKeyNotRegistered = $container->get(EnumFieldKeyNotRegisteredExceptionHandler::class);
+                    $enumFieldTypeMismatch = $container->get(EnumFieldTypeMismatchExceptionHandler::class);
+                    $boolFieldNotFound = $container->get(BoolFieldNotFoundExceptionHandler::class);
+                    $boolFieldKeyNotRegistered = $container->get(BoolFieldKeyNotRegisteredExceptionHandler::class);
+                    $boolFieldTypeMismatch = $container->get(BoolFieldTypeMismatchExceptionHandler::class);
+                    $datetimeFieldNotFound = $container->get(DateTimeFieldNotFoundExceptionHandler::class);
+                    $datetimeFieldKeyNotRegistered = $container->get(DateTimeFieldKeyNotRegisteredExceptionHandler::class);
+                    $datetimeFieldTypeMismatch = $container->get(DateTimeFieldTypeMismatchExceptionHandler::class);
 
                     foreach ([
                         $entityTypeNotFound,
@@ -91,6 +130,15 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $intFieldNotFound,
                         $intFieldKeyNotRegistered,
                         $intFieldTypeMismatch,
+                        $enumFieldNotFound,
+                        $enumFieldKeyNotRegistered,
+                        $enumFieldTypeMismatch,
+                        $boolFieldNotFound,
+                        $boolFieldKeyNotRegistered,
+                        $boolFieldTypeMismatch,
+                        $datetimeFieldNotFound,
+                        $datetimeFieldKeyNotRegistered,
+                        $datetimeFieldTypeMismatch,
                     ] as $handler) {
                         if (!$handler instanceof DomainExceptionHandlerInterface) {
                             throw new LogicException('Exception handler service is invalid.');
@@ -109,6 +157,15 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $intFieldNotFound,
                         $intFieldKeyNotRegistered,
                         $intFieldTypeMismatch,
+                        $enumFieldNotFound,
+                        $enumFieldKeyNotRegistered,
+                        $enumFieldTypeMismatch,
+                        $boolFieldNotFound,
+                        $boolFieldKeyNotRegistered,
+                        $boolFieldTypeMismatch,
+                        $datetimeFieldNotFound,
+                        $datetimeFieldKeyNotRegistered,
+                        $datetimeFieldTypeMismatch,
                     ];
                 },
             );

--- a/src/BoolField/BoolField.php
+++ b/src/BoolField/BoolField.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+final readonly class BoolField
+{
+    public function __construct(
+        public int $entityId,
+        public string $fieldKey,
+        public bool $value,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/BoolField/BoolFieldNotFoundException.php
+++ b/src/BoolField/BoolFieldNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+use RuntimeException;
+
+final class BoolFieldNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("bool field with id {$id} was not found.");
+    }
+}

--- a/src/BoolField/BoolFieldNotFoundExceptionHandler.php
+++ b/src/BoolField/BoolFieldNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class BoolFieldNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof BoolFieldNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'not-found',
+            'Not Found',
+            404,
+            'The requested int field was not found.',
+        );
+    }
+}

--- a/src/BoolField/BoolFieldRepositoryInterface.php
+++ b/src/BoolField/BoolFieldRepositoryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+interface BoolFieldRepositoryInterface
+{
+    public function findById(int $id): ?BoolField;
+
+    /**
+     * Active (non-soft-deleted) rows only.
+     *
+     * @return list<BoolField>
+     */
+    public function findAll(int $limit, int $offset): array;
+
+    public function save(BoolField $intField): int;
+
+    public function update(BoolField $intField): void;
+
+    /**
+     * Soft delete: sets is_deleted and deleted_at.
+     *
+     * @throws BoolFieldNotFoundException When the id does not refer to an active row.
+     */
+    public function delete(int $id): void;
+}

--- a/src/BoolField/BoolFieldRouteRegistrar.php
+++ b/src/BoolField/BoolFieldRouteRegistrar.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class BoolFieldRouteRegistrar
+{
+    public function __construct(
+        private ListBoolFieldsHandler $listHandler,
+        private GetBoolFieldByIdHandler $getHandler,
+        private CreateBoolFieldHandler $createHandler,
+        private UpdateBoolFieldHandler $updateHandler,
+        private DeleteBoolFieldHandler $deleteHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $listHandler = $this->listHandler;
+        $getHandler = $this->getHandler;
+        $createHandler = $this->createHandler;
+        $updateHandler = $this->updateHandler;
+        $deleteHandler = $this->deleteHandler;
+
+        $router->get('/api/v1/bool-fields', static fn (ServerRequestInterface $request) => $listHandler->handle($request));
+        $router->get('/api/v1/bool-fields/{id}', static fn (ServerRequestInterface $request) => $getHandler->handle($request));
+        $router->post('/api/v1/bool-fields', static fn (ServerRequestInterface $request) => $createHandler->handle($request));
+        $router->put('/api/v1/bool-fields/{id}', static fn (ServerRequestInterface $request) => $updateHandler->handle($request));
+        $router->delete('/api/v1/bool-fields/{id}', static fn (ServerRequestInterface $request) => $deleteHandler->handle($request));
+    }
+}

--- a/src/BoolField/BoolFieldServiceProvider.php
+++ b/src/BoolField/BoolFieldServiceProvider.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class BoolFieldServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                BoolFieldRepositoryInterface::class,
+                static function (ContainerInterface $container): BoolFieldRepositoryInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoBoolFieldRepository($query);
+                },
+            )
+            ->set(
+                CreateBoolFieldUseCaseInterface::class,
+                static function (ContainerInterface $container): CreateBoolFieldUseCaseInterface {
+                    $intFields = $container->get(BoolFieldRepositoryInterface::class);
+                    $entities = $container->get(EntityRepositoryInterface::class);
+                    $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
+
+                    if (!$intFields instanceof BoolFieldRepositoryInterface) {
+                        throw new LogicException('bool field repository service is invalid.');
+                    }
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field definition repository service is invalid.');
+                    }
+
+                    return new CreateBoolFieldUseCase($intFields, $entities, $fieldDefs);
+                },
+            )
+            ->set(
+                CreateBoolFieldHandler::class,
+                static function (ContainerInterface $container): CreateBoolFieldHandler {
+                    $useCase = $container->get(CreateBoolFieldUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof CreateBoolFieldUseCaseInterface) {
+                        throw new LogicException('CreateBoolField use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new CreateBoolFieldHandler($useCase, $response);
+                },
+            )
+            ->set(
+                DeleteBoolFieldUseCaseInterface::class,
+                static function (ContainerInterface $container): DeleteBoolFieldUseCaseInterface {
+                    $repository = $container->get(BoolFieldRepositoryInterface::class);
+
+                    if (!$repository instanceof BoolFieldRepositoryInterface) {
+                        throw new LogicException('bool field repository service is invalid.');
+                    }
+
+                    return new DeleteBoolFieldUseCase($repository);
+                },
+            )
+            ->set(
+                DeleteBoolFieldHandler::class,
+                static function (ContainerInterface $container): DeleteBoolFieldHandler {
+                    $useCase = $container->get(DeleteBoolFieldUseCaseInterface::class);
+                    $responseFactory = $container->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof DeleteBoolFieldUseCaseInterface) {
+                        throw new LogicException('DeleteBoolField use case service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    return new DeleteBoolFieldHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
+                GetBoolFieldByIdUseCaseInterface::class,
+                static function (ContainerInterface $container): GetBoolFieldByIdUseCaseInterface {
+                    $repository = $container->get(BoolFieldRepositoryInterface::class);
+
+                    if (!$repository instanceof BoolFieldRepositoryInterface) {
+                        throw new LogicException('bool field repository service is invalid.');
+                    }
+
+                    return new GetBoolFieldByIdUseCase($repository);
+                },
+            )
+            ->set(
+                GetBoolFieldByIdHandler::class,
+                static function (ContainerInterface $container): GetBoolFieldByIdHandler {
+                    $useCase = $container->get(GetBoolFieldByIdUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof GetBoolFieldByIdUseCaseInterface) {
+                        throw new LogicException('GetBoolFieldById use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new GetBoolFieldByIdHandler($useCase, $response);
+                },
+            )
+            ->set(
+                ListBoolFieldsUseCaseInterface::class,
+                static function (ContainerInterface $container): ListBoolFieldsUseCaseInterface {
+                    $repository = $container->get(BoolFieldRepositoryInterface::class);
+
+                    if (!$repository instanceof BoolFieldRepositoryInterface) {
+                        throw new LogicException('bool field repository service is invalid.');
+                    }
+
+                    return new ListBoolFieldsUseCase($repository);
+                },
+            )
+            ->set(
+                ListBoolFieldsHandler::class,
+                static function (ContainerInterface $container): ListBoolFieldsHandler {
+                    $useCase = $container->get(ListBoolFieldsUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListBoolFieldsUseCaseInterface) {
+                        throw new LogicException('ListBoolFields use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListBoolFieldsHandler($useCase, $response);
+                },
+            )
+            ->set(
+                UpdateBoolFieldUseCaseInterface::class,
+                static function (ContainerInterface $container): UpdateBoolFieldUseCaseInterface {
+                    $intFields = $container->get(BoolFieldRepositoryInterface::class);
+                    $entities = $container->get(EntityRepositoryInterface::class);
+                    $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
+
+                    if (!$intFields instanceof BoolFieldRepositoryInterface) {
+                        throw new LogicException('bool field repository service is invalid.');
+                    }
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field definition repository service is invalid.');
+                    }
+
+                    return new UpdateBoolFieldUseCase($intFields, $entities, $fieldDefs);
+                },
+            )
+            ->set(
+                UpdateBoolFieldHandler::class,
+                static function (ContainerInterface $container): UpdateBoolFieldHandler {
+                    $useCase = $container->get(UpdateBoolFieldUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof UpdateBoolFieldUseCaseInterface) {
+                        throw new LogicException('UpdateBoolField use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new UpdateBoolFieldHandler($useCase, $response);
+                },
+            )
+            ->set(
+                BoolFieldNotFoundExceptionHandler::class,
+                static function (ContainerInterface $container): BoolFieldNotFoundExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new BoolFieldNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                FieldKeyNotRegisteredExceptionHandler::class,
+                static function (ContainerInterface $container): FieldKeyNotRegisteredExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new FieldKeyNotRegisteredExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                FieldTypeMismatchExceptionHandler::class,
+                static function (ContainerInterface $container): FieldTypeMismatchExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new FieldTypeMismatchExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.bool_field',
+                static function (ContainerInterface $container): BoolFieldRouteRegistrar {
+                    $list = $container->get(ListBoolFieldsHandler::class);
+                    $get = $container->get(GetBoolFieldByIdHandler::class);
+                    $create = $container->get(CreateBoolFieldHandler::class);
+                    $update = $container->get(UpdateBoolFieldHandler::class);
+                    $delete = $container->get(DeleteBoolFieldHandler::class);
+
+                    if (!$list instanceof ListBoolFieldsHandler) {
+                        throw new LogicException('ListBoolFields handler service is invalid.');
+                    }
+
+                    if (!$get instanceof GetBoolFieldByIdHandler) {
+                        throw new LogicException('GetBoolFieldById handler service is invalid.');
+                    }
+
+                    if (!$create instanceof CreateBoolFieldHandler) {
+                        throw new LogicException('CreateBoolField handler service is invalid.');
+                    }
+
+                    if (!$update instanceof UpdateBoolFieldHandler) {
+                        throw new LogicException('UpdateBoolField handler service is invalid.');
+                    }
+
+                    if (!$delete instanceof DeleteBoolFieldHandler) {
+                        throw new LogicException('DeleteBoolField handler service is invalid.');
+                    }
+
+                    return new BoolFieldRouteRegistrar($list, $get, $create, $update, $delete);
+                },
+            );
+    }
+}

--- a/src/BoolField/CreateBoolFieldHandler.php
+++ b/src/BoolField/CreateBoolFieldHandler.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateBoolFieldHandler
+{
+    public function __construct(
+        private CreateBoolFieldUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+
+        $entityId = (int) ($body['entity_id'] ?? 0);
+        $fieldKey = trim((string) ($body['field_key'] ?? ''));
+
+        if ($entityId <= 0) {
+            $errors[] = new ValidationError('entity_id', 'Entity id must be a positive integer.', 'invalid');
+        }
+
+        if ($fieldKey === '') {
+            $errors[] = new ValidationError('field_key', 'Field key is required.', 'required');
+        }
+
+        if (!array_key_exists('value', $body)) {
+            $errors[] = new ValidationError('value', 'Value is required.', 'required');
+        } elseif (!is_bool($body['value'])) {
+            $errors[] = new ValidationError('value', 'Value must be a boolean.', 'invalid');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        /** @var bool $value */
+        $value = $body['value'];
+
+        $output = $this->useCase->execute(new CreateBoolFieldInput(
+            entityId: $entityId,
+            fieldKey: $fieldKey,
+            value: $value,
+        ));
+
+        return $this->response->create(
+            [
+                'id'         => $output->id,
+                'entity_id'  => $output->entityId,
+                'field_key'  => $output->fieldKey,
+                'value'      => $output->value,
+            ],
+            201,
+            ['Location' => '/api/v1/bool-fields/' . $output->id],
+        );
+    }
+}

--- a/src/BoolField/CreateBoolFieldInput.php
+++ b/src/BoolField/CreateBoolFieldInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+final readonly class CreateBoolFieldInput
+{
+    public function __construct(
+        public int $entityId,
+        public string $fieldKey,
+        public bool $value,
+    ) {
+    }
+}

--- a/src/BoolField/CreateBoolFieldOutput.php
+++ b/src/BoolField/CreateBoolFieldOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+final readonly class CreateBoolFieldOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public bool $value,
+    ) {
+    }
+}

--- a/src/BoolField/CreateBoolFieldUseCase.php
+++ b/src/BoolField/CreateBoolFieldUseCase.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+
+final readonly class CreateBoolFieldUseCase implements CreateBoolFieldUseCaseInterface
+{
+    private const BOOL_DATA_TYPE = 'bool';
+
+    public function __construct(
+        private BoolFieldRepositoryInterface $intFields,
+        private EntityRepositoryInterface $entities,
+        private FieldDefRepositoryInterface $fieldDefs,
+    ) {
+    }
+
+    public function execute(CreateBoolFieldInput $input): CreateBoolFieldOutput
+    {
+        $entity = $this->entities->findById($input->entityId);
+
+        if ($entity === null) {
+            throw new EntityNotFoundException($input->entityId);
+        }
+
+        $this->assertBoolFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
+
+        $id = $this->intFields->save(new BoolField(
+            entityId: $input->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+        ));
+
+        return new CreateBoolFieldOutput(
+            id: $id,
+            entityId: $input->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+        );
+    }
+
+    private function assertBoolFieldKeyRegistered(int $entityTypeId, string $fieldKey): void
+    {
+        $fieldDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($entityTypeId, $fieldKey);
+
+        if ($fieldDef === null) {
+            throw new FieldKeyNotRegisteredException($entityTypeId, $fieldKey);
+        }
+
+        if ($fieldDef->dataType !== self::BOOL_DATA_TYPE) {
+            throw new FieldTypeMismatchException($fieldKey, self::BOOL_DATA_TYPE, $fieldDef->dataType);
+        }
+    }
+}

--- a/src/BoolField/CreateBoolFieldUseCaseInterface.php
+++ b/src/BoolField/CreateBoolFieldUseCaseInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+
+interface CreateBoolFieldUseCaseInterface
+{
+    /**
+     * @throws EntityNotFoundException When {@see CreateBoolFieldInput::$entityId} does not exist.
+     */
+    public function execute(CreateBoolFieldInput $input): CreateBoolFieldOutput;
+}

--- a/src/BoolField/DeleteBoolFieldByIdInput.php
+++ b/src/BoolField/DeleteBoolFieldByIdInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+final readonly class DeleteBoolFieldByIdInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/BoolField/DeleteBoolFieldHandler.php
+++ b/src/BoolField/DeleteBoolFieldHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteBoolFieldHandler
+{
+    public function __construct(
+        private DeleteBoolFieldUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new BoolFieldNotFoundException($id);
+        }
+
+        $this->useCase->execute(new DeleteBoolFieldByIdInput($id));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/BoolField/DeleteBoolFieldUseCase.php
+++ b/src/BoolField/DeleteBoolFieldUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+final readonly class DeleteBoolFieldUseCase implements DeleteBoolFieldUseCaseInterface
+{
+    public function __construct(
+        private BoolFieldRepositoryInterface $intFields,
+    ) {
+    }
+
+    public function execute(DeleteBoolFieldByIdInput $input): void
+    {
+        $intField = $this->intFields->findById($input->id);
+
+        if ($intField === null) {
+            throw new BoolFieldNotFoundException($input->id);
+        }
+
+        $this->intFields->delete($input->id);
+    }
+}

--- a/src/BoolField/DeleteBoolFieldUseCaseInterface.php
+++ b/src/BoolField/DeleteBoolFieldUseCaseInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+interface DeleteBoolFieldUseCaseInterface
+{
+    /**
+     * Soft-deletes the int field.
+     *
+     * @throws BoolFieldNotFoundException when no int field matches the given id.
+     */
+    public function execute(DeleteBoolFieldByIdInput $input): void;
+}

--- a/src/BoolField/FieldKeyNotRegisteredException.php
+++ b/src/BoolField/FieldKeyNotRegisteredException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+use RuntimeException;
+
+final class FieldKeyNotRegisteredException extends RuntimeException
+{
+    public function __construct(
+        public int $entityTypeId,
+        public string $fieldKey,
+    ) {
+        parent::__construct("Field key {$fieldKey} is not registered for entity type {$entityTypeId}.");
+    }
+}

--- a/src/BoolField/FieldKeyNotRegisteredExceptionHandler.php
+++ b/src/BoolField/FieldKeyNotRegisteredExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class FieldKeyNotRegisteredExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof FieldKeyNotRegisteredException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'field-key-not-registered',
+            'Field Key Not Registered',
+            422,
+            'The field key is not registered for this entity type.',
+        );
+    }
+}

--- a/src/BoolField/FieldTypeMismatchException.php
+++ b/src/BoolField/FieldTypeMismatchException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+use RuntimeException;
+
+final class FieldTypeMismatchException extends RuntimeException
+{
+    public function __construct(
+        public string $fieldKey,
+        public string $expectedDataType,
+        public string $actualDataType,
+    ) {
+        parent::__construct("Field key {$fieldKey} has data type {$actualDataType}, expected {$expectedDataType}.");
+    }
+}

--- a/src/BoolField/FieldTypeMismatchExceptionHandler.php
+++ b/src/BoolField/FieldTypeMismatchExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class FieldTypeMismatchExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof FieldTypeMismatchException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'field-type-mismatch',
+            'Field Type Mismatch',
+            422,
+            'The field key is registered with a different data type.',
+        );
+    }
+}

--- a/src/BoolField/GetBoolFieldByIdHandler.php
+++ b/src/BoolField/GetBoolFieldByIdHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetBoolFieldByIdHandler
+{
+    public function __construct(
+        private GetBoolFieldByIdUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new BoolFieldNotFoundException($id);
+        }
+
+        $output = $this->useCase->execute(new GetBoolFieldByIdInput($id));
+
+        return $this->response->create([
+            'id'        => $output->id,
+            'entity_id' => $output->entityId,
+            'field_key' => $output->fieldKey,
+            'value'     => $output->value,
+        ]);
+    }
+}

--- a/src/BoolField/GetBoolFieldByIdInput.php
+++ b/src/BoolField/GetBoolFieldByIdInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+final readonly class GetBoolFieldByIdInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/BoolField/GetBoolFieldByIdOutput.php
+++ b/src/BoolField/GetBoolFieldByIdOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+final readonly class GetBoolFieldByIdOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public bool $value,
+    ) {
+    }
+}

--- a/src/BoolField/GetBoolFieldByIdUseCase.php
+++ b/src/BoolField/GetBoolFieldByIdUseCase.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+final readonly class GetBoolFieldByIdUseCase implements GetBoolFieldByIdUseCaseInterface
+{
+    public function __construct(
+        private BoolFieldRepositoryInterface $intFields,
+    ) {
+    }
+
+    public function execute(GetBoolFieldByIdInput $input): GetBoolFieldByIdOutput
+    {
+        $intField = $this->intFields->findById($input->id);
+
+        if ($intField === null) {
+            throw new BoolFieldNotFoundException($input->id);
+        }
+
+        return new GetBoolFieldByIdOutput(
+            id: (int) $intField->id,
+            entityId: $intField->entityId,
+            fieldKey: $intField->fieldKey,
+            value: $intField->value,
+        );
+    }
+}

--- a/src/BoolField/GetBoolFieldByIdUseCaseInterface.php
+++ b/src/BoolField/GetBoolFieldByIdUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+interface GetBoolFieldByIdUseCaseInterface
+{
+    /**
+     * @throws BoolFieldNotFoundException when no int field matches the given id.
+     */
+    public function execute(GetBoolFieldByIdInput $input): GetBoolFieldByIdOutput;
+}

--- a/src/BoolField/ListBoolFieldItem.php
+++ b/src/BoolField/ListBoolFieldItem.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+final readonly class ListBoolFieldItem
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public bool $value,
+    ) {
+    }
+}

--- a/src/BoolField/ListBoolFieldsHandler.php
+++ b/src/BoolField/ListBoolFieldsHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListBoolFieldsHandler
+{
+    public function __construct(
+        private ListBoolFieldsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $pagination = PaginationQueryParser::parse($request);
+
+        $output = $this->useCase->execute(new ListBoolFieldsInput($pagination->limit, $pagination->offset));
+
+        return $this->response->create(
+            (new PaginationResponse(
+                items: array_map(
+                    static fn (ListBoolFieldItem $item) => [
+                        'id'        => $item->id,
+                        'entity_id' => $item->entityId,
+                        'field_key' => $item->fieldKey,
+                        'value'     => $item->value,
+                    ],
+                    $output->items,
+                ),
+                limit:  $output->limit,
+                offset: $output->offset,
+            ))->toArray(),
+        );
+    }
+}

--- a/src/BoolField/ListBoolFieldsInput.php
+++ b/src/BoolField/ListBoolFieldsInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+final readonly class ListBoolFieldsInput
+{
+    public function __construct(
+        public int $limit = 20,
+        public int $offset = 0,
+    ) {
+    }
+}

--- a/src/BoolField/ListBoolFieldsOutput.php
+++ b/src/BoolField/ListBoolFieldsOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+final readonly class ListBoolFieldsOutput
+{
+    /** @param list<ListBoolFieldItem> $items */
+    public function __construct(
+        public array $items,
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/BoolField/ListBoolFieldsUseCase.php
+++ b/src/BoolField/ListBoolFieldsUseCase.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+final readonly class ListBoolFieldsUseCase implements ListBoolFieldsUseCaseInterface
+{
+    public function __construct(
+        private BoolFieldRepositoryInterface $intFields,
+    ) {
+    }
+
+    public function execute(ListBoolFieldsInput $input): ListBoolFieldsOutput
+    {
+        $rows = $this->intFields->findAll($input->limit, $input->offset);
+
+        $items = array_map(
+            static fn (BoolField $field) => new ListBoolFieldItem(
+                id: (int) $field->id,
+                entityId: $field->entityId,
+                fieldKey: $field->fieldKey,
+                value: $field->value,
+            ),
+            $rows,
+        );
+
+        return new ListBoolFieldsOutput(
+            items: $items,
+            limit: $input->limit,
+            offset: $input->offset,
+        );
+    }
+}

--- a/src/BoolField/ListBoolFieldsUseCaseInterface.php
+++ b/src/BoolField/ListBoolFieldsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+interface ListBoolFieldsUseCaseInterface
+{
+    public function execute(ListBoolFieldsInput $input): ListBoolFieldsOutput;
+}

--- a/src/BoolField/PdoBoolFieldRepository.php
+++ b/src/BoolField/PdoBoolFieldRepository.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoBoolFieldRepository implements BoolFieldRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?BoolField
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, entity_id, field_key, value FROM bool_fields WHERE id = ? AND is_deleted = 0',
+            [$id],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return new BoolField(
+            entityId: (int) $row['entity_id'],
+            fieldKey: (string) $row['field_key'],
+            value: (bool) (int) $row['value'],
+            id: (int) $row['id'],
+        );
+    }
+
+    /** @return list<BoolField> */
+    public function findAll(int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, entity_id, field_key, value FROM bool_fields WHERE is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$limit, $offset],
+        );
+
+        return array_map(
+            static fn (array $row) => new BoolField(
+                entityId: (int) $row['entity_id'],
+                fieldKey: (string) $row['field_key'],
+                value: (bool) (int) $row['value'],
+                id: (int) $row['id'],
+            ),
+            $rows,
+        );
+    }
+
+    public function save(BoolField $intField): int
+    {
+        $this->query->execute(
+            'INSERT INTO bool_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$intField->entityId, $intField->fieldKey, $intField->value],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function update(BoolField $intField): void
+    {
+        if ($intField->id === null) {
+            throw new LogicException('BoolField id is required when updating.');
+        }
+
+        $affected = $this->query->execute(
+            'UPDATE bool_fields SET field_key = ?, value = ? WHERE id = ? AND is_deleted = 0',
+            [$intField->fieldKey, $intField->value, $intField->id],
+        );
+
+        if ($affected === 0) {
+            throw new BoolFieldNotFoundException($intField->id);
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        $affected = $this->query->execute(
+            'UPDATE bool_fields SET is_deleted = 1, deleted_at = CURRENT_TIMESTAMP WHERE id = ? AND is_deleted = 0',
+            [$id],
+        );
+
+        if ($affected === 0) {
+            throw new BoolFieldNotFoundException($id);
+        }
+    }
+}

--- a/src/BoolField/UpdateBoolFieldHandler.php
+++ b/src/BoolField/UpdateBoolFieldHandler.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateBoolFieldHandler
+{
+    public function __construct(
+        private UpdateBoolFieldUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new BoolFieldNotFoundException($id);
+        }
+
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+
+        $fieldKey = trim((string) ($body['field_key'] ?? ''));
+
+        if ($fieldKey === '') {
+            $errors[] = new ValidationError('field_key', 'Field key is required.', 'required');
+        }
+
+        if (!array_key_exists('value', $body)) {
+            $errors[] = new ValidationError('value', 'Value is required.', 'required');
+        } elseif (!is_bool($body['value'])) {
+            $errors[] = new ValidationError('value', 'Value must be a boolean.', 'invalid');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        /** @var bool $value */
+        $value = $body['value'];
+
+        $output = $this->useCase->execute(new UpdateBoolFieldInput(id: $id, fieldKey: $fieldKey, value: $value));
+
+        return $this->response->create([
+            'id'        => $output->id,
+            'entity_id' => $output->entityId,
+            'field_key' => $output->fieldKey,
+            'value'     => $output->value,
+        ]);
+    }
+}

--- a/src/BoolField/UpdateBoolFieldInput.php
+++ b/src/BoolField/UpdateBoolFieldInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+final readonly class UpdateBoolFieldInput
+{
+    public function __construct(
+        public int $id,
+        public string $fieldKey,
+        public bool $value,
+    ) {
+    }
+}

--- a/src/BoolField/UpdateBoolFieldOutput.php
+++ b/src/BoolField/UpdateBoolFieldOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+final readonly class UpdateBoolFieldOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public bool $value,
+    ) {
+    }
+}

--- a/src/BoolField/UpdateBoolFieldUseCase.php
+++ b/src/BoolField/UpdateBoolFieldUseCase.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+
+final readonly class UpdateBoolFieldUseCase implements UpdateBoolFieldUseCaseInterface
+{
+    private const BOOL_DATA_TYPE = 'bool';
+
+    public function __construct(
+        private BoolFieldRepositoryInterface $intFields,
+        private EntityRepositoryInterface $entities,
+        private FieldDefRepositoryInterface $fieldDefs,
+    ) {
+    }
+
+    public function execute(UpdateBoolFieldInput $input): UpdateBoolFieldOutput
+    {
+        $existing = $this->intFields->findById($input->id);
+
+        if ($existing === null) {
+            throw new BoolFieldNotFoundException($input->id);
+        }
+
+        $entity = $this->entities->findById($existing->entityId);
+
+        if ($entity === null) {
+            throw new EntityNotFoundException($existing->entityId);
+        }
+
+        $this->assertBoolFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
+
+        $updated = new BoolField(
+            entityId: $existing->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+            id: $input->id,
+        );
+        $this->intFields->update($updated);
+
+        return new UpdateBoolFieldOutput(
+            id: $input->id,
+            entityId: $existing->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+        );
+    }
+
+    private function assertBoolFieldKeyRegistered(int $entityTypeId, string $fieldKey): void
+    {
+        $fieldDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($entityTypeId, $fieldKey);
+
+        if ($fieldDef === null) {
+            throw new FieldKeyNotRegisteredException($entityTypeId, $fieldKey);
+        }
+
+        if ($fieldDef->dataType !== self::BOOL_DATA_TYPE) {
+            throw new FieldTypeMismatchException($fieldKey, self::BOOL_DATA_TYPE, $fieldDef->dataType);
+        }
+    }
+}

--- a/src/BoolField/UpdateBoolFieldUseCaseInterface.php
+++ b/src/BoolField/UpdateBoolFieldUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BoolField;
+
+interface UpdateBoolFieldUseCaseInterface
+{
+    /**
+     * @throws BoolFieldNotFoundException when no int field matches the given id.
+     */
+    public function execute(UpdateBoolFieldInput $input): UpdateBoolFieldOutput;
+}

--- a/src/DateTimeField/CreateDateTimeFieldHandler.php
+++ b/src/DateTimeField/CreateDateTimeFieldHandler.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateDateTimeFieldHandler
+{
+    public function __construct(
+        private CreateDateTimeFieldUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+
+        $entityId = (int) ($body['entity_id'] ?? 0);
+        $fieldKey = trim((string) ($body['field_key'] ?? ''));
+
+        if ($entityId <= 0) {
+            $errors[] = new ValidationError('entity_id', 'Entity id must be a positive integer.', 'invalid');
+        }
+
+        if ($fieldKey === '') {
+            $errors[] = new ValidationError('field_key', 'Field key is required.', 'required');
+        }
+
+        if (!array_key_exists('value', $body)) {
+            $errors[] = new ValidationError('value', 'Value is required.', 'required');
+        } elseif (!is_string($body['value']) || trim($body['value']) === '') {
+            $errors[] = new ValidationError('value', 'Value must be a non-empty ISO8601 datetime string.', 'invalid');
+        } elseif (!self::isValidIso8601(trim($body['value']))) {
+            $errors[] = new ValidationError('value', 'Value must be a valid ISO8601 datetime string.', 'invalid');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        /** @var string $value */
+        $value = trim((string) $body['value']);
+
+        $output = $this->useCase->execute(new CreateDateTimeFieldInput(
+            entityId: $entityId,
+            fieldKey: $fieldKey,
+            value: $value,
+        ));
+
+        return $this->response->create(
+            [
+                'id'         => $output->id,
+                'entity_id'  => $output->entityId,
+                'field_key'  => $output->fieldKey,
+                'value'      => $output->value,
+            ],
+            201,
+            ['Location' => '/api/v1/datetime-fields/' . $output->id],
+        );
+    }
+
+    private static function isValidIso8601(string $value): bool
+    {
+        $parsed = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, $value);
+
+        return $parsed !== false && $parsed->format(\DateTimeInterface::ATOM) === $value;
+    }
+
+}

--- a/src/DateTimeField/CreateDateTimeFieldInput.php
+++ b/src/DateTimeField/CreateDateTimeFieldInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+final readonly class CreateDateTimeFieldInput
+{
+    public function __construct(
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+    ) {
+    }
+}

--- a/src/DateTimeField/CreateDateTimeFieldOutput.php
+++ b/src/DateTimeField/CreateDateTimeFieldOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+final readonly class CreateDateTimeFieldOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+    ) {
+    }
+}

--- a/src/DateTimeField/CreateDateTimeFieldUseCase.php
+++ b/src/DateTimeField/CreateDateTimeFieldUseCase.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+
+final readonly class CreateDateTimeFieldUseCase implements CreateDateTimeFieldUseCaseInterface
+{
+    private const DATETIME_DATA_TYPE = 'datetime';
+
+    public function __construct(
+        private DateTimeFieldRepositoryInterface $intFields,
+        private EntityRepositoryInterface $entities,
+        private FieldDefRepositoryInterface $fieldDefs,
+    ) {
+    }
+
+    public function execute(CreateDateTimeFieldInput $input): CreateDateTimeFieldOutput
+    {
+        $entity = $this->entities->findById($input->entityId);
+
+        if ($entity === null) {
+            throw new EntityNotFoundException($input->entityId);
+        }
+
+        $this->assertDateTimeFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
+
+        $id = $this->intFields->save(new DateTimeField(
+            entityId: $input->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+        ));
+
+        return new CreateDateTimeFieldOutput(
+            id: $id,
+            entityId: $input->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+        );
+    }
+
+    private function assertDateTimeFieldKeyRegistered(int $entityTypeId, string $fieldKey): void
+    {
+        $fieldDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($entityTypeId, $fieldKey);
+
+        if ($fieldDef === null) {
+            throw new FieldKeyNotRegisteredException($entityTypeId, $fieldKey);
+        }
+
+        if ($fieldDef->dataType !== self::DATETIME_DATA_TYPE) {
+            throw new FieldTypeMismatchException($fieldKey, self::DATETIME_DATA_TYPE, $fieldDef->dataType);
+        }
+    }
+}

--- a/src/DateTimeField/CreateDateTimeFieldUseCaseInterface.php
+++ b/src/DateTimeField/CreateDateTimeFieldUseCaseInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+
+interface CreateDateTimeFieldUseCaseInterface
+{
+    /**
+     * @throws EntityNotFoundException When {@see CreateDateTimeFieldInput::$entityId} does not exist.
+     */
+    public function execute(CreateDateTimeFieldInput $input): CreateDateTimeFieldOutput;
+}

--- a/src/DateTimeField/DateTimeField.php
+++ b/src/DateTimeField/DateTimeField.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+final readonly class DateTimeField
+{
+    public function __construct(
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/DateTimeField/DateTimeFieldNotFoundException.php
+++ b/src/DateTimeField/DateTimeFieldNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+use RuntimeException;
+
+final class DateTimeFieldNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("datetime field with id {$id} was not found.");
+    }
+}

--- a/src/DateTimeField/DateTimeFieldNotFoundExceptionHandler.php
+++ b/src/DateTimeField/DateTimeFieldNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class DateTimeFieldNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof DateTimeFieldNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'not-found',
+            'Not Found',
+            404,
+            'The requested int field was not found.',
+        );
+    }
+}

--- a/src/DateTimeField/DateTimeFieldRepositoryInterface.php
+++ b/src/DateTimeField/DateTimeFieldRepositoryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+interface DateTimeFieldRepositoryInterface
+{
+    public function findById(int $id): ?DateTimeField;
+
+    /**
+     * Active (non-soft-deleted) rows only.
+     *
+     * @return list<DateTimeField>
+     */
+    public function findAll(int $limit, int $offset): array;
+
+    public function save(DateTimeField $intField): int;
+
+    public function update(DateTimeField $intField): void;
+
+    /**
+     * Soft delete: sets is_deleted and deleted_at.
+     *
+     * @throws DateTimeFieldNotFoundException When the id does not refer to an active row.
+     */
+    public function delete(int $id): void;
+}

--- a/src/DateTimeField/DateTimeFieldRouteRegistrar.php
+++ b/src/DateTimeField/DateTimeFieldRouteRegistrar.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DateTimeFieldRouteRegistrar
+{
+    public function __construct(
+        private ListDateTimeFieldsHandler $listHandler,
+        private GetDateTimeFieldByIdHandler $getHandler,
+        private CreateDateTimeFieldHandler $createHandler,
+        private UpdateDateTimeFieldHandler $updateHandler,
+        private DeleteDateTimeFieldHandler $deleteHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $listHandler = $this->listHandler;
+        $getHandler = $this->getHandler;
+        $createHandler = $this->createHandler;
+        $updateHandler = $this->updateHandler;
+        $deleteHandler = $this->deleteHandler;
+
+        $router->get('/api/v1/datetime-fields', static fn (ServerRequestInterface $request) => $listHandler->handle($request));
+        $router->get('/api/v1/datetime-fields/{id}', static fn (ServerRequestInterface $request) => $getHandler->handle($request));
+        $router->post('/api/v1/datetime-fields', static fn (ServerRequestInterface $request) => $createHandler->handle($request));
+        $router->put('/api/v1/datetime-fields/{id}', static fn (ServerRequestInterface $request) => $updateHandler->handle($request));
+        $router->delete('/api/v1/datetime-fields/{id}', static fn (ServerRequestInterface $request) => $deleteHandler->handle($request));
+    }
+}

--- a/src/DateTimeField/DateTimeFieldServiceProvider.php
+++ b/src/DateTimeField/DateTimeFieldServiceProvider.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class DateTimeFieldServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                DateTimeFieldRepositoryInterface::class,
+                static function (ContainerInterface $container): DateTimeFieldRepositoryInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoDateTimeFieldRepository($query);
+                },
+            )
+            ->set(
+                CreateDateTimeFieldUseCaseInterface::class,
+                static function (ContainerInterface $container): CreateDateTimeFieldUseCaseInterface {
+                    $intFields = $container->get(DateTimeFieldRepositoryInterface::class);
+                    $entities = $container->get(EntityRepositoryInterface::class);
+                    $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
+
+                    if (!$intFields instanceof DateTimeFieldRepositoryInterface) {
+                        throw new LogicException('datetime field repository service is invalid.');
+                    }
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field definition repository service is invalid.');
+                    }
+
+                    return new CreateDateTimeFieldUseCase($intFields, $entities, $fieldDefs);
+                },
+            )
+            ->set(
+                CreateDateTimeFieldHandler::class,
+                static function (ContainerInterface $container): CreateDateTimeFieldHandler {
+                    $useCase = $container->get(CreateDateTimeFieldUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof CreateDateTimeFieldUseCaseInterface) {
+                        throw new LogicException('CreateDateTimeField use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new CreateDateTimeFieldHandler($useCase, $response);
+                },
+            )
+            ->set(
+                DeleteDateTimeFieldUseCaseInterface::class,
+                static function (ContainerInterface $container): DeleteDateTimeFieldUseCaseInterface {
+                    $repository = $container->get(DateTimeFieldRepositoryInterface::class);
+
+                    if (!$repository instanceof DateTimeFieldRepositoryInterface) {
+                        throw new LogicException('datetime field repository service is invalid.');
+                    }
+
+                    return new DeleteDateTimeFieldUseCase($repository);
+                },
+            )
+            ->set(
+                DeleteDateTimeFieldHandler::class,
+                static function (ContainerInterface $container): DeleteDateTimeFieldHandler {
+                    $useCase = $container->get(DeleteDateTimeFieldUseCaseInterface::class);
+                    $responseFactory = $container->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof DeleteDateTimeFieldUseCaseInterface) {
+                        throw new LogicException('DeleteDateTimeField use case service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    return new DeleteDateTimeFieldHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
+                GetDateTimeFieldByIdUseCaseInterface::class,
+                static function (ContainerInterface $container): GetDateTimeFieldByIdUseCaseInterface {
+                    $repository = $container->get(DateTimeFieldRepositoryInterface::class);
+
+                    if (!$repository instanceof DateTimeFieldRepositoryInterface) {
+                        throw new LogicException('datetime field repository service is invalid.');
+                    }
+
+                    return new GetDateTimeFieldByIdUseCase($repository);
+                },
+            )
+            ->set(
+                GetDateTimeFieldByIdHandler::class,
+                static function (ContainerInterface $container): GetDateTimeFieldByIdHandler {
+                    $useCase = $container->get(GetDateTimeFieldByIdUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof GetDateTimeFieldByIdUseCaseInterface) {
+                        throw new LogicException('GetDateTimeFieldById use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new GetDateTimeFieldByIdHandler($useCase, $response);
+                },
+            )
+            ->set(
+                ListDateTimeFieldsUseCaseInterface::class,
+                static function (ContainerInterface $container): ListDateTimeFieldsUseCaseInterface {
+                    $repository = $container->get(DateTimeFieldRepositoryInterface::class);
+
+                    if (!$repository instanceof DateTimeFieldRepositoryInterface) {
+                        throw new LogicException('datetime field repository service is invalid.');
+                    }
+
+                    return new ListDateTimeFieldsUseCase($repository);
+                },
+            )
+            ->set(
+                ListDateTimeFieldsHandler::class,
+                static function (ContainerInterface $container): ListDateTimeFieldsHandler {
+                    $useCase = $container->get(ListDateTimeFieldsUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListDateTimeFieldsUseCaseInterface) {
+                        throw new LogicException('ListDateTimeFields use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListDateTimeFieldsHandler($useCase, $response);
+                },
+            )
+            ->set(
+                UpdateDateTimeFieldUseCaseInterface::class,
+                static function (ContainerInterface $container): UpdateDateTimeFieldUseCaseInterface {
+                    $intFields = $container->get(DateTimeFieldRepositoryInterface::class);
+                    $entities = $container->get(EntityRepositoryInterface::class);
+                    $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
+
+                    if (!$intFields instanceof DateTimeFieldRepositoryInterface) {
+                        throw new LogicException('datetime field repository service is invalid.');
+                    }
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field definition repository service is invalid.');
+                    }
+
+                    return new UpdateDateTimeFieldUseCase($intFields, $entities, $fieldDefs);
+                },
+            )
+            ->set(
+                UpdateDateTimeFieldHandler::class,
+                static function (ContainerInterface $container): UpdateDateTimeFieldHandler {
+                    $useCase = $container->get(UpdateDateTimeFieldUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof UpdateDateTimeFieldUseCaseInterface) {
+                        throw new LogicException('UpdateDateTimeField use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new UpdateDateTimeFieldHandler($useCase, $response);
+                },
+            )
+            ->set(
+                DateTimeFieldNotFoundExceptionHandler::class,
+                static function (ContainerInterface $container): DateTimeFieldNotFoundExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new DateTimeFieldNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                FieldKeyNotRegisteredExceptionHandler::class,
+                static function (ContainerInterface $container): FieldKeyNotRegisteredExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new FieldKeyNotRegisteredExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                FieldTypeMismatchExceptionHandler::class,
+                static function (ContainerInterface $container): FieldTypeMismatchExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new FieldTypeMismatchExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.datetime_field',
+                static function (ContainerInterface $container): DateTimeFieldRouteRegistrar {
+                    $list = $container->get(ListDateTimeFieldsHandler::class);
+                    $get = $container->get(GetDateTimeFieldByIdHandler::class);
+                    $create = $container->get(CreateDateTimeFieldHandler::class);
+                    $update = $container->get(UpdateDateTimeFieldHandler::class);
+                    $delete = $container->get(DeleteDateTimeFieldHandler::class);
+
+                    if (!$list instanceof ListDateTimeFieldsHandler) {
+                        throw new LogicException('ListDateTimeFields handler service is invalid.');
+                    }
+
+                    if (!$get instanceof GetDateTimeFieldByIdHandler) {
+                        throw new LogicException('GetDateTimeFieldById handler service is invalid.');
+                    }
+
+                    if (!$create instanceof CreateDateTimeFieldHandler) {
+                        throw new LogicException('CreateDateTimeField handler service is invalid.');
+                    }
+
+                    if (!$update instanceof UpdateDateTimeFieldHandler) {
+                        throw new LogicException('UpdateDateTimeField handler service is invalid.');
+                    }
+
+                    if (!$delete instanceof DeleteDateTimeFieldHandler) {
+                        throw new LogicException('DeleteDateTimeField handler service is invalid.');
+                    }
+
+                    return new DateTimeFieldRouteRegistrar($list, $get, $create, $update, $delete);
+                },
+            );
+    }
+}

--- a/src/DateTimeField/DeleteDateTimeFieldByIdInput.php
+++ b/src/DateTimeField/DeleteDateTimeFieldByIdInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+final readonly class DeleteDateTimeFieldByIdInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/DateTimeField/DeleteDateTimeFieldHandler.php
+++ b/src/DateTimeField/DeleteDateTimeFieldHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteDateTimeFieldHandler
+{
+    public function __construct(
+        private DeleteDateTimeFieldUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new DateTimeFieldNotFoundException($id);
+        }
+
+        $this->useCase->execute(new DeleteDateTimeFieldByIdInput($id));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/DateTimeField/DeleteDateTimeFieldUseCase.php
+++ b/src/DateTimeField/DeleteDateTimeFieldUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+final readonly class DeleteDateTimeFieldUseCase implements DeleteDateTimeFieldUseCaseInterface
+{
+    public function __construct(
+        private DateTimeFieldRepositoryInterface $intFields,
+    ) {
+    }
+
+    public function execute(DeleteDateTimeFieldByIdInput $input): void
+    {
+        $intField = $this->intFields->findById($input->id);
+
+        if ($intField === null) {
+            throw new DateTimeFieldNotFoundException($input->id);
+        }
+
+        $this->intFields->delete($input->id);
+    }
+}

--- a/src/DateTimeField/DeleteDateTimeFieldUseCaseInterface.php
+++ b/src/DateTimeField/DeleteDateTimeFieldUseCaseInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+interface DeleteDateTimeFieldUseCaseInterface
+{
+    /**
+     * Soft-deletes the int field.
+     *
+     * @throws DateTimeFieldNotFoundException when no int field matches the given id.
+     */
+    public function execute(DeleteDateTimeFieldByIdInput $input): void;
+}

--- a/src/DateTimeField/FieldKeyNotRegisteredException.php
+++ b/src/DateTimeField/FieldKeyNotRegisteredException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+use RuntimeException;
+
+final class FieldKeyNotRegisteredException extends RuntimeException
+{
+    public function __construct(
+        public int $entityTypeId,
+        public string $fieldKey,
+    ) {
+        parent::__construct("Field key {$fieldKey} is not registered for entity type {$entityTypeId}.");
+    }
+}

--- a/src/DateTimeField/FieldKeyNotRegisteredExceptionHandler.php
+++ b/src/DateTimeField/FieldKeyNotRegisteredExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class FieldKeyNotRegisteredExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof FieldKeyNotRegisteredException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'field-key-not-registered',
+            'Field Key Not Registered',
+            422,
+            'The field key is not registered for this entity type.',
+        );
+    }
+}

--- a/src/DateTimeField/FieldTypeMismatchException.php
+++ b/src/DateTimeField/FieldTypeMismatchException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+use RuntimeException;
+
+final class FieldTypeMismatchException extends RuntimeException
+{
+    public function __construct(
+        public string $fieldKey,
+        public string $expectedDataType,
+        public string $actualDataType,
+    ) {
+        parent::__construct("Field key {$fieldKey} has data type {$actualDataType}, expected {$expectedDataType}.");
+    }
+}

--- a/src/DateTimeField/FieldTypeMismatchExceptionHandler.php
+++ b/src/DateTimeField/FieldTypeMismatchExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class FieldTypeMismatchExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof FieldTypeMismatchException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'field-type-mismatch',
+            'Field Type Mismatch',
+            422,
+            'The field key is registered with a different data type.',
+        );
+    }
+}

--- a/src/DateTimeField/GetDateTimeFieldByIdHandler.php
+++ b/src/DateTimeField/GetDateTimeFieldByIdHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetDateTimeFieldByIdHandler
+{
+    public function __construct(
+        private GetDateTimeFieldByIdUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new DateTimeFieldNotFoundException($id);
+        }
+
+        $output = $this->useCase->execute(new GetDateTimeFieldByIdInput($id));
+
+        return $this->response->create([
+            'id'        => $output->id,
+            'entity_id' => $output->entityId,
+            'field_key' => $output->fieldKey,
+            'value'     => $output->value,
+        ]);
+    }
+}

--- a/src/DateTimeField/GetDateTimeFieldByIdInput.php
+++ b/src/DateTimeField/GetDateTimeFieldByIdInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+final readonly class GetDateTimeFieldByIdInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/DateTimeField/GetDateTimeFieldByIdOutput.php
+++ b/src/DateTimeField/GetDateTimeFieldByIdOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+final readonly class GetDateTimeFieldByIdOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+    ) {
+    }
+}

--- a/src/DateTimeField/GetDateTimeFieldByIdUseCase.php
+++ b/src/DateTimeField/GetDateTimeFieldByIdUseCase.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+final readonly class GetDateTimeFieldByIdUseCase implements GetDateTimeFieldByIdUseCaseInterface
+{
+    public function __construct(
+        private DateTimeFieldRepositoryInterface $intFields,
+    ) {
+    }
+
+    public function execute(GetDateTimeFieldByIdInput $input): GetDateTimeFieldByIdOutput
+    {
+        $intField = $this->intFields->findById($input->id);
+
+        if ($intField === null) {
+            throw new DateTimeFieldNotFoundException($input->id);
+        }
+
+        return new GetDateTimeFieldByIdOutput(
+            id: (int) $intField->id,
+            entityId: $intField->entityId,
+            fieldKey: $intField->fieldKey,
+            value: $intField->value,
+        );
+    }
+}

--- a/src/DateTimeField/GetDateTimeFieldByIdUseCaseInterface.php
+++ b/src/DateTimeField/GetDateTimeFieldByIdUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+interface GetDateTimeFieldByIdUseCaseInterface
+{
+    /**
+     * @throws DateTimeFieldNotFoundException when no int field matches the given id.
+     */
+    public function execute(GetDateTimeFieldByIdInput $input): GetDateTimeFieldByIdOutput;
+}

--- a/src/DateTimeField/ListDateTimeFieldItem.php
+++ b/src/DateTimeField/ListDateTimeFieldItem.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+final readonly class ListDateTimeFieldItem
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+    ) {
+    }
+}

--- a/src/DateTimeField/ListDateTimeFieldsHandler.php
+++ b/src/DateTimeField/ListDateTimeFieldsHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListDateTimeFieldsHandler
+{
+    public function __construct(
+        private ListDateTimeFieldsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $pagination = PaginationQueryParser::parse($request);
+
+        $output = $this->useCase->execute(new ListDateTimeFieldsInput($pagination->limit, $pagination->offset));
+
+        return $this->response->create(
+            (new PaginationResponse(
+                items: array_map(
+                    static fn (ListDateTimeFieldItem $item) => [
+                        'id'        => $item->id,
+                        'entity_id' => $item->entityId,
+                        'field_key' => $item->fieldKey,
+                        'value'     => $item->value,
+                    ],
+                    $output->items,
+                ),
+                limit:  $output->limit,
+                offset: $output->offset,
+            ))->toArray(),
+        );
+    }
+}

--- a/src/DateTimeField/ListDateTimeFieldsInput.php
+++ b/src/DateTimeField/ListDateTimeFieldsInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+final readonly class ListDateTimeFieldsInput
+{
+    public function __construct(
+        public int $limit = 20,
+        public int $offset = 0,
+    ) {
+    }
+}

--- a/src/DateTimeField/ListDateTimeFieldsOutput.php
+++ b/src/DateTimeField/ListDateTimeFieldsOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+final readonly class ListDateTimeFieldsOutput
+{
+    /** @param list<ListDateTimeFieldItem> $items */
+    public function __construct(
+        public array $items,
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/DateTimeField/ListDateTimeFieldsUseCase.php
+++ b/src/DateTimeField/ListDateTimeFieldsUseCase.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+final readonly class ListDateTimeFieldsUseCase implements ListDateTimeFieldsUseCaseInterface
+{
+    public function __construct(
+        private DateTimeFieldRepositoryInterface $intFields,
+    ) {
+    }
+
+    public function execute(ListDateTimeFieldsInput $input): ListDateTimeFieldsOutput
+    {
+        $rows = $this->intFields->findAll($input->limit, $input->offset);
+
+        $items = array_map(
+            static fn (DateTimeField $field) => new ListDateTimeFieldItem(
+                id: (int) $field->id,
+                entityId: $field->entityId,
+                fieldKey: $field->fieldKey,
+                value: $field->value,
+            ),
+            $rows,
+        );
+
+        return new ListDateTimeFieldsOutput(
+            items: $items,
+            limit: $input->limit,
+            offset: $input->offset,
+        );
+    }
+}

--- a/src/DateTimeField/ListDateTimeFieldsUseCaseInterface.php
+++ b/src/DateTimeField/ListDateTimeFieldsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+interface ListDateTimeFieldsUseCaseInterface
+{
+    public function execute(ListDateTimeFieldsInput $input): ListDateTimeFieldsOutput;
+}

--- a/src/DateTimeField/PdoDateTimeFieldRepository.php
+++ b/src/DateTimeField/PdoDateTimeFieldRepository.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoDateTimeFieldRepository implements DateTimeFieldRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?DateTimeField
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, entity_id, field_key, value FROM datetime_fields WHERE id = ? AND is_deleted = 0',
+            [$id],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return new DateTimeField(
+            entityId: (int) $row['entity_id'],
+            fieldKey: (string) $row['field_key'],
+            value: (string) $row['value'],
+            id: (int) $row['id'],
+        );
+    }
+
+    /** @return list<DateTimeField> */
+    public function findAll(int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, entity_id, field_key, value FROM datetime_fields WHERE is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$limit, $offset],
+        );
+
+        return array_map(
+            static fn (array $row) => new DateTimeField(
+                entityId: (int) $row['entity_id'],
+                fieldKey: (string) $row['field_key'],
+                value: (string) $row['value'],
+                id: (int) $row['id'],
+            ),
+            $rows,
+        );
+    }
+
+    public function save(DateTimeField $intField): int
+    {
+        $this->query->execute(
+            'INSERT INTO datetime_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$intField->entityId, $intField->fieldKey, $intField->value],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function update(DateTimeField $intField): void
+    {
+        if ($intField->id === null) {
+            throw new LogicException('DateTimeField id is required when updating.');
+        }
+
+        $affected = $this->query->execute(
+            'UPDATE datetime_fields SET field_key = ?, value = ? WHERE id = ? AND is_deleted = 0',
+            [$intField->fieldKey, $intField->value, $intField->id],
+        );
+
+        if ($affected === 0) {
+            throw new DateTimeFieldNotFoundException($intField->id);
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        $affected = $this->query->execute(
+            'UPDATE datetime_fields SET is_deleted = 1, deleted_at = CURRENT_TIMESTAMP WHERE id = ? AND is_deleted = 0',
+            [$id],
+        );
+
+        if ($affected === 0) {
+            throw new DateTimeFieldNotFoundException($id);
+        }
+    }
+}

--- a/src/DateTimeField/UpdateDateTimeFieldHandler.php
+++ b/src/DateTimeField/UpdateDateTimeFieldHandler.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateDateTimeFieldHandler
+{
+    public function __construct(
+        private UpdateDateTimeFieldUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new DateTimeFieldNotFoundException($id);
+        }
+
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+
+        $fieldKey = trim((string) ($body['field_key'] ?? ''));
+
+        if ($fieldKey === '') {
+            $errors[] = new ValidationError('field_key', 'Field key is required.', 'required');
+        }
+
+        if (!array_key_exists('value', $body)) {
+            $errors[] = new ValidationError('value', 'Value is required.', 'required');
+        } elseif (!is_string($body['value']) || trim($body['value']) === '') {
+            $errors[] = new ValidationError('value', 'Value must be a non-empty ISO8601 datetime string.', 'invalid');
+        } elseif (!self::isValidIso8601(trim($body['value']))) {
+            $errors[] = new ValidationError('value', 'Value must be a valid ISO8601 datetime string.', 'invalid');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        /** @var string $value */
+        $value = trim((string) $body['value']);
+
+        $output = $this->useCase->execute(new UpdateDateTimeFieldInput(id: $id, fieldKey: $fieldKey, value: $value));
+
+        return $this->response->create([
+            'id'        => $output->id,
+            'entity_id' => $output->entityId,
+            'field_key' => $output->fieldKey,
+            'value'     => $output->value,
+        ]);
+    }
+
+    private static function isValidIso8601(string $value): bool
+    {
+        $parsed = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, $value);
+
+        return $parsed !== false && $parsed->format(\DateTimeInterface::ATOM) === $value;
+    }
+
+}

--- a/src/DateTimeField/UpdateDateTimeFieldInput.php
+++ b/src/DateTimeField/UpdateDateTimeFieldInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+final readonly class UpdateDateTimeFieldInput
+{
+    public function __construct(
+        public int $id,
+        public string $fieldKey,
+        public string $value,
+    ) {
+    }
+}

--- a/src/DateTimeField/UpdateDateTimeFieldOutput.php
+++ b/src/DateTimeField/UpdateDateTimeFieldOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+final readonly class UpdateDateTimeFieldOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+    ) {
+    }
+}

--- a/src/DateTimeField/UpdateDateTimeFieldUseCase.php
+++ b/src/DateTimeField/UpdateDateTimeFieldUseCase.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+
+final readonly class UpdateDateTimeFieldUseCase implements UpdateDateTimeFieldUseCaseInterface
+{
+    private const DATETIME_DATA_TYPE = 'datetime';
+
+    public function __construct(
+        private DateTimeFieldRepositoryInterface $intFields,
+        private EntityRepositoryInterface $entities,
+        private FieldDefRepositoryInterface $fieldDefs,
+    ) {
+    }
+
+    public function execute(UpdateDateTimeFieldInput $input): UpdateDateTimeFieldOutput
+    {
+        $existing = $this->intFields->findById($input->id);
+
+        if ($existing === null) {
+            throw new DateTimeFieldNotFoundException($input->id);
+        }
+
+        $entity = $this->entities->findById($existing->entityId);
+
+        if ($entity === null) {
+            throw new EntityNotFoundException($existing->entityId);
+        }
+
+        $this->assertDateTimeFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
+
+        $updated = new DateTimeField(
+            entityId: $existing->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+            id: $input->id,
+        );
+        $this->intFields->update($updated);
+
+        return new UpdateDateTimeFieldOutput(
+            id: $input->id,
+            entityId: $existing->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+        );
+    }
+
+    private function assertDateTimeFieldKeyRegistered(int $entityTypeId, string $fieldKey): void
+    {
+        $fieldDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($entityTypeId, $fieldKey);
+
+        if ($fieldDef === null) {
+            throw new FieldKeyNotRegisteredException($entityTypeId, $fieldKey);
+        }
+
+        if ($fieldDef->dataType !== self::DATETIME_DATA_TYPE) {
+            throw new FieldTypeMismatchException($fieldKey, self::DATETIME_DATA_TYPE, $fieldDef->dataType);
+        }
+    }
+}

--- a/src/DateTimeField/UpdateDateTimeFieldUseCaseInterface.php
+++ b/src/DateTimeField/UpdateDateTimeFieldUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DateTimeField;
+
+interface UpdateDateTimeFieldUseCaseInterface
+{
+    /**
+     * @throws DateTimeFieldNotFoundException when no int field matches the given id.
+     */
+    public function execute(UpdateDateTimeFieldInput $input): UpdateDateTimeFieldOutput;
+}

--- a/src/EnumField/CreateEnumFieldHandler.php
+++ b/src/EnumField/CreateEnumFieldHandler.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateEnumFieldHandler
+{
+    public function __construct(
+        private CreateEnumFieldUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+
+        $entityId = (int) ($body['entity_id'] ?? 0);
+        $fieldKey = trim((string) ($body['field_key'] ?? ''));
+
+        if ($entityId <= 0) {
+            $errors[] = new ValidationError('entity_id', 'Entity id must be a positive integer.', 'invalid');
+        }
+
+        if ($fieldKey === '') {
+            $errors[] = new ValidationError('field_key', 'Field key is required.', 'required');
+        }
+
+        if (!array_key_exists('value', $body)) {
+            $errors[] = new ValidationError('value', 'Value is required.', 'required');
+        } elseif (!is_string($body['value']) || trim($body['value']) === '') {
+            $errors[] = new ValidationError('value', 'Value must be a non-empty string.', 'invalid');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        /** @var string $value */
+        $value = trim((string) $body['value']);
+
+        $output = $this->useCase->execute(new CreateEnumFieldInput(
+            entityId: $entityId,
+            fieldKey: $fieldKey,
+            value: $value,
+        ));
+
+        return $this->response->create(
+            [
+                'id'         => $output->id,
+                'entity_id'  => $output->entityId,
+                'field_key'  => $output->fieldKey,
+                'value'      => $output->value,
+            ],
+            201,
+            ['Location' => '/api/v1/enum-fields/' . $output->id],
+        );
+    }
+}

--- a/src/EnumField/CreateEnumFieldInput.php
+++ b/src/EnumField/CreateEnumFieldInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+final readonly class CreateEnumFieldInput
+{
+    public function __construct(
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+    ) {
+    }
+}

--- a/src/EnumField/CreateEnumFieldOutput.php
+++ b/src/EnumField/CreateEnumFieldOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+final readonly class CreateEnumFieldOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+    ) {
+    }
+}

--- a/src/EnumField/CreateEnumFieldUseCase.php
+++ b/src/EnumField/CreateEnumFieldUseCase.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+
+final readonly class CreateEnumFieldUseCase implements CreateEnumFieldUseCaseInterface
+{
+    private const ENUM_DATA_TYPE = 'enum';
+
+    public function __construct(
+        private EnumFieldRepositoryInterface $intFields,
+        private EntityRepositoryInterface $entities,
+        private FieldDefRepositoryInterface $fieldDefs,
+    ) {
+    }
+
+    public function execute(CreateEnumFieldInput $input): CreateEnumFieldOutput
+    {
+        $entity = $this->entities->findById($input->entityId);
+
+        if ($entity === null) {
+            throw new EntityNotFoundException($input->entityId);
+        }
+
+        $this->assertEnumFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
+
+        $id = $this->intFields->save(new EnumField(
+            entityId: $input->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+        ));
+
+        return new CreateEnumFieldOutput(
+            id: $id,
+            entityId: $input->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+        );
+    }
+
+    private function assertEnumFieldKeyRegistered(int $entityTypeId, string $fieldKey): void
+    {
+        $fieldDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($entityTypeId, $fieldKey);
+
+        if ($fieldDef === null) {
+            throw new FieldKeyNotRegisteredException($entityTypeId, $fieldKey);
+        }
+
+        if ($fieldDef->dataType !== self::ENUM_DATA_TYPE) {
+            throw new FieldTypeMismatchException($fieldKey, self::ENUM_DATA_TYPE, $fieldDef->dataType);
+        }
+    }
+}

--- a/src/EnumField/CreateEnumFieldUseCaseInterface.php
+++ b/src/EnumField/CreateEnumFieldUseCaseInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+
+interface CreateEnumFieldUseCaseInterface
+{
+    /**
+     * @throws EntityNotFoundException When {@see CreateEnumFieldInput::$entityId} does not exist.
+     */
+    public function execute(CreateEnumFieldInput $input): CreateEnumFieldOutput;
+}

--- a/src/EnumField/DeleteEnumFieldByIdInput.php
+++ b/src/EnumField/DeleteEnumFieldByIdInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+final readonly class DeleteEnumFieldByIdInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/EnumField/DeleteEnumFieldHandler.php
+++ b/src/EnumField/DeleteEnumFieldHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteEnumFieldHandler
+{
+    public function __construct(
+        private DeleteEnumFieldUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new EnumFieldNotFoundException($id);
+        }
+
+        $this->useCase->execute(new DeleteEnumFieldByIdInput($id));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/EnumField/DeleteEnumFieldUseCase.php
+++ b/src/EnumField/DeleteEnumFieldUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+final readonly class DeleteEnumFieldUseCase implements DeleteEnumFieldUseCaseInterface
+{
+    public function __construct(
+        private EnumFieldRepositoryInterface $intFields,
+    ) {
+    }
+
+    public function execute(DeleteEnumFieldByIdInput $input): void
+    {
+        $intField = $this->intFields->findById($input->id);
+
+        if ($intField === null) {
+            throw new EnumFieldNotFoundException($input->id);
+        }
+
+        $this->intFields->delete($input->id);
+    }
+}

--- a/src/EnumField/DeleteEnumFieldUseCaseInterface.php
+++ b/src/EnumField/DeleteEnumFieldUseCaseInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+interface DeleteEnumFieldUseCaseInterface
+{
+    /**
+     * Soft-deletes the int field.
+     *
+     * @throws EnumFieldNotFoundException when no int field matches the given id.
+     */
+    public function execute(DeleteEnumFieldByIdInput $input): void;
+}

--- a/src/EnumField/EnumField.php
+++ b/src/EnumField/EnumField.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+final readonly class EnumField
+{
+    public function __construct(
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/EnumField/EnumFieldNotFoundException.php
+++ b/src/EnumField/EnumFieldNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+use RuntimeException;
+
+final class EnumFieldNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("enum field with id {$id} was not found.");
+    }
+}

--- a/src/EnumField/EnumFieldNotFoundExceptionHandler.php
+++ b/src/EnumField/EnumFieldNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class EnumFieldNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof EnumFieldNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'not-found',
+            'Not Found',
+            404,
+            'The requested int field was not found.',
+        );
+    }
+}

--- a/src/EnumField/EnumFieldRepositoryInterface.php
+++ b/src/EnumField/EnumFieldRepositoryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+interface EnumFieldRepositoryInterface
+{
+    public function findById(int $id): ?EnumField;
+
+    /**
+     * Active (non-soft-deleted) rows only.
+     *
+     * @return list<EnumField>
+     */
+    public function findAll(int $limit, int $offset): array;
+
+    public function save(EnumField $intField): int;
+
+    public function update(EnumField $intField): void;
+
+    /**
+     * Soft delete: sets is_deleted and deleted_at.
+     *
+     * @throws EnumFieldNotFoundException When the id does not refer to an active row.
+     */
+    public function delete(int $id): void;
+}

--- a/src/EnumField/EnumFieldRouteRegistrar.php
+++ b/src/EnumField/EnumFieldRouteRegistrar.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class EnumFieldRouteRegistrar
+{
+    public function __construct(
+        private ListEnumFieldsHandler $listHandler,
+        private GetEnumFieldByIdHandler $getHandler,
+        private CreateEnumFieldHandler $createHandler,
+        private UpdateEnumFieldHandler $updateHandler,
+        private DeleteEnumFieldHandler $deleteHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $listHandler = $this->listHandler;
+        $getHandler = $this->getHandler;
+        $createHandler = $this->createHandler;
+        $updateHandler = $this->updateHandler;
+        $deleteHandler = $this->deleteHandler;
+
+        $router->get('/api/v1/enum-fields', static fn (ServerRequestInterface $request) => $listHandler->handle($request));
+        $router->get('/api/v1/enum-fields/{id}', static fn (ServerRequestInterface $request) => $getHandler->handle($request));
+        $router->post('/api/v1/enum-fields', static fn (ServerRequestInterface $request) => $createHandler->handle($request));
+        $router->put('/api/v1/enum-fields/{id}', static fn (ServerRequestInterface $request) => $updateHandler->handle($request));
+        $router->delete('/api/v1/enum-fields/{id}', static fn (ServerRequestInterface $request) => $deleteHandler->handle($request));
+    }
+}

--- a/src/EnumField/EnumFieldServiceProvider.php
+++ b/src/EnumField/EnumFieldServiceProvider.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class EnumFieldServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                EnumFieldRepositoryInterface::class,
+                static function (ContainerInterface $container): EnumFieldRepositoryInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoEnumFieldRepository($query);
+                },
+            )
+            ->set(
+                CreateEnumFieldUseCaseInterface::class,
+                static function (ContainerInterface $container): CreateEnumFieldUseCaseInterface {
+                    $intFields = $container->get(EnumFieldRepositoryInterface::class);
+                    $entities = $container->get(EntityRepositoryInterface::class);
+                    $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
+
+                    if (!$intFields instanceof EnumFieldRepositoryInterface) {
+                        throw new LogicException('enum field repository service is invalid.');
+                    }
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field definition repository service is invalid.');
+                    }
+
+                    return new CreateEnumFieldUseCase($intFields, $entities, $fieldDefs);
+                },
+            )
+            ->set(
+                CreateEnumFieldHandler::class,
+                static function (ContainerInterface $container): CreateEnumFieldHandler {
+                    $useCase = $container->get(CreateEnumFieldUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof CreateEnumFieldUseCaseInterface) {
+                        throw new LogicException('CreateEnumField use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new CreateEnumFieldHandler($useCase, $response);
+                },
+            )
+            ->set(
+                DeleteEnumFieldUseCaseInterface::class,
+                static function (ContainerInterface $container): DeleteEnumFieldUseCaseInterface {
+                    $repository = $container->get(EnumFieldRepositoryInterface::class);
+
+                    if (!$repository instanceof EnumFieldRepositoryInterface) {
+                        throw new LogicException('enum field repository service is invalid.');
+                    }
+
+                    return new DeleteEnumFieldUseCase($repository);
+                },
+            )
+            ->set(
+                DeleteEnumFieldHandler::class,
+                static function (ContainerInterface $container): DeleteEnumFieldHandler {
+                    $useCase = $container->get(DeleteEnumFieldUseCaseInterface::class);
+                    $responseFactory = $container->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof DeleteEnumFieldUseCaseInterface) {
+                        throw new LogicException('DeleteEnumField use case service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    return new DeleteEnumFieldHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
+                GetEnumFieldByIdUseCaseInterface::class,
+                static function (ContainerInterface $container): GetEnumFieldByIdUseCaseInterface {
+                    $repository = $container->get(EnumFieldRepositoryInterface::class);
+
+                    if (!$repository instanceof EnumFieldRepositoryInterface) {
+                        throw new LogicException('enum field repository service is invalid.');
+                    }
+
+                    return new GetEnumFieldByIdUseCase($repository);
+                },
+            )
+            ->set(
+                GetEnumFieldByIdHandler::class,
+                static function (ContainerInterface $container): GetEnumFieldByIdHandler {
+                    $useCase = $container->get(GetEnumFieldByIdUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof GetEnumFieldByIdUseCaseInterface) {
+                        throw new LogicException('GetEnumFieldById use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new GetEnumFieldByIdHandler($useCase, $response);
+                },
+            )
+            ->set(
+                ListEnumFieldsUseCaseInterface::class,
+                static function (ContainerInterface $container): ListEnumFieldsUseCaseInterface {
+                    $repository = $container->get(EnumFieldRepositoryInterface::class);
+
+                    if (!$repository instanceof EnumFieldRepositoryInterface) {
+                        throw new LogicException('enum field repository service is invalid.');
+                    }
+
+                    return new ListEnumFieldsUseCase($repository);
+                },
+            )
+            ->set(
+                ListEnumFieldsHandler::class,
+                static function (ContainerInterface $container): ListEnumFieldsHandler {
+                    $useCase = $container->get(ListEnumFieldsUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListEnumFieldsUseCaseInterface) {
+                        throw new LogicException('ListEnumFields use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListEnumFieldsHandler($useCase, $response);
+                },
+            )
+            ->set(
+                UpdateEnumFieldUseCaseInterface::class,
+                static function (ContainerInterface $container): UpdateEnumFieldUseCaseInterface {
+                    $intFields = $container->get(EnumFieldRepositoryInterface::class);
+                    $entities = $container->get(EntityRepositoryInterface::class);
+                    $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
+
+                    if (!$intFields instanceof EnumFieldRepositoryInterface) {
+                        throw new LogicException('enum field repository service is invalid.');
+                    }
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field definition repository service is invalid.');
+                    }
+
+                    return new UpdateEnumFieldUseCase($intFields, $entities, $fieldDefs);
+                },
+            )
+            ->set(
+                UpdateEnumFieldHandler::class,
+                static function (ContainerInterface $container): UpdateEnumFieldHandler {
+                    $useCase = $container->get(UpdateEnumFieldUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof UpdateEnumFieldUseCaseInterface) {
+                        throw new LogicException('UpdateEnumField use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new UpdateEnumFieldHandler($useCase, $response);
+                },
+            )
+            ->set(
+                EnumFieldNotFoundExceptionHandler::class,
+                static function (ContainerInterface $container): EnumFieldNotFoundExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new EnumFieldNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                FieldKeyNotRegisteredExceptionHandler::class,
+                static function (ContainerInterface $container): FieldKeyNotRegisteredExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new FieldKeyNotRegisteredExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                FieldTypeMismatchExceptionHandler::class,
+                static function (ContainerInterface $container): FieldTypeMismatchExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new FieldTypeMismatchExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.enum_field',
+                static function (ContainerInterface $container): EnumFieldRouteRegistrar {
+                    $list = $container->get(ListEnumFieldsHandler::class);
+                    $get = $container->get(GetEnumFieldByIdHandler::class);
+                    $create = $container->get(CreateEnumFieldHandler::class);
+                    $update = $container->get(UpdateEnumFieldHandler::class);
+                    $delete = $container->get(DeleteEnumFieldHandler::class);
+
+                    if (!$list instanceof ListEnumFieldsHandler) {
+                        throw new LogicException('ListEnumFields handler service is invalid.');
+                    }
+
+                    if (!$get instanceof GetEnumFieldByIdHandler) {
+                        throw new LogicException('GetEnumFieldById handler service is invalid.');
+                    }
+
+                    if (!$create instanceof CreateEnumFieldHandler) {
+                        throw new LogicException('CreateEnumField handler service is invalid.');
+                    }
+
+                    if (!$update instanceof UpdateEnumFieldHandler) {
+                        throw new LogicException('UpdateEnumField handler service is invalid.');
+                    }
+
+                    if (!$delete instanceof DeleteEnumFieldHandler) {
+                        throw new LogicException('DeleteEnumField handler service is invalid.');
+                    }
+
+                    return new EnumFieldRouteRegistrar($list, $get, $create, $update, $delete);
+                },
+            );
+    }
+}

--- a/src/EnumField/FieldKeyNotRegisteredException.php
+++ b/src/EnumField/FieldKeyNotRegisteredException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+use RuntimeException;
+
+final class FieldKeyNotRegisteredException extends RuntimeException
+{
+    public function __construct(
+        public int $entityTypeId,
+        public string $fieldKey,
+    ) {
+        parent::__construct("Field key {$fieldKey} is not registered for entity type {$entityTypeId}.");
+    }
+}

--- a/src/EnumField/FieldKeyNotRegisteredExceptionHandler.php
+++ b/src/EnumField/FieldKeyNotRegisteredExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class FieldKeyNotRegisteredExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof FieldKeyNotRegisteredException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'field-key-not-registered',
+            'Field Key Not Registered',
+            422,
+            'The field key is not registered for this entity type.',
+        );
+    }
+}

--- a/src/EnumField/FieldTypeMismatchException.php
+++ b/src/EnumField/FieldTypeMismatchException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+use RuntimeException;
+
+final class FieldTypeMismatchException extends RuntimeException
+{
+    public function __construct(
+        public string $fieldKey,
+        public string $expectedDataType,
+        public string $actualDataType,
+    ) {
+        parent::__construct("Field key {$fieldKey} has data type {$actualDataType}, expected {$expectedDataType}.");
+    }
+}

--- a/src/EnumField/FieldTypeMismatchExceptionHandler.php
+++ b/src/EnumField/FieldTypeMismatchExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class FieldTypeMismatchExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof FieldTypeMismatchException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'field-type-mismatch',
+            'Field Type Mismatch',
+            422,
+            'The field key is registered with a different data type.',
+        );
+    }
+}

--- a/src/EnumField/GetEnumFieldByIdHandler.php
+++ b/src/EnumField/GetEnumFieldByIdHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetEnumFieldByIdHandler
+{
+    public function __construct(
+        private GetEnumFieldByIdUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new EnumFieldNotFoundException($id);
+        }
+
+        $output = $this->useCase->execute(new GetEnumFieldByIdInput($id));
+
+        return $this->response->create([
+            'id'        => $output->id,
+            'entity_id' => $output->entityId,
+            'field_key' => $output->fieldKey,
+            'value'     => $output->value,
+        ]);
+    }
+}

--- a/src/EnumField/GetEnumFieldByIdInput.php
+++ b/src/EnumField/GetEnumFieldByIdInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+final readonly class GetEnumFieldByIdInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/EnumField/GetEnumFieldByIdOutput.php
+++ b/src/EnumField/GetEnumFieldByIdOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+final readonly class GetEnumFieldByIdOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+    ) {
+    }
+}

--- a/src/EnumField/GetEnumFieldByIdUseCase.php
+++ b/src/EnumField/GetEnumFieldByIdUseCase.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+final readonly class GetEnumFieldByIdUseCase implements GetEnumFieldByIdUseCaseInterface
+{
+    public function __construct(
+        private EnumFieldRepositoryInterface $intFields,
+    ) {
+    }
+
+    public function execute(GetEnumFieldByIdInput $input): GetEnumFieldByIdOutput
+    {
+        $intField = $this->intFields->findById($input->id);
+
+        if ($intField === null) {
+            throw new EnumFieldNotFoundException($input->id);
+        }
+
+        return new GetEnumFieldByIdOutput(
+            id: (int) $intField->id,
+            entityId: $intField->entityId,
+            fieldKey: $intField->fieldKey,
+            value: $intField->value,
+        );
+    }
+}

--- a/src/EnumField/GetEnumFieldByIdUseCaseInterface.php
+++ b/src/EnumField/GetEnumFieldByIdUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+interface GetEnumFieldByIdUseCaseInterface
+{
+    /**
+     * @throws EnumFieldNotFoundException when no int field matches the given id.
+     */
+    public function execute(GetEnumFieldByIdInput $input): GetEnumFieldByIdOutput;
+}

--- a/src/EnumField/ListEnumFieldItem.php
+++ b/src/EnumField/ListEnumFieldItem.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+final readonly class ListEnumFieldItem
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+    ) {
+    }
+}

--- a/src/EnumField/ListEnumFieldsHandler.php
+++ b/src/EnumField/ListEnumFieldsHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListEnumFieldsHandler
+{
+    public function __construct(
+        private ListEnumFieldsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $pagination = PaginationQueryParser::parse($request);
+
+        $output = $this->useCase->execute(new ListEnumFieldsInput($pagination->limit, $pagination->offset));
+
+        return $this->response->create(
+            (new PaginationResponse(
+                items: array_map(
+                    static fn (ListEnumFieldItem $item) => [
+                        'id'        => $item->id,
+                        'entity_id' => $item->entityId,
+                        'field_key' => $item->fieldKey,
+                        'value'     => $item->value,
+                    ],
+                    $output->items,
+                ),
+                limit:  $output->limit,
+                offset: $output->offset,
+            ))->toArray(),
+        );
+    }
+}

--- a/src/EnumField/ListEnumFieldsInput.php
+++ b/src/EnumField/ListEnumFieldsInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+final readonly class ListEnumFieldsInput
+{
+    public function __construct(
+        public int $limit = 20,
+        public int $offset = 0,
+    ) {
+    }
+}

--- a/src/EnumField/ListEnumFieldsOutput.php
+++ b/src/EnumField/ListEnumFieldsOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+final readonly class ListEnumFieldsOutput
+{
+    /** @param list<ListEnumFieldItem> $items */
+    public function __construct(
+        public array $items,
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/EnumField/ListEnumFieldsUseCase.php
+++ b/src/EnumField/ListEnumFieldsUseCase.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+final readonly class ListEnumFieldsUseCase implements ListEnumFieldsUseCaseInterface
+{
+    public function __construct(
+        private EnumFieldRepositoryInterface $intFields,
+    ) {
+    }
+
+    public function execute(ListEnumFieldsInput $input): ListEnumFieldsOutput
+    {
+        $rows = $this->intFields->findAll($input->limit, $input->offset);
+
+        $items = array_map(
+            static fn (EnumField $field) => new ListEnumFieldItem(
+                id: (int) $field->id,
+                entityId: $field->entityId,
+                fieldKey: $field->fieldKey,
+                value: $field->value,
+            ),
+            $rows,
+        );
+
+        return new ListEnumFieldsOutput(
+            items: $items,
+            limit: $input->limit,
+            offset: $input->offset,
+        );
+    }
+}

--- a/src/EnumField/ListEnumFieldsUseCaseInterface.php
+++ b/src/EnumField/ListEnumFieldsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+interface ListEnumFieldsUseCaseInterface
+{
+    public function execute(ListEnumFieldsInput $input): ListEnumFieldsOutput;
+}

--- a/src/EnumField/PdoEnumFieldRepository.php
+++ b/src/EnumField/PdoEnumFieldRepository.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoEnumFieldRepository implements EnumFieldRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?EnumField
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, entity_id, field_key, value FROM enum_fields WHERE id = ? AND is_deleted = 0',
+            [$id],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return new EnumField(
+            entityId: (int) $row['entity_id'],
+            fieldKey: (string) $row['field_key'],
+            value: (string) $row['value'],
+            id: (int) $row['id'],
+        );
+    }
+
+    /** @return list<EnumField> */
+    public function findAll(int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, entity_id, field_key, value FROM enum_fields WHERE is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$limit, $offset],
+        );
+
+        return array_map(
+            static fn (array $row) => new EnumField(
+                entityId: (int) $row['entity_id'],
+                fieldKey: (string) $row['field_key'],
+                value: (string) $row['value'],
+                id: (int) $row['id'],
+            ),
+            $rows,
+        );
+    }
+
+    public function save(EnumField $intField): int
+    {
+        $this->query->execute(
+            'INSERT INTO enum_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$intField->entityId, $intField->fieldKey, $intField->value],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function update(EnumField $intField): void
+    {
+        if ($intField->id === null) {
+            throw new LogicException('EnumField id is required when updating.');
+        }
+
+        $affected = $this->query->execute(
+            'UPDATE enum_fields SET field_key = ?, value = ? WHERE id = ? AND is_deleted = 0',
+            [$intField->fieldKey, $intField->value, $intField->id],
+        );
+
+        if ($affected === 0) {
+            throw new EnumFieldNotFoundException($intField->id);
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        $affected = $this->query->execute(
+            'UPDATE enum_fields SET is_deleted = 1, deleted_at = CURRENT_TIMESTAMP WHERE id = ? AND is_deleted = 0',
+            [$id],
+        );
+
+        if ($affected === 0) {
+            throw new EnumFieldNotFoundException($id);
+        }
+    }
+}

--- a/src/EnumField/UpdateEnumFieldHandler.php
+++ b/src/EnumField/UpdateEnumFieldHandler.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateEnumFieldHandler
+{
+    public function __construct(
+        private UpdateEnumFieldUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new EnumFieldNotFoundException($id);
+        }
+
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+
+        $fieldKey = trim((string) ($body['field_key'] ?? ''));
+
+        if ($fieldKey === '') {
+            $errors[] = new ValidationError('field_key', 'Field key is required.', 'required');
+        }
+
+        if (!array_key_exists('value', $body)) {
+            $errors[] = new ValidationError('value', 'Value is required.', 'required');
+        } elseif (!is_string($body['value']) || trim($body['value']) === '') {
+            $errors[] = new ValidationError('value', 'Value must be a non-empty string.', 'invalid');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        /** @var string $value */
+        $value = trim((string) $body['value']);
+
+        $output = $this->useCase->execute(new UpdateEnumFieldInput(id: $id, fieldKey: $fieldKey, value: $value));
+
+        return $this->response->create([
+            'id'        => $output->id,
+            'entity_id' => $output->entityId,
+            'field_key' => $output->fieldKey,
+            'value'     => $output->value,
+        ]);
+    }
+}

--- a/src/EnumField/UpdateEnumFieldInput.php
+++ b/src/EnumField/UpdateEnumFieldInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+final readonly class UpdateEnumFieldInput
+{
+    public function __construct(
+        public int $id,
+        public string $fieldKey,
+        public string $value,
+    ) {
+    }
+}

--- a/src/EnumField/UpdateEnumFieldOutput.php
+++ b/src/EnumField/UpdateEnumFieldOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+final readonly class UpdateEnumFieldOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+    ) {
+    }
+}

--- a/src/EnumField/UpdateEnumFieldUseCase.php
+++ b/src/EnumField/UpdateEnumFieldUseCase.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+
+final readonly class UpdateEnumFieldUseCase implements UpdateEnumFieldUseCaseInterface
+{
+    private const ENUM_DATA_TYPE = 'enum';
+
+    public function __construct(
+        private EnumFieldRepositoryInterface $intFields,
+        private EntityRepositoryInterface $entities,
+        private FieldDefRepositoryInterface $fieldDefs,
+    ) {
+    }
+
+    public function execute(UpdateEnumFieldInput $input): UpdateEnumFieldOutput
+    {
+        $existing = $this->intFields->findById($input->id);
+
+        if ($existing === null) {
+            throw new EnumFieldNotFoundException($input->id);
+        }
+
+        $entity = $this->entities->findById($existing->entityId);
+
+        if ($entity === null) {
+            throw new EntityNotFoundException($existing->entityId);
+        }
+
+        $this->assertEnumFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
+
+        $updated = new EnumField(
+            entityId: $existing->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+            id: $input->id,
+        );
+        $this->intFields->update($updated);
+
+        return new UpdateEnumFieldOutput(
+            id: $input->id,
+            entityId: $existing->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+        );
+    }
+
+    private function assertEnumFieldKeyRegistered(int $entityTypeId, string $fieldKey): void
+    {
+        $fieldDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($entityTypeId, $fieldKey);
+
+        if ($fieldDef === null) {
+            throw new FieldKeyNotRegisteredException($entityTypeId, $fieldKey);
+        }
+
+        if ($fieldDef->dataType !== self::ENUM_DATA_TYPE) {
+            throw new FieldTypeMismatchException($fieldKey, self::ENUM_DATA_TYPE, $fieldDef->dataType);
+        }
+    }
+}

--- a/src/EnumField/UpdateEnumFieldUseCaseInterface.php
+++ b/src/EnumField/UpdateEnumFieldUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EnumField;
+
+interface UpdateEnumFieldUseCaseInterface
+{
+    /**
+     * @throws EnumFieldNotFoundException when no int field matches the given id.
+     */
+    public function execute(UpdateEnumFieldInput $input): UpdateEnumFieldOutput;
+}

--- a/src/FieldDef/CreateFieldDefHandler.php
+++ b/src/FieldDef/CreateFieldDefHandler.php
@@ -14,7 +14,7 @@ use Psr\Http\Message\ServerRequestInterface;
 final readonly class CreateFieldDefHandler
 {
     /** @var list<string> */
-    private const ALLOWED_DATA_TYPES = ['text', 'int'];
+    private const ALLOWED_DATA_TYPES = ['text', 'int', 'enum', 'bool', 'datetime'];
 
     public function __construct(
         private CreateFieldDefUseCaseInterface $useCase,
@@ -43,7 +43,7 @@ final readonly class CreateFieldDefHandler
         if ($dataType === '') {
             $errors[] = new ValidationError('data_type', 'Data type is required.', 'required');
         } elseif (!in_array($dataType, self::ALLOWED_DATA_TYPES, true)) {
-            $errors[] = new ValidationError('data_type', 'Data type must be one of: text, int.', 'invalid');
+            $errors[] = new ValidationError('data_type', 'Data type must be one of: text, int, enum, bool, datetime.', 'invalid');
         }
 
         if ($errors !== []) {

--- a/src/FieldDef/UpdateFieldDefHandler.php
+++ b/src/FieldDef/UpdateFieldDefHandler.php
@@ -15,7 +15,7 @@ use Psr\Http\Message\ServerRequestInterface;
 final readonly class UpdateFieldDefHandler
 {
     /** @var list<string> */
-    private const ALLOWED_DATA_TYPES = ['text', 'int'];
+    private const ALLOWED_DATA_TYPES = ['text', 'int', 'enum', 'bool', 'datetime'];
 
     public function __construct(
         private UpdateFieldDefUseCaseInterface $useCase,
@@ -51,7 +51,7 @@ final readonly class UpdateFieldDefHandler
         if ($dataType === '') {
             $errors[] = new ValidationError('data_type', 'Data type is required.', 'required');
         } elseif (!in_array($dataType, self::ALLOWED_DATA_TYPES, true)) {
-            $errors[] = new ValidationError('data_type', 'Data type must be one of: text, int.', 'invalid');
+            $errors[] = new ValidationError('data_type', 'Data type must be one of: text, int, enum, bool, datetime.', 'invalid');
         }
 
         if ($errors !== []) {

--- a/tests/BoolField/BoolFieldHttpTest.php
+++ b/tests/BoolField/BoolFieldHttpTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\BoolField;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\BoolField\BoolFieldNotFoundExceptionHandler;
+use NeNeRecords\BoolField\BoolFieldRouteRegistrar;
+use NeNeRecords\BoolField\CreateBoolFieldHandler;
+use NeNeRecords\BoolField\CreateBoolFieldUseCase;
+use NeNeRecords\BoolField\DeleteBoolFieldHandler;
+use NeNeRecords\BoolField\DeleteBoolFieldUseCase;
+use NeNeRecords\BoolField\FieldKeyNotRegisteredExceptionHandler;
+use NeNeRecords\BoolField\FieldTypeMismatchExceptionHandler;
+use NeNeRecords\BoolField\GetBoolFieldByIdHandler;
+use NeNeRecords\BoolField\GetBoolFieldByIdUseCase;
+use NeNeRecords\BoolField\ListBoolFieldsHandler;
+use NeNeRecords\BoolField\ListBoolFieldsUseCase;
+use NeNeRecords\BoolField\UpdateBoolFieldHandler;
+use NeNeRecords\BoolField\UpdateBoolFieldUseCase;
+use NeNeRecords\Entity\CreateEntityHandler;
+use NeNeRecords\Entity\CreateEntityUseCase;
+use NeNeRecords\Entity\DeleteEntityHandler;
+use NeNeRecords\Entity\DeleteEntityUseCase;
+use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
+use NeNeRecords\Entity\EntityRouteRegistrar;
+use NeNeRecords\Entity\GetEntityByIdHandler;
+use NeNeRecords\Entity\GetEntityByIdUseCase;
+use NeNeRecords\Entity\ListEntitiesHandler;
+use NeNeRecords\Entity\ListEntitiesUseCase;
+use NeNeRecords\Entity\UpdateEntityHandler;
+use NeNeRecords\Entity\UpdateEntityUseCase;
+use NeNeRecords\EntityType\EntityType;
+use NeNeRecords\EntityType\EntityTypeNotFoundExceptionHandler;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class BoolFieldHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryEntityTypeRepository $entityTypes;
+    private InMemoryEntityRepository $entities;
+    private InMemoryFieldDefRepository $fieldDefs;
+    private InMemoryBoolFieldRepository $boolFields;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->entityTypes = new InMemoryEntityTypeRepository();
+        $this->entities = new InMemoryEntityRepository();
+        $this->fieldDefs = new InMemoryFieldDefRepository();
+        $this->boolFields = new InMemoryBoolFieldRepository();
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+
+        $entityRegistrar = new EntityRouteRegistrar(
+            new GetEntityByIdHandler(new GetEntityByIdUseCase($this->entities), $jsonResponse),
+            new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
+            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
+            new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse),
+        );
+
+        $intFieldRegistrar = new BoolFieldRouteRegistrar(
+            new ListBoolFieldsHandler(new ListBoolFieldsUseCase($this->boolFields), $jsonResponse),
+            new GetBoolFieldByIdHandler(new GetBoolFieldByIdUseCase($this->boolFields), $jsonResponse),
+            new CreateBoolFieldHandler(new CreateBoolFieldUseCase($this->boolFields, $this->entities, $this->fieldDefs), $jsonResponse),
+            new UpdateBoolFieldHandler(new UpdateBoolFieldUseCase($this->boolFields, $this->entities, $this->fieldDefs), $jsonResponse),
+            new DeleteBoolFieldHandler(new DeleteBoolFieldUseCase($this->boolFields), $this->factory),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [
+                new EntityTypeNotFoundExceptionHandler($problemDetails),
+                new EntityNotFoundExceptionHandler($problemDetails),
+                new BoolFieldNotFoundExceptionHandler($problemDetails),
+                new FieldKeyNotRegisteredExceptionHandler($problemDetails),
+                new FieldTypeMismatchExceptionHandler($problemDetails),
+            ],
+            routeRegistrars: [$entityRegistrar, $intFieldRegistrar],
+        ))->create();
+    }
+
+    public function testPostBoolFieldCreatesFieldAndReturns201WithLocation(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'title', dataType: 'bool'));
+
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        self::assertSame(201, $entityResponse->getStatusCode());
+        $createdEntity = $this->decodeJson($entityResponse);
+        $entityId = (int) $createdEntity['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'title',
+            'value' => true,
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/bool-fields')->withBody($bodyTf),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertStringStartsWith('/api/v1/bool-fields/', $response->getHeaderLine('Location'));
+        self::assertSame($entityId, $payload['entity_id']);
+        self::assertSame('title', $payload['field_key']);
+        self::assertSame(true, $payload['value']);
+    }
+
+    public function testPostUnregisteredFieldKeyReturns422(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        $entityId = (int) $this->decodeJson($entityResponse)['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'title',
+            'value' => true,
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/bool-fields')->withBody($bodyTf),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringEndsWith('field-key-not-registered', (string) $payload['type']);
+    }
+
+    public function testPostMismatchedFieldTypeReturns422(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'count', dataType: 'text'));
+
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        $entityId = (int) $this->decodeJson($entityResponse)['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'count',
+            'value' => true,
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/bool-fields')->withBody($bodyTf),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringEndsWith('field-type-mismatch', (string) $payload['type']);
+    }
+
+    public function testAfterDeleteGetBoolFieldReturns404(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'body', dataType: 'bool'));
+
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        $entityId = (int) $this->decodeJson($entityResponse)['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'body',
+            'value' => true,
+        ], JSON_THROW_ON_ERROR));
+
+        $createTf = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/bool-fields')->withBody($bodyTf),
+        );
+        self::assertSame(201, $createTf->getStatusCode());
+        $id = (int) $this->decodeJson($createTf)['id'];
+
+        $getBefore = $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/bool-fields/{$id}"),
+        );
+        self::assertSame(200, $getBefore->getStatusCode());
+
+        $del = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', "https://example.test/api/v1/bool-fields/{$id}"),
+        );
+        self::assertSame(204, $del->getStatusCode());
+
+        $getAfter = $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/bool-fields/{$id}"),
+        );
+        $payload = $this->decodeJson($getAfter);
+
+        self::assertSame(404, $getAfter->getStatusCode());
+        self::assertStringEndsWith('not-found', (string) $payload['type']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/tests/BoolField/CreateBoolFieldUseCaseTest.php
+++ b/tests/BoolField/CreateBoolFieldUseCaseTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\BoolField;
+
+use NeNeRecords\BoolField\BoolField;
+use NeNeRecords\BoolField\CreateBoolFieldInput;
+use NeNeRecords\BoolField\CreateBoolFieldUseCase;
+use NeNeRecords\BoolField\FieldKeyNotRegisteredException;
+use NeNeRecords\BoolField\FieldTypeMismatchException;
+use NeNeRecords\BoolField\UpdateBoolFieldInput;
+use NeNeRecords\BoolField\UpdateBoolFieldUseCase;
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use PHPUnit\Framework\TestCase;
+
+final class CreateBoolFieldUseCaseTest extends TestCase
+{
+    public function testReturnsOutputWithNewId(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 99));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 99, fieldKey: 'count', dataType: 'bool', id: 1),
+        ]);
+
+        $boolFields = new InMemoryBoolFieldRepository([]);
+        $useCase = new CreateBoolFieldUseCase($boolFields, $entities, $fieldDefs);
+
+        $output = $useCase->execute(new CreateBoolFieldInput(entityId: $entityId, fieldKey: 'count', value: true));
+
+        self::assertSame(1, $output->id);
+        self::assertSame($entityId, $output->entityId);
+        self::assertSame('count', $output->fieldKey);
+        self::assertSame(true, $output->value);
+    }
+
+    public function testAssignsSequentialIds(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'a', dataType: 'bool', id: 1),
+            new FieldDef(entityTypeId: 1, fieldKey: 'b', dataType: 'bool', id: 2),
+        ]);
+
+        $boolFields = new InMemoryBoolFieldRepository([]);
+        $useCase = new CreateBoolFieldUseCase($boolFields, $entities, $fieldDefs);
+
+        $first = $useCase->execute(new CreateBoolFieldInput(entityId: $entityId, fieldKey: 'a', value: true));
+        $second = $useCase->execute(new CreateBoolFieldInput(entityId: $entityId, fieldKey: 'b', value: false));
+
+        self::assertSame(1, $first->id);
+        self::assertSame(2, $second->id);
+    }
+
+    public function testThrowsFieldKeyNotRegisteredExceptionWhenFieldDefAbsent(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([]);
+        $boolFields = new InMemoryBoolFieldRepository([]);
+        $useCase = new CreateBoolFieldUseCase($boolFields, $entities, $fieldDefs);
+
+        $this->expectException(FieldKeyNotRegisteredException::class);
+
+        $useCase->execute(new CreateBoolFieldInput(entityId: $entityId, fieldKey: 'count', value: true));
+    }
+
+    public function testThrowsFieldTypeMismatchExceptionWhenDataTypeIsNotBool(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'title', dataType: 'text', id: 1),
+        ]);
+
+        $boolFields = new InMemoryBoolFieldRepository([]);
+        $useCase = new CreateBoolFieldUseCase($boolFields, $entities, $fieldDefs);
+
+        $this->expectException(FieldTypeMismatchException::class);
+
+        $useCase->execute(new CreateBoolFieldInput(entityId: $entityId, fieldKey: 'title', value: true));
+    }
+}
+
+final class UpdateBoolFieldUseCaseTest extends TestCase
+{
+    public function testThrowsFieldKeyNotRegisteredExceptionWhenUpdatedKeyIsUnregistered(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'count', dataType: 'bool', id: 1),
+        ]);
+
+        $boolFields = new InMemoryBoolFieldRepository([]);
+        $boolFields->save(new BoolField(entityId: $entityId, fieldKey: 'count', value: true, id: null));
+
+        $useCase = new UpdateBoolFieldUseCase($boolFields, $entities, $fieldDefs);
+
+        $this->expectException(FieldKeyNotRegisteredException::class);
+
+        $useCase->execute(new UpdateBoolFieldInput(id: 1, fieldKey: 'body', value: false));
+    }
+}

--- a/tests/BoolField/InMemoryBoolFieldRepository.php
+++ b/tests/BoolField/InMemoryBoolFieldRepository.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\BoolField;
+
+use NeNeRecords\BoolField\BoolField;
+use NeNeRecords\BoolField\BoolFieldNotFoundException;
+use NeNeRecords\BoolField\BoolFieldRepositoryInterface;
+
+final class InMemoryBoolFieldRepository implements BoolFieldRepositoryInterface
+{
+    /** @var array<int, BoolField> */
+    private array $fields;
+
+    /** @var array<int, true> */
+    private array $deletedIds;
+
+    private int $nextId;
+
+    /** @param list<BoolField> $seed */
+    public function __construct(array $seed = [])
+    {
+        $this->fields = [];
+        $this->deletedIds = [];
+        $this->nextId = 1;
+
+        foreach ($seed as $textField) {
+            $id = $textField->id;
+            if ($id !== null) {
+                $this->fields[$id] = $textField;
+                $this->nextId = max($this->nextId, $id + 1);
+            }
+        }
+    }
+
+    public function findById(int $id): ?BoolField
+    {
+        if (isset($this->deletedIds[$id])) {
+            return null;
+        }
+
+        return $this->fields[$id] ?? null;
+    }
+
+    /** @return list<BoolField> */
+    public function findAll(int $limit, int $offset): array
+    {
+        $active = [];
+
+        foreach ($this->fields as $id => $textField) {
+            if (!isset($this->deletedIds[$id])) {
+                $active[] = $textField;
+            }
+        }
+
+        usort($active, static fn (BoolField $a, BoolField $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
+
+        return array_slice($active, $offset, $limit);
+    }
+
+    public function save(BoolField $intField): int
+    {
+        $id = $this->nextId++;
+        $this->fields[$id] = new BoolField(
+            entityId: $intField->entityId,
+            fieldKey: $intField->fieldKey,
+            value: $intField->value,
+            id: $id,
+        );
+
+        return $id;
+    }
+
+    public function update(BoolField $intField): void
+    {
+        $id = $intField->id;
+
+        if ($id === null) {
+            return;
+        }
+
+        if ($this->findById($id) === null) {
+            throw new BoolFieldNotFoundException($id);
+        }
+
+        $this->fields[$id] = $intField;
+    }
+
+    public function delete(int $id): void
+    {
+        if (!isset($this->fields[$id]) || isset($this->deletedIds[$id])) {
+            throw new BoolFieldNotFoundException($id);
+        }
+
+        unset($this->fields[$id]);
+        $this->deletedIds[$id] = true;
+    }
+}

--- a/tests/BoolField/PdoBoolFieldRepositoryTest.php
+++ b/tests/BoolField/PdoBoolFieldRepositoryTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\BoolField;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeNeRecords\BoolField\BoolField;
+use NeNeRecords\BoolField\BoolFieldNotFoundException;
+use NeNeRecords\BoolField\PdoBoolFieldRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PdoBoolFieldRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene-records-test',
+            '',
+            'utf8',
+        )));
+
+        $this->executor->execute('PRAGMA foreign_keys = ON');
+
+        foreach ($this->schemaStatements() as $statement) {
+            $this->executor->execute($statement);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function schemaStatements(): array
+    {
+        $projectRoot = dirname(__DIR__, 2);
+        $paths = [
+            $projectRoot . '/database/schema/entity_types.sql',
+            $projectRoot . '/database/schema/entities.sql',
+            $projectRoot . '/database/schema/bool_fields.sql',
+        ];
+
+        $statements = [];
+
+        foreach ($paths as $path) {
+            self::assertFileExists($path);
+            $raw = trim((string) file_get_contents($path));
+            foreach (preg_split('/;\R/s', $raw) ?: [] as $chunk) {
+                $statement = trim($chunk);
+                if ($statement !== '') {
+                    $statements[] = $statement;
+                }
+            }
+        }
+
+        return $statements;
+    }
+
+    /** @return array{entityTypeId: int, entityId: int} */
+    private function insertEntityHierarchy(): array
+    {
+        $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('Base', 'base')");
+        $entityTypeId = $this->executor->lastInsertId();
+
+        $this->executor->execute('INSERT INTO entities (entity_type_id) VALUES (?)', [$entityTypeId]);
+        $entityId = $this->executor->lastInsertId();
+
+        return ['entityTypeId' => $entityTypeId, 'entityId' => $entityId];
+    }
+
+    public function testFindByIdReturnsBoolField(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $this->executor->execute(
+            'INSERT INTO bool_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$ids['entityId'], 'count', 1],
+        );
+
+        $repository = new PdoBoolFieldRepository($this->executor);
+        $boolField = $repository->findById(1);
+
+        self::assertNotNull($boolField);
+        self::assertSame(1, $boolField->id);
+        self::assertSame($ids['entityId'], $boolField->entityId);
+        self::assertSame('count', $boolField->fieldKey);
+        self::assertSame(true, $boolField->value);
+    }
+
+    public function testFindByIdReturnsNullAfterSoftDelete(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $this->executor->execute(
+            'INSERT INTO bool_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$ids['entityId'], 'count', 1],
+        );
+
+        $repository = new PdoBoolFieldRepository($this->executor);
+        $repository->delete(1);
+
+        self::assertNull($repository->findById(1));
+    }
+
+    public function testSaveReturnsNewId(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $repository = new PdoBoolFieldRepository($this->executor);
+        $id = $repository->save(new BoolField(entityId: $ids['entityId'], fieldKey: 'k', value: true));
+
+        self::assertSame(1, $id);
+    }
+
+    public function testUpdateThrowsWhenRowIsSoftDeleted(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $this->executor->execute(
+            'INSERT INTO bool_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$ids['entityId'], 'count', 1],
+        );
+
+        $repository = new PdoBoolFieldRepository($this->executor);
+        $repository->delete(1);
+
+        $this->expectException(BoolFieldNotFoundException::class);
+
+        $repository->update(new BoolField(entityId: $ids['entityId'], fieldKey: 'count', value: false, id: 1));
+    }
+
+    public function testFindAllExcludesDeleted(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $repository = new PdoBoolFieldRepository($this->executor);
+
+        $repository->save(new BoolField(entityId: $ids['entityId'], fieldKey: 'a', value: true));
+        $b = $repository->save(new BoolField(entityId: $ids['entityId'], fieldKey: 'b', value: false));
+
+        $repository->delete($b);
+
+        $list = $repository->findAll(10, 0);
+
+        self::assertCount(1, $list);
+        self::assertSame('a', $list[0]->fieldKey);
+    }
+}

--- a/tests/DateTimeField/CreateDateTimeFieldUseCaseTest.php
+++ b/tests/DateTimeField/CreateDateTimeFieldUseCaseTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\DateTimeField;
+
+use NeNeRecords\DateTimeField\CreateDateTimeFieldInput;
+use NeNeRecords\DateTimeField\CreateDateTimeFieldUseCase;
+use NeNeRecords\DateTimeField\DateTimeField;
+use NeNeRecords\DateTimeField\FieldKeyNotRegisteredException;
+use NeNeRecords\DateTimeField\FieldTypeMismatchException;
+use NeNeRecords\DateTimeField\UpdateDateTimeFieldInput;
+use NeNeRecords\DateTimeField\UpdateDateTimeFieldUseCase;
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use PHPUnit\Framework\TestCase;
+
+final class CreateDateTimeFieldUseCaseTest extends TestCase
+{
+    public function testReturnsOutputWithNewId(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 99));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 99, fieldKey: 'count', dataType: 'datetime', id: 1),
+        ]);
+
+        $datetimeFields = new InMemoryDateTimeFieldRepository([]);
+        $useCase = new CreateDateTimeFieldUseCase($datetimeFields, $entities, $fieldDefs);
+
+        $output = $useCase->execute(new CreateDateTimeFieldInput(entityId: $entityId, fieldKey: 'count', value: '2026-05-24T12:00:00+00:00'));
+
+        self::assertSame(1, $output->id);
+        self::assertSame($entityId, $output->entityId);
+        self::assertSame('count', $output->fieldKey);
+        self::assertSame('2026-05-24T12:00:00+00:00', $output->value);
+    }
+
+    public function testAssignsSequentialIds(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'a', dataType: 'datetime', id: 1),
+            new FieldDef(entityTypeId: 1, fieldKey: 'b', dataType: 'datetime', id: 2),
+        ]);
+
+        $datetimeFields = new InMemoryDateTimeFieldRepository([]);
+        $useCase = new CreateDateTimeFieldUseCase($datetimeFields, $entities, $fieldDefs);
+
+        $first = $useCase->execute(new CreateDateTimeFieldInput(entityId: $entityId, fieldKey: 'a', value: '2026-05-24T12:00:00+00:00'));
+        $second = $useCase->execute(new CreateDateTimeFieldInput(entityId: $entityId, fieldKey: 'b', value: '2026-05-25T12:00:00+00:00'));
+
+        self::assertSame(1, $first->id);
+        self::assertSame(2, $second->id);
+    }
+
+    public function testThrowsFieldKeyNotRegisteredExceptionWhenFieldDefAbsent(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([]);
+        $datetimeFields = new InMemoryDateTimeFieldRepository([]);
+        $useCase = new CreateDateTimeFieldUseCase($datetimeFields, $entities, $fieldDefs);
+
+        $this->expectException(FieldKeyNotRegisteredException::class);
+
+        $useCase->execute(new CreateDateTimeFieldInput(entityId: $entityId, fieldKey: 'count', value: '2026-05-24T12:00:00+00:00'));
+    }
+
+    public function testThrowsFieldTypeMismatchExceptionWhenDataTypeIsNotDateTime(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'title', dataType: 'text', id: 1),
+        ]);
+
+        $datetimeFields = new InMemoryDateTimeFieldRepository([]);
+        $useCase = new CreateDateTimeFieldUseCase($datetimeFields, $entities, $fieldDefs);
+
+        $this->expectException(FieldTypeMismatchException::class);
+
+        $useCase->execute(new CreateDateTimeFieldInput(entityId: $entityId, fieldKey: 'title', value: '2026-05-24T12:00:00+00:00'));
+    }
+}
+
+final class UpdateDateTimeFieldUseCaseTest extends TestCase
+{
+    public function testThrowsFieldKeyNotRegisteredExceptionWhenUpdatedKeyIsUnregistered(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'count', dataType: 'datetime', id: 1),
+        ]);
+
+        $datetimeFields = new InMemoryDateTimeFieldRepository([]);
+        $datetimeFields->save(new DateTimeField(entityId: $entityId, fieldKey: 'count', value: '2026-05-24T12:00:00+00:00', id: null));
+
+        $useCase = new UpdateDateTimeFieldUseCase($datetimeFields, $entities, $fieldDefs);
+
+        $this->expectException(FieldKeyNotRegisteredException::class);
+
+        $useCase->execute(new UpdateDateTimeFieldInput(id: 1, fieldKey: 'body', value: '2026-05-25T12:00:00+00:00'));
+    }
+}

--- a/tests/DateTimeField/DateTimeFieldHttpTest.php
+++ b/tests/DateTimeField/DateTimeFieldHttpTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\DateTimeField;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\DateTimeField\CreateDateTimeFieldHandler;
+use NeNeRecords\DateTimeField\CreateDateTimeFieldUseCase;
+use NeNeRecords\DateTimeField\DateTimeFieldNotFoundExceptionHandler;
+use NeNeRecords\DateTimeField\DateTimeFieldRouteRegistrar;
+use NeNeRecords\DateTimeField\DeleteDateTimeFieldHandler;
+use NeNeRecords\DateTimeField\DeleteDateTimeFieldUseCase;
+use NeNeRecords\DateTimeField\FieldKeyNotRegisteredExceptionHandler;
+use NeNeRecords\DateTimeField\FieldTypeMismatchExceptionHandler;
+use NeNeRecords\DateTimeField\GetDateTimeFieldByIdHandler;
+use NeNeRecords\DateTimeField\GetDateTimeFieldByIdUseCase;
+use NeNeRecords\DateTimeField\ListDateTimeFieldsHandler;
+use NeNeRecords\DateTimeField\ListDateTimeFieldsUseCase;
+use NeNeRecords\DateTimeField\UpdateDateTimeFieldHandler;
+use NeNeRecords\DateTimeField\UpdateDateTimeFieldUseCase;
+use NeNeRecords\Entity\CreateEntityHandler;
+use NeNeRecords\Entity\CreateEntityUseCase;
+use NeNeRecords\Entity\DeleteEntityHandler;
+use NeNeRecords\Entity\DeleteEntityUseCase;
+use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
+use NeNeRecords\Entity\EntityRouteRegistrar;
+use NeNeRecords\Entity\GetEntityByIdHandler;
+use NeNeRecords\Entity\GetEntityByIdUseCase;
+use NeNeRecords\Entity\ListEntitiesHandler;
+use NeNeRecords\Entity\ListEntitiesUseCase;
+use NeNeRecords\Entity\UpdateEntityHandler;
+use NeNeRecords\Entity\UpdateEntityUseCase;
+use NeNeRecords\EntityType\EntityType;
+use NeNeRecords\EntityType\EntityTypeNotFoundExceptionHandler;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class DateTimeFieldHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryEntityTypeRepository $entityTypes;
+    private InMemoryEntityRepository $entities;
+    private InMemoryFieldDefRepository $fieldDefs;
+    private InMemoryDateTimeFieldRepository $datetimeFields;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->entityTypes = new InMemoryEntityTypeRepository();
+        $this->entities = new InMemoryEntityRepository();
+        $this->fieldDefs = new InMemoryFieldDefRepository();
+        $this->datetimeFields = new InMemoryDateTimeFieldRepository();
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+
+        $entityRegistrar = new EntityRouteRegistrar(
+            new GetEntityByIdHandler(new GetEntityByIdUseCase($this->entities), $jsonResponse),
+            new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
+            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
+            new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse),
+        );
+
+        $intFieldRegistrar = new DateTimeFieldRouteRegistrar(
+            new ListDateTimeFieldsHandler(new ListDateTimeFieldsUseCase($this->datetimeFields), $jsonResponse),
+            new GetDateTimeFieldByIdHandler(new GetDateTimeFieldByIdUseCase($this->datetimeFields), $jsonResponse),
+            new CreateDateTimeFieldHandler(new CreateDateTimeFieldUseCase($this->datetimeFields, $this->entities, $this->fieldDefs), $jsonResponse),
+            new UpdateDateTimeFieldHandler(new UpdateDateTimeFieldUseCase($this->datetimeFields, $this->entities, $this->fieldDefs), $jsonResponse),
+            new DeleteDateTimeFieldHandler(new DeleteDateTimeFieldUseCase($this->datetimeFields), $this->factory),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [
+                new EntityTypeNotFoundExceptionHandler($problemDetails),
+                new EntityNotFoundExceptionHandler($problemDetails),
+                new DateTimeFieldNotFoundExceptionHandler($problemDetails),
+                new FieldKeyNotRegisteredExceptionHandler($problemDetails),
+                new FieldTypeMismatchExceptionHandler($problemDetails),
+            ],
+            routeRegistrars: [$entityRegistrar, $intFieldRegistrar],
+        ))->create();
+    }
+
+    public function testPostDateTimeFieldCreatesFieldAndReturns201WithLocation(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'title', dataType: 'datetime'));
+
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        self::assertSame(201, $entityResponse->getStatusCode());
+        $createdEntity = $this->decodeJson($entityResponse);
+        $entityId = (int) $createdEntity['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'title',
+            'value' => '2026-05-24T12:00:00+00:00',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/datetime-fields')->withBody($bodyTf),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertStringStartsWith('/api/v1/datetime-fields/', $response->getHeaderLine('Location'));
+        self::assertSame($entityId, $payload['entity_id']);
+        self::assertSame('title', $payload['field_key']);
+        self::assertSame('2026-05-24T12:00:00+00:00', $payload['value']);
+    }
+
+    public function testPostUnregisteredFieldKeyReturns422(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        $entityId = (int) $this->decodeJson($entityResponse)['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'title',
+            'value' => '2026-05-24T12:00:00+00:00',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/datetime-fields')->withBody($bodyTf),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringEndsWith('field-key-not-registered', (string) $payload['type']);
+    }
+
+    public function testPostMismatchedFieldTypeReturns422(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'count', dataType: 'text'));
+
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        $entityId = (int) $this->decodeJson($entityResponse)['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'count',
+            'value' => '2026-05-24T12:00:00+00:00',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/datetime-fields')->withBody($bodyTf),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringEndsWith('field-type-mismatch', (string) $payload['type']);
+    }
+
+    public function testAfterDeleteGetDateTimeFieldReturns404(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'body', dataType: 'datetime'));
+
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        $entityId = (int) $this->decodeJson($entityResponse)['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'body',
+            'value' => '2026-05-24T12:00:00+00:00',
+        ], JSON_THROW_ON_ERROR));
+
+        $createTf = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/datetime-fields')->withBody($bodyTf),
+        );
+        self::assertSame(201, $createTf->getStatusCode());
+        $id = (int) $this->decodeJson($createTf)['id'];
+
+        $getBefore = $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/datetime-fields/{$id}"),
+        );
+        self::assertSame(200, $getBefore->getStatusCode());
+
+        $del = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', "https://example.test/api/v1/datetime-fields/{$id}"),
+        );
+        self::assertSame(204, $del->getStatusCode());
+
+        $getAfter = $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/datetime-fields/{$id}"),
+        );
+        $payload = $this->decodeJson($getAfter);
+
+        self::assertSame(404, $getAfter->getStatusCode());
+        self::assertStringEndsWith('not-found', (string) $payload['type']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/tests/DateTimeField/InMemoryDateTimeFieldRepository.php
+++ b/tests/DateTimeField/InMemoryDateTimeFieldRepository.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\DateTimeField;
+
+use NeNeRecords\DateTimeField\DateTimeField;
+use NeNeRecords\DateTimeField\DateTimeFieldNotFoundException;
+use NeNeRecords\DateTimeField\DateTimeFieldRepositoryInterface;
+
+final class InMemoryDateTimeFieldRepository implements DateTimeFieldRepositoryInterface
+{
+    /** @var array<int, DateTimeField> */
+    private array $fields;
+
+    /** @var array<int, true> */
+    private array $deletedIds;
+
+    private int $nextId;
+
+    /** @param list<DateTimeField> $seed */
+    public function __construct(array $seed = [])
+    {
+        $this->fields = [];
+        $this->deletedIds = [];
+        $this->nextId = 1;
+
+        foreach ($seed as $textField) {
+            $id = $textField->id;
+            if ($id !== null) {
+                $this->fields[$id] = $textField;
+                $this->nextId = max($this->nextId, $id + 1);
+            }
+        }
+    }
+
+    public function findById(int $id): ?DateTimeField
+    {
+        if (isset($this->deletedIds[$id])) {
+            return null;
+        }
+
+        return $this->fields[$id] ?? null;
+    }
+
+    /** @return list<DateTimeField> */
+    public function findAll(int $limit, int $offset): array
+    {
+        $active = [];
+
+        foreach ($this->fields as $id => $textField) {
+            if (!isset($this->deletedIds[$id])) {
+                $active[] = $textField;
+            }
+        }
+
+        usort($active, static fn (DateTimeField $a, DateTimeField $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
+
+        return array_slice($active, $offset, $limit);
+    }
+
+    public function save(DateTimeField $intField): int
+    {
+        $id = $this->nextId++;
+        $this->fields[$id] = new DateTimeField(
+            entityId: $intField->entityId,
+            fieldKey: $intField->fieldKey,
+            value: $intField->value,
+            id: $id,
+        );
+
+        return $id;
+    }
+
+    public function update(DateTimeField $intField): void
+    {
+        $id = $intField->id;
+
+        if ($id === null) {
+            return;
+        }
+
+        if ($this->findById($id) === null) {
+            throw new DateTimeFieldNotFoundException($id);
+        }
+
+        $this->fields[$id] = $intField;
+    }
+
+    public function delete(int $id): void
+    {
+        if (!isset($this->fields[$id]) || isset($this->deletedIds[$id])) {
+            throw new DateTimeFieldNotFoundException($id);
+        }
+
+        unset($this->fields[$id]);
+        $this->deletedIds[$id] = true;
+    }
+}

--- a/tests/DateTimeField/PdoDateTimeFieldRepositoryTest.php
+++ b/tests/DateTimeField/PdoDateTimeFieldRepositoryTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\DateTimeField;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeNeRecords\DateTimeField\DateTimeField;
+use NeNeRecords\DateTimeField\DateTimeFieldNotFoundException;
+use NeNeRecords\DateTimeField\PdoDateTimeFieldRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PdoDateTimeFieldRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene-records-test',
+            '',
+            'utf8',
+        )));
+
+        $this->executor->execute('PRAGMA foreign_keys = ON');
+
+        foreach ($this->schemaStatements() as $statement) {
+            $this->executor->execute($statement);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function schemaStatements(): array
+    {
+        $projectRoot = dirname(__DIR__, 2);
+        $paths = [
+            $projectRoot . '/database/schema/entity_types.sql',
+            $projectRoot . '/database/schema/entities.sql',
+            $projectRoot . '/database/schema/datetime_fields.sql',
+        ];
+
+        $statements = [];
+
+        foreach ($paths as $path) {
+            self::assertFileExists($path);
+            $raw = trim((string) file_get_contents($path));
+            foreach (preg_split('/;\R/s', $raw) ?: [] as $chunk) {
+                $statement = trim($chunk);
+                if ($statement !== '') {
+                    $statements[] = $statement;
+                }
+            }
+        }
+
+        return $statements;
+    }
+
+    /** @return array{entityTypeId: int, entityId: int} */
+    private function insertEntityHierarchy(): array
+    {
+        $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('Base', 'base')");
+        $entityTypeId = $this->executor->lastInsertId();
+
+        $this->executor->execute('INSERT INTO entities (entity_type_id) VALUES (?)', [$entityTypeId]);
+        $entityId = $this->executor->lastInsertId();
+
+        return ['entityTypeId' => $entityTypeId, 'entityId' => $entityId];
+    }
+
+    public function testFindByIdReturnsDateTimeField(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $this->executor->execute(
+            'INSERT INTO datetime_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$ids['entityId'], 'count', '2026-05-24T12:00:00+00:00'],
+        );
+
+        $repository = new PdoDateTimeFieldRepository($this->executor);
+        $datetimeField = $repository->findById(1);
+
+        self::assertNotNull($datetimeField);
+        self::assertSame(1, $datetimeField->id);
+        self::assertSame($ids['entityId'], $datetimeField->entityId);
+        self::assertSame('count', $datetimeField->fieldKey);
+        self::assertSame('2026-05-24T12:00:00+00:00', $datetimeField->value);
+    }
+
+    public function testFindByIdReturnsNullAfterSoftDelete(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $this->executor->execute(
+            'INSERT INTO datetime_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$ids['entityId'], 'count', '2026-05-24T12:00:00+00:00'],
+        );
+
+        $repository = new PdoDateTimeFieldRepository($this->executor);
+        $repository->delete(1);
+
+        self::assertNull($repository->findById(1));
+    }
+
+    public function testSaveReturnsNewId(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $repository = new PdoDateTimeFieldRepository($this->executor);
+        $id = $repository->save(new DateTimeField(entityId: $ids['entityId'], fieldKey: 'k', value: '2026-05-24T12:00:00+00:00'));
+
+        self::assertSame(1, $id);
+    }
+
+    public function testUpdateThrowsWhenRowIsSoftDeleted(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $this->executor->execute(
+            'INSERT INTO datetime_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$ids['entityId'], 'count', '2026-05-24T12:00:00+00:00'],
+        );
+
+        $repository = new PdoDateTimeFieldRepository($this->executor);
+        $repository->delete(1);
+
+        $this->expectException(DateTimeFieldNotFoundException::class);
+
+        $repository->update(new DateTimeField(entityId: $ids['entityId'], fieldKey: 'count', value: '2026-05-25T12:00:00+00:00', id: 1));
+    }
+
+    public function testFindAllExcludesDeleted(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $repository = new PdoDateTimeFieldRepository($this->executor);
+
+        $repository->save(new DateTimeField(entityId: $ids['entityId'], fieldKey: 'a', value: '2026-05-24T12:00:00+00:00'));
+        $b = $repository->save(new DateTimeField(entityId: $ids['entityId'], fieldKey: 'b', value: '2026-05-25T12:00:00+00:00'));
+
+        $repository->delete($b);
+
+        $list = $repository->findAll(10, 0);
+
+        self::assertCount(1, $list);
+        self::assertSame('a', $list[0]->fieldKey);
+    }
+}

--- a/tests/EnumField/CreateEnumFieldUseCaseTest.php
+++ b/tests/EnumField/CreateEnumFieldUseCaseTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\EnumField;
+
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\EnumField\CreateEnumFieldInput;
+use NeNeRecords\EnumField\CreateEnumFieldUseCase;
+use NeNeRecords\EnumField\EnumField;
+use NeNeRecords\EnumField\FieldKeyNotRegisteredException;
+use NeNeRecords\EnumField\FieldTypeMismatchException;
+use NeNeRecords\EnumField\UpdateEnumFieldInput;
+use NeNeRecords\EnumField\UpdateEnumFieldUseCase;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use PHPUnit\Framework\TestCase;
+
+final class CreateEnumFieldUseCaseTest extends TestCase
+{
+    public function testReturnsOutputWithNewId(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 99));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 99, fieldKey: 'count', dataType: 'enum', id: 1),
+        ]);
+
+        $enumFields = new InMemoryEnumFieldRepository([]);
+        $useCase = new CreateEnumFieldUseCase($enumFields, $entities, $fieldDefs);
+
+        $output = $useCase->execute(new CreateEnumFieldInput(entityId: $entityId, fieldKey: 'count', value: 'active'));
+
+        self::assertSame(1, $output->id);
+        self::assertSame($entityId, $output->entityId);
+        self::assertSame('count', $output->fieldKey);
+        self::assertSame('active', $output->value);
+    }
+
+    public function testAssignsSequentialIds(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'a', dataType: 'enum', id: 1),
+            new FieldDef(entityTypeId: 1, fieldKey: 'b', dataType: 'enum', id: 2),
+        ]);
+
+        $enumFields = new InMemoryEnumFieldRepository([]);
+        $useCase = new CreateEnumFieldUseCase($enumFields, $entities, $fieldDefs);
+
+        $first = $useCase->execute(new CreateEnumFieldInput(entityId: $entityId, fieldKey: 'a', value: 'active'));
+        $second = $useCase->execute(new CreateEnumFieldInput(entityId: $entityId, fieldKey: 'b', value: 'inactive'));
+
+        self::assertSame(1, $first->id);
+        self::assertSame(2, $second->id);
+    }
+
+    public function testThrowsFieldKeyNotRegisteredExceptionWhenFieldDefAbsent(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([]);
+        $enumFields = new InMemoryEnumFieldRepository([]);
+        $useCase = new CreateEnumFieldUseCase($enumFields, $entities, $fieldDefs);
+
+        $this->expectException(FieldKeyNotRegisteredException::class);
+
+        $useCase->execute(new CreateEnumFieldInput(entityId: $entityId, fieldKey: 'count', value: 'active'));
+    }
+
+    public function testThrowsFieldTypeMismatchExceptionWhenDataTypeIsNotEnum(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'title', dataType: 'text', id: 1),
+        ]);
+
+        $enumFields = new InMemoryEnumFieldRepository([]);
+        $useCase = new CreateEnumFieldUseCase($enumFields, $entities, $fieldDefs);
+
+        $this->expectException(FieldTypeMismatchException::class);
+
+        $useCase->execute(new CreateEnumFieldInput(entityId: $entityId, fieldKey: 'title', value: 'active'));
+    }
+}
+
+final class UpdateEnumFieldUseCaseTest extends TestCase
+{
+    public function testThrowsFieldKeyNotRegisteredExceptionWhenUpdatedKeyIsUnregistered(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'count', dataType: 'enum', id: 1),
+        ]);
+
+        $enumFields = new InMemoryEnumFieldRepository([]);
+        $enumFields->save(new EnumField(entityId: $entityId, fieldKey: 'count', value: 'active', id: null));
+
+        $useCase = new UpdateEnumFieldUseCase($enumFields, $entities, $fieldDefs);
+
+        $this->expectException(FieldKeyNotRegisteredException::class);
+
+        $useCase->execute(new UpdateEnumFieldInput(id: 1, fieldKey: 'body', value: 'inactive'));
+    }
+}

--- a/tests/EnumField/EnumFieldHttpTest.php
+++ b/tests/EnumField/EnumFieldHttpTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\EnumField;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Entity\CreateEntityHandler;
+use NeNeRecords\Entity\CreateEntityUseCase;
+use NeNeRecords\Entity\DeleteEntityHandler;
+use NeNeRecords\Entity\DeleteEntityUseCase;
+use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
+use NeNeRecords\Entity\EntityRouteRegistrar;
+use NeNeRecords\Entity\GetEntityByIdHandler;
+use NeNeRecords\Entity\GetEntityByIdUseCase;
+use NeNeRecords\Entity\ListEntitiesHandler;
+use NeNeRecords\Entity\ListEntitiesUseCase;
+use NeNeRecords\Entity\UpdateEntityHandler;
+use NeNeRecords\Entity\UpdateEntityUseCase;
+use NeNeRecords\EntityType\EntityType;
+use NeNeRecords\EntityType\EntityTypeNotFoundExceptionHandler;
+use NeNeRecords\EnumField\CreateEnumFieldHandler;
+use NeNeRecords\EnumField\CreateEnumFieldUseCase;
+use NeNeRecords\EnumField\DeleteEnumFieldHandler;
+use NeNeRecords\EnumField\DeleteEnumFieldUseCase;
+use NeNeRecords\EnumField\EnumFieldNotFoundExceptionHandler;
+use NeNeRecords\EnumField\EnumFieldRouteRegistrar;
+use NeNeRecords\EnumField\FieldKeyNotRegisteredExceptionHandler;
+use NeNeRecords\EnumField\FieldTypeMismatchExceptionHandler;
+use NeNeRecords\EnumField\GetEnumFieldByIdHandler;
+use NeNeRecords\EnumField\GetEnumFieldByIdUseCase;
+use NeNeRecords\EnumField\ListEnumFieldsHandler;
+use NeNeRecords\EnumField\ListEnumFieldsUseCase;
+use NeNeRecords\EnumField\UpdateEnumFieldHandler;
+use NeNeRecords\EnumField\UpdateEnumFieldUseCase;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class EnumFieldHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryEntityTypeRepository $entityTypes;
+    private InMemoryEntityRepository $entities;
+    private InMemoryFieldDefRepository $fieldDefs;
+    private InMemoryEnumFieldRepository $enumFields;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->entityTypes = new InMemoryEntityTypeRepository();
+        $this->entities = new InMemoryEntityRepository();
+        $this->fieldDefs = new InMemoryFieldDefRepository();
+        $this->enumFields = new InMemoryEnumFieldRepository();
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+
+        $entityRegistrar = new EntityRouteRegistrar(
+            new GetEntityByIdHandler(new GetEntityByIdUseCase($this->entities), $jsonResponse),
+            new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
+            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
+            new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse),
+        );
+
+        $intFieldRegistrar = new EnumFieldRouteRegistrar(
+            new ListEnumFieldsHandler(new ListEnumFieldsUseCase($this->enumFields), $jsonResponse),
+            new GetEnumFieldByIdHandler(new GetEnumFieldByIdUseCase($this->enumFields), $jsonResponse),
+            new CreateEnumFieldHandler(new CreateEnumFieldUseCase($this->enumFields, $this->entities, $this->fieldDefs), $jsonResponse),
+            new UpdateEnumFieldHandler(new UpdateEnumFieldUseCase($this->enumFields, $this->entities, $this->fieldDefs), $jsonResponse),
+            new DeleteEnumFieldHandler(new DeleteEnumFieldUseCase($this->enumFields), $this->factory),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [
+                new EntityTypeNotFoundExceptionHandler($problemDetails),
+                new EntityNotFoundExceptionHandler($problemDetails),
+                new EnumFieldNotFoundExceptionHandler($problemDetails),
+                new FieldKeyNotRegisteredExceptionHandler($problemDetails),
+                new FieldTypeMismatchExceptionHandler($problemDetails),
+            ],
+            routeRegistrars: [$entityRegistrar, $intFieldRegistrar],
+        ))->create();
+    }
+
+    public function testPostEnumFieldCreatesFieldAndReturns201WithLocation(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'title', dataType: 'enum'));
+
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        self::assertSame(201, $entityResponse->getStatusCode());
+        $createdEntity = $this->decodeJson($entityResponse);
+        $entityId = (int) $createdEntity['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'title',
+            'value' => 'active',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/enum-fields')->withBody($bodyTf),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertStringStartsWith('/api/v1/enum-fields/', $response->getHeaderLine('Location'));
+        self::assertSame($entityId, $payload['entity_id']);
+        self::assertSame('title', $payload['field_key']);
+        self::assertSame('active', $payload['value']);
+    }
+
+    public function testPostUnregisteredFieldKeyReturns422(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        $entityId = (int) $this->decodeJson($entityResponse)['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'title',
+            'value' => 'active',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/enum-fields')->withBody($bodyTf),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringEndsWith('field-key-not-registered', (string) $payload['type']);
+    }
+
+    public function testPostMismatchedFieldTypeReturns422(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'count', dataType: 'text'));
+
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        $entityId = (int) $this->decodeJson($entityResponse)['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'count',
+            'value' => 'active',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/enum-fields')->withBody($bodyTf),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringEndsWith('field-type-mismatch', (string) $payload['type']);
+    }
+
+    public function testAfterDeleteGetEnumFieldReturns404(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'body', dataType: 'enum'));
+
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        $entityId = (int) $this->decodeJson($entityResponse)['id'];
+
+        $bodyTf = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'body',
+            'value' => 'active',
+        ], JSON_THROW_ON_ERROR));
+
+        $createTf = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/enum-fields')->withBody($bodyTf),
+        );
+        self::assertSame(201, $createTf->getStatusCode());
+        $id = (int) $this->decodeJson($createTf)['id'];
+
+        $getBefore = $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/enum-fields/{$id}"),
+        );
+        self::assertSame(200, $getBefore->getStatusCode());
+
+        $del = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', "https://example.test/api/v1/enum-fields/{$id}"),
+        );
+        self::assertSame(204, $del->getStatusCode());
+
+        $getAfter = $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/enum-fields/{$id}"),
+        );
+        $payload = $this->decodeJson($getAfter);
+
+        self::assertSame(404, $getAfter->getStatusCode());
+        self::assertStringEndsWith('not-found', (string) $payload['type']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/tests/EnumField/InMemoryEnumFieldRepository.php
+++ b/tests/EnumField/InMemoryEnumFieldRepository.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\EnumField;
+
+use NeNeRecords\EnumField\EnumField;
+use NeNeRecords\EnumField\EnumFieldNotFoundException;
+use NeNeRecords\EnumField\EnumFieldRepositoryInterface;
+
+final class InMemoryEnumFieldRepository implements EnumFieldRepositoryInterface
+{
+    /** @var array<int, EnumField> */
+    private array $fields;
+
+    /** @var array<int, true> */
+    private array $deletedIds;
+
+    private int $nextId;
+
+    /** @param list<EnumField> $seed */
+    public function __construct(array $seed = [])
+    {
+        $this->fields = [];
+        $this->deletedIds = [];
+        $this->nextId = 1;
+
+        foreach ($seed as $textField) {
+            $id = $textField->id;
+            if ($id !== null) {
+                $this->fields[$id] = $textField;
+                $this->nextId = max($this->nextId, $id + 1);
+            }
+        }
+    }
+
+    public function findById(int $id): ?EnumField
+    {
+        if (isset($this->deletedIds[$id])) {
+            return null;
+        }
+
+        return $this->fields[$id] ?? null;
+    }
+
+    /** @return list<EnumField> */
+    public function findAll(int $limit, int $offset): array
+    {
+        $active = [];
+
+        foreach ($this->fields as $id => $textField) {
+            if (!isset($this->deletedIds[$id])) {
+                $active[] = $textField;
+            }
+        }
+
+        usort($active, static fn (EnumField $a, EnumField $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
+
+        return array_slice($active, $offset, $limit);
+    }
+
+    public function save(EnumField $intField): int
+    {
+        $id = $this->nextId++;
+        $this->fields[$id] = new EnumField(
+            entityId: $intField->entityId,
+            fieldKey: $intField->fieldKey,
+            value: $intField->value,
+            id: $id,
+        );
+
+        return $id;
+    }
+
+    public function update(EnumField $intField): void
+    {
+        $id = $intField->id;
+
+        if ($id === null) {
+            return;
+        }
+
+        if ($this->findById($id) === null) {
+            throw new EnumFieldNotFoundException($id);
+        }
+
+        $this->fields[$id] = $intField;
+    }
+
+    public function delete(int $id): void
+    {
+        if (!isset($this->fields[$id]) || isset($this->deletedIds[$id])) {
+            throw new EnumFieldNotFoundException($id);
+        }
+
+        unset($this->fields[$id]);
+        $this->deletedIds[$id] = true;
+    }
+}

--- a/tests/EnumField/PdoEnumFieldRepositoryTest.php
+++ b/tests/EnumField/PdoEnumFieldRepositoryTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\EnumField;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeNeRecords\EnumField\EnumField;
+use NeNeRecords\EnumField\EnumFieldNotFoundException;
+use NeNeRecords\EnumField\PdoEnumFieldRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PdoEnumFieldRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene-records-test',
+            '',
+            'utf8',
+        )));
+
+        $this->executor->execute('PRAGMA foreign_keys = ON');
+
+        foreach ($this->schemaStatements() as $statement) {
+            $this->executor->execute($statement);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function schemaStatements(): array
+    {
+        $projectRoot = dirname(__DIR__, 2);
+        $paths = [
+            $projectRoot . '/database/schema/entity_types.sql',
+            $projectRoot . '/database/schema/entities.sql',
+            $projectRoot . '/database/schema/enum_fields.sql',
+        ];
+
+        $statements = [];
+
+        foreach ($paths as $path) {
+            self::assertFileExists($path);
+            $raw = trim((string) file_get_contents($path));
+            foreach (preg_split('/;\R/s', $raw) ?: [] as $chunk) {
+                $statement = trim($chunk);
+                if ($statement !== '') {
+                    $statements[] = $statement;
+                }
+            }
+        }
+
+        return $statements;
+    }
+
+    /** @return array{entityTypeId: int, entityId: int} */
+    private function insertEntityHierarchy(): array
+    {
+        $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('Base', 'base')");
+        $entityTypeId = $this->executor->lastInsertId();
+
+        $this->executor->execute('INSERT INTO entities (entity_type_id) VALUES (?)', [$entityTypeId]);
+        $entityId = $this->executor->lastInsertId();
+
+        return ['entityTypeId' => $entityTypeId, 'entityId' => $entityId];
+    }
+
+    public function testFindByIdReturnsEnumField(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $this->executor->execute(
+            'INSERT INTO enum_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$ids['entityId'], 'count', 'active'],
+        );
+
+        $repository = new PdoEnumFieldRepository($this->executor);
+        $enumField = $repository->findById(1);
+
+        self::assertNotNull($enumField);
+        self::assertSame(1, $enumField->id);
+        self::assertSame($ids['entityId'], $enumField->entityId);
+        self::assertSame('count', $enumField->fieldKey);
+        self::assertSame('active', $enumField->value);
+    }
+
+    public function testFindByIdReturnsNullAfterSoftDelete(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $this->executor->execute(
+            'INSERT INTO enum_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$ids['entityId'], 'count', 'active'],
+        );
+
+        $repository = new PdoEnumFieldRepository($this->executor);
+        $repository->delete(1);
+
+        self::assertNull($repository->findById(1));
+    }
+
+    public function testSaveReturnsNewId(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $repository = new PdoEnumFieldRepository($this->executor);
+        $id = $repository->save(new EnumField(entityId: $ids['entityId'], fieldKey: 'k', value: 'active'));
+
+        self::assertSame(1, $id);
+    }
+
+    public function testUpdateThrowsWhenRowIsSoftDeleted(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $this->executor->execute(
+            'INSERT INTO enum_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$ids['entityId'], 'count', 'active'],
+        );
+
+        $repository = new PdoEnumFieldRepository($this->executor);
+        $repository->delete(1);
+
+        $this->expectException(EnumFieldNotFoundException::class);
+
+        $repository->update(new EnumField(entityId: $ids['entityId'], fieldKey: 'count', value: 'inactive', id: 1));
+    }
+
+    public function testFindAllExcludesDeleted(): void
+    {
+        $ids = $this->insertEntityHierarchy();
+
+        $repository = new PdoEnumFieldRepository($this->executor);
+
+        $repository->save(new EnumField(entityId: $ids['entityId'], fieldKey: 'a', value: 'active'));
+        $b = $repository->save(new EnumField(entityId: $ids['entityId'], fieldKey: 'b', value: 'inactive'));
+
+        $repository->delete($b);
+
+        $list = $repository->findAll(10, 0);
+
+        self::assertCount(1, $list);
+        self::assertSame('a', $list[0]->fieldKey);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 残りの型付きフィールドを一括追加:

- **`enum_fields`** — `/api/v1/enum-fields` (value: string option key)
- **`bool_fields`** — `/api/v1/bool-fields` (value: boolean)
- **`datetime_fields`** — `/api/v1/datetime-fields` (value: ISO8601 ATOM)
- **field_defs** — `data_type`: text, int, enum, bool, datetime
- 各ドメイン field_def スキーマ検証 + マイグレーション + OpenAPI + tests

**112 tests**, `composer check` green.

## Test plan

- [x] `composer check`

## Self-review

`Self-review: backend-api, openapi-contract, database`

Closes #14


Made with [Cursor](https://cursor.com)