### PR TITLE
feat(api): タグ・entity_tags と entities フィルタ (#16)

### DIFF
--- a/database/migrations/20260524000008_create_tags_table.php
+++ b/database/migrations/20260524000008_create_tags_table.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateTagsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('tags')
+            ->addColumn('slug', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('name', 'string', ['limit' => 255, 'null' => false])
+            ->addIndex(['slug'], ['unique' => true])
+            ->create();
+    }
+}

--- a/database/migrations/20260524000009_create_entity_tags_table.php
+++ b/database/migrations/20260524000009_create_entity_tags_table.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateEntityTagsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('entity_tags')
+            ->addColumn('entity_id', 'integer', ['null' => false])
+            ->addColumn('tag_id', 'integer', ['null' => false])
+            ->addForeignKey('entity_id', 'entities', 'id', ['delete' => 'CASCADE', 'update' => 'NO_ACTION'])
+            ->addForeignKey('tag_id', 'tags', 'id', ['delete' => 'CASCADE', 'update' => 'NO_ACTION'])
+            ->addIndex(['entity_id', 'tag_id'], ['unique' => true])
+            ->create();
+    }
+}

--- a/database/schema/entity_tags.sql
+++ b/database/schema/entity_tags.sql
@@ -1,0 +1,8 @@
+CREATE TABLE entity_tags (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_id INTEGER NOT NULL,
+    tag_id INTEGER NOT NULL,
+    FOREIGN KEY (entity_id) REFERENCES entities (id) ON DELETE CASCADE ON UPDATE NO ACTION,
+    FOREIGN KEY (tag_id) REFERENCES tags (id) ON DELETE CASCADE ON UPDATE NO ACTION
+);
+CREATE UNIQUE INDEX entity_tags_entity_id_tag_id ON entity_tags (entity_id, tag_id);

--- a/database/schema/tags.sql
+++ b/database/schema/tags.sql
@@ -1,0 +1,6 @@
+CREATE TABLE tags (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug VARCHAR(255) NOT NULL,
+    name VARCHAR(255) NOT NULL
+);
+CREATE UNIQUE INDEX tags_slug ON tags (slug);

--- a/docs/adr/0003-tags-and-entity-tags.md
+++ b/docs/adr/0003-tags-and-entity-tags.md
@@ -1,0 +1,52 @@
+# ADR 0003: Tags and Entity Tags
+
+## Status
+
+accepted
+
+## Context
+
+Phase 3 (Issue #16) adds taxonomy-style classification without embedding untyped meta on entities. Tags are shared labels; `entity_tags` is a many-to-many join between `entities` and `tags`.
+
+Constraints:
+
+- Tag slugs are unique (same pattern as `entity_types.slug`).
+- Entity list filtering by tag uses **OR** semantics (entity has **any** of the given slugs).
+- Attach/detach routes live under `/api/v1/entities/{entityId}/tags` to keep entity as the aggregate entry point.
+
+## Decision
+
+### Tables
+
+| Table | Purpose |
+| --- | --- |
+| `tags` | Tag definition (`slug`, `name`) |
+| `entity_tags` | Join rows (`entity_id`, `tag_id`); unique composite index |
+
+### API
+
+| Area | Routes |
+| --- | --- |
+| Tag CRUD | `/api/v1/tags` |
+| Entity tags | `GET/POST /api/v1/entities/{entityId}/tags`, `DELETE .../tags/{tagId}` |
+| Filtered list | `GET /api/v1/entities?entity_type_id=&tags=&tag=` with `total` in pagination envelope |
+
+### Domains
+
+- `NeNeRecords\Tag\` — full Tag CRUD
+- `NeNeRecords\EntityTag\` — attach/detach/list only (no Tag CRUD duplication)
+- `NeNeRecords\Entity\EntityListCriteria` — list filter DTO consumed by `PdoEntityRepository`
+
+### Errors
+
+| Exception | HTTP |
+| --- | --- |
+| `TagSlugConflictException` | 409 |
+| `EntityTagAlreadyAttachedException` | 409 |
+| `EntityTagNotAttachedException` | 404 |
+
+## Consequences
+
+- Deleting a tag cascades join rows (`ON DELETE CASCADE`).
+- Entity list `total` is always returned when using criteria-based queries.
+- Future search/index features can extend `EntityListCriteria` without new list endpoints.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: NeNe Records API
   version: 0.1.0
   description: >
-    NeNe Records public API contract — entity_types, field_defs, entities, text_fields, int_fields, enum_fields, bool_fields, and datetime_fields CRUD (MVP + Phase 2 registry).
+    NeNe Records public API contract — entity_types, field_defs, entities, tags, entity_tags, text_fields, int_fields, enum_fields, bool_fields, and datetime_fields CRUD (MVP + Phase 2 registry + Phase 3 tags).
 servers:
   - url: http://localhost:8080
     description: Local development server
@@ -26,6 +26,10 @@ tags:
     description: Typed boolean field values on entities.
   - name: DateTimeFields
     description: Typed datetime field values on entities.
+  - name: Tags
+    description: Tag definitions for entity classification.
+  - name: EntityTags
+    description: Tags attached to entity instances.
 paths:
   /health:
     get:
@@ -197,11 +201,14 @@ paths:
       tags:
         - Entities
       summary: List entities
-      description: Returns non-deleted entities.
+      description: Returns non-deleted entities, optionally filtered by entity type and tags.
       operationId: listEntities
       parameters:
         - $ref: '#/components/parameters/LimitQuery'
         - $ref: '#/components/parameters/OffsetQuery'
+        - $ref: '#/components/parameters/EntityTypeIdQuery'
+        - $ref: '#/components/parameters/TagsQuery'
+        - $ref: '#/components/parameters/TagQuery'
       responses:
         '200':
           description: Paginated entity list.
@@ -216,6 +223,7 @@ paths:
                     items: []
                     limit: 20
                     offset: 0
+                    total: 0
         '422':
           $ref: '#/components/responses/ValidationFailed'
         '500':
@@ -328,6 +336,83 @@ paths:
       responses:
         '204':
           description: Entity soft-deleted.
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/entities/{entityId}/tags:
+    get:
+      tags:
+        - EntityTags
+      summary: List tags attached to entity
+      operationId: listEntityTags
+      parameters:
+        - $ref: '#/components/parameters/EntityIdPath'
+      responses:
+        '200':
+          description: Tags attached to the entity.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityTagListResponse'
+              examples:
+                ok:
+                  value:
+                    items: []
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - EntityTags
+      summary: Attach tag to entity
+      operationId: attachEntityTag
+      parameters:
+        - $ref: '#/components/parameters/EntityIdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AttachEntityTagRequest'
+            examples:
+              ok:
+                value:
+                  tag_id: 1
+      responses:
+        '201':
+          description: Tag attached.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    slug: featured
+                    name: Featured
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/entities/{entityId}/tags/{tagId}:
+    delete:
+      tags:
+        - EntityTags
+      summary: Detach tag from entity
+      operationId: detachEntityTag
+      parameters:
+        - $ref: '#/components/parameters/EntityIdPath'
+        - $ref: '#/components/parameters/TagIdPath'
+      responses:
+        '204':
+          description: Tag detached.
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -1257,6 +1342,149 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/tags:
+    get:
+      tags:
+        - Tags
+      summary: List tags
+      description: Returns a paginated list of tags.
+      operationId: listTags
+      parameters:
+        - $ref: '#/components/parameters/LimitQuery'
+        - $ref: '#/components/parameters/OffsetQuery'
+      responses:
+        '200':
+          description: Paginated tag list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagListResponse'
+              examples:
+                ok:
+                  summary: Empty list
+                  value:
+                    items: []
+                    limit: 20
+                    offset: 0
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Tags
+      summary: Create tag
+      description: Creates a new tag with a unique slug.
+      operationId: createTag
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTagRequest'
+            examples:
+              ok:
+                value:
+                  name: Featured
+                  slug: featured
+      responses:
+        '201':
+          description: Tag created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    slug: featured
+                    name: Featured
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/tags/{id}:
+    get:
+      tags:
+        - Tags
+      summary: Get tag by id
+      operationId: getTagById
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      responses:
+        '200':
+          description: Tag found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    slug: featured
+                    name: Featured
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      tags:
+        - Tags
+      summary: Update tag
+      operationId: updateTag
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateTagRequest'
+            examples:
+              ok:
+                value:
+                  name: Featured Item
+                  slug: featured-item
+      responses:
+        '200':
+          description: Tag updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    slug: featured-item
+                    name: Featured Item
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - Tags
+      summary: Delete tag
+      description: Permanently deletes a tag (hard delete).
+      operationId: deleteTag
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      responses:
+        '204':
+          description: Tag deleted.
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   parameters:
     IdPath:
@@ -1291,6 +1519,40 @@ components:
       name: entity_type_id
       in: query
       required: false
+      schema:
+        type: integer
+        format: int64
+        minimum: 1
+      example: 1
+    TagsQuery:
+      name: tags
+      in: query
+      required: false
+      description: Comma-separated tag slugs; entities matching any slug are returned.
+      schema:
+        type: string
+      example: featured,draft
+    TagQuery:
+      name: tag
+      in: query
+      required: false
+      description: Alias for a single tag slug or comma-separated slugs (merged with `tags`).
+      schema:
+        type: string
+      example: featured
+    EntityIdPath:
+      name: entityId
+      in: path
+      required: true
+      schema:
+        type: integer
+        format: int64
+        minimum: 1
+      example: 1
+    TagIdPath:
+      name: tagId
+      in: path
+      required: true
       schema:
         type: integer
         format: int64
@@ -1561,6 +1823,7 @@ components:
         - items
         - limit
         - offset
+        - total
       properties:
         items:
           type: array
@@ -1570,6 +1833,72 @@ components:
           type: integer
         offset:
           type: integer
+        total:
+          type: integer
+          minimum: 0
+    TagResponse:
+      type: object
+      required:
+        - id
+        - slug
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        slug:
+          type: string
+        name:
+          type: string
+    CreateTagRequest:
+      type: object
+      required:
+        - name
+        - slug
+      properties:
+        name:
+          type: string
+          minLength: 1
+        slug:
+          type: string
+          pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
+      additionalProperties: false
+    UpdateTagRequest:
+      $ref: '#/components/schemas/CreateTagRequest'
+    TagListResponse:
+      type: object
+      required:
+        - items
+        - limit
+        - offset
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagResponse'
+        limit:
+          type: integer
+        offset:
+          type: integer
+    EntityTagListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagResponse'
+    AttachEntityTagRequest:
+      type: object
+      required:
+        - tag_id
+      properties:
+        tag_id:
+          type: integer
+          format: int64
+          minimum: 1
+      additionalProperties: false
     FieldDefResponse:
       type: object
       required:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -12,13 +12,13 @@ New contributors and AI agents: read [`handoff-2026-05-24-workspace-switch.md`](
 
 | Issue | Branch | Summary |
 | --- | --- | --- |
-| — | — | _(none — Phase 3 planning)_ |
+| #16 | `feat/16-tags-and-entity-filters` | Tags CRUD, entity tag attach/detach/list, filtered entity list API |
 
 ## Up Next
 
 | Issue | Summary |
 | --- | --- |
-| TBD | **Phase 3:** relations, tags, filtered list/search API |
+| TBD | **Phase 3:** relations, search API extensions |
 
 ## Recently Completed
 
@@ -35,8 +35,9 @@ New contributors and AI agents: read [`handoff-2026-05-24-workspace-switch.md`](
 ## Handoff Notes
 
 - **Phase 2 complete.** Typed fields: text, int, enum, bool, datetime + `field_defs` registry.
-- **112 tests** via `composer check` (PHPUnit + PHPStan + CS + OpenAPI).
+- **Issue #16 in progress:** `tags`, `entity_tags`, filtered `GET /entities`.
 - ADR 0002: `docs/adr/0002-entity-model-and-field-defs.md`
+- ADR 0003: `docs/adr/0003-tags-and-entity-tags.md`
 - Phase 4 admin frontend not started; see `docs/development/frontend-standards.md`.
 
 ## Verification Commands

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -18,6 +18,9 @@ use NeNeRecords\DateTimeField\FieldKeyNotRegisteredExceptionHandler as DateTimeF
 use NeNeRecords\DateTimeField\FieldTypeMismatchExceptionHandler as DateTimeFieldTypeMismatchExceptionHandler;
 use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
 use NeNeRecords\Entity\EntityServiceProvider;
+use NeNeRecords\EntityTag\EntityTagAlreadyAttachedExceptionHandler;
+use NeNeRecords\EntityTag\EntityTagNotAttachedExceptionHandler;
+use NeNeRecords\EntityTag\EntityTagServiceProvider;
 use NeNeRecords\EntityType\EntityTypeNotFoundExceptionHandler;
 use NeNeRecords\EntityType\EntityTypeServiceProvider;
 use NeNeRecords\EntityType\EntityTypeSlugConflictExceptionHandler;
@@ -32,6 +35,9 @@ use NeNeRecords\IntField\FieldKeyNotRegisteredExceptionHandler as IntFieldKeyNot
 use NeNeRecords\IntField\FieldTypeMismatchExceptionHandler as IntFieldTypeMismatchExceptionHandler;
 use NeNeRecords\IntField\IntFieldNotFoundExceptionHandler;
 use NeNeRecords\IntField\IntFieldServiceProvider;
+use NeNeRecords\Tag\TagNotFoundExceptionHandler;
+use NeNeRecords\Tag\TagServiceProvider;
+use NeNeRecords\Tag\TagSlugConflictExceptionHandler;
 use NeNeRecords\TextField\FieldKeyNotRegisteredExceptionHandler as TextFieldKeyNotRegisteredExceptionHandler;
 use NeNeRecords\TextField\FieldTypeMismatchExceptionHandler as TextFieldTypeMismatchExceptionHandler;
 use NeNeRecords\TextField\TextFieldNotFoundExceptionHandler;
@@ -54,7 +60,9 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new IntFieldServiceProvider())
             ->addProvider(new EnumFieldServiceProvider())
             ->addProvider(new BoolFieldServiceProvider())
-            ->addProvider(new DateTimeFieldServiceProvider());
+            ->addProvider(new DateTimeFieldServiceProvider())
+            ->addProvider(new TagServiceProvider())
+            ->addProvider(new EntityTagServiceProvider());
 
         $builder
             ->set(
@@ -68,6 +76,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $enumField = $container->get('nene-records.route_registrar.enum_field');
                     $boolField = $container->get('nene-records.route_registrar.bool_field');
                     $datetimeField = $container->get('nene-records.route_registrar.datetime_field');
+                    $tag = $container->get('nene-records.route_registrar.tag');
+                    $entityTag = $container->get('nene-records.route_registrar.entity_tag');
 
                     if (
                         !is_callable($entityType)
@@ -78,6 +88,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !is_callable($enumField)
                         || !is_callable($boolField)
                         || !is_callable($datetimeField)
+                        || !is_callable($tag)
+                        || !is_callable($entityTag)
                     ) {
                         throw new LogicException('Route registrar service is invalid.');
                     }
@@ -91,6 +103,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $enumField,
                         $boolField,
                         $datetimeField,
+                        $tag,
+                        $entityTag,
                     ];
                 },
             )
@@ -117,6 +131,10 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $datetimeFieldNotFound = $container->get(DateTimeFieldNotFoundExceptionHandler::class);
                     $datetimeFieldKeyNotRegistered = $container->get(DateTimeFieldKeyNotRegisteredExceptionHandler::class);
                     $datetimeFieldTypeMismatch = $container->get(DateTimeFieldTypeMismatchExceptionHandler::class);
+                    $tagNotFound = $container->get(TagNotFoundExceptionHandler::class);
+                    $tagSlugConflict = $container->get(TagSlugConflictExceptionHandler::class);
+                    $entityTagAlreadyAttached = $container->get(EntityTagAlreadyAttachedExceptionHandler::class);
+                    $entityTagNotAttached = $container->get(EntityTagNotAttachedExceptionHandler::class);
 
                     foreach ([
                         $entityTypeNotFound,
@@ -139,6 +157,10 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $datetimeFieldNotFound,
                         $datetimeFieldKeyNotRegistered,
                         $datetimeFieldTypeMismatch,
+                        $tagNotFound,
+                        $tagSlugConflict,
+                        $entityTagAlreadyAttached,
+                        $entityTagNotAttached,
                     ] as $handler) {
                         if (!$handler instanceof DomainExceptionHandlerInterface) {
                             throw new LogicException('Exception handler service is invalid.');
@@ -166,6 +188,10 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $datetimeFieldNotFound,
                         $datetimeFieldKeyNotRegistered,
                         $datetimeFieldTypeMismatch,
+                        $tagNotFound,
+                        $tagSlugConflict,
+                        $entityTagAlreadyAttached,
+                        $entityTagNotAttached,
                     ];
                 },
             );

--- a/src/Entity/EntityListCriteria.php
+++ b/src/Entity/EntityListCriteria.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+final readonly class EntityListCriteria
+{
+    /** @param list<string> $tagSlugs */
+    public function __construct(
+        public ?int $entityTypeId = null,
+        public array $tagSlugs = [],
+    ) {
+    }
+}

--- a/src/Entity/EntityRepositoryInterface.php
+++ b/src/Entity/EntityRepositoryInterface.php
@@ -11,6 +11,11 @@ interface EntityRepositoryInterface
     /** @return list<Entity> */
     public function findAll(int $limit, int $offset): array;
 
+    /** @return list<Entity> */
+    public function findByCriteria(EntityListCriteria $criteria, int $limit, int $offset): array;
+
+    public function countByCriteria(EntityListCriteria $criteria): int;
+
     public function save(Entity $entity): int;
 
     public function update(Entity $entity): void;

--- a/src/Entity/ListEntitiesHandler.php
+++ b/src/Entity/ListEntitiesHandler.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Entity;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
 use Nene2\Http\PaginationResponse;
+use Nene2\Http\QueryStringParser;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -22,7 +23,20 @@ final readonly class ListEntitiesHandler
     {
         $pagination = PaginationQueryParser::parse($request);
 
-        $output = $this->useCase->execute(new ListEntitiesInput($pagination->limit, $pagination->offset));
+        $tagsFromTags = QueryStringParser::commaSeparated($request, 'tags') ?? [];
+        $tagsFromTag = QueryStringParser::commaSeparated($request, 'tag') ?? [];
+        $tagSlugs = array_values(array_unique([...$tagsFromTags, ...$tagsFromTag]));
+
+        $entityTypeId = QueryStringParser::int($request, 'entity_type_id');
+
+        $output = $this->useCase->execute(new ListEntitiesInput(
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+            criteria: new EntityListCriteria(
+                entityTypeId: $entityTypeId,
+                tagSlugs: $tagSlugs,
+            ),
+        ));
 
         return $this->response->create(
             (new PaginationResponse(
@@ -37,6 +51,7 @@ final readonly class ListEntitiesHandler
                 ),
                 limit: $output->limit,
                 offset: $output->offset,
+                total: $output->total,
             ))->toArray(),
         );
     }

--- a/src/Entity/ListEntitiesUseCase.php
+++ b/src/Entity/ListEntitiesUseCase.php
@@ -16,7 +16,8 @@ final readonly class ListEntitiesUseCase implements ListEntitiesUseCaseInterface
 
     public function execute(ListEntitiesInput $input): ListEntitiesOutput
     {
-        $rows = $this->entities->findAll($input->limit, $input->offset);
+        $rows = $this->entities->findByCriteria($input->criteria, $input->limit, $input->offset);
+        $total = $this->entities->countByCriteria($input->criteria);
 
         $items = array_map(static function (Entity $entity): ListEntityItem {
             $entityId = $entity->id;
@@ -37,6 +38,7 @@ final readonly class ListEntitiesUseCase implements ListEntitiesUseCaseInterface
             items: $items,
             limit: $input->limit,
             offset: $input->offset,
+            total: $total,
         );
     }
 }

--- a/src/Entity/PdoEntityRepository.php
+++ b/src/Entity/PdoEntityRepository.php
@@ -36,18 +36,75 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
     /** @return list<Entity> */
     public function findAll(int $limit, int $offset): array
     {
+        return $this->findByCriteria(new EntityListCriteria(), $limit, $offset);
+    }
+
+    /** @return list<Entity> */
+    public function findByCriteria(EntityListCriteria $criteria, int $limit, int $offset): array
+    {
+        [$where, $params] = $this->buildCriteriaWhere($criteria);
+        $params[] = $limit;
+        $params[] = $offset;
+
         $rows = $this->query->fetchAll(
-            <<<'SQL'
-                SELECT id, entity_type_id, is_deleted, deleted_at
-                FROM entities
-                WHERE is_deleted = 0
-                ORDER BY id ASC
+            <<<SQL
+                SELECT e.id, e.entity_type_id, e.is_deleted, e.deleted_at
+                FROM entities e
+                WHERE {$where}
+                ORDER BY e.id ASC
                 LIMIT ? OFFSET ?
                 SQL,
-            [$limit, $offset],
+            $params,
         );
 
         return array_map(fn (array $row) => $this->mapRow($row), $rows);
+    }
+
+    public function countByCriteria(EntityListCriteria $criteria): int
+    {
+        [$where, $params] = $this->buildCriteriaWhere($criteria);
+
+        $row = $this->query->fetchOne(
+            <<<SQL
+                SELECT COUNT(*) AS total
+                FROM entities e
+                WHERE {$where}
+                SQL,
+            $params,
+        );
+
+        return (int) ($row['total'] ?? 0);
+    }
+
+    /**
+     * @return array{0: string, 1: list<mixed>}
+     */
+    private function buildCriteriaWhere(EntityListCriteria $criteria): array
+    {
+        $conditions = ['e.is_deleted = 0'];
+        $params = [];
+
+        if ($criteria->entityTypeId !== null) {
+            $conditions[] = 'e.entity_type_id = ?';
+            $params[] = $criteria->entityTypeId;
+        }
+
+        if ($criteria->tagSlugs !== []) {
+            $placeholders = implode(', ', array_fill(0, count($criteria->tagSlugs), '?'));
+            $conditions[] = <<<SQL
+                EXISTS (
+                    SELECT 1
+                    FROM entity_tags et
+                    INNER JOIN tags t ON t.id = et.tag_id
+                    WHERE et.entity_id = e.id AND t.slug IN ({$placeholders})
+                )
+                SQL;
+            foreach ($criteria->tagSlugs as $slug) {
+                $params[] = $slug;
+            }
+        }
+
+        return [implode(' AND ', $conditions), $params];
     }
 
     public function save(Entity $entity): int

--- a/src/EntityTag/AttachEntityTagHandler.php
+++ b/src/EntityTag/AttachEntityTagHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeNeRecords\Entity\EntityNotFoundException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class AttachEntityTagHandler
+{
+    public function __construct(
+        private AttachEntityTagUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $entityId = (int) ($parameters['entityId'] ?? 0);
+
+        if ($entityId <= 0) {
+            throw new EntityNotFoundException($entityId);
+        }
+
+        $body = JsonRequestBodyParser::parse($request);
+
+        $tagIdRaw = $body['tag_id'] ?? null;
+
+        if (!is_int($tagIdRaw) && !(is_string($tagIdRaw) && ctype_digit($tagIdRaw))) {
+            throw new ValidationException([
+                new ValidationError('tag_id', 'Tag id is required.', 'required'),
+            ]);
+        }
+
+        $tagId = (int) $tagIdRaw;
+
+        if ($tagId <= 0) {
+            throw new ValidationException([
+                new ValidationError('tag_id', 'Tag id must be a positive integer.', 'format'),
+            ]);
+        }
+
+        $output = $this->useCase->execute(new AttachEntityTagInput($entityId, $tagId));
+
+        return $this->response->create(
+            ['id' => $output->id, 'slug' => $output->slug, 'name' => $output->name],
+            201,
+        );
+    }
+}

--- a/src/EntityTag/AttachEntityTagInput.php
+++ b/src/EntityTag/AttachEntityTagInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+final readonly class AttachEntityTagInput
+{
+    public function __construct(
+        public int $entityId,
+        public int $tagId,
+    ) {
+    }
+}

--- a/src/EntityTag/AttachEntityTagOutput.php
+++ b/src/EntityTag/AttachEntityTagOutput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+final readonly class AttachEntityTagOutput
+{
+    public function __construct(
+        public int $id,
+        public string $slug,
+        public string $name,
+    ) {
+    }
+}

--- a/src/EntityTag/AttachEntityTagUseCase.php
+++ b/src/EntityTag/AttachEntityTagUseCase.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\Tag\TagNotFoundException;
+use NeNeRecords\Tag\TagRepositoryInterface;
+
+final readonly class AttachEntityTagUseCase implements AttachEntityTagUseCaseInterface
+{
+    public function __construct(
+        private EntityRepositoryInterface $entities,
+        private TagRepositoryInterface $tags,
+        private EntityTagRepositoryInterface $entityTags,
+    ) {
+    }
+
+    public function execute(AttachEntityTagInput $input): AttachEntityTagOutput
+    {
+        if ($this->entities->findById($input->entityId) === null) {
+            throw new EntityNotFoundException($input->entityId);
+        }
+
+        $tag = $this->tags->findById($input->tagId);
+
+        if ($tag === null) {
+            throw new TagNotFoundException($input->tagId);
+        }
+
+        if ($this->entityTags->isAttached($input->entityId, $input->tagId)) {
+            throw new EntityTagAlreadyAttachedException($input->entityId, $input->tagId);
+        }
+
+        $this->entityTags->attach($input->entityId, $input->tagId);
+
+        return new AttachEntityTagOutput(
+            id: $tag->id ?? $input->tagId,
+            slug: $tag->slug,
+            name: $tag->name,
+        );
+    }
+}

--- a/src/EntityTag/AttachEntityTagUseCaseInterface.php
+++ b/src/EntityTag/AttachEntityTagUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+interface AttachEntityTagUseCaseInterface
+{
+    public function execute(AttachEntityTagInput $input): AttachEntityTagOutput;
+}

--- a/src/EntityTag/DetachEntityTagHandler.php
+++ b/src/EntityTag/DetachEntityTagHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+use Nene2\Routing\Router;
+use NeNeRecords\Entity\EntityNotFoundException;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DetachEntityTagHandler
+{
+    public function __construct(
+        private DetachEntityTagUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $entityId = (int) ($parameters['entityId'] ?? 0);
+        $tagId = (int) ($parameters['tagId'] ?? 0);
+
+        if ($entityId <= 0) {
+            throw new EntityNotFoundException($entityId);
+        }
+
+        if ($tagId <= 0) {
+            throw new EntityTagNotAttachedException($entityId, $tagId);
+        }
+
+        $this->useCase->execute(new DetachEntityTagInput($entityId, $tagId));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/EntityTag/DetachEntityTagInput.php
+++ b/src/EntityTag/DetachEntityTagInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+final readonly class DetachEntityTagInput
+{
+    public function __construct(
+        public int $entityId,
+        public int $tagId,
+    ) {
+    }
+}

--- a/src/EntityTag/DetachEntityTagUseCase.php
+++ b/src/EntityTag/DetachEntityTagUseCase.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+
+final readonly class DetachEntityTagUseCase implements DetachEntityTagUseCaseInterface
+{
+    public function __construct(
+        private EntityRepositoryInterface $entities,
+        private EntityTagRepositoryInterface $entityTags,
+    ) {
+    }
+
+    public function execute(DetachEntityTagInput $input): void
+    {
+        if ($this->entities->findById($input->entityId) === null) {
+            throw new EntityNotFoundException($input->entityId);
+        }
+
+        if (!$this->entityTags->isAttached($input->entityId, $input->tagId)) {
+            throw new EntityTagNotAttachedException($input->entityId, $input->tagId);
+        }
+
+        $this->entityTags->detach($input->entityId, $input->tagId);
+    }
+}

--- a/src/EntityTag/DetachEntityTagUseCaseInterface.php
+++ b/src/EntityTag/DetachEntityTagUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+interface DetachEntityTagUseCaseInterface
+{
+    public function execute(DetachEntityTagInput $input): void;
+}

--- a/src/EntityTag/EntityTagAlreadyAttachedException.php
+++ b/src/EntityTag/EntityTagAlreadyAttachedException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+use RuntimeException;
+
+final class EntityTagAlreadyAttachedException extends RuntimeException
+{
+    public function __construct(
+        public int $entityId,
+        public int $tagId,
+    ) {
+        parent::__construct("Tag {$tagId} is already attached to entity {$entityId}.");
+    }
+}

--- a/src/EntityTag/EntityTagAlreadyAttachedExceptionHandler.php
+++ b/src/EntityTag/EntityTagAlreadyAttachedExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class EntityTagAlreadyAttachedExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof EntityTagAlreadyAttachedException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'conflict',
+            'Conflict',
+            409,
+            'The tag is already attached to this entity.',
+        );
+    }
+}

--- a/src/EntityTag/EntityTagListItem.php
+++ b/src/EntityTag/EntityTagListItem.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+final readonly class EntityTagListItem
+{
+    public function __construct(
+        public int $id,
+        public string $slug,
+        public string $name,
+    ) {
+    }
+}

--- a/src/EntityTag/EntityTagNotAttachedException.php
+++ b/src/EntityTag/EntityTagNotAttachedException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+use RuntimeException;
+
+final class EntityTagNotAttachedException extends RuntimeException
+{
+    public function __construct(
+        public int $entityId,
+        public int $tagId,
+    ) {
+        parent::__construct("Tag {$tagId} is not attached to entity {$entityId}.");
+    }
+}

--- a/src/EntityTag/EntityTagNotAttachedExceptionHandler.php
+++ b/src/EntityTag/EntityTagNotAttachedExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class EntityTagNotAttachedExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof EntityTagNotAttachedException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'not-found',
+            'Not Found',
+            404,
+            'The tag is not attached to this entity.',
+        );
+    }
+}

--- a/src/EntityTag/EntityTagRepositoryInterface.php
+++ b/src/EntityTag/EntityTagRepositoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+interface EntityTagRepositoryInterface
+{
+    /** @return list<EntityTagListItem> */
+    public function findTagsByEntityId(int $entityId): array;
+
+    public function isAttached(int $entityId, int $tagId): bool;
+
+    public function attach(int $entityId, int $tagId): void;
+
+    public function detach(int $entityId, int $tagId): void;
+}

--- a/src/EntityTag/EntityTagRouteRegistrar.php
+++ b/src/EntityTag/EntityTagRouteRegistrar.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class EntityTagRouteRegistrar
+{
+    public function __construct(
+        private ListEntityTagsHandler $listHandler,
+        private AttachEntityTagHandler $attachHandler,
+        private DetachEntityTagHandler $detachHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $listHandler = $this->listHandler;
+        $attachHandler = $this->attachHandler;
+        $detachHandler = $this->detachHandler;
+
+        $router->get(
+            '/api/v1/entities/{entityId}/tags',
+            static fn (ServerRequestInterface $request) => $listHandler->handle($request),
+        );
+        $router->post(
+            '/api/v1/entities/{entityId}/tags',
+            static fn (ServerRequestInterface $request) => $attachHandler->handle($request),
+        );
+        $router->delete(
+            '/api/v1/entities/{entityId}/tags/{tagId}',
+            static fn (ServerRequestInterface $request) => $detachHandler->handle($request),
+        );
+    }
+}

--- a/src/EntityTag/EntityTagServiceProvider.php
+++ b/src/EntityTag/EntityTagServiceProvider.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\Tag\TagRepositoryInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class EntityTagServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                EntityTagRepositoryInterface::class,
+                static function (ContainerInterface $c): EntityTagRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoEntityTagRepository($query);
+                },
+            )
+            ->set(
+                ListEntityTagsUseCaseInterface::class,
+                static function (ContainerInterface $c): ListEntityTagsUseCaseInterface {
+                    $entities = $c->get(EntityRepositoryInterface::class);
+                    $entityTags = $c->get(EntityTagRepositoryInterface::class);
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$entityTags instanceof EntityTagRepositoryInterface) {
+                        throw new LogicException('Entity tag repository service is invalid.');
+                    }
+
+                    return new ListEntityTagsUseCase($entities, $entityTags);
+                },
+            )
+            ->set(
+                ListEntityTagsHandler::class,
+                static function (ContainerInterface $c): ListEntityTagsHandler {
+                    $useCase = $c->get(ListEntityTagsUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListEntityTagsUseCaseInterface) {
+                        throw new LogicException('ListEntityTags use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListEntityTagsHandler($useCase, $response);
+                },
+            )
+            ->set(
+                AttachEntityTagUseCaseInterface::class,
+                static function (ContainerInterface $c): AttachEntityTagUseCaseInterface {
+                    $entities = $c->get(EntityRepositoryInterface::class);
+                    $tags = $c->get(TagRepositoryInterface::class);
+                    $entityTags = $c->get(EntityTagRepositoryInterface::class);
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$tags instanceof TagRepositoryInterface) {
+                        throw new LogicException('Tag repository service is invalid.');
+                    }
+
+                    if (!$entityTags instanceof EntityTagRepositoryInterface) {
+                        throw new LogicException('Entity tag repository service is invalid.');
+                    }
+
+                    return new AttachEntityTagUseCase($entities, $tags, $entityTags);
+                },
+            )
+            ->set(
+                AttachEntityTagHandler::class,
+                static function (ContainerInterface $c): AttachEntityTagHandler {
+                    $useCase = $c->get(AttachEntityTagUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof AttachEntityTagUseCaseInterface) {
+                        throw new LogicException('AttachEntityTag use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new AttachEntityTagHandler($useCase, $response);
+                },
+            )
+            ->set(
+                DetachEntityTagUseCaseInterface::class,
+                static function (ContainerInterface $c): DetachEntityTagUseCaseInterface {
+                    $entities = $c->get(EntityRepositoryInterface::class);
+                    $entityTags = $c->get(EntityTagRepositoryInterface::class);
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$entityTags instanceof EntityTagRepositoryInterface) {
+                        throw new LogicException('Entity tag repository service is invalid.');
+                    }
+
+                    return new DetachEntityTagUseCase($entities, $entityTags);
+                },
+            )
+            ->set(
+                DetachEntityTagHandler::class,
+                static function (ContainerInterface $c): DetachEntityTagHandler {
+                    $useCase = $c->get(DetachEntityTagUseCaseInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof DetachEntityTagUseCaseInterface) {
+                        throw new LogicException('DetachEntityTag use case service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    return new DetachEntityTagHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
+                EntityTagAlreadyAttachedExceptionHandler::class,
+                static function (ContainerInterface $c): EntityTagAlreadyAttachedExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new EntityTagAlreadyAttachedExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                EntityTagNotAttachedExceptionHandler::class,
+                static function (ContainerInterface $c): EntityTagNotAttachedExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new EntityTagNotAttachedExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.entity_tag',
+                static function (ContainerInterface $c): EntityTagRouteRegistrar {
+                    $list = $c->get(ListEntityTagsHandler::class);
+                    $attach = $c->get(AttachEntityTagHandler::class);
+                    $detach = $c->get(DetachEntityTagHandler::class);
+
+                    if (!$list instanceof ListEntityTagsHandler) {
+                        throw new LogicException('ListEntityTags handler service is invalid.');
+                    }
+
+                    if (!$attach instanceof AttachEntityTagHandler) {
+                        throw new LogicException('AttachEntityTag handler service is invalid.');
+                    }
+
+                    if (!$detach instanceof DetachEntityTagHandler) {
+                        throw new LogicException('DetachEntityTag handler service is invalid.');
+                    }
+
+                    return new EntityTagRouteRegistrar($list, $attach, $detach);
+                },
+            );
+    }
+}

--- a/src/EntityTag/ListEntityTagsHandler.php
+++ b/src/EntityTag/ListEntityTagsHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeNeRecords\Entity\EntityNotFoundException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListEntityTagsHandler
+{
+    public function __construct(
+        private ListEntityTagsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $entityId = (int) ($parameters['entityId'] ?? 0);
+
+        if ($entityId <= 0) {
+            throw new EntityNotFoundException($entityId);
+        }
+
+        $output = $this->useCase->execute(new ListEntityTagsInput($entityId));
+
+        return $this->response->create([
+            'items' => array_map(
+                static fn (EntityTagListItem $item) => [
+                    'id' => $item->id,
+                    'slug' => $item->slug,
+                    'name' => $item->name,
+                ],
+                $output->items,
+            ),
+        ]);
+    }
+}

--- a/src/EntityTag/ListEntityTagsInput.php
+++ b/src/EntityTag/ListEntityTagsInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+final readonly class ListEntityTagsInput
+{
+    public function __construct(
+        public int $entityId,
+    ) {
+    }
+}

--- a/src/EntityTag/ListEntityTagsOutput.php
+++ b/src/EntityTag/ListEntityTagsOutput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+final readonly class ListEntityTagsOutput
+{
+    /** @param list<EntityTagListItem> $items */
+    public function __construct(
+        public array $items,
+    ) {
+    }
+}

--- a/src/EntityTag/ListEntityTagsUseCase.php
+++ b/src/EntityTag/ListEntityTagsUseCase.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+
+final readonly class ListEntityTagsUseCase implements ListEntityTagsUseCaseInterface
+{
+    public function __construct(
+        private EntityRepositoryInterface $entities,
+        private EntityTagRepositoryInterface $entityTags,
+    ) {
+    }
+
+    public function execute(ListEntityTagsInput $input): ListEntityTagsOutput
+    {
+        if ($this->entities->findById($input->entityId) === null) {
+            throw new EntityNotFoundException($input->entityId);
+        }
+
+        return new ListEntityTagsOutput(
+            items: $this->entityTags->findTagsByEntityId($input->entityId),
+        );
+    }
+}

--- a/src/EntityTag/ListEntityTagsUseCaseInterface.php
+++ b/src/EntityTag/ListEntityTagsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+interface ListEntityTagsUseCaseInterface
+{
+    public function execute(ListEntityTagsInput $input): ListEntityTagsOutput;
+}

--- a/src/EntityTag/PdoEntityTagRepository.php
+++ b/src/EntityTag/PdoEntityTagRepository.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityTag;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoEntityTagRepository implements EntityTagRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    /** @return list<EntityTagListItem> */
+    public function findTagsByEntityId(int $entityId): array
+    {
+        $rows = $this->query->fetchAll(
+            <<<'SQL'
+                SELECT t.id, t.slug, t.name
+                FROM entity_tags et
+                INNER JOIN tags t ON t.id = et.tag_id
+                WHERE et.entity_id = ?
+                ORDER BY t.id ASC
+                SQL,
+            [$entityId],
+        );
+
+        return array_map(
+            static fn (array $row) => new EntityTagListItem(
+                id: (int) $row['id'],
+                slug: (string) $row['slug'],
+                name: (string) $row['name'],
+            ),
+            $rows,
+        );
+    }
+
+    public function isAttached(int $entityId, int $tagId): bool
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id FROM entity_tags WHERE entity_id = ? AND tag_id = ?',
+            [$entityId, $tagId],
+        );
+
+        return $row !== null;
+    }
+
+    public function attach(int $entityId, int $tagId): void
+    {
+        $this->query->execute(
+            'INSERT INTO entity_tags (entity_id, tag_id) VALUES (?, ?)',
+            [$entityId, $tagId],
+        );
+    }
+
+    public function detach(int $entityId, int $tagId): void
+    {
+        $this->query->execute(
+            'DELETE FROM entity_tags WHERE entity_id = ? AND tag_id = ?',
+            [$entityId, $tagId],
+        );
+    }
+}

--- a/src/Tag/CreateTagHandler.php
+++ b/src/Tag/CreateTagHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateTagHandler
+{
+    private const SLUG_PATTERN = '/^[a-z0-9]+(?:-[a-z0-9]+)*$/';
+
+    public function __construct(
+        private CreateTagUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+
+        $name = trim((string) ($body['name'] ?? ''));
+        $slug = trim((string) ($body['slug'] ?? ''));
+
+        if ($name === '') {
+            $errors[] = new ValidationError('name', 'Name is required.', 'required');
+        }
+
+        if ($slug === '') {
+            $errors[] = new ValidationError('slug', 'Slug is required.', 'required');
+        } elseif (preg_match(self::SLUG_PATTERN, $slug) !== 1) {
+            $errors[] = new ValidationError('slug', 'Slug format is invalid.', 'format');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new CreateTagInput(name: $name, slug: $slug));
+
+        return $this->response->create(
+            ['id' => $output->id, 'slug' => $output->slug, 'name' => $output->name],
+            201,
+            ['Location' => '/api/v1/tags/' . $output->id],
+        );
+    }
+}

--- a/src/Tag/CreateTagInput.php
+++ b/src/Tag/CreateTagInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+final readonly class CreateTagInput
+{
+    public function __construct(
+        public string $name,
+        public string $slug,
+    ) {
+    }
+}

--- a/src/Tag/CreateTagOutput.php
+++ b/src/Tag/CreateTagOutput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+final readonly class CreateTagOutput
+{
+    public function __construct(
+        public int $id,
+        public string $slug,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Tag/CreateTagUseCase.php
+++ b/src/Tag/CreateTagUseCase.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+final readonly class CreateTagUseCase implements CreateTagUseCaseInterface
+{
+    public function __construct(
+        private TagRepositoryInterface $tags,
+    ) {
+    }
+
+    public function execute(CreateTagInput $input): CreateTagOutput
+    {
+        $existing = $this->tags->findBySlug($input->slug);
+
+        if ($existing !== null) {
+            throw new TagSlugConflictException($input->slug);
+        }
+
+        $id = $this->tags->save(new Tag(slug: $input->slug, name: $input->name));
+
+        return new CreateTagOutput(id: $id, slug: $input->slug, name: $input->name);
+    }
+}

--- a/src/Tag/CreateTagUseCaseInterface.php
+++ b/src/Tag/CreateTagUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+interface CreateTagUseCaseInterface
+{
+    public function execute(CreateTagInput $input): CreateTagOutput;
+}

--- a/src/Tag/DeleteTagHandler.php
+++ b/src/Tag/DeleteTagHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteTagHandler
+{
+    public function __construct(
+        private DeleteTagUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new TagNotFoundException($id);
+        }
+
+        $this->useCase->execute(new DeleteTagInput($id));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/Tag/DeleteTagInput.php
+++ b/src/Tag/DeleteTagInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+final readonly class DeleteTagInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/Tag/DeleteTagUseCase.php
+++ b/src/Tag/DeleteTagUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+final readonly class DeleteTagUseCase implements DeleteTagUseCaseInterface
+{
+    public function __construct(
+        private TagRepositoryInterface $tags,
+    ) {
+    }
+
+    public function execute(DeleteTagInput $input): void
+    {
+        $tag = $this->tags->findById($input->id);
+
+        if ($tag === null) {
+            throw new TagNotFoundException($input->id);
+        }
+
+        $this->tags->delete($input->id);
+    }
+}

--- a/src/Tag/DeleteTagUseCaseInterface.php
+++ b/src/Tag/DeleteTagUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+interface DeleteTagUseCaseInterface
+{
+    public function execute(DeleteTagInput $input): void;
+}

--- a/src/Tag/GetTagByIdHandler.php
+++ b/src/Tag/GetTagByIdHandler.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetTagByIdHandler
+{
+    public function __construct(
+        private GetTagByIdUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new TagNotFoundException($id);
+        }
+
+        $output = $this->useCase->execute(new GetTagByIdInput($id));
+
+        return $this->response->create([
+            'id' => $output->id,
+            'slug' => $output->slug,
+            'name' => $output->name,
+        ]);
+    }
+}

--- a/src/Tag/GetTagByIdInput.php
+++ b/src/Tag/GetTagByIdInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+final readonly class GetTagByIdInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/Tag/GetTagByIdOutput.php
+++ b/src/Tag/GetTagByIdOutput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+final readonly class GetTagByIdOutput
+{
+    public function __construct(
+        public int $id,
+        public string $slug,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Tag/GetTagByIdUseCase.php
+++ b/src/Tag/GetTagByIdUseCase.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+final readonly class GetTagByIdUseCase implements GetTagByIdUseCaseInterface
+{
+    public function __construct(
+        private TagRepositoryInterface $tags,
+    ) {
+    }
+
+    public function execute(GetTagByIdInput $input): GetTagByIdOutput
+    {
+        $tag = $this->tags->findById($input->id);
+
+        if ($tag === null) {
+            throw new TagNotFoundException($input->id);
+        }
+
+        return new GetTagByIdOutput(
+            id: $tag->id ?? $input->id,
+            slug: $tag->slug,
+            name: $tag->name,
+        );
+    }
+}

--- a/src/Tag/GetTagByIdUseCaseInterface.php
+++ b/src/Tag/GetTagByIdUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+interface GetTagByIdUseCaseInterface
+{
+    public function execute(GetTagByIdInput $input): GetTagByIdOutput;
+}

--- a/src/Tag/ListTagItem.php
+++ b/src/Tag/ListTagItem.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+final readonly class ListTagItem
+{
+    public function __construct(
+        public int $id,
+        public string $slug,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Tag/ListTagsHandler.php
+++ b/src/Tag/ListTagsHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListTagsHandler
+{
+    public function __construct(
+        private ListTagsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $pagination = PaginationQueryParser::parse($request);
+
+        $output = $this->useCase->execute(new ListTagsInput($pagination->limit, $pagination->offset));
+
+        return $this->response->create(
+            (new PaginationResponse(
+                items: array_map(
+                    static fn (ListTagItem $item) => [
+                        'id' => $item->id,
+                        'slug' => $item->slug,
+                        'name' => $item->name,
+                    ],
+                    $output->items,
+                ),
+                limit: $output->limit,
+                offset: $output->offset,
+            ))->toArray(),
+        );
+    }
+}

--- a/src/Tag/ListTagsInput.php
+++ b/src/Tag/ListTagsInput.php
@@ -2,14 +2,13 @@
 
 declare(strict_types=1);
 
-namespace NeNeRecords\Entity;
+namespace NeNeRecords\Tag;
 
-final readonly class ListEntitiesInput
+final readonly class ListTagsInput
 {
     public function __construct(
         public int $limit = 20,
         public int $offset = 0,
-        public EntityListCriteria $criteria = new EntityListCriteria(),
     ) {
     }
 }

--- a/src/Tag/ListTagsOutput.php
+++ b/src/Tag/ListTagsOutput.php
@@ -2,16 +2,15 @@
 
 declare(strict_types=1);
 
-namespace NeNeRecords\Entity;
+namespace NeNeRecords\Tag;
 
-final readonly class ListEntitiesOutput
+final readonly class ListTagsOutput
 {
-    /** @param list<ListEntityItem> $items */
+    /** @param list<ListTagItem> $items */
     public function __construct(
         public array $items,
         public int $limit,
         public int $offset,
-        public int $total,
     ) {
     }
 }

--- a/src/Tag/ListTagsUseCase.php
+++ b/src/Tag/ListTagsUseCase.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+use LogicException;
+
+final readonly class ListTagsUseCase implements ListTagsUseCaseInterface
+{
+    public function __construct(
+        private TagRepositoryInterface $tags,
+    ) {
+    }
+
+    public function execute(ListTagsInput $input): ListTagsOutput
+    {
+        $rows = $this->tags->findAll($input->limit, $input->offset);
+
+        $items = array_map(static function (Tag $tag): ListTagItem {
+            $tagId = $tag->id;
+
+            if ($tagId === null) {
+                throw new LogicException('Listed tag missing id.');
+            }
+
+            return new ListTagItem(
+                id: $tagId,
+                slug: $tag->slug,
+                name: $tag->name,
+            );
+        }, $rows);
+
+        return new ListTagsOutput(
+            items: $items,
+            limit: $input->limit,
+            offset: $input->offset,
+        );
+    }
+}

--- a/src/Tag/ListTagsUseCaseInterface.php
+++ b/src/Tag/ListTagsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+interface ListTagsUseCaseInterface
+{
+    public function execute(ListTagsInput $input): ListTagsOutput;
+}

--- a/src/Tag/PdoTagRepository.php
+++ b/src/Tag/PdoTagRepository.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoTagRepository implements TagRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?Tag
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, slug, name FROM tags WHERE id = ?',
+            [$id],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return new Tag(
+            slug: (string) $row['slug'],
+            name: (string) $row['name'],
+            id: (int) $row['id'],
+        );
+    }
+
+    public function findBySlug(string $slug): ?Tag
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, slug, name FROM tags WHERE slug = ?',
+            [$slug],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return new Tag(
+            slug: (string) $row['slug'],
+            name: (string) $row['name'],
+            id: (int) $row['id'],
+        );
+    }
+
+    /** @return list<Tag> */
+    public function findAll(int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, slug, name FROM tags ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$limit, $offset],
+        );
+
+        return array_map(
+            static fn (array $row) => new Tag(
+                slug: (string) $row['slug'],
+                name: (string) $row['name'],
+                id: (int) $row['id'],
+            ),
+            $rows,
+        );
+    }
+
+    public function save(Tag $tag): int
+    {
+        $this->query->execute(
+            'INSERT INTO tags (slug, name) VALUES (?, ?)',
+            [$tag->slug, $tag->name],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function update(Tag $tag): void
+    {
+        $this->query->execute(
+            'UPDATE tags SET slug = ?, name = ? WHERE id = ?',
+            [$tag->slug, $tag->name, $tag->id],
+        );
+    }
+
+    public function delete(int $id): void
+    {
+        $this->query->execute('DELETE FROM tags WHERE id = ?', [$id]);
+    }
+}

--- a/src/Tag/Tag.php
+++ b/src/Tag/Tag.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+final readonly class Tag
+{
+    public function __construct(
+        public string $slug,
+        public string $name,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/Tag/TagNotFoundException.php
+++ b/src/Tag/TagNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+use RuntimeException;
+
+final class TagNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("Tag with id {$id} was not found.");
+    }
+}

--- a/src/Tag/TagNotFoundExceptionHandler.php
+++ b/src/Tag/TagNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class TagNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof TagNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'not-found',
+            'Not Found',
+            404,
+            'The requested tag was not found.',
+        );
+    }
+}

--- a/src/Tag/TagRepositoryInterface.php
+++ b/src/Tag/TagRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+interface TagRepositoryInterface
+{
+    public function findById(int $id): ?Tag;
+
+    public function findBySlug(string $slug): ?Tag;
+
+    /** @return list<Tag> */
+    public function findAll(int $limit, int $offset): array;
+
+    public function save(Tag $tag): int;
+
+    public function update(Tag $tag): void;
+
+    public function delete(int $id): void;
+}

--- a/src/Tag/TagRouteRegistrar.php
+++ b/src/Tag/TagRouteRegistrar.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class TagRouteRegistrar
+{
+    public function __construct(
+        private GetTagByIdHandler $getHandler,
+        private CreateTagHandler $createHandler,
+        private UpdateTagHandler $updateHandler,
+        private DeleteTagHandler $deleteHandler,
+        private ListTagsHandler $listHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $getHandler = $this->getHandler;
+        $createHandler = $this->createHandler;
+        $updateHandler = $this->updateHandler;
+        $deleteHandler = $this->deleteHandler;
+        $listHandler = $this->listHandler;
+
+        $router->get('/api/v1/tags', static fn (ServerRequestInterface $request) => $listHandler->handle($request));
+        $router->get('/api/v1/tags/{id}', static fn (ServerRequestInterface $request) => $getHandler->handle($request));
+        $router->post('/api/v1/tags', static fn (ServerRequestInterface $request) => $createHandler->handle($request));
+        $router->put('/api/v1/tags/{id}', static fn (ServerRequestInterface $request) => $updateHandler->handle($request));
+        $router->delete('/api/v1/tags/{id}', static fn (ServerRequestInterface $request) => $deleteHandler->handle($request));
+    }
+}

--- a/src/Tag/TagServiceProvider.php
+++ b/src/Tag/TagServiceProvider.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class TagServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                TagRepositoryInterface::class,
+                static function (ContainerInterface $c): TagRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoTagRepository($query);
+                },
+            )
+            ->set(
+                GetTagByIdUseCaseInterface::class,
+                static function (ContainerInterface $c): GetTagByIdUseCaseInterface {
+                    $repository = $c->get(TagRepositoryInterface::class);
+
+                    if (!$repository instanceof TagRepositoryInterface) {
+                        throw new LogicException('Tag repository service is invalid.');
+                    }
+
+                    return new GetTagByIdUseCase($repository);
+                },
+            )
+            ->set(
+                GetTagByIdHandler::class,
+                static function (ContainerInterface $c): GetTagByIdHandler {
+                    $useCase = $c->get(GetTagByIdUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof GetTagByIdUseCaseInterface) {
+                        throw new LogicException('GetTagById use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new GetTagByIdHandler($useCase, $response);
+                },
+            )
+            ->set(
+                CreateTagUseCaseInterface::class,
+                static function (ContainerInterface $c): CreateTagUseCaseInterface {
+                    $repository = $c->get(TagRepositoryInterface::class);
+
+                    if (!$repository instanceof TagRepositoryInterface) {
+                        throw new LogicException('Tag repository service is invalid.');
+                    }
+
+                    return new CreateTagUseCase($repository);
+                },
+            )
+            ->set(
+                CreateTagHandler::class,
+                static function (ContainerInterface $c): CreateTagHandler {
+                    $useCase = $c->get(CreateTagUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof CreateTagUseCaseInterface) {
+                        throw new LogicException('CreateTag use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new CreateTagHandler($useCase, $response);
+                },
+            )
+            ->set(
+                DeleteTagUseCaseInterface::class,
+                static function (ContainerInterface $c): DeleteTagUseCaseInterface {
+                    $repository = $c->get(TagRepositoryInterface::class);
+
+                    if (!$repository instanceof TagRepositoryInterface) {
+                        throw new LogicException('Tag repository service is invalid.');
+                    }
+
+                    return new DeleteTagUseCase($repository);
+                },
+            )
+            ->set(
+                DeleteTagHandler::class,
+                static function (ContainerInterface $c): DeleteTagHandler {
+                    $useCase = $c->get(DeleteTagUseCaseInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof DeleteTagUseCaseInterface) {
+                        throw new LogicException('DeleteTag use case service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    return new DeleteTagHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
+                ListTagsUseCaseInterface::class,
+                static function (ContainerInterface $c): ListTagsUseCaseInterface {
+                    $repository = $c->get(TagRepositoryInterface::class);
+
+                    if (!$repository instanceof TagRepositoryInterface) {
+                        throw new LogicException('Tag repository service is invalid.');
+                    }
+
+                    return new ListTagsUseCase($repository);
+                },
+            )
+            ->set(
+                ListTagsHandler::class,
+                static function (ContainerInterface $c): ListTagsHandler {
+                    $useCase = $c->get(ListTagsUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListTagsUseCaseInterface) {
+                        throw new LogicException('ListTags use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListTagsHandler($useCase, $response);
+                },
+            )
+            ->set(
+                UpdateTagUseCaseInterface::class,
+                static function (ContainerInterface $c): UpdateTagUseCaseInterface {
+                    $repository = $c->get(TagRepositoryInterface::class);
+
+                    if (!$repository instanceof TagRepositoryInterface) {
+                        throw new LogicException('Tag repository service is invalid.');
+                    }
+
+                    return new UpdateTagUseCase($repository);
+                },
+            )
+            ->set(
+                UpdateTagHandler::class,
+                static function (ContainerInterface $c): UpdateTagHandler {
+                    $useCase = $c->get(UpdateTagUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof UpdateTagUseCaseInterface) {
+                        throw new LogicException('UpdateTag use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new UpdateTagHandler($useCase, $response);
+                },
+            )
+            ->set(
+                TagNotFoundExceptionHandler::class,
+                static function (ContainerInterface $c): TagNotFoundExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new TagNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                TagSlugConflictExceptionHandler::class,
+                static function (ContainerInterface $c): TagSlugConflictExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new TagSlugConflictExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.tag',
+                static function (ContainerInterface $c): TagRouteRegistrar {
+                    $get = $c->get(GetTagByIdHandler::class);
+                    $create = $c->get(CreateTagHandler::class);
+                    $update = $c->get(UpdateTagHandler::class);
+                    $delete = $c->get(DeleteTagHandler::class);
+                    $list = $c->get(ListTagsHandler::class);
+
+                    if (!$get instanceof GetTagByIdHandler) {
+                        throw new LogicException('GetTagById handler service is invalid.');
+                    }
+
+                    if (!$create instanceof CreateTagHandler) {
+                        throw new LogicException('CreateTag handler service is invalid.');
+                    }
+
+                    if (!$update instanceof UpdateTagHandler) {
+                        throw new LogicException('UpdateTag handler service is invalid.');
+                    }
+
+                    if (!$delete instanceof DeleteTagHandler) {
+                        throw new LogicException('DeleteTag handler service is invalid.');
+                    }
+
+                    if (!$list instanceof ListTagsHandler) {
+                        throw new LogicException('ListTags handler service is invalid.');
+                    }
+
+                    return new TagRouteRegistrar($get, $create, $update, $delete, $list);
+                },
+            );
+    }
+}

--- a/src/Tag/TagSlugConflictException.php
+++ b/src/Tag/TagSlugConflictException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+use RuntimeException;
+
+final class TagSlugConflictException extends RuntimeException
+{
+    public function __construct(
+        public string $slug,
+    ) {
+        parent::__construct("A tag with slug {$slug} already exists.");
+    }
+}

--- a/src/Tag/TagSlugConflictExceptionHandler.php
+++ b/src/Tag/TagSlugConflictExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class TagSlugConflictExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof TagSlugConflictException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'conflict',
+            'Conflict',
+            409,
+            'The slug is already in use.',
+        );
+    }
+}

--- a/src/Tag/UpdateTagHandler.php
+++ b/src/Tag/UpdateTagHandler.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateTagHandler
+{
+    private const SLUG_PATTERN = '/^[a-z0-9]+(?:-[a-z0-9]+)*$/';
+
+    public function __construct(
+        private UpdateTagUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new TagNotFoundException($id);
+        }
+
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+
+        $name = trim((string) ($body['name'] ?? ''));
+        $slug = trim((string) ($body['slug'] ?? ''));
+
+        if ($name === '') {
+            $errors[] = new ValidationError('name', 'Name is required.', 'required');
+        }
+
+        if ($slug === '') {
+            $errors[] = new ValidationError('slug', 'Slug is required.', 'required');
+        } elseif (preg_match(self::SLUG_PATTERN, $slug) !== 1) {
+            $errors[] = new ValidationError('slug', 'Slug format is invalid.', 'format');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new UpdateTagInput(id: $id, name: $name, slug: $slug));
+
+        return $this->response->create(['id' => $output->id, 'slug' => $output->slug, 'name' => $output->name]);
+    }
+}

--- a/src/Tag/UpdateTagInput.php
+++ b/src/Tag/UpdateTagInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+final readonly class UpdateTagInput
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+        public string $slug,
+    ) {
+    }
+}

--- a/src/Tag/UpdateTagOutput.php
+++ b/src/Tag/UpdateTagOutput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+final readonly class UpdateTagOutput
+{
+    public function __construct(
+        public int $id,
+        public string $slug,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Tag/UpdateTagUseCase.php
+++ b/src/Tag/UpdateTagUseCase.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+final readonly class UpdateTagUseCase implements UpdateTagUseCaseInterface
+{
+    public function __construct(
+        private TagRepositoryInterface $tags,
+    ) {
+    }
+
+    public function execute(UpdateTagInput $input): UpdateTagOutput
+    {
+        $tag = $this->tags->findById($input->id);
+
+        if ($tag === null) {
+            throw new TagNotFoundException($input->id);
+        }
+
+        if ($input->slug !== $tag->slug) {
+            $existing = $this->tags->findBySlug($input->slug);
+
+            if ($existing !== null && $existing->id !== $input->id) {
+                throw new TagSlugConflictException($input->slug);
+            }
+        }
+
+        $updated = new Tag(slug: $input->slug, name: $input->name, id: $input->id);
+        $this->tags->update($updated);
+
+        return new UpdateTagOutput(id: $input->id, slug: $input->slug, name: $input->name);
+    }
+}

--- a/src/Tag/UpdateTagUseCaseInterface.php
+++ b/src/Tag/UpdateTagUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tag;
+
+interface UpdateTagUseCaseInterface
+{
+    public function execute(UpdateTagInput $input): UpdateTagOutput;
+}

--- a/tests/Entity/EntityFilterHttpTest.php
+++ b/tests/Entity/EntityFilterHttpTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Entity;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Entity\CreateEntityHandler;
+use NeNeRecords\Entity\CreateEntityUseCase;
+use NeNeRecords\Entity\DeleteEntityHandler;
+use NeNeRecords\Entity\DeleteEntityUseCase;
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
+use NeNeRecords\Entity\EntityRouteRegistrar;
+use NeNeRecords\Entity\GetEntityByIdHandler;
+use NeNeRecords\Entity\GetEntityByIdUseCase;
+use NeNeRecords\Entity\ListEntitiesHandler;
+use NeNeRecords\Entity\ListEntitiesUseCase;
+use NeNeRecords\Entity\UpdateEntityHandler;
+use NeNeRecords\Entity\UpdateEntityUseCase;
+use NeNeRecords\EntityType\EntityTypeNotFoundExceptionHandler;
+use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class EntityFilterHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryEntityRepository $entities;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->entities = new InMemoryEntityRepository([
+            new Entity(id: 1, entityTypeId: 1),
+            new Entity(id: 2, entityTypeId: 1),
+            new Entity(id: 3, entityTypeId: 2),
+        ]);
+        $this->entities->setTagSlugsForEntity(1, ['featured']);
+        $this->entities->setTagSlugsForEntity(2, ['draft']);
+        $this->entities->setTagSlugsForEntity(3, ['featured']);
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+        $entityTypes = new InMemoryEntityTypeRepository();
+
+        $registrar = new EntityRouteRegistrar(
+            new GetEntityByIdHandler(new GetEntityByIdUseCase($this->entities), $jsonResponse),
+            new CreateEntityHandler(new CreateEntityUseCase($this->entities, $entityTypes), $jsonResponse),
+            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $entityTypes), $jsonResponse),
+            new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [
+                new EntityTypeNotFoundExceptionHandler($problemDetails),
+                new EntityNotFoundExceptionHandler($problemDetails),
+            ],
+            routeRegistrars: [$registrar],
+        ))->create();
+    }
+
+    public function testListEntitiesFilteredByEntityTypeId(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/entities?entity_type_id=2'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(1, $payload['total']);
+        self::assertCount(1, $payload['items']);
+        self::assertSame(3, $payload['items'][0]['id']);
+    }
+
+    public function testListEntitiesFilteredByTagSlugsUsesOrSemantics(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/entities?tags=featured,draft'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(3, $payload['total']);
+        self::assertCount(3, $payload['items']);
+    }
+
+    public function testListEntitiesMergesTagAndTagsQueryParameters(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/entities?tag=draft&tags=featured'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(3, $payload['total']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/tests/Entity/InMemoryEntityRepository.php
+++ b/tests/Entity/InMemoryEntityRepository.php
@@ -6,6 +6,7 @@ namespace NeNeRecords\Tests\Entity;
 
 use DateTimeImmutable;
 use NeNeRecords\Entity\Entity;
+use NeNeRecords\Entity\EntityListCriteria;
 use NeNeRecords\Entity\EntityRepositoryInterface;
 
 final class InMemoryEntityRepository implements EntityRepositoryInterface
@@ -13,12 +14,16 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
     /** @var array<int, Entity> */
     private array $entities;
 
+    /** @var array<int, list<string>> entityId => tag slugs */
+    private array $tagSlugsByEntityId;
+
     private int $nextId;
 
     /** @param list<Entity> $seed */
     public function __construct(array $seed = [])
     {
         $this->entities = [];
+        $this->tagSlugsByEntityId = [];
         $this->nextId = 1;
 
         foreach ($seed as $entity) {
@@ -28,6 +33,12 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
                 $this->nextId = max($this->nextId, $id + 1);
             }
         }
+    }
+
+    /** @param list<string> $tagSlugs */
+    public function setTagSlugsForEntity(int $entityId, array $tagSlugs): void
+    {
+        $this->tagSlugsByEntityId[$entityId] = $tagSlugs;
     }
 
     public function findById(int $id): ?Entity
@@ -44,17 +55,51 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
     /** @return list<Entity> */
     public function findAll(int $limit, int $offset): array
     {
+        return $this->findByCriteria(new EntityListCriteria(), $limit, $offset);
+    }
+
+    /** @return list<Entity> */
+    public function findByCriteria(EntityListCriteria $criteria, int $limit, int $offset): array
+    {
         $active = [];
 
         foreach ($this->entities as $entity) {
-            if (!$entity->isDeleted) {
-                $active[] = $entity;
+            if ($entity->isDeleted) {
+                continue;
             }
+
+            if ($criteria->entityTypeId !== null && $entity->entityTypeId !== $criteria->entityTypeId) {
+                continue;
+            }
+
+            if ($criteria->tagSlugs !== []) {
+                $entityId = $entity->id ?? 0;
+                $entityTagSlugs = $this->tagSlugsByEntityId[$entityId] ?? [];
+                $matches = false;
+
+                foreach ($criteria->tagSlugs as $slug) {
+                    if (in_array($slug, $entityTagSlugs, true)) {
+                        $matches = true;
+                        break;
+                    }
+                }
+
+                if (!$matches) {
+                    continue;
+                }
+            }
+
+            $active[] = $entity;
         }
 
         usort($active, static fn (Entity $a, Entity $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
 
         return array_slice($active, $offset, $limit);
+    }
+
+    public function countByCriteria(EntityListCriteria $criteria): int
+    {
+        return count($this->findByCriteria($criteria, PHP_INT_MAX, 0));
     }
 
     public function save(Entity $entity): int

--- a/tests/Entity/PdoEntityRepositoryTest.php
+++ b/tests/Entity/PdoEntityRepositoryTest.php
@@ -8,6 +8,7 @@ use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeNeRecords\Entity\Entity;
+use NeNeRecords\Entity\EntityListCriteria;
 use NeNeRecords\Entity\PdoEntityRepository;
 use PHPUnit\Framework\TestCase;
 
@@ -47,6 +48,8 @@ final class PdoEntityRepositoryTest extends TestCase
         $paths = [
             $projectRoot . '/database/schema/entity_types.sql',
             $projectRoot . '/database/schema/entities.sql',
+            $projectRoot . '/database/schema/tags.sql',
+            $projectRoot . '/database/schema/entity_tags.sql',
             $projectRoot . '/database/schema/text_fields.sql',
         ];
 
@@ -169,5 +172,43 @@ final class PdoEntityRepositoryTest extends TestCase
         self::assertCount(2, $list);
         self::assertSame(3, $list[0]->id);
         self::assertSame(4, $list[1]->id);
+    }
+
+    public function testFindByCriteriaFiltersByEntityTypeId(): void
+    {
+        $typeA = $this->insertEntityTypeId();
+        $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('Other', 'other')");
+        $typeB = 2;
+
+        $repository = new PdoEntityRepository($this->executor);
+        $repository->save(new Entity(id: null, entityTypeId: $typeA));
+        $repository->save(new Entity(id: null, entityTypeId: $typeB));
+
+        $list = $repository->findByCriteria(new EntityListCriteria(entityTypeId: $typeB), 10, 0);
+
+        self::assertCount(1, $list);
+        self::assertSame($typeB, $list[0]->entityTypeId);
+        self::assertSame(1, $repository->countByCriteria(new EntityListCriteria(entityTypeId: $typeB)));
+    }
+
+    public function testFindByCriteriaFiltersByTagSlugsWithOrSemantics(): void
+    {
+        $typeId = $this->insertEntityTypeId();
+
+        $repository = new PdoEntityRepository($this->executor);
+        $entityA = $repository->save(new Entity(id: null, entityTypeId: $typeId));
+        $entityB = $repository->save(new Entity(id: null, entityTypeId: $typeId));
+        $repository->save(new Entity(id: null, entityTypeId: $typeId));
+
+        $this->executor->execute("INSERT INTO tags (slug, name) VALUES ('featured', 'Featured')");
+        $this->executor->execute("INSERT INTO tags (slug, name) VALUES ('draft', 'Draft')");
+        $this->executor->execute('INSERT INTO entity_tags (entity_id, tag_id) VALUES (?, 1)', [$entityA]);
+        $this->executor->execute('INSERT INTO entity_tags (entity_id, tag_id) VALUES (?, 2)', [$entityB]);
+
+        $criteria = new EntityListCriteria(tagSlugs: ['featured', 'draft']);
+        $list = $repository->findByCriteria($criteria, 10, 0);
+
+        self::assertCount(2, $list);
+        self::assertSame(2, $repository->countByCriteria($criteria));
     }
 }

--- a/tests/EntityTag/EntityTagHttpTest.php
+++ b/tests/EntityTag/EntityTagHttpTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\EntityTag;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
+use NeNeRecords\EntityTag\AttachEntityTagHandler;
+use NeNeRecords\EntityTag\AttachEntityTagUseCase;
+use NeNeRecords\EntityTag\DetachEntityTagHandler;
+use NeNeRecords\EntityTag\DetachEntityTagUseCase;
+use NeNeRecords\EntityTag\EntityTagAlreadyAttachedExceptionHandler;
+use NeNeRecords\EntityTag\EntityTagNotAttachedExceptionHandler;
+use NeNeRecords\EntityTag\EntityTagRouteRegistrar;
+use NeNeRecords\EntityTag\ListEntityTagsHandler;
+use NeNeRecords\EntityTag\ListEntityTagsUseCase;
+use NeNeRecords\Tag\Tag;
+use NeNeRecords\Tag\TagNotFoundExceptionHandler;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\Tag\InMemoryTagRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class EntityTagHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryEntityRepository $entities;
+    private InMemoryTagRepository $tags;
+    private InMemoryEntityTagRepository $entityTags;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->entities = new InMemoryEntityRepository();
+        $this->tags = new InMemoryTagRepository();
+        $this->entityTags = new InMemoryEntityTagRepository();
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+
+        $registrar = new EntityTagRouteRegistrar(
+            new ListEntityTagsHandler(new ListEntityTagsUseCase($this->entities, $this->entityTags), $jsonResponse),
+            new AttachEntityTagHandler(new AttachEntityTagUseCase($this->entities, $this->tags, $this->entityTags), $jsonResponse),
+            new DetachEntityTagHandler(new DetachEntityTagUseCase($this->entities, $this->entityTags), $this->factory),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [
+                new EntityNotFoundExceptionHandler($problemDetails),
+                new TagNotFoundExceptionHandler($problemDetails),
+                new EntityTagAlreadyAttachedExceptionHandler($problemDetails),
+                new EntityTagNotAttachedExceptionHandler($problemDetails),
+            ],
+            routeRegistrars: [$registrar],
+        ))->create();
+    }
+
+    public function testAttachListAndDetachEntityTag(): void
+    {
+        $entityId = $this->entities->save(new Entity(id: null, entityTypeId: 1));
+        $tagId = $this->tags->save(new Tag(slug: 'featured', name: 'Featured'));
+        $this->entityTags->seedTag($tagId, 'featured', 'Featured');
+
+        $attachBody = $this->factory->createStream(json_encode(['tag_id' => $tagId], JSON_THROW_ON_ERROR));
+        $attachResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', "https://example.test/api/v1/entities/{$entityId}/tags")->withBody($attachBody),
+        );
+        $attachPayload = $this->decodeJson($attachResponse);
+
+        self::assertSame(201, $attachResponse->getStatusCode());
+        self::assertSame('featured', $attachPayload['slug']);
+
+        $listResponse = $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/entities/{$entityId}/tags"),
+        );
+        $listPayload = $this->decodeJson($listResponse);
+
+        self::assertSame(200, $listResponse->getStatusCode());
+        self::assertCount(1, $listPayload['items']);
+        self::assertSame($tagId, $listPayload['items'][0]['id']);
+
+        $detachResponse = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', "https://example.test/api/v1/entities/{$entityId}/tags/{$tagId}"),
+        );
+
+        self::assertSame(204, $detachResponse->getStatusCode());
+    }
+
+    public function testAttachDuplicateReturns409(): void
+    {
+        $entityId = $this->entities->save(new Entity(id: null, entityTypeId: 1));
+        $tagId = $this->tags->save(new Tag(slug: 'dup', name: 'Dup'));
+        $this->entityTags->seedTag($tagId, 'dup', 'Dup');
+        $this->entityTags->attach($entityId, $tagId);
+
+        $body = $this->factory->createStream(json_encode(['tag_id' => $tagId], JSON_THROW_ON_ERROR));
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', "https://example.test/api/v1/entities/{$entityId}/tags")->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(409, $response->getStatusCode());
+        self::assertStringEndsWith('conflict', (string) $payload['type']);
+    }
+
+    public function testDetachWhenNotAttachedReturns404(): void
+    {
+        $entityId = $this->entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', "https://example.test/api/v1/entities/{$entityId}/tags/99"),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertStringEndsWith('not-found', (string) $payload['type']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/tests/EntityTag/InMemoryEntityTagRepository.php
+++ b/tests/EntityTag/InMemoryEntityTagRepository.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\EntityTag;
+
+use NeNeRecords\EntityTag\EntityTagListItem;
+use NeNeRecords\EntityTag\EntityTagRepositoryInterface;
+
+final class InMemoryEntityTagRepository implements EntityTagRepositoryInterface
+{
+    /** @var array<string, true> "entityId:tagId" => attached */
+    private array $attachments;
+
+    /** @var array<int, EntityTagListItem> tagId => item */
+    private array $tagsById;
+
+    public function __construct()
+    {
+        $this->attachments = [];
+        $this->tagsById = [];
+    }
+
+    public function seedTag(int $id, string $slug, string $name): void
+    {
+        $this->tagsById[$id] = new EntityTagListItem(id: $id, slug: $slug, name: $name);
+    }
+
+    /** @return list<EntityTagListItem> */
+    public function findTagsByEntityId(int $entityId): array
+    {
+        $items = [];
+
+        foreach ($this->attachments as $key => $_attached) {
+            [$attachedEntityId, $tagId] = array_map('intval', explode(':', $key, 2));
+
+            if ($attachedEntityId !== $entityId) {
+                continue;
+            }
+
+            $tag = $this->tagsById[$tagId] ?? null;
+
+            if ($tag !== null) {
+                $items[] = $tag;
+            }
+        }
+
+        usort($items, static fn (EntityTagListItem $a, EntityTagListItem $b): int => $a->id <=> $b->id);
+
+        return $items;
+    }
+
+    public function isAttached(int $entityId, int $tagId): bool
+    {
+        return isset($this->attachments["{$entityId}:{$tagId}"]);
+    }
+
+    public function attach(int $entityId, int $tagId): void
+    {
+        $this->attachments["{$entityId}:{$tagId}"] = true;
+    }
+
+    public function detach(int $entityId, int $tagId): void
+    {
+        unset($this->attachments["{$entityId}:{$tagId}"]);
+    }
+}

--- a/tests/EntityTag/PdoEntityTagRepositoryTest.php
+++ b/tests/EntityTag/PdoEntityTagRepositoryTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\EntityTag;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeNeRecords\EntityTag\PdoEntityTagRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PdoEntityTagRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene-records-test',
+            '',
+            'utf8',
+        )));
+
+        $this->executor->execute('PRAGMA foreign_keys = ON');
+
+        foreach ($this->schemaStatements() as $statement) {
+            $this->executor->execute($statement);
+        }
+
+        $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('Base', 'base')");
+        $this->executor->execute('INSERT INTO entities (entity_type_id) VALUES (1)');
+        $this->executor->execute("INSERT INTO tags (slug, name) VALUES ('featured', 'Featured')");
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function schemaStatements(): array
+    {
+        $projectRoot = dirname(__DIR__, 2);
+        $paths = [
+            $projectRoot . '/database/schema/entity_types.sql',
+            $projectRoot . '/database/schema/entities.sql',
+            $projectRoot . '/database/schema/tags.sql',
+            $projectRoot . '/database/schema/entity_tags.sql',
+        ];
+
+        $statements = [];
+
+        foreach ($paths as $path) {
+            self::assertFileExists($path);
+            $raw = trim((string) file_get_contents($path));
+            foreach (preg_split('/;\R/s', $raw) ?: [] as $chunk) {
+                $statement = trim($chunk);
+                if ($statement !== '') {
+                    $statements[] = $statement;
+                }
+            }
+        }
+
+        return $statements;
+    }
+
+    public function testAttachFindAndDetach(): void
+    {
+        $repository = new PdoEntityTagRepository($this->executor);
+
+        self::assertFalse($repository->isAttached(1, 1));
+
+        $repository->attach(1, 1);
+
+        self::assertTrue($repository->isAttached(1, 1));
+
+        $tags = $repository->findTagsByEntityId(1);
+
+        self::assertCount(1, $tags);
+        self::assertSame('featured', $tags[0]->slug);
+
+        $repository->detach(1, 1);
+
+        self::assertFalse($repository->isAttached(1, 1));
+        self::assertSame([], $repository->findTagsByEntityId(1));
+    }
+}

--- a/tests/Tag/InMemoryTagRepository.php
+++ b/tests/Tag/InMemoryTagRepository.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Tag;
+
+use NeNeRecords\Tag\Tag;
+use NeNeRecords\Tag\TagRepositoryInterface;
+
+final class InMemoryTagRepository implements TagRepositoryInterface
+{
+    /** @var array<int, Tag> */
+    private array $byId;
+
+    /** @var array<string, int> */
+    private array $slugToId;
+
+    private int $nextId;
+
+    /** @param list<Tag> $seed */
+    public function __construct(array $seed = [])
+    {
+        $this->byId = [];
+        $this->slugToId = [];
+        $this->nextId = 1;
+
+        foreach ($seed as $tag) {
+            if ($tag->id !== null) {
+                $id = $tag->id;
+                $stored = new Tag(slug: $tag->slug, name: $tag->name, id: $id);
+                $this->byId[$id] = $stored;
+                $this->slugToId[$stored->slug] = $id;
+                $this->nextId = max($this->nextId, $id + 1);
+            }
+        }
+    }
+
+    public function findById(int $id): ?Tag
+    {
+        return $this->byId[$id] ?? null;
+    }
+
+    public function findBySlug(string $slug): ?Tag
+    {
+        $id = $this->slugToId[$slug] ?? null;
+
+        if ($id === null) {
+            return null;
+        }
+
+        return $this->byId[$id] ?? null;
+    }
+
+    /** @return list<Tag> */
+    public function findAll(int $limit, int $offset): array
+    {
+        $tags = array_values($this->byId);
+        usort($tags, static fn (Tag $a, Tag $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
+
+        return array_slice($tags, $offset, $limit);
+    }
+
+    public function save(Tag $tag): int
+    {
+        $id = $this->nextId++;
+        $stored = new Tag(slug: $tag->slug, name: $tag->name, id: $id);
+        $this->byId[$id] = $stored;
+        $this->slugToId[$stored->slug] = $id;
+
+        return $id;
+    }
+
+    public function update(Tag $tag): void
+    {
+        $id = $tag->id;
+
+        if ($id === null || !isset($this->byId[$id])) {
+            return;
+        }
+
+        $old = $this->byId[$id];
+        unset($this->slugToId[$old->slug]);
+
+        $this->slugToId[$tag->slug] = $id;
+        $this->byId[$id] = $tag;
+    }
+
+    public function delete(int $id): void
+    {
+        $tag = $this->byId[$id] ?? null;
+
+        if ($tag === null) {
+            return;
+        }
+
+        unset($this->slugToId[$tag->slug]);
+        unset($this->byId[$id]);
+    }
+}

--- a/tests/Tag/PdoTagRepositoryTest.php
+++ b/tests/Tag/PdoTagRepositoryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Tag;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeNeRecords\Tag\PdoTagRepository;
+use NeNeRecords\Tag\Tag;
+use PHPUnit\Framework\TestCase;
+
+final class PdoTagRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene-records-test',
+            '',
+            'utf8',
+        )));
+
+        foreach ($this->schemaStatements() as $statement) {
+            $this->executor->execute($statement);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function schemaStatements(): array
+    {
+        $path = dirname(__DIR__, 2) . '/database/schema/tags.sql';
+        self::assertFileExists($path);
+        $raw = trim((string) file_get_contents($path));
+        $statements = [];
+
+        foreach (preg_split('/;\R/s', $raw) ?: [] as $chunk) {
+            $statement = trim($chunk);
+            if ($statement !== '') {
+                $statements[] = $statement;
+            }
+        }
+
+        return $statements;
+    }
+
+    public function testSaveAndFindBySlug(): void
+    {
+        $repository = new PdoTagRepository($this->executor);
+        $id = $repository->save(new Tag(slug: 'featured', name: 'Featured'));
+
+        $tag = $repository->findBySlug('featured');
+
+        self::assertNotNull($tag);
+        self::assertSame($id, $tag->id);
+        self::assertSame('Featured', $tag->name);
+    }
+
+    public function testFindAllReturnsTagsInIdOrder(): void
+    {
+        $repository = new PdoTagRepository($this->executor);
+        $repository->save(new Tag(slug: 'a', name: 'A'));
+        $repository->save(new Tag(slug: 'b', name: 'B'));
+
+        $tags = $repository->findAll(10, 0);
+
+        self::assertCount(2, $tags);
+        self::assertSame('a', $tags[0]->slug);
+        self::assertSame('b', $tags[1]->slug);
+    }
+}

--- a/tests/Tag/TagHttpTest.php
+++ b/tests/Tag/TagHttpTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Tag;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Tag\CreateTagHandler;
+use NeNeRecords\Tag\CreateTagUseCase;
+use NeNeRecords\Tag\DeleteTagHandler;
+use NeNeRecords\Tag\DeleteTagUseCase;
+use NeNeRecords\Tag\GetTagByIdHandler;
+use NeNeRecords\Tag\GetTagByIdUseCase;
+use NeNeRecords\Tag\ListTagsHandler;
+use NeNeRecords\Tag\ListTagsUseCase;
+use NeNeRecords\Tag\Tag;
+use NeNeRecords\Tag\TagNotFoundExceptionHandler;
+use NeNeRecords\Tag\TagRouteRegistrar;
+use NeNeRecords\Tag\TagSlugConflictExceptionHandler;
+use NeNeRecords\Tag\UpdateTagHandler;
+use NeNeRecords\Tag\UpdateTagUseCase;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class TagHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryTagRepository $repository;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->repository = new InMemoryTagRepository();
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+
+        $registrar = new TagRouteRegistrar(
+            new GetTagByIdHandler(new GetTagByIdUseCase($this->repository), $jsonResponse),
+            new CreateTagHandler(new CreateTagUseCase($this->repository), $jsonResponse),
+            new UpdateTagHandler(new UpdateTagUseCase($this->repository), $jsonResponse),
+            new DeleteTagHandler(new DeleteTagUseCase($this->repository), $this->factory),
+            new ListTagsHandler(new ListTagsUseCase($this->repository), $jsonResponse),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [
+                new TagNotFoundExceptionHandler($problemDetails),
+                new TagSlugConflictExceptionHandler($problemDetails),
+            ],
+            routeRegistrars: [$registrar],
+        ))->create();
+    }
+
+    public function testPostTagCreatesTagAndReturns201WithLocation(): void
+    {
+        $body = $this->factory->createStream(json_encode(['name' => 'Featured', 'slug' => 'featured'], JSON_THROW_ON_ERROR));
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/tags')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertStringStartsWith('/api/v1/tags/', $response->getHeaderLine('Location'));
+        self::assertSame('Featured', $payload['name']);
+        self::assertSame('featured', $payload['slug']);
+        self::assertIsInt($payload['id']);
+    }
+
+    public function testPostDuplicateSlugReturns409WithConflictProblemType(): void
+    {
+        $this->repository->save(new Tag(slug: 'dup-slug', name: 'Existing'));
+
+        $body = $this->factory->createStream(json_encode(['name' => 'Try again', 'slug' => 'dup-slug'], JSON_THROW_ON_ERROR));
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/tags')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(409, $response->getStatusCode());
+        self::assertStringEndsWith('conflict', (string) $payload['type']);
+    }
+
+    public function testGetTagByIdReturnsTag(): void
+    {
+        $id = $this->repository->save(new Tag(slug: 'news', name: 'News'));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/tags/{$id}"),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame($id, $payload['id']);
+        self::assertSame('News', $payload['name']);
+        self::assertSame('news', $payload['slug']);
+    }
+
+    public function testDeleteTagReturns204(): void
+    {
+        $id = $this->repository->save(new Tag(slug: 'temp', name: 'Temp'));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', "https://example.test/api/v1/tags/{$id}"),
+        );
+
+        self::assertSame(204, $response->getStatusCode());
+        self::assertNull($this->repository->findById($id));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+
+        return $payload;
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3:

- **Tag** CRUD — `/api/v1/tags` (slug unique)
- **EntityTag** — attach/detach/list on `/api/v1/entities/{id}/tags`
- **Entity filters** — `?entity_type_id=` and `?tag=` / `?tags=` (OR), response includes `total`
- ADR 0003, OpenAPI, **127 tests**

## Test plan

- [x] `composer check`

## Self-review

`Self-review: backend-api, openapi-contract, database, docs-policy`

Closes #16


Made with [Cursor](https://cursor.com)