### PR TITLE
feat(frontend): Entity 一覧・作成・削除 UI (#26)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -12,19 +12,21 @@ New contributors and AI agents: read [`handoff-2026-05-24-workspace-switch.md`](
 
 | Issue | Branch | Summary |
 | --- | --- | --- |
-| #24 | `feat/24-entity-type-editor` | Entity type 作成・一覧・削除 UI |
+| #26 | `feat/26-entity-records-ui` | Entity（Record）一覧・作成・削除 UI |
 
 ## Up Next
 
 | Issue | Summary |
 | --- | --- |
 | TBD | Entity type 編集（PUT） |
-| TBD | Record CRUD screens |
+| TBD | text_fields / field value 編集 UI |
+| TBD | GitHub Actions frontend CI |
 
 ## Recently Completed
 
 | Issue | Summary |
 | --- | --- |
+| #24 | Entity type 作成・一覧・削除 UI (PR #25) |
 | #22 | Docker compose — MySQL + phpMyAdmin darkwolf + Mailpit (PR #23) |
 | #20 | Phase 4 Admin React scaffold (PR #21) |
 | #18 | Frontend design system / Storybook policy (PR #19) |
@@ -40,7 +42,7 @@ New contributors and AI agents: read [`handoff-2026-05-24-workspace-switch.md`](
 - **127 tests** via `composer check`.
 - ADRs: 0002 (field defs), 0003 (tags).
 - **Docker:** `docker compose up --build` → API `:8080`, phpMyAdmin `:8081`, Mailpit `:8025`. See `docs/development/docker.md`.
-- **Phase 4 scaffold:** `frontend/` — React + Tailwind theme + Storybook + `entities/entity-type`.
+- **Phase 4:** `frontend/` — entity types + entity records admin UI; route `/entity-types/:entityTypeId/entities`.
 - Run admin UI: `npm run dev --prefix frontend` (API on :8080 via Docker or PHP built-in).
 
 ## Verification Commands

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+import { EntityRecordsPage } from '@/pages/entity-records/EntityRecordsPage'
 import { EntityTypesPage } from '@/pages/entity-types/EntityTypesPage'
 import { HomePage } from '@/pages/home/HomePage'
 import { AppShell } from '@/pages/layout/AppShell'
@@ -10,6 +11,7 @@ const router = createBrowserRouter([
     children: [
       { index: true, element: <HomePage /> },
       { path: 'entity-types', element: <EntityTypesPage /> },
+      { path: 'entity-types/:entityTypeId/entities', element: <EntityRecordsPage /> },
     ],
   },
 ])

--- a/frontend/src/entities/entity/api-types.ts
+++ b/frontend/src/entities/entity/api-types.ts
@@ -1,0 +1,17 @@
+export interface EntityDto {
+  id: number
+  entity_type_id: number
+  is_deleted: boolean
+  deleted_at: string | null
+}
+
+export interface EntityListDto {
+  items: EntityDto[]
+  limit: number
+  offset: number
+  total: number
+}
+
+export interface CreateEntityDto {
+  entity_type_id: number
+}

--- a/frontend/src/entities/entity/ids.ts
+++ b/frontend/src/entities/entity/ids.ts
@@ -1,0 +1,7 @@
+declare const entityIdBrand: unique symbol
+
+export type EntityId = number & { readonly [entityIdBrand]: never }
+
+export function toEntityId(value: number): EntityId {
+  return value as EntityId
+}

--- a/frontend/src/entities/entity/index.ts
+++ b/frontend/src/entities/entity/index.ts
@@ -1,0 +1,7 @@
+export type { EntityId } from './ids'
+export { toEntityId } from './ids'
+export type { CreateEntityInput, Entity, EntityList } from './model'
+export { entityKeys } from './query-keys'
+export type { EntityListParams } from './query-keys'
+export { useCreateEntity, useDeleteEntity } from './mutations'
+export { defaultEntityListParams, useEntity, useEntityList } from './queries'

--- a/frontend/src/entities/entity/mapper.test.ts
+++ b/frontend/src/entities/entity/mapper.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { toEntityId } from './ids'
+import { mapCreateInputToDto, mapEntityDtoToModel, mapEntityListDtoToModel } from './mapper'
+
+describe('entity mapper', () => {
+  it('maps entity dto to model', () => {
+    const model = mapEntityDtoToModel({
+      id: 1,
+      entity_type_id: 2,
+      is_deleted: false,
+      deleted_at: null,
+    })
+
+    expect(model).toEqual({
+      id: toEntityId(1),
+      entityTypeId: 2,
+      isDeleted: false,
+      deletedAt: null,
+    })
+  })
+
+  it('maps list dto to model', () => {
+    const model = mapEntityListDtoToModel({
+      items: [
+        {
+          id: 3,
+          entity_type_id: 1,
+          is_deleted: false,
+          deleted_at: null,
+        },
+      ],
+      limit: 20,
+      offset: 0,
+      total: 1,
+    })
+
+    expect(model.items).toHaveLength(1)
+    expect(model.items[0]?.id).toEqual(toEntityId(3))
+    expect(model.total).toBe(1)
+  })
+
+  it('maps create input to dto', () => {
+    expect(mapCreateInputToDto({ entityTypeId: 5 })).toEqual({
+      entity_type_id: 5,
+    })
+  })
+})

--- a/frontend/src/entities/entity/mapper.ts
+++ b/frontend/src/entities/entity/mapper.ts
@@ -1,0 +1,27 @@
+import type { CreateEntityDto, EntityDto, EntityListDto } from './api-types'
+import { toEntityId } from './ids'
+import type { CreateEntityInput, Entity, EntityList } from './model'
+
+export function mapEntityDtoToModel(dto: EntityDto): Entity {
+  return {
+    id: toEntityId(dto.id),
+    entityTypeId: dto.entity_type_id,
+    isDeleted: dto.is_deleted,
+    deletedAt: dto.deleted_at,
+  }
+}
+
+export function mapEntityListDtoToModel(dto: EntityListDto): EntityList {
+  return {
+    items: dto.items.map(mapEntityDtoToModel),
+    limit: dto.limit,
+    offset: dto.offset,
+    total: dto.total,
+  }
+}
+
+export function mapCreateInputToDto(input: CreateEntityInput): CreateEntityDto {
+  return {
+    entity_type_id: input.entityTypeId,
+  }
+}

--- a/frontend/src/entities/entity/model.ts
+++ b/frontend/src/entities/entity/model.ts
@@ -1,0 +1,19 @@
+import type { EntityId } from './ids'
+
+export interface Entity {
+  id: EntityId
+  entityTypeId: number
+  isDeleted: boolean
+  deletedAt: string | null
+}
+
+export interface EntityList {
+  items: Entity[]
+  limit: number
+  offset: number
+  total: number
+}
+
+export interface CreateEntityInput {
+  entityTypeId: number
+}

--- a/frontend/src/entities/entity/mutations.ts
+++ b/frontend/src/entities/entity/mutations.ts
@@ -1,0 +1,60 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { EntityDto } from './api-types'
+import type { EntityId } from './ids'
+import { mapCreateInputToDto, mapEntityDtoToModel } from './mapper'
+import type { CreateEntityInput, Entity } from './model'
+import { entityKeys } from './query-keys'
+
+export function useCreateEntity(): UseMutationResult<Entity, AppError, CreateEntityInput> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input) => {
+      const dto = await apiClient.post<EntityDto>('/api/v1/entities', mapCreateInputToDto(input))
+      return mapEntityDtoToModel(dto)
+    },
+    onSuccess: async (_data, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: entityKeys.lists(),
+        predicate: (query) => {
+          const params = query.queryKey[2]
+          return (
+            typeof params === 'object' &&
+            params !== null &&
+            'entityTypeId' in params &&
+            params.entityTypeId === variables.entityTypeId
+          )
+        },
+      })
+    },
+  })
+}
+
+export function useDeleteEntity(): UseMutationResult<
+  void,
+  AppError,
+  { id: EntityId; entityTypeId: number }
+> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ id }) => {
+      await apiClient.delete(`/api/v1/entities/${String(id)}`)
+    },
+    onSuccess: async (_data, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: entityKeys.lists(),
+        predicate: (query) => {
+          const params = query.queryKey[2]
+          return (
+            typeof params === 'object' &&
+            params !== null &&
+            'entityTypeId' in params &&
+            params.entityTypeId === variables.entityTypeId
+          )
+        },
+      })
+    },
+  })
+}

--- a/frontend/src/entities/entity/queries.ts
+++ b/frontend/src/entities/entity/queries.ts
@@ -1,0 +1,44 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { EntityDto, EntityListDto } from './api-types'
+import type { EntityId } from './ids'
+import { mapEntityDtoToModel, mapEntityListDtoToModel } from './mapper'
+import type { Entity, EntityList } from './model'
+import { entityKeys, type EntityListParams } from './query-keys'
+
+const DEFAULT_LIST_PARAMS = { limit: 20, offset: 0 } as const
+
+export function useEntityList(params: EntityListParams): UseQueryResult<EntityList, AppError> {
+  return useQuery({
+    queryKey: entityKeys.list(params),
+    queryFn: async ({ signal }) => {
+      const search = new URLSearchParams({
+        limit: String(params.limit),
+        offset: String(params.offset),
+        entity_type_id: String(params.entityTypeId),
+      })
+      const dto = await apiClient.get<EntityListDto>(
+        `/api/v1/entities?${search.toString()}`,
+        signal,
+      )
+      return mapEntityListDtoToModel(dto)
+    },
+  })
+}
+
+export function useEntity(id: EntityId): UseQueryResult<Entity, AppError> {
+  return useQuery({
+    queryKey: entityKeys.detail(id),
+    queryFn: async ({ signal }) => {
+      const dto = await apiClient.get<EntityDto>(`/api/v1/entities/${String(id)}`, signal)
+      return mapEntityDtoToModel(dto)
+    },
+  })
+}
+
+export function defaultEntityListParams(entityTypeId: number): EntityListParams {
+  return {
+    entityTypeId,
+    ...DEFAULT_LIST_PARAMS,
+  }
+}

--- a/frontend/src/entities/entity/query-keys.ts
+++ b/frontend/src/entities/entity/query-keys.ts
@@ -1,0 +1,15 @@
+import type { EntityId } from './ids'
+
+export interface EntityListParams {
+  entityTypeId: number
+  limit: number
+  offset: number
+}
+
+export const entityKeys = {
+  all: ['entities'] as const,
+  lists: () => [...entityKeys.all, 'list'] as const,
+  list: (params: EntityListParams) => [...entityKeys.lists(), params] as const,
+  details: () => [...entityKeys.all, 'detail'] as const,
+  detail: (id: EntityId) => [...entityKeys.details(), id] as const,
+}

--- a/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
+++ b/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
@@ -1,0 +1,56 @@
+import { useCallback, useState } from 'react'
+import {
+  defaultEntityListParams,
+  useCreateEntity,
+  useDeleteEntity,
+  useEntityList,
+  type Entity,
+  type EntityId,
+} from '@/entities/entity'
+
+export function useManageEntitiesPage(entityTypeId: number) {
+  const listParams = defaultEntityListParams(entityTypeId)
+  const listQuery = useEntityList(listParams)
+  const createMutation = useCreateEntity()
+  const deleteMutation = useDeleteEntity()
+  const [deleteTarget, setDeleteTarget] = useState<Entity | null>(null)
+
+  const createEntity = useCallback(async () => {
+    await createMutation.mutateAsync({ entityTypeId })
+  }, [createMutation, entityTypeId])
+
+  const requestDelete = useCallback((entity: Entity) => {
+    setDeleteTarget(entity)
+  }, [])
+
+  const cancelDelete = useCallback(() => {
+    setDeleteTarget(null)
+  }, [])
+
+  const confirmDelete = useCallback(async () => {
+    if (deleteTarget === null) {
+      return
+    }
+
+    const id: EntityId = deleteTarget.id
+    await deleteMutation.mutateAsync({ id, entityTypeId })
+    setDeleteTarget(null)
+  }, [deleteMutation, deleteTarget, entityTypeId])
+
+  return {
+    items: listQuery.data?.items ?? [],
+    total: listQuery.data?.total ?? 0,
+    isLoading: listQuery.isLoading,
+    isError: listQuery.isError,
+    errorTitle: listQuery.error?.title ?? null,
+    refetch: listQuery.refetch,
+    createEntity,
+    isCreating: createMutation.isPending,
+    createErrorTitle: createMutation.error?.title ?? null,
+    deleteTarget,
+    requestDelete,
+    cancelDelete,
+    confirmDelete,
+    isDeleting: deleteMutation.isPending,
+  }
+}

--- a/frontend/src/features/manage-entities/index.ts
+++ b/frontend/src/features/manage-entities/index.ts
@@ -1,0 +1,2 @@
+export { useManageEntitiesPage } from './hooks/use-manage-entities-page'
+export { ManageEntitiesView } from './ui/ManageEntitiesView'

--- a/frontend/src/features/manage-entities/ui/EntityCreatePanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityCreatePanel.tsx
@@ -1,0 +1,35 @@
+import { Button, Stack, Text } from '@/shared/ui'
+
+export interface EntityCreatePanelProps {
+  isSubmitting: boolean
+  serverErrorTitle: string | null
+  onCreate: () => Promise<void>
+}
+
+export function EntityCreatePanel({
+  isSubmitting,
+  serverErrorTitle,
+  onCreate,
+}: EntityCreatePanelProps) {
+  return (
+    <Stack gap="sm">
+      <Text as="h2" variant="heading-sm">
+        Create record
+      </Text>
+      <Text muted>
+        Records are created for this entity type. Field values will be editable in a later phase.
+      </Text>
+      {serverErrorTitle !== null ? <Text muted>{serverErrorTitle}</Text> : null}
+      <div>
+        <Button
+          disabled={isSubmitting}
+          onClick={() => {
+            void onCreate()
+          }}
+        >
+          {isSubmitting ? 'Creating…' : 'Create record'}
+        </Button>
+      </div>
+    </Stack>
+  )
+}

--- a/frontend/src/features/manage-entities/ui/EntityListPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityListPanel.tsx
@@ -1,18 +1,17 @@
-import { Link } from 'react-router-dom'
-import type { EntityType } from '@/entities/entity-type'
+import type { Entity } from '@/entities/entity'
 import { Button, EmptyState, Stack, Text } from '@/shared/ui'
 
-export interface EntityTypeListPanelProps {
-  items: EntityType[]
+export interface EntityListPanelProps {
+  items: Entity[]
   isLoading: boolean
   isError: boolean
   errorTitle: string | null
   isDeleting: boolean
   onRetry: () => void
-  onDelete: (entityType: EntityType) => void
+  onDelete: (entity: Entity) => void
 }
 
-export function EntityTypeListPanel({
+export function EntityListPanel({
   items,
   isLoading,
   isError,
@@ -20,15 +19,15 @@ export function EntityTypeListPanel({
   isDeleting,
   onRetry,
   onDelete,
-}: EntityTypeListPanelProps) {
+}: EntityListPanelProps) {
   if (isLoading) {
-    return <Text muted>Loading entity types…</Text>
+    return <Text muted>Loading records…</Text>
   }
 
   if (isError) {
     return (
       <Stack gap="sm">
-        <Text variant="heading-sm">Could not load entity types</Text>
+        <Text variant="heading-sm">Could not load records</Text>
         <Text muted>{errorTitle ?? 'Unknown error'}</Text>
         <Button variant="secondary" onClick={onRetry}>
           Retry
@@ -40,8 +39,8 @@ export function EntityTypeListPanel({
   if (items.length === 0) {
     return (
       <EmptyState
-        title="No entity types yet"
-        description="Create your first entity type using the form above."
+        title="No records yet"
+        description="Create your first record using the button above."
       />
     )
   }
@@ -55,29 +54,22 @@ export function EntityTypeListPanel({
         >
           <Stack gap="xs">
             <Text as="span" variant="heading-sm">
-              {item.name}
+              Record #{String(item.id)}
             </Text>
             <Text as="span" muted>
-              {item.slug}
+              Entity type ID {String(item.entityTypeId)}
             </Text>
           </Stack>
-          <div className="flex items-center gap-inline-sm">
-            <Link to={`/entity-types/${String(item.id)}/entities`}>
-              <Button variant="secondary" size="sm">
-                Records
-              </Button>
-            </Link>
-            <Button
-              variant="danger"
-              size="sm"
-              disabled={isDeleting}
-              onClick={() => {
-                onDelete(item)
-              }}
-            >
-              Delete
-            </Button>
-          </div>
+          <Button
+            variant="danger"
+            size="sm"
+            disabled={isDeleting}
+            onClick={() => {
+              onDelete(item)
+            }}
+          >
+            Delete
+          </Button>
         </li>
       ))}
     </ul>

--- a/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
+++ b/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
@@ -1,0 +1,91 @@
+import type { Entity } from '@/entities/entity'
+import { ConfirmDialog, Stack, Text } from '@/shared/ui'
+import { EntityCreatePanel } from './EntityCreatePanel'
+import { EntityListPanel } from './EntityListPanel'
+
+export interface ManageEntitiesViewProps {
+  entityTypeName: string | null
+  entityTypeSlug: string | null
+  items: Entity[]
+  total: number
+  isLoading: boolean
+  isError: boolean
+  errorTitle: string | null
+  isCreating: boolean
+  createErrorTitle: string | null
+  deleteTarget: Entity | null
+  isDeleting: boolean
+  onRetry: () => void
+  onCreate: () => Promise<void>
+  onRequestDelete: (entity: Entity) => void
+  onCancelDelete: () => void
+  onConfirmDelete: () => Promise<void>
+}
+
+export function ManageEntitiesView({
+  entityTypeName,
+  entityTypeSlug,
+  items,
+  total,
+  isLoading,
+  isError,
+  errorTitle,
+  isCreating,
+  createErrorTitle,
+  deleteTarget,
+  isDeleting,
+  onRetry,
+  onCreate,
+  onRequestDelete,
+  onCancelDelete,
+  onConfirmDelete,
+}: ManageEntitiesViewProps) {
+  return (
+    <>
+      <Stack gap="lg">
+        <Stack gap="xs">
+          <Text as="p" muted>
+            {entityTypeSlug ?? '…'}
+          </Text>
+          <Text as="p" muted>
+            {total} record{total === 1 ? '' : 's'}
+          </Text>
+        </Stack>
+        <EntityCreatePanel
+          isSubmitting={isCreating}
+          serverErrorTitle={createErrorTitle}
+          onCreate={onCreate}
+        />
+        <Stack gap="sm">
+          <Text as="h2" variant="heading-sm">
+            {entityTypeName !== null ? `${entityTypeName} records` : 'Records'}
+          </Text>
+          <EntityListPanel
+            items={items}
+            isLoading={isLoading}
+            isError={isError}
+            errorTitle={errorTitle}
+            isDeleting={isDeleting}
+            onRetry={onRetry}
+            onDelete={onRequestDelete}
+          />
+        </Stack>
+      </Stack>
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title="Delete record?"
+        description={
+          deleteTarget !== null
+            ? `Record #${String(deleteTarget.id)} will be soft-deleted.`
+            : undefined
+        }
+        confirmLabel={isDeleting ? 'Deleting…' : 'Delete'}
+        isPending={isDeleting}
+        onCancel={onCancelDelete}
+        onConfirm={() => {
+          void onConfirmDelete()
+        }}
+      />
+    </>
+  )
+}

--- a/frontend/src/pages/entity-records/EntityRecordsPage.test.tsx
+++ b/frontend/src/pages/entity-records/EntityRecordsPage.test.tsx
@@ -1,0 +1,109 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { cleanup, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { EntityRecordsPage } from '@/pages/entity-records/EntityRecordsPage'
+import { EntityTypesPage } from '@/pages/entity-types/EntityTypesPage'
+import { resetEntityStore } from '@tests/msw/handlers/entity'
+import { resetEntityTypeStore, seedEntityTypes } from '@tests/msw/handlers/entity-type'
+import { mswServer } from '@tests/msw/server'
+import { renderWithProviders } from '@tests/render/render-with-providers'
+
+function renderRecordsPage(entityTypeId = 1) {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={[`/entity-types/${String(entityTypeId)}/entities`]}>
+      <Routes>
+        <Route path="/entity-types/:entityTypeId/entities" element={<EntityRecordsPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('EntityRecordsPage', () => {
+  beforeAll(() => {
+    mswServer.listen()
+  })
+
+  afterEach(() => {
+    mswServer.resetHandlers()
+    resetEntityTypeStore()
+    resetEntityStore()
+    cleanup()
+  })
+
+  afterAll(() => {
+    mswServer.close()
+  })
+
+  it('creates a record and lists it', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    const user = userEvent.setup()
+    renderRecordsPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Article' })).toBeInTheDocument()
+      expect(screen.getByText('No records yet')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Create record' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Record #1')).toBeInTheDocument()
+      expect(screen.getByText('1 record')).toBeInTheDocument()
+    })
+  })
+
+  it('deletes a record after confirmation', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    const user = userEvent.setup()
+    renderRecordsPage()
+
+    await user.click(screen.getByRole('button', { name: 'Create record' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Record #1')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeInTheDocument()
+
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Record #1')).not.toBeInTheDocument()
+      expect(screen.getByText('No records yet')).toBeInTheDocument()
+    })
+  })
+
+  it('links from entity types page to records', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/entity-types']}>
+        <Routes>
+          <Route path="/entity-types" element={<EntityTypesPage />} />
+          <Route path="/entity-types/:entityTypeId/entities" element={<EntityRecordsPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.type(screen.getByLabelText('Name'), 'Article')
+    await user.type(screen.getByLabelText('Slug'), 'article')
+    const form = screen.getByRole('heading', { name: 'Create entity type' }).closest('form')
+    if (form === null) {
+      throw new Error('Create entity type form not found')
+    }
+    await user.click(within(form).getByRole('button', { name: 'Create entity type' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Article')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('link', { name: 'Records' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Article' })).toBeInTheDocument()
+      expect(screen.getByText('article')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/entity-records/EntityRecordsPage.tsx
+++ b/frontend/src/pages/entity-records/EntityRecordsPage.tsx
@@ -1,0 +1,62 @@
+import { Link, useParams } from 'react-router-dom'
+import { toEntityTypeId, useEntityType } from '@/entities/entity-type'
+import { ManageEntitiesView, useManageEntitiesPage } from '@/features/manage-entities'
+import { Button, Stack, Text } from '@/shared/ui'
+
+export function EntityRecordsPage() {
+  const { entityTypeId: entityTypeIdParam } = useParams()
+  const entityTypeId = Number(entityTypeIdParam)
+
+  const entityTypeQuery = useEntityType(toEntityTypeId(entityTypeId))
+  const {
+    items,
+    total,
+    isLoading,
+    isError,
+    errorTitle,
+    refetch,
+    createEntity,
+    isCreating,
+    createErrorTitle,
+    deleteTarget,
+    requestDelete,
+    cancelDelete,
+    confirmDelete,
+    isDeleting,
+  } = useManageEntitiesPage(entityTypeId)
+
+  return (
+    <Stack gap="md">
+      <Stack gap="sm">
+        <Link to="/entity-types">
+          <Button variant="secondary" size="sm">
+            Back to entity types
+          </Button>
+        </Link>
+        <Text as="h1" variant="heading-md">
+          {entityTypeQuery.data?.name ?? 'Records'}
+        </Text>
+      </Stack>
+      <ManageEntitiesView
+        entityTypeName={entityTypeQuery.data?.name ?? null}
+        entityTypeSlug={entityTypeQuery.data?.slug ?? null}
+        items={items}
+        total={total}
+        isLoading={isLoading}
+        isError={isError}
+        errorTitle={errorTitle}
+        isCreating={isCreating}
+        createErrorTitle={createErrorTitle}
+        deleteTarget={deleteTarget}
+        isDeleting={isDeleting}
+        onRetry={() => {
+          void refetch()
+        }}
+        onCreate={createEntity}
+        onRequestDelete={requestDelete}
+        onCancelDelete={cancelDelete}
+        onConfirmDelete={confirmDelete}
+      />
+    </Stack>
+  )
+}

--- a/frontend/src/pages/entity-types/EntityTypesPage.test.tsx
+++ b/frontend/src/pages/entity-types/EntityTypesPage.test.tsx
@@ -1,10 +1,19 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { cleanup, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
 import { EntityTypesPage } from '@/pages/entity-types/EntityTypesPage'
 import { resetEntityTypeStore } from '@tests/msw/handlers/entity-type'
 import { mswServer } from '@tests/msw/server'
 import { renderWithProviders } from '@tests/render/render-with-providers'
+
+function renderEntityTypesPage() {
+  return renderWithProviders(
+    <MemoryRouter>
+      <EntityTypesPage />
+    </MemoryRouter>,
+  )
+}
 
 function getCreateForm(): HTMLElement {
   const form = screen.getByRole('heading', { name: 'Create entity type' }).closest('form')
@@ -31,7 +40,7 @@ describe('EntityTypesPage', () => {
 
   it('creates an entity type and lists it', async () => {
     const user = userEvent.setup()
-    renderWithProviders(<EntityTypesPage />)
+    renderEntityTypesPage()
 
     await waitFor(() => {
       expect(screen.getByText('No entity types yet')).toBeInTheDocument()
@@ -50,7 +59,7 @@ describe('EntityTypesPage', () => {
 
   it('shows validation errors for invalid slug', async () => {
     const user = userEvent.setup()
-    renderWithProviders(<EntityTypesPage />)
+    renderEntityTypesPage()
 
     await user.type(screen.getByLabelText('Name'), 'Bad Slug')
     await user.type(screen.getByLabelText('Slug'), 'Bad Slug')
@@ -64,7 +73,7 @@ describe('EntityTypesPage', () => {
 
   it('deletes an entity type after confirmation', async () => {
     const user = userEvent.setup()
-    renderWithProviders(<EntityTypesPage />)
+    renderEntityTypesPage()
 
     await user.type(screen.getByLabelText('Name'), 'Page')
     await user.type(screen.getByLabelText('Slug'), 'page')

--- a/frontend/tests/msw/handlers/entity-type.ts
+++ b/frontend/tests/msw/handlers/entity-type.ts
@@ -68,6 +68,24 @@ export const entityTypeHandlers = [
 
     return HttpResponse.json(created, { status: 201 })
   }),
+  http.get('/api/v1/entity-types/:id', ({ params }) => {
+    const id = Number(params.id)
+    const item = items.find((entry) => entry.id === id)
+
+    if (item === undefined) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/not-found',
+          title: 'Not found',
+          status: 404,
+          instance: `/api/v1/entity-types/${String(id)}`,
+        },
+        { status: 404 },
+      )
+    }
+
+    return HttpResponse.json(item)
+  }),
   http.delete('/api/v1/entity-types/:id', ({ params }) => {
     const id = Number(params.id)
     const exists = items.some((item) => item.id === id)

--- a/frontend/tests/msw/handlers/entity.ts
+++ b/frontend/tests/msw/handlers/entity.ts
@@ -1,0 +1,110 @@
+import { http, HttpResponse } from 'msw'
+
+interface EntityRecord {
+  id: number
+  entity_type_id: number
+  is_deleted: boolean
+  deleted_at: string | null
+}
+
+let nextId = 1
+let items: EntityRecord[] = []
+
+export function resetEntityStore(): void {
+  nextId = 1
+  items = []
+}
+
+export function seedEntities(seed: EntityRecord[]): void {
+  items = [...seed]
+  nextId = Math.max(0, ...seed.map((item) => item.id)) + 1
+}
+
+export const entityHandlers = [
+  http.get('/api/v1/entities', ({ request }) => {
+    const url = new URL(request.url)
+    const limit = Number(url.searchParams.get('limit') ?? '20')
+    const offset = Number(url.searchParams.get('offset') ?? '0')
+    const entityTypeIdParam = url.searchParams.get('entity_type_id')
+    const entityTypeId = entityTypeIdParam === null ? null : Number(entityTypeIdParam)
+
+    const active = items.filter((item) => !item.is_deleted)
+    const filtered =
+      entityTypeId === null ? active : active.filter((item) => item.entity_type_id === entityTypeId)
+
+    return HttpResponse.json({
+      items: filtered.slice(offset, offset + limit),
+      limit,
+      offset,
+      total: filtered.length,
+    })
+  }),
+  http.get('/api/v1/entities/:id', ({ params }) => {
+    const id = Number(params.id)
+    const item = items.find((entry) => entry.id === id && !entry.is_deleted)
+
+    if (item === undefined) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/not-found',
+          title: 'Not found',
+          status: 404,
+          instance: `/api/v1/entities/${String(id)}`,
+        },
+        { status: 404 },
+      )
+    }
+
+    return HttpResponse.json(item)
+  }),
+  http.post('/api/v1/entities', async ({ request }) => {
+    const body = (await request.json()) as { entity_type_id?: number }
+
+    if (typeof body.entity_type_id !== 'number' || body.entity_type_id < 1) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/validation-failed',
+          title: 'Validation failed',
+          status: 422,
+          instance: '/api/v1/entities',
+          errors: [{ field: 'entity_type_id', message: 'Required', code: 'required' }],
+        },
+        { status: 422 },
+      )
+    }
+
+    const created: EntityRecord = {
+      id: nextId++,
+      entity_type_id: body.entity_type_id,
+      is_deleted: false,
+      deleted_at: null,
+    }
+    items = [...items, created]
+
+    return HttpResponse.json(created, { status: 201 })
+  }),
+  http.delete('/api/v1/entities/:id', ({ params }) => {
+    const id = Number(params.id)
+    const index = items.findIndex((item) => item.id === id && !item.is_deleted)
+
+    if (index === -1) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/not-found',
+          title: 'Not found',
+          status: 404,
+          instance: `/api/v1/entities/${String(id)}`,
+        },
+        { status: 404 },
+      )
+    }
+
+    items = items.map((item, itemIndex) =>
+      itemIndex === index
+        ? { ...item, is_deleted: true, deleted_at: new Date().toISOString() }
+        : item,
+    )
+
+    return new HttpResponse(null, { status: 204 })
+  }),
+]

--- a/frontend/tests/msw/server.ts
+++ b/frontend/tests/msw/server.ts
@@ -1,4 +1,5 @@
 import { setupServer } from 'msw/node'
+import { entityHandlers } from './handlers/entity'
 import { entityTypeHandlers } from './handlers/entity-type'
 
-export const mswServer = setupServer(...entityTypeHandlers)
+export const mswServer = setupServer(...entityTypeHandlers, ...entityHandlers)


### PR DESCRIPTION
## Summary

- `entities/entity/` スライス（mapper, queries, mutations）を追加
- `/entity-types/:entityTypeId/entities` で type 別レコードの一覧・作成・削除
- entity type 一覧に **Records** リンクを追加
- MSW handlers + ページ統合テスト 3 件（計 15 tests green）

## 検証

```bash
npm run check --prefix frontend
```

- type-check / lint / format / vitest (15 passed) / build-storybook — すべて成功

## チェックリスト

- [x] Issue スコープ内の変更のみ
- [x] `npm run check --prefix frontend` green
- [x] MSW + page テスト追加

Closes #26

Made with [Cursor](https://cursor.com)