### PR TITLE
feat(frontend): text_fields 値編集 UI (#30)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -12,57 +12,40 @@ New contributors and AI agents: read [`handoff-2026-05-24-workspace-switch.md`](
 
 | Issue | Branch | Summary |
 | --- | --- | --- |
-| #28 | `feat/28-field-defs-ui` | field_defs 一覧・作成・削除 UI |
+| #30 | `feat/30-text-fields-ui` | text_fields 値編集 UI（レコード詳細） |
 
 ## Up Next
 
 | Issue | Summary |
 | --- | --- |
-| TBD | text_fields 等のフィールド値編集 UI |
+| TBD | int/enum/bool/datetime フィールド値 UI |
 | TBD | Entity type 編集（PUT） |
+| TBD | API: text-fields list filter by entity_id |
 | TBD | GitHub Actions frontend CI |
 
 ## Recently Completed
 
 | Issue | Summary |
 | --- | --- |
+| #28 | field_defs 一覧・作成・削除 UI (PR #29) |
 | #26 | Entity（Record）一覧・作成・削除 UI (PR #27) |
 | #24 | Entity type 作成・一覧・削除 UI (PR #25) |
-| #22 | Docker compose — MySQL + phpMyAdmin darkwolf + Mailpit (PR #23) |
+| #22 | Docker compose (PR #23) |
 | #20 | Phase 4 Admin React scaffold (PR #21) |
-| #18 | Frontend design system / Storybook policy (PR #19) |
-| #16 | Tags, entity_tags, entity list filters (PR #17, ADR 0003) — **Phase 3 complete** |
-| #14 | enum/bool/datetime fields (PR #15) — Phase 2 complete |
-| #11 | int_fields CRUD (PR #12) |
-| #9 | field_defs schema registry (PR #10, ADR 0002) |
-| #1 | MVP entity CRUD (PR #8) — Phase 1 |
+| #18 | Frontend design system / Storybook (PR #19) |
+| #16 | Tags + entity list filters (PR #17) — **Phase 3 complete** |
 
 ## Handoff Notes
 
-- **Phase 3 complete.** Tags + entity tag attach/detach + filtered entity list with `total`.
-- **127 tests** via `composer check`.
-- ADRs: 0002 (field defs), 0003 (tags).
-- **Docker:** `docker compose up --build` → API `:8080`, phpMyAdmin `:8081`, Mailpit `:8025`. See `docs/development/docker.md`.
-- **Phase 4:** entity types, field defs, entity records admin UI.
-- Run admin UI: `npm run dev --prefix frontend` (API on :8080 via Docker or PHP built-in).
+- **Phase 4:** entity types → field defs → records → text field values admin flow.
+- text-fields list has no `entity_id` filter yet; frontend filters client-side (limit 100).
+- Run admin UI: `npm run dev --prefix frontend` + Docker API on :8080.
 
 ## Verification Commands
 
 ```bash
 composer check
-composer openapi
+npm run check --prefix frontend
 docker compose up --build
 curl http://localhost:8080/health
-npm run check --prefix frontend
-```
-
-## Example queries (Phase 3)
-
-```bash
-# Entities for type 1 tagged php or api
-curl 'http://localhost:8080/api/v1/entities?entity_type_id=1&tags=php,api'
-
-# Attach tag 2 to entity 5
-curl -X POST http://localhost:8080/api/v1/entities/5/tags \
-  -H 'Content-Type: application/json' -d '{"tag_id":2}'
 ```

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+import { EntityRecordPage } from '@/pages/entity-record/EntityRecordPage'
 import { EntityRecordsPage } from '@/pages/entity-records/EntityRecordsPage'
 import { EntityTypesPage } from '@/pages/entity-types/EntityTypesPage'
 import { FieldDefsPage } from '@/pages/field-defs/FieldDefsPage'
@@ -14,6 +15,7 @@ const router = createBrowserRouter([
       { path: 'entity-types', element: <EntityTypesPage /> },
       { path: 'entity-types/:entityTypeId/fields', element: <FieldDefsPage /> },
       { path: 'entity-types/:entityTypeId/entities', element: <EntityRecordsPage /> },
+      { path: 'entity-types/:entityTypeId/entities/:entityId', element: <EntityRecordPage /> },
     ],
   },
 ])

--- a/frontend/src/entities/text-field/api-types.ts
+++ b/frontend/src/entities/text-field/api-types.ts
@@ -1,0 +1,23 @@
+export interface TextFieldDto {
+  id: number
+  entity_id: number
+  field_key: string
+  value: string
+}
+
+export interface TextFieldListDto {
+  items: TextFieldDto[]
+  limit: number
+  offset: number
+}
+
+export interface CreateTextFieldDto {
+  entity_id: number
+  field_key: string
+  value: string
+}
+
+export interface UpdateTextFieldDto {
+  field_key: string
+  value: string
+}

--- a/frontend/src/entities/text-field/ids.ts
+++ b/frontend/src/entities/text-field/ids.ts
@@ -1,0 +1,7 @@
+declare const textFieldIdBrand: unique symbol
+
+export type TextFieldId = number & { readonly [textFieldIdBrand]: never }
+
+export function toTextFieldId(value: number): TextFieldId {
+  return value as TextFieldId
+}

--- a/frontend/src/entities/text-field/index.ts
+++ b/frontend/src/entities/text-field/index.ts
@@ -1,0 +1,7 @@
+export type { TextFieldId } from './ids'
+export { toTextFieldId } from './ids'
+export type { CreateTextFieldInput, TextField, TextFieldList, UpdateTextFieldInput } from './model'
+export { textFieldKeys } from './query-keys'
+export type { TextFieldListParams } from './query-keys'
+export { useCreateTextField, useUpdateTextField } from './mutations'
+export { useTextField, useTextFieldList } from './queries'

--- a/frontend/src/entities/text-field/mapper.test.ts
+++ b/frontend/src/entities/text-field/mapper.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { toTextFieldId } from './ids'
+import {
+  mapCreateInputToDto,
+  mapTextFieldDtoToModel,
+  mapTextFieldListDtoToModel,
+  mapUpdateInputToDto,
+} from './mapper'
+
+describe('text-field mapper', () => {
+  it('maps text field dto to model', () => {
+    const model = mapTextFieldDtoToModel({
+      id: 1,
+      entity_id: 2,
+      field_key: 'title',
+      value: 'Hello',
+    })
+
+    expect(model).toEqual({
+      id: toTextFieldId(1),
+      entityId: 2,
+      fieldKey: 'title',
+      value: 'Hello',
+    })
+  })
+
+  it('maps list dto to model', () => {
+    const model = mapTextFieldListDtoToModel({
+      items: [{ id: 3, entity_id: 1, field_key: 'body', value: 'Text' }],
+      limit: 100,
+      offset: 0,
+    })
+
+    expect(model.items).toHaveLength(1)
+    expect(model.items[0]?.fieldKey).toBe('body')
+  })
+
+  it('maps create and update inputs to dto', () => {
+    expect(mapCreateInputToDto({ entityId: 5, fieldKey: 'title', value: 'Hi' })).toEqual({
+      entity_id: 5,
+      field_key: 'title',
+      value: 'Hi',
+    })
+
+    expect(mapUpdateInputToDto({ fieldKey: 'title', value: 'Updated' })).toEqual({
+      field_key: 'title',
+      value: 'Updated',
+    })
+  })
+})

--- a/frontend/src/entities/text-field/mapper.ts
+++ b/frontend/src/entities/text-field/mapper.ts
@@ -1,0 +1,40 @@
+import type {
+  CreateTextFieldDto,
+  TextFieldDto,
+  TextFieldListDto,
+  UpdateTextFieldDto,
+} from './api-types'
+import { toTextFieldId } from './ids'
+import type { CreateTextFieldInput, TextField, TextFieldList, UpdateTextFieldInput } from './model'
+
+export function mapTextFieldDtoToModel(dto: TextFieldDto): TextField {
+  return {
+    id: toTextFieldId(dto.id),
+    entityId: dto.entity_id,
+    fieldKey: dto.field_key,
+    value: dto.value,
+  }
+}
+
+export function mapTextFieldListDtoToModel(dto: TextFieldListDto): TextFieldList {
+  return {
+    items: dto.items.map(mapTextFieldDtoToModel),
+    limit: dto.limit,
+    offset: dto.offset,
+  }
+}
+
+export function mapCreateInputToDto(input: CreateTextFieldInput): CreateTextFieldDto {
+  return {
+    entity_id: input.entityId,
+    field_key: input.fieldKey,
+    value: input.value,
+  }
+}
+
+export function mapUpdateInputToDto(input: UpdateTextFieldInput): UpdateTextFieldDto {
+  return {
+    field_key: input.fieldKey,
+    value: input.value,
+  }
+}

--- a/frontend/src/entities/text-field/model.ts
+++ b/frontend/src/entities/text-field/model.ts
@@ -1,0 +1,25 @@
+import type { TextFieldId } from './ids'
+
+export interface TextField {
+  id: TextFieldId
+  entityId: number
+  fieldKey: string
+  value: string
+}
+
+export interface TextFieldList {
+  items: TextField[]
+  limit: number
+  offset: number
+}
+
+export interface CreateTextFieldInput {
+  entityId: number
+  fieldKey: string
+  value: string
+}
+
+export interface UpdateTextFieldInput {
+  fieldKey: string
+  value: string
+}

--- a/frontend/src/entities/text-field/mutations.ts
+++ b/frontend/src/entities/text-field/mutations.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { TextFieldDto } from './api-types'
+import type { TextFieldId } from './ids'
+import { mapCreateInputToDto, mapTextFieldDtoToModel, mapUpdateInputToDto } from './mapper'
+import type { CreateTextFieldInput, TextField, UpdateTextFieldInput } from './model'
+import { textFieldKeys } from './query-keys'
+
+export function useCreateTextField(): UseMutationResult<TextField, AppError, CreateTextFieldInput> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input) => {
+      const dto = await apiClient.post<TextFieldDto>(
+        '/api/v1/text-fields',
+        mapCreateInputToDto(input),
+      )
+      return mapTextFieldDtoToModel(dto)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: textFieldKeys.lists() })
+    },
+  })
+}
+
+export function useUpdateTextField(): UseMutationResult<
+  TextField,
+  AppError,
+  { id: TextFieldId; input: UpdateTextFieldInput }
+> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ id, input }) => {
+      const dto = await apiClient.put<TextFieldDto>(
+        `/api/v1/text-fields/${String(id)}`,
+        mapUpdateInputToDto(input),
+      )
+      return mapTextFieldDtoToModel(dto)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: textFieldKeys.lists() })
+    },
+  })
+}

--- a/frontend/src/entities/text-field/queries.ts
+++ b/frontend/src/entities/text-field/queries.ts
@@ -1,0 +1,38 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { TextFieldDto, TextFieldListDto } from './api-types'
+import type { TextFieldId } from './ids'
+import { mapTextFieldDtoToModel, mapTextFieldListDtoToModel } from './mapper'
+import type { TextField, TextFieldList } from './model'
+import { textFieldKeys, type TextFieldListParams } from './query-keys'
+
+const DEFAULT_LIST_PARAMS = { limit: 100, offset: 0 } as const
+
+export function useTextFieldList(
+  params: TextFieldListParams = DEFAULT_LIST_PARAMS,
+): UseQueryResult<TextFieldList, AppError> {
+  return useQuery({
+    queryKey: textFieldKeys.list(params),
+    queryFn: async ({ signal }) => {
+      const search = new URLSearchParams({
+        limit: String(params.limit),
+        offset: String(params.offset),
+      })
+      const dto = await apiClient.get<TextFieldListDto>(
+        `/api/v1/text-fields?${search.toString()}`,
+        signal,
+      )
+      return mapTextFieldListDtoToModel(dto)
+    },
+  })
+}
+
+export function useTextField(id: TextFieldId): UseQueryResult<TextField, AppError> {
+  return useQuery({
+    queryKey: textFieldKeys.detail(id),
+    queryFn: async ({ signal }) => {
+      const dto = await apiClient.get<TextFieldDto>(`/api/v1/text-fields/${String(id)}`, signal)
+      return mapTextFieldDtoToModel(dto)
+    },
+  })
+}

--- a/frontend/src/entities/text-field/query-keys.ts
+++ b/frontend/src/entities/text-field/query-keys.ts
@@ -1,0 +1,14 @@
+import type { TextFieldId } from './ids'
+
+export interface TextFieldListParams {
+  limit: number
+  offset: number
+}
+
+export const textFieldKeys = {
+  all: ['text-fields'] as const,
+  lists: () => [...textFieldKeys.all, 'list'] as const,
+  list: (params: TextFieldListParams) => [...textFieldKeys.lists(), params] as const,
+  details: () => [...textFieldKeys.all, 'detail'] as const,
+  detail: (id: TextFieldId) => [...textFieldKeys.details(), id] as const,
+}

--- a/frontend/src/features/edit-entity-text-fields/hooks/use-edit-entity-text-fields-page.ts
+++ b/frontend/src/features/edit-entity-text-fields/hooks/use-edit-entity-text-fields-page.ts
@@ -1,0 +1,78 @@
+import { useCallback, useMemo } from 'react'
+import { defaultFieldDefListParams, useFieldDefList } from '@/entities/field-def'
+import { toEntityId, useEntity } from '@/entities/entity'
+import {
+  useCreateTextField,
+  useTextFieldList,
+  useUpdateTextField,
+  type TextField,
+} from '@/entities/text-field'
+
+export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: number) {
+  const entityQuery = useEntity(toEntityId(entityId))
+  const fieldDefQuery = useFieldDefList(defaultFieldDefListParams(entityTypeId))
+  const textFieldQuery = useTextFieldList()
+  const createMutation = useCreateTextField()
+  const updateMutation = useUpdateTextField()
+
+  const textFieldDefs = useMemo(
+    () => (fieldDefQuery.data?.items ?? []).filter((item) => item.dataType === 'text'),
+    [fieldDefQuery.data?.items],
+  )
+
+  const textFieldsForEntity = useMemo((): TextField[] => {
+    return (textFieldQuery.data?.items ?? []).filter((item) => item.entityId === entityId)
+  }, [textFieldQuery.data?.items, entityId])
+
+  const initialValues = useMemo((): Record<string, string> => {
+    return Object.fromEntries(
+      textFieldDefs.map((fieldDef) => {
+        const existing = textFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
+        return [fieldDef.fieldKey, existing?.value ?? '']
+      }),
+    )
+  }, [textFieldDefs, textFieldsForEntity])
+
+  const saveTextFields = useCallback(
+    async (values: Record<string, string>) => {
+      for (const fieldDef of textFieldDefs) {
+        const value = values[fieldDef.fieldKey] ?? ''
+        const existing = textFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
+
+        if (existing !== undefined) {
+          await updateMutation.mutateAsync({
+            id: existing.id,
+            input: { fieldKey: fieldDef.fieldKey, value },
+          })
+        } else {
+          await createMutation.mutateAsync({
+            entityId,
+            fieldKey: fieldDef.fieldKey,
+            value,
+          })
+        }
+      }
+    },
+    [createMutation, entityId, textFieldDefs, textFieldsForEntity, updateMutation],
+  )
+
+  const isLoading = entityQuery.isLoading || fieldDefQuery.isLoading || textFieldQuery.isLoading
+  const isError = entityQuery.isError || fieldDefQuery.isError || textFieldQuery.isError
+  const errorTitle =
+    entityQuery.error?.title ?? fieldDefQuery.error?.title ?? textFieldQuery.error?.title ?? null
+
+  return {
+    entity: entityQuery.data ?? null,
+    textFieldDefs,
+    initialValues,
+    isLoading,
+    isError,
+    errorTitle,
+    refetch: async () => {
+      await Promise.all([entityQuery.refetch(), fieldDefQuery.refetch(), textFieldQuery.refetch()])
+    },
+    saveTextFields,
+    isSaving: createMutation.isPending || updateMutation.isPending,
+    saveErrorTitle: createMutation.error?.title ?? updateMutation.error?.title ?? null,
+  }
+}

--- a/frontend/src/features/edit-entity-text-fields/index.ts
+++ b/frontend/src/features/edit-entity-text-fields/index.ts
@@ -1,0 +1,2 @@
+export { useEditEntityTextFieldsPage } from './hooks/use-edit-entity-text-fields-page'
+export { EditEntityTextFieldsView } from './ui/EditEntityTextFieldsView'

--- a/frontend/src/features/edit-entity-text-fields/ui/EditEntityTextFieldsView.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/EditEntityTextFieldsView.tsx
@@ -1,0 +1,66 @@
+import type { FieldDef } from '@/entities/field-def'
+import type { Entity } from '@/entities/entity'
+import { Button, Stack, Text } from '@/shared/ui'
+import { EntityTextFieldsForm } from './EntityTextFieldsForm'
+
+export interface EditEntityTextFieldsViewProps {
+  entity: Entity | null
+  textFieldDefs: FieldDef[]
+  initialValues: Record<string, string>
+  isLoading: boolean
+  isError: boolean
+  errorTitle: string | null
+  isSaving: boolean
+  saveErrorTitle: string | null
+  onRetry: () => void
+  onSave: (values: Record<string, string>) => Promise<void>
+}
+
+export function EditEntityTextFieldsView({
+  entity,
+  textFieldDefs,
+  initialValues,
+  isLoading,
+  isError,
+  errorTitle,
+  isSaving,
+  saveErrorTitle,
+  onRetry,
+  onSave,
+}: EditEntityTextFieldsViewProps) {
+  if (isLoading) {
+    return <Text muted>Loading record…</Text>
+  }
+
+  if (isError) {
+    return (
+      <Stack gap="sm">
+        <Text variant="heading-sm">Could not load record</Text>
+        <Text muted>{errorTitle ?? 'Unknown error'}</Text>
+        <Button variant="secondary" onClick={onRetry}>
+          Retry
+        </Button>
+      </Stack>
+    )
+  }
+
+  if (entity === null) {
+    return <Text muted>Record not found.</Text>
+  }
+
+  return (
+    <Stack gap="lg">
+      <Text as="p" muted>
+        Record #{String(entity.id)}
+      </Text>
+      <EntityTextFieldsForm
+        key={JSON.stringify(initialValues)}
+        fieldDefs={textFieldDefs}
+        defaultValues={initialValues}
+        isSubmitting={isSaving}
+        serverErrorTitle={saveErrorTitle}
+        onSubmit={onSave}
+      />
+    </Stack>
+  )
+}

--- a/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react'
+import type { FieldDef } from '@/entities/field-def'
+import { Button, EmptyState, Input, Stack, Text } from '@/shared/ui'
+
+export interface EntityTextFieldsFormProps {
+  fieldDefs: FieldDef[]
+  defaultValues: Record<string, string>
+  isSubmitting: boolean
+  serverErrorTitle: string | null
+  onSubmit: (values: Record<string, string>) => Promise<void>
+}
+
+export function EntityTextFieldsForm({
+  fieldDefs,
+  defaultValues,
+  isSubmitting,
+  serverErrorTitle,
+  onSubmit,
+}: EntityTextFieldsFormProps) {
+  const [values, setValues] = useState(defaultValues)
+  if (fieldDefs.length === 0) {
+    return (
+      <EmptyState
+        title="No text fields defined"
+        description="Add text field definitions for this entity type first."
+      />
+    )
+  }
+
+  return (
+    <form
+      className="rounded-md border border-border bg-surface-raised p-inline-md shadow-sm"
+      onSubmit={(event) => {
+        event.preventDefault()
+        void onSubmit(values)
+      }}
+    >
+      <Stack gap="md">
+        <Text as="h2" variant="heading-sm">
+          Text field values
+        </Text>
+        {fieldDefs.map((fieldDef) => (
+          <Input
+            key={fieldDef.fieldKey}
+            id={`text-field-${fieldDef.fieldKey}`}
+            label={fieldDef.fieldKey}
+            autoComplete="off"
+            disabled={isSubmitting}
+            value={values[fieldDef.fieldKey] ?? ''}
+            onChange={(event) => {
+              setValues((current) => ({ ...current, [fieldDef.fieldKey]: event.target.value }))
+            }}
+          />
+        ))}
+        {serverErrorTitle !== null ? <Text muted>{serverErrorTitle}</Text> : null}
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? 'Saving…' : 'Save values'}
+        </Button>
+      </Stack>
+    </form>
+  )
+}

--- a/frontend/src/features/manage-entities/ui/EntityListPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityListPanel.tsx
@@ -1,7 +1,9 @@
+import { Link } from 'react-router-dom'
 import type { Entity } from '@/entities/entity'
 import { Button, EmptyState, Stack, Text } from '@/shared/ui'
 
 export interface EntityListPanelProps {
+  entityTypeId: number
   items: Entity[]
   isLoading: boolean
   isError: boolean
@@ -12,6 +14,7 @@ export interface EntityListPanelProps {
 }
 
 export function EntityListPanel({
+  entityTypeId,
   items,
   isLoading,
   isError,
@@ -60,16 +63,23 @@ export function EntityListPanel({
               Entity type ID {String(item.entityTypeId)}
             </Text>
           </Stack>
-          <Button
-            variant="danger"
-            size="sm"
-            disabled={isDeleting}
-            onClick={() => {
-              onDelete(item)
-            }}
-          >
-            Delete
-          </Button>
+          <div className="flex items-center gap-inline-sm">
+            <Link to={`/entity-types/${String(entityTypeId)}/entities/${String(item.id)}`}>
+              <Button variant="secondary" size="sm">
+                Edit
+              </Button>
+            </Link>
+            <Button
+              variant="danger"
+              size="sm"
+              disabled={isDeleting}
+              onClick={() => {
+                onDelete(item)
+              }}
+            >
+              Delete
+            </Button>
+          </div>
         </li>
       ))}
     </ul>

--- a/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
+++ b/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
@@ -4,6 +4,7 @@ import { EntityCreatePanel } from './EntityCreatePanel'
 import { EntityListPanel } from './EntityListPanel'
 
 export interface ManageEntitiesViewProps {
+  entityTypeId: number
   entityTypeName: string | null
   entityTypeSlug: string | null
   items: Entity[]
@@ -23,6 +24,7 @@ export interface ManageEntitiesViewProps {
 }
 
 export function ManageEntitiesView({
+  entityTypeId,
   entityTypeName,
   entityTypeSlug,
   items,
@@ -61,6 +63,7 @@ export function ManageEntitiesView({
             {entityTypeName !== null ? `${entityTypeName} records` : 'Records'}
           </Text>
           <EntityListPanel
+            entityTypeId={entityTypeId}
             items={items}
             isLoading={isLoading}
             isError={isError}

--- a/frontend/src/pages/entity-record/EntityRecordPage.test.tsx
+++ b/frontend/src/pages/entity-record/EntityRecordPage.test.tsx
@@ -1,0 +1,123 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { cleanup, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { EntityRecordPage } from '@/pages/entity-record/EntityRecordPage'
+import { resetEntityStore, seedEntities } from '@tests/msw/handlers/entity'
+import { resetEntityTypeStore, seedEntityTypes } from '@tests/msw/handlers/entity-type'
+import { resetFieldDefStore, seedFieldDefs } from '@tests/msw/handlers/field-def'
+import { resetTextFieldStore } from '@tests/msw/handlers/text-field'
+import { mswServer } from '@tests/msw/server'
+import { renderWithProviders } from '@tests/render/render-with-providers'
+
+function renderEntityRecordPage(entityTypeId = 1, entityId = 1) {
+  return renderWithProviders(
+    <MemoryRouter
+      initialEntries={[`/entity-types/${String(entityTypeId)}/entities/${String(entityId)}`]}
+    >
+      <Routes>
+        <Route
+          path="/entity-types/:entityTypeId/entities/:entityId"
+          element={<EntityRecordPage />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('EntityRecordPage', () => {
+  beforeAll(() => {
+    mswServer.listen()
+  })
+
+  afterEach(() => {
+    mswServer.resetHandlers()
+    resetEntityTypeStore()
+    resetFieldDefStore()
+    resetEntityStore()
+    resetTextFieldStore()
+    cleanup()
+  })
+
+  afterAll(() => {
+    mswServer.close()
+  })
+
+  it('creates text field values on save', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    seedFieldDefs([{ id: 1, entity_type_id: 1, field_key: 'title', data_type: 'text' }])
+    seedEntities([
+      {
+        id: 1,
+        entity_type_id: 1,
+        is_deleted: false,
+        deleted_at: null,
+      },
+    ])
+
+    const user = userEvent.setup()
+    renderEntityRecordPage()
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('title')).toBeInTheDocument()
+    })
+
+    await user.type(screen.getByLabelText('title'), 'Hello world')
+    await user.click(screen.getByRole('button', { name: 'Save values' }))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('title')).toHaveValue('Hello world')
+    })
+  })
+
+  it('updates existing text field values on save', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    seedFieldDefs([{ id: 1, entity_type_id: 1, field_key: 'title', data_type: 'text' }])
+    seedEntities([
+      {
+        id: 1,
+        entity_type_id: 1,
+        is_deleted: false,
+        deleted_at: null,
+      },
+    ])
+
+    const user = userEvent.setup()
+    renderEntityRecordPage()
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('title')).toBeInTheDocument()
+    })
+
+    await user.type(screen.getByLabelText('title'), 'First title')
+    await user.click(screen.getByRole('button', { name: 'Save values' }))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('title')).toHaveValue('First title')
+    })
+
+    await user.clear(screen.getByLabelText('title'))
+    await user.type(screen.getByLabelText('title'), 'Updated title')
+    await user.click(screen.getByRole('button', { name: 'Save values' }))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('title')).toHaveValue('Updated title')
+    })
+  })
+
+  it('shows empty state when no text field defs exist', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    seedEntities([
+      {
+        id: 1,
+        entity_type_id: 1,
+        is_deleted: false,
+        deleted_at: null,
+      },
+    ])
+
+    renderEntityRecordPage()
+
+    expect(await screen.findByText('No text fields defined')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/entity-record/EntityRecordPage.tsx
+++ b/frontend/src/pages/entity-record/EntityRecordPage.tsx
@@ -1,0 +1,56 @@
+import { Link, useParams } from 'react-router-dom'
+import { toEntityTypeId, useEntityType } from '@/entities/entity-type'
+import {
+  EditEntityTextFieldsView,
+  useEditEntityTextFieldsPage,
+} from '@/features/edit-entity-text-fields'
+import { Button, Stack, Text } from '@/shared/ui'
+
+export function EntityRecordPage() {
+  const { entityTypeId: entityTypeIdParam, entityId: entityIdParam } = useParams()
+  const entityTypeId = Number(entityTypeIdParam)
+  const entityId = Number(entityIdParam)
+
+  const entityTypeQuery = useEntityType(toEntityTypeId(entityTypeId))
+  const {
+    entity,
+    textFieldDefs,
+    initialValues,
+    isLoading,
+    isError,
+    errorTitle,
+    refetch,
+    saveTextFields,
+    isSaving,
+    saveErrorTitle,
+  } = useEditEntityTextFieldsPage(entityTypeId, entityId)
+
+  return (
+    <Stack gap="md">
+      <Stack gap="sm">
+        <Link to={`/entity-types/${String(entityTypeId)}/entities`}>
+          <Button variant="secondary" size="sm">
+            Back to records
+          </Button>
+        </Link>
+        <Text as="h1" variant="heading-md">
+          {entityTypeQuery.data?.name ?? 'Record'}
+        </Text>
+      </Stack>
+      <EditEntityTextFieldsView
+        entity={entity}
+        textFieldDefs={textFieldDefs}
+        initialValues={initialValues}
+        isLoading={isLoading}
+        isError={isError}
+        errorTitle={errorTitle}
+        isSaving={isSaving}
+        saveErrorTitle={saveErrorTitle}
+        onRetry={() => {
+          void refetch()
+        }}
+        onSave={saveTextFields}
+      />
+    </Stack>
+  )
+}

--- a/frontend/src/pages/entity-records/EntityRecordsPage.tsx
+++ b/frontend/src/pages/entity-records/EntityRecordsPage.tsx
@@ -38,6 +38,7 @@ export function EntityRecordsPage() {
         </Text>
       </Stack>
       <ManageEntitiesView
+        entityTypeId={entityTypeId}
         entityTypeName={entityTypeQuery.data?.name ?? null}
         entityTypeSlug={entityTypeQuery.data?.slug ?? null}
         items={items}

--- a/frontend/tests/msw/handlers/text-field.ts
+++ b/frontend/tests/msw/handlers/text-field.ts
@@ -1,0 +1,167 @@
+import { http, HttpResponse } from 'msw'
+
+interface TextFieldRecord {
+  id: number
+  entity_id: number
+  field_key: string
+  value: string
+  is_deleted: boolean
+}
+
+let nextId = 1
+let items: TextFieldRecord[] = []
+
+export function resetTextFieldStore(): void {
+  nextId = 1
+  items = []
+}
+
+export function seedTextFields(seed: Omit<TextFieldRecord, 'is_deleted'>[]): void {
+  items = seed.map((item) => ({ ...item, is_deleted: false }))
+  nextId = Math.max(0, ...seed.map((item) => item.id)) + 1
+}
+
+export const textFieldHandlers = [
+  http.get('/api/v1/text-fields', ({ request }) => {
+    const url = new URL(request.url)
+    const limit = Number(url.searchParams.get('limit') ?? '20')
+    const offset = Number(url.searchParams.get('offset') ?? '0')
+
+    const active = items.filter((item) => !item.is_deleted)
+
+    return HttpResponse.json({
+      items: active.slice(offset, offset + limit).map((item) => ({
+        id: item.id,
+        entity_id: item.entity_id,
+        field_key: item.field_key,
+        value: item.value,
+      })),
+      limit,
+      offset,
+    })
+  }),
+  http.get('/api/v1/text-fields/:id', ({ params }) => {
+    const id = Number(params.id)
+    const item = items.find((entry) => entry.id === id && !entry.is_deleted)
+
+    if (item === undefined) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/not-found',
+          title: 'Not found',
+          status: 404,
+          instance: `/api/v1/text-fields/${String(id)}`,
+        },
+        { status: 404 },
+      )
+    }
+
+    return HttpResponse.json({
+      id: item.id,
+      entity_id: item.entity_id,
+      field_key: item.field_key,
+      value: item.value,
+    })
+  }),
+  http.post('/api/v1/text-fields', async ({ request }) => {
+    const body = (await request.json()) as {
+      entity_id?: number
+      field_key?: string
+      value?: string
+    }
+
+    if (typeof body.entity_id !== 'number' || body.entity_id < 1) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/validation-failed',
+          title: 'Validation failed',
+          status: 422,
+          instance: '/api/v1/text-fields',
+          errors: [{ field: 'entity_id', message: 'Invalid', code: 'invalid' }],
+        },
+        { status: 422 },
+      )
+    }
+
+    if (typeof body.field_key !== 'string' || body.field_key.trim() === '') {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/validation-failed',
+          title: 'Validation failed',
+          status: 422,
+          instance: '/api/v1/text-fields',
+          errors: [{ field: 'field_key', message: 'Required', code: 'required' }],
+        },
+        { status: 422 },
+      )
+    }
+
+    if (typeof body.value !== 'string') {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/validation-failed',
+          title: 'Validation failed',
+          status: 422,
+          instance: '/api/v1/text-fields',
+          errors: [{ field: 'value', message: 'Required', code: 'required' }],
+        },
+        { status: 422 },
+      )
+    }
+
+    const created: TextFieldRecord = {
+      id: nextId++,
+      entity_id: body.entity_id,
+      field_key: body.field_key,
+      value: body.value,
+      is_deleted: false,
+    }
+    items = [...items, created]
+
+    return HttpResponse.json(
+      {
+        id: created.id,
+        entity_id: created.entity_id,
+        field_key: created.field_key,
+        value: created.value,
+      },
+      { status: 201 },
+    )
+  }),
+  http.put('/api/v1/text-fields/:id', async ({ params, request }) => {
+    const id = Number(params.id)
+    const index = items.findIndex((item) => item.id === id && !item.is_deleted)
+
+    if (index === -1) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/not-found',
+          title: 'Not found',
+          status: 404,
+          instance: `/api/v1/text-fields/${String(id)}`,
+        },
+        { status: 404 },
+      )
+    }
+
+    const body = (await request.json()) as { field_key?: string; value?: string }
+    const current = items[index]
+    if (current === undefined) {
+      return HttpResponse.json({ title: 'Not found' }, { status: 404 })
+    }
+
+    const updated: TextFieldRecord = {
+      ...current,
+      field_key: body.field_key ?? current.field_key,
+      value: body.value ?? current.value,
+    }
+    items = items.map((item, itemIndex) => (itemIndex === index ? updated : item))
+
+    return HttpResponse.json({
+      id: updated.id,
+      entity_id: updated.entity_id,
+      field_key: updated.field_key,
+      value: updated.value,
+    })
+  }),
+]

--- a/frontend/tests/msw/server.ts
+++ b/frontend/tests/msw/server.ts
@@ -2,5 +2,11 @@ import { setupServer } from 'msw/node'
 import { entityHandlers } from './handlers/entity'
 import { entityTypeHandlers } from './handlers/entity-type'
 import { fieldDefHandlers } from './handlers/field-def'
+import { textFieldHandlers } from './handlers/text-field'
 
-export const mswServer = setupServer(...entityTypeHandlers, ...entityHandlers, ...fieldDefHandlers)
+export const mswServer = setupServer(
+  ...entityTypeHandlers,
+  ...entityHandlers,
+  ...fieldDefHandlers,
+  ...textFieldHandlers,
+)


### PR DESCRIPTION
## Summary

- `entities/text-field/` スライス（create/update, list）
- `/entity-types/:entityTypeId/entities/:entityId` — text field_defs に沿ったフォーム
- records 一覧に **Edit** リンク
- 保存時 upsert（既存値は PUT、未作成は POST）
- MSW + ページテスト 3 件（計 27 tests green）

## 注意

API の `GET /api/v1/text-fields` に `entity_id` フィルタがないため、フロントは limit=100 で取得後クライアント側フィルタ。後続 Issue で API 改善予定。

## 検証

```bash
npm run check --prefix frontend
```

## チェックリスト

- [x] Issue スコープ内
- [x] `npm run check --prefix frontend` green

Closes #30

Made with [Cursor](https://cursor.com)