### PR TITLE
feat(frontend): レコード一覧に title 表示 (#32)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -12,7 +12,7 @@ New contributors and AI agents: read [`handoff-2026-05-24-workspace-switch.md`](
 
 | Issue | Branch | Summary |
 | --- | --- | --- |
-| #30 | `feat/30-text-fields-ui` | text_fields 値編集 UI（レコード詳細） |
+| #32 | `feat/32-record-list-labels` | レコード一覧に title 表示 |
 
 ## Up Next
 
@@ -27,19 +27,18 @@ New contributors and AI agents: read [`handoff-2026-05-24-workspace-switch.md`](
 
 | Issue | Summary |
 | --- | --- |
+| #30 | text_fields 値編集 UI (PR #31) |
 | #28 | field_defs 一覧・作成・削除 UI (PR #29) |
 | #26 | Entity（Record）一覧・作成・削除 UI (PR #27) |
 | #24 | Entity type 作成・一覧・削除 UI (PR #25) |
 | #22 | Docker compose (PR #23) |
 | #20 | Phase 4 Admin React scaffold (PR #21) |
-| #18 | Frontend design system / Storybook (PR #19) |
-| #16 | Tags + entity list filters (PR #17) — **Phase 3 complete** |
 
 ## Handoff Notes
 
-- **Phase 4:** entity types → field defs → records → text field values admin flow.
-- text-fields list has no `entity_id` filter yet; frontend filters client-side (limit 100).
-- Run admin UI: `npm run dev --prefix frontend` + Docker API on :8080.
+- **Phase 4:** entity types → field defs → records → text values — admin loop complete for text.
+- text-fields list: client-side filter (limit 100) until API adds `entity_id` query.
+- Run: `npm run dev --prefix frontend` + Docker API :8080.
 
 ## Verification Commands
 

--- a/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
+++ b/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import {
   defaultEntityListParams,
   useCreateEntity,
@@ -7,13 +7,29 @@ import {
   type Entity,
   type EntityId,
 } from '@/entities/entity'
+import { useTextFieldList } from '@/entities/text-field'
+import { getRecordDisplayLabel } from '../lib/get-record-display-label'
 
 export function useManageEntitiesPage(entityTypeId: number) {
   const listParams = defaultEntityListParams(entityTypeId)
   const listQuery = useEntityList(listParams)
+  const textFieldQuery = useTextFieldList()
   const createMutation = useCreateEntity()
   const deleteMutation = useDeleteEntity()
   const [deleteTarget, setDeleteTarget] = useState<Entity | null>(null)
+
+  const items = useMemo(() => listQuery.data?.items ?? [], [listQuery.data?.items])
+
+  const recordLabels = useMemo((): Record<string, string> => {
+    const textFields = textFieldQuery.data?.items ?? []
+
+    return Object.fromEntries(
+      items.map((entity) => [
+        String(entity.id),
+        getRecordDisplayLabel(Number(entity.id), textFields, `Record #${String(entity.id)}`),
+      ]),
+    )
+  }, [items, textFieldQuery.data?.items])
 
   const createEntity = useCallback(async () => {
     await createMutation.mutateAsync({ entityTypeId })
@@ -37,13 +53,20 @@ export function useManageEntitiesPage(entityTypeId: number) {
     setDeleteTarget(null)
   }, [deleteMutation, deleteTarget, entityTypeId])
 
+  const isLoading = listQuery.isLoading || textFieldQuery.isLoading
+  const isError = listQuery.isError || textFieldQuery.isError
+  const errorTitle = listQuery.error?.title ?? textFieldQuery.error?.title ?? null
+
   return {
-    items: listQuery.data?.items ?? [],
+    items,
+    recordLabels,
     total: listQuery.data?.total ?? 0,
-    isLoading: listQuery.isLoading,
-    isError: listQuery.isError,
-    errorTitle: listQuery.error?.title ?? null,
-    refetch: listQuery.refetch,
+    isLoading,
+    isError,
+    errorTitle,
+    refetch: async () => {
+      await Promise.all([listQuery.refetch(), textFieldQuery.refetch()])
+    },
     createEntity,
     isCreating: createMutation.isPending,
     createErrorTitle: createMutation.error?.title ?? null,

--- a/frontend/src/features/manage-entities/lib/get-record-display-label.test.ts
+++ b/frontend/src/features/manage-entities/lib/get-record-display-label.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { toTextFieldId } from '@/entities/text-field'
+import { getRecordDisplayLabel } from './get-record-display-label'
+
+describe('getRecordDisplayLabel', () => {
+  it('prefers title field value', () => {
+    const label = getRecordDisplayLabel(
+      1,
+      [
+        {
+          id: toTextFieldId(1),
+          entityId: 1,
+          fieldKey: 'body',
+          value: 'Body text',
+        },
+        {
+          id: toTextFieldId(2),
+          entityId: 1,
+          fieldKey: 'title',
+          value: 'My article',
+        },
+      ],
+      'Record #1',
+    )
+
+    expect(label).toBe('My article')
+  })
+
+  it('falls back to first non-empty text field', () => {
+    const label = getRecordDisplayLabel(
+      2,
+      [
+        {
+          id: toTextFieldId(3),
+          entityId: 2,
+          fieldKey: 'summary',
+          value: 'Short summary',
+        },
+      ],
+      'Record #2',
+    )
+
+    expect(label).toBe('Short summary')
+  })
+
+  it('uses fallback when no values exist', () => {
+    expect(getRecordDisplayLabel(3, [], 'Record #3')).toBe('Record #3')
+  })
+})

--- a/frontend/src/features/manage-entities/lib/get-record-display-label.ts
+++ b/frontend/src/features/manage-entities/lib/get-record-display-label.ts
@@ -1,0 +1,21 @@
+import type { TextField } from '@/entities/text-field'
+
+export function getRecordDisplayLabel(
+  entityId: number,
+  textFields: TextField[],
+  fallback: string,
+): string {
+  const forEntity = textFields.filter((item) => item.entityId === entityId)
+
+  const titleField = forEntity.find((item) => item.fieldKey === 'title')
+  if (titleField !== undefined && titleField.value.trim() !== '') {
+    return titleField.value.trim()
+  }
+
+  const firstWithValue = forEntity.find((item) => item.value.trim() !== '')
+  if (firstWithValue !== undefined) {
+    return firstWithValue.value.trim()
+  }
+
+  return fallback
+}

--- a/frontend/src/features/manage-entities/ui/EntityListPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityListPanel.tsx
@@ -5,6 +5,7 @@ import { Button, EmptyState, Stack, Text } from '@/shared/ui'
 export interface EntityListPanelProps {
   entityTypeId: number
   items: Entity[]
+  recordLabels: Record<string, string>
   isLoading: boolean
   isError: boolean
   errorTitle: string | null
@@ -16,6 +17,7 @@ export interface EntityListPanelProps {
 export function EntityListPanel({
   entityTypeId,
   items,
+  recordLabels,
   isLoading,
   isError,
   errorTitle,
@@ -57,10 +59,10 @@ export function EntityListPanel({
         >
           <Stack gap="xs">
             <Text as="span" variant="heading-sm">
-              Record #{String(item.id)}
+              {recordLabels[String(item.id)] ?? `Record #${String(item.id)}`}
             </Text>
             <Text as="span" muted>
-              Entity type ID {String(item.entityTypeId)}
+              #{String(item.id)}
             </Text>
           </Stack>
           <div className="flex items-center gap-inline-sm">

--- a/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
+++ b/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
@@ -8,6 +8,7 @@ export interface ManageEntitiesViewProps {
   entityTypeName: string | null
   entityTypeSlug: string | null
   items: Entity[]
+  recordLabels: Record<string, string>
   total: number
   isLoading: boolean
   isError: boolean
@@ -28,6 +29,7 @@ export function ManageEntitiesView({
   entityTypeName,
   entityTypeSlug,
   items,
+  recordLabels,
   total,
   isLoading,
   isError,
@@ -65,6 +67,7 @@ export function ManageEntitiesView({
           <EntityListPanel
             entityTypeId={entityTypeId}
             items={items}
+            recordLabels={recordLabels}
             isLoading={isLoading}
             isError={isError}
             errorTitle={errorTitle}

--- a/frontend/src/pages/entity-records/EntityRecordsPage.test.tsx
+++ b/frontend/src/pages/entity-records/EntityRecordsPage.test.tsx
@@ -4,8 +4,9 @@ import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { EntityRecordsPage } from '@/pages/entity-records/EntityRecordsPage'
 import { EntityTypesPage } from '@/pages/entity-types/EntityTypesPage'
-import { resetEntityStore } from '@tests/msw/handlers/entity'
+import { resetEntityStore, seedEntities } from '@tests/msw/handlers/entity'
 import { resetEntityTypeStore, seedEntityTypes } from '@tests/msw/handlers/entity-type'
+import { resetTextFieldStore, seedTextFields } from '@tests/msw/handlers/text-field'
 import { mswServer } from '@tests/msw/server'
 import { renderWithProviders } from '@tests/render/render-with-providers'
 
@@ -28,6 +29,7 @@ describe('EntityRecordsPage', () => {
     mswServer.resetHandlers()
     resetEntityTypeStore()
     resetEntityStore()
+    resetTextFieldStore()
     cleanup()
   })
 
@@ -74,6 +76,31 @@ describe('EntityRecordsPage', () => {
       expect(screen.queryByText('Record #1')).not.toBeInTheDocument()
       expect(screen.getByText('No records yet')).toBeInTheDocument()
     })
+  })
+
+  it('shows title text field value as the record label', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    seedEntities([
+      {
+        id: 1,
+        entity_type_id: 1,
+        is_deleted: false,
+        deleted_at: null,
+      },
+    ])
+    seedTextFields([
+      {
+        id: 1,
+        entity_id: 1,
+        field_key: 'title',
+        value: 'My article',
+      },
+    ])
+
+    renderRecordsPage()
+
+    expect(await screen.findByText('My article')).toBeInTheDocument()
+    expect(screen.getByText('#1')).toBeInTheDocument()
   })
 
   it('links from entity types page to records', async () => {

--- a/frontend/src/pages/entity-records/EntityRecordsPage.tsx
+++ b/frontend/src/pages/entity-records/EntityRecordsPage.tsx
@@ -10,6 +10,7 @@ export function EntityRecordsPage() {
   const entityTypeQuery = useEntityType(toEntityTypeId(entityTypeId))
   const {
     items,
+    recordLabels,
     total,
     isLoading,
     isError,
@@ -42,6 +43,7 @@ export function EntityRecordsPage() {
         entityTypeName={entityTypeQuery.data?.name ?? null}
         entityTypeSlug={entityTypeQuery.data?.slug ?? null}
         items={items}
+        recordLabels={recordLabels}
         total={total}
         isLoading={isLoading}
         isError={isError}


### PR DESCRIPTION
## Summary

- Records 一覧の見出しを `title` text_field 値で表示（なければ最初の text 値、なければ `Record #id`）
- 副行に `#id` を表示
- ユニットテスト + ページテスト追加（31 tests green）

## 検証

```bash
npm run check --prefix frontend
```

Closes #32

Made with [Cursor](https://cursor.com)