### PR TITLE
feat(frontend): int_fields 値編集 UI (#34)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -2,49 +2,33 @@
 
 Last updated: 2026-05-24
 
-## Workspace
-
-**Main Cursor workspace:** `/home/xi/docker/nene-records`
-
-New contributors and AI agents: read [`handoff-2026-05-24-workspace-switch.md`](./handoff-2026-05-24-workspace-switch.md) and [`docs/explanation/product-vision.md`](../explanation/product-vision.md) first.
-
 ## In Progress
 
 | Issue | Branch | Summary |
 | --- | --- | --- |
-| #32 | `feat/32-record-list-labels` | レコード一覧に title 表示 |
+| #34 | `feat/34-int-fields-ui` | int_fields 値編集 UI |
 
 ## Up Next
 
 | Issue | Summary |
 | --- | --- |
-| TBD | int/enum/bool/datetime フィールド値 UI |
+| TBD | enum/bool/datetime フィールド値 UI |
 | TBD | Entity type 編集（PUT） |
-| TBD | API: text-fields list filter by entity_id |
+| TBD | API: field list filter by entity_id |
 | TBD | GitHub Actions frontend CI |
 
 ## Recently Completed
 
 | Issue | Summary |
 | --- | --- |
+| #32 | レコード一覧 title 表示 (PR #33) |
 | #30 | text_fields 値編集 UI (PR #31) |
-| #28 | field_defs 一覧・作成・削除 UI (PR #29) |
-| #26 | Entity（Record）一覧・作成・削除 UI (PR #27) |
-| #24 | Entity type 作成・一覧・削除 UI (PR #25) |
-| #22 | Docker compose (PR #23) |
-| #20 | Phase 4 Admin React scaffold (PR #21) |
+| #28 | field_defs UI (PR #29) |
+| #26 | Entity records UI (PR #27) |
 
-## Handoff Notes
-
-- **Phase 4:** entity types → field defs → records → text values — admin loop complete for text.
-- text-fields list: client-side filter (limit 100) until API adds `entity_id` query.
-- Run: `npm run dev --prefix frontend` + Docker API :8080.
-
-## Verification Commands
+## Verification
 
 ```bash
-composer check
 npm run check --prefix frontend
-docker compose up --build
-curl http://localhost:8080/health
+composer check
 ```

--- a/frontend/src/entities/int-field/api-types.ts
+++ b/frontend/src/entities/int-field/api-types.ts
@@ -1,0 +1,23 @@
+export interface IntFieldDto {
+  id: number
+  entity_id: number
+  field_key: string
+  value: number
+}
+
+export interface IntFieldListDto {
+  items: IntFieldDto[]
+  limit: number
+  offset: number
+}
+
+export interface CreateIntFieldDto {
+  entity_id: number
+  field_key: string
+  value: number
+}
+
+export interface UpdateIntFieldDto {
+  field_key: string
+  value: number
+}

--- a/frontend/src/entities/int-field/ids.ts
+++ b/frontend/src/entities/int-field/ids.ts
@@ -1,0 +1,7 @@
+declare const intFieldIdBrand: unique symbol
+
+export type IntFieldId = number & { readonly [intFieldIdBrand]: never }
+
+export function toIntFieldId(value: number): IntFieldId {
+  return value as IntFieldId
+}

--- a/frontend/src/entities/int-field/index.ts
+++ b/frontend/src/entities/int-field/index.ts
@@ -1,0 +1,7 @@
+export type { IntFieldId } from './ids'
+export { toIntFieldId } from './ids'
+export type { CreateIntFieldInput, IntField, IntFieldList, UpdateIntFieldInput } from './model'
+export { intFieldKeys } from './query-keys'
+export type { IntFieldListParams } from './query-keys'
+export { useCreateIntField, useUpdateIntField } from './mutations'
+export { useIntField, useIntFieldList } from './queries'

--- a/frontend/src/entities/int-field/mapper.test.ts
+++ b/frontend/src/entities/int-field/mapper.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { toIntFieldId } from './ids'
+import {
+  mapCreateInputToDto,
+  mapIntFieldDtoToModel,
+  mapIntFieldListDtoToModel,
+  mapUpdateInputToDto,
+} from './mapper'
+
+describe('int-field mapper', () => {
+  it('maps int field dto to model', () => {
+    const model = mapIntFieldDtoToModel({
+      id: 1,
+      entity_id: 2,
+      field_key: 'count',
+      value: 42,
+    })
+
+    expect(model).toEqual({
+      id: toIntFieldId(1),
+      entityId: 2,
+      fieldKey: 'count',
+      value: 42,
+    })
+  })
+
+  it('maps create and update inputs to dto', () => {
+    expect(mapCreateInputToDto({ entityId: 5, fieldKey: 'count', value: 7 })).toEqual({
+      entity_id: 5,
+      field_key: 'count',
+      value: 7,
+    })
+
+    expect(mapUpdateInputToDto({ fieldKey: 'count', value: 9 })).toEqual({
+      field_key: 'count',
+      value: 9,
+    })
+  })
+
+  it('maps list dto to model', () => {
+    const model = mapIntFieldListDtoToModel({
+      items: [{ id: 3, entity_id: 1, field_key: 'views', value: 100 }],
+      limit: 100,
+      offset: 0,
+    })
+
+    expect(model.items[0]?.value).toBe(100)
+  })
+})

--- a/frontend/src/entities/int-field/mapper.ts
+++ b/frontend/src/entities/int-field/mapper.ts
@@ -1,0 +1,40 @@
+import type {
+  CreateIntFieldDto,
+  IntFieldDto,
+  IntFieldListDto,
+  UpdateIntFieldDto,
+} from './api-types'
+import { toIntFieldId } from './ids'
+import type { CreateIntFieldInput, IntField, IntFieldList, UpdateIntFieldInput } from './model'
+
+export function mapIntFieldDtoToModel(dto: IntFieldDto): IntField {
+  return {
+    id: toIntFieldId(dto.id),
+    entityId: dto.entity_id,
+    fieldKey: dto.field_key,
+    value: dto.value,
+  }
+}
+
+export function mapIntFieldListDtoToModel(dto: IntFieldListDto): IntFieldList {
+  return {
+    items: dto.items.map(mapIntFieldDtoToModel),
+    limit: dto.limit,
+    offset: dto.offset,
+  }
+}
+
+export function mapCreateInputToDto(input: CreateIntFieldInput): CreateIntFieldDto {
+  return {
+    entity_id: input.entityId,
+    field_key: input.fieldKey,
+    value: input.value,
+  }
+}
+
+export function mapUpdateInputToDto(input: UpdateIntFieldInput): UpdateIntFieldDto {
+  return {
+    field_key: input.fieldKey,
+    value: input.value,
+  }
+}

--- a/frontend/src/entities/int-field/model.ts
+++ b/frontend/src/entities/int-field/model.ts
@@ -1,0 +1,25 @@
+import type { IntFieldId } from './ids'
+
+export interface IntField {
+  id: IntFieldId
+  entityId: number
+  fieldKey: string
+  value: number
+}
+
+export interface IntFieldList {
+  items: IntField[]
+  limit: number
+  offset: number
+}
+
+export interface CreateIntFieldInput {
+  entityId: number
+  fieldKey: string
+  value: number
+}
+
+export interface UpdateIntFieldInput {
+  fieldKey: string
+  value: number
+}

--- a/frontend/src/entities/int-field/mutations.ts
+++ b/frontend/src/entities/int-field/mutations.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { IntFieldDto } from './api-types'
+import type { IntFieldId } from './ids'
+import { mapCreateInputToDto, mapIntFieldDtoToModel, mapUpdateInputToDto } from './mapper'
+import type { CreateIntFieldInput, IntField, UpdateIntFieldInput } from './model'
+import { intFieldKeys } from './query-keys'
+
+export function useCreateIntField(): UseMutationResult<IntField, AppError, CreateIntFieldInput> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input) => {
+      const dto = await apiClient.post<IntFieldDto>(
+        '/api/v1/int-fields',
+        mapCreateInputToDto(input),
+      )
+      return mapIntFieldDtoToModel(dto)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: intFieldKeys.lists() })
+    },
+  })
+}
+
+export function useUpdateIntField(): UseMutationResult<
+  IntField,
+  AppError,
+  { id: IntFieldId; input: UpdateIntFieldInput }
+> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ id, input }) => {
+      const dto = await apiClient.put<IntFieldDto>(
+        `/api/v1/int-fields/${String(id)}`,
+        mapUpdateInputToDto(input),
+      )
+      return mapIntFieldDtoToModel(dto)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: intFieldKeys.lists() })
+    },
+  })
+}

--- a/frontend/src/entities/int-field/queries.ts
+++ b/frontend/src/entities/int-field/queries.ts
@@ -1,0 +1,38 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { IntFieldDto, IntFieldListDto } from './api-types'
+import type { IntFieldId } from './ids'
+import { mapIntFieldDtoToModel, mapIntFieldListDtoToModel } from './mapper'
+import type { IntField, IntFieldList } from './model'
+import { intFieldKeys, type IntFieldListParams } from './query-keys'
+
+const DEFAULT_LIST_PARAMS = { limit: 100, offset: 0 } as const
+
+export function useIntFieldList(
+  params: IntFieldListParams = DEFAULT_LIST_PARAMS,
+): UseQueryResult<IntFieldList, AppError> {
+  return useQuery({
+    queryKey: intFieldKeys.list(params),
+    queryFn: async ({ signal }) => {
+      const search = new URLSearchParams({
+        limit: String(params.limit),
+        offset: String(params.offset),
+      })
+      const dto = await apiClient.get<IntFieldListDto>(
+        `/api/v1/int-fields?${search.toString()}`,
+        signal,
+      )
+      return mapIntFieldListDtoToModel(dto)
+    },
+  })
+}
+
+export function useIntField(id: IntFieldId): UseQueryResult<IntField, AppError> {
+  return useQuery({
+    queryKey: intFieldKeys.detail(id),
+    queryFn: async ({ signal }) => {
+      const dto = await apiClient.get<IntFieldDto>(`/api/v1/int-fields/${String(id)}`, signal)
+      return mapIntFieldDtoToModel(dto)
+    },
+  })
+}

--- a/frontend/src/entities/int-field/query-keys.ts
+++ b/frontend/src/entities/int-field/query-keys.ts
@@ -1,0 +1,14 @@
+import type { IntFieldId } from './ids'
+
+export interface IntFieldListParams {
+  limit: number
+  offset: number
+}
+
+export const intFieldKeys = {
+  all: ['int-fields'] as const,
+  lists: () => [...intFieldKeys.all, 'list'] as const,
+  list: (params: IntFieldListParams) => [...intFieldKeys.lists(), params] as const,
+  details: () => [...intFieldKeys.all, 'detail'] as const,
+  detail: (id: IntFieldId) => [...intFieldKeys.details(), id] as const,
+}

--- a/frontend/src/features/edit-entity-text-fields/hooks/use-edit-entity-text-fields-page.ts
+++ b/frontend/src/features/edit-entity-text-fields/hooks/use-edit-entity-text-fields-page.ts
@@ -1,6 +1,13 @@
 import { useCallback, useMemo } from 'react'
+import type { FieldDataType } from '@/entities/field-def'
 import { defaultFieldDefListParams, useFieldDefList } from '@/entities/field-def'
 import { toEntityId, useEntity } from '@/entities/entity'
+import {
+  useCreateIntField,
+  useIntFieldList,
+  useUpdateIntField,
+  type IntField,
+} from '@/entities/int-field'
 import {
   useCreateTextField,
   useTextFieldList,
@@ -8,15 +15,33 @@ import {
   type TextField,
 } from '@/entities/text-field'
 
+const EDITABLE_DATA_TYPES: FieldDataType[] = ['text', 'int']
+
+function parseIntFieldValue(raw: string): number {
+  const trimmed = raw.trim()
+  if (trimmed === '') {
+    return 0
+  }
+
+  const parsed = Number.parseInt(trimmed, 10)
+  return Number.isNaN(parsed) ? 0 : parsed
+}
+
 export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: number) {
   const entityQuery = useEntity(toEntityId(entityId))
   const fieldDefQuery = useFieldDefList(defaultFieldDefListParams(entityTypeId))
   const textFieldQuery = useTextFieldList()
-  const createMutation = useCreateTextField()
-  const updateMutation = useUpdateTextField()
+  const intFieldQuery = useIntFieldList()
+  const createTextMutation = useCreateTextField()
+  const updateTextMutation = useUpdateTextField()
+  const createIntMutation = useCreateIntField()
+  const updateIntMutation = useUpdateIntField()
 
-  const textFieldDefs = useMemo(
-    () => (fieldDefQuery.data?.items ?? []).filter((item) => item.dataType === 'text'),
+  const editableFieldDefs = useMemo(
+    () =>
+      (fieldDefQuery.data?.items ?? []).filter((item) =>
+        EDITABLE_DATA_TYPES.includes(item.dataType),
+      ),
     [fieldDefQuery.data?.items],
   )
 
@@ -24,55 +49,117 @@ export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: numb
     return (textFieldQuery.data?.items ?? []).filter((item) => item.entityId === entityId)
   }, [textFieldQuery.data?.items, entityId])
 
+  const intFieldsForEntity = useMemo((): IntField[] => {
+    return (intFieldQuery.data?.items ?? []).filter((item) => item.entityId === entityId)
+  }, [intFieldQuery.data?.items, entityId])
+
   const initialValues = useMemo((): Record<string, string> => {
     return Object.fromEntries(
-      textFieldDefs.map((fieldDef) => {
-        const existing = textFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
-        return [fieldDef.fieldKey, existing?.value ?? '']
+      editableFieldDefs.map((fieldDef) => {
+        if (fieldDef.dataType === 'text') {
+          const existing = textFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
+          return [fieldDef.fieldKey, existing?.value ?? '']
+        }
+
+        const existing = intFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
+        return [fieldDef.fieldKey, existing !== undefined ? String(existing.value) : '']
       }),
     )
-  }, [textFieldDefs, textFieldsForEntity])
+  }, [editableFieldDefs, intFieldsForEntity, textFieldsForEntity])
 
   const saveTextFields = useCallback(
     async (values: Record<string, string>) => {
-      for (const fieldDef of textFieldDefs) {
-        const value = values[fieldDef.fieldKey] ?? ''
-        const existing = textFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
+      for (const fieldDef of editableFieldDefs) {
+        const rawValue = values[fieldDef.fieldKey] ?? ''
+
+        if (fieldDef.dataType === 'text') {
+          const existing = textFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
+
+          if (existing !== undefined) {
+            await updateTextMutation.mutateAsync({
+              id: existing.id,
+              input: { fieldKey: fieldDef.fieldKey, value: rawValue },
+            })
+          } else {
+            await createTextMutation.mutateAsync({
+              entityId,
+              fieldKey: fieldDef.fieldKey,
+              value: rawValue,
+            })
+          }
+
+          continue
+        }
+
+        const intValue = parseIntFieldValue(rawValue)
+        const existing = intFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
 
         if (existing !== undefined) {
-          await updateMutation.mutateAsync({
+          await updateIntMutation.mutateAsync({
             id: existing.id,
-            input: { fieldKey: fieldDef.fieldKey, value },
+            input: { fieldKey: fieldDef.fieldKey, value: intValue },
           })
         } else {
-          await createMutation.mutateAsync({
+          await createIntMutation.mutateAsync({
             entityId,
             fieldKey: fieldDef.fieldKey,
-            value,
+            value: intValue,
           })
         }
       }
     },
-    [createMutation, entityId, textFieldDefs, textFieldsForEntity, updateMutation],
+    [
+      createIntMutation,
+      createTextMutation,
+      editableFieldDefs,
+      entityId,
+      intFieldsForEntity,
+      textFieldsForEntity,
+      updateIntMutation,
+      updateTextMutation,
+    ],
   )
 
-  const isLoading = entityQuery.isLoading || fieldDefQuery.isLoading || textFieldQuery.isLoading
-  const isError = entityQuery.isError || fieldDefQuery.isError || textFieldQuery.isError
+  const isLoading =
+    entityQuery.isLoading ||
+    fieldDefQuery.isLoading ||
+    textFieldQuery.isLoading ||
+    intFieldQuery.isLoading
+  const isError =
+    entityQuery.isError || fieldDefQuery.isError || textFieldQuery.isError || intFieldQuery.isError
   const errorTitle =
-    entityQuery.error?.title ?? fieldDefQuery.error?.title ?? textFieldQuery.error?.title ?? null
+    entityQuery.error?.title ??
+    fieldDefQuery.error?.title ??
+    textFieldQuery.error?.title ??
+    intFieldQuery.error?.title ??
+    null
 
   return {
     entity: entityQuery.data ?? null,
-    textFieldDefs,
+    textFieldDefs: editableFieldDefs,
     initialValues,
     isLoading,
     isError,
     errorTitle,
     refetch: async () => {
-      await Promise.all([entityQuery.refetch(), fieldDefQuery.refetch(), textFieldQuery.refetch()])
+      await Promise.all([
+        entityQuery.refetch(),
+        fieldDefQuery.refetch(),
+        textFieldQuery.refetch(),
+        intFieldQuery.refetch(),
+      ])
     },
     saveTextFields,
-    isSaving: createMutation.isPending || updateMutation.isPending,
-    saveErrorTitle: createMutation.error?.title ?? updateMutation.error?.title ?? null,
+    isSaving:
+      createTextMutation.isPending ||
+      updateTextMutation.isPending ||
+      createIntMutation.isPending ||
+      updateIntMutation.isPending,
+    saveErrorTitle:
+      createTextMutation.error?.title ??
+      updateTextMutation.error?.title ??
+      createIntMutation.error?.title ??
+      updateIntMutation.error?.title ??
+      null,
   }
 }

--- a/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
@@ -18,11 +18,12 @@ export function EntityTextFieldsForm({
   onSubmit,
 }: EntityTextFieldsFormProps) {
   const [values, setValues] = useState(defaultValues)
+
   if (fieldDefs.length === 0) {
     return (
       <EmptyState
-        title="No text fields defined"
-        description="Add text field definitions for this entity type first."
+        title="No editable fields defined"
+        description="Add text or integer field definitions for this entity type first."
       />
     )
   }
@@ -37,13 +38,14 @@ export function EntityTextFieldsForm({
     >
       <Stack gap="md">
         <Text as="h2" variant="heading-sm">
-          Text field values
+          Field values
         </Text>
         {fieldDefs.map((fieldDef) => (
           <Input
             key={fieldDef.fieldKey}
-            id={`text-field-${fieldDef.fieldKey}`}
-            label={fieldDef.fieldKey}
+            id={`record-field-${fieldDef.fieldKey}`}
+            label={`${fieldDef.fieldKey} (${fieldDef.dataType})`}
+            type={fieldDef.dataType === 'int' ? 'number' : 'text'}
             autoComplete="off"
             disabled={isSubmitting}
             value={values[fieldDef.fieldKey] ?? ''}

--- a/frontend/src/pages/entity-record/EntityRecordPage.test.tsx
+++ b/frontend/src/pages/entity-record/EntityRecordPage.test.tsx
@@ -6,6 +6,7 @@ import { EntityRecordPage } from '@/pages/entity-record/EntityRecordPage'
 import { resetEntityStore, seedEntities } from '@tests/msw/handlers/entity'
 import { resetEntityTypeStore, seedEntityTypes } from '@tests/msw/handlers/entity-type'
 import { resetFieldDefStore, seedFieldDefs } from '@tests/msw/handlers/field-def'
+import { resetIntFieldStore } from '@tests/msw/handlers/int-field'
 import { resetTextFieldStore } from '@tests/msw/handlers/text-field'
 import { mswServer } from '@tests/msw/server'
 import { renderWithProviders } from '@tests/render/render-with-providers'
@@ -36,6 +37,7 @@ describe('EntityRecordPage', () => {
     resetFieldDefStore()
     resetEntityStore()
     resetTextFieldStore()
+    resetIntFieldStore()
     cleanup()
   })
 
@@ -59,14 +61,14 @@ describe('EntityRecordPage', () => {
     renderEntityRecordPage()
 
     await waitFor(() => {
-      expect(screen.getByLabelText('title')).toBeInTheDocument()
+      expect(screen.getByLabelText('title (text)')).toBeInTheDocument()
     })
 
-    await user.type(screen.getByLabelText('title'), 'Hello world')
+    await user.type(screen.getByLabelText('title (text)'), 'Hello world')
     await user.click(screen.getByRole('button', { name: 'Save values' }))
 
     await waitFor(() => {
-      expect(screen.getByLabelText('title')).toHaveValue('Hello world')
+      expect(screen.getByLabelText('title (text)')).toHaveValue('Hello world')
     })
   })
 
@@ -86,22 +88,22 @@ describe('EntityRecordPage', () => {
     renderEntityRecordPage()
 
     await waitFor(() => {
-      expect(screen.getByLabelText('title')).toBeInTheDocument()
+      expect(screen.getByLabelText('title (text)')).toBeInTheDocument()
     })
 
-    await user.type(screen.getByLabelText('title'), 'First title')
+    await user.type(screen.getByLabelText('title (text)'), 'First title')
     await user.click(screen.getByRole('button', { name: 'Save values' }))
 
     await waitFor(() => {
-      expect(screen.getByLabelText('title')).toHaveValue('First title')
+      expect(screen.getByLabelText('title (text)')).toHaveValue('First title')
     })
 
-    await user.clear(screen.getByLabelText('title'))
-    await user.type(screen.getByLabelText('title'), 'Updated title')
+    await user.clear(screen.getByLabelText('title (text)'))
+    await user.type(screen.getByLabelText('title (text)'), 'Updated title')
     await user.click(screen.getByRole('button', { name: 'Save values' }))
 
     await waitFor(() => {
-      expect(screen.getByLabelText('title')).toHaveValue('Updated title')
+      expect(screen.getByLabelText('title (text)')).toHaveValue('Updated title')
     })
   })
 
@@ -118,6 +120,33 @@ describe('EntityRecordPage', () => {
 
     renderEntityRecordPage()
 
-    expect(await screen.findByText('No text fields defined')).toBeInTheDocument()
+    expect(await screen.findByText('No editable fields defined')).toBeInTheDocument()
+  })
+
+  it('creates int field values on save', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    seedFieldDefs([{ id: 1, entity_type_id: 1, field_key: 'count', data_type: 'int' }])
+    seedEntities([
+      {
+        id: 1,
+        entity_type_id: 1,
+        is_deleted: false,
+        deleted_at: null,
+      },
+    ])
+
+    const user = userEvent.setup()
+    renderEntityRecordPage()
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('count (int)')).toBeInTheDocument()
+    })
+
+    await user.type(screen.getByLabelText('count (int)'), '42')
+    await user.click(screen.getByRole('button', { name: 'Save values' }))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('count (int)')).toHaveValue(42)
+    })
   })
 })

--- a/frontend/src/shared/ui/primitives/Input.tsx
+++ b/frontend/src/shared/ui/primitives/Input.tsx
@@ -1,7 +1,7 @@
 export interface InputProps {
   id: string
   label: string
-  type?: 'text' | 'email' | 'password'
+  type?: 'text' | 'email' | 'password' | 'number'
   value: string
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void

--- a/frontend/tests/msw/handlers/int-field.ts
+++ b/frontend/tests/msw/handlers/int-field.ts
@@ -1,0 +1,108 @@
+import { http, HttpResponse } from 'msw'
+
+interface IntFieldRecord {
+  id: number
+  entity_id: number
+  field_key: string
+  value: number
+  is_deleted: boolean
+}
+
+let nextId = 1
+let items: IntFieldRecord[] = []
+
+export function resetIntFieldStore(): void {
+  nextId = 1
+  items = []
+}
+
+export function seedIntFields(seed: Omit<IntFieldRecord, 'is_deleted'>[]): void {
+  items = seed.map((item) => ({ ...item, is_deleted: false }))
+  nextId = Math.max(0, ...seed.map((item) => item.id)) + 1
+}
+
+export const intFieldHandlers = [
+  http.get('/api/v1/int-fields', ({ request }) => {
+    const url = new URL(request.url)
+    const limit = Number(url.searchParams.get('limit') ?? '20')
+    const offset = Number(url.searchParams.get('offset') ?? '0')
+    const active = items.filter((item) => !item.is_deleted)
+
+    return HttpResponse.json({
+      items: active.slice(offset, offset + limit).map((item) => ({
+        id: item.id,
+        entity_id: item.entity_id,
+        field_key: item.field_key,
+        value: item.value,
+      })),
+      limit,
+      offset,
+    })
+  }),
+  http.post('/api/v1/int-fields', async ({ request }) => {
+    const body = (await request.json()) as {
+      entity_id?: number
+      field_key?: string
+      value?: number
+    }
+
+    if (typeof body.entity_id !== 'number' || body.entity_id < 1) {
+      return HttpResponse.json({ title: 'Validation failed', status: 422 }, { status: 422 })
+    }
+
+    if (typeof body.field_key !== 'string' || body.field_key.trim() === '') {
+      return HttpResponse.json({ title: 'Validation failed', status: 422 }, { status: 422 })
+    }
+
+    if (typeof body.value !== 'number') {
+      return HttpResponse.json({ title: 'Validation failed', status: 422 }, { status: 422 })
+    }
+
+    const created: IntFieldRecord = {
+      id: nextId++,
+      entity_id: body.entity_id,
+      field_key: body.field_key,
+      value: body.value,
+      is_deleted: false,
+    }
+    items = [...items, created]
+
+    return HttpResponse.json(
+      {
+        id: created.id,
+        entity_id: created.entity_id,
+        field_key: created.field_key,
+        value: created.value,
+      },
+      { status: 201 },
+    )
+  }),
+  http.put('/api/v1/int-fields/:id', async ({ params, request }) => {
+    const id = Number(params.id)
+    const index = items.findIndex((item) => item.id === id && !item.is_deleted)
+
+    if (index === -1) {
+      return HttpResponse.json({ title: 'Not found', status: 404 }, { status: 404 })
+    }
+
+    const body = (await request.json()) as { field_key?: string; value?: number }
+    const current = items[index]
+    if (current === undefined) {
+      return HttpResponse.json({ title: 'Not found', status: 404 }, { status: 404 })
+    }
+
+    const updated: IntFieldRecord = {
+      ...current,
+      field_key: body.field_key ?? current.field_key,
+      value: body.value ?? current.value,
+    }
+    items = items.map((item, itemIndex) => (itemIndex === index ? updated : item))
+
+    return HttpResponse.json({
+      id: updated.id,
+      entity_id: updated.entity_id,
+      field_key: updated.field_key,
+      value: updated.value,
+    })
+  }),
+]

--- a/frontend/tests/msw/server.ts
+++ b/frontend/tests/msw/server.ts
@@ -2,6 +2,7 @@ import { setupServer } from 'msw/node'
 import { entityHandlers } from './handlers/entity'
 import { entityTypeHandlers } from './handlers/entity-type'
 import { fieldDefHandlers } from './handlers/field-def'
+import { intFieldHandlers } from './handlers/int-field'
 import { textFieldHandlers } from './handlers/text-field'
 
 export const mswServer = setupServer(
@@ -9,4 +10,5 @@ export const mswServer = setupServer(
   ...entityHandlers,
   ...fieldDefHandlers,
   ...textFieldHandlers,
+  ...intFieldHandlers,
 )


### PR DESCRIPTION
## Summary

- `entities/int-field/` スライス（create/update, list）
- レコード詳細フォームを **text + int** field_defs に対応
- `Input` に `type="number"` を追加
- MSW + テスト更新（35 tests green）

## 検証

```bash
npm run check --prefix frontend
```

Closes #34

Made with [Cursor](https://cursor.com)