### PR TITLE
feat: Phase 4 完走 — 全フィールド型 UI、API filter、CI (#36)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,33 @@
+name: Frontend CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run checks
+        run: npm run check

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -577,6 +577,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/LimitQuery'
         - $ref: '#/components/parameters/OffsetQuery'
+        - $ref: '#/components/parameters/EntityIdQuery'
       responses:
         '200':
           description: Paginated text field list.
@@ -732,6 +733,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/LimitQuery'
         - $ref: '#/components/parameters/OffsetQuery'
+        - $ref: '#/components/parameters/EntityIdQuery'
       responses:
         '200':
           description: Paginated int field list.
@@ -887,6 +889,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/LimitQuery'
         - $ref: '#/components/parameters/OffsetQuery'
+        - $ref: '#/components/parameters/EntityIdQuery'
       responses:
         '200':
           description: Paginated enum field list.
@@ -1042,6 +1045,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/LimitQuery'
         - $ref: '#/components/parameters/OffsetQuery'
+        - $ref: '#/components/parameters/EntityIdQuery'
       responses:
         '200':
           description: Paginated bool field list.
@@ -1197,6 +1201,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/LimitQuery'
         - $ref: '#/components/parameters/OffsetQuery'
+        - $ref: '#/components/parameters/EntityIdQuery'
       responses:
         '200':
           description: Paginated datetime field list.
@@ -1517,6 +1522,15 @@ components:
       example: 0
     EntityTypeIdQuery:
       name: entity_type_id
+      in: query
+      required: false
+      schema:
+        type: integer
+        format: int64
+        minimum: 1
+      example: 1
+    EntityIdQuery:
+      name: entity_id
       in: query
       required: false
       schema:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,29 +6,26 @@ Last updated: 2026-05-24
 
 | Issue | Branch | Summary |
 | --- | --- | --- |
-| #34 | `feat/34-int-fields-ui` | int_fields 値編集 UI |
+| #36 | `feat/36-phase4-batch` | Phase 4 完走（enum/bool/datetime, entity type 編集, API filter, CI） |
 
 ## Up Next
 
 | Issue | Summary |
 | --- | --- |
-| TBD | enum/bool/datetime フィールド値 UI |
-| TBD | Entity type 編集（PUT） |
-| TBD | API: field list filter by entity_id |
-| TBD | GitHub Actions frontend CI |
+| TBD | Records 一覧のラベル取得を API 最適化 |
+| TBD | field_def 編集（PUT） |
+| TBD | Consumer views / public site |
 
-## Recently Completed
+## Recently Completed (Phase 4 batch)
 
-| Issue | Summary |
-| --- | --- |
-| #32 | レコード一覧 title 表示 (PR #33) |
-| #30 | text_fields 値編集 UI (PR #31) |
-| #28 | field_defs UI (PR #29) |
-| #26 | Entity records UI (PR #27) |
+- enum / bool / datetime フィールド値 UI
+- Entity type 編集（PUT）
+- API field list `entity_id` フィルタ
+- GitHub Actions frontend CI
 
 ## Verification
 
 ```bash
-npm run check --prefix frontend
 composer check
+npm run check --prefix frontend
 ```

--- a/frontend/src/entities/bool-field/api-types.ts
+++ b/frontend/src/entities/bool-field/api-types.ts
@@ -1,0 +1,23 @@
+export interface BoolFieldDto {
+  id: number
+  entity_id: number
+  field_key: string
+  value: boolean
+}
+
+export interface BoolFieldListDto {
+  items: BoolFieldDto[]
+  limit: number
+  offset: number
+}
+
+export interface CreateBoolFieldDto {
+  entity_id: number
+  field_key: string
+  value: boolean
+}
+
+export interface UpdateBoolFieldDto {
+  field_key: string
+  value: boolean
+}

--- a/frontend/src/entities/bool-field/ids.ts
+++ b/frontend/src/entities/bool-field/ids.ts
@@ -1,0 +1,7 @@
+declare const boolFieldIdBrand: unique symbol
+
+export type BoolFieldId = number & { readonly [boolFieldIdBrand]: never }
+
+export function toBoolFieldId(value: number): BoolFieldId {
+  return value as BoolFieldId
+}

--- a/frontend/src/entities/bool-field/index.ts
+++ b/frontend/src/entities/bool-field/index.ts
@@ -1,0 +1,7 @@
+export type { BoolFieldId } from './ids'
+export { toBoolFieldId } from './ids'
+export type { BoolField, BoolFieldList, CreateBoolFieldInput, UpdateBoolFieldInput } from './model'
+export { boolFieldKeys } from './query-keys'
+export type { BoolFieldListParams } from './query-keys'
+export { useCreateBoolField, useUpdateBoolField } from './mutations'
+export { useBoolField, useBoolFieldList } from './queries'

--- a/frontend/src/entities/bool-field/mapper.test.ts
+++ b/frontend/src/entities/bool-field/mapper.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { toBoolFieldId } from './ids'
+import {
+  mapBoolFieldDtoToModel,
+  mapBoolFieldListDtoToModel,
+  mapCreateInputToDto,
+  mapUpdateInputToDto,
+} from './mapper'
+
+describe('bool-field mapper', () => {
+  it('maps bool field dto to model', () => {
+    const model = mapBoolFieldDtoToModel({
+      id: 1,
+      entity_id: 2,
+      field_key: 'enabled',
+      value: true,
+    })
+
+    expect(model).toEqual({
+      id: toBoolFieldId(1),
+      entityId: 2,
+      fieldKey: 'enabled',
+      value: true,
+    })
+  })
+
+  it('maps create and update inputs to dto', () => {
+    expect(mapCreateInputToDto({ entityId: 5, fieldKey: 'enabled', value: false })).toEqual({
+      entity_id: 5,
+      field_key: 'enabled',
+      value: false,
+    })
+
+    expect(mapUpdateInputToDto({ fieldKey: 'enabled', value: true })).toEqual({
+      field_key: 'enabled',
+      value: true,
+    })
+  })
+
+  it('maps list dto to model', () => {
+    const model = mapBoolFieldListDtoToModel({
+      items: [{ id: 3, entity_id: 1, field_key: 'enabled', value: false }],
+      limit: 100,
+      offset: 0,
+    })
+
+    expect(model.items[0]?.value).toBe(false)
+  })
+})

--- a/frontend/src/entities/bool-field/mapper.ts
+++ b/frontend/src/entities/bool-field/mapper.ts
@@ -1,0 +1,40 @@
+import type {
+  BoolFieldDto,
+  BoolFieldListDto,
+  CreateBoolFieldDto,
+  UpdateBoolFieldDto,
+} from './api-types'
+import { toBoolFieldId } from './ids'
+import type { BoolField, BoolFieldList, CreateBoolFieldInput, UpdateBoolFieldInput } from './model'
+
+export function mapBoolFieldDtoToModel(dto: BoolFieldDto): BoolField {
+  return {
+    id: toBoolFieldId(dto.id),
+    entityId: dto.entity_id,
+    fieldKey: dto.field_key,
+    value: dto.value,
+  }
+}
+
+export function mapBoolFieldListDtoToModel(dto: BoolFieldListDto): BoolFieldList {
+  return {
+    items: dto.items.map(mapBoolFieldDtoToModel),
+    limit: dto.limit,
+    offset: dto.offset,
+  }
+}
+
+export function mapCreateInputToDto(input: CreateBoolFieldInput): CreateBoolFieldDto {
+  return {
+    entity_id: input.entityId,
+    field_key: input.fieldKey,
+    value: input.value,
+  }
+}
+
+export function mapUpdateInputToDto(input: UpdateBoolFieldInput): UpdateBoolFieldDto {
+  return {
+    field_key: input.fieldKey,
+    value: input.value,
+  }
+}

--- a/frontend/src/entities/bool-field/model.ts
+++ b/frontend/src/entities/bool-field/model.ts
@@ -1,0 +1,25 @@
+import type { BoolFieldId } from './ids'
+
+export interface BoolField {
+  id: BoolFieldId
+  entityId: number
+  fieldKey: string
+  value: boolean
+}
+
+export interface BoolFieldList {
+  items: BoolField[]
+  limit: number
+  offset: number
+}
+
+export interface CreateBoolFieldInput {
+  entityId: number
+  fieldKey: string
+  value: boolean
+}
+
+export interface UpdateBoolFieldInput {
+  fieldKey: string
+  value: boolean
+}

--- a/frontend/src/entities/bool-field/mutations.ts
+++ b/frontend/src/entities/bool-field/mutations.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { BoolFieldDto } from './api-types'
+import type { BoolFieldId } from './ids'
+import { mapBoolFieldDtoToModel, mapCreateInputToDto, mapUpdateInputToDto } from './mapper'
+import type { BoolField, CreateBoolFieldInput, UpdateBoolFieldInput } from './model'
+import { boolFieldKeys } from './query-keys'
+
+export function useCreateBoolField(): UseMutationResult<BoolField, AppError, CreateBoolFieldInput> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input) => {
+      const dto = await apiClient.post<BoolFieldDto>(
+        '/api/v1/bool-fields',
+        mapCreateInputToDto(input),
+      )
+      return mapBoolFieldDtoToModel(dto)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: boolFieldKeys.lists() })
+    },
+  })
+}
+
+export function useUpdateBoolField(): UseMutationResult<
+  BoolField,
+  AppError,
+  { id: BoolFieldId; input: UpdateBoolFieldInput }
+> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ id, input }) => {
+      const dto = await apiClient.put<BoolFieldDto>(
+        `/api/v1/bool-fields/${String(id)}`,
+        mapUpdateInputToDto(input),
+      )
+      return mapBoolFieldDtoToModel(dto)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: boolFieldKeys.lists() })
+    },
+  })
+}

--- a/frontend/src/entities/bool-field/queries.ts
+++ b/frontend/src/entities/bool-field/queries.ts
@@ -1,0 +1,41 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { BoolFieldDto, BoolFieldListDto } from './api-types'
+import type { BoolFieldId } from './ids'
+import { mapBoolFieldDtoToModel, mapBoolFieldListDtoToModel } from './mapper'
+import type { BoolField, BoolFieldList } from './model'
+import { boolFieldKeys, type BoolFieldListParams } from './query-keys'
+
+const DEFAULT_LIST_PARAMS = { limit: 100, offset: 0 } as const
+
+export function useBoolFieldList(
+  params: BoolFieldListParams = DEFAULT_LIST_PARAMS,
+): UseQueryResult<BoolFieldList, AppError> {
+  return useQuery({
+    queryKey: boolFieldKeys.list(params),
+    queryFn: async ({ signal }) => {
+      const search = new URLSearchParams({
+        limit: String(params.limit),
+        offset: String(params.offset),
+      })
+      if (params.entityId !== undefined) {
+        search.set('entity_id', String(params.entityId))
+      }
+      const dto = await apiClient.get<BoolFieldListDto>(
+        `/api/v1/bool-fields?${search.toString()}`,
+        signal,
+      )
+      return mapBoolFieldListDtoToModel(dto)
+    },
+  })
+}
+
+export function useBoolField(id: BoolFieldId): UseQueryResult<BoolField, AppError> {
+  return useQuery({
+    queryKey: boolFieldKeys.detail(id),
+    queryFn: async ({ signal }) => {
+      const dto = await apiClient.get<BoolFieldDto>(`/api/v1/bool-fields/${String(id)}`, signal)
+      return mapBoolFieldDtoToModel(dto)
+    },
+  })
+}

--- a/frontend/src/entities/bool-field/query-keys.ts
+++ b/frontend/src/entities/bool-field/query-keys.ts
@@ -1,0 +1,15 @@
+import type { BoolFieldId } from './ids'
+
+export interface BoolFieldListParams {
+  limit: number
+  offset: number
+  entityId?: number
+}
+
+export const boolFieldKeys = {
+  all: ['bool-fields'] as const,
+  lists: () => [...boolFieldKeys.all, 'list'] as const,
+  list: (params: BoolFieldListParams) => [...boolFieldKeys.lists(), params] as const,
+  details: () => [...boolFieldKeys.all, 'detail'] as const,
+  detail: (id: BoolFieldId) => [...boolFieldKeys.details(), id] as const,
+}

--- a/frontend/src/entities/datetime-field/api-types.ts
+++ b/frontend/src/entities/datetime-field/api-types.ts
@@ -1,0 +1,23 @@
+export interface DateTimeFieldDto {
+  id: number
+  entity_id: number
+  field_key: string
+  value: string
+}
+
+export interface DateTimeFieldListDto {
+  items: DateTimeFieldDto[]
+  limit: number
+  offset: number
+}
+
+export interface CreateDateTimeFieldDto {
+  entity_id: number
+  field_key: string
+  value: string
+}
+
+export interface UpdateDateTimeFieldDto {
+  field_key: string
+  value: string
+}

--- a/frontend/src/entities/datetime-field/ids.ts
+++ b/frontend/src/entities/datetime-field/ids.ts
@@ -1,0 +1,7 @@
+declare const dateTimeFieldIdBrand: unique symbol
+
+export type DateTimeFieldId = number & { readonly [dateTimeFieldIdBrand]: never }
+
+export function toDateTimeFieldId(value: number): DateTimeFieldId {
+  return value as DateTimeFieldId
+}

--- a/frontend/src/entities/datetime-field/index.ts
+++ b/frontend/src/entities/datetime-field/index.ts
@@ -1,0 +1,12 @@
+export type { DateTimeFieldId } from './ids'
+export { toDateTimeFieldId } from './ids'
+export type {
+  CreateDateTimeFieldInput,
+  DateTimeField,
+  DateTimeFieldList,
+  UpdateDateTimeFieldInput,
+} from './model'
+export { dateTimeFieldKeys } from './query-keys'
+export type { DateTimeFieldListParams } from './query-keys'
+export { useCreateDateTimeField, useUpdateDateTimeField } from './mutations'
+export { useDateTimeField, useDateTimeFieldList } from './queries'

--- a/frontend/src/entities/datetime-field/mapper.test.ts
+++ b/frontend/src/entities/datetime-field/mapper.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { toDateTimeFieldId } from './ids'
+import {
+  mapCreateInputToDto,
+  mapDateTimeFieldDtoToModel,
+  mapDateTimeFieldListDtoToModel,
+  mapUpdateInputToDto,
+} from './mapper'
+
+describe('datetime-field mapper', () => {
+  it('maps datetime field dto to model', () => {
+    const model = mapDateTimeFieldDtoToModel({
+      id: 1,
+      entity_id: 2,
+      field_key: 'published_at',
+      value: '2026-05-24T12:00:00.000Z',
+    })
+
+    expect(model).toEqual({
+      id: toDateTimeFieldId(1),
+      entityId: 2,
+      fieldKey: 'published_at',
+      value: '2026-05-24T12:00:00.000Z',
+    })
+  })
+
+  it('maps create and update inputs to dto', () => {
+    expect(
+      mapCreateInputToDto({
+        entityId: 5,
+        fieldKey: 'published_at',
+        value: '2026-05-24T12:00:00.000Z',
+      }),
+    ).toEqual({
+      entity_id: 5,
+      field_key: 'published_at',
+      value: '2026-05-24T12:00:00.000Z',
+    })
+
+    expect(
+      mapUpdateInputToDto({
+        fieldKey: 'published_at',
+        value: '2026-05-25T08:30:00.000Z',
+      }),
+    ).toEqual({
+      field_key: 'published_at',
+      value: '2026-05-25T08:30:00.000Z',
+    })
+  })
+
+  it('maps list dto to model', () => {
+    const model = mapDateTimeFieldListDtoToModel({
+      items: [
+        {
+          id: 3,
+          entity_id: 1,
+          field_key: 'published_at',
+          value: '2026-05-24T12:00:00.000Z',
+        },
+      ],
+      limit: 100,
+      offset: 0,
+    })
+
+    expect(model.items[0]?.value).toBe('2026-05-24T12:00:00.000Z')
+  })
+})

--- a/frontend/src/entities/datetime-field/mapper.ts
+++ b/frontend/src/entities/datetime-field/mapper.ts
@@ -1,0 +1,45 @@
+import type {
+  CreateDateTimeFieldDto,
+  DateTimeFieldDto,
+  DateTimeFieldListDto,
+  UpdateDateTimeFieldDto,
+} from './api-types'
+import { toDateTimeFieldId } from './ids'
+import type {
+  CreateDateTimeFieldInput,
+  DateTimeField,
+  DateTimeFieldList,
+  UpdateDateTimeFieldInput,
+} from './model'
+
+export function mapDateTimeFieldDtoToModel(dto: DateTimeFieldDto): DateTimeField {
+  return {
+    id: toDateTimeFieldId(dto.id),
+    entityId: dto.entity_id,
+    fieldKey: dto.field_key,
+    value: dto.value,
+  }
+}
+
+export function mapDateTimeFieldListDtoToModel(dto: DateTimeFieldListDto): DateTimeFieldList {
+  return {
+    items: dto.items.map(mapDateTimeFieldDtoToModel),
+    limit: dto.limit,
+    offset: dto.offset,
+  }
+}
+
+export function mapCreateInputToDto(input: CreateDateTimeFieldInput): CreateDateTimeFieldDto {
+  return {
+    entity_id: input.entityId,
+    field_key: input.fieldKey,
+    value: input.value,
+  }
+}
+
+export function mapUpdateInputToDto(input: UpdateDateTimeFieldInput): UpdateDateTimeFieldDto {
+  return {
+    field_key: input.fieldKey,
+    value: input.value,
+  }
+}

--- a/frontend/src/entities/datetime-field/model.ts
+++ b/frontend/src/entities/datetime-field/model.ts
@@ -1,0 +1,25 @@
+import type { DateTimeFieldId } from './ids'
+
+export interface DateTimeField {
+  id: DateTimeFieldId
+  entityId: number
+  fieldKey: string
+  value: string
+}
+
+export interface DateTimeFieldList {
+  items: DateTimeField[]
+  limit: number
+  offset: number
+}
+
+export interface CreateDateTimeFieldInput {
+  entityId: number
+  fieldKey: string
+  value: string
+}
+
+export interface UpdateDateTimeFieldInput {
+  fieldKey: string
+  value: string
+}

--- a/frontend/src/entities/datetime-field/mutations.ts
+++ b/frontend/src/entities/datetime-field/mutations.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { DateTimeFieldDto } from './api-types'
+import type { DateTimeFieldId } from './ids'
+import { mapCreateInputToDto, mapDateTimeFieldDtoToModel, mapUpdateInputToDto } from './mapper'
+import type { CreateDateTimeFieldInput, DateTimeField, UpdateDateTimeFieldInput } from './model'
+import { dateTimeFieldKeys } from './query-keys'
+
+export function useCreateDateTimeField(): UseMutationResult<
+  DateTimeField,
+  AppError,
+  CreateDateTimeFieldInput
+> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input) => {
+      const dto = await apiClient.post<DateTimeFieldDto>(
+        '/api/v1/datetime-fields',
+        mapCreateInputToDto(input),
+      )
+      return mapDateTimeFieldDtoToModel(dto)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: dateTimeFieldKeys.lists() })
+    },
+  })
+}
+
+export function useUpdateDateTimeField(): UseMutationResult<
+  DateTimeField,
+  AppError,
+  { id: DateTimeFieldId; input: UpdateDateTimeFieldInput }
+> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ id, input }) => {
+      const dto = await apiClient.put<DateTimeFieldDto>(
+        `/api/v1/datetime-fields/${String(id)}`,
+        mapUpdateInputToDto(input),
+      )
+      return mapDateTimeFieldDtoToModel(dto)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: dateTimeFieldKeys.lists() })
+    },
+  })
+}

--- a/frontend/src/entities/datetime-field/queries.ts
+++ b/frontend/src/entities/datetime-field/queries.ts
@@ -1,0 +1,44 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { DateTimeFieldDto, DateTimeFieldListDto } from './api-types'
+import type { DateTimeFieldId } from './ids'
+import { mapDateTimeFieldDtoToModel, mapDateTimeFieldListDtoToModel } from './mapper'
+import type { DateTimeField, DateTimeFieldList } from './model'
+import { dateTimeFieldKeys, type DateTimeFieldListParams } from './query-keys'
+
+const DEFAULT_LIST_PARAMS = { limit: 100, offset: 0 } as const
+
+export function useDateTimeFieldList(
+  params: DateTimeFieldListParams = DEFAULT_LIST_PARAMS,
+): UseQueryResult<DateTimeFieldList, AppError> {
+  return useQuery({
+    queryKey: dateTimeFieldKeys.list(params),
+    queryFn: async ({ signal }) => {
+      const search = new URLSearchParams({
+        limit: String(params.limit),
+        offset: String(params.offset),
+      })
+      if (params.entityId !== undefined) {
+        search.set('entity_id', String(params.entityId))
+      }
+      const dto = await apiClient.get<DateTimeFieldListDto>(
+        `/api/v1/datetime-fields?${search.toString()}`,
+        signal,
+      )
+      return mapDateTimeFieldListDtoToModel(dto)
+    },
+  })
+}
+
+export function useDateTimeField(id: DateTimeFieldId): UseQueryResult<DateTimeField, AppError> {
+  return useQuery({
+    queryKey: dateTimeFieldKeys.detail(id),
+    queryFn: async ({ signal }) => {
+      const dto = await apiClient.get<DateTimeFieldDto>(
+        `/api/v1/datetime-fields/${String(id)}`,
+        signal,
+      )
+      return mapDateTimeFieldDtoToModel(dto)
+    },
+  })
+}

--- a/frontend/src/entities/datetime-field/query-keys.ts
+++ b/frontend/src/entities/datetime-field/query-keys.ts
@@ -1,0 +1,15 @@
+import type { DateTimeFieldId } from './ids'
+
+export interface DateTimeFieldListParams {
+  limit: number
+  offset: number
+  entityId?: number
+}
+
+export const dateTimeFieldKeys = {
+  all: ['datetime-fields'] as const,
+  lists: () => [...dateTimeFieldKeys.all, 'list'] as const,
+  list: (params: DateTimeFieldListParams) => [...dateTimeFieldKeys.lists(), params] as const,
+  details: () => [...dateTimeFieldKeys.all, 'detail'] as const,
+  detail: (id: DateTimeFieldId) => [...dateTimeFieldKeys.details(), id] as const,
+}

--- a/frontend/src/entities/enum-field/api-types.ts
+++ b/frontend/src/entities/enum-field/api-types.ts
@@ -1,0 +1,23 @@
+export interface EnumFieldDto {
+  id: number
+  entity_id: number
+  field_key: string
+  value: string
+}
+
+export interface EnumFieldListDto {
+  items: EnumFieldDto[]
+  limit: number
+  offset: number
+}
+
+export interface CreateEnumFieldDto {
+  entity_id: number
+  field_key: string
+  value: string
+}
+
+export interface UpdateEnumFieldDto {
+  field_key: string
+  value: string
+}

--- a/frontend/src/entities/enum-field/ids.ts
+++ b/frontend/src/entities/enum-field/ids.ts
@@ -1,0 +1,7 @@
+declare const enumFieldIdBrand: unique symbol
+
+export type EnumFieldId = number & { readonly [enumFieldIdBrand]: never }
+
+export function toEnumFieldId(value: number): EnumFieldId {
+  return value as EnumFieldId
+}

--- a/frontend/src/entities/enum-field/index.ts
+++ b/frontend/src/entities/enum-field/index.ts
@@ -1,0 +1,7 @@
+export type { EnumFieldId } from './ids'
+export { toEnumFieldId } from './ids'
+export type { CreateEnumFieldInput, EnumField, EnumFieldList, UpdateEnumFieldInput } from './model'
+export { enumFieldKeys } from './query-keys'
+export type { EnumFieldListParams } from './query-keys'
+export { useCreateEnumField, useUpdateEnumField } from './mutations'
+export { useEnumField, useEnumFieldList } from './queries'

--- a/frontend/src/entities/enum-field/mapper.test.ts
+++ b/frontend/src/entities/enum-field/mapper.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { toEnumFieldId } from './ids'
+import {
+  mapCreateInputToDto,
+  mapEnumFieldDtoToModel,
+  mapEnumFieldListDtoToModel,
+  mapUpdateInputToDto,
+} from './mapper'
+
+describe('enum-field mapper', () => {
+  it('maps enum field dto to model', () => {
+    const model = mapEnumFieldDtoToModel({
+      id: 1,
+      entity_id: 2,
+      field_key: 'status',
+      value: 'active',
+    })
+
+    expect(model).toEqual({
+      id: toEnumFieldId(1),
+      entityId: 2,
+      fieldKey: 'status',
+      value: 'active',
+    })
+  })
+
+  it('maps create and update inputs to dto', () => {
+    expect(mapCreateInputToDto({ entityId: 5, fieldKey: 'status', value: 'draft' })).toEqual({
+      entity_id: 5,
+      field_key: 'status',
+      value: 'draft',
+    })
+
+    expect(mapUpdateInputToDto({ fieldKey: 'status', value: 'published' })).toEqual({
+      field_key: 'status',
+      value: 'published',
+    })
+  })
+
+  it('maps list dto to model', () => {
+    const model = mapEnumFieldListDtoToModel({
+      items: [{ id: 3, entity_id: 1, field_key: 'status', value: 'inactive' }],
+      limit: 100,
+      offset: 0,
+    })
+
+    expect(model.items[0]?.value).toBe('inactive')
+  })
+})

--- a/frontend/src/entities/enum-field/mapper.ts
+++ b/frontend/src/entities/enum-field/mapper.ts
@@ -1,0 +1,40 @@
+import type {
+  CreateEnumFieldDto,
+  EnumFieldDto,
+  EnumFieldListDto,
+  UpdateEnumFieldDto,
+} from './api-types'
+import { toEnumFieldId } from './ids'
+import type { CreateEnumFieldInput, EnumField, EnumFieldList, UpdateEnumFieldInput } from './model'
+
+export function mapEnumFieldDtoToModel(dto: EnumFieldDto): EnumField {
+  return {
+    id: toEnumFieldId(dto.id),
+    entityId: dto.entity_id,
+    fieldKey: dto.field_key,
+    value: dto.value,
+  }
+}
+
+export function mapEnumFieldListDtoToModel(dto: EnumFieldListDto): EnumFieldList {
+  return {
+    items: dto.items.map(mapEnumFieldDtoToModel),
+    limit: dto.limit,
+    offset: dto.offset,
+  }
+}
+
+export function mapCreateInputToDto(input: CreateEnumFieldInput): CreateEnumFieldDto {
+  return {
+    entity_id: input.entityId,
+    field_key: input.fieldKey,
+    value: input.value,
+  }
+}
+
+export function mapUpdateInputToDto(input: UpdateEnumFieldInput): UpdateEnumFieldDto {
+  return {
+    field_key: input.fieldKey,
+    value: input.value,
+  }
+}

--- a/frontend/src/entities/enum-field/model.ts
+++ b/frontend/src/entities/enum-field/model.ts
@@ -1,0 +1,25 @@
+import type { EnumFieldId } from './ids'
+
+export interface EnumField {
+  id: EnumFieldId
+  entityId: number
+  fieldKey: string
+  value: string
+}
+
+export interface EnumFieldList {
+  items: EnumField[]
+  limit: number
+  offset: number
+}
+
+export interface CreateEnumFieldInput {
+  entityId: number
+  fieldKey: string
+  value: string
+}
+
+export interface UpdateEnumFieldInput {
+  fieldKey: string
+  value: string
+}

--- a/frontend/src/entities/enum-field/mutations.ts
+++ b/frontend/src/entities/enum-field/mutations.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { EnumFieldDto } from './api-types'
+import type { EnumFieldId } from './ids'
+import { mapCreateInputToDto, mapEnumFieldDtoToModel, mapUpdateInputToDto } from './mapper'
+import type { CreateEnumFieldInput, EnumField, UpdateEnumFieldInput } from './model'
+import { enumFieldKeys } from './query-keys'
+
+export function useCreateEnumField(): UseMutationResult<EnumField, AppError, CreateEnumFieldInput> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input) => {
+      const dto = await apiClient.post<EnumFieldDto>(
+        '/api/v1/enum-fields',
+        mapCreateInputToDto(input),
+      )
+      return mapEnumFieldDtoToModel(dto)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: enumFieldKeys.lists() })
+    },
+  })
+}
+
+export function useUpdateEnumField(): UseMutationResult<
+  EnumField,
+  AppError,
+  { id: EnumFieldId; input: UpdateEnumFieldInput }
+> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ id, input }) => {
+      const dto = await apiClient.put<EnumFieldDto>(
+        `/api/v1/enum-fields/${String(id)}`,
+        mapUpdateInputToDto(input),
+      )
+      return mapEnumFieldDtoToModel(dto)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: enumFieldKeys.lists() })
+    },
+  })
+}

--- a/frontend/src/entities/enum-field/queries.ts
+++ b/frontend/src/entities/enum-field/queries.ts
@@ -1,0 +1,41 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { EnumFieldDto, EnumFieldListDto } from './api-types'
+import type { EnumFieldId } from './ids'
+import { mapEnumFieldDtoToModel, mapEnumFieldListDtoToModel } from './mapper'
+import type { EnumField, EnumFieldList } from './model'
+import { enumFieldKeys, type EnumFieldListParams } from './query-keys'
+
+const DEFAULT_LIST_PARAMS = { limit: 100, offset: 0 } as const
+
+export function useEnumFieldList(
+  params: EnumFieldListParams = DEFAULT_LIST_PARAMS,
+): UseQueryResult<EnumFieldList, AppError> {
+  return useQuery({
+    queryKey: enumFieldKeys.list(params),
+    queryFn: async ({ signal }) => {
+      const search = new URLSearchParams({
+        limit: String(params.limit),
+        offset: String(params.offset),
+      })
+      if (params.entityId !== undefined) {
+        search.set('entity_id', String(params.entityId))
+      }
+      const dto = await apiClient.get<EnumFieldListDto>(
+        `/api/v1/enum-fields?${search.toString()}`,
+        signal,
+      )
+      return mapEnumFieldListDtoToModel(dto)
+    },
+  })
+}
+
+export function useEnumField(id: EnumFieldId): UseQueryResult<EnumField, AppError> {
+  return useQuery({
+    queryKey: enumFieldKeys.detail(id),
+    queryFn: async ({ signal }) => {
+      const dto = await apiClient.get<EnumFieldDto>(`/api/v1/enum-fields/${String(id)}`, signal)
+      return mapEnumFieldDtoToModel(dto)
+    },
+  })
+}

--- a/frontend/src/entities/enum-field/query-keys.ts
+++ b/frontend/src/entities/enum-field/query-keys.ts
@@ -1,0 +1,15 @@
+import type { EnumFieldId } from './ids'
+
+export interface EnumFieldListParams {
+  limit: number
+  offset: number
+  entityId?: number
+}
+
+export const enumFieldKeys = {
+  all: ['enum-fields'] as const,
+  lists: () => [...enumFieldKeys.all, 'list'] as const,
+  list: (params: EnumFieldListParams) => [...enumFieldKeys.lists(), params] as const,
+  details: () => [...enumFieldKeys.all, 'detail'] as const,
+  detail: (id: EnumFieldId) => [...enumFieldKeys.details(), id] as const,
+}

--- a/frontend/src/entities/int-field/queries.ts
+++ b/frontend/src/entities/int-field/queries.ts
@@ -18,6 +18,9 @@ export function useIntFieldList(
         limit: String(params.limit),
         offset: String(params.offset),
       })
+      if (params.entityId !== undefined) {
+        search.set('entity_id', String(params.entityId))
+      }
       const dto = await apiClient.get<IntFieldListDto>(
         `/api/v1/int-fields?${search.toString()}`,
         signal,

--- a/frontend/src/entities/int-field/query-keys.ts
+++ b/frontend/src/entities/int-field/query-keys.ts
@@ -3,6 +3,7 @@ import type { IntFieldId } from './ids'
 export interface IntFieldListParams {
   limit: number
   offset: number
+  entityId?: number
 }
 
 export const intFieldKeys = {

--- a/frontend/src/entities/text-field/queries.ts
+++ b/frontend/src/entities/text-field/queries.ts
@@ -18,6 +18,9 @@ export function useTextFieldList(
         limit: String(params.limit),
         offset: String(params.offset),
       })
+      if (params.entityId !== undefined) {
+        search.set('entity_id', String(params.entityId))
+      }
       const dto = await apiClient.get<TextFieldListDto>(
         `/api/v1/text-fields?${search.toString()}`,
         signal,

--- a/frontend/src/entities/text-field/query-keys.ts
+++ b/frontend/src/entities/text-field/query-keys.ts
@@ -3,6 +3,7 @@ import type { TextFieldId } from './ids'
 export interface TextFieldListParams {
   limit: number
   offset: number
+  entityId?: number
 }
 
 export const textFieldKeys = {

--- a/frontend/src/features/edit-entity-text-fields/hooks/use-edit-entity-text-fields-page.ts
+++ b/frontend/src/features/edit-entity-text-fields/hooks/use-edit-entity-text-fields-page.ts
@@ -1,7 +1,25 @@
 import { useCallback, useMemo } from 'react'
-import type { FieldDataType } from '@/entities/field-def'
+import { FIELD_DATA_TYPES, type FieldDataType } from '@/entities/field-def'
 import { defaultFieldDefListParams, useFieldDefList } from '@/entities/field-def'
 import { toEntityId, useEntity } from '@/entities/entity'
+import {
+  useCreateBoolField,
+  useBoolFieldList,
+  useUpdateBoolField,
+  type BoolField,
+} from '@/entities/bool-field'
+import {
+  useCreateDateTimeField,
+  useDateTimeFieldList,
+  useUpdateDateTimeField,
+  type DateTimeField,
+} from '@/entities/datetime-field'
+import {
+  useCreateEnumField,
+  useEnumFieldList,
+  useUpdateEnumField,
+  type EnumField,
+} from '@/entities/enum-field'
 import {
   useCreateIntField,
   useIntFieldList,
@@ -15,7 +33,9 @@ import {
   type TextField,
 } from '@/entities/text-field'
 
-const EDITABLE_DATA_TYPES: FieldDataType[] = ['text', 'int']
+const EDITABLE_DATA_TYPES: FieldDataType[] = [...FIELD_DATA_TYPES]
+
+const FIELD_LIST_PARAMS = { limit: 100, offset: 0 } as const
 
 function parseIntFieldValue(raw: string): number {
   const trimmed = raw.trim()
@@ -27,15 +47,58 @@ function parseIntFieldValue(raw: string): number {
   return Number.isNaN(parsed) ? 0 : parsed
 }
 
+function parseBoolFieldValue(raw: string): boolean {
+  return raw === 'true'
+}
+
+function isoToDatetimeLocal(iso: string): string {
+  if (iso.trim() === '') {
+    return ''
+  }
+
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+
+  const pad = (value: number): string => String(value).padStart(2, '0')
+
+  return `${String(date.getFullYear())}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
+}
+
+function datetimeLocalToIso(local: string): string {
+  if (local.trim() === '') {
+    return ''
+  }
+
+  const date = new Date(local)
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+
+  return date.toISOString()
+}
+
 export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: number) {
+  const listParams = useMemo(() => ({ ...FIELD_LIST_PARAMS, entityId }), [entityId])
+
   const entityQuery = useEntity(toEntityId(entityId))
   const fieldDefQuery = useFieldDefList(defaultFieldDefListParams(entityTypeId))
-  const textFieldQuery = useTextFieldList()
-  const intFieldQuery = useIntFieldList()
+  const textFieldQuery = useTextFieldList(listParams)
+  const intFieldQuery = useIntFieldList(listParams)
+  const enumFieldQuery = useEnumFieldList(listParams)
+  const boolFieldQuery = useBoolFieldList(listParams)
+  const dateTimeFieldQuery = useDateTimeFieldList(listParams)
   const createTextMutation = useCreateTextField()
   const updateTextMutation = useUpdateTextField()
   const createIntMutation = useCreateIntField()
   const updateIntMutation = useUpdateIntField()
+  const createEnumMutation = useCreateEnumField()
+  const updateEnumMutation = useUpdateEnumField()
+  const createBoolMutation = useCreateBoolField()
+  const updateBoolMutation = useUpdateBoolField()
+  const createDateTimeMutation = useCreateDateTimeField()
+  const updateDateTimeMutation = useUpdateDateTimeField()
 
   const editableFieldDefs = useMemo(
     () =>
@@ -46,75 +109,183 @@ export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: numb
   )
 
   const textFieldsForEntity = useMemo((): TextField[] => {
-    return (textFieldQuery.data?.items ?? []).filter((item) => item.entityId === entityId)
-  }, [textFieldQuery.data?.items, entityId])
+    return textFieldQuery.data?.items ?? []
+  }, [textFieldQuery.data?.items])
 
   const intFieldsForEntity = useMemo((): IntField[] => {
-    return (intFieldQuery.data?.items ?? []).filter((item) => item.entityId === entityId)
-  }, [intFieldQuery.data?.items, entityId])
+    return intFieldQuery.data?.items ?? []
+  }, [intFieldQuery.data?.items])
+
+  const enumFieldsForEntity = useMemo((): EnumField[] => {
+    return enumFieldQuery.data?.items ?? []
+  }, [enumFieldQuery.data?.items])
+
+  const boolFieldsForEntity = useMemo((): BoolField[] => {
+    return boolFieldQuery.data?.items ?? []
+  }, [boolFieldQuery.data?.items])
+
+  const dateTimeFieldsForEntity = useMemo((): DateTimeField[] => {
+    return dateTimeFieldQuery.data?.items ?? []
+  }, [dateTimeFieldQuery.data?.items])
 
   const initialValues = useMemo((): Record<string, string> => {
     return Object.fromEntries(
       editableFieldDefs.map((fieldDef) => {
-        if (fieldDef.dataType === 'text') {
-          const existing = textFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
-          return [fieldDef.fieldKey, existing?.value ?? '']
+        switch (fieldDef.dataType) {
+          case 'text': {
+            const existing = textFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
+            return [fieldDef.fieldKey, existing?.value ?? '']
+          }
+          case 'int': {
+            const existing = intFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
+            return [fieldDef.fieldKey, existing !== undefined ? String(existing.value) : '']
+          }
+          case 'enum': {
+            const existing = enumFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
+            return [fieldDef.fieldKey, existing?.value ?? '']
+          }
+          case 'bool': {
+            const existing = boolFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
+            return [fieldDef.fieldKey, existing?.value === true ? 'true' : 'false']
+          }
+          case 'datetime': {
+            const existing = dateTimeFieldsForEntity.find(
+              (item) => item.fieldKey === fieldDef.fieldKey,
+            )
+            return [
+              fieldDef.fieldKey,
+              existing !== undefined ? isoToDatetimeLocal(existing.value) : '',
+            ]
+          }
+          default:
+            return [fieldDef.fieldKey, '']
         }
-
-        const existing = intFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
-        return [fieldDef.fieldKey, existing !== undefined ? String(existing.value) : '']
       }),
     )
-  }, [editableFieldDefs, intFieldsForEntity, textFieldsForEntity])
+  }, [
+    boolFieldsForEntity,
+    dateTimeFieldsForEntity,
+    editableFieldDefs,
+    enumFieldsForEntity,
+    intFieldsForEntity,
+    textFieldsForEntity,
+  ])
 
   const saveTextFields = useCallback(
     async (values: Record<string, string>) => {
       for (const fieldDef of editableFieldDefs) {
         const rawValue = values[fieldDef.fieldKey] ?? ''
 
-        if (fieldDef.dataType === 'text') {
-          const existing = textFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
+        switch (fieldDef.dataType) {
+          case 'text': {
+            const existing = textFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
 
-          if (existing !== undefined) {
-            await updateTextMutation.mutateAsync({
-              id: existing.id,
-              input: { fieldKey: fieldDef.fieldKey, value: rawValue },
-            })
-          } else {
-            await createTextMutation.mutateAsync({
-              entityId,
-              fieldKey: fieldDef.fieldKey,
-              value: rawValue,
-            })
+            if (existing !== undefined) {
+              await updateTextMutation.mutateAsync({
+                id: existing.id,
+                input: { fieldKey: fieldDef.fieldKey, value: rawValue },
+              })
+            } else {
+              await createTextMutation.mutateAsync({
+                entityId,
+                fieldKey: fieldDef.fieldKey,
+                value: rawValue,
+              })
+            }
+            break
           }
+          case 'int': {
+            const intValue = parseIntFieldValue(rawValue)
+            const existing = intFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
 
-          continue
-        }
+            if (existing !== undefined) {
+              await updateIntMutation.mutateAsync({
+                id: existing.id,
+                input: { fieldKey: fieldDef.fieldKey, value: intValue },
+              })
+            } else {
+              await createIntMutation.mutateAsync({
+                entityId,
+                fieldKey: fieldDef.fieldKey,
+                value: intValue,
+              })
+            }
+            break
+          }
+          case 'enum': {
+            const existing = enumFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
 
-        const intValue = parseIntFieldValue(rawValue)
-        const existing = intFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
+            if (existing !== undefined) {
+              await updateEnumMutation.mutateAsync({
+                id: existing.id,
+                input: { fieldKey: fieldDef.fieldKey, value: rawValue },
+              })
+            } else {
+              await createEnumMutation.mutateAsync({
+                entityId,
+                fieldKey: fieldDef.fieldKey,
+                value: rawValue,
+              })
+            }
+            break
+          }
+          case 'bool': {
+            const boolValue = parseBoolFieldValue(rawValue)
+            const existing = boolFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
 
-        if (existing !== undefined) {
-          await updateIntMutation.mutateAsync({
-            id: existing.id,
-            input: { fieldKey: fieldDef.fieldKey, value: intValue },
-          })
-        } else {
-          await createIntMutation.mutateAsync({
-            entityId,
-            fieldKey: fieldDef.fieldKey,
-            value: intValue,
-          })
+            if (existing !== undefined) {
+              await updateBoolMutation.mutateAsync({
+                id: existing.id,
+                input: { fieldKey: fieldDef.fieldKey, value: boolValue },
+              })
+            } else {
+              await createBoolMutation.mutateAsync({
+                entityId,
+                fieldKey: fieldDef.fieldKey,
+                value: boolValue,
+              })
+            }
+            break
+          }
+          case 'datetime': {
+            const isoValue = datetimeLocalToIso(rawValue)
+            const existing = dateTimeFieldsForEntity.find(
+              (item) => item.fieldKey === fieldDef.fieldKey,
+            )
+
+            if (existing !== undefined) {
+              await updateDateTimeMutation.mutateAsync({
+                id: existing.id,
+                input: { fieldKey: fieldDef.fieldKey, value: isoValue },
+              })
+            } else {
+              await createDateTimeMutation.mutateAsync({
+                entityId,
+                fieldKey: fieldDef.fieldKey,
+                value: isoValue,
+              })
+            }
+            break
+          }
         }
       }
     },
     [
+      boolFieldsForEntity,
+      createBoolMutation,
+      createDateTimeMutation,
+      createEnumMutation,
       createIntMutation,
       createTextMutation,
+      dateTimeFieldsForEntity,
       editableFieldDefs,
       entityId,
+      enumFieldsForEntity,
       intFieldsForEntity,
       textFieldsForEntity,
+      updateBoolMutation,
+      updateDateTimeMutation,
+      updateEnumMutation,
       updateIntMutation,
       updateTextMutation,
     ],
@@ -124,14 +295,26 @@ export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: numb
     entityQuery.isLoading ||
     fieldDefQuery.isLoading ||
     textFieldQuery.isLoading ||
-    intFieldQuery.isLoading
+    intFieldQuery.isLoading ||
+    enumFieldQuery.isLoading ||
+    boolFieldQuery.isLoading ||
+    dateTimeFieldQuery.isLoading
   const isError =
-    entityQuery.isError || fieldDefQuery.isError || textFieldQuery.isError || intFieldQuery.isError
+    entityQuery.isError ||
+    fieldDefQuery.isError ||
+    textFieldQuery.isError ||
+    intFieldQuery.isError ||
+    enumFieldQuery.isError ||
+    boolFieldQuery.isError ||
+    dateTimeFieldQuery.isError
   const errorTitle =
     entityQuery.error?.title ??
     fieldDefQuery.error?.title ??
     textFieldQuery.error?.title ??
     intFieldQuery.error?.title ??
+    enumFieldQuery.error?.title ??
+    boolFieldQuery.error?.title ??
+    dateTimeFieldQuery.error?.title ??
     null
 
   return {
@@ -147,6 +330,9 @@ export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: numb
         fieldDefQuery.refetch(),
         textFieldQuery.refetch(),
         intFieldQuery.refetch(),
+        enumFieldQuery.refetch(),
+        boolFieldQuery.refetch(),
+        dateTimeFieldQuery.refetch(),
       ])
     },
     saveTextFields,
@@ -154,12 +340,24 @@ export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: numb
       createTextMutation.isPending ||
       updateTextMutation.isPending ||
       createIntMutation.isPending ||
-      updateIntMutation.isPending,
+      updateIntMutation.isPending ||
+      createEnumMutation.isPending ||
+      updateEnumMutation.isPending ||
+      createBoolMutation.isPending ||
+      updateBoolMutation.isPending ||
+      createDateTimeMutation.isPending ||
+      updateDateTimeMutation.isPending,
     saveErrorTitle:
       createTextMutation.error?.title ??
       updateTextMutation.error?.title ??
       createIntMutation.error?.title ??
       updateIntMutation.error?.title ??
+      createEnumMutation.error?.title ??
+      updateEnumMutation.error?.title ??
+      createBoolMutation.error?.title ??
+      updateBoolMutation.error?.title ??
+      createDateTimeMutation.error?.title ??
+      updateDateTimeMutation.error?.title ??
       null,
   }
 }

--- a/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import type { FieldDef } from '@/entities/field-def'
+import type { FieldDataType, FieldDef } from '@/entities/field-def'
 import { Button, EmptyState, Input, Stack, Text } from '@/shared/ui'
 
 export interface EntityTextFieldsFormProps {
@@ -8,6 +8,17 @@ export interface EntityTextFieldsFormProps {
   isSubmitting: boolean
   serverErrorTitle: string | null
   onSubmit: (values: Record<string, string>) => Promise<void>
+}
+
+function getInputType(dataType: FieldDataType): 'text' | 'number' | 'datetime-local' {
+  switch (dataType) {
+    case 'int':
+      return 'number'
+    case 'datetime':
+      return 'datetime-local'
+    default:
+      return 'text'
+  }
 }
 
 export function EntityTextFieldsForm({
@@ -23,7 +34,7 @@ export function EntityTextFieldsForm({
     return (
       <EmptyState
         title="No editable fields defined"
-        description="Add text or integer field definitions for this entity type first."
+        description="Add field definitions for this entity type first."
       />
     )
   }
@@ -40,20 +51,51 @@ export function EntityTextFieldsForm({
         <Text as="h2" variant="heading-sm">
           Field values
         </Text>
-        {fieldDefs.map((fieldDef) => (
-          <Input
-            key={fieldDef.fieldKey}
-            id={`record-field-${fieldDef.fieldKey}`}
-            label={`${fieldDef.fieldKey} (${fieldDef.dataType})`}
-            type={fieldDef.dataType === 'int' ? 'number' : 'text'}
-            autoComplete="off"
-            disabled={isSubmitting}
-            value={values[fieldDef.fieldKey] ?? ''}
-            onChange={(event) => {
-              setValues((current) => ({ ...current, [fieldDef.fieldKey]: event.target.value }))
-            }}
-          />
-        ))}
+        {fieldDefs.map((fieldDef) => {
+          const fieldId = `record-field-${fieldDef.fieldKey}`
+          const label = `${fieldDef.fieldKey} (${fieldDef.dataType})`
+
+          if (fieldDef.dataType === 'bool') {
+            return (
+              <div key={fieldDef.fieldKey} className="flex flex-col gap-stack-xs">
+                <label
+                  htmlFor={fieldId}
+                  className="flex items-center gap-inline-sm font-sans text-body font-medium text-text-primary"
+                >
+                  <input
+                    id={fieldId}
+                    type="checkbox"
+                    disabled={isSubmitting}
+                    checked={values[fieldDef.fieldKey] === 'true'}
+                    onChange={(event) => {
+                      setValues((current) => ({
+                        ...current,
+                        [fieldDef.fieldKey]: event.target.checked ? 'true' : 'false',
+                      }))
+                    }}
+                    className="size-4 rounded border border-border"
+                  />
+                  {label}
+                </label>
+              </div>
+            )
+          }
+
+          return (
+            <Input
+              key={fieldDef.fieldKey}
+              id={fieldId}
+              label={label}
+              type={getInputType(fieldDef.dataType)}
+              autoComplete="off"
+              disabled={isSubmitting}
+              value={values[fieldDef.fieldKey] ?? ''}
+              onChange={(event) => {
+                setValues((current) => ({ ...current, [fieldDef.fieldKey]: event.target.value }))
+              }}
+            />
+          )
+        })}
         {serverErrorTitle !== null ? <Text muted>{serverErrorTitle}</Text> : null}
         <Button type="submit" disabled={isSubmitting}>
           {isSubmitting ? 'Saving…' : 'Save values'}

--- a/frontend/src/features/manage-entity-types/hooks/use-create-entity-type-form.ts
+++ b/frontend/src/features/manage-entity-types/hooks/use-create-entity-type-form.ts
@@ -21,3 +21,10 @@ export function useCreateEntityTypeForm() {
     },
   })
 }
+
+export function useEditEntityTypeForm(defaultValues: CreateEntityTypeFormValues) {
+  return useForm<CreateEntityTypeFormValues>({
+    resolver: zodResolver(createEntityTypeFormSchema),
+    defaultValues,
+  })
+}

--- a/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.ts
+++ b/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.ts
@@ -3,6 +3,7 @@ import {
   useCreateEntityType,
   useDeleteEntityType,
   useEntityTypeList,
+  useUpdateEntityType,
   type EntityType,
   type EntityTypeId,
 } from '@/entities/entity-type'
@@ -11,7 +12,9 @@ import type { CreateEntityTypeFormValues } from './use-create-entity-type-form'
 export function useManageEntityTypesPage() {
   const listQuery = useEntityTypeList()
   const createMutation = useCreateEntityType()
+  const updateMutation = useUpdateEntityType()
   const deleteMutation = useDeleteEntityType()
+  const [editTarget, setEditTarget] = useState<EntityType | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<EntityType | null>(null)
 
   const createEntityType = useCallback(
@@ -19,6 +22,29 @@ export function useManageEntityTypesPage() {
       await createMutation.mutateAsync(values)
     },
     [createMutation],
+  )
+
+  const requestEdit = useCallback((entityType: EntityType) => {
+    setEditTarget(entityType)
+  }, [])
+
+  const cancelEdit = useCallback(() => {
+    setEditTarget(null)
+  }, [])
+
+  const updateEntityType = useCallback(
+    async (values: CreateEntityTypeFormValues) => {
+      if (editTarget === null) {
+        return
+      }
+
+      await updateMutation.mutateAsync({
+        id: editTarget.id,
+        input: values,
+      })
+      setEditTarget(null)
+    },
+    [editTarget, updateMutation],
   )
 
   const requestDelete = useCallback((entityType: EntityType) => {
@@ -48,6 +74,12 @@ export function useManageEntityTypesPage() {
     createEntityType,
     isCreating: createMutation.isPending,
     createErrorTitle: createMutation.error?.title ?? null,
+    editTarget,
+    requestEdit,
+    cancelEdit,
+    updateEntityType,
+    isUpdating: updateMutation.isPending,
+    updateErrorTitle: updateMutation.error?.title ?? null,
     deleteTarget,
     requestDelete,
     cancelDelete,

--- a/frontend/src/features/manage-entity-types/ui/EntityTypeEditForm.tsx
+++ b/frontend/src/features/manage-entity-types/ui/EntityTypeEditForm.tsx
@@ -1,0 +1,88 @@
+import { Controller } from 'react-hook-form'
+import type { EntityType } from '@/entities/entity-type'
+import { Button, Input, Stack, Text } from '@/shared/ui'
+import { useEditEntityTypeForm } from '../hooks/use-create-entity-type-form'
+
+export interface EntityTypeEditFormProps {
+  entityType: EntityType
+  isSubmitting: boolean
+  serverErrorTitle: string | null
+  onSubmit: (values: { name: string; slug: string }) => Promise<void>
+  onCancel: () => void
+}
+
+export function EntityTypeEditForm({
+  entityType,
+  isSubmitting,
+  serverErrorTitle,
+  onSubmit,
+  onCancel,
+}: EntityTypeEditFormProps) {
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useEditEntityTypeForm({
+    name: entityType.name,
+    slug: entityType.slug,
+  })
+
+  return (
+    <form
+      key={String(entityType.id)}
+      className="rounded-md border border-border bg-surface-raised p-inline-md shadow-sm"
+      onSubmit={(event) => {
+        void handleSubmit(async (values) => {
+          await onSubmit(values)
+        })(event)
+      }}
+    >
+      <Stack gap="md">
+        <Text as="h2" variant="heading-sm">
+          Edit entity type
+        </Text>
+        <Controller
+          name="name"
+          control={control}
+          render={({ field }) => (
+            <Input
+              id="entity-type-edit-name"
+              label="Name"
+              error={errors.name?.message}
+              autoComplete="off"
+              disabled={isSubmitting}
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+            />
+          )}
+        />
+        <Controller
+          name="slug"
+          control={control}
+          render={({ field }) => (
+            <Input
+              id="entity-type-edit-slug"
+              label="Slug"
+              error={errors.slug?.message}
+              autoComplete="off"
+              disabled={isSubmitting}
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+            />
+          )}
+        />
+        {serverErrorTitle !== null ? <Text muted>{serverErrorTitle}</Text> : null}
+        <div className="flex items-center gap-inline-sm">
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Saving…' : 'Save changes'}
+          </Button>
+          <Button type="button" variant="secondary" disabled={isSubmitting} onClick={onCancel}>
+            Cancel
+          </Button>
+        </div>
+      </Stack>
+    </form>
+  )
+}

--- a/frontend/src/features/manage-entity-types/ui/EntityTypeListPanel.tsx
+++ b/frontend/src/features/manage-entity-types/ui/EntityTypeListPanel.tsx
@@ -9,6 +9,7 @@ export interface EntityTypeListPanelProps {
   errorTitle: string | null
   isDeleting: boolean
   onRetry: () => void
+  onEdit: (entityType: EntityType) => void
   onDelete: (entityType: EntityType) => void
 }
 
@@ -19,6 +20,7 @@ export function EntityTypeListPanel({
   errorTitle,
   isDeleting,
   onRetry,
+  onEdit,
   onDelete,
 }: EntityTypeListPanelProps) {
   if (isLoading) {
@@ -72,6 +74,15 @@ export function EntityTypeListPanel({
                 Records
               </Button>
             </Link>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                onEdit(item)
+              }}
+            >
+              Edit
+            </Button>
             <Button
               variant="danger"
               size="sm"

--- a/frontend/src/features/manage-entity-types/ui/ManageEntityTypesView.tsx
+++ b/frontend/src/features/manage-entity-types/ui/ManageEntityTypesView.tsx
@@ -1,6 +1,7 @@
 import type { EntityType } from '@/entities/entity-type'
 import { ConfirmDialog, Stack, Text } from '@/shared/ui'
 import { EntityTypeCreateForm } from './EntityTypeCreateForm'
+import { EntityTypeEditForm } from './EntityTypeEditForm'
 import { EntityTypeListPanel } from './EntityTypeListPanel'
 
 export interface ManageEntityTypesViewProps {
@@ -10,10 +11,16 @@ export interface ManageEntityTypesViewProps {
   errorTitle: string | null
   isCreating: boolean
   createErrorTitle: string | null
+  editTarget: EntityType | null
+  isUpdating: boolean
+  updateErrorTitle: string | null
   deleteTarget: EntityType | null
   isDeleting: boolean
   onRetry: () => void
   onCreate: (values: { name: string; slug: string }) => Promise<void>
+  onRequestEdit: (entityType: EntityType) => void
+  onCancelEdit: () => void
+  onUpdate: (values: { name: string; slug: string }) => Promise<void>
   onRequestDelete: (entityType: EntityType) => void
   onCancelDelete: () => void
   onConfirmDelete: () => Promise<void>
@@ -26,10 +33,16 @@ export function ManageEntityTypesView({
   errorTitle,
   isCreating,
   createErrorTitle,
+  editTarget,
+  isUpdating,
+  updateErrorTitle,
   deleteTarget,
   isDeleting,
   onRetry,
   onCreate,
+  onRequestEdit,
+  onCancelEdit,
+  onUpdate,
   onRequestDelete,
   onCancelDelete,
   onConfirmDelete,
@@ -42,6 +55,15 @@ export function ManageEntityTypesView({
           serverErrorTitle={createErrorTitle}
           onSubmit={onCreate}
         />
+        {editTarget !== null ? (
+          <EntityTypeEditForm
+            entityType={editTarget}
+            isSubmitting={isUpdating}
+            serverErrorTitle={updateErrorTitle}
+            onSubmit={onUpdate}
+            onCancel={onCancelEdit}
+          />
+        ) : null}
         <Stack gap="sm">
           <Text as="h2" variant="heading-sm">
             Existing types
@@ -53,6 +75,7 @@ export function ManageEntityTypesView({
             errorTitle={errorTitle}
             isDeleting={isDeleting}
             onRetry={onRetry}
+            onEdit={onRequestEdit}
             onDelete={onRequestDelete}
           />
         </Stack>

--- a/frontend/src/pages/entity-record/EntityRecordPage.test.tsx
+++ b/frontend/src/pages/entity-record/EntityRecordPage.test.tsx
@@ -3,8 +3,11 @@ import { cleanup, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { EntityRecordPage } from '@/pages/entity-record/EntityRecordPage'
+import { resetBoolFieldStore } from '@tests/msw/handlers/bool-field'
+import { resetDateTimeFieldStore } from '@tests/msw/handlers/datetime-field'
 import { resetEntityStore, seedEntities } from '@tests/msw/handlers/entity'
 import { resetEntityTypeStore, seedEntityTypes } from '@tests/msw/handlers/entity-type'
+import { resetEnumFieldStore } from '@tests/msw/handlers/enum-field'
 import { resetFieldDefStore, seedFieldDefs } from '@tests/msw/handlers/field-def'
 import { resetIntFieldStore } from '@tests/msw/handlers/int-field'
 import { resetTextFieldStore } from '@tests/msw/handlers/text-field'
@@ -38,6 +41,9 @@ describe('EntityRecordPage', () => {
     resetEntityStore()
     resetTextFieldStore()
     resetIntFieldStore()
+    resetEnumFieldStore()
+    resetBoolFieldStore()
+    resetDateTimeFieldStore()
     cleanup()
   })
 
@@ -147,6 +153,33 @@ describe('EntityRecordPage', () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText('count (int)')).toHaveValue(42)
+    })
+  })
+
+  it('creates bool field values on save', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    seedFieldDefs([{ id: 1, entity_type_id: 1, field_key: 'enabled', data_type: 'bool' }])
+    seedEntities([
+      {
+        id: 1,
+        entity_type_id: 1,
+        is_deleted: false,
+        deleted_at: null,
+      },
+    ])
+
+    const user = userEvent.setup()
+    renderEntityRecordPage()
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('enabled (bool)')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByLabelText('enabled (bool)'))
+    await user.click(screen.getByRole('button', { name: 'Save values' }))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('enabled (bool)')).toBeChecked()
     })
   })
 })

--- a/frontend/src/pages/entity-types/EntityTypesPage.test.tsx
+++ b/frontend/src/pages/entity-types/EntityTypesPage.test.tsx
@@ -23,6 +23,14 @@ function getCreateForm(): HTMLElement {
   return form
 }
 
+function getEditForm(): HTMLElement {
+  const form = screen.getByRole('heading', { name: 'Edit entity type' }).closest('form')
+  if (form === null) {
+    throw new Error('Edit entity type form not found')
+  }
+  return form
+}
+
 describe('EntityTypesPage', () => {
   beforeAll(() => {
     mswServer.listen()
@@ -69,6 +77,39 @@ describe('EntityTypesPage', () => {
     expect(
       await screen.findByText('Use lowercase letters, numbers, and hyphens'),
     ).toBeInTheDocument()
+  })
+
+  it('updates an entity type name and slug', async () => {
+    const user = userEvent.setup()
+    renderEntityTypesPage()
+
+    await user.type(screen.getByLabelText('Name'), 'Article')
+    await user.type(screen.getByLabelText('Slug'), 'article')
+    const createForm = getCreateForm()
+    await user.click(within(createForm).getByRole('button', { name: 'Create entity type' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Article')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+
+    const editForm = getEditForm()
+    const nameInput = within(editForm).getByLabelText('Name')
+    const slugInput = within(editForm).getByLabelText('Slug')
+
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Blog post')
+    await user.clear(slugInput)
+    await user.type(slugInput, 'blog-post')
+    await user.click(within(editForm).getByRole('button', { name: 'Save changes' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Blog post')).toBeInTheDocument()
+      expect(screen.getByText('blog-post')).toBeInTheDocument()
+      expect(screen.queryByText('Article')).not.toBeInTheDocument()
+      expect(screen.queryByText('article')).not.toBeInTheDocument()
+    })
   })
 
   it('deletes an entity type after confirmation', async () => {

--- a/frontend/src/pages/entity-types/EntityTypesPage.tsx
+++ b/frontend/src/pages/entity-types/EntityTypesPage.tsx
@@ -11,6 +11,12 @@ export function EntityTypesPage() {
     createEntityType,
     isCreating,
     createErrorTitle,
+    editTarget,
+    requestEdit,
+    cancelEdit,
+    updateEntityType,
+    isUpdating,
+    updateErrorTitle,
     deleteTarget,
     requestDelete,
     cancelDelete,
@@ -30,12 +36,18 @@ export function EntityTypesPage() {
         errorTitle={errorTitle}
         isCreating={isCreating}
         createErrorTitle={createErrorTitle}
+        editTarget={editTarget}
+        isUpdating={isUpdating}
+        updateErrorTitle={updateErrorTitle}
         deleteTarget={deleteTarget}
         isDeleting={isDeleting}
         onRetry={() => {
           void refetch()
         }}
         onCreate={createEntityType}
+        onRequestEdit={requestEdit}
+        onCancelEdit={cancelEdit}
+        onUpdate={updateEntityType}
         onRequestDelete={requestDelete}
         onCancelDelete={cancelDelete}
         onConfirmDelete={confirmDelete}

--- a/frontend/src/shared/ui/primitives/Input.tsx
+++ b/frontend/src/shared/ui/primitives/Input.tsx
@@ -1,7 +1,7 @@
 export interface InputProps {
   id: string
   label: string
-  type?: 'text' | 'email' | 'password' | 'number'
+  type?: 'text' | 'email' | 'password' | 'number' | 'datetime-local'
   value: string
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void

--- a/frontend/tests/msw/handlers/bool-field.ts
+++ b/frontend/tests/msw/handlers/bool-field.ts
@@ -1,0 +1,112 @@
+import { http, HttpResponse } from 'msw'
+
+interface BoolFieldRecord {
+  id: number
+  entity_id: number
+  field_key: string
+  value: boolean
+  is_deleted: boolean
+}
+
+let nextId = 1
+let items: BoolFieldRecord[] = []
+
+export function resetBoolFieldStore(): void {
+  nextId = 1
+  items = []
+}
+
+export function seedBoolFields(seed: Omit<BoolFieldRecord, 'is_deleted'>[]): void {
+  items = seed.map((item) => ({ ...item, is_deleted: false }))
+  nextId = Math.max(0, ...seed.map((item) => item.id)) + 1
+}
+
+export const boolFieldHandlers = [
+  http.get('/api/v1/bool-fields', ({ request }) => {
+    const url = new URL(request.url)
+    const limit = Number(url.searchParams.get('limit') ?? '20')
+    const offset = Number(url.searchParams.get('offset') ?? '0')
+    const entityIdParam = url.searchParams.get('entity_id')
+    const entityId = entityIdParam === null ? null : Number(entityIdParam)
+    const active = items.filter((item) => !item.is_deleted)
+    const filtered =
+      entityId === null ? active : active.filter((item) => item.entity_id === entityId)
+
+    return HttpResponse.json({
+      items: filtered.slice(offset, offset + limit).map((item) => ({
+        id: item.id,
+        entity_id: item.entity_id,
+        field_key: item.field_key,
+        value: item.value,
+      })),
+      limit,
+      offset,
+    })
+  }),
+  http.post('/api/v1/bool-fields', async ({ request }) => {
+    const body = (await request.json()) as {
+      entity_id?: number
+      field_key?: string
+      value?: boolean
+    }
+
+    if (typeof body.entity_id !== 'number' || body.entity_id < 1) {
+      return HttpResponse.json({ title: 'Validation failed', status: 422 }, { status: 422 })
+    }
+
+    if (typeof body.field_key !== 'string' || body.field_key.trim() === '') {
+      return HttpResponse.json({ title: 'Validation failed', status: 422 }, { status: 422 })
+    }
+
+    if (typeof body.value !== 'boolean') {
+      return HttpResponse.json({ title: 'Validation failed', status: 422 }, { status: 422 })
+    }
+
+    const created: BoolFieldRecord = {
+      id: nextId++,
+      entity_id: body.entity_id,
+      field_key: body.field_key,
+      value: body.value,
+      is_deleted: false,
+    }
+    items = [...items, created]
+
+    return HttpResponse.json(
+      {
+        id: created.id,
+        entity_id: created.entity_id,
+        field_key: created.field_key,
+        value: created.value,
+      },
+      { status: 201 },
+    )
+  }),
+  http.put('/api/v1/bool-fields/:id', async ({ params, request }) => {
+    const id = Number(params.id)
+    const index = items.findIndex((item) => item.id === id && !item.is_deleted)
+
+    if (index === -1) {
+      return HttpResponse.json({ title: 'Not found', status: 404 }, { status: 404 })
+    }
+
+    const body = (await request.json()) as { field_key?: string; value?: boolean }
+    const current = items[index]
+    if (current === undefined) {
+      return HttpResponse.json({ title: 'Not found', status: 404 }, { status: 404 })
+    }
+
+    const updated: BoolFieldRecord = {
+      ...current,
+      field_key: body.field_key ?? current.field_key,
+      value: body.value ?? current.value,
+    }
+    items = items.map((item, itemIndex) => (itemIndex === index ? updated : item))
+
+    return HttpResponse.json({
+      id: updated.id,
+      entity_id: updated.entity_id,
+      field_key: updated.field_key,
+      value: updated.value,
+    })
+  }),
+]

--- a/frontend/tests/msw/handlers/datetime-field.ts
+++ b/frontend/tests/msw/handlers/datetime-field.ts
@@ -1,0 +1,112 @@
+import { http, HttpResponse } from 'msw'
+
+interface DateTimeFieldRecord {
+  id: number
+  entity_id: number
+  field_key: string
+  value: string
+  is_deleted: boolean
+}
+
+let nextId = 1
+let items: DateTimeFieldRecord[] = []
+
+export function resetDateTimeFieldStore(): void {
+  nextId = 1
+  items = []
+}
+
+export function seedDateTimeFields(seed: Omit<DateTimeFieldRecord, 'is_deleted'>[]): void {
+  items = seed.map((item) => ({ ...item, is_deleted: false }))
+  nextId = Math.max(0, ...seed.map((item) => item.id)) + 1
+}
+
+export const dateTimeFieldHandlers = [
+  http.get('/api/v1/datetime-fields', ({ request }) => {
+    const url = new URL(request.url)
+    const limit = Number(url.searchParams.get('limit') ?? '20')
+    const offset = Number(url.searchParams.get('offset') ?? '0')
+    const entityIdParam = url.searchParams.get('entity_id')
+    const entityId = entityIdParam === null ? null : Number(entityIdParam)
+    const active = items.filter((item) => !item.is_deleted)
+    const filtered =
+      entityId === null ? active : active.filter((item) => item.entity_id === entityId)
+
+    return HttpResponse.json({
+      items: filtered.slice(offset, offset + limit).map((item) => ({
+        id: item.id,
+        entity_id: item.entity_id,
+        field_key: item.field_key,
+        value: item.value,
+      })),
+      limit,
+      offset,
+    })
+  }),
+  http.post('/api/v1/datetime-fields', async ({ request }) => {
+    const body = (await request.json()) as {
+      entity_id?: number
+      field_key?: string
+      value?: string
+    }
+
+    if (typeof body.entity_id !== 'number' || body.entity_id < 1) {
+      return HttpResponse.json({ title: 'Validation failed', status: 422 }, { status: 422 })
+    }
+
+    if (typeof body.field_key !== 'string' || body.field_key.trim() === '') {
+      return HttpResponse.json({ title: 'Validation failed', status: 422 }, { status: 422 })
+    }
+
+    if (typeof body.value !== 'string') {
+      return HttpResponse.json({ title: 'Validation failed', status: 422 }, { status: 422 })
+    }
+
+    const created: DateTimeFieldRecord = {
+      id: nextId++,
+      entity_id: body.entity_id,
+      field_key: body.field_key,
+      value: body.value,
+      is_deleted: false,
+    }
+    items = [...items, created]
+
+    return HttpResponse.json(
+      {
+        id: created.id,
+        entity_id: created.entity_id,
+        field_key: created.field_key,
+        value: created.value,
+      },
+      { status: 201 },
+    )
+  }),
+  http.put('/api/v1/datetime-fields/:id', async ({ params, request }) => {
+    const id = Number(params.id)
+    const index = items.findIndex((item) => item.id === id && !item.is_deleted)
+
+    if (index === -1) {
+      return HttpResponse.json({ title: 'Not found', status: 404 }, { status: 404 })
+    }
+
+    const body = (await request.json()) as { field_key?: string; value?: string }
+    const current = items[index]
+    if (current === undefined) {
+      return HttpResponse.json({ title: 'Not found', status: 404 }, { status: 404 })
+    }
+
+    const updated: DateTimeFieldRecord = {
+      ...current,
+      field_key: body.field_key ?? current.field_key,
+      value: body.value ?? current.value,
+    }
+    items = items.map((item, itemIndex) => (itemIndex === index ? updated : item))
+
+    return HttpResponse.json({
+      id: updated.id,
+      entity_id: updated.entity_id,
+      field_key: updated.field_key,
+      value: updated.value,
+    })
+  }),
+]

--- a/frontend/tests/msw/handlers/entity-type.ts
+++ b/frontend/tests/msw/handlers/entity-type.ts
@@ -86,6 +86,58 @@ export const entityTypeHandlers = [
 
     return HttpResponse.json(item)
   }),
+  http.put('/api/v1/entity-types/:id', async ({ params, request }) => {
+    const id = Number(params.id)
+    const index = items.findIndex((entry) => entry.id === id)
+
+    if (index === -1) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/not-found',
+          title: 'Not found',
+          status: 404,
+          instance: `/api/v1/entity-types/${String(id)}`,
+        },
+        { status: 404 },
+      )
+    }
+
+    const body = (await request.json()) as { name?: string; slug?: string }
+
+    if (typeof body.name !== 'string' || body.name.trim() === '') {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/validation-failed',
+          title: 'Validation failed',
+          status: 422,
+          instance: `/api/v1/entity-types/${String(id)}`,
+          errors: [{ field: 'name', message: 'Required', code: 'required' }],
+        },
+        { status: 422 },
+      )
+    }
+
+    if (items.some((item) => item.id !== id && item.slug === body.slug)) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/conflict',
+          title: 'Conflict',
+          status: 409,
+          instance: `/api/v1/entity-types/${String(id)}`,
+        },
+        { status: 409 },
+      )
+    }
+
+    const updated = {
+      id,
+      name: body.name,
+      slug: body.slug ?? '',
+    }
+    items = [...items.slice(0, index), updated, ...items.slice(index + 1)]
+
+    return HttpResponse.json(updated)
+  }),
   http.delete('/api/v1/entity-types/:id', ({ params }) => {
     const id = Number(params.id)
     const exists = items.some((item) => item.id === id)

--- a/frontend/tests/msw/handlers/enum-field.ts
+++ b/frontend/tests/msw/handlers/enum-field.ts
@@ -1,0 +1,112 @@
+import { http, HttpResponse } from 'msw'
+
+interface EnumFieldRecord {
+  id: number
+  entity_id: number
+  field_key: string
+  value: string
+  is_deleted: boolean
+}
+
+let nextId = 1
+let items: EnumFieldRecord[] = []
+
+export function resetEnumFieldStore(): void {
+  nextId = 1
+  items = []
+}
+
+export function seedEnumFields(seed: Omit<EnumFieldRecord, 'is_deleted'>[]): void {
+  items = seed.map((item) => ({ ...item, is_deleted: false }))
+  nextId = Math.max(0, ...seed.map((item) => item.id)) + 1
+}
+
+export const enumFieldHandlers = [
+  http.get('/api/v1/enum-fields', ({ request }) => {
+    const url = new URL(request.url)
+    const limit = Number(url.searchParams.get('limit') ?? '20')
+    const offset = Number(url.searchParams.get('offset') ?? '0')
+    const entityIdParam = url.searchParams.get('entity_id')
+    const entityId = entityIdParam === null ? null : Number(entityIdParam)
+    const active = items.filter((item) => !item.is_deleted)
+    const filtered =
+      entityId === null ? active : active.filter((item) => item.entity_id === entityId)
+
+    return HttpResponse.json({
+      items: filtered.slice(offset, offset + limit).map((item) => ({
+        id: item.id,
+        entity_id: item.entity_id,
+        field_key: item.field_key,
+        value: item.value,
+      })),
+      limit,
+      offset,
+    })
+  }),
+  http.post('/api/v1/enum-fields', async ({ request }) => {
+    const body = (await request.json()) as {
+      entity_id?: number
+      field_key?: string
+      value?: string
+    }
+
+    if (typeof body.entity_id !== 'number' || body.entity_id < 1) {
+      return HttpResponse.json({ title: 'Validation failed', status: 422 }, { status: 422 })
+    }
+
+    if (typeof body.field_key !== 'string' || body.field_key.trim() === '') {
+      return HttpResponse.json({ title: 'Validation failed', status: 422 }, { status: 422 })
+    }
+
+    if (typeof body.value !== 'string') {
+      return HttpResponse.json({ title: 'Validation failed', status: 422 }, { status: 422 })
+    }
+
+    const created: EnumFieldRecord = {
+      id: nextId++,
+      entity_id: body.entity_id,
+      field_key: body.field_key,
+      value: body.value,
+      is_deleted: false,
+    }
+    items = [...items, created]
+
+    return HttpResponse.json(
+      {
+        id: created.id,
+        entity_id: created.entity_id,
+        field_key: created.field_key,
+        value: created.value,
+      },
+      { status: 201 },
+    )
+  }),
+  http.put('/api/v1/enum-fields/:id', async ({ params, request }) => {
+    const id = Number(params.id)
+    const index = items.findIndex((item) => item.id === id && !item.is_deleted)
+
+    if (index === -1) {
+      return HttpResponse.json({ title: 'Not found', status: 404 }, { status: 404 })
+    }
+
+    const body = (await request.json()) as { field_key?: string; value?: string }
+    const current = items[index]
+    if (current === undefined) {
+      return HttpResponse.json({ title: 'Not found', status: 404 }, { status: 404 })
+    }
+
+    const updated: EnumFieldRecord = {
+      ...current,
+      field_key: body.field_key ?? current.field_key,
+      value: body.value ?? current.value,
+    }
+    items = items.map((item, itemIndex) => (itemIndex === index ? updated : item))
+
+    return HttpResponse.json({
+      id: updated.id,
+      entity_id: updated.entity_id,
+      field_key: updated.field_key,
+      value: updated.value,
+    })
+  }),
+]

--- a/frontend/tests/msw/handlers/int-field.ts
+++ b/frontend/tests/msw/handlers/int-field.ts
@@ -26,10 +26,14 @@ export const intFieldHandlers = [
     const url = new URL(request.url)
     const limit = Number(url.searchParams.get('limit') ?? '20')
     const offset = Number(url.searchParams.get('offset') ?? '0')
+    const entityIdParam = url.searchParams.get('entity_id')
+    const entityId = entityIdParam === null ? null : Number(entityIdParam)
     const active = items.filter((item) => !item.is_deleted)
+    const filtered =
+      entityId === null ? active : active.filter((item) => item.entity_id === entityId)
 
     return HttpResponse.json({
-      items: active.slice(offset, offset + limit).map((item) => ({
+      items: filtered.slice(offset, offset + limit).map((item) => ({
         id: item.id,
         entity_id: item.entity_id,
         field_key: item.field_key,

--- a/frontend/tests/msw/handlers/text-field.ts
+++ b/frontend/tests/msw/handlers/text-field.ts
@@ -26,11 +26,15 @@ export const textFieldHandlers = [
     const url = new URL(request.url)
     const limit = Number(url.searchParams.get('limit') ?? '20')
     const offset = Number(url.searchParams.get('offset') ?? '0')
+    const entityIdParam = url.searchParams.get('entity_id')
+    const entityId = entityIdParam === null ? null : Number(entityIdParam)
 
     const active = items.filter((item) => !item.is_deleted)
+    const filtered =
+      entityId === null ? active : active.filter((item) => item.entity_id === entityId)
 
     return HttpResponse.json({
-      items: active.slice(offset, offset + limit).map((item) => ({
+      items: filtered.slice(offset, offset + limit).map((item) => ({
         id: item.id,
         entity_id: item.entity_id,
         field_key: item.field_key,

--- a/frontend/tests/msw/server.ts
+++ b/frontend/tests/msw/server.ts
@@ -1,6 +1,9 @@
 import { setupServer } from 'msw/node'
+import { boolFieldHandlers } from './handlers/bool-field'
+import { dateTimeFieldHandlers } from './handlers/datetime-field'
 import { entityHandlers } from './handlers/entity'
 import { entityTypeHandlers } from './handlers/entity-type'
+import { enumFieldHandlers } from './handlers/enum-field'
 import { fieldDefHandlers } from './handlers/field-def'
 import { intFieldHandlers } from './handlers/int-field'
 import { textFieldHandlers } from './handlers/text-field'
@@ -11,4 +14,7 @@ export const mswServer = setupServer(
   ...fieldDefHandlers,
   ...textFieldHandlers,
   ...intFieldHandlers,
+  ...enumFieldHandlers,
+  ...boolFieldHandlers,
+  ...dateTimeFieldHandlers,
 )

--- a/src/BoolField/BoolFieldRepositoryInterface.php
+++ b/src/BoolField/BoolFieldRepositoryInterface.php
@@ -15,6 +15,13 @@ interface BoolFieldRepositoryInterface
      */
     public function findAll(int $limit, int $offset): array;
 
+    /**
+     * Active (non-soft-deleted) rows for the given entity only.
+     *
+     * @return list<BoolField>
+     */
+    public function findByEntityId(int $entityId, int $limit, int $offset): array;
+
     public function save(BoolField $intField): int;
 
     public function update(BoolField $intField): void;

--- a/src/BoolField/ListBoolFieldsHandler.php
+++ b/src/BoolField/ListBoolFieldsHandler.php
@@ -21,8 +21,21 @@ final readonly class ListBoolFieldsHandler
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $pagination = PaginationQueryParser::parse($request);
+        $query = $request->getQueryParams();
 
-        $output = $this->useCase->execute(new ListBoolFieldsInput($pagination->limit, $pagination->offset));
+        $entityId = null;
+        if (isset($query['entity_id'])) {
+            $raw = (int) $query['entity_id'];
+            if ($raw > 0) {
+                $entityId = $raw;
+            }
+        }
+
+        $output = $this->useCase->execute(new ListBoolFieldsInput(
+            entityId: $entityId,
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+        ));
 
         return $this->response->create(
             (new PaginationResponse(

--- a/src/BoolField/ListBoolFieldsInput.php
+++ b/src/BoolField/ListBoolFieldsInput.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\BoolField;
 final readonly class ListBoolFieldsInput
 {
     public function __construct(
+        public ?int $entityId = null,
         public int $limit = 20,
         public int $offset = 0,
     ) {

--- a/src/BoolField/ListBoolFieldsUseCase.php
+++ b/src/BoolField/ListBoolFieldsUseCase.php
@@ -13,7 +13,9 @@ final readonly class ListBoolFieldsUseCase implements ListBoolFieldsUseCaseInter
 
     public function execute(ListBoolFieldsInput $input): ListBoolFieldsOutput
     {
-        $rows = $this->intFields->findAll($input->limit, $input->offset);
+        $rows = $input->entityId !== null
+            ? $this->intFields->findByEntityId($input->entityId, $input->limit, $input->offset)
+            : $this->intFields->findAll($input->limit, $input->offset);
 
         $items = array_map(
             static fn (BoolField $field) => new ListBoolFieldItem(

--- a/src/BoolField/PdoBoolFieldRepository.php
+++ b/src/BoolField/PdoBoolFieldRepository.php
@@ -52,6 +52,25 @@ final readonly class PdoBoolFieldRepository implements BoolFieldRepositoryInterf
         );
     }
 
+    /** @return list<BoolField> */
+    public function findByEntityId(int $entityId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, entity_id, field_key, value FROM bool_fields WHERE entity_id = ? AND is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$entityId, $limit, $offset],
+        );
+
+        return array_map(
+            static fn (array $row) => new BoolField(
+                entityId: (int) $row['entity_id'],
+                fieldKey: (string) $row['field_key'],
+                value: (bool) (int) $row['value'],
+                id: (int) $row['id'],
+            ),
+            $rows,
+        );
+    }
+
     public function save(BoolField $intField): int
     {
         $this->query->execute(

--- a/src/DateTimeField/DateTimeFieldRepositoryInterface.php
+++ b/src/DateTimeField/DateTimeFieldRepositoryInterface.php
@@ -15,6 +15,13 @@ interface DateTimeFieldRepositoryInterface
      */
     public function findAll(int $limit, int $offset): array;
 
+    /**
+     * Active (non-soft-deleted) rows for the given entity only.
+     *
+     * @return list<DateTimeField>
+     */
+    public function findByEntityId(int $entityId, int $limit, int $offset): array;
+
     public function save(DateTimeField $intField): int;
 
     public function update(DateTimeField $intField): void;

--- a/src/DateTimeField/ListDateTimeFieldsHandler.php
+++ b/src/DateTimeField/ListDateTimeFieldsHandler.php
@@ -21,8 +21,21 @@ final readonly class ListDateTimeFieldsHandler
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $pagination = PaginationQueryParser::parse($request);
+        $query = $request->getQueryParams();
 
-        $output = $this->useCase->execute(new ListDateTimeFieldsInput($pagination->limit, $pagination->offset));
+        $entityId = null;
+        if (isset($query['entity_id'])) {
+            $raw = (int) $query['entity_id'];
+            if ($raw > 0) {
+                $entityId = $raw;
+            }
+        }
+
+        $output = $this->useCase->execute(new ListDateTimeFieldsInput(
+            entityId: $entityId,
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+        ));
 
         return $this->response->create(
             (new PaginationResponse(

--- a/src/DateTimeField/ListDateTimeFieldsInput.php
+++ b/src/DateTimeField/ListDateTimeFieldsInput.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\DateTimeField;
 final readonly class ListDateTimeFieldsInput
 {
     public function __construct(
+        public ?int $entityId = null,
         public int $limit = 20,
         public int $offset = 0,
     ) {

--- a/src/DateTimeField/ListDateTimeFieldsUseCase.php
+++ b/src/DateTimeField/ListDateTimeFieldsUseCase.php
@@ -13,7 +13,9 @@ final readonly class ListDateTimeFieldsUseCase implements ListDateTimeFieldsUseC
 
     public function execute(ListDateTimeFieldsInput $input): ListDateTimeFieldsOutput
     {
-        $rows = $this->intFields->findAll($input->limit, $input->offset);
+        $rows = $input->entityId !== null
+            ? $this->intFields->findByEntityId($input->entityId, $input->limit, $input->offset)
+            : $this->intFields->findAll($input->limit, $input->offset);
 
         $items = array_map(
             static fn (DateTimeField $field) => new ListDateTimeFieldItem(

--- a/src/DateTimeField/PdoDateTimeFieldRepository.php
+++ b/src/DateTimeField/PdoDateTimeFieldRepository.php
@@ -52,6 +52,25 @@ final readonly class PdoDateTimeFieldRepository implements DateTimeFieldReposito
         );
     }
 
+    /** @return list<DateTimeField> */
+    public function findByEntityId(int $entityId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, entity_id, field_key, value FROM datetime_fields WHERE entity_id = ? AND is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$entityId, $limit, $offset],
+        );
+
+        return array_map(
+            static fn (array $row) => new DateTimeField(
+                entityId: (int) $row['entity_id'],
+                fieldKey: (string) $row['field_key'],
+                value: (string) $row['value'],
+                id: (int) $row['id'],
+            ),
+            $rows,
+        );
+    }
+
     public function save(DateTimeField $intField): int
     {
         $this->query->execute(

--- a/src/EnumField/EnumFieldRepositoryInterface.php
+++ b/src/EnumField/EnumFieldRepositoryInterface.php
@@ -15,6 +15,13 @@ interface EnumFieldRepositoryInterface
      */
     public function findAll(int $limit, int $offset): array;
 
+    /**
+     * Active (non-soft-deleted) rows for the given entity only.
+     *
+     * @return list<EnumField>
+     */
+    public function findByEntityId(int $entityId, int $limit, int $offset): array;
+
     public function save(EnumField $intField): int;
 
     public function update(EnumField $intField): void;

--- a/src/EnumField/ListEnumFieldsHandler.php
+++ b/src/EnumField/ListEnumFieldsHandler.php
@@ -21,8 +21,21 @@ final readonly class ListEnumFieldsHandler
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $pagination = PaginationQueryParser::parse($request);
+        $query = $request->getQueryParams();
 
-        $output = $this->useCase->execute(new ListEnumFieldsInput($pagination->limit, $pagination->offset));
+        $entityId = null;
+        if (isset($query['entity_id'])) {
+            $raw = (int) $query['entity_id'];
+            if ($raw > 0) {
+                $entityId = $raw;
+            }
+        }
+
+        $output = $this->useCase->execute(new ListEnumFieldsInput(
+            entityId: $entityId,
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+        ));
 
         return $this->response->create(
             (new PaginationResponse(

--- a/src/EnumField/ListEnumFieldsInput.php
+++ b/src/EnumField/ListEnumFieldsInput.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\EnumField;
 final readonly class ListEnumFieldsInput
 {
     public function __construct(
+        public ?int $entityId = null,
         public int $limit = 20,
         public int $offset = 0,
     ) {

--- a/src/EnumField/ListEnumFieldsUseCase.php
+++ b/src/EnumField/ListEnumFieldsUseCase.php
@@ -13,7 +13,9 @@ final readonly class ListEnumFieldsUseCase implements ListEnumFieldsUseCaseInter
 
     public function execute(ListEnumFieldsInput $input): ListEnumFieldsOutput
     {
-        $rows = $this->intFields->findAll($input->limit, $input->offset);
+        $rows = $input->entityId !== null
+            ? $this->intFields->findByEntityId($input->entityId, $input->limit, $input->offset)
+            : $this->intFields->findAll($input->limit, $input->offset);
 
         $items = array_map(
             static fn (EnumField $field) => new ListEnumFieldItem(

--- a/src/EnumField/PdoEnumFieldRepository.php
+++ b/src/EnumField/PdoEnumFieldRepository.php
@@ -52,6 +52,25 @@ final readonly class PdoEnumFieldRepository implements EnumFieldRepositoryInterf
         );
     }
 
+    /** @return list<EnumField> */
+    public function findByEntityId(int $entityId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, entity_id, field_key, value FROM enum_fields WHERE entity_id = ? AND is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$entityId, $limit, $offset],
+        );
+
+        return array_map(
+            static fn (array $row) => new EnumField(
+                entityId: (int) $row['entity_id'],
+                fieldKey: (string) $row['field_key'],
+                value: (string) $row['value'],
+                id: (int) $row['id'],
+            ),
+            $rows,
+        );
+    }
+
     public function save(EnumField $intField): int
     {
         $this->query->execute(

--- a/src/IntField/IntFieldRepositoryInterface.php
+++ b/src/IntField/IntFieldRepositoryInterface.php
@@ -15,6 +15,13 @@ interface IntFieldRepositoryInterface
      */
     public function findAll(int $limit, int $offset): array;
 
+    /**
+     * Active (non-soft-deleted) rows for the given entity only.
+     *
+     * @return list<IntField>
+     */
+    public function findByEntityId(int $entityId, int $limit, int $offset): array;
+
     public function save(IntField $intField): int;
 
     public function update(IntField $intField): void;

--- a/src/IntField/ListIntFieldsHandler.php
+++ b/src/IntField/ListIntFieldsHandler.php
@@ -21,8 +21,21 @@ final readonly class ListIntFieldsHandler
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $pagination = PaginationQueryParser::parse($request);
+        $query = $request->getQueryParams();
 
-        $output = $this->useCase->execute(new ListIntFieldsInput($pagination->limit, $pagination->offset));
+        $entityId = null;
+        if (isset($query['entity_id'])) {
+            $raw = (int) $query['entity_id'];
+            if ($raw > 0) {
+                $entityId = $raw;
+            }
+        }
+
+        $output = $this->useCase->execute(new ListIntFieldsInput(
+            entityId: $entityId,
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+        ));
 
         return $this->response->create(
             (new PaginationResponse(

--- a/src/IntField/ListIntFieldsInput.php
+++ b/src/IntField/ListIntFieldsInput.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\IntField;
 final readonly class ListIntFieldsInput
 {
     public function __construct(
+        public ?int $entityId = null,
         public int $limit = 20,
         public int $offset = 0,
     ) {

--- a/src/IntField/ListIntFieldsUseCase.php
+++ b/src/IntField/ListIntFieldsUseCase.php
@@ -13,7 +13,9 @@ final readonly class ListIntFieldsUseCase implements ListIntFieldsUseCaseInterfa
 
     public function execute(ListIntFieldsInput $input): ListIntFieldsOutput
     {
-        $rows = $this->intFields->findAll($input->limit, $input->offset);
+        $rows = $input->entityId !== null
+            ? $this->intFields->findByEntityId($input->entityId, $input->limit, $input->offset)
+            : $this->intFields->findAll($input->limit, $input->offset);
 
         $items = array_map(
             static fn (IntField $field) => new ListIntFieldItem(

--- a/src/IntField/PdoIntFieldRepository.php
+++ b/src/IntField/PdoIntFieldRepository.php
@@ -52,6 +52,25 @@ final readonly class PdoIntFieldRepository implements IntFieldRepositoryInterfac
         );
     }
 
+    /** @return list<IntField> */
+    public function findByEntityId(int $entityId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, entity_id, field_key, value FROM int_fields WHERE entity_id = ? AND is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$entityId, $limit, $offset],
+        );
+
+        return array_map(
+            static fn (array $row) => new IntField(
+                entityId: (int) $row['entity_id'],
+                fieldKey: (string) $row['field_key'],
+                value: (int) $row['value'],
+                id: (int) $row['id'],
+            ),
+            $rows,
+        );
+    }
+
     public function save(IntField $intField): int
     {
         $this->query->execute(

--- a/src/TextField/ListTextFieldsHandler.php
+++ b/src/TextField/ListTextFieldsHandler.php
@@ -21,8 +21,21 @@ final readonly class ListTextFieldsHandler
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $pagination = PaginationQueryParser::parse($request);
+        $query = $request->getQueryParams();
 
-        $output = $this->useCase->execute(new ListTextFieldsInput($pagination->limit, $pagination->offset));
+        $entityId = null;
+        if (isset($query['entity_id'])) {
+            $raw = (int) $query['entity_id'];
+            if ($raw > 0) {
+                $entityId = $raw;
+            }
+        }
+
+        $output = $this->useCase->execute(new ListTextFieldsInput(
+            entityId: $entityId,
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+        ));
 
         return $this->response->create(
             (new PaginationResponse(

--- a/src/TextField/ListTextFieldsInput.php
+++ b/src/TextField/ListTextFieldsInput.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\TextField;
 final readonly class ListTextFieldsInput
 {
     public function __construct(
+        public ?int $entityId = null,
         public int $limit = 20,
         public int $offset = 0,
     ) {

--- a/src/TextField/ListTextFieldsUseCase.php
+++ b/src/TextField/ListTextFieldsUseCase.php
@@ -13,7 +13,9 @@ final readonly class ListTextFieldsUseCase implements ListTextFieldsUseCaseInter
 
     public function execute(ListTextFieldsInput $input): ListTextFieldsOutput
     {
-        $rows = $this->textFields->findAll($input->limit, $input->offset);
+        $rows = $input->entityId !== null
+            ? $this->textFields->findByEntityId($input->entityId, $input->limit, $input->offset)
+            : $this->textFields->findAll($input->limit, $input->offset);
 
         $items = array_map(
             static fn (TextField $textField) => new ListTextFieldItem(

--- a/src/TextField/PdoTextFieldRepository.php
+++ b/src/TextField/PdoTextFieldRepository.php
@@ -52,6 +52,25 @@ final readonly class PdoTextFieldRepository implements TextFieldRepositoryInterf
         );
     }
 
+    /** @return list<TextField> */
+    public function findByEntityId(int $entityId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, entity_id, field_key, value FROM text_fields WHERE entity_id = ? AND is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$entityId, $limit, $offset],
+        );
+
+        return array_map(
+            static fn (array $row) => new TextField(
+                entityId: (int) $row['entity_id'],
+                fieldKey: (string) $row['field_key'],
+                value: (string) $row['value'],
+                id: (int) $row['id'],
+            ),
+            $rows,
+        );
+    }
+
     public function save(TextField $textField): int
     {
         $this->query->execute(

--- a/src/TextField/TextFieldRepositoryInterface.php
+++ b/src/TextField/TextFieldRepositoryInterface.php
@@ -15,6 +15,13 @@ interface TextFieldRepositoryInterface
      */
     public function findAll(int $limit, int $offset): array;
 
+    /**
+     * Active (non-soft-deleted) rows for the given entity only.
+     *
+     * @return list<TextField>
+     */
+    public function findByEntityId(int $entityId, int $limit, int $offset): array;
+
     public function save(TextField $textField): int;
 
     public function update(TextField $textField): void;

--- a/tests/BoolField/InMemoryBoolFieldRepository.php
+++ b/tests/BoolField/InMemoryBoolFieldRepository.php
@@ -59,6 +59,22 @@ final class InMemoryBoolFieldRepository implements BoolFieldRepositoryInterface
         return array_slice($active, $offset, $limit);
     }
 
+    /** @return list<BoolField> */
+    public function findByEntityId(int $entityId, int $limit, int $offset): array
+    {
+        $active = [];
+
+        foreach ($this->fields as $id => $textField) {
+            if (!isset($this->deletedIds[$id]) && $textField->entityId === $entityId) {
+                $active[] = $textField;
+            }
+        }
+
+        usort($active, static fn (BoolField $a, BoolField $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
+
+        return array_slice($active, $offset, $limit);
+    }
+
     public function save(BoolField $intField): int
     {
         $id = $this->nextId++;

--- a/tests/DateTimeField/InMemoryDateTimeFieldRepository.php
+++ b/tests/DateTimeField/InMemoryDateTimeFieldRepository.php
@@ -59,6 +59,22 @@ final class InMemoryDateTimeFieldRepository implements DateTimeFieldRepositoryIn
         return array_slice($active, $offset, $limit);
     }
 
+    /** @return list<DateTimeField> */
+    public function findByEntityId(int $entityId, int $limit, int $offset): array
+    {
+        $active = [];
+
+        foreach ($this->fields as $id => $textField) {
+            if (!isset($this->deletedIds[$id]) && $textField->entityId === $entityId) {
+                $active[] = $textField;
+            }
+        }
+
+        usort($active, static fn (DateTimeField $a, DateTimeField $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
+
+        return array_slice($active, $offset, $limit);
+    }
+
     public function save(DateTimeField $intField): int
     {
         $id = $this->nextId++;

--- a/tests/EnumField/InMemoryEnumFieldRepository.php
+++ b/tests/EnumField/InMemoryEnumFieldRepository.php
@@ -59,6 +59,22 @@ final class InMemoryEnumFieldRepository implements EnumFieldRepositoryInterface
         return array_slice($active, $offset, $limit);
     }
 
+    /** @return list<EnumField> */
+    public function findByEntityId(int $entityId, int $limit, int $offset): array
+    {
+        $active = [];
+
+        foreach ($this->fields as $id => $textField) {
+            if (!isset($this->deletedIds[$id]) && $textField->entityId === $entityId) {
+                $active[] = $textField;
+            }
+        }
+
+        usort($active, static fn (EnumField $a, EnumField $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
+
+        return array_slice($active, $offset, $limit);
+    }
+
     public function save(EnumField $intField): int
     {
         $id = $this->nextId++;

--- a/tests/IntField/InMemoryIntFieldRepository.php
+++ b/tests/IntField/InMemoryIntFieldRepository.php
@@ -59,6 +59,22 @@ final class InMemoryIntFieldRepository implements IntFieldRepositoryInterface
         return array_slice($active, $offset, $limit);
     }
 
+    /** @return list<IntField> */
+    public function findByEntityId(int $entityId, int $limit, int $offset): array
+    {
+        $active = [];
+
+        foreach ($this->fields as $id => $textField) {
+            if (!isset($this->deletedIds[$id]) && $textField->entityId === $entityId) {
+                $active[] = $textField;
+            }
+        }
+
+        usort($active, static fn (IntField $a, IntField $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
+
+        return array_slice($active, $offset, $limit);
+    }
+
     public function save(IntField $intField): int
     {
         $id = $this->nextId++;

--- a/tests/TextField/InMemoryTextFieldRepository.php
+++ b/tests/TextField/InMemoryTextFieldRepository.php
@@ -59,6 +59,22 @@ final class InMemoryTextFieldRepository implements TextFieldRepositoryInterface
         return array_slice($active, $offset, $limit);
     }
 
+    /** @return list<TextField> */
+    public function findByEntityId(int $entityId, int $limit, int $offset): array
+    {
+        $active = [];
+
+        foreach ($this->fields as $id => $textField) {
+            if (!isset($this->deletedIds[$id]) && $textField->entityId === $entityId) {
+                $active[] = $textField;
+            }
+        }
+
+        usort($active, static fn (TextField $a, TextField $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
+
+        return array_slice($active, $offset, $limit);
+    }
+
     public function save(TextField $textField): int
     {
         $id = $this->nextId++;

--- a/tests/TextField/TextFieldHttpTest.php
+++ b/tests/TextField/TextFieldHttpTest.php
@@ -223,6 +223,56 @@ final class TextFieldHttpTest extends TestCase
         self::assertStringEndsWith('not-found', (string) $payload['type']);
     }
 
+    public function testListTextFieldsFiltersByEntityId(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Item', slug: 'item'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'title', dataType: 'text'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'body', dataType: 'text'));
+
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR));
+
+        $entityAResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+        $entityAId = (int) $this->decodeJson($entityAResponse)['id'];
+
+        $entityBResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody(
+                $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR)),
+            ),
+        );
+        $entityBId = (int) $this->decodeJson($entityBResponse)['id'];
+
+        $bodyA = $this->factory->createStream(json_encode([
+            'entity_id' => $entityAId,
+            'field_key' => 'title',
+            'value' => 'Entity A title',
+        ], JSON_THROW_ON_ERROR));
+        $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/text-fields')->withBody($bodyA),
+        );
+
+        $bodyB = $this->factory->createStream(json_encode([
+            'entity_id' => $entityBId,
+            'field_key' => 'body',
+            'value' => 'Entity B body',
+        ], JSON_THROW_ON_ERROR));
+        $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/text-fields')->withBody($bodyB),
+        );
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/text-fields?entity_id={$entityAId}"),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertCount(1, $payload['items']);
+        self::assertSame($entityAId, $payload['items'][0]['entity_id']);
+        self::assertSame('title', $payload['items'][0]['field_key']);
+        self::assertSame('Entity A title', $payload['items'][0]['value']);
+    }
+
     /**
      * @return array<string, mixed>
      */


### PR DESCRIPTION
## Summary

### 1. enum / bool / datetime フィールド値 UI
- `entities/enum-field`, `bool-field`, `datetime-field` スライス
- レコード詳細フォームを全 `field_defs` 型に対応（checkbox / datetime-local 含む）

### 2. Entity type 編集（PUT）
- 一覧行 **Edit** → 編集フォーム → Save changes
- MSW PUT + ページテスト

### 3. API: field list `entity_id` フィルタ
- text / int / enum / bool / datetime の list GET に `entity_id` クエリ追加
- OpenAPI `EntityIdQuery` パラメータ
- TextField HTTP テスト追加

### 4. GitHub Actions frontend CI
- `.github/workflows/frontend-ci.yml` — push/PR to main で `npm run check`

## 検証

```bash
composer check          # 128 tests
npm run check --prefix frontend   # 46 tests
```

Closes #36

Made with [Cursor](https://cursor.com)