### PR TITLE
feat: text-fields entity_type_id フィルタ + 一覧ラベル最適化 (#42)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -578,6 +578,7 @@ paths:
         - $ref: '#/components/parameters/LimitQuery'
         - $ref: '#/components/parameters/OffsetQuery'
         - $ref: '#/components/parameters/EntityIdQuery'
+        - $ref: '#/components/parameters/EntityTypeIdQuery'
       responses:
         '200':
           description: Paginated text field list.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,18 +6,19 @@ Last updated: 2026-05-24
 
 | Issue | Summary |
 | --- | --- |
-| TBD | Records 一覧ラベル取得の API 最適化（entity_type 単位 batch 等） |
+| TBD | （次フェーズ: Relations / MCP 等 — Issue 起票待ち） |
 
 ## In Progress
 
 | Issue | Summary |
 | --- | --- |
-| #40 | field_def 編集（PUT）UI |
+| #42 | text-fields `entity_type_id` フィルタ + 一覧ラベル取得最適化 |
 
 ## Recently Completed
 
 | Issue | Summary |
 | --- | --- |
+| #40 | field_def 編集（PUT）UI (PR #41) |
 | #38 | Consumer views — `/view/:slug` 一覧・詳細、PublicShell (PR #39) |
 | #36 | Phase 4 完走 — enum/bool/datetime UI, entity type 編集, API entity_id filter, frontend CI (PR #37) |
 | #34 | int_fields 値編集 UI (PR #35) |
@@ -28,18 +29,18 @@ Last updated: 2026-05-24
 | #24 | Entity type CRUD UI (PR #25) |
 | #20 | Admin React scaffold (PR #21) |
 
-## Phase 4 Admin（ほぼ完了）
+## Phase 4 Admin（完了）
 
 - Entity types（作成・一覧・編集・削除）
-- Field defs（作成・一覧・削除 → **編集 #40 進行中**）
+- Field defs（作成・一覧・編集・削除）
 - Records（作成・一覧・削除・全型フィールド値編集）
-- Records 一覧に title ラベル表示
+- Records 一覧に title ラベル表示（entity type スコープ fetch）
 - Consumer views（`/view/:slug`）
-- CI: `.github/workflows/frontend-ci.yml`
+- CI: `.github/workflows/frontend-ci.yml` + `frontend/.npmrc`
 
 ## Verification
 
 ```bash
-composer check                    # 128 tests
+composer check                    # 130 tests
 npm run check --prefix frontend   # 52 tests
 ```

--- a/frontend/src/entities/text-field/index.ts
+++ b/frontend/src/entities/text-field/index.ts
@@ -4,4 +4,4 @@ export type { CreateTextFieldInput, TextField, TextFieldList, UpdateTextFieldInp
 export { textFieldKeys } from './query-keys'
 export type { TextFieldListParams } from './query-keys'
 export { useCreateTextField, useUpdateTextField } from './mutations'
-export { useTextField, useTextFieldList } from './queries'
+export { defaultTextFieldListParamsForEntityType, useTextField, useTextFieldList } from './queries'

--- a/frontend/src/entities/text-field/queries.ts
+++ b/frontend/src/entities/text-field/queries.ts
@@ -8,11 +8,20 @@ import { textFieldKeys, type TextFieldListParams } from './query-keys'
 
 const DEFAULT_LIST_PARAMS = { limit: 100, offset: 0 } as const
 
+export function defaultTextFieldListParamsForEntityType(entityTypeId: number): TextFieldListParams {
+  return {
+    entityTypeId,
+    ...DEFAULT_LIST_PARAMS,
+  }
+}
+
 export function useTextFieldList(
   params: TextFieldListParams = DEFAULT_LIST_PARAMS,
+  options?: { enabled?: boolean },
 ): UseQueryResult<TextFieldList, AppError> {
   return useQuery({
     queryKey: textFieldKeys.list(params),
+    enabled: options?.enabled ?? true,
     queryFn: async ({ signal }) => {
       const search = new URLSearchParams({
         limit: String(params.limit),
@@ -20,6 +29,8 @@ export function useTextFieldList(
       })
       if (params.entityId !== undefined) {
         search.set('entity_id', String(params.entityId))
+      } else if (params.entityTypeId !== undefined) {
+        search.set('entity_type_id', String(params.entityTypeId))
       }
       const dto = await apiClient.get<TextFieldListDto>(
         `/api/v1/text-fields?${search.toString()}`,

--- a/frontend/src/entities/text-field/query-keys.ts
+++ b/frontend/src/entities/text-field/query-keys.ts
@@ -4,6 +4,7 @@ export interface TextFieldListParams {
   limit: number
   offset: number
   entityId?: number
+  entityTypeId?: number
 }
 
 export const textFieldKeys = {

--- a/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
+++ b/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
@@ -7,13 +7,13 @@ import {
   type Entity,
   type EntityId,
 } from '@/entities/entity'
-import { useTextFieldList } from '@/entities/text-field'
+import { defaultTextFieldListParamsForEntityType, useTextFieldList } from '@/entities/text-field'
 import { getRecordDisplayLabel } from '@/shared/lib/get-record-display-label'
 
 export function useManageEntitiesPage(entityTypeId: number) {
   const listParams = defaultEntityListParams(entityTypeId)
   const listQuery = useEntityList(listParams)
-  const textFieldQuery = useTextFieldList()
+  const textFieldQuery = useTextFieldList(defaultTextFieldListParamsForEntityType(entityTypeId))
   const createMutation = useCreateEntity()
   const deleteMutation = useDeleteEntity()
   const [deleteTarget, setDeleteTarget] = useState<Entity | null>(null)

--- a/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.ts
+++ b/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { defaultEntityListParams, useEntityList } from '@/entities/entity'
 import { useEntityTypeList } from '@/entities/entity-type'
-import { useTextFieldList } from '@/entities/text-field'
+import { defaultTextFieldListParamsForEntityType, useTextFieldList } from '@/entities/text-field'
 import { findEntityTypeBySlug } from '@/shared/lib/find-entity-type-by-slug'
 import { getRecordDisplayLabel } from '@/shared/lib/get-record-display-label'
 
@@ -20,7 +20,11 @@ export function usePublicBrowseEntityRecordsPage(entityTypeSlug: string) {
   const entityTypeId = entityType !== undefined ? Number(entityType.id) : 0
   const listParams = defaultEntityListParams(entityTypeId)
   const entityListQuery = useEntityList(listParams, { enabled: entityTypeId > 0 })
-  const textFieldQuery = useTextFieldList()
+  const textFieldListParams = useMemo(
+    () => defaultTextFieldListParamsForEntityType(entityTypeId),
+    [entityTypeId],
+  )
+  const textFieldQuery = useTextFieldList(textFieldListParams, { enabled: entityTypeId > 0 })
 
   const items = useMemo((): PublicRecordListItem[] => {
     const entities = entityListQuery.data?.items ?? []
@@ -35,7 +39,7 @@ export function usePublicBrowseEntityRecordsPage(entityTypeSlug: string) {
   const isLoading =
     entityTypeQuery.isLoading ||
     (entityTypeId > 0 && entityListQuery.isLoading) ||
-    textFieldQuery.isLoading
+    (entityTypeId > 0 && textFieldQuery.isLoading)
   const isError = entityTypeQuery.isError || entityListQuery.isError || textFieldQuery.isError
   const errorTitle =
     entityTypeQuery.error?.title ??

--- a/frontend/tests/msw/handlers/entity.ts
+++ b/frontend/tests/msw/handlers/entity.ts
@@ -20,6 +20,10 @@ export function seedEntities(seed: EntityRecord[]): void {
   nextId = Math.max(0, ...seed.map((item) => item.id)) + 1
 }
 
+export function getActiveEntities(): EntityRecord[] {
+  return items.filter((item) => !item.is_deleted)
+}
+
 export const entityHandlers = [
   http.get('/api/v1/entities', ({ request }) => {
     const url = new URL(request.url)

--- a/frontend/tests/msw/handlers/text-field.ts
+++ b/frontend/tests/msw/handlers/text-field.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from 'msw'
+import { getActiveEntities } from './entity'
 
 interface TextFieldRecord {
   id: number
@@ -28,10 +29,22 @@ export const textFieldHandlers = [
     const offset = Number(url.searchParams.get('offset') ?? '0')
     const entityIdParam = url.searchParams.get('entity_id')
     const entityId = entityIdParam === null ? null : Number(entityIdParam)
+    const entityTypeIdParam = url.searchParams.get('entity_type_id')
+    const entityTypeId = entityTypeIdParam === null ? null : Number(entityTypeIdParam)
 
     const active = items.filter((item) => !item.is_deleted)
-    const filtered =
-      entityId === null ? active : active.filter((item) => item.entity_id === entityId)
+    let filtered = active
+
+    if (entityId !== null) {
+      filtered = active.filter((item) => item.entity_id === entityId)
+    } else if (entityTypeId !== null) {
+      const entityIds = new Set(
+        getActiveEntities()
+          .filter((entity) => entity.entity_type_id === entityTypeId)
+          .map((entity) => entity.id),
+      )
+      filtered = active.filter((item) => entityIds.has(item.entity_id))
+    }
 
     return HttpResponse.json({
       items: filtered.slice(offset, offset + limit).map((item) => ({

--- a/src/TextField/ListTextFieldsHandler.php
+++ b/src/TextField/ListTextFieldsHandler.php
@@ -31,8 +31,17 @@ final readonly class ListTextFieldsHandler
             }
         }
 
+        $entityTypeId = null;
+        if ($entityId === null && isset($query['entity_type_id'])) {
+            $raw = (int) $query['entity_type_id'];
+            if ($raw > 0) {
+                $entityTypeId = $raw;
+            }
+        }
+
         $output = $this->useCase->execute(new ListTextFieldsInput(
             entityId: $entityId,
+            entityTypeId: $entityTypeId,
             limit: $pagination->limit,
             offset: $pagination->offset,
         ));

--- a/src/TextField/ListTextFieldsInput.php
+++ b/src/TextField/ListTextFieldsInput.php
@@ -8,6 +8,7 @@ final readonly class ListTextFieldsInput
 {
     public function __construct(
         public ?int $entityId = null,
+        public ?int $entityTypeId = null,
         public int $limit = 20,
         public int $offset = 0,
     ) {

--- a/src/TextField/ListTextFieldsUseCase.php
+++ b/src/TextField/ListTextFieldsUseCase.php
@@ -13,9 +13,19 @@ final readonly class ListTextFieldsUseCase implements ListTextFieldsUseCaseInter
 
     public function execute(ListTextFieldsInput $input): ListTextFieldsOutput
     {
-        $rows = $input->entityId !== null
-            ? $this->textFields->findByEntityId($input->entityId, $input->limit, $input->offset)
-            : $this->textFields->findAll($input->limit, $input->offset);
+        $rows = match (true) {
+            $input->entityId !== null => $this->textFields->findByEntityId(
+                $input->entityId,
+                $input->limit,
+                $input->offset,
+            ),
+            $input->entityTypeId !== null => $this->textFields->findByEntityTypeId(
+                $input->entityTypeId,
+                $input->limit,
+                $input->offset,
+            ),
+            default => $this->textFields->findAll($input->limit, $input->offset),
+        };
 
         $items = array_map(
             static fn (TextField $textField) => new ListTextFieldItem(

--- a/src/TextField/PdoTextFieldRepository.php
+++ b/src/TextField/PdoTextFieldRepository.php
@@ -71,6 +71,34 @@ final readonly class PdoTextFieldRepository implements TextFieldRepositoryInterf
         );
     }
 
+    /** @return list<TextField> */
+    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            <<<'SQL'
+            SELECT tf.id, tf.entity_id, tf.field_key, tf.value
+            FROM text_fields tf
+            INNER JOIN entities e ON e.id = tf.entity_id
+            WHERE tf.is_deleted = 0
+              AND e.is_deleted = 0
+              AND e.entity_type_id = ?
+            ORDER BY tf.id ASC
+            LIMIT ? OFFSET ?
+            SQL,
+            [$entityTypeId, $limit, $offset],
+        );
+
+        return array_map(
+            static fn (array $row) => new TextField(
+                entityId: (int) $row['entity_id'],
+                fieldKey: (string) $row['field_key'],
+                value: (string) $row['value'],
+                id: (int) $row['id'],
+            ),
+            $rows,
+        );
+    }
+
     public function save(TextField $textField): int
     {
         $this->query->execute(

--- a/src/TextField/TextFieldRepositoryInterface.php
+++ b/src/TextField/TextFieldRepositoryInterface.php
@@ -22,6 +22,13 @@ interface TextFieldRepositoryInterface
      */
     public function findByEntityId(int $entityId, int $limit, int $offset): array;
 
+    /**
+     * Active (non-soft-deleted) rows for entities belonging to the given entity type.
+     *
+     * @return list<TextField>
+     */
+    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset): array;
+
     public function save(TextField $textField): int;
 
     public function update(TextField $textField): void;

--- a/tests/TextField/InMemoryTextFieldRepository.php
+++ b/tests/TextField/InMemoryTextFieldRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Tests\TextField;
 
+use NeNeRecords\Entity\EntityRepositoryInterface;
 use NeNeRecords\TextField\TextField;
 use NeNeRecords\TextField\TextFieldNotFoundException;
 use NeNeRecords\TextField\TextFieldRepositoryInterface;
@@ -18,9 +19,13 @@ final class InMemoryTextFieldRepository implements TextFieldRepositoryInterface
 
     private int $nextId;
 
-    /** @param list<TextField> $seed */
-    public function __construct(array $seed = [])
-    {
+    /**
+     * @param list<TextField> $seed
+     */
+    public function __construct(
+        array $seed = [],
+        private ?EntityRepositoryInterface $entities = null,
+    ) {
         $this->fields = [];
         $this->deletedIds = [];
         $this->nextId = 1;
@@ -66,6 +71,32 @@ final class InMemoryTextFieldRepository implements TextFieldRepositoryInterface
 
         foreach ($this->fields as $id => $textField) {
             if (!isset($this->deletedIds[$id]) && $textField->entityId === $entityId) {
+                $active[] = $textField;
+            }
+        }
+
+        usort($active, static fn (TextField $a, TextField $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
+
+        return array_slice($active, $offset, $limit);
+    }
+
+    /** @return list<TextField> */
+    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset): array
+    {
+        $active = [];
+
+        foreach ($this->fields as $id => $textField) {
+            if (isset($this->deletedIds[$id])) {
+                continue;
+            }
+
+            if ($this->entities === null) {
+                continue;
+            }
+
+            $entity = $this->entities->findById($textField->entityId);
+
+            if ($entity !== null && $entity->entityTypeId === $entityTypeId) {
                 $active[] = $textField;
             }
         }

--- a/tests/TextField/PdoTextFieldRepositoryTest.php
+++ b/tests/TextField/PdoTextFieldRepositoryTest.php
@@ -156,4 +156,30 @@ final class PdoTextFieldRepositoryTest extends TestCase
         self::assertCount(1, $list);
         self::assertSame('a', $list[0]->fieldKey);
     }
+
+    public function testFindByEntityTypeIdExcludesOtherTypesAndDeleted(): void
+    {
+        $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('A', 'a')");
+        $typeAId = $this->executor->lastInsertId();
+        $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('B', 'b')");
+        $typeBId = $this->executor->lastInsertId();
+
+        $this->executor->execute('INSERT INTO entities (entity_type_id) VALUES (?)', [$typeAId]);
+        $entityAId = $this->executor->lastInsertId();
+        $this->executor->execute('INSERT INTO entities (entity_type_id) VALUES (?)', [$typeBId]);
+        $entityBId = $this->executor->lastInsertId();
+
+        $repository = new PdoTextFieldRepository($this->executor);
+
+        $repository->save(new TextField(entityId: $entityAId, fieldKey: 'title', value: 'A'));
+        $repository->save(new TextField(entityId: $entityBId, fieldKey: 'title', value: 'B'));
+        $deletedId = $repository->save(new TextField(entityId: $entityAId, fieldKey: 'body', value: 'gone'));
+        $repository->delete($deletedId);
+
+        $list = $repository->findByEntityTypeId($typeAId, 10, 0);
+
+        self::assertCount(1, $list);
+        self::assertSame('title', $list[0]->fieldKey);
+        self::assertSame('A', $list[0]->value);
+    }
 }

--- a/tests/TextField/TextFieldHttpTest.php
+++ b/tests/TextField/TextFieldHttpTest.php
@@ -61,7 +61,7 @@ final class TextFieldHttpTest extends TestCase
         $this->entityTypes = new InMemoryEntityTypeRepository();
         $this->entities = new InMemoryEntityRepository();
         $this->fieldDefs = new InMemoryFieldDefRepository();
-        $this->textFields = new InMemoryTextFieldRepository();
+        $this->textFields = new InMemoryTextFieldRepository([], $this->entities);
 
         $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
         $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
@@ -271,6 +271,53 @@ final class TextFieldHttpTest extends TestCase
         self::assertSame($entityAId, $payload['items'][0]['entity_id']);
         self::assertSame('title', $payload['items'][0]['field_key']);
         self::assertSame('Entity A title', $payload['items'][0]['value']);
+    }
+
+    public function testListTextFieldsFiltersByEntityTypeId(): void
+    {
+        $typeAId = $this->entityTypes->save(new EntityType(name: 'Type A', slug: 'type-a'));
+        $typeBId = $this->entityTypes->save(new EntityType(name: 'Type B', slug: 'type-b'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeAId, fieldKey: 'title', dataType: 'text'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeBId, fieldKey: 'title', dataType: 'text'));
+
+        $entityAId = $this->createEntity($typeAId);
+        $entityBId = $this->createEntity($typeBId);
+
+        $this->createTextField($entityAId, 'title', 'Type A title');
+        $this->createTextField($entityBId, 'title', 'Type B title');
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/text-fields?entity_type_id={$typeAId}"),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertCount(1, $payload['items']);
+        self::assertSame($entityAId, $payload['items'][0]['entity_id']);
+        self::assertSame('Type A title', $payload['items'][0]['value']);
+    }
+
+    private function createEntity(int $entityTypeId): int
+    {
+        $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $entityTypeId], JSON_THROW_ON_ERROR));
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody($bodyEntity),
+        );
+
+        return (int) $this->decodeJson($response)['id'];
+    }
+
+    private function createTextField(int $entityId, string $fieldKey, string $value): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => $fieldKey,
+            'value' => $value,
+        ], JSON_THROW_ON_ERROR));
+
+        $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/text-fields')->withBody($body),
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary

- API: `GET /api/v1/text-fields?entity_type_id=` — entities JOIN で entity type スコープの行のみ返却
- Frontend: `manage-entities` / `public-browse` が全件 fetch せず entity type 単位で text_fields 取得
- `defaultTextFieldListParamsForEntityType` + `useTextFieldList` の `enabled` オプション
- OpenAPI / MSW / PHPUnit テスト追加

## Test plan

- [x] `composer check` — 130 tests
- [x] `npm run check --prefix frontend` — 52 tests
- [x] Records 一覧・Consumer 一覧で title ラベル表示は従来通り

Closes #42

使用チェックリスト: frontend-self-review

Made with [Cursor](https://cursor.com)