### PR TITLE
feat(frontend): Tag CRUD Admin UI (#44)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,41 +6,34 @@ Last updated: 2026-05-24
 
 | Issue | Summary |
 | --- | --- |
-| TBD | （次フェーズ: Relations / MCP 等 — Issue 起票待ち） |
+| TBD | Record への tag attach/detach UI |
+| TBD | Records 一覧 tag フィルタ UI |
+| TBD | entity-to-entity relations（要設計） |
 
 ## In Progress
 
 | Issue | Summary |
 | --- | --- |
-| #42 | text-fields `entity_type_id` フィルタ + 一覧ラベル取得最適化 |
+| #44 | Tag CRUD Admin UI（Phase 3 開始） |
 
 ## Recently Completed
 
 | Issue | Summary |
 | --- | --- |
+| #42 | text-fields entity_type_id フィルタ + 一覧ラベル最適化 (PR #43) |
 | #40 | field_def 編集（PUT）UI (PR #41) |
-| #38 | Consumer views — `/view/:slug` 一覧・詳細、PublicShell (PR #39) |
-| #36 | Phase 4 完走 — enum/bool/datetime UI, entity type 編集, API entity_id filter, frontend CI (PR #37) |
-| #34 | int_fields 値編集 UI (PR #35) |
-| #32 | レコード一覧 title 表示 (PR #33) |
-| #30 | text_fields 値編集 UI (PR #31) |
-| #28 | field_defs UI (PR #29) |
-| #26 | Entity records UI (PR #27) |
-| #24 | Entity type CRUD UI (PR #25) |
-| #20 | Admin React scaffold (PR #21) |
+| #38 | Consumer views (PR #39) |
+| #36 | Phase 4 完走 (PR #37) |
 
-## Phase 4 Admin（完了）
+## Phase 3 Tags / Query
 
-- Entity types（作成・一覧・編集・削除）
-- Field defs（作成・一覧・編集・削除）
-- Records（作成・一覧・削除・全型フィールド値編集）
-- Records 一覧に title ラベル表示（entity type スコープ fetch）
-- Consumer views（`/view/:slug`）
-- CI: `.github/workflows/frontend-ci.yml` + `frontend/.npmrc`
+- **API（済）:** tags CRUD, entity_tags attach/detach, entities `?tags=` フィルタ
+- **Admin UI（進行中）:** Tag CRUD (#44)
+- **未着手:** Record tag 管理、一覧フィルタ、relations モデル
 
 ## Verification
 
 ```bash
 composer check                    # 130 tests
-npm run check --prefix frontend   # 52 tests
+npm run check --prefix frontend   # 56 tests
 ```

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -8,6 +8,7 @@ import { EntityTypesPage } from '@/pages/entity-types/EntityTypesPage'
 import { FieldDefsPage } from '@/pages/field-defs/FieldDefsPage'
 import { HomePage } from '@/pages/home/HomePage'
 import { AppShell } from '@/pages/layout/AppShell'
+import { TagsPage } from '@/pages/tags/TagsPage'
 
 const router = createBrowserRouter([
   {
@@ -16,6 +17,7 @@ const router = createBrowserRouter([
     children: [
       { index: true, element: <HomePage /> },
       { path: 'entity-types', element: <EntityTypesPage /> },
+      { path: 'tags', element: <TagsPage /> },
       { path: 'entity-types/:entityTypeId/fields', element: <FieldDefsPage /> },
       { path: 'entity-types/:entityTypeId/entities', element: <EntityRecordsPage /> },
       { path: 'entity-types/:entityTypeId/entities/:entityId', element: <EntityRecordPage /> },

--- a/frontend/src/entities/tag/api-types.ts
+++ b/frontend/src/entities/tag/api-types.ts
@@ -1,0 +1,18 @@
+export interface TagDto {
+  id: number
+  name: string
+  slug: string
+}
+
+export interface TagListDto {
+  items: TagDto[]
+  limit: number
+  offset: number
+}
+
+export interface CreateTagDto {
+  name: string
+  slug: string
+}
+
+export type UpdateTagDto = CreateTagDto

--- a/frontend/src/entities/tag/ids.ts
+++ b/frontend/src/entities/tag/ids.ts
@@ -1,0 +1,7 @@
+declare const tagIdBrand: unique symbol
+
+export type TagId = number & { readonly [tagIdBrand]: never }
+
+export function toTagId(value: number): TagId {
+  return value as TagId
+}

--- a/frontend/src/entities/tag/index.ts
+++ b/frontend/src/entities/tag/index.ts
@@ -1,0 +1,6 @@
+export type { TagId } from './ids'
+export { toTagId } from './ids'
+export type { CreateTagInput, Tag, TagList, UpdateTagInput } from './model'
+export { tagKeys } from './query-keys'
+export { useCreateTag, useDeleteTag, useUpdateTag } from './mutations'
+export { useTag, useTagList } from './queries'

--- a/frontend/src/entities/tag/mapper.ts
+++ b/frontend/src/entities/tag/mapper.ts
@@ -1,0 +1,30 @@
+import type { CreateTagDto, TagDto, TagListDto, UpdateTagDto } from './api-types'
+import { toTagId } from './ids'
+import type { CreateTagInput, Tag, TagList, UpdateTagInput } from './model'
+
+export function mapTagDtoToModel(dto: TagDto): Tag {
+  return {
+    id: toTagId(dto.id),
+    name: dto.name,
+    slug: dto.slug,
+  }
+}
+
+export function mapTagListDtoToModel(dto: TagListDto): TagList {
+  return {
+    items: dto.items.map(mapTagDtoToModel),
+    limit: dto.limit,
+    offset: dto.offset,
+  }
+}
+
+export function mapCreateInputToDto(input: CreateTagInput): CreateTagDto {
+  return {
+    name: input.name,
+    slug: input.slug,
+  }
+}
+
+export function mapUpdateInputToDto(input: UpdateTagInput): UpdateTagDto {
+  return mapCreateInputToDto(input)
+}

--- a/frontend/src/entities/tag/model.ts
+++ b/frontend/src/entities/tag/model.ts
@@ -1,0 +1,20 @@
+import type { TagId } from './ids'
+
+export interface Tag {
+  id: TagId
+  name: string
+  slug: string
+}
+
+export interface TagList {
+  items: Tag[]
+  limit: number
+  offset: number
+}
+
+export interface CreateTagInput {
+  name: string
+  slug: string
+}
+
+export type UpdateTagInput = CreateTagInput

--- a/frontend/src/entities/tag/mutations.ts
+++ b/frontend/src/entities/tag/mutations.ts
@@ -1,0 +1,56 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { TagDto } from './api-types'
+import type { TagId } from './ids'
+import { mapCreateInputToDto, mapTagDtoToModel, mapUpdateInputToDto } from './mapper'
+import type { CreateTagInput, Tag, UpdateTagInput } from './model'
+import { tagKeys } from './query-keys'
+
+export function useCreateTag(): UseMutationResult<Tag, AppError, CreateTagInput> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input) => {
+      const dto = await apiClient.post<TagDto>('/api/v1/tags', mapCreateInputToDto(input))
+      return mapTagDtoToModel(dto)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: tagKeys.lists() })
+    },
+  })
+}
+
+export function useUpdateTag(): UseMutationResult<
+  Tag,
+  AppError,
+  { id: TagId; input: UpdateTagInput }
+> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ id, input }) => {
+      const dto = await apiClient.put<TagDto>(
+        `/api/v1/tags/${String(id)}`,
+        mapUpdateInputToDto(input),
+      )
+      return mapTagDtoToModel(dto)
+    },
+    onSuccess: async (_data, variables) => {
+      await queryClient.invalidateQueries({ queryKey: tagKeys.lists() })
+      await queryClient.invalidateQueries({ queryKey: tagKeys.detail(variables.id) })
+    },
+  })
+}
+
+export function useDeleteTag(): UseMutationResult<void, AppError, TagId> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (id) => {
+      await apiClient.delete(`/api/v1/tags/${String(id)}`)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: tagKeys.lists() })
+    },
+  })
+}

--- a/frontend/src/entities/tag/queries.ts
+++ b/frontend/src/entities/tag/queries.ts
@@ -1,0 +1,35 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { TagDto, TagListDto } from './api-types'
+import type { TagId } from './ids'
+import { mapTagDtoToModel, mapTagListDtoToModel } from './mapper'
+import type { Tag, TagList } from './model'
+import { tagKeys } from './query-keys'
+
+const DEFAULT_LIST_PARAMS = { limit: 20, offset: 0 } as const
+
+export function useTagList(
+  params: { limit: number; offset: number } = DEFAULT_LIST_PARAMS,
+): UseQueryResult<TagList, AppError> {
+  return useQuery({
+    queryKey: tagKeys.list(params),
+    queryFn: async ({ signal }) => {
+      const search = new URLSearchParams({
+        limit: String(params.limit),
+        offset: String(params.offset),
+      })
+      const dto = await apiClient.get<TagListDto>(`/api/v1/tags?${search.toString()}`, signal)
+      return mapTagListDtoToModel(dto)
+    },
+  })
+}
+
+export function useTag(id: TagId): UseQueryResult<Tag, AppError> {
+  return useQuery({
+    queryKey: tagKeys.detail(id),
+    queryFn: async ({ signal }) => {
+      const dto = await apiClient.get<TagDto>(`/api/v1/tags/${String(id)}`, signal)
+      return mapTagDtoToModel(dto)
+    },
+  })
+}

--- a/frontend/src/entities/tag/query-keys.ts
+++ b/frontend/src/entities/tag/query-keys.ts
@@ -1,0 +1,9 @@
+import type { TagId } from './ids'
+
+export const tagKeys = {
+  all: ['tags'] as const,
+  lists: () => [...tagKeys.all, 'list'] as const,
+  list: (params: { limit: number; offset: number }) => [...tagKeys.lists(), params] as const,
+  details: () => [...tagKeys.all, 'detail'] as const,
+  detail: (id: TagId) => [...tagKeys.details(), id] as const,
+}

--- a/frontend/src/features/manage-tags/hooks/use-create-tag-form.ts
+++ b/frontend/src/features/manage-tags/hooks/use-create-tag-form.ts
@@ -1,0 +1,30 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+export const createTagFormSchema = z.object({
+  name: z.string().trim().min(1, 'Name is required'),
+  slug: z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Use lowercase letters, numbers, and hyphens'),
+})
+
+export type CreateTagFormValues = z.infer<typeof createTagFormSchema>
+
+export function useCreateTagForm() {
+  return useForm<CreateTagFormValues>({
+    resolver: zodResolver(createTagFormSchema),
+    defaultValues: {
+      name: '',
+      slug: '',
+    },
+  })
+}
+
+export function useEditTagForm(defaultValues: CreateTagFormValues) {
+  return useForm<CreateTagFormValues>({
+    resolver: zodResolver(createTagFormSchema),
+    defaultValues,
+  })
+}

--- a/frontend/src/features/manage-tags/hooks/use-manage-tags-page.ts
+++ b/frontend/src/features/manage-tags/hooks/use-manage-tags-page.ts
@@ -1,0 +1,89 @@
+import { useCallback, useState } from 'react'
+import {
+  useCreateTag,
+  useDeleteTag,
+  useTagList,
+  useUpdateTag,
+  type Tag,
+  type TagId,
+} from '@/entities/tag'
+import type { CreateTagFormValues } from './use-create-tag-form'
+
+export function useManageTagsPage() {
+  const listQuery = useTagList()
+  const createMutation = useCreateTag()
+  const updateMutation = useUpdateTag()
+  const deleteMutation = useDeleteTag()
+  const [editTarget, setEditTarget] = useState<Tag | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<Tag | null>(null)
+
+  const createTag = useCallback(
+    async (values: CreateTagFormValues) => {
+      await createMutation.mutateAsync(values)
+    },
+    [createMutation],
+  )
+
+  const requestEdit = useCallback((tag: Tag) => {
+    setEditTarget(tag)
+  }, [])
+
+  const cancelEdit = useCallback(() => {
+    setEditTarget(null)
+  }, [])
+
+  const updateTag = useCallback(
+    async (values: CreateTagFormValues) => {
+      if (editTarget === null) {
+        return
+      }
+
+      await updateMutation.mutateAsync({
+        id: editTarget.id,
+        input: values,
+      })
+      setEditTarget(null)
+    },
+    [editTarget, updateMutation],
+  )
+
+  const requestDelete = useCallback((tag: Tag) => {
+    setDeleteTarget(tag)
+  }, [])
+
+  const cancelDelete = useCallback(() => {
+    setDeleteTarget(null)
+  }, [])
+
+  const confirmDelete = useCallback(async () => {
+    if (deleteTarget === null) {
+      return
+    }
+
+    const id: TagId = deleteTarget.id
+    await deleteMutation.mutateAsync(id)
+    setDeleteTarget(null)
+  }, [deleteMutation, deleteTarget])
+
+  return {
+    items: listQuery.data?.items ?? [],
+    isLoading: listQuery.isLoading,
+    isError: listQuery.isError,
+    errorTitle: listQuery.error?.title ?? null,
+    refetch: listQuery.refetch,
+    createTag,
+    isCreating: createMutation.isPending,
+    createErrorTitle: createMutation.error?.title ?? null,
+    editTarget,
+    requestEdit,
+    cancelEdit,
+    updateTag,
+    isUpdating: updateMutation.isPending,
+    updateErrorTitle: updateMutation.error?.title ?? null,
+    deleteTarget,
+    requestDelete,
+    cancelDelete,
+    confirmDelete,
+    isDeleting: deleteMutation.isPending,
+  }
+}

--- a/frontend/src/features/manage-tags/index.ts
+++ b/frontend/src/features/manage-tags/index.ts
@@ -1,0 +1,3 @@
+export { useManageTagsPage } from './hooks/use-manage-tags-page'
+export { ManageTagsView } from './ui/ManageTagsView'
+export type { ManageTagsViewProps } from './ui/ManageTagsView'

--- a/frontend/src/features/manage-tags/ui/ManageTagsView.tsx
+++ b/frontend/src/features/manage-tags/ui/ManageTagsView.tsx
@@ -1,0 +1,100 @@
+import type { Tag } from '@/entities/tag'
+import { ConfirmDialog, Stack, Text } from '@/shared/ui'
+import { TagCreateForm } from './TagCreateForm'
+import { TagEditForm } from './TagEditForm'
+import { TagListPanel } from './TagListPanel'
+
+export interface ManageTagsViewProps {
+  items: Tag[]
+  isLoading: boolean
+  isError: boolean
+  errorTitle: string | null
+  isCreating: boolean
+  createErrorTitle: string | null
+  editTarget: Tag | null
+  isUpdating: boolean
+  updateErrorTitle: string | null
+  deleteTarget: Tag | null
+  isDeleting: boolean
+  onRetry: () => void
+  onCreate: (values: { name: string; slug: string }) => Promise<void>
+  onRequestEdit: (tag: Tag) => void
+  onCancelEdit: () => void
+  onUpdate: (values: { name: string; slug: string }) => Promise<void>
+  onRequestDelete: (tag: Tag) => void
+  onCancelDelete: () => void
+  onConfirmDelete: () => Promise<void>
+}
+
+export function ManageTagsView({
+  items,
+  isLoading,
+  isError,
+  errorTitle,
+  isCreating,
+  createErrorTitle,
+  editTarget,
+  isUpdating,
+  updateErrorTitle,
+  deleteTarget,
+  isDeleting,
+  onRetry,
+  onCreate,
+  onRequestEdit,
+  onCancelEdit,
+  onUpdate,
+  onRequestDelete,
+  onCancelDelete,
+  onConfirmDelete,
+}: ManageTagsViewProps) {
+  return (
+    <>
+      <Stack gap="lg">
+        <TagCreateForm
+          isSubmitting={isCreating}
+          serverErrorTitle={createErrorTitle}
+          onSubmit={onCreate}
+        />
+        {editTarget !== null ? (
+          <TagEditForm
+            tag={editTarget}
+            isSubmitting={isUpdating}
+            serverErrorTitle={updateErrorTitle}
+            onSubmit={onUpdate}
+            onCancel={onCancelEdit}
+          />
+        ) : null}
+        <Stack gap="sm">
+          <Text as="h2" variant="heading-sm">
+            Existing tags
+          </Text>
+          <TagListPanel
+            items={items}
+            isLoading={isLoading}
+            isError={isError}
+            errorTitle={errorTitle}
+            isDeleting={isDeleting}
+            onRetry={onRetry}
+            onEdit={onRequestEdit}
+            onDelete={onRequestDelete}
+          />
+        </Stack>
+      </Stack>
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title="Delete tag?"
+        description={
+          deleteTarget !== null
+            ? `"${deleteTarget.name}" will be removed. Attached records keep their data but lose this tag.`
+            : undefined
+        }
+        confirmLabel={isDeleting ? 'Deleting…' : 'Delete'}
+        isPending={isDeleting}
+        onCancel={onCancelDelete}
+        onConfirm={() => {
+          void onConfirmDelete()
+        }}
+      />
+    </>
+  )
+}

--- a/frontend/src/features/manage-tags/ui/TagCreateForm.tsx
+++ b/frontend/src/features/manage-tags/ui/TagCreateForm.tsx
@@ -1,0 +1,72 @@
+import { Controller } from 'react-hook-form'
+import { Button, Input, Stack, Text } from '@/shared/ui'
+import { useCreateTagForm } from '../hooks/use-create-tag-form'
+
+export interface TagCreateFormProps {
+  isSubmitting: boolean
+  serverErrorTitle: string | null
+  onSubmit: (values: { name: string; slug: string }) => Promise<void>
+}
+
+export function TagCreateForm({ isSubmitting, serverErrorTitle, onSubmit }: TagCreateFormProps) {
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useCreateTagForm()
+
+  return (
+    <form
+      className="rounded-md border border-border bg-surface-raised p-inline-md shadow-sm"
+      onSubmit={(event) => {
+        void handleSubmit(async (values) => {
+          await onSubmit(values)
+          reset()
+        })(event)
+      }}
+    >
+      <Stack gap="md">
+        <Text as="h2" variant="heading-sm">
+          Create tag
+        </Text>
+        <Controller
+          name="name"
+          control={control}
+          render={({ field }) => (
+            <Input
+              id="tag-name"
+              label="Name"
+              error={errors.name?.message}
+              autoComplete="off"
+              disabled={isSubmitting}
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+            />
+          )}
+        />
+        <Controller
+          name="slug"
+          control={control}
+          render={({ field }) => (
+            <Input
+              id="tag-slug"
+              label="Slug"
+              error={errors.slug?.message}
+              autoComplete="off"
+              disabled={isSubmitting}
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+            />
+          )}
+        />
+        {serverErrorTitle !== null ? <Text muted>{serverErrorTitle}</Text> : null}
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? 'Creating…' : 'Create tag'}
+        </Button>
+      </Stack>
+    </form>
+  )
+}

--- a/frontend/src/features/manage-tags/ui/TagEditForm.tsx
+++ b/frontend/src/features/manage-tags/ui/TagEditForm.tsx
@@ -1,0 +1,88 @@
+import { Controller } from 'react-hook-form'
+import type { Tag } from '@/entities/tag'
+import { Button, Input, Stack, Text } from '@/shared/ui'
+import { useEditTagForm } from '../hooks/use-create-tag-form'
+
+export interface TagEditFormProps {
+  tag: Tag
+  isSubmitting: boolean
+  serverErrorTitle: string | null
+  onSubmit: (values: { name: string; slug: string }) => Promise<void>
+  onCancel: () => void
+}
+
+export function TagEditForm({
+  tag,
+  isSubmitting,
+  serverErrorTitle,
+  onSubmit,
+  onCancel,
+}: TagEditFormProps) {
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useEditTagForm({
+    name: tag.name,
+    slug: tag.slug,
+  })
+
+  return (
+    <form
+      key={String(tag.id)}
+      className="rounded-md border border-border bg-surface-raised p-inline-md shadow-sm"
+      onSubmit={(event) => {
+        void handleSubmit(async (values) => {
+          await onSubmit(values)
+        })(event)
+      }}
+    >
+      <Stack gap="md">
+        <Text as="h2" variant="heading-sm">
+          Edit tag
+        </Text>
+        <Controller
+          name="name"
+          control={control}
+          render={({ field }) => (
+            <Input
+              id="tag-edit-name"
+              label="Name"
+              error={errors.name?.message}
+              autoComplete="off"
+              disabled={isSubmitting}
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+            />
+          )}
+        />
+        <Controller
+          name="slug"
+          control={control}
+          render={({ field }) => (
+            <Input
+              id="tag-edit-slug"
+              label="Slug"
+              error={errors.slug?.message}
+              autoComplete="off"
+              disabled={isSubmitting}
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+            />
+          )}
+        />
+        {serverErrorTitle !== null ? <Text muted>{serverErrorTitle}</Text> : null}
+        <div className="flex items-center gap-inline-sm">
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Saving…' : 'Save changes'}
+          </Button>
+          <Button type="button" variant="secondary" disabled={isSubmitting} onClick={onCancel}>
+            Cancel
+          </Button>
+        </div>
+      </Stack>
+    </form>
+  )
+}

--- a/frontend/src/features/manage-tags/ui/TagListPanel.tsx
+++ b/frontend/src/features/manage-tags/ui/TagListPanel.tsx
@@ -1,0 +1,87 @@
+import type { Tag } from '@/entities/tag'
+import { Button, EmptyState, Stack, Text } from '@/shared/ui'
+
+export interface TagListPanelProps {
+  items: Tag[]
+  isLoading: boolean
+  isError: boolean
+  errorTitle: string | null
+  isDeleting: boolean
+  onRetry: () => void
+  onEdit: (tag: Tag) => void
+  onDelete: (tag: Tag) => void
+}
+
+export function TagListPanel({
+  items,
+  isLoading,
+  isError,
+  errorTitle,
+  isDeleting,
+  onRetry,
+  onEdit,
+  onDelete,
+}: TagListPanelProps) {
+  if (isLoading) {
+    return <Text muted>Loading tags…</Text>
+  }
+
+  if (isError) {
+    return (
+      <Stack gap="sm">
+        <Text variant="heading-sm">Could not load tags</Text>
+        <Text muted>{errorTitle ?? 'Unknown error'}</Text>
+        <Button variant="secondary" onClick={onRetry}>
+          Retry
+        </Button>
+      </Stack>
+    )
+  }
+
+  if (items.length === 0) {
+    return (
+      <EmptyState title="No tags yet" description="Create your first tag using the form above." />
+    )
+  }
+
+  return (
+    <ul className="flex flex-col gap-stack-sm">
+      {items.map((item) => (
+        <li
+          key={String(item.id)}
+          className="flex items-center justify-between gap-inline-md rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm shadow-sm"
+        >
+          <Stack gap="xs">
+            <Text as="span" variant="heading-sm">
+              {item.name}
+            </Text>
+            <Text as="span" muted>
+              {item.slug}
+            </Text>
+          </Stack>
+          <div className="flex items-center gap-inline-sm">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                onEdit(item)
+              }}
+            >
+              Edit
+            </Button>
+            <Button
+              variant="danger"
+              size="sm"
+              disabled={isDeleting}
+              onClick={() => {
+                onDelete(item)
+              }}
+            >
+              Delete
+            </Button>
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -23,6 +23,9 @@ export function AppShell() {
               <NavLink to="/entity-types" className={navLinkClass}>
                 Entity types
               </NavLink>
+              <NavLink to="/tags" className={navLinkClass}>
+                Tags
+              </NavLink>
             </Stack>
           </nav>
         </div>

--- a/frontend/src/pages/tags/TagsPage.test.tsx
+++ b/frontend/src/pages/tags/TagsPage.test.tsx
@@ -1,0 +1,136 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { cleanup, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { TagsPage } from '@/pages/tags/TagsPage'
+import { resetTagStore } from '@tests/msw/handlers/tag'
+import { mswServer } from '@tests/msw/server'
+import { renderWithProviders } from '@tests/render/render-with-providers'
+
+function renderTagsPage() {
+  return renderWithProviders(
+    <MemoryRouter>
+      <TagsPage />
+    </MemoryRouter>,
+  )
+}
+
+function getCreateForm(): HTMLElement {
+  const form = screen.getByRole('heading', { name: 'Create tag' }).closest('form')
+  if (form === null) {
+    throw new Error('Create tag form not found')
+  }
+  return form
+}
+
+function getEditForm(): HTMLElement {
+  const form = screen.getByRole('heading', { name: 'Edit tag' }).closest('form')
+  if (form === null) {
+    throw new Error('Edit tag form not found')
+  }
+  return form
+}
+
+describe('TagsPage', () => {
+  beforeAll(() => {
+    mswServer.listen()
+  })
+
+  afterEach(() => {
+    mswServer.resetHandlers()
+    resetTagStore()
+    cleanup()
+  })
+
+  afterAll(() => {
+    mswServer.close()
+  })
+
+  it('creates a tag and lists it', async () => {
+    const user = userEvent.setup()
+    renderTagsPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('No tags yet')).toBeInTheDocument()
+    })
+
+    await user.type(screen.getByLabelText('Name'), 'Featured')
+    await user.type(screen.getByLabelText('Slug'), 'featured')
+    const form = getCreateForm()
+    await user.click(within(form).getByRole('button', { name: 'Create tag' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Featured')).toBeInTheDocument()
+      expect(screen.getByText('featured')).toBeInTheDocument()
+    })
+  })
+
+  it('shows validation errors for invalid slug', async () => {
+    const user = userEvent.setup()
+    renderTagsPage()
+
+    await user.type(screen.getByLabelText('Name'), 'Bad Slug')
+    await user.type(screen.getByLabelText('Slug'), 'Bad Slug')
+    const form = getCreateForm()
+    await user.click(within(form).getByRole('button', { name: 'Create tag' }))
+
+    expect(
+      await screen.findByText('Use lowercase letters, numbers, and hyphens'),
+    ).toBeInTheDocument()
+  })
+
+  it('updates a tag name and slug', async () => {
+    const user = userEvent.setup()
+    renderTagsPage()
+
+    await user.type(screen.getByLabelText('Name'), 'Featured')
+    await user.type(screen.getByLabelText('Slug'), 'featured')
+    const createForm = getCreateForm()
+    await user.click(within(createForm).getByRole('button', { name: 'Create tag' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Featured')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+
+    const editForm = getEditForm()
+    const nameInput = within(editForm).getByLabelText('Name')
+    const slugInput = within(editForm).getByLabelText('Slug')
+
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Highlight')
+    await user.clear(slugInput)
+    await user.type(slugInput, 'highlight')
+    await user.click(within(editForm).getByRole('button', { name: 'Save changes' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Highlight')).toBeInTheDocument()
+      expect(screen.getByText('highlight')).toBeInTheDocument()
+    })
+  })
+
+  it('deletes a tag after confirmation', async () => {
+    const user = userEvent.setup()
+    renderTagsPage()
+
+    await user.type(screen.getByLabelText('Name'), 'Draft')
+    await user.type(screen.getByLabelText('Slug'), 'draft')
+    const form = getCreateForm()
+    await user.click(within(form).getByRole('button', { name: 'Create tag' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Draft')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeInTheDocument()
+
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Draft')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/tags/TagsPage.tsx
+++ b/frontend/src/pages/tags/TagsPage.tsx
@@ -1,0 +1,57 @@
+import { ManageTagsView, useManageTagsPage } from '@/features/manage-tags'
+import { Stack, Text } from '@/shared/ui'
+
+export function TagsPage() {
+  const {
+    items,
+    isLoading,
+    isError,
+    errorTitle,
+    refetch,
+    createTag,
+    isCreating,
+    createErrorTitle,
+    editTarget,
+    requestEdit,
+    cancelEdit,
+    updateTag,
+    isUpdating,
+    updateErrorTitle,
+    deleteTarget,
+    requestDelete,
+    cancelDelete,
+    confirmDelete,
+    isDeleting,
+  } = useManageTagsPage()
+
+  return (
+    <Stack gap="md">
+      <Text as="h1" variant="heading-md">
+        Tags
+      </Text>
+      <ManageTagsView
+        items={items}
+        isLoading={isLoading}
+        isError={isError}
+        errorTitle={errorTitle}
+        isCreating={isCreating}
+        createErrorTitle={createErrorTitle}
+        editTarget={editTarget}
+        isUpdating={isUpdating}
+        updateErrorTitle={updateErrorTitle}
+        deleteTarget={deleteTarget}
+        isDeleting={isDeleting}
+        onRetry={() => {
+          void refetch()
+        }}
+        onCreate={createTag}
+        onRequestEdit={requestEdit}
+        onCancelEdit={cancelEdit}
+        onUpdate={updateTag}
+        onRequestDelete={requestDelete}
+        onCancelDelete={cancelDelete}
+        onConfirmDelete={confirmDelete}
+      />
+    </Stack>
+  )
+}

--- a/frontend/tests/msw/handlers/tag.ts
+++ b/frontend/tests/msw/handlers/tag.ts
@@ -1,0 +1,160 @@
+import { http, HttpResponse } from 'msw'
+
+interface TagRecord {
+  id: number
+  name: string
+  slug: string
+}
+
+let nextId = 1
+let items: TagRecord[] = []
+
+export function resetTagStore(): void {
+  nextId = 1
+  items = []
+}
+
+export function seedTags(seed: TagRecord[]): void {
+  items = [...seed]
+  nextId = Math.max(0, ...seed.map((item) => item.id)) + 1
+}
+
+export const tagHandlers = [
+  http.get('/api/v1/tags', ({ request }) => {
+    const url = new URL(request.url)
+    const limit = Number(url.searchParams.get('limit') ?? '20')
+    const offset = Number(url.searchParams.get('offset') ?? '0')
+
+    return HttpResponse.json({
+      items: items.slice(offset, offset + limit),
+      limit,
+      offset,
+    })
+  }),
+  http.post('/api/v1/tags', async ({ request }) => {
+    const body = (await request.json()) as { name?: string; slug?: string }
+
+    if (typeof body.name !== 'string' || body.name.trim() === '') {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/validation-failed',
+          title: 'Validation failed',
+          status: 422,
+          instance: '/api/v1/tags',
+          errors: [{ field: 'name', message: 'Required', code: 'required' }],
+        },
+        { status: 422 },
+      )
+    }
+
+    if (items.some((item) => item.slug === body.slug)) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/conflict',
+          title: 'Conflict',
+          status: 409,
+          instance: '/api/v1/tags',
+        },
+        { status: 409 },
+      )
+    }
+
+    const created = {
+      id: nextId++,
+      name: body.name,
+      slug: body.slug ?? '',
+    }
+    items = [...items, created]
+
+    return HttpResponse.json(created, { status: 201 })
+  }),
+  http.get('/api/v1/tags/:id', ({ params }) => {
+    const id = Number(params.id)
+    const item = items.find((entry) => entry.id === id)
+
+    if (item === undefined) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/not-found',
+          title: 'Not found',
+          status: 404,
+          instance: `/api/v1/tags/${String(id)}`,
+        },
+        { status: 404 },
+      )
+    }
+
+    return HttpResponse.json(item)
+  }),
+  http.put('/api/v1/tags/:id', async ({ params, request }) => {
+    const id = Number(params.id)
+    const index = items.findIndex((entry) => entry.id === id)
+
+    if (index === -1) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/not-found',
+          title: 'Not found',
+          status: 404,
+          instance: `/api/v1/tags/${String(id)}`,
+        },
+        { status: 404 },
+      )
+    }
+
+    const body = (await request.json()) as { name?: string; slug?: string }
+
+    if (typeof body.name !== 'string' || body.name.trim() === '') {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/validation-failed',
+          title: 'Validation failed',
+          status: 422,
+          instance: `/api/v1/tags/${String(id)}`,
+          errors: [{ field: 'name', message: 'Required', code: 'required' }],
+        },
+        { status: 422 },
+      )
+    }
+
+    if (items.some((item) => item.id !== id && item.slug === body.slug)) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/conflict',
+          title: 'Conflict',
+          status: 409,
+          instance: `/api/v1/tags/${String(id)}`,
+        },
+        { status: 409 },
+      )
+    }
+
+    const updated = {
+      id,
+      name: body.name,
+      slug: body.slug ?? '',
+    }
+    items = [...items.slice(0, index), updated, ...items.slice(index + 1)]
+
+    return HttpResponse.json(updated)
+  }),
+  http.delete('/api/v1/tags/:id', ({ params }) => {
+    const id = Number(params.id)
+    const exists = items.some((item) => item.id === id)
+
+    if (!exists) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/not-found',
+          title: 'Not found',
+          status: 404,
+          instance: `/api/v1/tags/${String(id)}`,
+        },
+        { status: 404 },
+      )
+    }
+
+    items = items.filter((item) => item.id !== id)
+    return new HttpResponse(null, { status: 204 })
+  }),
+]

--- a/frontend/tests/msw/server.ts
+++ b/frontend/tests/msw/server.ts
@@ -6,6 +6,7 @@ import { entityTypeHandlers } from './handlers/entity-type'
 import { enumFieldHandlers } from './handlers/enum-field'
 import { fieldDefHandlers } from './handlers/field-def'
 import { intFieldHandlers } from './handlers/int-field'
+import { tagHandlers } from './handlers/tag'
 import { textFieldHandlers } from './handlers/text-field'
 
 export const mswServer = setupServer(
@@ -17,4 +18,5 @@ export const mswServer = setupServer(
   ...enumFieldHandlers,
   ...boolFieldHandlers,
   ...dateTimeFieldHandlers,
+  ...tagHandlers,
 )


### PR DESCRIPTION
## Summary

Phase 3 着手 — backend 済みの Tags API に Admin UI を接続。

- `entities/tag` — queries / mutations / mapper
- `/tags` — 作成・一覧・編集・削除（entity types と同パターン）
- AppShell ナビに **Tags** 追加
- MSW handlers + `TagsPage` テスト 4 件

## Test plan

- [x] `npm run check --prefix frontend` — 56 tests green
- [x] http://localhost:5173/tags で tag CRUD

Closes #44

使用チェックリスト: frontend-self-review

Made with [Cursor](https://cursor.com)