### PR TITLE
feat(frontend): Record tag attach/detach UI (#46)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,7 +6,6 @@ Last updated: 2026-05-24
 
 | Issue | Summary |
 | --- | --- |
-| TBD | Record への tag attach/detach UI |
 | TBD | Records 一覧 tag フィルタ UI |
 | TBD | entity-to-entity relations（要設計） |
 
@@ -14,26 +13,27 @@ Last updated: 2026-05-24
 
 | Issue | Summary |
 | --- | --- |
-| #44 | Tag CRUD Admin UI（Phase 3 開始） |
+| #46 | Record への tag attach/detach UI |
 
 ## Recently Completed
 
 | Issue | Summary |
 | --- | --- |
-| #42 | text-fields entity_type_id フィルタ + 一覧ラベル最適化 (PR #43) |
-| #40 | field_def 編集（PUT）UI (PR #41) |
+| #44 | Tag CRUD Admin UI (PR #45) |
+| #42 | text-fields entity_type_id フィルタ (PR #43) |
+| #40 | field_def 編集 UI (PR #41) |
 | #38 | Consumer views (PR #39) |
-| #36 | Phase 4 完走 (PR #37) |
 
 ## Phase 3 Tags / Query
 
-- **API（済）:** tags CRUD, entity_tags attach/detach, entities `?tags=` フィルタ
-- **Admin UI（進行中）:** Tag CRUD (#44)
-- **未着手:** Record tag 管理、一覧フィルタ、relations モデル
+- **API（済）:** tags CRUD, entity_tags, entities `?tags=` フィルタ
+- **Admin UI（済）:** Tag CRUD (#44)
+- **Admin UI（進行中）:** Record tag attach/detach (#46)
+- **未着手:** Records 一覧フィルタ、relations モデル
 
 ## Verification
 
 ```bash
 composer check                    # 130 tests
-npm run check --prefix frontend   # 56 tests
+npm run check --prefix frontend   # 57 tests
 ```

--- a/frontend/src/entities/entity-tag/api-types.ts
+++ b/frontend/src/entities/entity-tag/api-types.ts
@@ -1,0 +1,13 @@
+export interface EntityTagDto {
+  id: number
+  slug: string
+  name: string
+}
+
+export interface EntityTagListDto {
+  items: EntityTagDto[]
+}
+
+export interface AttachEntityTagDto {
+  tag_id: number
+}

--- a/frontend/src/entities/entity-tag/index.ts
+++ b/frontend/src/entities/entity-tag/index.ts
@@ -1,0 +1,4 @@
+export type { AttachEntityTagInput, DetachEntityTagInput, EntityTag, EntityTagList } from './model'
+export { entityTagKeys } from './query-keys'
+export { useAttachEntityTag, useDetachEntityTag } from './mutations'
+export { useEntityTagList } from './queries'

--- a/frontend/src/entities/entity-tag/mapper.ts
+++ b/frontend/src/entities/entity-tag/mapper.ts
@@ -1,0 +1,23 @@
+import { toTagId } from '@/entities/tag'
+import type { EntityTagDto, EntityTagListDto } from './api-types'
+import type { AttachEntityTagInput, EntityTag, EntityTagList } from './model'
+
+export function mapEntityTagDtoToModel(dto: EntityTagDto): EntityTag {
+  return {
+    id: toTagId(dto.id),
+    slug: dto.slug,
+    name: dto.name,
+  }
+}
+
+export function mapEntityTagListDtoToModel(dto: EntityTagListDto): EntityTagList {
+  return {
+    items: dto.items.map(mapEntityTagDtoToModel),
+  }
+}
+
+export function mapAttachInputToDto(input: AttachEntityTagInput): { tag_id: number } {
+  return {
+    tag_id: Number(input.tagId),
+  }
+}

--- a/frontend/src/entities/entity-tag/model.ts
+++ b/frontend/src/entities/entity-tag/model.ts
@@ -1,0 +1,21 @@
+import type { TagId } from '@/entities/tag'
+
+export interface EntityTag {
+  id: TagId
+  slug: string
+  name: string
+}
+
+export interface EntityTagList {
+  items: EntityTag[]
+}
+
+export interface AttachEntityTagInput {
+  entityId: number
+  tagId: TagId
+}
+
+export interface DetachEntityTagInput {
+  entityId: number
+  tagId: TagId
+}

--- a/frontend/src/entities/entity-tag/mutations.ts
+++ b/frontend/src/entities/entity-tag/mutations.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { EntityTagDto } from './api-types'
+import { mapAttachInputToDto, mapEntityTagDtoToModel } from './mapper'
+import type { AttachEntityTagInput, DetachEntityTagInput, EntityTag } from './model'
+import { entityTagKeys } from './query-keys'
+
+export function useAttachEntityTag(): UseMutationResult<EntityTag, AppError, AttachEntityTagInput> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input) => {
+      const dto = await apiClient.post<EntityTagDto>(
+        `/api/v1/entities/${String(input.entityId)}/tags`,
+        mapAttachInputToDto(input),
+      )
+      return mapEntityTagDtoToModel(dto)
+    },
+    onSuccess: async (_data, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: entityTagKeys.list(variables.entityId),
+      })
+    },
+  })
+}
+
+export function useDetachEntityTag(): UseMutationResult<void, AppError, DetachEntityTagInput> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input) => {
+      await apiClient.delete(
+        `/api/v1/entities/${String(input.entityId)}/tags/${String(input.tagId)}`,
+      )
+    },
+    onSuccess: async (_data, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: entityTagKeys.list(variables.entityId),
+      })
+    },
+  })
+}

--- a/frontend/src/entities/entity-tag/queries.ts
+++ b/frontend/src/entities/entity-tag/queries.ts
@@ -1,0 +1,23 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { EntityTagListDto } from './api-types'
+import { mapEntityTagListDtoToModel } from './mapper'
+import type { EntityTagList } from './model'
+import { entityTagKeys } from './query-keys'
+
+export function useEntityTagList(
+  entityId: number,
+  options?: { enabled?: boolean },
+): UseQueryResult<EntityTagList, AppError> {
+  return useQuery({
+    queryKey: entityTagKeys.list(entityId),
+    enabled: options?.enabled ?? entityId > 0,
+    queryFn: async ({ signal }) => {
+      const dto = await apiClient.get<EntityTagListDto>(
+        `/api/v1/entities/${String(entityId)}/tags`,
+        signal,
+      )
+      return mapEntityTagListDtoToModel(dto)
+    },
+  })
+}

--- a/frontend/src/entities/entity-tag/query-keys.ts
+++ b/frontend/src/entities/entity-tag/query-keys.ts
@@ -1,0 +1,5 @@
+export const entityTagKeys = {
+  all: ['entity-tags'] as const,
+  lists: () => [...entityTagKeys.all, 'list'] as const,
+  list: (entityId: number) => [...entityTagKeys.lists(), entityId] as const,
+}

--- a/frontend/src/features/manage-entity-tags/hooks/use-manage-entity-tags-page.ts
+++ b/frontend/src/features/manage-entity-tags/hooks/use-manage-entity-tags-page.ts
@@ -1,0 +1,68 @@
+import { useCallback, useMemo, useState } from 'react'
+import {
+  useAttachEntityTag,
+  useDetachEntityTag,
+  useEntityTagList,
+  type EntityTag,
+} from '@/entities/entity-tag'
+import { useTagList, toTagId, type Tag } from '@/entities/tag'
+
+export function useManageEntityTagsPage(entityId: number) {
+  const entityTagQuery = useEntityTagList(entityId)
+  const tagListQuery = useTagList({ limit: 100, offset: 0 })
+  const attachMutation = useAttachEntityTag()
+  const detachMutation = useDetachEntityTag()
+  const [selectedTagId, setSelectedTagId] = useState('')
+
+  const attachedTags = useMemo(() => entityTagQuery.data?.items ?? [], [entityTagQuery.data?.items])
+
+  const availableTags = useMemo((): Tag[] => {
+    const attachedIds = new Set(attachedTags.map((tag) => String(tag.id)))
+    return (tagListQuery.data?.items ?? []).filter((tag) => !attachedIds.has(String(tag.id)))
+  }, [attachedTags, tagListQuery.data?.items])
+
+  const attachTag = useCallback(async () => {
+    if (selectedTagId === '') {
+      return
+    }
+
+    await attachMutation.mutateAsync({
+      entityId,
+      tagId: toTagId(Number(selectedTagId)),
+    })
+    setSelectedTagId('')
+  }, [attachMutation, entityId, selectedTagId])
+
+  const detachTag = useCallback(
+    async (tag: EntityTag) => {
+      await detachMutation.mutateAsync({
+        entityId,
+        tagId: tag.id,
+      })
+    },
+    [detachMutation, entityId],
+  )
+
+  const isLoading = entityTagQuery.isLoading || tagListQuery.isLoading
+  const isError = entityTagQuery.isError || tagListQuery.isError
+  const errorTitle = entityTagQuery.error?.title ?? tagListQuery.error?.title ?? null
+
+  return {
+    attachedTags,
+    availableTags,
+    selectedTagId,
+    setSelectedTagId,
+    isLoading,
+    isError,
+    errorTitle,
+    isAttaching: attachMutation.isPending,
+    attachErrorTitle: attachMutation.error?.title ?? null,
+    isDetaching: detachMutation.isPending,
+    detachErrorTitle: detachMutation.error?.title ?? null,
+    attachTag,
+    detachTag,
+    refetch: async () => {
+      await Promise.all([entityTagQuery.refetch(), tagListQuery.refetch()])
+    },
+  }
+}

--- a/frontend/src/features/manage-entity-tags/index.ts
+++ b/frontend/src/features/manage-entity-tags/index.ts
@@ -1,0 +1,3 @@
+export { useManageEntityTagsPage } from './hooks/use-manage-entity-tags-page'
+export { ManageEntityTagsView } from './ui/ManageEntityTagsView'
+export type { ManageEntityTagsViewProps } from './ui/ManageEntityTagsView'

--- a/frontend/src/features/manage-entity-tags/ui/ManageEntityTagsView.tsx
+++ b/frontend/src/features/manage-entity-tags/ui/ManageEntityTagsView.tsx
@@ -1,0 +1,128 @@
+import type { EntityTag } from '@/entities/entity-tag'
+import type { Tag } from '@/entities/tag'
+import { Button, Stack, Text } from '@/shared/ui'
+
+export interface ManageEntityTagsViewProps {
+  attachedTags: EntityTag[]
+  availableTags: Tag[]
+  selectedTagId: string
+  isLoading: boolean
+  isError: boolean
+  errorTitle: string | null
+  isAttaching: boolean
+  attachErrorTitle: string | null
+  isDetaching: boolean
+  onSelectedTagIdChange: (value: string) => void
+  onRetry: () => void
+  onAttach: () => Promise<void>
+  onDetach: (tag: EntityTag) => Promise<void>
+}
+
+export function ManageEntityTagsView({
+  attachedTags,
+  availableTags,
+  selectedTagId,
+  isLoading,
+  isError,
+  errorTitle,
+  isAttaching,
+  attachErrorTitle,
+  isDetaching,
+  onSelectedTagIdChange,
+  onRetry,
+  onAttach,
+  onDetach,
+}: ManageEntityTagsViewProps) {
+  if (isLoading) {
+    return <Text muted>Loading tags…</Text>
+  }
+
+  if (isError) {
+    return (
+      <Stack gap="sm">
+        <Text variant="heading-sm">Could not load tags</Text>
+        <Text muted>{errorTitle ?? 'Unknown error'}</Text>
+        <Button variant="secondary" onClick={onRetry}>
+          Retry
+        </Button>
+      </Stack>
+    )
+  }
+
+  return (
+    <Stack gap="md">
+      <Text as="h2" variant="heading-sm">
+        Tags
+      </Text>
+      {attachedTags.length === 0 ? (
+        <Text muted>No tags attached yet.</Text>
+      ) : (
+        <ul className="flex flex-col gap-stack-sm">
+          {attachedTags.map((tag) => (
+            <li
+              key={String(tag.id)}
+              className="flex items-center justify-between gap-inline-md rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm shadow-sm"
+            >
+              <Stack gap="xs">
+                <Text as="span" variant="heading-sm">
+                  {tag.name}
+                </Text>
+                <Text as="span" muted>
+                  {tag.slug}
+                </Text>
+              </Stack>
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={isDetaching}
+                onClick={() => {
+                  void onDetach(tag)
+                }}
+              >
+                Remove
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <Stack gap="sm">
+        <div className="flex flex-col gap-stack-xs">
+          <label
+            htmlFor="entity-tag-select"
+            className="font-sans text-body font-medium text-text-primary"
+          >
+            Add tag
+          </label>
+          <select
+            id="entity-tag-select"
+            disabled={isAttaching || availableTags.length === 0}
+            value={selectedTagId}
+            onChange={(event) => {
+              onSelectedTagIdChange(event.target.value)
+            }}
+            className="rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm font-sans text-body text-text-primary shadow-sm focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <option value="">
+              {availableTags.length === 0 ? 'No tags available' : 'Select tag…'}
+            </option>
+            {availableTags.map((tag) => (
+              <option key={String(tag.id)} value={String(tag.id)}>
+                {tag.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        {attachErrorTitle !== null ? <Text muted>{attachErrorTitle}</Text> : null}
+        <Button
+          variant="secondary"
+          disabled={isAttaching || selectedTagId === ''}
+          onClick={() => {
+            void onAttach()
+          }}
+        >
+          {isAttaching ? 'Adding…' : 'Add tag'}
+        </Button>
+      </Stack>
+    </Stack>
+  )
+}

--- a/frontend/src/pages/entity-record/EntityRecordPage.test.tsx
+++ b/frontend/src/pages/entity-record/EntityRecordPage.test.tsx
@@ -11,6 +11,8 @@ import { resetEnumFieldStore } from '@tests/msw/handlers/enum-field'
 import { resetFieldDefStore, seedFieldDefs } from '@tests/msw/handlers/field-def'
 import { resetIntFieldStore } from '@tests/msw/handlers/int-field'
 import { resetTextFieldStore } from '@tests/msw/handlers/text-field'
+import { resetEntityTagStore } from '@tests/msw/handlers/entity-tag'
+import { resetTagStore, seedTags } from '@tests/msw/handlers/tag'
 import { mswServer } from '@tests/msw/server'
 import { renderWithProviders } from '@tests/render/render-with-providers'
 
@@ -44,6 +46,8 @@ describe('EntityRecordPage', () => {
     resetEnumFieldStore()
     resetBoolFieldStore()
     resetDateTimeFieldStore()
+    resetTagStore()
+    resetEntityTagStore()
     cleanup()
   })
 
@@ -180,6 +184,42 @@ describe('EntityRecordPage', () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText('enabled (bool)')).toBeChecked()
+    })
+  })
+
+  it('attaches and removes tags on the record', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    seedEntities([
+      {
+        id: 1,
+        entity_type_id: 1,
+        is_deleted: false,
+        deleted_at: null,
+      },
+    ])
+    seedTags([
+      { id: 1, name: 'Featured', slug: 'featured' },
+      { id: 2, name: 'Draft', slug: 'draft' },
+    ])
+
+    const user = userEvent.setup()
+    renderEntityRecordPage()
+
+    expect(await screen.findByText('No tags attached yet.')).toBeInTheDocument()
+
+    await user.selectOptions(screen.getByLabelText('Add tag'), '1')
+    await user.click(screen.getByRole('button', { name: 'Add tag' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Featured')).toBeInTheDocument()
+      expect(screen.getByText('featured')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Remove' }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument()
+      expect(screen.getByText('No tags attached yet.')).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/pages/entity-record/EntityRecordPage.tsx
+++ b/frontend/src/pages/entity-record/EntityRecordPage.tsx
@@ -4,6 +4,7 @@ import {
   EditEntityTextFieldsView,
   useEditEntityTextFieldsPage,
 } from '@/features/edit-entity-text-fields'
+import { ManageEntityTagsView, useManageEntityTagsPage } from '@/features/manage-entity-tags'
 import { Button, Stack, Text } from '@/shared/ui'
 
 export function EntityRecordPage() {
@@ -24,6 +25,22 @@ export function EntityRecordPage() {
     isSaving,
     saveErrorTitle,
   } = useEditEntityTextFieldsPage(entityTypeId, entityId)
+
+  const {
+    attachedTags,
+    availableTags,
+    selectedTagId,
+    setSelectedTagId,
+    isLoading: isTagsLoading,
+    isError: isTagsError,
+    errorTitle: tagsErrorTitle,
+    isAttaching,
+    attachErrorTitle,
+    isDetaching,
+    attachTag,
+    detachTag,
+    refetch: refetchTags,
+  } = useManageEntityTagsPage(entityId)
 
   return (
     <Stack gap="md">
@@ -50,6 +67,23 @@ export function EntityRecordPage() {
           void refetch()
         }}
         onSave={saveTextFields}
+      />
+      <ManageEntityTagsView
+        attachedTags={attachedTags}
+        availableTags={availableTags}
+        selectedTagId={selectedTagId}
+        isLoading={isTagsLoading}
+        isError={isTagsError}
+        errorTitle={tagsErrorTitle}
+        isAttaching={isAttaching}
+        attachErrorTitle={attachErrorTitle}
+        isDetaching={isDetaching}
+        onSelectedTagIdChange={setSelectedTagId}
+        onRetry={() => {
+          void refetchTags()
+        }}
+        onAttach={attachTag}
+        onDetach={detachTag}
       />
     </Stack>
   )

--- a/frontend/tests/msw/handlers/entity-tag.ts
+++ b/frontend/tests/msw/handlers/entity-tag.ts
@@ -1,0 +1,129 @@
+import { http, HttpResponse } from 'msw'
+import { getActiveEntities } from './entity'
+import { getTagById } from './tag'
+
+interface EntityTagLink {
+  entity_id: number
+  tag_id: number
+}
+
+let links: EntityTagLink[] = []
+
+export function resetEntityTagStore(): void {
+  links = []
+}
+
+export function seedEntityTags(seed: EntityTagLink[]): void {
+  links = [...seed]
+}
+
+export const entityTagHandlers = [
+  http.get('/api/v1/entities/:entityId/tags', ({ params }) => {
+    const entityId = Number(params.entityId)
+    const entity = getActiveEntities().find((item) => item.id === entityId)
+
+    if (entity === undefined) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/not-found',
+          title: 'Not found',
+          status: 404,
+          instance: `/api/v1/entities/${String(entityId)}/tags`,
+        },
+        { status: 404 },
+      )
+    }
+
+    const items = links
+      .filter((link) => link.entity_id === entityId)
+      .map((link) => getTagById(link.tag_id))
+      .filter((tag) => tag !== undefined)
+
+    return HttpResponse.json({ items })
+  }),
+  http.post('/api/v1/entities/:entityId/tags', async ({ params, request }) => {
+    const entityId = Number(params.entityId)
+    const entity = getActiveEntities().find((item) => item.id === entityId)
+
+    if (entity === undefined) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/not-found',
+          title: 'Not found',
+          status: 404,
+          instance: `/api/v1/entities/${String(entityId)}/tags`,
+        },
+        { status: 404 },
+      )
+    }
+
+    const body = (await request.json()) as { tag_id?: number }
+    const tagId = body.tag_id
+
+    if (typeof tagId !== 'number' || tagId < 1) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/validation-failed',
+          title: 'Validation failed',
+          status: 422,
+          instance: `/api/v1/entities/${String(entityId)}/tags`,
+          errors: [{ field: 'tag_id', message: 'Required', code: 'required' }],
+        },
+        { status: 422 },
+      )
+    }
+
+    const tag = getTagById(tagId)
+
+    if (tag === undefined) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/not-found',
+          title: 'Not found',
+          status: 404,
+          instance: `/api/v1/tags/${String(tagId)}`,
+        },
+        { status: 404 },
+      )
+    }
+
+    const exists = links.some((link) => link.entity_id === entityId && link.tag_id === tagId)
+
+    if (exists) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/conflict',
+          title: 'Conflict',
+          status: 409,
+          instance: `/api/v1/entities/${String(entityId)}/tags`,
+        },
+        { status: 409 },
+      )
+    }
+
+    links = [...links, { entity_id: entityId, tag_id: tagId }]
+
+    return HttpResponse.json(tag, { status: 201 })
+  }),
+  http.delete('/api/v1/entities/:entityId/tags/:tagId', ({ params }) => {
+    const entityId = Number(params.entityId)
+    const tagId = Number(params.tagId)
+    const index = links.findIndex((link) => link.entity_id === entityId && link.tag_id === tagId)
+
+    if (index === -1) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/not-found',
+          title: 'Not found',
+          status: 404,
+          instance: `/api/v1/entities/${String(entityId)}/tags/${String(tagId)}`,
+        },
+        { status: 404 },
+      )
+    }
+
+    links = links.filter((_link, linkIndex) => linkIndex !== index)
+
+    return new HttpResponse(null, { status: 204 })
+  }),
+]

--- a/frontend/tests/msw/handlers/tag.ts
+++ b/frontend/tests/msw/handlers/tag.ts
@@ -19,6 +19,10 @@ export function seedTags(seed: TagRecord[]): void {
   nextId = Math.max(0, ...seed.map((item) => item.id)) + 1
 }
 
+export function getTagById(id: number): TagRecord | undefined {
+  return items.find((item) => item.id === id)
+}
+
 export const tagHandlers = [
   http.get('/api/v1/tags', ({ request }) => {
     const url = new URL(request.url)

--- a/frontend/tests/msw/server.ts
+++ b/frontend/tests/msw/server.ts
@@ -1,6 +1,7 @@
 import { setupServer } from 'msw/node'
 import { boolFieldHandlers } from './handlers/bool-field'
 import { dateTimeFieldHandlers } from './handlers/datetime-field'
+import { entityTagHandlers } from './handlers/entity-tag'
 import { entityHandlers } from './handlers/entity'
 import { entityTypeHandlers } from './handlers/entity-type'
 import { enumFieldHandlers } from './handlers/enum-field'
@@ -12,6 +13,7 @@ import { textFieldHandlers } from './handlers/text-field'
 export const mswServer = setupServer(
   ...entityTypeHandlers,
   ...entityHandlers,
+  ...entityTagHandlers,
   ...fieldDefHandlers,
   ...textFieldHandlers,
   ...intFieldHandlers,


### PR DESCRIPTION
## Summary

- `entities/entity-tag` — list / attach / detach mutations
- Record 詳細（`/entity-types/:id/entities/:entityId`）に Tags セクション追加
- 付与済み tag 一覧 + select から attach + Remove で detach
- MSW entity-tag handlers + page テスト

## Test plan

- [x] `npm run check --prefix frontend` — 57 tests green
- [x] Record 詳細で tag を Add → Remove

Closes #46

使用チェックリスト: frontend-self-review

Made with [Cursor](https://cursor.com)