### PR TITLE
feat(frontend): Records 一覧に tag フィルタ UI を追加 (#48)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,19 +6,19 @@ Last updated: 2026-05-24
 
 | Issue | Summary |
 | --- | --- |
-| TBD | Records 一覧 tag フィルタ UI |
 | TBD | entity-to-entity relations（要設計） |
 
 ## In Progress
 
 | Issue | Summary |
 | --- | --- |
-| #46 | Record への tag attach/detach UI |
+| #48 | Records 一覧 tag フィルタ UI |
 
 ## Recently Completed
 
 | Issue | Summary |
 | --- | --- |
+| #46 | Record tag attach/detach UI (PR #47) |
 | #44 | Tag CRUD Admin UI (PR #45) |
 | #42 | text-fields entity_type_id フィルタ (PR #43) |
 | #40 | field_def 編集 UI (PR #41) |
@@ -27,13 +27,13 @@ Last updated: 2026-05-24
 ## Phase 3 Tags / Query
 
 - **API（済）:** tags CRUD, entity_tags, entities `?tags=` フィルタ
-- **Admin UI（済）:** Tag CRUD (#44)
-- **Admin UI（進行中）:** Record tag attach/detach (#46)
-- **未着手:** Records 一覧フィルタ、relations モデル
+- **Admin UI（済）:** Tag CRUD (#44), Record tag attach/detach (#46)
+- **Admin UI（進行中）:** Records 一覧 tag フィルタ (#48)
+- **未着手:** relations モデル
 
 ## Verification
 
 ```bash
 composer check                    # 130 tests
-npm run check --prefix frontend   # 57 tests
+npm run check --prefix frontend   # 59 tests
 ```

--- a/frontend/src/entities/entity/queries.ts
+++ b/frontend/src/entities/entity/queries.ts
@@ -21,6 +21,9 @@ export function useEntityList(
         offset: String(params.offset),
         entity_type_id: String(params.entityTypeId),
       })
+      if (params.tagSlugs !== undefined && params.tagSlugs.length > 0) {
+        search.set('tags', params.tagSlugs.join(','))
+      }
       const dto = await apiClient.get<EntityListDto>(
         `/api/v1/entities?${search.toString()}`,
         signal,
@@ -40,9 +43,13 @@ export function useEntity(id: EntityId): UseQueryResult<Entity, AppError> {
   })
 }
 
-export function defaultEntityListParams(entityTypeId: number): EntityListParams {
+export function defaultEntityListParams(
+  entityTypeId: number,
+  tagSlugs: string[] = [],
+): EntityListParams {
   return {
     entityTypeId,
+    tagSlugs,
     ...DEFAULT_LIST_PARAMS,
   }
 }

--- a/frontend/src/entities/entity/query-keys.ts
+++ b/frontend/src/entities/entity/query-keys.ts
@@ -4,6 +4,7 @@ export interface EntityListParams {
   entityTypeId: number
   limit: number
   offset: number
+  tagSlugs?: string[]
 }
 
 export const entityKeys = {

--- a/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
+++ b/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
@@ -7,12 +7,18 @@ import {
   type Entity,
   type EntityId,
 } from '@/entities/entity'
+import { useTagList } from '@/entities/tag'
 import { defaultTextFieldListParamsForEntityType, useTextFieldList } from '@/entities/text-field'
 import { getRecordDisplayLabel } from '@/shared/lib/get-record-display-label'
 
 export function useManageEntitiesPage(entityTypeId: number) {
-  const listParams = defaultEntityListParams(entityTypeId)
+  const [selectedTagSlugs, setSelectedTagSlugs] = useState<string[]>([])
+  const listParams = useMemo(
+    () => defaultEntityListParams(entityTypeId, selectedTagSlugs),
+    [entityTypeId, selectedTagSlugs],
+  )
   const listQuery = useEntityList(listParams)
+  const tagListQuery = useTagList({ limit: 100, offset: 0 })
   const textFieldQuery = useTextFieldList(defaultTextFieldListParamsForEntityType(entityTypeId))
   const createMutation = useCreateEntity()
   const deleteMutation = useDeleteEntity()
@@ -30,6 +36,16 @@ export function useManageEntitiesPage(entityTypeId: number) {
       ]),
     )
   }, [items, textFieldQuery.data?.items])
+
+  const toggleTagSlug = useCallback((slug: string) => {
+    setSelectedTagSlugs((current) =>
+      current.includes(slug) ? current.filter((item) => item !== slug) : [...current, slug],
+    )
+  }, [])
+
+  const clearTagFilter = useCallback(() => {
+    setSelectedTagSlugs([])
+  }, [])
 
   const createEntity = useCallback(async () => {
     await createMutation.mutateAsync({ entityTypeId })
@@ -61,11 +77,16 @@ export function useManageEntitiesPage(entityTypeId: number) {
     items,
     recordLabels,
     total: listQuery.data?.total ?? 0,
+    availableTags: tagListQuery.data?.items ?? [],
+    selectedTagSlugs,
+    toggleTagSlug,
+    clearTagFilter,
+    isFilterActive: selectedTagSlugs.length > 0,
     isLoading,
     isError,
     errorTitle,
     refetch: async () => {
-      await Promise.all([listQuery.refetch(), textFieldQuery.refetch()])
+      await Promise.all([listQuery.refetch(), textFieldQuery.refetch(), tagListQuery.refetch()])
     },
     createEntity,
     isCreating: createMutation.isPending,

--- a/frontend/src/features/manage-entities/ui/EntityListPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityListPanel.tsx
@@ -10,6 +10,7 @@ export interface EntityListPanelProps {
   isError: boolean
   errorTitle: string | null
   isDeleting: boolean
+  isFilterActive: boolean
   onRetry: () => void
   onDelete: (entity: Entity) => void
 }
@@ -22,6 +23,7 @@ export function EntityListPanel({
   isError,
   errorTitle,
   isDeleting,
+  isFilterActive,
   onRetry,
   onDelete,
 }: EntityListPanelProps) {
@@ -44,8 +46,12 @@ export function EntityListPanel({
   if (items.length === 0) {
     return (
       <EmptyState
-        title="No records yet"
-        description="Create your first record using the button above."
+        title={isFilterActive ? 'No matching records' : 'No records yet'}
+        description={
+          isFilterActive
+            ? 'Try clearing the tag filter or selecting different tags.'
+            : 'Create your first record using the button above.'
+        }
       />
     )
   }

--- a/frontend/src/features/manage-entities/ui/EntityTagFilterPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityTagFilterPanel.tsx
@@ -1,0 +1,57 @@
+import type { Tag } from '@/entities/tag'
+import { Button, Stack, Text } from '@/shared/ui'
+
+export interface EntityTagFilterPanelProps {
+  tags: Tag[]
+  selectedTagSlugs: string[]
+  onToggleTagSlug: (slug: string) => void
+  onClear: () => void
+}
+
+export function EntityTagFilterPanel({
+  tags,
+  selectedTagSlugs,
+  onToggleTagSlug,
+  onClear,
+}: EntityTagFilterPanelProps) {
+  if (tags.length === 0) {
+    return null
+  }
+
+  return (
+    <Stack gap="sm">
+      <Stack direction="horizontal" gap="sm">
+        <Text as="h2" variant="heading-sm">
+          Filter by tag
+        </Text>
+        {selectedTagSlugs.length > 0 ? (
+          <Button variant="secondary" size="sm" onClick={onClear}>
+            Clear
+          </Button>
+        ) : null}
+      </Stack>
+      <div className="flex flex-wrap gap-inline-sm">
+        {tags.map((tag) => {
+          const isSelected = selectedTagSlugs.includes(tag.slug)
+
+          return (
+            <Button
+              key={String(tag.id)}
+              variant={isSelected ? 'primary' : 'secondary'}
+              size="sm"
+              aria-pressed={isSelected}
+              onClick={() => {
+                onToggleTagSlug(tag.slug)
+              }}
+            >
+              {tag.name}
+            </Button>
+          )
+        })}
+      </div>
+      {selectedTagSlugs.length > 0 ? (
+        <Text muted>Showing records with any selected tag.</Text>
+      ) : null}
+    </Stack>
+  )
+}

--- a/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
+++ b/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
@@ -1,7 +1,9 @@
 import type { Entity } from '@/entities/entity'
+import type { Tag } from '@/entities/tag'
 import { ConfirmDialog, Stack, Text } from '@/shared/ui'
 import { EntityCreatePanel } from './EntityCreatePanel'
 import { EntityListPanel } from './EntityListPanel'
+import { EntityTagFilterPanel } from './EntityTagFilterPanel'
 
 export interface ManageEntitiesViewProps {
   entityTypeId: number
@@ -10,6 +12,9 @@ export interface ManageEntitiesViewProps {
   items: Entity[]
   recordLabels: Record<string, string>
   total: number
+  availableTags: Tag[]
+  selectedTagSlugs: string[]
+  isFilterActive: boolean
   isLoading: boolean
   isError: boolean
   errorTitle: string | null
@@ -18,6 +23,8 @@ export interface ManageEntitiesViewProps {
   deleteTarget: Entity | null
   isDeleting: boolean
   onRetry: () => void
+  onToggleTagSlug: (slug: string) => void
+  onClearTagFilter: () => void
   onCreate: () => Promise<void>
   onRequestDelete: (entity: Entity) => void
   onCancelDelete: () => void
@@ -31,6 +38,9 @@ export function ManageEntitiesView({
   items,
   recordLabels,
   total,
+  availableTags,
+  selectedTagSlugs,
+  isFilterActive,
   isLoading,
   isError,
   errorTitle,
@@ -39,6 +49,8 @@ export function ManageEntitiesView({
   deleteTarget,
   isDeleting,
   onRetry,
+  onToggleTagSlug,
+  onClearTagFilter,
   onCreate,
   onRequestDelete,
   onCancelDelete,
@@ -60,6 +72,12 @@ export function ManageEntitiesView({
           serverErrorTitle={createErrorTitle}
           onCreate={onCreate}
         />
+        <EntityTagFilterPanel
+          tags={availableTags}
+          selectedTagSlugs={selectedTagSlugs}
+          onToggleTagSlug={onToggleTagSlug}
+          onClear={onClearTagFilter}
+        />
         <Stack gap="sm">
           <Text as="h2" variant="heading-sm">
             {entityTypeName !== null ? `${entityTypeName} records` : 'Records'}
@@ -72,6 +90,7 @@ export function ManageEntitiesView({
             isError={isError}
             errorTitle={errorTitle}
             isDeleting={isDeleting}
+            isFilterActive={isFilterActive}
             onRetry={onRetry}
             onDelete={onRequestDelete}
           />

--- a/frontend/src/pages/entity-records/EntityRecordsPage.test.tsx
+++ b/frontend/src/pages/entity-records/EntityRecordsPage.test.tsx
@@ -5,7 +5,9 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { EntityRecordsPage } from '@/pages/entity-records/EntityRecordsPage'
 import { EntityTypesPage } from '@/pages/entity-types/EntityTypesPage'
 import { resetEntityStore, seedEntities } from '@tests/msw/handlers/entity'
+import { resetEntityTagStore, seedEntityTags } from '@tests/msw/handlers/entity-tag'
 import { resetEntityTypeStore, seedEntityTypes } from '@tests/msw/handlers/entity-type'
+import { resetTagStore, seedTags } from '@tests/msw/handlers/tag'
 import { resetTextFieldStore, seedTextFields } from '@tests/msw/handlers/text-field'
 import { mswServer } from '@tests/msw/server'
 import { renderWithProviders } from '@tests/render/render-with-providers'
@@ -29,6 +31,8 @@ describe('EntityRecordsPage', () => {
     mswServer.resetHandlers()
     resetEntityTypeStore()
     resetEntityStore()
+    resetEntityTagStore()
+    resetTagStore()
     resetTextFieldStore()
     cleanup()
   })
@@ -101,6 +105,61 @@ describe('EntityRecordsPage', () => {
 
     expect(await screen.findByText('My article')).toBeInTheDocument()
     expect(screen.getByText('#1')).toBeInTheDocument()
+  })
+
+  it('filters records by selected tags', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    seedTags([
+      { id: 1, name: 'Featured', slug: 'featured' },
+      { id: 2, name: 'Draft', slug: 'draft' },
+    ])
+    seedEntities([
+      { id: 1, entity_type_id: 1, is_deleted: false, deleted_at: null },
+      { id: 2, entity_type_id: 1, is_deleted: false, deleted_at: null },
+    ])
+    seedEntityTags([
+      { entity_id: 1, tag_id: 1 },
+      { entity_id: 2, tag_id: 2 },
+    ])
+
+    const user = userEvent.setup()
+    renderRecordsPage()
+
+    expect(await screen.findByText('Record #1')).toBeInTheDocument()
+    expect(screen.getByText('Record #2')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Featured' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Record #1')).toBeInTheDocument()
+      expect(screen.queryByText('Record #2')).not.toBeInTheDocument()
+      expect(screen.getByText('1 record')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Clear' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Record #1')).toBeInTheDocument()
+      expect(screen.getByText('Record #2')).toBeInTheDocument()
+      expect(screen.getByText('2 records')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no records match the tag filter', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    seedTags([{ id: 1, name: 'Featured', slug: 'featured' }])
+    seedEntities([{ id: 1, entity_type_id: 1, is_deleted: false, deleted_at: null }])
+
+    const user = userEvent.setup()
+    renderRecordsPage()
+
+    expect(await screen.findByText('Record #1')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Featured' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('No matching records')).toBeInTheDocument()
+    })
   })
 
   it('links from entity types page to records', async () => {

--- a/frontend/src/pages/entity-records/EntityRecordsPage.tsx
+++ b/frontend/src/pages/entity-records/EntityRecordsPage.tsx
@@ -12,6 +12,9 @@ export function EntityRecordsPage() {
     items,
     recordLabels,
     total,
+    availableTags,
+    selectedTagSlugs,
+    isFilterActive,
     isLoading,
     isError,
     errorTitle,
@@ -19,6 +22,8 @@ export function EntityRecordsPage() {
     createEntity,
     isCreating,
     createErrorTitle,
+    toggleTagSlug,
+    clearTagFilter,
     deleteTarget,
     requestDelete,
     cancelDelete,
@@ -45,6 +50,9 @@ export function EntityRecordsPage() {
         items={items}
         recordLabels={recordLabels}
         total={total}
+        availableTags={availableTags}
+        selectedTagSlugs={selectedTagSlugs}
+        isFilterActive={isFilterActive}
         isLoading={isLoading}
         isError={isError}
         errorTitle={errorTitle}
@@ -55,6 +63,8 @@ export function EntityRecordsPage() {
         onRetry={() => {
           void refetch()
         }}
+        onToggleTagSlug={toggleTagSlug}
+        onClearTagFilter={clearTagFilter}
         onCreate={createEntity}
         onRequestDelete={requestDelete}
         onCancelDelete={cancelDelete}

--- a/frontend/tests/msw/handlers/entity-tag.ts
+++ b/frontend/tests/msw/handlers/entity-tag.ts
@@ -17,6 +17,10 @@ export function seedEntityTags(seed: EntityTagLink[]): void {
   links = [...seed]
 }
 
+export function getEntityTagLinks(): EntityTagLink[] {
+  return links
+}
+
 export const entityTagHandlers = [
   http.get('/api/v1/entities/:entityId/tags', ({ params }) => {
     const entityId = Number(params.entityId)

--- a/frontend/tests/msw/handlers/entity.ts
+++ b/frontend/tests/msw/handlers/entity.ts
@@ -1,4 +1,6 @@
 import { http, HttpResponse } from 'msw'
+import { getEntityTagLinks } from './entity-tag'
+import { getTagBySlug } from './tag'
 
 interface EntityRecord {
   id: number
@@ -24,6 +26,21 @@ export function getActiveEntities(): EntityRecord[] {
   return items.filter((item) => !item.is_deleted)
 }
 
+function getEntityIdsMatchingTagSlugs(slugs: string[]): Set<number> {
+  const tagIds = new Set(
+    slugs.map((slug) => getTagBySlug(slug)?.id).filter((id): id is number => id !== undefined),
+  )
+  const entityIds = new Set<number>()
+
+  for (const link of getEntityTagLinks()) {
+    if (tagIds.has(link.tag_id)) {
+      entityIds.add(link.entity_id)
+    }
+  }
+
+  return entityIds
+}
+
 export const entityHandlers = [
   http.get('/api/v1/entities', ({ request }) => {
     const url = new URL(request.url)
@@ -31,10 +48,23 @@ export const entityHandlers = [
     const offset = Number(url.searchParams.get('offset') ?? '0')
     const entityTypeIdParam = url.searchParams.get('entity_type_id')
     const entityTypeId = entityTypeIdParam === null ? null : Number(entityTypeIdParam)
+    const tagsParam = url.searchParams.get('tags')
+    const tagSlugs =
+      tagsParam === null
+        ? []
+        : tagsParam
+            .split(',')
+            .map((slug) => slug.trim())
+            .filter((slug) => slug.length > 0)
 
     const active = items.filter((item) => !item.is_deleted)
-    const filtered =
+    let filtered =
       entityTypeId === null ? active : active.filter((item) => item.entity_type_id === entityTypeId)
+
+    if (tagSlugs.length > 0) {
+      const matchingEntityIds = getEntityIdsMatchingTagSlugs(tagSlugs)
+      filtered = filtered.filter((item) => matchingEntityIds.has(item.id))
+    }
 
     return HttpResponse.json({
       items: filtered.slice(offset, offset + limit),

--- a/frontend/tests/msw/handlers/tag.ts
+++ b/frontend/tests/msw/handlers/tag.ts
@@ -23,6 +23,10 @@ export function getTagById(id: number): TagRecord | undefined {
   return items.find((item) => item.id === id)
 }
 
+export function getTagBySlug(slug: string): TagRecord | undefined {
+  return items.find((item) => item.slug === slug)
+}
+
 export const tagHandlers = [
   http.get('/api/v1/tags', ({ request }) => {
     const url = new URL(request.url)


### PR DESCRIPTION
## Summary

- Records 一覧（`/entity-types/:entityTypeId/entities`）に tag フィルタパネルを追加
- 複数 tag をトグル選択し、API の `?tags=slug1,slug2`（OR セマンティクス）で一覧を絞り込み
- フィルタ active 時の empty state（「No matching records」）を表示
- MSW entity handler に tags クエリフィルタ、page テスト 2 件を追加

## Test plan

- [x] `npm run check --prefix frontend` — 59 tests passed
- [ ] Records 一覧で tag を選択 → 該当 record のみ表示
- [ ] Clear でフィルタ解除
- [ ] tag 未付与 record のみの場合、フィルタ選択で empty state

Closes #48

セルフレビュー: frontend-standards checklist


Made with [Cursor](https://cursor.com)