### PR TITLE
feat: entity relations API と field_defs relation 型を追加 (#51)

### DIFF
--- a/database/migrations/20260524000010_alter_field_defs_add_relation_columns.php
+++ b/database/migrations/20260524000010_alter_field_defs_add_relation_columns.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AlterFieldDefsAddRelationColumns extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('field_defs')
+            ->addColumn('target_entity_type_id', 'integer', ['null' => true, 'signed' => false, 'after' => 'data_type'])
+            ->addColumn('cardinality', 'string', ['null' => true, 'limit' => 16, 'after' => 'target_entity_type_id'])
+            ->addForeignKey('target_entity_type_id', 'entity_types', 'id', ['delete' => 'RESTRICT', 'update' => 'NO_ACTION'])
+            ->update();
+    }
+}

--- a/database/migrations/20260524000011_create_entity_relations_table.php
+++ b/database/migrations/20260524000011_create_entity_relations_table.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateEntityRelationsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('entity_relations')
+            ->addColumn('source_entity_id', 'integer', ['null' => false])
+            ->addColumn('target_entity_id', 'integer', ['null' => false])
+            ->addColumn('field_key', 'string', ['null' => false])
+            ->addIndex(['source_entity_id', 'field_key'])
+            ->addIndex(['source_entity_id', 'target_entity_id', 'field_key'], ['unique' => true])
+            ->addForeignKey('source_entity_id', 'entities', 'id', ['delete' => 'CASCADE', 'update' => 'NO_ACTION'])
+            ->addForeignKey('target_entity_id', 'entities', 'id', ['delete' => 'CASCADE', 'update' => 'NO_ACTION'])
+            ->create();
+    }
+}

--- a/database/schema/entity_relations.sql
+++ b/database/schema/entity_relations.sql
@@ -1,0 +1,10 @@
+CREATE TABLE entity_relations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_entity_id INTEGER NOT NULL,
+    target_entity_id INTEGER NOT NULL,
+    field_key TEXT NOT NULL,
+    FOREIGN KEY (source_entity_id) REFERENCES entities (id) ON DELETE CASCADE ON UPDATE NO ACTION,
+    FOREIGN KEY (target_entity_id) REFERENCES entities (id) ON DELETE CASCADE ON UPDATE NO ACTION
+);
+CREATE INDEX entity_relations_source_entity_id_field_key ON entity_relations (source_entity_id, field_key);
+CREATE UNIQUE INDEX entity_relations_source_target_field_key ON entity_relations (source_entity_id, target_entity_id, field_key);

--- a/database/schema/field_defs.sql
+++ b/database/schema/field_defs.sql
@@ -3,9 +3,12 @@ CREATE TABLE field_defs (
     entity_type_id INTEGER NOT NULL,
     field_key TEXT NOT NULL,
     data_type TEXT NOT NULL,
+    target_entity_type_id INTEGER NULL,
+    cardinality TEXT NULL,
     is_deleted BOOLEAN NOT NULL DEFAULT 0,
     deleted_at DATETIME NULL,
-    FOREIGN KEY (entity_type_id) REFERENCES entity_types (id) ON DELETE RESTRICT ON UPDATE NO ACTION
+    FOREIGN KEY (entity_type_id) REFERENCES entity_types (id) ON DELETE RESTRICT ON UPDATE NO ACTION,
+    FOREIGN KEY (target_entity_type_id) REFERENCES entity_types (id) ON DELETE RESTRICT ON UPDATE NO ACTION
 );
 CREATE INDEX field_defs_entity_type_id ON field_defs (entity_type_id);
 CREATE UNIQUE INDEX field_defs_entity_type_id_field_key_active ON field_defs (entity_type_id, field_key) WHERE is_deleted = 0;

--- a/docs/adr/0004-entity-relations.md
+++ b/docs/adr/0004-entity-relations.md
@@ -75,7 +75,7 @@ On attach:
 4. Target entity exists and is not soft-deleted.
 5. `target.entity_type_id === field_def.target_entity_type_id`.
 6. Duplicate `(source, target, field_key)` → **409**.
-7. `cardinality === 'one'` and a link already exists for `(source, field_key)` → replace existing target or **409** (pick one in implementation; document in OpenAPI).
+7. `cardinality === 'one'` and a link already exists for `(source, field_key)` → **replace** the existing target (same field, new target).
 
 Self-reference and cycles are **not** blocked in Phase 3a.
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: NeNe Records API
   version: 0.1.0
   description: >
-    NeNe Records public API contract — entity_types, field_defs, entities, tags, entity_tags, text_fields, int_fields, enum_fields, bool_fields, and datetime_fields CRUD (MVP + Phase 2 registry + Phase 3 tags).
+    NeNe Records public API contract — entity_types, field_defs, entities, tags, entity_tags, entity_relations, text_fields, int_fields, enum_fields, bool_fields, and datetime_fields CRUD (MVP + Phase 2 registry + Phase 3 tags/relations).
 servers:
   - url: http://localhost:8080
     description: Local development server
@@ -30,6 +30,8 @@ tags:
     description: Tag definitions for entity classification.
   - name: EntityTags
     description: Tags attached to entity instances.
+  - name: EntityRelations
+    description: Typed relation links between entity instances.
 paths:
   /health:
     get:
@@ -415,6 +417,100 @@ paths:
           description: Tag detached.
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/entities/{entityId}/relations:
+    get:
+      tags:
+        - EntityRelations
+      summary: List relations attached to entity
+      operationId: listEntityRelations
+      parameters:
+        - $ref: '#/components/parameters/EntityIdPath'
+        - name: field_key
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 1
+      responses:
+        '200':
+          description: Relations for the given field key.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityRelationListResponse'
+              examples:
+                ok:
+                  value:
+                    items: []
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - EntityRelations
+      summary: Attach relation target to entity
+      operationId: attachEntityRelation
+      parameters:
+        - $ref: '#/components/parameters/EntityIdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AttachEntityRelationRequest'
+            examples:
+              ok:
+                value:
+                  field_key: author
+                  target_entity_id: 2
+      responses:
+        '201':
+          description: Relation attached.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityRelationItemResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/entities/{entityId}/relations/{targetEntityId}:
+    delete:
+      tags:
+        - EntityRelations
+      summary: Detach relation target from entity
+      operationId: detachEntityRelation
+      parameters:
+        - $ref: '#/components/parameters/EntityIdPath'
+        - name: targetEntityId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+        - name: field_key
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 1
+      responses:
+        '204':
+          description: Relation detached.
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /api/v1/field-defs:
@@ -1938,6 +2034,16 @@ components:
             - enum
             - bool
             - datetime
+            - relation
+        target_entity_type_id:
+          type: integer
+          format: int64
+          minimum: 1
+        cardinality:
+          type: string
+          enum:
+            - one
+            - many
     CreateFieldDefRequest:
       type: object
       required:
@@ -1960,6 +2066,16 @@ components:
             - enum
             - bool
             - datetime
+            - relation
+        target_entity_type_id:
+          type: integer
+          format: int64
+          minimum: 1
+        cardinality:
+          type: string
+          enum:
+            - one
+            - many
       additionalProperties: false
     UpdateFieldDefRequest:
       $ref: '#/components/schemas/CreateFieldDefRequest'
@@ -1978,6 +2094,43 @@ components:
           type: integer
         offset:
           type: integer
+      additionalProperties: false
+    EntityRelationListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntityRelationItemResponse'
+    EntityRelationItemResponse:
+      type: object
+      required:
+        - field_key
+        - target_entity_id
+      properties:
+        field_key:
+          type: string
+        target_entity_id:
+          type: integer
+          format: int64
+          minimum: 1
+      additionalProperties: false
+    AttachEntityRelationRequest:
+      type: object
+      required:
+        - field_key
+        - target_entity_id
+      properties:
+        field_key:
+          type: string
+          minLength: 1
+        target_entity_id:
+          type: integer
+          format: int64
+          minimum: 1
+      additionalProperties: false
     TextFieldResponse:
       type: object
       required:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -35,6 +35,6 @@ Last updated: 2026-05-24
 ## Verification
 
 ```bash
-composer check                    # 130 tests
+composer check                    # 137 tests
 npm run check --prefix frontend   # 59 tests
 ```

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -18,6 +18,12 @@ use NeNeRecords\DateTimeField\FieldKeyNotRegisteredExceptionHandler as DateTimeF
 use NeNeRecords\DateTimeField\FieldTypeMismatchExceptionHandler as DateTimeFieldTypeMismatchExceptionHandler;
 use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
 use NeNeRecords\Entity\EntityServiceProvider;
+use NeNeRecords\EntityRelation\EntityRelationServiceProvider;
+use NeNeRecords\EntityRelation\FieldKeyNotRegisteredExceptionHandler as EntityRelationFieldKeyNotRegisteredExceptionHandler;
+use NeNeRecords\EntityRelation\FieldTypeMismatchExceptionHandler as EntityRelationFieldTypeMismatchExceptionHandler;
+use NeNeRecords\EntityRelation\RelationAlreadyAttachedExceptionHandler;
+use NeNeRecords\EntityRelation\RelationNotAttachedExceptionHandler;
+use NeNeRecords\EntityRelation\RelationTargetTypeMismatchExceptionHandler;
 use NeNeRecords\EntityTag\EntityTagAlreadyAttachedExceptionHandler;
 use NeNeRecords\EntityTag\EntityTagNotAttachedExceptionHandler;
 use NeNeRecords\EntityTag\EntityTagServiceProvider;
@@ -62,7 +68,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new BoolFieldServiceProvider())
             ->addProvider(new DateTimeFieldServiceProvider())
             ->addProvider(new TagServiceProvider())
-            ->addProvider(new EntityTagServiceProvider());
+            ->addProvider(new EntityTagServiceProvider())
+            ->addProvider(new EntityRelationServiceProvider());
 
         $builder
             ->set(
@@ -78,6 +85,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $datetimeField = $container->get('nene-records.route_registrar.datetime_field');
                     $tag = $container->get('nene-records.route_registrar.tag');
                     $entityTag = $container->get('nene-records.route_registrar.entity_tag');
+                    $entityRelation = $container->get('nene-records.route_registrar.entity_relation');
 
                     if (
                         !is_callable($entityType)
@@ -90,6 +98,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !is_callable($datetimeField)
                         || !is_callable($tag)
                         || !is_callable($entityTag)
+                        || !is_callable($entityRelation)
                     ) {
                         throw new LogicException('Route registrar service is invalid.');
                     }
@@ -105,6 +114,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $datetimeField,
                         $tag,
                         $entityTag,
+                        $entityRelation,
                     ];
                 },
             )
@@ -135,6 +145,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $tagSlugConflict = $container->get(TagSlugConflictExceptionHandler::class);
                     $entityTagAlreadyAttached = $container->get(EntityTagAlreadyAttachedExceptionHandler::class);
                     $entityTagNotAttached = $container->get(EntityTagNotAttachedExceptionHandler::class);
+                    $entityRelationFieldKeyNotRegistered = $container->get(EntityRelationFieldKeyNotRegisteredExceptionHandler::class);
+                    $entityRelationFieldTypeMismatch = $container->get(EntityRelationFieldTypeMismatchExceptionHandler::class);
+                    $relationTargetTypeMismatch = $container->get(RelationTargetTypeMismatchExceptionHandler::class);
+                    $relationAlreadyAttached = $container->get(RelationAlreadyAttachedExceptionHandler::class);
+                    $relationNotAttached = $container->get(RelationNotAttachedExceptionHandler::class);
 
                     foreach ([
                         $entityTypeNotFound,
@@ -161,6 +176,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $tagSlugConflict,
                         $entityTagAlreadyAttached,
                         $entityTagNotAttached,
+                        $entityRelationFieldKeyNotRegistered,
+                        $entityRelationFieldTypeMismatch,
+                        $relationTargetTypeMismatch,
+                        $relationAlreadyAttached,
+                        $relationNotAttached,
                     ] as $handler) {
                         if (!$handler instanceof DomainExceptionHandlerInterface) {
                             throw new LogicException('Exception handler service is invalid.');
@@ -192,6 +212,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $tagSlugConflict,
                         $entityTagAlreadyAttached,
                         $entityTagNotAttached,
+                        $entityRelationFieldKeyNotRegistered,
+                        $entityRelationFieldTypeMismatch,
+                        $relationTargetTypeMismatch,
+                        $relationAlreadyAttached,
+                        $relationNotAttached,
                     ];
                 },
             );

--- a/src/EntityRelation/AttachEntityRelationHandler.php
+++ b/src/EntityRelation/AttachEntityRelationHandler.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeNeRecords\Entity\EntityNotFoundException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class AttachEntityRelationHandler
+{
+    public function __construct(
+        private AttachEntityRelationUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $entityId = (int) ($parameters['entityId'] ?? 0);
+
+        if ($entityId <= 0) {
+            throw new EntityNotFoundException($entityId);
+        }
+
+        $body = JsonRequestBodyParser::parse($request);
+        $fieldKey = trim((string) ($body['field_key'] ?? ''));
+        $targetEntityIdRaw = $body['target_entity_id'] ?? null;
+
+        $errors = [];
+
+        if ($fieldKey === '') {
+            $errors[] = new ValidationError('field_key', 'Field key is required.', 'required');
+        }
+
+        if (!is_int($targetEntityIdRaw) && !(is_string($targetEntityIdRaw) && ctype_digit($targetEntityIdRaw))) {
+            $errors[] = new ValidationError('target_entity_id', 'Target entity id is required.', 'required');
+        } else {
+            $targetEntityId = (int) $targetEntityIdRaw;
+
+            if ($targetEntityId <= 0) {
+                $errors[] = new ValidationError('target_entity_id', 'Target entity id must be a positive integer.', 'invalid');
+            }
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $targetEntityId = (int) $targetEntityIdRaw;
+
+        $output = $this->useCase->execute(new AttachEntityRelationInput(
+            entityId: $entityId,
+            fieldKey: $fieldKey,
+            targetEntityId: $targetEntityId,
+        ));
+
+        return $this->response->create([
+            'field_key' => $output->fieldKey,
+            'target_entity_id' => $output->targetEntityId,
+        ], 201);
+    }
+}

--- a/src/EntityRelation/AttachEntityRelationInput.php
+++ b/src/EntityRelation/AttachEntityRelationInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+final readonly class AttachEntityRelationInput
+{
+    public function __construct(
+        public int $entityId,
+        public string $fieldKey,
+        public int $targetEntityId,
+    ) {
+    }
+}

--- a/src/EntityRelation/AttachEntityRelationOutput.php
+++ b/src/EntityRelation/AttachEntityRelationOutput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+final readonly class AttachEntityRelationOutput
+{
+    public function __construct(
+        public string $fieldKey,
+        public int $targetEntityId,
+    ) {
+    }
+}

--- a/src/EntityRelation/AttachEntityRelationUseCase.php
+++ b/src/EntityRelation/AttachEntityRelationUseCase.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+
+final readonly class AttachEntityRelationUseCase implements AttachEntityRelationUseCaseInterface
+{
+    public function __construct(
+        private EntityRepositoryInterface $entities,
+        private FieldDefRepositoryInterface $fieldDefs,
+        private EntityRelationRepositoryInterface $entityRelations,
+    ) {
+    }
+
+    public function execute(AttachEntityRelationInput $input): AttachEntityRelationOutput
+    {
+        $sourceEntity = $this->requireEntity($input->entityId);
+        $fieldDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($sourceEntity->entityTypeId, $input->fieldKey);
+
+        if ($fieldDef === null) {
+            throw new FieldKeyNotRegisteredException($input->fieldKey);
+        }
+
+        if ($fieldDef->dataType !== 'relation') {
+            throw new FieldTypeMismatchException($input->fieldKey, 'relation', $fieldDef->dataType);
+        }
+
+        $targetEntity = $this->requireEntity($input->targetEntityId);
+
+        if ($fieldDef->targetEntityTypeId === null || $targetEntity->entityTypeId !== $fieldDef->targetEntityTypeId) {
+            throw new RelationTargetTypeMismatchException(
+                $input->fieldKey,
+                $fieldDef->targetEntityTypeId ?? 0,
+                $targetEntity->entityTypeId,
+            );
+        }
+
+        if ($this->entityRelations->isAttached($input->entityId, $input->targetEntityId, $input->fieldKey)) {
+            throw new RelationAlreadyAttachedException($input->entityId, $input->targetEntityId, $input->fieldKey);
+        }
+
+        if ($fieldDef->cardinality === 'one') {
+            $this->entityRelations->detachAllForFieldKey($input->entityId, $input->fieldKey);
+        }
+
+        $this->entityRelations->attach($input->entityId, $input->targetEntityId, $input->fieldKey);
+
+        return new AttachEntityRelationOutput(
+            fieldKey: $input->fieldKey,
+            targetEntityId: $input->targetEntityId,
+        );
+    }
+
+    private function requireEntity(int $entityId): Entity
+    {
+        $entity = $this->entities->findById($entityId);
+
+        if ($entity === null) {
+            throw new EntityNotFoundException($entityId);
+        }
+
+        return $entity;
+    }
+}

--- a/src/EntityRelation/AttachEntityRelationUseCaseInterface.php
+++ b/src/EntityRelation/AttachEntityRelationUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+interface AttachEntityRelationUseCaseInterface
+{
+    public function execute(AttachEntityRelationInput $input): AttachEntityRelationOutput;
+}

--- a/src/EntityRelation/DetachEntityRelationHandler.php
+++ b/src/EntityRelation/DetachEntityRelationHandler.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeNeRecords\Entity\EntityNotFoundException;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DetachEntityRelationHandler
+{
+    public function __construct(
+        private DetachEntityRelationUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $entityId = (int) ($parameters['entityId'] ?? 0);
+        $targetEntityId = (int) ($parameters['targetEntityId'] ?? 0);
+
+        if ($entityId <= 0) {
+            throw new EntityNotFoundException($entityId);
+        }
+
+        if ($targetEntityId <= 0) {
+            throw new RelationNotAttachedException($entityId, $targetEntityId, '');
+        }
+
+        $fieldKey = trim((string) ($request->getQueryParams()['field_key'] ?? ''));
+
+        if ($fieldKey === '') {
+            throw new ValidationException([
+                new ValidationError('field_key', 'Field key is required.', 'required'),
+            ]);
+        }
+
+        $this->useCase->execute(new DetachEntityRelationInput($entityId, $fieldKey, $targetEntityId));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/EntityRelation/DetachEntityRelationInput.php
+++ b/src/EntityRelation/DetachEntityRelationInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+final readonly class DetachEntityRelationInput
+{
+    public function __construct(
+        public int $entityId,
+        public string $fieldKey,
+        public int $targetEntityId,
+    ) {
+    }
+}

--- a/src/EntityRelation/DetachEntityRelationUseCase.php
+++ b/src/EntityRelation/DetachEntityRelationUseCase.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+
+final readonly class DetachEntityRelationUseCase implements DetachEntityRelationUseCaseInterface
+{
+    public function __construct(
+        private EntityRepositoryInterface $entities,
+        private EntityRelationRepositoryInterface $entityRelations,
+    ) {
+    }
+
+    public function execute(DetachEntityRelationInput $input): void
+    {
+        if ($this->entities->findById($input->entityId) === null) {
+            throw new EntityNotFoundException($input->entityId);
+        }
+
+        if (!$this->entityRelations->isAttached($input->entityId, $input->targetEntityId, $input->fieldKey)) {
+            throw new RelationNotAttachedException($input->entityId, $input->targetEntityId, $input->fieldKey);
+        }
+
+        $this->entityRelations->detach($input->entityId, $input->targetEntityId, $input->fieldKey);
+    }
+}

--- a/src/EntityRelation/DetachEntityRelationUseCaseInterface.php
+++ b/src/EntityRelation/DetachEntityRelationUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+interface DetachEntityRelationUseCaseInterface
+{
+    public function execute(DetachEntityRelationInput $input): void;
+}

--- a/src/EntityRelation/EntityRelationListItem.php
+++ b/src/EntityRelation/EntityRelationListItem.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+final readonly class EntityRelationListItem
+{
+    public function __construct(
+        public string $fieldKey,
+        public int $targetEntityId,
+    ) {
+    }
+}

--- a/src/EntityRelation/EntityRelationRepositoryInterface.php
+++ b/src/EntityRelation/EntityRelationRepositoryInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+interface EntityRelationRepositoryInterface
+{
+    /** @return list<EntityRelationListItem> */
+    public function findByEntityIdAndFieldKey(int $entityId, string $fieldKey): array;
+
+    public function isAttached(int $sourceEntityId, int $targetEntityId, string $fieldKey): bool;
+
+    public function attach(int $sourceEntityId, int $targetEntityId, string $fieldKey): void;
+
+    public function detach(int $sourceEntityId, int $targetEntityId, string $fieldKey): void;
+
+    public function detachAllForFieldKey(int $sourceEntityId, string $fieldKey): void;
+}

--- a/src/EntityRelation/EntityRelationRouteRegistrar.php
+++ b/src/EntityRelation/EntityRelationRouteRegistrar.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class EntityRelationRouteRegistrar
+{
+    public function __construct(
+        private ListEntityRelationsHandler $listHandler,
+        private AttachEntityRelationHandler $attachHandler,
+        private DetachEntityRelationHandler $detachHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $listHandler = $this->listHandler;
+        $attachHandler = $this->attachHandler;
+        $detachHandler = $this->detachHandler;
+
+        $router->get(
+            '/api/v1/entities/{entityId}/relations',
+            static fn (ServerRequestInterface $request) => $listHandler->handle($request),
+        );
+        $router->post(
+            '/api/v1/entities/{entityId}/relations',
+            static fn (ServerRequestInterface $request) => $attachHandler->handle($request),
+        );
+        $router->delete(
+            '/api/v1/entities/{entityId}/relations/{targetEntityId}',
+            static fn (ServerRequestInterface $request) => $detachHandler->handle($request),
+        );
+    }
+}

--- a/src/EntityRelation/EntityRelationServiceProvider.php
+++ b/src/EntityRelation/EntityRelationServiceProvider.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class EntityRelationServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                EntityRelationRepositoryInterface::class,
+                static function (ContainerInterface $c): EntityRelationRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoEntityRelationRepository($query);
+                },
+            )
+            ->set(
+                ListEntityRelationsUseCaseInterface::class,
+                static function (ContainerInterface $c): ListEntityRelationsUseCaseInterface {
+                    $entities = $c->get(EntityRepositoryInterface::class);
+                    $fieldDefs = $c->get(FieldDefRepositoryInterface::class);
+                    $entityRelations = $c->get(EntityRelationRepositoryInterface::class);
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field def repository service is invalid.');
+                    }
+
+                    if (!$entityRelations instanceof EntityRelationRepositoryInterface) {
+                        throw new LogicException('Entity relation repository service is invalid.');
+                    }
+
+                    return new ListEntityRelationsUseCase($entities, $fieldDefs, $entityRelations);
+                },
+            )
+            ->set(
+                ListEntityRelationsHandler::class,
+                static function (ContainerInterface $c): ListEntityRelationsHandler {
+                    $useCase = $c->get(ListEntityRelationsUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListEntityRelationsUseCaseInterface) {
+                        throw new LogicException('ListEntityRelations use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListEntityRelationsHandler($useCase, $response);
+                },
+            )
+            ->set(
+                AttachEntityRelationUseCaseInterface::class,
+                static function (ContainerInterface $c): AttachEntityRelationUseCaseInterface {
+                    $entities = $c->get(EntityRepositoryInterface::class);
+                    $fieldDefs = $c->get(FieldDefRepositoryInterface::class);
+                    $entityRelations = $c->get(EntityRelationRepositoryInterface::class);
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field def repository service is invalid.');
+                    }
+
+                    if (!$entityRelations instanceof EntityRelationRepositoryInterface) {
+                        throw new LogicException('Entity relation repository service is invalid.');
+                    }
+
+                    return new AttachEntityRelationUseCase($entities, $fieldDefs, $entityRelations);
+                },
+            )
+            ->set(
+                AttachEntityRelationHandler::class,
+                static function (ContainerInterface $c): AttachEntityRelationHandler {
+                    $useCase = $c->get(AttachEntityRelationUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof AttachEntityRelationUseCaseInterface) {
+                        throw new LogicException('AttachEntityRelation use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new AttachEntityRelationHandler($useCase, $response);
+                },
+            )
+            ->set(
+                DetachEntityRelationUseCaseInterface::class,
+                static function (ContainerInterface $c): DetachEntityRelationUseCaseInterface {
+                    $entities = $c->get(EntityRepositoryInterface::class);
+                    $entityRelations = $c->get(EntityRelationRepositoryInterface::class);
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$entityRelations instanceof EntityRelationRepositoryInterface) {
+                        throw new LogicException('Entity relation repository service is invalid.');
+                    }
+
+                    return new DetachEntityRelationUseCase($entities, $entityRelations);
+                },
+            )
+            ->set(
+                DetachEntityRelationHandler::class,
+                static function (ContainerInterface $c): DetachEntityRelationHandler {
+                    $useCase = $c->get(DetachEntityRelationUseCaseInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof DetachEntityRelationUseCaseInterface) {
+                        throw new LogicException('DetachEntityRelation use case service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    return new DetachEntityRelationHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
+                FieldKeyNotRegisteredExceptionHandler::class,
+                static function (ContainerInterface $c): FieldKeyNotRegisteredExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new FieldKeyNotRegisteredExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                FieldTypeMismatchExceptionHandler::class,
+                static function (ContainerInterface $c): FieldTypeMismatchExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new FieldTypeMismatchExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                RelationTargetTypeMismatchExceptionHandler::class,
+                static function (ContainerInterface $c): RelationTargetTypeMismatchExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new RelationTargetTypeMismatchExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                RelationAlreadyAttachedExceptionHandler::class,
+                static function (ContainerInterface $c): RelationAlreadyAttachedExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new RelationAlreadyAttachedExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                RelationNotAttachedExceptionHandler::class,
+                static function (ContainerInterface $c): RelationNotAttachedExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new RelationNotAttachedExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.entity_relation',
+                static function (ContainerInterface $c): EntityRelationRouteRegistrar {
+                    $list = $c->get(ListEntityRelationsHandler::class);
+                    $attach = $c->get(AttachEntityRelationHandler::class);
+                    $detach = $c->get(DetachEntityRelationHandler::class);
+
+                    if (!$list instanceof ListEntityRelationsHandler) {
+                        throw new LogicException('ListEntityRelations handler service is invalid.');
+                    }
+
+                    if (!$attach instanceof AttachEntityRelationHandler) {
+                        throw new LogicException('AttachEntityRelation handler service is invalid.');
+                    }
+
+                    if (!$detach instanceof DetachEntityRelationHandler) {
+                        throw new LogicException('DetachEntityRelation handler service is invalid.');
+                    }
+
+                    return new EntityRelationRouteRegistrar($list, $attach, $detach);
+                },
+            );
+    }
+}

--- a/src/EntityRelation/FieldKeyNotRegisteredException.php
+++ b/src/EntityRelation/FieldKeyNotRegisteredException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use RuntimeException;
+
+final class FieldKeyNotRegisteredException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $fieldKey,
+    ) {
+        parent::__construct(sprintf('Field key "%s" is not registered for this entity type.', $fieldKey));
+    }
+}

--- a/src/EntityRelation/FieldKeyNotRegisteredExceptionHandler.php
+++ b/src/EntityRelation/FieldKeyNotRegisteredExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class FieldKeyNotRegisteredExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof FieldKeyNotRegisteredException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'field-key-not-registered',
+            'Field Key Not Registered',
+            422,
+            'The field key is not registered for this entity type.',
+        );
+    }
+}

--- a/src/EntityRelation/FieldTypeMismatchException.php
+++ b/src/EntityRelation/FieldTypeMismatchException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use RuntimeException;
+
+final class FieldTypeMismatchException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $fieldKey,
+        public readonly string $expectedDataType,
+        public readonly string $actualDataType,
+    ) {
+        parent::__construct(sprintf(
+            'Field key "%s" expects data type "%s" but is registered as "%s".',
+            $fieldKey,
+            $expectedDataType,
+            $actualDataType,
+        ));
+    }
+}

--- a/src/EntityRelation/FieldTypeMismatchExceptionHandler.php
+++ b/src/EntityRelation/FieldTypeMismatchExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class FieldTypeMismatchExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof FieldTypeMismatchException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'field-type-mismatch',
+            'Field Type Mismatch',
+            422,
+            'The field key is registered with a different data type.',
+        );
+    }
+}

--- a/src/EntityRelation/ListEntityRelationsHandler.php
+++ b/src/EntityRelation/ListEntityRelationsHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeNeRecords\Entity\EntityNotFoundException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListEntityRelationsHandler
+{
+    public function __construct(
+        private ListEntityRelationsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $entityId = (int) ($parameters['entityId'] ?? 0);
+
+        if ($entityId <= 0) {
+            throw new EntityNotFoundException($entityId);
+        }
+
+        $fieldKey = trim((string) ($request->getQueryParams()['field_key'] ?? ''));
+
+        if ($fieldKey === '') {
+            throw new ValidationException([
+                new ValidationError('field_key', 'Field key is required.', 'required'),
+            ]);
+        }
+
+        $output = $this->useCase->execute(new ListEntityRelationsInput($entityId, $fieldKey));
+
+        return $this->response->create([
+            'items' => array_map(
+                static fn (EntityRelationListItem $item) => [
+                    'field_key' => $item->fieldKey,
+                    'target_entity_id' => $item->targetEntityId,
+                ],
+                $output->items,
+            ),
+        ]);
+    }
+}

--- a/src/EntityRelation/ListEntityRelationsInput.php
+++ b/src/EntityRelation/ListEntityRelationsInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+final readonly class ListEntityRelationsInput
+{
+    public function __construct(
+        public int $entityId,
+        public string $fieldKey,
+    ) {
+    }
+}

--- a/src/EntityRelation/ListEntityRelationsOutput.php
+++ b/src/EntityRelation/ListEntityRelationsOutput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+final readonly class ListEntityRelationsOutput
+{
+    /** @param list<EntityRelationListItem> $items */
+    public function __construct(
+        public array $items,
+    ) {
+    }
+}

--- a/src/EntityRelation/ListEntityRelationsUseCase.php
+++ b/src/EntityRelation/ListEntityRelationsUseCase.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+
+final readonly class ListEntityRelationsUseCase implements ListEntityRelationsUseCaseInterface
+{
+    public function __construct(
+        private EntityRepositoryInterface $entities,
+        private FieldDefRepositoryInterface $fieldDefs,
+        private EntityRelationRepositoryInterface $entityRelations,
+    ) {
+    }
+
+    public function execute(ListEntityRelationsInput $input): ListEntityRelationsOutput
+    {
+        $entity = $this->entities->findById($input->entityId);
+
+        if ($entity === null) {
+            throw new EntityNotFoundException($input->entityId);
+        }
+
+        $fieldDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($entity->entityTypeId, $input->fieldKey);
+
+        if ($fieldDef === null) {
+            throw new FieldKeyNotRegisteredException($input->fieldKey);
+        }
+
+        if ($fieldDef->dataType !== 'relation') {
+            throw new FieldTypeMismatchException($input->fieldKey, 'relation', $fieldDef->dataType);
+        }
+
+        return new ListEntityRelationsOutput(
+            items: $this->entityRelations->findByEntityIdAndFieldKey($input->entityId, $input->fieldKey),
+        );
+    }
+}

--- a/src/EntityRelation/ListEntityRelationsUseCaseInterface.php
+++ b/src/EntityRelation/ListEntityRelationsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+interface ListEntityRelationsUseCaseInterface
+{
+    public function execute(ListEntityRelationsInput $input): ListEntityRelationsOutput;
+}

--- a/src/EntityRelation/PdoEntityRelationRepository.php
+++ b/src/EntityRelation/PdoEntityRelationRepository.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoEntityRelationRepository implements EntityRelationRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    /** @return list<EntityRelationListItem> */
+    public function findByEntityIdAndFieldKey(int $entityId, string $fieldKey): array
+    {
+        $rows = $this->query->fetchAll(
+            <<<'SQL'
+                SELECT field_key, target_entity_id
+                FROM entity_relations
+                WHERE source_entity_id = ? AND field_key = ?
+                ORDER BY target_entity_id ASC
+                SQL,
+            [$entityId, $fieldKey],
+        );
+
+        return array_map(
+            static fn (array $row) => new EntityRelationListItem(
+                fieldKey: (string) $row['field_key'],
+                targetEntityId: (int) $row['target_entity_id'],
+            ),
+            $rows,
+        );
+    }
+
+    public function isAttached(int $sourceEntityId, int $targetEntityId, string $fieldKey): bool
+    {
+        $row = $this->query->fetchOne(
+            <<<'SQL'
+                SELECT id
+                FROM entity_relations
+                WHERE source_entity_id = ? AND target_entity_id = ? AND field_key = ?
+                SQL,
+            [$sourceEntityId, $targetEntityId, $fieldKey],
+        );
+
+        return $row !== null;
+    }
+
+    public function attach(int $sourceEntityId, int $targetEntityId, string $fieldKey): void
+    {
+        $this->query->execute(
+            'INSERT INTO entity_relations (source_entity_id, target_entity_id, field_key) VALUES (?, ?, ?)',
+            [$sourceEntityId, $targetEntityId, $fieldKey],
+        );
+    }
+
+    public function detach(int $sourceEntityId, int $targetEntityId, string $fieldKey): void
+    {
+        $this->query->execute(
+            <<<'SQL'
+                DELETE FROM entity_relations
+                WHERE source_entity_id = ? AND target_entity_id = ? AND field_key = ?
+                SQL,
+            [$sourceEntityId, $targetEntityId, $fieldKey],
+        );
+    }
+
+    public function detachAllForFieldKey(int $sourceEntityId, string $fieldKey): void
+    {
+        $this->query->execute(
+            'DELETE FROM entity_relations WHERE source_entity_id = ? AND field_key = ?',
+            [$sourceEntityId, $fieldKey],
+        );
+    }
+}

--- a/src/EntityRelation/RelationAlreadyAttachedException.php
+++ b/src/EntityRelation/RelationAlreadyAttachedException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use RuntimeException;
+
+final class RelationAlreadyAttachedException extends RuntimeException
+{
+    public function __construct(
+        public readonly int $entityId,
+        public readonly int $targetEntityId,
+        public readonly string $fieldKey,
+    ) {
+        parent::__construct(sprintf(
+            'Target entity %d is already attached to entity %d for field key "%s".',
+            $targetEntityId,
+            $entityId,
+            $fieldKey,
+        ));
+    }
+}

--- a/src/EntityRelation/RelationAlreadyAttachedExceptionHandler.php
+++ b/src/EntityRelation/RelationAlreadyAttachedExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class RelationAlreadyAttachedExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof RelationAlreadyAttachedException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'relation-already-attached',
+            'Conflict',
+            409,
+            'The target entity is already attached for this relation field.',
+        );
+    }
+}

--- a/src/EntityRelation/RelationNotAttachedException.php
+++ b/src/EntityRelation/RelationNotAttachedException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use RuntimeException;
+
+final class RelationNotAttachedException extends RuntimeException
+{
+    public function __construct(
+        public readonly int $entityId,
+        public readonly int $targetEntityId,
+        public readonly string $fieldKey,
+    ) {
+        parent::__construct(sprintf(
+            'Target entity %d is not attached to entity %d for field key "%s".',
+            $targetEntityId,
+            $entityId,
+            $fieldKey,
+        ));
+    }
+}

--- a/src/EntityRelation/RelationNotAttachedExceptionHandler.php
+++ b/src/EntityRelation/RelationNotAttachedExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class RelationNotAttachedExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof RelationNotAttachedException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'relation-not-attached',
+            'Not Found',
+            404,
+            'The target entity is not attached for this relation field.',
+        );
+    }
+}

--- a/src/EntityRelation/RelationTargetTypeMismatchException.php
+++ b/src/EntityRelation/RelationTargetTypeMismatchException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use RuntimeException;
+
+final class RelationTargetTypeMismatchException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $fieldKey,
+        public readonly int $expectedEntityTypeId,
+        public readonly int $actualEntityTypeId,
+    ) {
+        parent::__construct(sprintf(
+            'Relation field "%s" requires target entity type id %d but target has type id %d.',
+            $fieldKey,
+            $expectedEntityTypeId,
+            $actualEntityTypeId,
+        ));
+    }
+}

--- a/src/EntityRelation/RelationTargetTypeMismatchExceptionHandler.php
+++ b/src/EntityRelation/RelationTargetTypeMismatchExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityRelation;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class RelationTargetTypeMismatchExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof RelationTargetTypeMismatchException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'relation-target-type-mismatch',
+            'Relation Target Type Mismatch',
+            422,
+            'The target entity type does not match the relation field definition.',
+        );
+    }
+}

--- a/src/FieldDef/CreateFieldDefHandler.php
+++ b/src/FieldDef/CreateFieldDefHandler.php
@@ -6,16 +6,12 @@ namespace NeNeRecords\FieldDef;
 
 use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
-use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 final readonly class CreateFieldDefHandler
 {
-    /** @var list<string> */
-    private const ALLOWED_DATA_TYPES = ['text', 'int', 'enum', 'bool', 'datetime'];
-
     public function __construct(
         private CreateFieldDefUseCaseInterface $useCase,
         private JsonResponseFactory $response,
@@ -25,44 +21,29 @@ final readonly class CreateFieldDefHandler
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $body = JsonRequestBodyParser::parse($request);
-
-        $errors = [];
-
-        $entityTypeId = (int) ($body['entity_type_id'] ?? 0);
-        $fieldKey = trim((string) ($body['field_key'] ?? ''));
-        $dataType = trim((string) ($body['data_type'] ?? ''));
-
-        if ($entityTypeId <= 0) {
-            $errors[] = new ValidationError('entity_type_id', 'Entity type id must be a positive integer.', 'invalid');
-        }
-
-        if ($fieldKey === '') {
-            $errors[] = new ValidationError('field_key', 'Field key is required.', 'required');
-        }
-
-        if ($dataType === '') {
-            $errors[] = new ValidationError('data_type', 'Data type is required.', 'required');
-        } elseif (!in_array($dataType, self::ALLOWED_DATA_TYPES, true)) {
-            $errors[] = new ValidationError('data_type', 'Data type must be one of: text, int, enum, bool, datetime.', 'invalid');
-        }
+        $errors = FieldDefWriteValidator::validate($body);
 
         if ($errors !== []) {
             throw new ValidationException($errors);
         }
 
         $output = $this->useCase->execute(new CreateFieldDefInput(
-            entityTypeId: $entityTypeId,
-            fieldKey: $fieldKey,
-            dataType: $dataType,
+            entityTypeId: (int) $body['entity_type_id'],
+            fieldKey: trim((string) $body['field_key']),
+            dataType: trim((string) $body['data_type']),
+            targetEntityTypeId: FieldDefWriteValidator::parseTargetEntityTypeId($body),
+            cardinality: FieldDefWriteValidator::parseCardinality($body),
         ));
 
         return $this->response->create(
-            [
-                'id' => $output->id,
-                'entity_type_id' => $output->entityTypeId,
-                'field_key' => $output->fieldKey,
-                'data_type' => $output->dataType,
-            ],
+            FieldDefHttpMapper::toResponse(
+                id: $output->id,
+                entityTypeId: $output->entityTypeId,
+                fieldKey: $output->fieldKey,
+                dataType: $output->dataType,
+                targetEntityTypeId: $output->targetEntityTypeId,
+                cardinality: $output->cardinality,
+            ),
             201,
             ['Location' => '/api/v1/field-defs/' . $output->id],
         );

--- a/src/FieldDef/CreateFieldDefInput.php
+++ b/src/FieldDef/CreateFieldDefInput.php
@@ -10,6 +10,8 @@ final readonly class CreateFieldDefInput
         public int $entityTypeId,
         public string $fieldKey,
         public string $dataType,
+        public ?int $targetEntityTypeId = null,
+        public ?string $cardinality = null,
     ) {
     }
 }

--- a/src/FieldDef/CreateFieldDefOutput.php
+++ b/src/FieldDef/CreateFieldDefOutput.php
@@ -11,6 +11,8 @@ final readonly class CreateFieldDefOutput
         public int $entityTypeId,
         public string $fieldKey,
         public string $dataType,
+        public ?int $targetEntityTypeId = null,
+        public ?string $cardinality = null,
     ) {
     }
 }

--- a/src/FieldDef/CreateFieldDefUseCase.php
+++ b/src/FieldDef/CreateFieldDefUseCase.php
@@ -21,6 +21,10 @@ final readonly class CreateFieldDefUseCase implements CreateFieldDefUseCaseInter
             throw new EntityTypeNotFoundException($input->entityTypeId);
         }
 
+        if ($input->dataType === 'relation') {
+            $this->assertRelationTargetEntityTypeExists($input->targetEntityTypeId);
+        }
+
         $existing = $this->fieldDefs->findByEntityTypeIdAndFieldKey($input->entityTypeId, $input->fieldKey);
 
         if ($existing !== null) {
@@ -31,6 +35,8 @@ final readonly class CreateFieldDefUseCase implements CreateFieldDefUseCaseInter
             entityTypeId: $input->entityTypeId,
             fieldKey: $input->fieldKey,
             dataType: $input->dataType,
+            targetEntityTypeId: $input->targetEntityTypeId,
+            cardinality: $input->cardinality,
         ));
 
         return new CreateFieldDefOutput(
@@ -38,6 +44,15 @@ final readonly class CreateFieldDefUseCase implements CreateFieldDefUseCaseInter
             entityTypeId: $input->entityTypeId,
             fieldKey: $input->fieldKey,
             dataType: $input->dataType,
+            targetEntityTypeId: $input->targetEntityTypeId,
+            cardinality: $input->cardinality,
         );
+    }
+
+    private function assertRelationTargetEntityTypeExists(?int $targetEntityTypeId): void
+    {
+        if ($targetEntityTypeId === null || $this->entityTypes->findById($targetEntityTypeId) === null) {
+            throw new EntityTypeNotFoundException($targetEntityTypeId ?? 0);
+        }
     }
 }

--- a/src/FieldDef/FieldDef.php
+++ b/src/FieldDef/FieldDef.php
@@ -15,6 +15,8 @@ final readonly class FieldDef
         public ?int $id = null,
         public bool $isDeleted = false,
         public ?DateTimeImmutable $deletedAt = null,
+        public ?int $targetEntityTypeId = null,
+        public ?string $cardinality = null,
     ) {
     }
 }

--- a/src/FieldDef/FieldDefHttpMapper.php
+++ b/src/FieldDef/FieldDefHttpMapper.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+final readonly class FieldDefHttpMapper
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function toResponse(
+        int $id,
+        int $entityTypeId,
+        string $fieldKey,
+        string $dataType,
+        ?int $targetEntityTypeId = null,
+        ?string $cardinality = null,
+    ): array {
+        $payload = [
+            'id' => $id,
+            'entity_type_id' => $entityTypeId,
+            'field_key' => $fieldKey,
+            'data_type' => $dataType,
+        ];
+
+        if ($dataType === 'relation') {
+            $payload['target_entity_type_id'] = $targetEntityTypeId;
+            $payload['cardinality'] = $cardinality;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function fromFieldDef(FieldDef $fieldDef): array
+    {
+        return self::toResponse(
+            id: $fieldDef->id ?? 0,
+            entityTypeId: $fieldDef->entityTypeId,
+            fieldKey: $fieldDef->fieldKey,
+            dataType: $fieldDef->dataType,
+            targetEntityTypeId: $fieldDef->targetEntityTypeId,
+            cardinality: $fieldDef->cardinality,
+        );
+    }
+}

--- a/src/FieldDef/FieldDefWriteValidator.php
+++ b/src/FieldDef/FieldDefWriteValidator.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\FieldDef;
+
+use Nene2\Validation\ValidationError;
+
+final readonly class FieldDefWriteValidator
+{
+    /** @var list<string> */
+    public const ALLOWED_DATA_TYPES = ['text', 'int', 'enum', 'bool', 'datetime', 'relation'];
+
+    /** @var list<string> */
+    public const ALLOWED_CARDINALITIES = ['one', 'many'];
+
+    /**
+     * @param array<string, mixed> $body
+     * @return list<ValidationError>
+     */
+    public static function validate(array $body): array
+    {
+        $errors = [];
+
+        $entityTypeId = (int) ($body['entity_type_id'] ?? 0);
+        $fieldKey = trim((string) ($body['field_key'] ?? ''));
+        $dataType = trim((string) ($body['data_type'] ?? ''));
+        $targetEntityTypeIdRaw = $body['target_entity_type_id'] ?? null;
+        $cardinality = trim((string) ($body['cardinality'] ?? ''));
+
+        if ($entityTypeId <= 0) {
+            $errors[] = new ValidationError('entity_type_id', 'Entity type id must be a positive integer.', 'invalid');
+        }
+
+        if ($fieldKey === '') {
+            $errors[] = new ValidationError('field_key', 'Field key is required.', 'required');
+        }
+
+        if ($dataType === '') {
+            $errors[] = new ValidationError('data_type', 'Data type is required.', 'required');
+        } elseif (!in_array($dataType, self::ALLOWED_DATA_TYPES, true)) {
+            $errors[] = new ValidationError(
+                'data_type',
+                'Data type must be one of: text, int, enum, bool, datetime, relation.',
+                'invalid',
+            );
+        }
+
+        if ($dataType === 'relation') {
+            $targetEntityTypeId = self::parsePositiveInt($targetEntityTypeIdRaw);
+
+            if ($targetEntityTypeId === null) {
+                $errors[] = new ValidationError(
+                    'target_entity_type_id',
+                    'Target entity type id is required for relation fields.',
+                    'required',
+                );
+            }
+
+            if ($cardinality === '') {
+                $errors[] = new ValidationError('cardinality', 'Cardinality is required for relation fields.', 'required');
+            } elseif (!in_array($cardinality, self::ALLOWED_CARDINALITIES, true)) {
+                $errors[] = new ValidationError('cardinality', 'Cardinality must be one of: one, many.', 'invalid');
+            }
+        } elseif ($targetEntityTypeIdRaw !== null || $cardinality !== '') {
+            $errors[] = new ValidationError(
+                'data_type',
+                'Target entity type id and cardinality are only allowed for relation fields.',
+                'invalid',
+            );
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    public static function parseTargetEntityTypeId(array $body): ?int
+    {
+        if (trim((string) ($body['data_type'] ?? '')) !== 'relation') {
+            return null;
+        }
+
+        return self::parsePositiveInt($body['target_entity_type_id'] ?? null);
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    public static function parseCardinality(array $body): ?string
+    {
+        if (trim((string) ($body['data_type'] ?? '')) !== 'relation') {
+            return null;
+        }
+
+        $cardinality = trim((string) ($body['cardinality'] ?? ''));
+
+        return $cardinality === '' ? null : $cardinality;
+    }
+
+    private static function parsePositiveInt(mixed $value): ?int
+    {
+        if (!is_int($value) && !(is_string($value) && ctype_digit($value))) {
+            return null;
+        }
+
+        $parsed = (int) $value;
+
+        return $parsed > 0 ? $parsed : null;
+    }
+}

--- a/src/FieldDef/GetFieldDefByIdHandler.php
+++ b/src/FieldDef/GetFieldDefByIdHandler.php
@@ -28,11 +28,13 @@ final readonly class GetFieldDefByIdHandler
 
         $output = $this->useCase->execute(new GetFieldDefByIdInput($id));
 
-        return $this->response->create([
-            'id' => $output->id,
-            'entity_type_id' => $output->entityTypeId,
-            'field_key' => $output->fieldKey,
-            'data_type' => $output->dataType,
-        ]);
+        return $this->response->create(FieldDefHttpMapper::toResponse(
+            id: $output->id,
+            entityTypeId: $output->entityTypeId,
+            fieldKey: $output->fieldKey,
+            dataType: $output->dataType,
+            targetEntityTypeId: $output->targetEntityTypeId,
+            cardinality: $output->cardinality,
+        ));
     }
 }

--- a/src/FieldDef/GetFieldDefByIdOutput.php
+++ b/src/FieldDef/GetFieldDefByIdOutput.php
@@ -11,6 +11,8 @@ final readonly class GetFieldDefByIdOutput
         public int $entityTypeId,
         public string $fieldKey,
         public string $dataType,
+        public ?int $targetEntityTypeId = null,
+        public ?string $cardinality = null,
     ) {
     }
 }

--- a/src/FieldDef/GetFieldDefByIdUseCase.php
+++ b/src/FieldDef/GetFieldDefByIdUseCase.php
@@ -24,6 +24,8 @@ final readonly class GetFieldDefByIdUseCase implements GetFieldDefByIdUseCaseInt
             entityTypeId: $fieldDef->entityTypeId,
             fieldKey: $fieldDef->fieldKey,
             dataType: $fieldDef->dataType,
+            targetEntityTypeId: $fieldDef->targetEntityTypeId,
+            cardinality: $fieldDef->cardinality,
         );
     }
 }

--- a/src/FieldDef/ListFieldDefItem.php
+++ b/src/FieldDef/ListFieldDefItem.php
@@ -11,6 +11,8 @@ final readonly class ListFieldDefItem
         public int $entityTypeId,
         public string $fieldKey,
         public string $dataType,
+        public ?int $targetEntityTypeId = null,
+        public ?string $cardinality = null,
     ) {
     }
 }

--- a/src/FieldDef/ListFieldDefsHandler.php
+++ b/src/FieldDef/ListFieldDefsHandler.php
@@ -40,12 +40,14 @@ final readonly class ListFieldDefsHandler
         return $this->response->create(
             (new PaginationResponse(
                 items: array_map(
-                    static fn (ListFieldDefItem $item) => [
-                        'id' => $item->id,
-                        'entity_type_id' => $item->entityTypeId,
-                        'field_key' => $item->fieldKey,
-                        'data_type' => $item->dataType,
-                    ],
+                    static fn (ListFieldDefItem $item) => FieldDefHttpMapper::toResponse(
+                        id: $item->id,
+                        entityTypeId: $item->entityTypeId,
+                        fieldKey: $item->fieldKey,
+                        dataType: $item->dataType,
+                        targetEntityTypeId: $item->targetEntityTypeId,
+                        cardinality: $item->cardinality,
+                    ),
                     $output->items,
                 ),
                 limit: $output->limit,

--- a/src/FieldDef/ListFieldDefsUseCase.php
+++ b/src/FieldDef/ListFieldDefsUseCase.php
@@ -21,6 +21,8 @@ final readonly class ListFieldDefsUseCase implements ListFieldDefsUseCaseInterfa
                 entityTypeId: $fieldDef->entityTypeId,
                 fieldKey: $fieldDef->fieldKey,
                 dataType: $fieldDef->dataType,
+                targetEntityTypeId: $fieldDef->targetEntityTypeId,
+                cardinality: $fieldDef->cardinality,
             ),
             $rows,
         );

--- a/src/FieldDef/PdoFieldDefRepository.php
+++ b/src/FieldDef/PdoFieldDefRepository.php
@@ -19,7 +19,7 @@ final readonly class PdoFieldDefRepository implements FieldDefRepositoryInterfac
     {
         $row = $this->query->fetchOne(
             <<<'SQL'
-                SELECT id, entity_type_id, field_key, data_type, is_deleted, deleted_at
+                SELECT id, entity_type_id, field_key, data_type, target_entity_type_id, cardinality, is_deleted, deleted_at
                 FROM field_defs
                 WHERE id = ? AND is_deleted = 0
                 SQL,
@@ -37,7 +37,7 @@ final readonly class PdoFieldDefRepository implements FieldDefRepositoryInterfac
     {
         $row = $this->query->fetchOne(
             <<<'SQL'
-                SELECT id, entity_type_id, field_key, data_type, is_deleted, deleted_at
+                SELECT id, entity_type_id, field_key, data_type, target_entity_type_id, cardinality, is_deleted, deleted_at
                 FROM field_defs
                 WHERE entity_type_id = ? AND field_key = ? AND is_deleted = 0
                 SQL,
@@ -57,7 +57,7 @@ final readonly class PdoFieldDefRepository implements FieldDefRepositoryInterfac
         if ($entityTypeId !== null) {
             $rows = $this->query->fetchAll(
                 <<<'SQL'
-                    SELECT id, entity_type_id, field_key, data_type, is_deleted, deleted_at
+                    SELECT id, entity_type_id, field_key, data_type, target_entity_type_id, cardinality, is_deleted, deleted_at
                     FROM field_defs
                     WHERE is_deleted = 0 AND entity_type_id = ?
                     ORDER BY id ASC
@@ -68,7 +68,7 @@ final readonly class PdoFieldDefRepository implements FieldDefRepositoryInterfac
         } else {
             $rows = $this->query->fetchAll(
                 <<<'SQL'
-                    SELECT id, entity_type_id, field_key, data_type, is_deleted, deleted_at
+                    SELECT id, entity_type_id, field_key, data_type, target_entity_type_id, cardinality, is_deleted, deleted_at
                     FROM field_defs
                     WHERE is_deleted = 0
                     ORDER BY id ASC
@@ -84,8 +84,17 @@ final readonly class PdoFieldDefRepository implements FieldDefRepositoryInterfac
     public function save(FieldDef $fieldDef): int
     {
         $this->query->execute(
-            'INSERT INTO field_defs (entity_type_id, field_key, data_type) VALUES (?, ?, ?)',
-            [$fieldDef->entityTypeId, $fieldDef->fieldKey, $fieldDef->dataType],
+            <<<'SQL'
+                INSERT INTO field_defs (entity_type_id, field_key, data_type, target_entity_type_id, cardinality)
+                VALUES (?, ?, ?, ?, ?)
+                SQL,
+            [
+                $fieldDef->entityTypeId,
+                $fieldDef->fieldKey,
+                $fieldDef->dataType,
+                $fieldDef->targetEntityTypeId,
+                $fieldDef->cardinality,
+            ],
         );
 
         return $this->query->lastInsertId();
@@ -102,10 +111,17 @@ final readonly class PdoFieldDefRepository implements FieldDefRepositoryInterfac
         $this->query->execute(
             <<<'SQL'
                 UPDATE field_defs
-                SET entity_type_id = ?, field_key = ?, data_type = ?
+                SET entity_type_id = ?, field_key = ?, data_type = ?, target_entity_type_id = ?, cardinality = ?
                 WHERE id = ? AND is_deleted = 0
                 SQL,
-            [$fieldDef->entityTypeId, $fieldDef->fieldKey, $fieldDef->dataType, $id],
+            [
+                $fieldDef->entityTypeId,
+                $fieldDef->fieldKey,
+                $fieldDef->dataType,
+                $fieldDef->targetEntityTypeId,
+                $fieldDef->cardinality,
+                $id,
+            ],
         );
     }
 
@@ -126,6 +142,7 @@ final readonly class PdoFieldDefRepository implements FieldDefRepositoryInterfac
     {
         $deletedRaw = $row['deleted_at'] ?? null;
         $deletedAt = ($deletedRaw !== null && $deletedRaw !== '') ? new DateTimeImmutable((string) $deletedRaw) : null;
+        $targetEntityTypeIdRaw = $row['target_entity_type_id'] ?? null;
 
         return new FieldDef(
             entityTypeId: (int) $row['entity_type_id'],
@@ -134,6 +151,10 @@ final readonly class PdoFieldDefRepository implements FieldDefRepositoryInterfac
             id: (int) $row['id'],
             isDeleted: (bool) (int) $row['is_deleted'],
             deletedAt: $deletedAt,
+            targetEntityTypeId: $targetEntityTypeIdRaw === null ? null : (int) $targetEntityTypeIdRaw,
+            cardinality: ($row['cardinality'] ?? null) !== null && $row['cardinality'] !== ''
+                ? (string) $row['cardinality']
+                : null,
         );
     }
 }

--- a/src/FieldDef/UpdateFieldDefHandler.php
+++ b/src/FieldDef/UpdateFieldDefHandler.php
@@ -7,16 +7,12 @@ namespace NeNeRecords\FieldDef;
 use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
-use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 final readonly class UpdateFieldDefHandler
 {
-    /** @var list<string> */
-    private const ALLOWED_DATA_TYPES = ['text', 'int', 'enum', 'bool', 'datetime'];
-
     public function __construct(
         private UpdateFieldDefUseCaseInterface $useCase,
         private JsonResponseFactory $response,
@@ -33,26 +29,7 @@ final readonly class UpdateFieldDefHandler
         }
 
         $body = JsonRequestBodyParser::parse($request);
-
-        $errors = [];
-
-        $entityTypeId = (int) ($body['entity_type_id'] ?? 0);
-        $fieldKey = trim((string) ($body['field_key'] ?? ''));
-        $dataType = trim((string) ($body['data_type'] ?? ''));
-
-        if ($entityTypeId <= 0) {
-            $errors[] = new ValidationError('entity_type_id', 'Entity type id must be a positive integer.', 'invalid');
-        }
-
-        if ($fieldKey === '') {
-            $errors[] = new ValidationError('field_key', 'Field key is required.', 'required');
-        }
-
-        if ($dataType === '') {
-            $errors[] = new ValidationError('data_type', 'Data type is required.', 'required');
-        } elseif (!in_array($dataType, self::ALLOWED_DATA_TYPES, true)) {
-            $errors[] = new ValidationError('data_type', 'Data type must be one of: text, int, enum, bool, datetime.', 'invalid');
-        }
+        $errors = FieldDefWriteValidator::validate($body);
 
         if ($errors !== []) {
             throw new ValidationException($errors);
@@ -60,16 +37,20 @@ final readonly class UpdateFieldDefHandler
 
         $output = $this->useCase->execute(new UpdateFieldDefInput(
             id: $id,
-            entityTypeId: $entityTypeId,
-            fieldKey: $fieldKey,
-            dataType: $dataType,
+            entityTypeId: (int) $body['entity_type_id'],
+            fieldKey: trim((string) $body['field_key']),
+            dataType: trim((string) $body['data_type']),
+            targetEntityTypeId: FieldDefWriteValidator::parseTargetEntityTypeId($body),
+            cardinality: FieldDefWriteValidator::parseCardinality($body),
         ));
 
-        return $this->response->create([
-            'id' => $output->id,
-            'entity_type_id' => $output->entityTypeId,
-            'field_key' => $output->fieldKey,
-            'data_type' => $output->dataType,
-        ]);
+        return $this->response->create(FieldDefHttpMapper::toResponse(
+            id: $output->id,
+            entityTypeId: $output->entityTypeId,
+            fieldKey: $output->fieldKey,
+            dataType: $output->dataType,
+            targetEntityTypeId: $output->targetEntityTypeId,
+            cardinality: $output->cardinality,
+        ));
     }
 }

--- a/src/FieldDef/UpdateFieldDefInput.php
+++ b/src/FieldDef/UpdateFieldDefInput.php
@@ -11,6 +11,8 @@ final readonly class UpdateFieldDefInput
         public int $entityTypeId,
         public string $fieldKey,
         public string $dataType,
+        public ?int $targetEntityTypeId = null,
+        public ?string $cardinality = null,
     ) {
     }
 }

--- a/src/FieldDef/UpdateFieldDefOutput.php
+++ b/src/FieldDef/UpdateFieldDefOutput.php
@@ -11,6 +11,8 @@ final readonly class UpdateFieldDefOutput
         public int $entityTypeId,
         public string $fieldKey,
         public string $dataType,
+        public ?int $targetEntityTypeId = null,
+        public ?string $cardinality = null,
     ) {
     }
 }

--- a/src/FieldDef/UpdateFieldDefUseCase.php
+++ b/src/FieldDef/UpdateFieldDefUseCase.php
@@ -27,6 +27,14 @@ final readonly class UpdateFieldDefUseCase implements UpdateFieldDefUseCaseInter
             throw new EntityTypeNotFoundException($input->entityTypeId);
         }
 
+        if ($input->dataType === 'relation') {
+            $targetEntityTypeId = $input->targetEntityTypeId;
+
+            if ($targetEntityTypeId === null || $this->entityTypes->findById($targetEntityTypeId) === null) {
+                throw new EntityTypeNotFoundException($targetEntityTypeId ?? 0);
+            }
+        }
+
         $existing = $this->fieldDefs->findByEntityTypeIdAndFieldKey($input->entityTypeId, $input->fieldKey);
 
         if ($existing !== null && $existing->id !== $input->id) {
@@ -38,6 +46,8 @@ final readonly class UpdateFieldDefUseCase implements UpdateFieldDefUseCaseInter
             fieldKey: $input->fieldKey,
             dataType: $input->dataType,
             id: $input->id,
+            targetEntityTypeId: $input->targetEntityTypeId,
+            cardinality: $input->cardinality,
         );
         $this->fieldDefs->update($updated);
 
@@ -46,6 +56,8 @@ final readonly class UpdateFieldDefUseCase implements UpdateFieldDefUseCaseInter
             entityTypeId: $input->entityTypeId,
             fieldKey: $input->fieldKey,
             dataType: $input->dataType,
+            targetEntityTypeId: $input->targetEntityTypeId,
+            cardinality: $input->cardinality,
         );
     }
 }

--- a/tests/EntityRelation/EntityRelationHttpTest.php
+++ b/tests/EntityRelation/EntityRelationHttpTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\EntityRelation;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
+use NeNeRecords\EntityRelation\AttachEntityRelationHandler;
+use NeNeRecords\EntityRelation\AttachEntityRelationUseCase;
+use NeNeRecords\EntityRelation\DetachEntityRelationHandler;
+use NeNeRecords\EntityRelation\DetachEntityRelationUseCase;
+use NeNeRecords\EntityRelation\EntityRelationRouteRegistrar;
+use NeNeRecords\EntityRelation\FieldKeyNotRegisteredExceptionHandler;
+use NeNeRecords\EntityRelation\FieldTypeMismatchExceptionHandler;
+use NeNeRecords\EntityRelation\ListEntityRelationsHandler;
+use NeNeRecords\EntityRelation\ListEntityRelationsUseCase;
+use NeNeRecords\EntityRelation\RelationAlreadyAttachedExceptionHandler;
+use NeNeRecords\EntityRelation\RelationNotAttachedExceptionHandler;
+use NeNeRecords\EntityRelation\RelationTargetTypeMismatchExceptionHandler;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class EntityRelationHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryEntityRepository $entities;
+    private InMemoryFieldDefRepository $fieldDefs;
+    private InMemoryEntityRelationRepository $entityRelations;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->entities = new InMemoryEntityRepository();
+        $this->fieldDefs = new InMemoryFieldDefRepository();
+        $this->entityRelations = new InMemoryEntityRelationRepository();
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+
+        $registrar = new EntityRelationRouteRegistrar(
+            new ListEntityRelationsHandler(
+                new ListEntityRelationsUseCase($this->entities, $this->fieldDefs, $this->entityRelations),
+                $jsonResponse,
+            ),
+            new AttachEntityRelationHandler(
+                new AttachEntityRelationUseCase($this->entities, $this->fieldDefs, $this->entityRelations),
+                $jsonResponse,
+            ),
+            new DetachEntityRelationHandler(
+                new DetachEntityRelationUseCase($this->entities, $this->entityRelations),
+                $this->factory,
+            ),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [
+                new EntityNotFoundExceptionHandler($problemDetails),
+                new FieldKeyNotRegisteredExceptionHandler($problemDetails),
+                new FieldTypeMismatchExceptionHandler($problemDetails),
+                new RelationTargetTypeMismatchExceptionHandler($problemDetails),
+                new RelationAlreadyAttachedExceptionHandler($problemDetails),
+                new RelationNotAttachedExceptionHandler($problemDetails),
+            ],
+            routeRegistrars: [$registrar],
+        ))->create();
+    }
+
+    public function testAttachListAndDetachEntityRelation(): void
+    {
+        $articleId = $this->entities->save(new Entity(id: null, entityTypeId: 1));
+        $authorId = $this->entities->save(new Entity(id: null, entityTypeId: 2));
+        $this->fieldDefs->save(new FieldDef(
+            entityTypeId: 1,
+            fieldKey: 'author',
+            dataType: 'relation',
+            targetEntityTypeId: 2,
+            cardinality: 'one',
+        ));
+
+        $attachBody = $this->factory->createStream(json_encode([
+            'field_key' => 'author',
+            'target_entity_id' => $authorId,
+        ], JSON_THROW_ON_ERROR));
+        $attachResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', "https://example.test/api/v1/entities/{$articleId}/relations")->withBody($attachBody),
+        );
+        $attachPayload = $this->decodeJson($attachResponse);
+
+        self::assertSame(201, $attachResponse->getStatusCode());
+        self::assertSame('author', $attachPayload['field_key']);
+        self::assertSame($authorId, $attachPayload['target_entity_id']);
+
+        $listResponse = $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/entities/{$articleId}/relations?field_key=author"),
+        );
+        $listPayload = $this->decodeJson($listResponse);
+
+        self::assertSame(200, $listResponse->getStatusCode());
+        self::assertCount(1, $listPayload['items']);
+        self::assertSame($authorId, $listPayload['items'][0]['target_entity_id']);
+
+        $detachResponse = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', "https://example.test/api/v1/entities/{$articleId}/relations/{$authorId}?field_key=author"),
+        );
+
+        self::assertSame(204, $detachResponse->getStatusCode());
+    }
+
+    public function testAttachDuplicateReturns409(): void
+    {
+        $articleId = $this->entities->save(new Entity(id: null, entityTypeId: 1));
+        $authorId = $this->entities->save(new Entity(id: null, entityTypeId: 2));
+        $this->fieldDefs->save(new FieldDef(
+            entityTypeId: 1,
+            fieldKey: 'author',
+            dataType: 'relation',
+            targetEntityTypeId: 2,
+            cardinality: 'many',
+        ));
+        $this->entityRelations->attach($articleId, $authorId, 'author');
+
+        $body = $this->factory->createStream(json_encode([
+            'field_key' => 'author',
+            'target_entity_id' => $authorId,
+        ], JSON_THROW_ON_ERROR));
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', "https://example.test/api/v1/entities/{$articleId}/relations")->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(409, $response->getStatusCode());
+        self::assertStringEndsWith('relation-already-attached', (string) $payload['type']);
+    }
+
+    public function testAttachOneCardinalityReplacesExistingTarget(): void
+    {
+        $articleId = $this->entities->save(new Entity(id: null, entityTypeId: 1));
+        $authorOneId = $this->entities->save(new Entity(id: null, entityTypeId: 2));
+        $authorTwoId = $this->entities->save(new Entity(id: null, entityTypeId: 2));
+        $this->fieldDefs->save(new FieldDef(
+            entityTypeId: 1,
+            fieldKey: 'author',
+            dataType: 'relation',
+            targetEntityTypeId: 2,
+            cardinality: 'one',
+        ));
+        $this->entityRelations->attach($articleId, $authorOneId, 'author');
+
+        $body = $this->factory->createStream(json_encode([
+            'field_key' => 'author',
+            'target_entity_id' => $authorTwoId,
+        ], JSON_THROW_ON_ERROR));
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', "https://example.test/api/v1/entities/{$articleId}/relations")->withBody($body),
+        );
+
+        self::assertSame(201, $response->getStatusCode());
+
+        $listResponse = $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/entities/{$articleId}/relations?field_key=author"),
+        );
+        $listPayload = $this->decodeJson($listResponse);
+
+        self::assertCount(1, $listPayload['items']);
+        self::assertSame($authorTwoId, $listPayload['items'][0]['target_entity_id']);
+    }
+
+    public function testAttachWithWrongTargetTypeReturns422(): void
+    {
+        $articleId = $this->entities->save(new Entity(id: null, entityTypeId: 1));
+        $wrongTargetId = $this->entities->save(new Entity(id: null, entityTypeId: 3));
+        $this->fieldDefs->save(new FieldDef(
+            entityTypeId: 1,
+            fieldKey: 'author',
+            dataType: 'relation',
+            targetEntityTypeId: 2,
+            cardinality: 'one',
+        ));
+
+        $body = $this->factory->createStream(json_encode([
+            'field_key' => 'author',
+            'target_entity_id' => $wrongTargetId,
+        ], JSON_THROW_ON_ERROR));
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', "https://example.test/api/v1/entities/{$articleId}/relations")->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringEndsWith('relation-target-type-mismatch', (string) $payload['type']);
+    }
+
+    public function testDetachWhenNotAttachedReturns404(): void
+    {
+        $articleId = $this->entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', "https://example.test/api/v1/entities/{$articleId}/relations/99?field_key=author"),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertStringEndsWith('relation-not-attached', (string) $payload['type']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/tests/EntityRelation/InMemoryEntityRelationRepository.php
+++ b/tests/EntityRelation/InMemoryEntityRelationRepository.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\EntityRelation;
+
+use NeNeRecords\EntityRelation\EntityRelationListItem;
+use NeNeRecords\EntityRelation\EntityRelationRepositoryInterface;
+
+final class InMemoryEntityRelationRepository implements EntityRelationRepositoryInterface
+{
+    /** @var array<string, true> */
+    private array $attachments;
+
+    public function __construct()
+    {
+        $this->attachments = [];
+    }
+
+    /** @return list<EntityRelationListItem> */
+    public function findByEntityIdAndFieldKey(int $entityId, string $fieldKey): array
+    {
+        $items = [];
+
+        foreach ($this->attachments as $key => $_attached) {
+            [$sourceEntityId, $targetEntityId, $attachedFieldKey] = explode(':', $key, 3);
+
+            if ((int) $sourceEntityId !== $entityId || $attachedFieldKey !== $fieldKey) {
+                continue;
+            }
+
+            $items[] = new EntityRelationListItem(
+                fieldKey: $fieldKey,
+                targetEntityId: (int) $targetEntityId,
+            );
+        }
+
+        usort($items, static fn (EntityRelationListItem $a, EntityRelationListItem $b): int => $a->targetEntityId <=> $b->targetEntityId);
+
+        return $items;
+    }
+
+    public function isAttached(int $sourceEntityId, int $targetEntityId, string $fieldKey): bool
+    {
+        return isset($this->attachments[$this->compositeKey($sourceEntityId, $targetEntityId, $fieldKey)]);
+    }
+
+    public function attach(int $sourceEntityId, int $targetEntityId, string $fieldKey): void
+    {
+        $this->attachments[$this->compositeKey($sourceEntityId, $targetEntityId, $fieldKey)] = true;
+    }
+
+    public function detach(int $sourceEntityId, int $targetEntityId, string $fieldKey): void
+    {
+        unset($this->attachments[$this->compositeKey($sourceEntityId, $targetEntityId, $fieldKey)]);
+    }
+
+    public function detachAllForFieldKey(int $sourceEntityId, string $fieldKey): void
+    {
+        foreach (array_keys($this->attachments) as $key) {
+            [$attachedSourceEntityId, $_targetEntityId, $attachedFieldKey] = explode(':', $key, 3);
+
+            if ((int) $attachedSourceEntityId === $sourceEntityId && $attachedFieldKey === $fieldKey) {
+                unset($this->attachments[$key]);
+            }
+        }
+    }
+
+    private function compositeKey(int $sourceEntityId, int $targetEntityId, string $fieldKey): string
+    {
+        return $sourceEntityId . ':' . $targetEntityId . ':' . $fieldKey;
+    }
+}

--- a/tests/EntityRelation/PdoEntityRelationRepositoryTest.php
+++ b/tests/EntityRelation/PdoEntityRelationRepositoryTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\EntityRelation;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeNeRecords\EntityRelation\PdoEntityRelationRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PdoEntityRelationRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+    private PdoEntityRelationRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene-records-test',
+            '',
+            'utf8',
+        )));
+
+        $this->executor->execute('PRAGMA foreign_keys = ON');
+
+        foreach ($this->schemaStatements() as $statement) {
+            $this->executor->execute($statement);
+        }
+
+        $this->executor->execute("INSERT INTO entity_types (id, name, slug) VALUES (1, 'Article', 'article'), (2, 'Author', 'author')");
+        $this->executor->execute('INSERT INTO entities (id, entity_type_id) VALUES (1, 1), (2, 2), (3, 2)');
+
+        $this->repository = new PdoEntityRelationRepository($this->executor);
+    }
+
+    public function testAttachListDetachAndReplaceOneCardinality(): void
+    {
+        self::assertSame([], $this->repository->findByEntityIdAndFieldKey(1, 'author'));
+
+        $this->repository->attach(1, 2, 'author');
+        self::assertTrue($this->repository->isAttached(1, 2, 'author'));
+        self::assertCount(1, $this->repository->findByEntityIdAndFieldKey(1, 'author'));
+
+        $this->repository->detachAllForFieldKey(1, 'author');
+        $this->repository->attach(1, 3, 'author');
+
+        self::assertFalse($this->repository->isAttached(1, 2, 'author'));
+        self::assertTrue($this->repository->isAttached(1, 3, 'author'));
+
+        $this->repository->detach(1, 3, 'author');
+        self::assertFalse($this->repository->isAttached(1, 3, 'author'));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function schemaStatements(): array
+    {
+        $projectRoot = dirname(__DIR__, 2);
+        $paths = [
+            $projectRoot . '/database/schema/entity_types.sql',
+            $projectRoot . '/database/schema/entities.sql',
+            $projectRoot . '/database/schema/entity_relations.sql',
+        ];
+
+        $statements = [];
+
+        foreach ($paths as $path) {
+            $sql = file_get_contents($path);
+
+            if ($sql === false) {
+                throw new \RuntimeException('Failed to read schema file: ' . $path);
+            }
+
+            foreach (array_filter(array_map('trim', explode(';', $sql))) as $statement) {
+                $statements[] = $statement;
+            }
+        }
+
+        return $statements;
+    }
+}

--- a/tests/FieldDef/FieldDefHttpTest.php
+++ b/tests/FieldDef/FieldDefHttpTest.php
@@ -147,6 +147,30 @@ final class FieldDefHttpTest extends TestCase
         self::assertSame('int', $payload['data_type']);
     }
 
+    public function testPostFieldDefWithRelationDataTypeCreatesDefinition(): void
+    {
+        $articleTypeId = $this->entityTypes->save(new EntityType(name: 'Article', slug: 'article'));
+        $authorTypeId = $this->entityTypes->save(new EntityType(name: 'Author', slug: 'author'));
+
+        $body = $this->factory->createStream(json_encode([
+            'entity_type_id' => $articleTypeId,
+            'field_key' => 'author',
+            'data_type' => 'relation',
+            'target_entity_type_id' => $authorTypeId,
+            'cardinality' => 'one',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/field-defs')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame('relation', $payload['data_type']);
+        self::assertSame($authorTypeId, $payload['target_entity_type_id']);
+        self::assertSame('one', $payload['cardinality']);
+    }
+
     public function testPostInvalidDataTypeReturns422(): void
     {
         $typeId = $this->entityTypes->save(new EntityType(name: 'Article', slug: 'article'));

--- a/tests/FieldDef/InMemoryFieldDefRepository.php
+++ b/tests/FieldDef/InMemoryFieldDefRepository.php
@@ -35,6 +35,8 @@ final class InMemoryFieldDefRepository implements FieldDefRepositoryInterface
                     id: $id,
                     isDeleted: $fieldDef->isDeleted,
                     deletedAt: $fieldDef->deletedAt,
+                    targetEntityTypeId: $fieldDef->targetEntityTypeId,
+                    cardinality: $fieldDef->cardinality,
                 );
                 $this->byId[$id] = $stored;
                 if (!$stored->isDeleted) {
@@ -88,6 +90,8 @@ final class InMemoryFieldDefRepository implements FieldDefRepositoryInterface
             fieldKey: $fieldDef->fieldKey,
             dataType: $fieldDef->dataType,
             id: $id,
+            targetEntityTypeId: $fieldDef->targetEntityTypeId,
+            cardinality: $fieldDef->cardinality,
         );
         $this->byId[$id] = $stored;
         $this->entityTypeFieldKeyToId[$this->compositeKey($stored->entityTypeId, $stored->fieldKey)] = $id;
@@ -127,6 +131,8 @@ final class InMemoryFieldDefRepository implements FieldDefRepositoryInterface
             id: $id,
             isDeleted: true,
             deletedAt: new DateTimeImmutable(),
+            targetEntityTypeId: $fieldDef->targetEntityTypeId,
+            cardinality: $fieldDef->cardinality,
         );
     }
 


### PR DESCRIPTION
## Summary

- `field_defs.data_type = relation` + `target_entity_type_id` + `cardinality`（one/many）を追加
- `entity_relations` テーブルと `/api/v1/entities/{id}/relations` API（list / attach / detach）
- write 検証: field_def 存在、target entity type 一致、duplicate 409
- `cardinality = one` は既存 target を **置換**
- OpenAPI 更新、ADR 0004 に置換方針を反映

## Test plan

- [x] `composer check` — 137 tests passed
- [ ] relation field_def 作成 → attach → list → detach
- [ ] cardinality one で target 差し替え
- [ ] wrong target type → 422

Closes #51

セルフレビュー: backend-standards checklist


Made with [Cursor](https://cursor.com)