### PR TITLE
feat(frontend): Record 詳細 relation attach/detach UI (#52)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -12,12 +12,13 @@ Last updated: 2026-05-24
 
 | Issue | Summary |
 | --- | --- |
-| #52 | Record 詳細 relation attach/detach UI |
+| — | （なし） |
 
 ## Recently Completed
 
 | Issue | Summary |
 | --- | --- |
+| #52 | Record 詳細 relation attach/detach UI |
 | #51 | entity relations API + field_defs relation 型 (PR #54) |
 | #48 | Records 一覧 tag フィルタ UI (PR #49) |
 | #46 | Record tag attach/detach UI (PR #47) |
@@ -30,13 +31,12 @@ Last updated: 2026-05-24
 
 - **API（済）:** tags CRUD, entity_tags, entities `?tags=` フィルタ
 - **Admin UI（済）:** Tag CRUD (#44), Record tag attach/detach (#46), Records 一覧 tag フィルタ (#48)
-- **Relations（進行中）:** Admin UI #52
-- **Relations API（済）:** field_defs relation 型、entity_relations、attach/detach/list (#51)
+- **Relations（済）:** API #51, Admin UI #52
 - **Relations 後続:** list filter `?relation.{field_key}=`, inverse, MCP
 
 ## Verification
 
 ```bash
 composer check                    # 137 tests
-npm run check --prefix frontend   # 59 tests
+npm run check --prefix frontend   # 61 tests
 ```

--- a/frontend/src/entities/entity-relation/api-types.ts
+++ b/frontend/src/entities/entity-relation/api-types.ts
@@ -1,0 +1,13 @@
+export interface EntityRelationItemDto {
+  field_key: string
+  target_entity_id: number
+}
+
+export interface EntityRelationListDto {
+  items: EntityRelationItemDto[]
+}
+
+export interface AttachEntityRelationDto {
+  field_key: string
+  target_entity_id: number
+}

--- a/frontend/src/entities/entity-relation/index.ts
+++ b/frontend/src/entities/entity-relation/index.ts
@@ -1,0 +1,9 @@
+export type {
+  AttachEntityRelationInput,
+  DetachEntityRelationInput,
+  EntityRelation,
+  EntityRelationList,
+} from './model'
+export { entityRelationKeys } from './query-keys'
+export { useAttachEntityRelation, useDetachEntityRelation } from './mutations'
+export { useEntityRelationList } from './queries'

--- a/frontend/src/entities/entity-relation/mapper.ts
+++ b/frontend/src/entities/entity-relation/mapper.ts
@@ -1,0 +1,25 @@
+import type { EntityRelationItemDto, EntityRelationListDto } from './api-types'
+import type { AttachEntityRelationInput, EntityRelation, EntityRelationList } from './model'
+
+export function mapEntityRelationItemDtoToModel(dto: EntityRelationItemDto): EntityRelation {
+  return {
+    fieldKey: dto.field_key,
+    targetEntityId: dto.target_entity_id,
+  }
+}
+
+export function mapEntityRelationListDtoToModel(dto: EntityRelationListDto): EntityRelationList {
+  return {
+    items: dto.items.map(mapEntityRelationItemDtoToModel),
+  }
+}
+
+export function mapAttachInputToDto(input: AttachEntityRelationInput): {
+  field_key: string
+  target_entity_id: number
+} {
+  return {
+    field_key: input.fieldKey,
+    target_entity_id: input.targetEntityId,
+  }
+}

--- a/frontend/src/entities/entity-relation/model.ts
+++ b/frontend/src/entities/entity-relation/model.ts
@@ -1,0 +1,20 @@
+export interface EntityRelation {
+  fieldKey: string
+  targetEntityId: number
+}
+
+export interface EntityRelationList {
+  items: EntityRelation[]
+}
+
+export interface AttachEntityRelationInput {
+  entityId: number
+  fieldKey: string
+  targetEntityId: number
+}
+
+export interface DetachEntityRelationInput {
+  entityId: number
+  fieldKey: string
+  targetEntityId: number
+}

--- a/frontend/src/entities/entity-relation/mutations.ts
+++ b/frontend/src/entities/entity-relation/mutations.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { EntityRelationItemDto } from './api-types'
+import { mapAttachInputToDto, mapEntityRelationItemDtoToModel } from './mapper'
+import type { AttachEntityRelationInput, DetachEntityRelationInput, EntityRelation } from './model'
+import { entityRelationKeys } from './query-keys'
+
+export function useAttachEntityRelation(): UseMutationResult<
+  EntityRelation,
+  AppError,
+  AttachEntityRelationInput
+> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input) => {
+      const dto = await apiClient.post<EntityRelationItemDto>(
+        `/api/v1/entities/${String(input.entityId)}/relations`,
+        mapAttachInputToDto(input),
+      )
+      return mapEntityRelationItemDtoToModel(dto)
+    },
+    onSuccess: async (_data, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: entityRelationKeys.list(variables.entityId, variables.fieldKey),
+      })
+    },
+  })
+}
+
+export function useDetachEntityRelation(): UseMutationResult<
+  void,
+  AppError,
+  DetachEntityRelationInput
+> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input) => {
+      const search = new URLSearchParams({ field_key: input.fieldKey })
+      await apiClient.delete(
+        `/api/v1/entities/${String(input.entityId)}/relations/${String(input.targetEntityId)}?${search.toString()}`,
+      )
+    },
+    onSuccess: async (_data, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: entityRelationKeys.list(variables.entityId, variables.fieldKey),
+      })
+    },
+  })
+}

--- a/frontend/src/entities/entity-relation/queries.ts
+++ b/frontend/src/entities/entity-relation/queries.ts
@@ -1,0 +1,25 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { EntityRelationListDto } from './api-types'
+import { mapEntityRelationListDtoToModel } from './mapper'
+import type { EntityRelationList } from './model'
+import { entityRelationKeys } from './query-keys'
+
+export function useEntityRelationList(
+  entityId: number,
+  fieldKey: string,
+  options?: { enabled?: boolean },
+): UseQueryResult<EntityRelationList, AppError> {
+  return useQuery({
+    queryKey: entityRelationKeys.list(entityId, fieldKey),
+    enabled: options?.enabled ?? (entityId > 0 && fieldKey.length > 0),
+    queryFn: async ({ signal }) => {
+      const search = new URLSearchParams({ field_key: fieldKey })
+      const dto = await apiClient.get<EntityRelationListDto>(
+        `/api/v1/entities/${String(entityId)}/relations?${search.toString()}`,
+        signal,
+      )
+      return mapEntityRelationListDtoToModel(dto)
+    },
+  })
+}

--- a/frontend/src/entities/entity-relation/query-keys.ts
+++ b/frontend/src/entities/entity-relation/query-keys.ts
@@ -1,0 +1,6 @@
+export const entityRelationKeys = {
+  all: ['entity-relations'] as const,
+  lists: () => [...entityRelationKeys.all, 'list'] as const,
+  list: (entityId: number, fieldKey: string) =>
+    [...entityRelationKeys.lists(), entityId, fieldKey] as const,
+}

--- a/frontend/src/entities/field-def/api-types.ts
+++ b/frontend/src/entities/field-def/api-types.ts
@@ -1,10 +1,12 @@
-import type { FieldDataType } from './enum'
+import type { FieldDataType, RelationCardinality } from './enum'
 
 export interface FieldDefDto {
   id: number
   entity_type_id: number
   field_key: string
   data_type: FieldDataType
+  target_entity_type_id?: number
+  cardinality?: RelationCardinality
 }
 
 export interface FieldDefListDto {
@@ -17,6 +19,8 @@ export interface CreateFieldDefDto {
   entity_type_id: number
   field_key: string
   data_type: FieldDataType
+  target_entity_type_id?: number
+  cardinality?: RelationCardinality
 }
 
 export type UpdateFieldDefDto = CreateFieldDefDto

--- a/frontend/src/entities/field-def/enum.ts
+++ b/frontend/src/entities/field-def/enum.ts
@@ -1,7 +1,15 @@
-export const FIELD_DATA_TYPES = ['text', 'int', 'enum', 'bool', 'datetime'] as const
+export const FIELD_DATA_TYPES = ['text', 'int', 'enum', 'bool', 'datetime', 'relation'] as const
 
 export type FieldDataType = (typeof FIELD_DATA_TYPES)[number]
 
+export const RELATION_CARDINALITIES = ['one', 'many'] as const
+
+export type RelationCardinality = (typeof RELATION_CARDINALITIES)[number]
+
 export function isFieldDataType(value: string): value is FieldDataType {
   return (FIELD_DATA_TYPES as readonly string[]).includes(value)
+}
+
+export function isRelationCardinality(value: string): value is RelationCardinality {
+  return (RELATION_CARDINALITIES as readonly string[]).includes(value)
 }

--- a/frontend/src/entities/field-def/index.ts
+++ b/frontend/src/entities/field-def/index.ts
@@ -1,8 +1,20 @@
-export { FIELD_DATA_TYPES, isFieldDataType } from './enum'
-export type { FieldDataType } from './enum'
+export {
+  FIELD_DATA_TYPES,
+  isFieldDataType,
+  isRelationCardinality,
+  RELATION_CARDINALITIES,
+} from './enum'
+export type { FieldDataType, RelationCardinality } from './enum'
 export type { FieldDefId } from './ids'
 export { toFieldDefId } from './ids'
-export type { CreateFieldDefInput, FieldDef, FieldDefList, UpdateFieldDefInput } from './model'
+export type {
+  CreateFieldDefInput,
+  FieldDef,
+  FieldDefList,
+  RelationFieldDef,
+  UpdateFieldDefInput,
+} from './model'
+export { isRelationFieldDef } from './model'
 export { fieldDefKeys } from './query-keys'
 export type { FieldDefListParams } from './query-keys'
 export { useCreateFieldDef, useDeleteFieldDef, useUpdateFieldDef } from './mutations'

--- a/frontend/src/entities/field-def/mapper.ts
+++ b/frontend/src/entities/field-def/mapper.ts
@@ -4,7 +4,7 @@ import type {
   FieldDefListDto,
   UpdateFieldDefDto,
 } from './api-types'
-import { isFieldDataType } from './enum'
+import { isFieldDataType, isRelationCardinality } from './enum'
 import { toFieldDefId } from './ids'
 import type { CreateFieldDefInput, FieldDef, FieldDefList, UpdateFieldDefInput } from './model'
 
@@ -22,6 +22,11 @@ export function mapFieldDefDtoToModel(dto: FieldDefDto): FieldDef {
     entityTypeId: dto.entity_type_id,
     fieldKey: dto.field_key,
     dataType: mapDataType(dto.data_type),
+    targetEntityTypeId: dto.target_entity_type_id,
+    cardinality:
+      dto.cardinality !== undefined && isRelationCardinality(dto.cardinality)
+        ? dto.cardinality
+        : undefined,
   }
 }
 
@@ -34,11 +39,18 @@ export function mapFieldDefListDtoToModel(dto: FieldDefListDto): FieldDefList {
 }
 
 export function mapCreateInputToDto(input: CreateFieldDefInput): CreateFieldDefDto {
-  return {
+  const dto: CreateFieldDefDto = {
     entity_type_id: input.entityTypeId,
     field_key: input.fieldKey,
     data_type: input.dataType,
   }
+
+  if (input.dataType === 'relation') {
+    dto.target_entity_type_id = input.targetEntityTypeId
+    dto.cardinality = input.cardinality
+  }
+
+  return dto
 }
 
 export function mapUpdateInputToDto(input: UpdateFieldDefInput): UpdateFieldDefDto {

--- a/frontend/src/entities/field-def/model.ts
+++ b/frontend/src/entities/field-def/model.ts
@@ -1,4 +1,4 @@
-import type { FieldDataType } from './enum'
+import type { FieldDataType, RelationCardinality } from './enum'
 import type { FieldDefId } from './ids'
 
 export interface FieldDef {
@@ -6,6 +6,14 @@ export interface FieldDef {
   entityTypeId: number
   fieldKey: string
   dataType: FieldDataType
+  targetEntityTypeId?: number
+  cardinality?: RelationCardinality
+}
+
+export interface RelationFieldDef extends FieldDef {
+  dataType: 'relation'
+  targetEntityTypeId: number
+  cardinality: RelationCardinality
 }
 
 export interface FieldDefList {
@@ -18,6 +26,16 @@ export interface CreateFieldDefInput {
   entityTypeId: number
   fieldKey: string
   dataType: FieldDataType
+  targetEntityTypeId?: number
+  cardinality?: RelationCardinality
 }
 
 export type UpdateFieldDefInput = CreateFieldDefInput
+
+export function isRelationFieldDef(fieldDef: FieldDef): fieldDef is RelationFieldDef {
+  return (
+    fieldDef.dataType === 'relation' &&
+    fieldDef.targetEntityTypeId !== undefined &&
+    fieldDef.cardinality !== undefined
+  )
+}

--- a/frontend/src/features/edit-entity-text-fields/hooks/use-edit-entity-text-fields-page.ts
+++ b/frontend/src/features/edit-entity-text-fields/hooks/use-edit-entity-text-fields-page.ts
@@ -33,7 +33,9 @@ import {
   type TextField,
 } from '@/entities/text-field'
 
-const EDITABLE_DATA_TYPES: FieldDataType[] = [...FIELD_DATA_TYPES]
+const EDITABLE_DATA_TYPES: FieldDataType[] = FIELD_DATA_TYPES.filter(
+  (dataType) => dataType !== 'relation',
+)
 
 const FIELD_LIST_PARAMS = { limit: 100, offset: 0 } as const
 

--- a/frontend/src/features/manage-entity-relations/hooks/use-relation-field-panel.ts
+++ b/frontend/src/features/manage-entity-relations/hooks/use-relation-field-panel.ts
@@ -1,0 +1,106 @@
+import { useCallback, useMemo, useState } from 'react'
+import {
+  useAttachEntityRelation,
+  useDetachEntityRelation,
+  useEntityRelationList,
+  type EntityRelation,
+} from '@/entities/entity-relation'
+import { defaultEntityListParams, useEntityList } from '@/entities/entity'
+import type { RelationFieldDef } from '@/entities/field-def'
+import { defaultTextFieldListParamsForEntityType, useTextFieldList } from '@/entities/text-field'
+import { getRecordDisplayLabel } from '@/shared/lib/get-record-display-label'
+
+export function useRelationFieldPanel(entityId: number, fieldDef: RelationFieldDef) {
+  const relationQuery = useEntityRelationList(entityId, fieldDef.fieldKey)
+  const targetEntityQuery = useEntityList(defaultEntityListParams(fieldDef.targetEntityTypeId))
+  const textFieldQuery = useTextFieldList(
+    defaultTextFieldListParamsForEntityType(fieldDef.targetEntityTypeId),
+  )
+  const attachMutation = useAttachEntityRelation()
+  const detachMutation = useDetachEntityRelation()
+  const [selectedTargetId, setSelectedTargetId] = useState('')
+
+  const attachedRelations = useMemo(
+    () => relationQuery.data?.items ?? [],
+    [relationQuery.data?.items],
+  )
+
+  const targetLabels = useMemo((): Record<string, string> => {
+    const entities = targetEntityQuery.data?.items ?? []
+    const textFields = textFieldQuery.data?.items ?? []
+
+    return Object.fromEntries(
+      entities.map((entity) => [
+        String(entity.id),
+        getRecordDisplayLabel(Number(entity.id), textFields, `Record #${String(entity.id)}`),
+      ]),
+    )
+  }, [targetEntityQuery.data?.items, textFieldQuery.data?.items])
+
+  const attachedTargetIds = useMemo(
+    () => new Set(attachedRelations.map((relation) => relation.targetEntityId)),
+    [attachedRelations],
+  )
+
+  const availableTargetIds = useMemo((): number[] => {
+    const entities = targetEntityQuery.data?.items ?? []
+
+    return entities.map((entity) => Number(entity.id)).filter((id) => !attachedTargetIds.has(id))
+  }, [attachedTargetIds, targetEntityQuery.data?.items])
+
+  const attachTarget = useCallback(async () => {
+    if (selectedTargetId === '') {
+      return
+    }
+
+    await attachMutation.mutateAsync({
+      entityId,
+      fieldKey: fieldDef.fieldKey,
+      targetEntityId: Number(selectedTargetId),
+    })
+    setSelectedTargetId('')
+  }, [attachMutation, entityId, fieldDef.fieldKey, selectedTargetId])
+
+  const detachTarget = useCallback(
+    async (relation: EntityRelation) => {
+      await detachMutation.mutateAsync({
+        entityId,
+        fieldKey: fieldDef.fieldKey,
+        targetEntityId: relation.targetEntityId,
+      })
+    },
+    [detachMutation, entityId, fieldDef.fieldKey],
+  )
+
+  const isLoading =
+    relationQuery.isLoading || targetEntityQuery.isLoading || textFieldQuery.isLoading
+  const isError = relationQuery.isError || targetEntityQuery.isError || textFieldQuery.isError
+  const errorTitle =
+    relationQuery.error?.title ??
+    targetEntityQuery.error?.title ??
+    textFieldQuery.error?.title ??
+    null
+
+  return {
+    attachedRelations,
+    targetLabels,
+    availableTargetIds,
+    selectedTargetId,
+    setSelectedTargetId,
+    isLoading,
+    isError,
+    errorTitle,
+    isAttaching: attachMutation.isPending,
+    attachErrorTitle: attachMutation.error?.title ?? null,
+    isDetaching: detachMutation.isPending,
+    attachTarget,
+    detachTarget,
+    refetch: async () => {
+      await Promise.all([
+        relationQuery.refetch(),
+        targetEntityQuery.refetch(),
+        textFieldQuery.refetch(),
+      ])
+    },
+  }
+}

--- a/frontend/src/features/manage-entity-relations/index.ts
+++ b/frontend/src/features/manage-entity-relations/index.ts
@@ -1,0 +1,5 @@
+export { useRelationFieldPanel } from './hooks/use-relation-field-panel'
+export { ManageEntityRelationsView } from './ui/ManageEntityRelationsView'
+export { RelationFieldPanel } from './ui/RelationFieldPanel'
+export type { ManageEntityRelationsViewProps } from './ui/ManageEntityRelationsView'
+export type { RelationFieldPanelProps } from './ui/RelationFieldPanel'

--- a/frontend/src/features/manage-entity-relations/ui/ManageEntityRelationsView.tsx
+++ b/frontend/src/features/manage-entity-relations/ui/ManageEntityRelationsView.tsx
@@ -1,0 +1,53 @@
+import { useMemo } from 'react'
+import {
+  defaultFieldDefListParams,
+  isRelationFieldDef,
+  useFieldDefList,
+} from '@/entities/field-def'
+import { Stack, Text } from '@/shared/ui'
+import { RelationFieldPanel } from './RelationFieldPanel'
+
+export interface ManageEntityRelationsViewProps {
+  entityId: number
+  entityTypeId: number
+}
+
+export function ManageEntityRelationsView({
+  entityId,
+  entityTypeId,
+}: ManageEntityRelationsViewProps) {
+  const fieldDefQuery = useFieldDefList(defaultFieldDefListParams(entityTypeId))
+
+  const relationFieldDefs = useMemo(
+    () => (fieldDefQuery.data?.items ?? []).filter(isRelationFieldDef),
+    [fieldDefQuery.data?.items],
+  )
+
+  if (fieldDefQuery.isLoading) {
+    return <Text muted>Loading relations…</Text>
+  }
+
+  if (fieldDefQuery.isError) {
+    return (
+      <Stack gap="sm">
+        <Text variant="heading-sm">Could not load relation fields</Text>
+        <Text muted>{fieldDefQuery.error.title}</Text>
+      </Stack>
+    )
+  }
+
+  if (relationFieldDefs.length === 0) {
+    return null
+  }
+
+  return (
+    <Stack gap="lg">
+      <Text as="h2" variant="heading-sm">
+        Relations
+      </Text>
+      {relationFieldDefs.map((fieldDef) => (
+        <RelationFieldPanel key={String(fieldDef.id)} entityId={entityId} fieldDef={fieldDef} />
+      ))}
+    </Stack>
+  )
+}

--- a/frontend/src/features/manage-entity-relations/ui/RelationFieldPanel.tsx
+++ b/frontend/src/features/manage-entity-relations/ui/RelationFieldPanel.tsx
@@ -1,0 +1,126 @@
+import type { RelationFieldDef } from '@/entities/field-def'
+import { Button, Stack, Text } from '@/shared/ui'
+import { useRelationFieldPanel } from '../hooks/use-relation-field-panel'
+
+export interface RelationFieldPanelProps {
+  entityId: number
+  fieldDef: RelationFieldDef
+}
+
+export function RelationFieldPanel({ entityId, fieldDef }: RelationFieldPanelProps) {
+  const {
+    attachedRelations,
+    targetLabels,
+    availableTargetIds,
+    selectedTargetId,
+    setSelectedTargetId,
+    isLoading,
+    isError,
+    errorTitle,
+    isAttaching,
+    attachErrorTitle,
+    isDetaching,
+    attachTarget,
+    detachTarget,
+    refetch,
+  } = useRelationFieldPanel(entityId, fieldDef)
+
+  const attachLabel = fieldDef.cardinality === 'one' ? 'Set target' : 'Add target'
+  const selectId = `relation-target-${fieldDef.fieldKey}`
+
+  if (isLoading) {
+    return <Text muted>Loading {fieldDef.fieldKey}…</Text>
+  }
+
+  if (isError) {
+    return (
+      <Stack gap="sm">
+        <Text variant="heading-sm">Could not load {fieldDef.fieldKey}</Text>
+        <Text muted>{errorTitle ?? 'Unknown error'}</Text>
+        <Button variant="secondary" onClick={() => void refetch()}>
+          Retry
+        </Button>
+      </Stack>
+    )
+  }
+
+  return (
+    <Stack gap="md">
+      <Stack gap="xs">
+        <Text as="h3" variant="heading-sm">
+          {fieldDef.fieldKey}
+        </Text>
+        <Text muted>
+          relation · {fieldDef.cardinality} · target type #{String(fieldDef.targetEntityTypeId)}
+        </Text>
+      </Stack>
+      {attachedRelations.length === 0 ? (
+        <Text muted>No targets linked yet.</Text>
+      ) : (
+        <ul className="flex flex-col gap-stack-sm">
+          {attachedRelations.map((relation) => (
+            <li
+              key={`${relation.fieldKey}-${String(relation.targetEntityId)}`}
+              className="flex items-center justify-between gap-inline-md rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm shadow-sm"
+            >
+              <Stack gap="xs">
+                <Text as="span" variant="heading-sm">
+                  {targetLabels[String(relation.targetEntityId)] ??
+                    `Record #${String(relation.targetEntityId)}`}
+                </Text>
+                <Text as="span" muted>
+                  #{String(relation.targetEntityId)}
+                </Text>
+              </Stack>
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={isDetaching}
+                onClick={() => {
+                  void detachTarget(relation)
+                }}
+              >
+                Remove
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <Stack gap="sm">
+        <div className="flex flex-col gap-stack-xs">
+          <label htmlFor={selectId} className="font-sans text-body font-medium text-text-primary">
+            {attachLabel}
+          </label>
+          <select
+            id={selectId}
+            disabled={isAttaching || availableTargetIds.length === 0}
+            value={selectedTargetId}
+            onChange={(event) => {
+              setSelectedTargetId(event.target.value)
+            }}
+            className="rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm font-sans text-body text-text-primary shadow-sm focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <option value="">
+              {availableTargetIds.length === 0 ? 'No targets available' : 'Select target…'}
+            </option>
+            {availableTargetIds.map((targetId) => (
+              <option key={String(targetId)} value={String(targetId)}>
+                {targetLabels[String(targetId)] ?? `Record #${String(targetId)}`}
+              </option>
+            ))}
+          </select>
+        </div>
+        {attachErrorTitle !== null ? <Text muted>{attachErrorTitle}</Text> : null}
+        <Button
+          variant="secondary"
+          disabled={isAttaching || selectedTargetId === ''}
+          onClick={() => {
+            void attachTarget()
+          }}
+        >
+          {isAttaching ? 'Saving…' : attachLabel}
+        </Button>
+      </Stack>
+    </Stack>
+  )
+}

--- a/frontend/src/pages/entity-record/EntityRecordPage.test.tsx
+++ b/frontend/src/pages/entity-record/EntityRecordPage.test.tsx
@@ -10,7 +10,8 @@ import { resetEntityTypeStore, seedEntityTypes } from '@tests/msw/handlers/entit
 import { resetEnumFieldStore } from '@tests/msw/handlers/enum-field'
 import { resetFieldDefStore, seedFieldDefs } from '@tests/msw/handlers/field-def'
 import { resetIntFieldStore } from '@tests/msw/handlers/int-field'
-import { resetTextFieldStore } from '@tests/msw/handlers/text-field'
+import { resetTextFieldStore, seedTextFields } from '@tests/msw/handlers/text-field'
+import { resetEntityRelationStore } from '@tests/msw/handlers/entity-relation'
 import { resetEntityTagStore } from '@tests/msw/handlers/entity-tag'
 import { resetTagStore, seedTags } from '@tests/msw/handlers/tag'
 import { mswServer } from '@tests/msw/server'
@@ -48,6 +49,7 @@ describe('EntityRecordPage', () => {
     resetDateTimeFieldStore()
     resetTagStore()
     resetEntityTagStore()
+    resetEntityRelationStore()
     cleanup()
   })
 
@@ -220,6 +222,100 @@ describe('EntityRecordPage', () => {
     await waitFor(() => {
       expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument()
       expect(screen.getByText('No tags attached yet.')).toBeInTheDocument()
+    })
+  })
+
+  it('attaches and removes relation targets on the record', async () => {
+    seedEntityTypes([
+      { id: 1, name: 'Article', slug: 'article' },
+      { id: 2, name: 'Author', slug: 'author' },
+    ])
+    seedFieldDefs([
+      {
+        id: 1,
+        entity_type_id: 1,
+        field_key: 'author',
+        data_type: 'relation',
+        target_entity_type_id: 2,
+        cardinality: 'one',
+      },
+    ])
+    seedEntities([
+      { id: 1, entity_type_id: 1, is_deleted: false, deleted_at: null },
+      { id: 2, entity_type_id: 2, is_deleted: false, deleted_at: null },
+      { id: 3, entity_type_id: 2, is_deleted: false, deleted_at: null },
+    ])
+    seedTextFields([
+      { id: 1, entity_id: 2, field_key: 'title', value: 'Alice' },
+      { id: 2, entity_id: 3, field_key: 'title', value: 'Bob' },
+    ])
+
+    const user = userEvent.setup()
+    renderEntityRecordPage()
+
+    expect(await screen.findByRole('heading', { name: 'Relations' })).toBeInTheDocument()
+    expect(await screen.findByText('No targets linked yet.')).toBeInTheDocument()
+
+    await user.selectOptions(screen.getByLabelText('Set target'), '2')
+    await user.click(screen.getByRole('button', { name: 'Set target' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice')).toBeInTheDocument()
+      expect(screen.getByText('#2')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Remove' }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument()
+      expect(screen.getByText('No targets linked yet.')).toBeInTheDocument()
+    })
+  })
+
+  it('replaces one-cardinality relation target when setting a new target', async () => {
+    seedEntityTypes([
+      { id: 1, name: 'Article', slug: 'article' },
+      { id: 2, name: 'Author', slug: 'author' },
+    ])
+    seedFieldDefs([
+      {
+        id: 1,
+        entity_type_id: 1,
+        field_key: 'author',
+        data_type: 'relation',
+        target_entity_type_id: 2,
+        cardinality: 'one',
+      },
+    ])
+    seedEntities([
+      { id: 1, entity_type_id: 1, is_deleted: false, deleted_at: null },
+      { id: 2, entity_type_id: 2, is_deleted: false, deleted_at: null },
+      { id: 3, entity_type_id: 2, is_deleted: false, deleted_at: null },
+    ])
+    seedTextFields([
+      { id: 1, entity_id: 2, field_key: 'title', value: 'Alice' },
+      { id: 2, entity_id: 3, field_key: 'title', value: 'Bob' },
+    ])
+
+    const user = userEvent.setup()
+    renderEntityRecordPage()
+
+    expect(await screen.findByLabelText('Set target')).toBeInTheDocument()
+
+    await user.selectOptions(screen.getByLabelText('Set target'), '2')
+    await user.click(screen.getByRole('button', { name: 'Set target' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice')).toBeInTheDocument()
+    })
+
+    await user.selectOptions(screen.getByLabelText('Set target'), '3')
+    await user.click(screen.getByRole('button', { name: 'Set target' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('#2')).not.toBeInTheDocument()
+      expect(screen.getByText('Bob')).toBeInTheDocument()
+      expect(screen.getByText('#3')).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/pages/entity-record/EntityRecordPage.tsx
+++ b/frontend/src/pages/entity-record/EntityRecordPage.tsx
@@ -5,6 +5,7 @@ import {
   useEditEntityTextFieldsPage,
 } from '@/features/edit-entity-text-fields'
 import { ManageEntityTagsView, useManageEntityTagsPage } from '@/features/manage-entity-tags'
+import { ManageEntityRelationsView } from '@/features/manage-entity-relations'
 import { Button, Stack, Text } from '@/shared/ui'
 
 export function EntityRecordPage() {
@@ -85,6 +86,7 @@ export function EntityRecordPage() {
         onAttach={attachTag}
         onDetach={detachTag}
       />
+      <ManageEntityRelationsView entityId={entityId} entityTypeId={entityTypeId} />
     </Stack>
   )
 }

--- a/frontend/tests/msw/handlers/entity-relation.ts
+++ b/frontend/tests/msw/handlers/entity-relation.ts
@@ -1,0 +1,273 @@
+import { http, HttpResponse } from 'msw'
+import { getActiveEntities } from './entity'
+import { findFieldDefForEntityType } from './field-def'
+
+interface EntityRelationLink {
+  source_entity_id: number
+  target_entity_id: number
+  field_key: string
+}
+
+let links: EntityRelationLink[] = []
+
+export function resetEntityRelationStore(): void {
+  links = []
+}
+
+export function seedEntityRelations(seed: EntityRelationLink[]): void {
+  links = [...seed]
+}
+
+export const entityRelationHandlers = [
+  http.get('/api/v1/entities/:entityId/relations', ({ params, request }) => {
+    const entityId = Number(params.entityId)
+    const entity = getActiveEntities().find((item) => item.id === entityId)
+
+    if (entity === undefined) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/not-found',
+          title: 'Not found',
+          status: 404,
+          instance: `/api/v1/entities/${String(entityId)}/relations`,
+        },
+        { status: 404 },
+      )
+    }
+
+    const url = new URL(request.url)
+    const fieldKey = url.searchParams.get('field_key')?.trim() ?? ''
+
+    if (fieldKey === '') {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/validation-failed',
+          title: 'Validation failed',
+          status: 422,
+          instance: `/api/v1/entities/${String(entityId)}/relations`,
+          errors: [{ field: 'field_key', message: 'Required', code: 'required' }],
+        },
+        { status: 422 },
+      )
+    }
+
+    const fieldDef = findFieldDefForEntityType(entity.entity_type_id, fieldKey)
+
+    if (fieldDef === undefined) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/field-key-not-registered',
+          title: 'Field Key Not Registered',
+          status: 422,
+          instance: `/api/v1/entities/${String(entityId)}/relations`,
+        },
+        { status: 422 },
+      )
+    }
+
+    if (fieldDef.data_type !== 'relation') {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/field-type-mismatch',
+          title: 'Field Type Mismatch',
+          status: 422,
+          instance: `/api/v1/entities/${String(entityId)}/relations`,
+        },
+        { status: 422 },
+      )
+    }
+
+    const items = links
+      .filter((link) => link.source_entity_id === entityId && link.field_key === fieldKey)
+      .map((link) => ({
+        field_key: link.field_key,
+        target_entity_id: link.target_entity_id,
+      }))
+
+    return HttpResponse.json({ items })
+  }),
+  http.post('/api/v1/entities/:entityId/relations', async ({ params, request }) => {
+    const entityId = Number(params.entityId)
+    const sourceEntity = getActiveEntities().find((item) => item.id === entityId)
+
+    if (sourceEntity === undefined) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/not-found',
+          title: 'Not found',
+          status: 404,
+          instance: `/api/v1/entities/${String(entityId)}/relations`,
+        },
+        { status: 404 },
+      )
+    }
+
+    const body = (await request.json()) as {
+      field_key?: string
+      target_entity_id?: number
+    }
+    const fieldKey = body.field_key?.trim() ?? ''
+    const targetEntityId = body.target_entity_id
+
+    if (fieldKey === '') {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/validation-failed',
+          title: 'Validation failed',
+          status: 422,
+          instance: `/api/v1/entities/${String(entityId)}/relations`,
+          errors: [{ field: 'field_key', message: 'Required', code: 'required' }],
+        },
+        { status: 422 },
+      )
+    }
+
+    if (typeof targetEntityId !== 'number' || targetEntityId < 1) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/validation-failed',
+          title: 'Validation failed',
+          status: 422,
+          instance: `/api/v1/entities/${String(entityId)}/relations`,
+          errors: [{ field: 'target_entity_id', message: 'Required', code: 'required' }],
+        },
+        { status: 422 },
+      )
+    }
+
+    const fieldDef = findFieldDefForEntityType(sourceEntity.entity_type_id, fieldKey)
+
+    if (fieldDef === undefined) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/field-key-not-registered',
+          title: 'Field Key Not Registered',
+          status: 422,
+          instance: `/api/v1/entities/${String(entityId)}/relations`,
+        },
+        { status: 422 },
+      )
+    }
+
+    if (fieldDef.data_type !== 'relation') {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/field-type-mismatch',
+          title: 'Field Type Mismatch',
+          status: 422,
+          instance: `/api/v1/entities/${String(entityId)}/relations`,
+        },
+        { status: 422 },
+      )
+    }
+
+    const targetEntity = getActiveEntities().find((item) => item.id === targetEntityId)
+
+    if (targetEntity === undefined) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/not-found',
+          title: 'Not found',
+          status: 404,
+          instance: `/api/v1/entities/${String(targetEntityId)}`,
+        },
+        { status: 404 },
+      )
+    }
+
+    if (
+      fieldDef.target_entity_type_id !== undefined &&
+      targetEntity.entity_type_id !== fieldDef.target_entity_type_id
+    ) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/relation-target-type-mismatch',
+          title: 'Relation Target Type Mismatch',
+          status: 422,
+          instance: `/api/v1/entities/${String(entityId)}/relations`,
+        },
+        { status: 422 },
+      )
+    }
+
+    const exists = links.some(
+      (link) =>
+        link.source_entity_id === entityId &&
+        link.target_entity_id === targetEntityId &&
+        link.field_key === fieldKey,
+    )
+
+    if (exists) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/relation-already-attached',
+          title: 'Conflict',
+          status: 409,
+          instance: `/api/v1/entities/${String(entityId)}/relations`,
+        },
+        { status: 409 },
+      )
+    }
+
+    if (fieldDef.cardinality === 'one') {
+      links = links.filter(
+        (link) => !(link.source_entity_id === entityId && link.field_key === fieldKey),
+      )
+    }
+
+    links = [
+      ...links,
+      { source_entity_id: entityId, target_entity_id: targetEntityId, field_key: fieldKey },
+    ]
+
+    return HttpResponse.json(
+      {
+        field_key: fieldKey,
+        target_entity_id: targetEntityId,
+      },
+      { status: 201 },
+    )
+  }),
+  http.delete('/api/v1/entities/:entityId/relations/:targetEntityId', ({ params, request }) => {
+    const entityId = Number(params.entityId)
+    const targetEntityId = Number(params.targetEntityId)
+    const url = new URL(request.url)
+    const fieldKey = url.searchParams.get('field_key')?.trim() ?? ''
+
+    if (fieldKey === '') {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/validation-failed',
+          title: 'Validation failed',
+          status: 422,
+          instance: `/api/v1/entities/${String(entityId)}/relations/${String(targetEntityId)}`,
+          errors: [{ field: 'field_key', message: 'Required', code: 'required' }],
+        },
+        { status: 422 },
+      )
+    }
+
+    const index = links.findIndex(
+      (link) =>
+        link.source_entity_id === entityId &&
+        link.target_entity_id === targetEntityId &&
+        link.field_key === fieldKey,
+    )
+
+    if (index === -1) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/relation-not-attached',
+          title: 'Not Found',
+          status: 404,
+          instance: `/api/v1/entities/${String(entityId)}/relations/${String(targetEntityId)}`,
+        },
+        { status: 404 },
+      )
+    }
+
+    links = links.filter((_link, linkIndex) => linkIndex !== index)
+
+    return new HttpResponse(null, { status: 204 })
+  }),
+]

--- a/frontend/tests/msw/handlers/field-def.ts
+++ b/frontend/tests/msw/handlers/field-def.ts
@@ -1,18 +1,21 @@
 import { http, HttpResponse } from 'msw'
 
-type FieldDataType = 'text' | 'int' | 'enum' | 'bool' | 'datetime'
+type FieldDataType = 'text' | 'int' | 'enum' | 'bool' | 'datetime' | 'relation'
+type RelationCardinality = 'one' | 'many'
 
-const FIELD_DATA_TYPES: FieldDataType[] = ['text', 'int', 'enum', 'bool', 'datetime']
+const FIELD_DATA_TYPES: FieldDataType[] = ['text', 'int', 'enum', 'bool', 'datetime', 'relation']
 
 function isFieldDataType(value: string): value is FieldDataType {
   return (FIELD_DATA_TYPES as string[]).includes(value)
 }
 
-interface FieldDefRecord {
+export interface FieldDefRecord {
   id: number
   entity_type_id: number
   field_key: string
   data_type: FieldDataType
+  target_entity_type_id?: number
+  cardinality?: RelationCardinality
 }
 
 let nextId = 1
@@ -26,6 +29,13 @@ export function resetFieldDefStore(): void {
 export function seedFieldDefs(seed: FieldDefRecord[]): void {
   items = [...seed]
   nextId = Math.max(0, ...seed.map((item) => item.id)) + 1
+}
+
+export function findFieldDefForEntityType(
+  entityTypeId: number,
+  fieldKey: string,
+): FieldDefRecord | undefined {
+  return items.find((item) => item.entity_type_id === entityTypeId && item.field_key === fieldKey)
 }
 
 export const fieldDefHandlers = [
@@ -68,6 +78,8 @@ export const fieldDefHandlers = [
       entity_type_id?: number
       field_key?: string
       data_type?: string
+      target_entity_type_id?: number
+      cardinality?: RelationCardinality
     }
 
     if (typeof body.entity_type_id !== 'number' || body.entity_type_id < 1) {
@@ -130,6 +142,8 @@ export const fieldDefHandlers = [
       entity_type_id: body.entity_type_id,
       field_key: body.field_key,
       data_type: body.data_type,
+      target_entity_type_id: body.target_entity_type_id,
+      cardinality: body.cardinality,
     }
     items = [...items, created]
 
@@ -155,6 +169,8 @@ export const fieldDefHandlers = [
       entity_type_id?: number
       field_key?: string
       data_type?: string
+      target_entity_type_id?: number
+      cardinality?: RelationCardinality
     }
 
     if (typeof body.entity_type_id !== 'number' || body.entity_type_id < 1) {
@@ -225,6 +241,8 @@ export const fieldDefHandlers = [
       entity_type_id: body.entity_type_id,
       field_key: body.field_key,
       data_type: body.data_type,
+      target_entity_type_id: body.target_entity_type_id,
+      cardinality: body.cardinality,
     }
     items = items.map((item, itemIndex) => (itemIndex === index ? updated : item))
 

--- a/frontend/tests/msw/server.ts
+++ b/frontend/tests/msw/server.ts
@@ -1,6 +1,7 @@
 import { setupServer } from 'msw/node'
 import { boolFieldHandlers } from './handlers/bool-field'
 import { dateTimeFieldHandlers } from './handlers/datetime-field'
+import { entityRelationHandlers } from './handlers/entity-relation'
 import { entityTagHandlers } from './handlers/entity-tag'
 import { entityHandlers } from './handlers/entity'
 import { entityTypeHandlers } from './handlers/entity-type'
@@ -14,6 +15,7 @@ export const mswServer = setupServer(
   ...entityTypeHandlers,
   ...entityHandlers,
   ...entityTagHandlers,
+  ...entityRelationHandlers,
   ...fieldDefHandlers,
   ...textFieldHandlers,
   ...intFieldHandlers,


### PR DESCRIPTION
## Summary

- Record 詳細に `ManageEntityRelationsView` + `RelationFieldPanel` を追加
- relation field_def ごとに target 選択・attach/detach（one は Set target で置換）
- `entities/entity-relation` スライス、MSW handler、page テスト 2 件
- field values フォームから `relation` 型を除外

## Test plan

- [x] `npm run check --prefix frontend` — 61 tests passed
- [ ] Record 詳細で relation target を Set → Remove
- [ ] cardinality one で target 差し替え

Closes #52

セルフレビュー: frontend-standards checklist


Made with [Cursor](https://cursor.com)