### PR TITLE
feat(entity): 一覧 API に relation フィルタを追加 (#57)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -203,7 +203,7 @@ paths:
       tags:
         - Entities
       summary: List entities
-      description: Returns non-deleted entities, optionally filtered by entity type and tags.
+      description: Returns non-deleted entities, optionally filtered by entity type, tags, and relation fields.
       operationId: listEntities
       parameters:
         - $ref: '#/components/parameters/LimitQuery'
@@ -211,6 +211,7 @@ paths:
         - $ref: '#/components/parameters/EntityTypeIdQuery'
         - $ref: '#/components/parameters/TagsQuery'
         - $ref: '#/components/parameters/TagQuery'
+        - $ref: '#/components/parameters/RelationFilterQuery'
       responses:
         '200':
           description: Paginated entity list.
@@ -1651,6 +1652,19 @@ components:
       schema:
         type: string
       example: featured
+    RelationFilterQuery:
+      name: relation.{field_key}
+      in: query
+      required: false
+      description: |
+        Filter entities linked via a relation field. Use one query parameter per field key,
+        for example `relation.author=5`. Multiple relation filters are combined with AND.
+        PHP query parsing may expose these keys as `relation_{field_key}` in the parameter array.
+      schema:
+        type: integer
+        format: int64
+        minimum: 1
+      example: 5
     EntityIdPath:
       name: entityId
       in: path

--- a/src/Entity/EntityListCriteria.php
+++ b/src/Entity/EntityListCriteria.php
@@ -6,10 +6,14 @@ namespace NeNeRecords\Entity;
 
 final readonly class EntityListCriteria
 {
-    /** @param list<string> $tagSlugs */
+    /**
+     * @param list<string> $tagSlugs
+     * @param array<string, int> $relationFilters
+     */
     public function __construct(
         public ?int $entityTypeId = null,
         public array $tagSlugs = [],
+        public array $relationFilters = [],
     ) {
     }
 }

--- a/src/Entity/EntityRelationQueryParser.php
+++ b/src/Entity/EntityRelationQueryParser.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+final readonly class EntityRelationQueryParser
+{
+    private const DOT_PREFIX = 'relation.';
+
+    private const UNDERSCORE_PREFIX = 'relation_';
+
+    /**
+     * @param array<string, mixed> $queryParams
+     *
+     * @return array<string, int>
+     */
+    public static function parseRelationFilters(array $queryParams): array
+    {
+        $filters = [];
+
+        foreach ($queryParams as $key => $value) {
+            if ($key === 'relation' && is_array($value)) {
+                foreach ($value as $fieldKey => $targetValue) {
+                    if (!is_string($fieldKey)) {
+                        continue;
+                    }
+
+                    $targetEntityId = self::parseTargetEntityId($targetValue);
+
+                    if ($targetEntityId !== null) {
+                        $filters[$fieldKey] = $targetEntityId;
+                    }
+                }
+
+                continue;
+            }
+
+            if (str_starts_with($key, self::DOT_PREFIX)) {
+                $fieldKey = substr($key, strlen(self::DOT_PREFIX));
+            } elseif (str_starts_with($key, self::UNDERSCORE_PREFIX)) {
+                $fieldKey = substr($key, strlen(self::UNDERSCORE_PREFIX));
+            } else {
+                continue;
+            }
+
+            if ($fieldKey === '') {
+                continue;
+            }
+
+            $targetEntityId = self::parseTargetEntityId($value);
+
+            if ($targetEntityId !== null) {
+                $filters[$fieldKey] = $targetEntityId;
+            }
+        }
+
+        return $filters;
+    }
+
+    private static function parseTargetEntityId(mixed $value): ?int
+    {
+        if (!is_scalar($value)) {
+            return null;
+        }
+
+        $raw = trim((string) $value);
+
+        if ($raw === '' || !ctype_digit($raw)) {
+            return null;
+        }
+
+        $targetEntityId = (int) $raw;
+
+        return $targetEntityId > 0 ? $targetEntityId : null;
+    }
+}

--- a/src/Entity/ListEntitiesHandler.php
+++ b/src/Entity/ListEntitiesHandler.php
@@ -28,6 +28,7 @@ final readonly class ListEntitiesHandler
         $tagSlugs = array_values(array_unique([...$tagsFromTags, ...$tagsFromTag]));
 
         $entityTypeId = QueryStringParser::int($request, 'entity_type_id');
+        $relationFilters = EntityRelationQueryParser::parseRelationFilters($request->getQueryParams());
 
         $output = $this->useCase->execute(new ListEntitiesInput(
             limit: $pagination->limit,
@@ -35,6 +36,7 @@ final readonly class ListEntitiesHandler
             criteria: new EntityListCriteria(
                 entityTypeId: $entityTypeId,
                 tagSlugs: $tagSlugs,
+                relationFilters: $relationFilters,
             ),
         ));
 

--- a/src/Entity/PdoEntityRepository.php
+++ b/src/Entity/PdoEntityRepository.php
@@ -104,6 +104,20 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
             }
         }
 
+        foreach ($criteria->relationFilters as $fieldKey => $targetEntityId) {
+            $conditions[] = <<<'SQL'
+                EXISTS (
+                    SELECT 1
+                    FROM entity_relations er
+                    WHERE er.source_entity_id = e.id
+                      AND er.field_key = ?
+                      AND er.target_entity_id = ?
+                )
+                SQL;
+            $params[] = $fieldKey;
+            $params[] = $targetEntityId;
+        }
+
         return [implode(' AND ', $conditions), $params];
     }
 

--- a/tests/Entity/EntityFilterHttpTest.php
+++ b/tests/Entity/EntityFilterHttpTest.php
@@ -46,6 +46,9 @@ final class EntityFilterHttpTest extends TestCase
         $this->entities->setTagSlugsForEntity(1, ['featured']);
         $this->entities->setTagSlugsForEntity(2, ['draft']);
         $this->entities->setTagSlugsForEntity(3, ['featured']);
+        $this->entities->setRelationForEntity(1, 'author', 10);
+        $this->entities->setRelationForEntity(1, 'category', 20);
+        $this->entities->setRelationForEntity(2, 'author', 10);
 
         $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
         $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
@@ -103,6 +106,33 @@ final class EntityFilterHttpTest extends TestCase
         $payload = $this->decodeJson($response);
 
         self::assertSame(3, $payload['total']);
+    }
+
+    public function testListEntitiesFilteredByRelationFieldKey(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/entities?relation.author=10'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(2, $payload['total']);
+        self::assertSame([1, 2], array_column($payload['items'], 'id'));
+    }
+
+    public function testListEntitiesRelationFiltersUseAndSemantics(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest(
+                'GET',
+                'https://example.test/api/v1/entities?relation.author=10&relation.category=20',
+            ),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(1, $payload['total']);
+        self::assertSame(1, $payload['items'][0]['id']);
     }
 
     /**

--- a/tests/Entity/EntityRelationQueryParserTest.php
+++ b/tests/Entity/EntityRelationQueryParserTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Entity;
+
+use NeNeRecords\Entity\EntityRelationQueryParser;
+use PHPUnit\Framework\TestCase;
+
+final class EntityRelationQueryParserTest extends TestCase
+{
+    public function testParseRelationFiltersExtractsFieldKeyAndTargetId(): void
+    {
+        $filters = EntityRelationQueryParser::parseRelationFilters([
+            'entity_type_id' => '1',
+            'relation.author' => '5',
+            'relation.category' => '12',
+        ]);
+
+        self::assertSame(['author' => 5, 'category' => 12], $filters);
+    }
+
+    public function testParseRelationFiltersSupportsUnderscoreKeysFromPhpQueryParsing(): void
+    {
+        $filters = EntityRelationQueryParser::parseRelationFilters([
+            'relation_author' => '10',
+            'relation_category' => '20',
+        ]);
+
+        self::assertSame(['author' => 10, 'category' => 20], $filters);
+    }
+
+    public function testParseRelationFiltersSupportsNestedRelationArray(): void
+    {
+        $filters = EntityRelationQueryParser::parseRelationFilters([
+            'relation' => [
+                'author' => '7',
+            ],
+        ]);
+
+        self::assertSame(['author' => 7], $filters);
+    }
+
+    public function testParseRelationFiltersIgnoresInvalidValues(): void
+    {
+        $filters = EntityRelationQueryParser::parseRelationFilters([
+            'relation.author' => '0',
+            'relation.category' => '-1',
+            'relation.empty' => '',
+            'relation.bad' => 'abc',
+            'relation.' => '1',
+            'not-relation.author' => '2',
+        ]);
+
+        self::assertSame([], $filters);
+    }
+}

--- a/tests/Entity/InMemoryEntityRepository.php
+++ b/tests/Entity/InMemoryEntityRepository.php
@@ -17,6 +17,9 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
     /** @var array<int, list<string>> entityId => tag slugs */
     private array $tagSlugsByEntityId;
 
+    /** @var array<int, array<string, list<int>>> entityId => fieldKey => target entity ids */
+    private array $relationsByEntityId;
+
     private int $nextId;
 
     /** @param list<Entity> $seed */
@@ -24,6 +27,7 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
     {
         $this->entities = [];
         $this->tagSlugsByEntityId = [];
+        $this->relationsByEntityId = [];
         $this->nextId = 1;
 
         foreach ($seed as $entity) {
@@ -39,6 +43,11 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
     public function setTagSlugsForEntity(int $entityId, array $tagSlugs): void
     {
         $this->tagSlugsByEntityId[$entityId] = $tagSlugs;
+    }
+
+    public function setRelationForEntity(int $entityId, string $fieldKey, int $targetEntityId): void
+    {
+        $this->relationsByEntityId[$entityId][$fieldKey][] = $targetEntityId;
     }
 
     public function findById(int $id): ?Entity
@@ -86,6 +95,18 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
 
                 if (!$matches) {
                     continue;
+                }
+            }
+
+            if ($criteria->relationFilters !== []) {
+                $entityId = $entity->id ?? 0;
+
+                foreach ($criteria->relationFilters as $fieldKey => $targetEntityId) {
+                    $linkedTargetIds = $this->relationsByEntityId[$entityId][$fieldKey] ?? [];
+
+                    if (!in_array($targetEntityId, $linkedTargetIds, true)) {
+                        continue 2;
+                    }
                 }
             }
 

--- a/tests/Entity/PdoEntityRepositoryTest.php
+++ b/tests/Entity/PdoEntityRepositoryTest.php
@@ -50,6 +50,7 @@ final class PdoEntityRepositoryTest extends TestCase
             $projectRoot . '/database/schema/entities.sql',
             $projectRoot . '/database/schema/tags.sql',
             $projectRoot . '/database/schema/entity_tags.sql',
+            $projectRoot . '/database/schema/entity_relations.sql',
             $projectRoot . '/database/schema/text_fields.sql',
         ];
 
@@ -210,5 +211,43 @@ final class PdoEntityRepositoryTest extends TestCase
 
         self::assertCount(2, $list);
         self::assertSame(2, $repository->countByCriteria($criteria));
+    }
+
+    public function testFindByCriteriaFiltersByRelationFieldWithAndSemantics(): void
+    {
+        $typeId = $this->insertEntityTypeId();
+
+        $repository = new PdoEntityRepository($this->executor);
+        $entityA = $repository->save(new Entity(id: null, entityTypeId: $typeId));
+        $entityB = $repository->save(new Entity(id: null, entityTypeId: $typeId));
+        $repository->save(new Entity(id: null, entityTypeId: $typeId));
+        $targetAuthor = $repository->save(new Entity(id: null, entityTypeId: $typeId));
+        $targetCategory = $repository->save(new Entity(id: null, entityTypeId: $typeId));
+
+        $this->executor->execute(
+            'INSERT INTO entity_relations (source_entity_id, target_entity_id, field_key) VALUES (?, ?, ?)',
+            [$entityA, $targetAuthor, 'author'],
+        );
+        $this->executor->execute(
+            'INSERT INTO entity_relations (source_entity_id, target_entity_id, field_key) VALUES (?, ?, ?)',
+            [$entityA, $targetCategory, 'category'],
+        );
+        $this->executor->execute(
+            'INSERT INTO entity_relations (source_entity_id, target_entity_id, field_key) VALUES (?, ?, ?)',
+            [$entityB, $targetAuthor, 'author'],
+        );
+
+        $singleFilter = new EntityListCriteria(relationFilters: ['author' => $targetAuthor]);
+        $singleList = $repository->findByCriteria($singleFilter, 10, 0);
+
+        self::assertCount(2, $singleList);
+        self::assertSame(2, $repository->countByCriteria($singleFilter));
+
+        $andFilter = new EntityListCriteria(relationFilters: ['author' => $targetAuthor, 'category' => $targetCategory]);
+        $andList = $repository->findByCriteria($andFilter, 10, 0);
+
+        self::assertCount(1, $andList);
+        self::assertSame($entityA, $andList[0]->id);
+        self::assertSame(1, $repository->countByCriteria($andFilter));
     }
 }


### PR DESCRIPTION
## Summary

- `GET /api/v1/entities?relation.{field_key}={targetEntityId}` で relation フィールドによる一覧絞り込みを追加
- `EntityListCriteria` に `relationFilters` を拡張し、`PdoEntityRepository` では `entity_relations` への `EXISTS` サブクエリで AND 結合
- PHP のクエリ正規化（`relation.author` → `relation_author`）およびネスト配列形式にも `EntityRelationQueryParser` で対応
- OpenAPI に `RelationFilterQuery` パラメータを追記

Closes #57

## 検証

- [x] `composer check` — 144 tests, PHPStan, CS Fixer, OpenAPI valid

## セルフレビュー

- `docs/review/backend-api.md`
- `docs/review/openapi-contract.md`


Made with [Cursor](https://cursor.com)