### PR TITLE
feat(frontend): Record 詳細 inverse relation 参照元一覧を追加 (#61)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -12,12 +12,13 @@ Last updated: 2026-05-24
 
 | Issue | Summary |
 | --- | --- |
-| #61 | Record 詳細 inverse relation 参照元一覧 UI |
+| — | （なし） |
 
 ## Recently Completed
 
 | Issue | Summary |
 | --- | --- |
+| #61 | Record 詳細 inverse relation 参照元一覧 UI (PR #62) |
 | #59 | Records 一覧 relation フィルタ UI (PR #60) |
 | #57 | entities 一覧 relation フィルタ API (PR #58) |
 | #52 | Record 詳細 relation attach/detach UI |
@@ -33,12 +34,12 @@ Last updated: 2026-05-24
 
 - **API（済）:** tags CRUD, entity_tags, entities `?tags=` フィルタ
 - **Admin UI（済）:** Tag CRUD (#44), Record tag attach/detach (#46), Records 一覧 tag フィルタ (#48)
-- **Relations（済）:** API #51, Admin UI #52, list filter API #57, list filter UI #59
-- **Relations 後続:** inverse, Consumer view relation links, MCP
+- **Relations（済）:** API #51, Admin UI #52, list filter #57/#59, inverse UI #61
+- **Relations 後続:** Consumer view relation links, MCP
 
 ## Verification
 
 ```bash
 composer check                    # 144 tests
-npm run check --prefix frontend   # 63 tests
+npm run check --prefix frontend   # 64 tests
 ```

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,13 +6,13 @@ Last updated: 2026-05-24
 
 | Issue | Summary |
 | --- | --- |
-| — | inverse relation UI / Consumer view relation links |
+| — | Consumer view relation links |
 
 ## In Progress
 
 | Issue | Summary |
 | --- | --- |
-| — | （なし） |
+| #61 | Record 詳細 inverse relation 参照元一覧 UI |
 
 ## Recently Completed
 

--- a/frontend/src/entities/field-def/index.ts
+++ b/frontend/src/entities/field-def/index.ts
@@ -18,4 +18,9 @@ export { isRelationFieldDef } from './model'
 export { fieldDefKeys } from './query-keys'
 export type { FieldDefListParams } from './query-keys'
 export { useCreateFieldDef, useDeleteFieldDef, useUpdateFieldDef } from './mutations'
-export { defaultFieldDefListParams, useFieldDef, useFieldDefList } from './queries'
+export {
+  allFieldDefListParams,
+  defaultFieldDefListParams,
+  useFieldDef,
+  useFieldDefList,
+} from './queries'

--- a/frontend/src/entities/field-def/queries.ts
+++ b/frontend/src/entities/field-def/queries.ts
@@ -17,8 +17,10 @@ export function useFieldDefList(
       const search = new URLSearchParams({
         limit: String(params.limit),
         offset: String(params.offset),
-        entity_type_id: String(params.entityTypeId),
       })
+      if (params.entityTypeId !== undefined) {
+        search.set('entity_type_id', String(params.entityTypeId))
+      }
       const dto = await apiClient.get<FieldDefListDto>(
         `/api/v1/field-defs?${search.toString()}`,
         signal,
@@ -42,5 +44,14 @@ export function defaultFieldDefListParams(entityTypeId: number): FieldDefListPar
   return {
     entityTypeId,
     ...DEFAULT_LIST_PARAMS,
+  }
+}
+
+export function allFieldDefListParams(
+  params: { limit?: number; offset?: number } = {},
+): FieldDefListParams {
+  return {
+    limit: params.limit ?? 100,
+    offset: params.offset ?? 0,
   }
 }

--- a/frontend/src/entities/field-def/query-keys.ts
+++ b/frontend/src/entities/field-def/query-keys.ts
@@ -1,7 +1,7 @@
 import type { FieldDefId } from './ids'
 
 export interface FieldDefListParams {
-  entityTypeId: number
+  entityTypeId?: number
   limit: number
   offset: number
 }

--- a/frontend/src/features/inverse-entity-relations/hooks/use-inverse-relation-field-defs.ts
+++ b/frontend/src/features/inverse-entity-relations/hooks/use-inverse-relation-field-defs.ts
@@ -1,0 +1,28 @@
+import { useMemo } from 'react'
+import {
+  allFieldDefListParams,
+  isRelationFieldDef,
+  useFieldDefList,
+  type RelationFieldDef,
+} from '@/entities/field-def'
+
+export function useInverseRelationFieldDefs(targetEntityTypeId: number) {
+  const fieldDefQuery = useFieldDefList(allFieldDefListParams())
+
+  const inverseFieldDefs = useMemo((): RelationFieldDef[] => {
+    return (fieldDefQuery.data?.items ?? []).filter(
+      (fieldDef): fieldDef is RelationFieldDef =>
+        isRelationFieldDef(fieldDef) && fieldDef.targetEntityTypeId === targetEntityTypeId,
+    )
+  }, [fieldDefQuery.data?.items, targetEntityTypeId])
+
+  return {
+    inverseFieldDefs,
+    isLoading: fieldDefQuery.isLoading,
+    isError: fieldDefQuery.isError,
+    errorTitle: fieldDefQuery.error?.title ?? null,
+    refetch: async () => {
+      await fieldDefQuery.refetch()
+    },
+  }
+}

--- a/frontend/src/features/inverse-entity-relations/hooks/use-inverse-relation-panel.ts
+++ b/frontend/src/features/inverse-entity-relations/hooks/use-inverse-relation-panel.ts
@@ -1,0 +1,50 @@
+import { useMemo } from 'react'
+import { defaultEntityListParams, useEntityList } from '@/entities/entity'
+import { toEntityTypeId, useEntityType } from '@/entities/entity-type'
+import type { RelationFieldDef } from '@/entities/field-def'
+import { defaultTextFieldListParamsForEntityType, useTextFieldList } from '@/entities/text-field'
+import { getRecordDisplayLabel } from '@/shared/lib/get-record-display-label'
+
+export interface InverseRelationRecordItem {
+  id: number
+  label: string
+}
+
+export function useInverseRelationPanel(fieldDef: RelationFieldDef, targetEntityId: number) {
+  const listQuery = useEntityList(
+    defaultEntityListParams(fieldDef.entityTypeId, [], {
+      [fieldDef.fieldKey]: targetEntityId,
+    }),
+  )
+  const textFieldQuery = useTextFieldList(
+    defaultTextFieldListParamsForEntityType(fieldDef.entityTypeId),
+  )
+  const entityTypeQuery = useEntityType(toEntityTypeId(fieldDef.entityTypeId))
+
+  const items = useMemo((): InverseRelationRecordItem[] => {
+    const entities = listQuery.data?.items ?? []
+    const textFields = textFieldQuery.data?.items ?? []
+
+    return entities.map((entity) => ({
+      id: Number(entity.id),
+      label: getRecordDisplayLabel(Number(entity.id), textFields, `Record #${String(entity.id)}`),
+    }))
+  }, [listQuery.data?.items, textFieldQuery.data?.items])
+
+  const isLoading = listQuery.isLoading || textFieldQuery.isLoading || entityTypeQuery.isLoading
+  const isError = listQuery.isError || textFieldQuery.isError || entityTypeQuery.isError
+  const errorTitle =
+    listQuery.error?.title ?? textFieldQuery.error?.title ?? entityTypeQuery.error?.title ?? null
+
+  return {
+    sourceEntityTypeName: entityTypeQuery.data?.name ?? null,
+    items,
+    total: listQuery.data?.total ?? 0,
+    isLoading,
+    isError,
+    errorTitle,
+    refetch: async () => {
+      await Promise.all([listQuery.refetch(), textFieldQuery.refetch(), entityTypeQuery.refetch()])
+    },
+  }
+}

--- a/frontend/src/features/inverse-entity-relations/index.ts
+++ b/frontend/src/features/inverse-entity-relations/index.ts
@@ -1,0 +1,6 @@
+export { useInverseRelationFieldDefs } from './hooks/use-inverse-relation-field-defs'
+export { useInverseRelationPanel } from './hooks/use-inverse-relation-panel'
+export { InverseEntityRelationsView } from './ui/InverseEntityRelationsView'
+export { InverseRelationPanel } from './ui/InverseRelationPanel'
+export type { InverseEntityRelationsViewProps } from './ui/InverseEntityRelationsView'
+export type { InverseRelationPanelProps } from './ui/InverseRelationPanel'

--- a/frontend/src/features/inverse-entity-relations/ui/InverseEntityRelationsView.tsx
+++ b/frontend/src/features/inverse-entity-relations/ui/InverseEntityRelationsView.tsx
@@ -1,0 +1,48 @@
+import { Stack, Text } from '@/shared/ui'
+import { useInverseRelationFieldDefs } from '../hooks/use-inverse-relation-field-defs'
+import { InverseRelationPanel } from './InverseRelationPanel'
+
+export interface InverseEntityRelationsViewProps {
+  entityId: number
+  entityTypeId: number
+}
+
+export function InverseEntityRelationsView({
+  entityId,
+  entityTypeId,
+}: InverseEntityRelationsViewProps) {
+  const { inverseFieldDefs, isLoading, isError, errorTitle } =
+    useInverseRelationFieldDefs(entityTypeId)
+
+  if (isLoading) {
+    return <Text muted>Loading referenced-by relations…</Text>
+  }
+
+  if (isError) {
+    return (
+      <Stack gap="sm">
+        <Text variant="heading-sm">Could not load referenced-by relations</Text>
+        <Text muted>{errorTitle ?? 'Unknown error'}</Text>
+      </Stack>
+    )
+  }
+
+  if (inverseFieldDefs.length === 0) {
+    return null
+  }
+
+  return (
+    <Stack gap="lg">
+      <Text as="h2" variant="heading-sm">
+        Referenced by
+      </Text>
+      {inverseFieldDefs.map((fieldDef) => (
+        <InverseRelationPanel
+          key={String(fieldDef.id)}
+          fieldDef={fieldDef}
+          targetEntityId={entityId}
+        />
+      ))}
+    </Stack>
+  )
+}

--- a/frontend/src/features/inverse-entity-relations/ui/InverseRelationPanel.tsx
+++ b/frontend/src/features/inverse-entity-relations/ui/InverseRelationPanel.tsx
@@ -1,0 +1,71 @@
+import { Link } from 'react-router-dom'
+import type { RelationFieldDef } from '@/entities/field-def'
+import { Button, Stack, Text } from '@/shared/ui'
+import { useInverseRelationPanel } from '../hooks/use-inverse-relation-panel'
+
+export interface InverseRelationPanelProps {
+  fieldDef: RelationFieldDef
+  targetEntityId: number
+}
+
+export function InverseRelationPanel({ fieldDef, targetEntityId }: InverseRelationPanelProps) {
+  const { sourceEntityTypeName, items, isLoading, isError, errorTitle, refetch } =
+    useInverseRelationPanel(fieldDef, targetEntityId)
+
+  const panelTitle =
+    sourceEntityTypeName !== null
+      ? `${sourceEntityTypeName} · ${fieldDef.fieldKey}`
+      : fieldDef.fieldKey
+
+  if (isLoading) {
+    return <Text muted>Loading {panelTitle}…</Text>
+  }
+
+  if (isError) {
+    return (
+      <Stack gap="sm">
+        <Text variant="heading-sm">Could not load {panelTitle}</Text>
+        <Text muted>{errorTitle ?? 'Unknown error'}</Text>
+        <Button variant="secondary" onClick={() => void refetch()}>
+          Retry
+        </Button>
+      </Stack>
+    )
+  }
+
+  return (
+    <Stack gap="sm">
+      <Text as="h3" variant="heading-sm">
+        {panelTitle}
+      </Text>
+      {items.length === 0 ? (
+        <Text muted>No records reference this target via {fieldDef.fieldKey}.</Text>
+      ) : (
+        <ul className="flex flex-col gap-stack-sm">
+          {items.map((item) => (
+            <li
+              key={String(item.id)}
+              className="flex items-center justify-between gap-inline-md rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm shadow-sm"
+            >
+              <Stack gap="xs">
+                <Text as="span" variant="heading-sm">
+                  {item.label}
+                </Text>
+                <Text as="span" muted>
+                  #{String(item.id)}
+                </Text>
+              </Stack>
+              <Link
+                to={`/entity-types/${String(fieldDef.entityTypeId)}/entities/${String(item.id)}`}
+              >
+                <Button variant="secondary" size="sm">
+                  Open
+                </Button>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Stack>
+  )
+}

--- a/frontend/src/pages/entity-record/EntityRecordPage.test.tsx
+++ b/frontend/src/pages/entity-record/EntityRecordPage.test.tsx
@@ -11,7 +11,7 @@ import { resetEnumFieldStore } from '@tests/msw/handlers/enum-field'
 import { resetFieldDefStore, seedFieldDefs } from '@tests/msw/handlers/field-def'
 import { resetIntFieldStore } from '@tests/msw/handlers/int-field'
 import { resetTextFieldStore, seedTextFields } from '@tests/msw/handlers/text-field'
-import { resetEntityRelationStore } from '@tests/msw/handlers/entity-relation'
+import { resetEntityRelationStore, seedEntityRelations } from '@tests/msw/handlers/entity-relation'
 import { resetEntityTagStore } from '@tests/msw/handlers/entity-tag'
 import { resetTagStore, seedTags } from '@tests/msw/handlers/tag'
 import { mswServer } from '@tests/msw/server'
@@ -317,5 +317,48 @@ describe('EntityRecordPage', () => {
       expect(screen.getByText('Bob')).toBeInTheDocument()
       expect(screen.getByText('#3')).toBeInTheDocument()
     })
+  })
+
+  it('shows source records that reference this target via inverse relations', async () => {
+    seedEntityTypes([
+      { id: 1, name: 'Article', slug: 'article' },
+      { id: 2, name: 'Author', slug: 'author' },
+    ])
+    seedFieldDefs([
+      {
+        id: 1,
+        entity_type_id: 1,
+        field_key: 'author',
+        data_type: 'relation',
+        target_entity_type_id: 2,
+        cardinality: 'one',
+      },
+    ])
+    seedEntities([
+      { id: 1, entity_type_id: 1, is_deleted: false, deleted_at: null },
+      { id: 2, entity_type_id: 2, is_deleted: false, deleted_at: null },
+      { id: 3, entity_type_id: 1, is_deleted: false, deleted_at: null },
+      { id: 4, entity_type_id: 2, is_deleted: false, deleted_at: null },
+    ])
+    seedEntityRelations([
+      { source_entity_id: 1, target_entity_id: 2, field_key: 'author' },
+      { source_entity_id: 3, target_entity_id: 4, field_key: 'author' },
+    ])
+    seedTextFields([
+      { id: 1, entity_id: 1, field_key: 'title', value: 'My article' },
+      { id: 2, entity_id: 2, field_key: 'title', value: 'Alice' },
+      { id: 3, entity_id: 3, field_key: 'title', value: 'Other article' },
+    ])
+
+    renderEntityRecordPage(2, 2)
+
+    expect(await screen.findByRole('heading', { name: 'Referenced by' })).toBeInTheDocument()
+    expect(await screen.findByText('Article · author')).toBeInTheDocument()
+    expect(await screen.findByText('My article')).toBeInTheDocument()
+    expect(screen.queryByText('Other article')).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Open' })).toHaveAttribute(
+      'href',
+      '/entity-types/1/entities/1',
+    )
   })
 })

--- a/frontend/src/pages/entity-record/EntityRecordPage.tsx
+++ b/frontend/src/pages/entity-record/EntityRecordPage.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/features/edit-entity-text-fields'
 import { ManageEntityTagsView, useManageEntityTagsPage } from '@/features/manage-entity-tags'
 import { ManageEntityRelationsView } from '@/features/manage-entity-relations'
+import { InverseEntityRelationsView } from '@/features/inverse-entity-relations'
 import { Button, Stack, Text } from '@/shared/ui'
 
 export function EntityRecordPage() {
@@ -87,6 +88,7 @@ export function EntityRecordPage() {
         onDetach={detachTag}
       />
       <ManageEntityRelationsView entityId={entityId} entityTypeId={entityTypeId} />
+      <InverseEntityRelationsView entityId={entityId} entityTypeId={entityTypeId} />
     </Stack>
   )
 }


### PR DESCRIPTION
## Summary

- Record 詳細に **Referenced by** パネルを追加し、この record を relation target として参照している source records を表示
- 専用 API なし — 既存 `GET /entities?relation.{field_key}={targetId}` を inverse 探索に利用（ADR 0004 案 A）
- `field_defs` 全件取得（`entity_type_id` 省略）に対応し、`target_entity_type_id` で inverse field を特定

Closes #61

## 検証

- [x] `npm run check --prefix frontend` — 64 tests, Storybook build OK

## セルフレビュー

- `docs/review/frontend.md`


Made with [Cursor](https://cursor.com)