### PR TITLE
feat(frontend): Consumer view の relation をリンク表示 (#63)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,13 +6,13 @@ Last updated: 2026-05-24
 
 | Issue | Summary |
 | --- | --- |
-| — | Consumer view relation links |
+| — | MCP relation tools |
 
 ## In Progress
 
 | Issue | Summary |
 | --- | --- |
-| — | （なし） |
+| #63 | Consumer view relation リンク表示 |
 
 ## Recently Completed
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -12,12 +12,13 @@ Last updated: 2026-05-24
 
 | Issue | Summary |
 | --- | --- |
-| #63 | Consumer view relation リンク表示 |
+| — | （なし） |
 
 ## Recently Completed
 
 | Issue | Summary |
 | --- | --- |
+| #63 | Consumer view relation リンク表示 (PR #64) |
 | #61 | Record 詳細 inverse relation 参照元一覧 UI (PR #62) |
 | #59 | Records 一覧 relation フィルタ UI (PR #60) |
 | #57 | entities 一覧 relation フィルタ API (PR #58) |
@@ -34,12 +35,12 @@ Last updated: 2026-05-24
 
 - **API（済）:** tags CRUD, entity_tags, entities `?tags=` フィルタ
 - **Admin UI（済）:** Tag CRUD (#44), Record tag attach/detach (#46), Records 一覧 tag フィルタ (#48)
-- **Relations（済）:** API #51, Admin UI #52, list filter #57/#59, inverse UI #61
-- **Relations 後続:** Consumer view relation links, MCP
+- **Relations（済）:** API #51, Admin UI #52, list filter #57/#59, inverse UI #61, Consumer view #63
+- **Relations 後続:** MCP
 
 ## Verification
 
 ```bash
 composer check                    # 144 tests
-npm run check --prefix frontend   # 64 tests
+npm run check --prefix frontend   # 65 tests
 ```

--- a/frontend/src/features/public-view-entity-record/hooks/use-public-relation-field-display.ts
+++ b/frontend/src/features/public-view-entity-record/hooks/use-public-relation-field-display.ts
@@ -1,0 +1,58 @@
+import { useMemo } from 'react'
+import { useEntityRelationList } from '@/entities/entity-relation'
+import type { RelationFieldDef } from '@/entities/field-def'
+import { defaultTextFieldListParamsForEntityType, useTextFieldList } from '@/entities/text-field'
+import { getRecordDisplayLabel } from '@/shared/lib/get-record-display-label'
+
+export interface PublicRelationTargetLink {
+  targetEntityId: number
+  label: string
+  href: string
+}
+
+export function usePublicRelationFieldDisplay(
+  entityId: number,
+  fieldDef: RelationFieldDef,
+  entityTypeSlugById: Record<number, string>,
+) {
+  const relationQuery = useEntityRelationList(entityId, fieldDef.fieldKey)
+  const textFieldQuery = useTextFieldList(
+    defaultTextFieldListParamsForEntityType(fieldDef.targetEntityTypeId),
+  )
+
+  const targets = useMemo((): PublicRelationTargetLink[] => {
+    const relations = relationQuery.data?.items ?? []
+    const textFields = textFieldQuery.data?.items ?? []
+    const targetSlug =
+      entityTypeSlugById[fieldDef.targetEntityTypeId] ?? String(fieldDef.targetEntityTypeId)
+
+    return relations.map((relation) => ({
+      targetEntityId: relation.targetEntityId,
+      label: getRecordDisplayLabel(
+        relation.targetEntityId,
+        textFields,
+        `Record #${String(relation.targetEntityId)}`,
+      ),
+      href: `/view/${targetSlug}/${String(relation.targetEntityId)}`,
+    }))
+  }, [
+    entityTypeSlugById,
+    fieldDef.targetEntityTypeId,
+    relationQuery.data?.items,
+    textFieldQuery.data?.items,
+  ])
+
+  const isLoading = relationQuery.isLoading || textFieldQuery.isLoading
+  const isError = relationQuery.isError || textFieldQuery.isError
+  const errorTitle = relationQuery.error?.title ?? textFieldQuery.error?.title ?? null
+
+  return {
+    targets,
+    isLoading,
+    isError,
+    errorTitle,
+    refetch: async () => {
+      await Promise.all([relationQuery.refetch(), textFieldQuery.refetch()])
+    },
+  }
+}

--- a/frontend/src/features/public-view-entity-record/hooks/use-public-view-entity-record-page.ts
+++ b/frontend/src/features/public-view-entity-record/hooks/use-public-view-entity-record-page.ts
@@ -1,6 +1,11 @@
 import { useMemo } from 'react'
 import type { FieldDataType } from '@/entities/field-def'
-import { defaultFieldDefListParams, useFieldDefList } from '@/entities/field-def'
+import {
+  defaultFieldDefListParams,
+  isRelationFieldDef,
+  useFieldDefList,
+  type RelationFieldDef,
+} from '@/entities/field-def'
 import { toEntityId, useEntity } from '@/entities/entity'
 import { useBoolFieldList } from '@/entities/bool-field'
 import { useDateTimeFieldList } from '@/entities/datetime-field'
@@ -11,11 +16,19 @@ import { formatFieldDisplayValue } from '@/shared/lib/format-field-display-value
 
 const FIELD_LIST_PARAMS = { limit: 100, offset: 0 } as const
 
-export interface PublicFieldDisplay {
+export interface PublicScalarFieldDisplay {
+  kind: 'scalar'
   fieldKey: string
-  dataType: FieldDataType
+  dataType: Exclude<FieldDataType, 'relation'>
   displayValue: string
 }
+
+export interface PublicRelationFieldRow {
+  kind: 'relation'
+  fieldDef: RelationFieldDef
+}
+
+export type PublicFieldRow = PublicScalarFieldDisplay | PublicRelationFieldRow
 
 export function usePublicViewEntityRecordPage(entityTypeId: number, entityId: number) {
   const listParams = useMemo(() => ({ ...FIELD_LIST_PARAMS, entityId }), [entityId])
@@ -28,10 +41,14 @@ export function usePublicViewEntityRecordPage(entityTypeId: number, entityId: nu
   const boolFieldQuery = useBoolFieldList(listParams)
   const dateTimeFieldQuery = useDateTimeFieldList(listParams)
 
-  const fields = useMemo((): PublicFieldDisplay[] => {
+  const fieldRows = useMemo((): PublicFieldRow[] => {
     const fieldDefs = fieldDefQuery.data?.items ?? []
 
-    return fieldDefs.map((fieldDef) => {
+    return fieldDefs.flatMap((fieldDef): PublicFieldRow[] => {
+      if (isRelationFieldDef(fieldDef)) {
+        return [{ kind: 'relation', fieldDef }]
+      }
+
       let raw: string | number | boolean | null = null
 
       switch (fieldDef.dataType) {
@@ -62,11 +79,14 @@ export function usePublicViewEntityRecordPage(entityTypeId: number, entityId: nu
           break
       }
 
-      return {
-        fieldKey: fieldDef.fieldKey,
-        dataType: fieldDef.dataType,
-        displayValue: formatFieldDisplayValue(fieldDef.dataType, raw),
-      }
+      return [
+        {
+          kind: 'scalar',
+          fieldKey: fieldDef.fieldKey,
+          dataType: fieldDef.dataType,
+          displayValue: formatFieldDisplayValue(fieldDef.dataType, raw),
+        },
+      ]
     })
   }, [
     boolFieldQuery.data?.items,
@@ -105,7 +125,7 @@ export function usePublicViewEntityRecordPage(entityTypeId: number, entityId: nu
 
   return {
     entity: entityQuery.data ?? null,
-    fields,
+    fieldRows,
     isLoading,
     isError,
     errorTitle,

--- a/frontend/src/features/public-view-entity-record/index.ts
+++ b/frontend/src/features/public-view-entity-record/index.ts
@@ -1,3 +1,9 @@
+export { usePublicRelationFieldDisplay } from './hooks/use-public-relation-field-display'
+export type { PublicRelationTargetLink } from './hooks/use-public-relation-field-display'
 export { usePublicViewEntityRecordPage } from './hooks/use-public-view-entity-record-page'
-export type { PublicFieldDisplay } from './hooks/use-public-view-entity-record-page'
+export type {
+  PublicFieldRow,
+  PublicRelationFieldRow,
+  PublicScalarFieldDisplay,
+} from './hooks/use-public-view-entity-record-page'
 export { PublicRecordDetailView } from './ui/PublicRecordDetailView'

--- a/frontend/src/features/public-view-entity-record/ui/PublicRecordDetailView.tsx
+++ b/frontend/src/features/public-view-entity-record/ui/PublicRecordDetailView.tsx
@@ -1,10 +1,12 @@
 import type { Entity } from '@/entities/entity'
 import { Button, Stack, Text } from '@/shared/ui'
-import type { PublicFieldDisplay } from '../hooks/use-public-view-entity-record-page'
+import type { PublicFieldRow } from '../hooks/use-public-view-entity-record-page'
+import { PublicRelationFieldDisplay } from './PublicRelationFieldDisplay'
 
 export interface PublicRecordDetailViewProps {
   entity: Entity | null
-  fields: PublicFieldDisplay[]
+  fieldRows: PublicFieldRow[]
+  entityTypeSlugById: Record<number, string>
   isLoading: boolean
   isError: boolean
   errorTitle: string | null
@@ -13,7 +15,8 @@ export interface PublicRecordDetailViewProps {
 
 export function PublicRecordDetailView({
   entity,
-  fields,
+  fieldRows,
+  entityTypeSlugById,
   isLoading,
   isError,
   errorTitle,
@@ -39,22 +42,35 @@ export function PublicRecordDetailView({
     return <Text muted>Record not found.</Text>
   }
 
-  if (fields.length === 0) {
+  if (fieldRows.length === 0) {
     return <Text muted>No fields defined for this record.</Text>
   }
 
   return (
     <dl className="flex flex-col gap-stack-md">
-      {fields.map((field) => (
-        <div key={field.fieldKey} className="flex flex-col gap-stack-xs">
-          <Text as="dt" variant="heading-sm">
-            {field.fieldKey}
-          </Text>
-          <Text as="dd" muted>
-            {field.displayValue}
-          </Text>
-        </div>
-      ))}
+      {fieldRows.map((row) => {
+        if (row.kind === 'relation') {
+          return (
+            <PublicRelationFieldDisplay
+              key={row.fieldDef.fieldKey}
+              entityId={Number(entity.id)}
+              fieldDef={row.fieldDef}
+              entityTypeSlugById={entityTypeSlugById}
+            />
+          )
+        }
+
+        return (
+          <div key={row.fieldKey} className="flex flex-col gap-stack-xs">
+            <Text as="dt" variant="heading-sm">
+              {row.fieldKey}
+            </Text>
+            <Text as="dd" muted>
+              {row.displayValue}
+            </Text>
+          </div>
+        )
+      })}
     </dl>
   )
 }

--- a/frontend/src/features/public-view-entity-record/ui/PublicRelationFieldDisplay.tsx
+++ b/frontend/src/features/public-view-entity-record/ui/PublicRelationFieldDisplay.tsx
@@ -1,0 +1,78 @@
+import { Link } from 'react-router-dom'
+import type { RelationFieldDef } from '@/entities/field-def'
+import { Button, Stack, Text } from '@/shared/ui'
+import { usePublicRelationFieldDisplay } from '../hooks/use-public-relation-field-display'
+
+export interface PublicRelationFieldDisplayProps {
+  entityId: number
+  fieldDef: RelationFieldDef
+  entityTypeSlugById: Record<number, string>
+}
+
+export function PublicRelationFieldDisplay({
+  entityId,
+  fieldDef,
+  entityTypeSlugById,
+}: PublicRelationFieldDisplayProps) {
+  const { targets, isLoading, isError, errorTitle, refetch } = usePublicRelationFieldDisplay(
+    entityId,
+    fieldDef,
+    entityTypeSlugById,
+  )
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-stack-xs">
+        <Text as="dt" variant="heading-sm">
+          {fieldDef.fieldKey}
+        </Text>
+        <Text as="dd" muted>
+          Loading…
+        </Text>
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="flex flex-col gap-stack-xs">
+        <Text as="dt" variant="heading-sm">
+          {fieldDef.fieldKey}
+        </Text>
+        <Stack gap="sm">
+          <Text as="dd" muted>
+            {errorTitle ?? 'Could not load relation'}
+          </Text>
+          <Button variant="secondary" size="sm" onClick={() => void refetch()}>
+            Retry
+          </Button>
+        </Stack>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-stack-xs">
+      <Text as="dt" variant="heading-sm">
+        {fieldDef.fieldKey}
+      </Text>
+      {targets.length === 0 ? (
+        <Text as="dd" muted>
+          —
+        </Text>
+      ) : (
+        <dd className="flex flex-col gap-stack-xs">
+          {targets.map((target) => (
+            <Link
+              key={`${fieldDef.fieldKey}-${String(target.targetEntityId)}`}
+              to={target.href}
+              className="font-sans text-body text-accent hover:text-accent-hover"
+            >
+              {target.label}
+            </Link>
+          ))}
+        </dd>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.test.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { PublicRecordDetailPage } from '@/pages/consumer/PublicRecordDetailPage'
 import { resetBoolFieldStore, seedBoolFields } from '@tests/msw/handlers/bool-field'
 import { resetEntityStore, seedEntities } from '@tests/msw/handlers/entity'
+import { resetEntityRelationStore, seedEntityRelations } from '@tests/msw/handlers/entity-relation'
 import { resetEntityTypeStore, seedEntityTypes } from '@tests/msw/handlers/entity-type'
 import { resetFieldDefStore, seedFieldDefs } from '@tests/msw/handlers/field-def'
 import { resetIntFieldStore, seedIntFields } from '@tests/msw/handlers/int-field'
@@ -30,6 +31,7 @@ describe('PublicRecordDetailPage', () => {
     mswServer.resetHandlers()
     resetEntityTypeStore()
     resetEntityStore()
+    resetEntityRelationStore()
     resetFieldDefStore()
     resetTextFieldStore()
     resetIntFieldStore()
@@ -90,6 +92,41 @@ describe('PublicRecordDetailPage', () => {
     expect(screen.getByText('42')).toBeInTheDocument()
     expect(screen.getByText('published')).toBeInTheDocument()
     expect(screen.getByText('Yes')).toBeInTheDocument()
+  })
+
+  it('renders relation fields as links to target records', async () => {
+    seedEntityTypes([
+      { id: 1, name: 'Article', slug: 'article' },
+      { id: 2, name: 'Author', slug: 'author' },
+    ])
+    seedEntities([
+      { id: 1, entity_type_id: 1, is_deleted: false, deleted_at: null },
+      { id: 2, entity_type_id: 2, is_deleted: false, deleted_at: null },
+    ])
+    seedFieldDefs([
+      { id: 1, entity_type_id: 1, field_key: 'title', data_type: 'text' },
+      {
+        id: 2,
+        entity_type_id: 1,
+        field_key: 'author',
+        data_type: 'relation',
+        target_entity_type_id: 2,
+        cardinality: 'one',
+      },
+    ])
+    seedTextFields([
+      { id: 1, entity_id: 1, field_key: 'title', value: 'My article' },
+      { id: 2, entity_id: 2, field_key: 'title', value: 'Alice' },
+    ])
+    seedEntityRelations([{ source_entity_id: 1, target_entity_id: 2, field_key: 'author' }])
+
+    renderDetailPage('article', 1)
+
+    expect(await screen.findByText('My article')).toBeInTheDocument()
+    expect(await screen.findByText('author')).toBeInTheDocument()
+
+    const authorLink = screen.getByRole('link', { name: 'Alice' })
+    expect(authorLink).toHaveAttribute('href', '/view/author/2')
   })
 
   it('shows not found for unknown entity type slug', async () => {

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
@@ -13,16 +13,16 @@ function PublicRecordDetailContent({
   entityTypeName,
   entityTypeId,
   entityId,
+  entityTypeSlugById,
 }: {
   entityTypeSlug: string
   entityTypeName: string
   entityTypeId: number
   entityId: number
+  entityTypeSlugById: Record<number, string>
 }) {
-  const { entity, fields, isLoading, isError, errorTitle, refetch } = usePublicViewEntityRecordPage(
-    entityTypeId,
-    entityId,
-  )
+  const { entity, fieldRows, isLoading, isError, errorTitle, refetch } =
+    usePublicViewEntityRecordPage(entityTypeId, entityId)
 
   return (
     <Stack gap="md">
@@ -38,7 +38,8 @@ function PublicRecordDetailContent({
       </Stack>
       <PublicRecordDetailView
         entity={entity}
-        fields={fields}
+        fieldRows={fieldRows}
+        entityTypeSlugById={entityTypeSlugById}
         isLoading={isLoading}
         isError={isError}
         errorTitle={errorTitle}
@@ -58,6 +59,13 @@ export function PublicRecordDetailPage() {
   const entityType = useMemo(
     () => findEntityTypeBySlug(entityTypeQuery.data?.items ?? [], entityTypeSlug),
     [entityTypeQuery.data?.items, entityTypeSlug],
+  )
+  const entityTypeSlugById = useMemo(
+    (): Record<number, string> =>
+      Object.fromEntries(
+        (entityTypeQuery.data?.items ?? []).map((item) => [Number(item.id), item.slug]),
+      ),
+    [entityTypeQuery.data?.items],
   )
 
   if (entityTypeQuery.isLoading) {
@@ -79,6 +87,7 @@ export function PublicRecordDetailPage() {
       entityTypeName={entityType.name}
       entityTypeId={Number(entityType.id)}
       entityId={entityId}
+      entityTypeSlugById={entityTypeSlugById}
     />
   )
 }


### PR DESCRIPTION
## Summary

- 公開 Record 詳細で relation 型 field をラベル付きリンクとして表示
- `PublicRelationFieldDisplay` が relations API + target text fields からラベルを解決
- field def 定義順を保つ `PublicFieldRow`  discriminated union に整理

Closes #63

## 検証

- [x] `npm run check --prefix frontend` — 65 tests, Storybook build OK

## セルフレビュー

- `docs/review/frontend.md`


Made with [Cursor](https://cursor.com)