### PR TITLE
feat(mcp): entity relation ツールをカタログに追加 (#65)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "cs": "php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php",
         "cs:fix": "php-cs-fixer fix --config=.php-cs-fixer.php",
         "openapi": "php tools/validate-openapi.php",
+        "mcp": "php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php --root=.",
         "migrations:status": "phinx status -c phinx.php",
         "migrations:migrate": "phinx migrate -c phinx.php",
         "migrations:rollback": "phinx rollback -c phinx.php",
@@ -36,7 +37,8 @@
             "@test",
             "@analyse",
             "@cs",
-            "@openapi"
+            "@openapi",
+            "@mcp"
         ]
     },
     "config": {

--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -1,3 +1,110 @@
 {
-  "tools": []
+  "version": 1,
+  "source": "docs/openapi/openapi.yaml",
+  "tools": [
+    {
+      "name": "listEntityRelations",
+      "title": "List Entity Relations",
+      "description": "List relation targets attached to a source entity for a given relation field key.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "listEntityRelations",
+        "method": "GET",
+        "path": "/api/v1/entities/{entityId}/relations"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["entityId", "field_key"],
+        "properties": {
+          "entityId": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Source entity id."
+          },
+          "field_key": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Relation field key registered on the source entity type."
+          }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/EntityRelationListResponse"
+    },
+    {
+      "name": "attachEntityRelation",
+      "title": "Attach Entity Relation",
+      "description": "Attach a target entity to a source entity via a typed relation field. For cardinality=one fields, replaces the existing target.",
+      "safety": "write",
+      "source": {
+        "type": "openapi",
+        "operationId": "attachEntityRelation",
+        "method": "POST",
+        "path": "/api/v1/entities/{entityId}/relations"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["entityId", "field_key", "target_entity_id"],
+        "properties": {
+          "entityId": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Source entity id."
+          },
+          "field_key": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Relation field key on the source entity type."
+          },
+          "target_entity_id": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Target entity id to link."
+          }
+        }
+      },
+      "responseSchemaRef": null
+    },
+    {
+      "name": "listEntitiesByRelationTarget",
+      "title": "List Entities By Relation Target",
+      "description": "List source entities whose relation field points to a target entity. Pass entity_type_id and one query parameter per relation filter using the form relation_{fieldKey} (e.g. relation_author=5). Multiple relation_{fieldKey} parameters are combined with AND.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "listEntities",
+        "method": "GET",
+        "path": "/api/v1/entities"
+      },
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "entity_type_id": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Entity type id of records to list."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+          }
+        },
+        "additionalProperties": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Relation filter query param. Use key relation_{fieldKey} with the target entity id as value."
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/EntityListResponse"
+    }
+  ]
 }

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,13 +6,13 @@ Last updated: 2026-05-24
 
 | Issue | Summary |
 | --- | --- |
-| — | MCP relation tools |
+| — | Phase 5: 全 API MCP カタログ拡充 |
 
 ## In Progress
 
 | Issue | Summary |
 | --- | --- |
-| — | （なし） |
+| #65 | MCP relation tools カタログ |
 
 ## Recently Completed
 
@@ -41,6 +41,6 @@ Last updated: 2026-05-24
 ## Verification
 
 ```bash
-composer check                    # 144 tests
+composer check                    # 144 tests + openapi + mcp
 npm run check --prefix frontend   # 65 tests
 ```

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -12,12 +12,13 @@ Last updated: 2026-05-24
 
 | Issue | Summary |
 | --- | --- |
-| #65 | MCP relation tools カタログ |
+| — | （なし） |
 
 ## Recently Completed
 
 | Issue | Summary |
 | --- | --- |
+| #65 | MCP relation tools カタログ (PR #66) |
 | #63 | Consumer view relation リンク表示 (PR #64) |
 | #61 | Record 詳細 inverse relation 参照元一覧 UI (PR #62) |
 | #59 | Records 一覧 relation フィルタ UI (PR #60) |
@@ -35,8 +36,8 @@ Last updated: 2026-05-24
 
 - **API（済）:** tags CRUD, entity_tags, entities `?tags=` フィルタ
 - **Admin UI（済）:** Tag CRUD (#44), Record tag attach/detach (#46), Records 一覧 tag フィルタ (#48)
-- **Relations（済）:** API #51, Admin UI #52, list filter #57/#59, inverse UI #61, Consumer view #63
-- **Relations 後続:** MCP
+- **Relations（済）:** API #51, Admin UI #52, list filter #57/#59, inverse UI #61, Consumer view #63, MCP #65
+- **Relations 後続:** detach MCP（upstream 待ち）、Phase 5 全 API MCP 化
 
 ## Verification
 


### PR DESCRIPTION
## Summary

- `docs/mcp/tools.json` に relation 向け MCP ツール 3 件を追加
  - `listEntityRelations` — source entity の relation target 一覧
  - `attachEntityRelation` — relation link 作成（cardinality=one は置換）
  - `listEntitiesByRelationTarget` — `listEntities` の relation filter セマンティック alias（`relation_{fieldKey}` クエリ）
- `composer mcp` スクリプトを追加し `composer check` に含める

**Note:** `detachEntityRelation` は NENE2 LocalMcpServer が DELETE の query param 未対応のため Phase 5 / upstream 対応まで defer。

Closes #65

## 検証

- [x] `composer check` — 144 tests, OpenAPI valid, MCP catalog valid

## セルフレビュー

- `docs/review/openapi-contract.md`


Made with [Cursor](https://cursor.com)