### PR TITLE
feat(analytics): access log 永続化と日次集計 API (#69)

### DIFF
--- a/database/migrations/20260524000012_create_access_logs_table.php
+++ b/database/migrations/20260524000012_create_access_logs_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateAccessLogsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('access_logs')
+            ->addColumn('request_id', 'string', ['limit' => 64, 'null' => true])
+            ->addColumn('method', 'string', ['limit' => 10, 'null' => false])
+            ->addColumn('path', 'string', ['limit' => 2048, 'null' => false])
+            ->addColumn('status_code', 'integer', ['null' => false])
+            ->addColumn('duration_ms', 'float', ['null' => false])
+            ->addColumn('accessed_at', 'datetime', ['null' => false])
+            ->addColumn('access_date', 'date', ['null' => false])
+            ->addIndex(['access_date'])
+            ->addIndex(['accessed_at'])
+            ->create();
+    }
+}

--- a/database/schema/access_logs.sql
+++ b/database/schema/access_logs.sql
@@ -1,0 +1,13 @@
+CREATE TABLE access_logs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_id VARCHAR(64) NULL,
+    method VARCHAR(10) NOT NULL,
+    path VARCHAR(2048) NOT NULL,
+    status_code INTEGER NOT NULL,
+    duration_ms REAL NOT NULL,
+    accessed_at TEXT NOT NULL,
+    access_date TEXT NOT NULL
+);
+
+CREATE INDEX idx_access_logs_access_date ON access_logs (access_date);
+CREATE INDEX idx_access_logs_accessed_at ON access_logs (accessed_at);

--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -571,6 +571,39 @@
             "responseSchemaRef": null
         },
         {
+            "name": "getAccessStatsByDate",
+            "title": "Access Stats By Date",
+            "description": "Return daily HTTP access counts and average duration for an inclusive date range (YYYY-MM-DD).",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "getAccessStatsByDate",
+                "method": "GET",
+                "path": "/api/v1/analytics/access-stats"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "from": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Start date (inclusive), YYYY-MM-DD."
+                    },
+                    "to": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "End date (inclusive), YYYY-MM-DD. Range must not exceed 366 days."
+                    }
+                },
+                "required": [
+                    "from",
+                    "to"
+                ],
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/AccessStatsByDateResponse"
+        },
+        {
             "name": "listFieldDefs",
             "title": "List Field Definitions",
             "description": "List registered field definitions, optionally filtered by entity type.",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -32,6 +32,8 @@ tags:
     description: Tags attached to entity instances.
   - name: EntityRelations
     description: Typed relation links between entity instances.
+  - name: Analytics
+    description: HTTP access log aggregation and reporting.
 paths:
   /health:
     get:
@@ -1588,6 +1590,51 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/analytics/access-stats:
+    get:
+      tags:
+        - Analytics
+      summary: Access stats by date
+      description: Returns daily HTTP access counts and average duration for the inclusive date range.
+      operationId: getAccessStatsByDate
+      parameters:
+        - name: from
+          in: query
+          required: true
+          description: Start date (inclusive), YYYY-MM-DD.
+          schema:
+            type: string
+            format: date
+        - name: to
+          in: query
+          required: true
+          description: End date (inclusive), YYYY-MM-DD. Range must not exceed 366 days.
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: Daily access statistics.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessStatsByDateResponse'
+              examples:
+                ok:
+                  value:
+                    from: '2026-05-01'
+                    to: '2026-05-03'
+                    items:
+                      - date: '2026-05-01'
+                        request_count: 12
+                        avg_duration_ms: 8.5
+                      - date: '2026-05-02'
+                        request_count: 7
+                        avg_duration_ms: 11.2
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   parameters:
     IdPath:
@@ -2464,3 +2511,38 @@ components:
           type: integer
         offset:
           type: integer
+    AccessStatsByDateResponse:
+      type: object
+      required:
+        - from
+        - to
+        - items
+      properties:
+        from:
+          type: string
+          format: date
+        to:
+          type: string
+          format: date
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccessStatsDayItem'
+      additionalProperties: false
+    AccessStatsDayItem:
+      type: object
+      required:
+        - date
+        - request_count
+        - avg_duration_ms
+      properties:
+        date:
+          type: string
+          format: date
+        request_count:
+          type: integer
+          minimum: 0
+        avg_duration_ms:
+          type: number
+          minimum: 0
+      additionalProperties: false

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -6,13 +6,13 @@ Last updated: 2026-05-24
 
 | Issue | Summary |
 | --- | --- |
-| — | Analytics / access log API（Phase 5 残） |
+| — | （なし — Phase 5 Analytics 完了後） |
 
 ## In Progress
 
 | Issue | Summary |
 | --- | --- |
-| — | （なし） |
+| #69 | Analytics / access log API |
 
 ## Recently Completed
 
@@ -38,8 +38,8 @@ Last updated: 2026-05-24
 - **API（済）:** tags CRUD, entity_tags, entities `?tags=` フィルタ
 - **Admin UI（済）:** Tag CRUD (#44), Record tag attach/detach (#46), Records 一覧 tag フィルタ (#48)
 - **Relations（済）:** Phase 3 一式 + MCP #65/#67
-- **Phase 5（一部済）:** MCP 全 API カタログ（53 tools, `composer mcp:generate`）
-- **Phase 5 残:** Analytics / access log、detachEntityRelation MCP（upstream 待ち）
+- **Phase 5（一部済）:** MCP 全 API カタログ（53 tools → 54 tools, `composer mcp:generate`）
+- **Phase 5 残:** detachEntityRelation MCP（upstream 待ち）
 
 ## Verification
 

--- a/src/Analytics/AccessLogEntry.php
+++ b/src/Analytics/AccessLogEntry.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+use DateTimeImmutable;
+
+final readonly class AccessLogEntry
+{
+    public function __construct(
+        public ?string $requestId,
+        public string $method,
+        public string $path,
+        public int $statusCode,
+        public float $durationMs,
+        public DateTimeImmutable $accessedAt,
+    ) {
+    }
+}

--- a/src/Analytics/AccessLogMiddleware.php
+++ b/src/Analytics/AccessLogMiddleware.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+use DateTimeImmutable;
+use Nene2\Middleware\RequestIdMiddleware;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+final readonly class AccessLogMiddleware implements MiddlewareInterface
+{
+    /** @param list<string> $excludedPaths */
+    public function __construct(
+        private AccessLogRepositoryInterface $accessLogs,
+        private LoggerInterface $logger,
+        private array $excludedPaths = ['/health', '/', '/machine/health', '/examples/ping'],
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $path = $request->getUri()->getPath() ?: '/';
+
+        if (in_array($path, $this->excludedPaths, true)) {
+            return $handler->handle($request);
+        }
+
+        $startedAt = hrtime(true);
+        $response = $handler->handle($request);
+
+        try {
+            $this->accessLogs->insert(new AccessLogEntry(
+                requestId: $this->requestId($request),
+                method: $request->getMethod(),
+                path: $path,
+                statusCode: $response->getStatusCode(),
+                durationMs: $this->durationMilliseconds($startedAt),
+                accessedAt: new DateTimeImmutable('now', new \DateTimeZone('UTC')),
+            ));
+        } catch (Throwable $exception) {
+            $this->logger->error('Failed to persist access log entry.', [
+                'exception' => $exception->getMessage(),
+                'path' => $path,
+                'method' => $request->getMethod(),
+            ]);
+        }
+
+        return $response;
+    }
+
+    private function requestId(ServerRequestInterface $request): ?string
+    {
+        $requestId = $request->getAttribute(RequestIdMiddleware::ATTRIBUTE);
+
+        return is_string($requestId) && $requestId !== '' ? $requestId : null;
+    }
+
+    private function durationMilliseconds(int $startedAt): float
+    {
+        return round((hrtime(true) - $startedAt) / 1_000_000, 3);
+    }
+}

--- a/src/Analytics/AccessLogRepositoryInterface.php
+++ b/src/Analytics/AccessLogRepositoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+use DateTimeImmutable;
+
+interface AccessLogRepositoryInterface
+{
+    public function insert(AccessLogEntry $entry): void;
+
+    /**
+     * @return list<AccessStatsDayItem>
+     */
+    public function aggregateByDate(DateTimeImmutable $from, DateTimeImmutable $to): array;
+}

--- a/src/Analytics/AccessStatsDateRange.php
+++ b/src/Analytics/AccessStatsDateRange.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+use DateTimeImmutable;
+
+final readonly class AccessStatsDateRange
+{
+    public function __construct(
+        public DateTimeImmutable $from,
+        public DateTimeImmutable $to,
+    ) {
+    }
+}

--- a/src/Analytics/AccessStatsDateRangeParser.php
+++ b/src/Analytics/AccessStatsDateRangeParser.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+use DateTimeImmutable;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+
+final readonly class AccessStatsDateRangeParser
+{
+    private const MAX_RANGE_DAYS = 366;
+
+    /**
+     * @param array<string, mixed> $query
+     */
+    public static function parse(array $query): AccessStatsDateRange
+    {
+        $fromRaw = trim((string) ($query['from'] ?? ''));
+        $toRaw = trim((string) ($query['to'] ?? ''));
+
+        $errors = [];
+
+        if ($fromRaw === '') {
+            $errors[] = new ValidationError('from', 'Start date is required.', 'required');
+        }
+
+        if ($toRaw === '') {
+            $errors[] = new ValidationError('to', 'End date is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $from = self::parseDate('from', $fromRaw);
+        $to = self::parseDate('to', $toRaw);
+
+        if ($from > $to) {
+            throw new ValidationException([
+                new ValidationError('from', 'Start date must be on or before end date.', 'invalid'),
+            ]);
+        }
+
+        $rangeDays = (int) $from->diff($to)->days + 1;
+
+        if ($rangeDays > self::MAX_RANGE_DAYS) {
+            throw new ValidationException([
+                new ValidationError('to', sprintf('Date range must not exceed %d days.', self::MAX_RANGE_DAYS), 'invalid'),
+            ]);
+        }
+
+        return new AccessStatsDateRange($from, $to);
+    }
+
+    private static function parseDate(string $field, string $value): DateTimeImmutable
+    {
+        $parsed = DateTimeImmutable::createFromFormat('!Y-m-d', $value, new \DateTimeZone('UTC'));
+
+        if ($parsed === false || $parsed->format('Y-m-d') !== $value) {
+            throw new ValidationException([
+                new ValidationError($field, 'Date must use YYYY-MM-DD format.', 'format'),
+            ]);
+        }
+
+        return $parsed;
+    }
+}

--- a/src/Analytics/AccessStatsDayItem.php
+++ b/src/Analytics/AccessStatsDayItem.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+final readonly class AccessStatsDayItem
+{
+    public function __construct(
+        public string $date,
+        public int $requestCount,
+        public float $avgDurationMs,
+    ) {
+    }
+}

--- a/src/Analytics/AnalyticsRouteRegistrar.php
+++ b/src/Analytics/AnalyticsRouteRegistrar.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class AnalyticsRouteRegistrar
+{
+    public function __construct(
+        private GetAccessStatsByDateHandler $getAccessStatsHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $getAccessStatsHandler = $this->getAccessStatsHandler;
+
+        $router->get(
+            '/api/v1/analytics/access-stats',
+            static fn (ServerRequestInterface $request) => $getAccessStatsHandler->handle($request),
+        );
+    }
+}

--- a/src/Analytics/AnalyticsServiceProvider.php
+++ b/src/Analytics/AnalyticsServiceProvider.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+final readonly class AnalyticsServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                AccessLogRepositoryInterface::class,
+                static function (ContainerInterface $c): AccessLogRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoAccessLogRepository($query);
+                },
+            )
+            ->set(
+                GetAccessStatsByDateUseCaseInterface::class,
+                static function (ContainerInterface $c): GetAccessStatsByDateUseCaseInterface {
+                    $repository = $c->get(AccessLogRepositoryInterface::class);
+
+                    if (!$repository instanceof AccessLogRepositoryInterface) {
+                        throw new LogicException('Access log repository service is invalid.');
+                    }
+
+                    return new GetAccessStatsByDateUseCase($repository);
+                },
+            )
+            ->set(
+                GetAccessStatsByDateHandler::class,
+                static function (ContainerInterface $c): GetAccessStatsByDateHandler {
+                    $useCase = $c->get(GetAccessStatsByDateUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof GetAccessStatsByDateUseCaseInterface) {
+                        throw new LogicException('GetAccessStatsByDate use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new GetAccessStatsByDateHandler($useCase, $response);
+                },
+            )
+            ->set(
+                AccessLogMiddleware::class,
+                static function (ContainerInterface $c): AccessLogMiddleware {
+                    $repository = $c->get(AccessLogRepositoryInterface::class);
+                    $logger = $c->get(LoggerInterface::class);
+
+                    if (!$repository instanceof AccessLogRepositoryInterface) {
+                        throw new LogicException('Access log repository service is invalid.');
+                    }
+
+                    if (!$logger instanceof LoggerInterface) {
+                        throw new LogicException('Logger service is invalid.');
+                    }
+
+                    return new AccessLogMiddleware($repository, $logger);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.analytics',
+                static function (ContainerInterface $c): AnalyticsRouteRegistrar {
+                    $handler = $c->get(GetAccessStatsByDateHandler::class);
+
+                    if (!$handler instanceof GetAccessStatsByDateHandler) {
+                        throw new LogicException('GetAccessStatsByDate handler service is invalid.');
+                    }
+
+                    return new AnalyticsRouteRegistrar($handler);
+                },
+            );
+    }
+}

--- a/src/Analytics/GetAccessStatsByDateHandler.php
+++ b/src/Analytics/GetAccessStatsByDateHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetAccessStatsByDateHandler
+{
+    public function __construct(
+        private GetAccessStatsByDateUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $range = AccessStatsDateRangeParser::parse($request->getQueryParams());
+
+        $output = $this->useCase->execute(new GetAccessStatsByDateInput(
+            from: $range->from,
+            to: $range->to,
+        ));
+
+        return $this->response->create([
+            'from' => $output->from,
+            'to' => $output->to,
+            'items' => array_map(
+                static fn (AccessStatsDayItem $item) => [
+                    'date' => $item->date,
+                    'request_count' => $item->requestCount,
+                    'avg_duration_ms' => $item->avgDurationMs,
+                ],
+                $output->items,
+            ),
+        ]);
+    }
+}

--- a/src/Analytics/GetAccessStatsByDateInput.php
+++ b/src/Analytics/GetAccessStatsByDateInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+use DateTimeImmutable;
+
+final readonly class GetAccessStatsByDateInput
+{
+    public function __construct(
+        public DateTimeImmutable $from,
+        public DateTimeImmutable $to,
+    ) {
+    }
+}

--- a/src/Analytics/GetAccessStatsByDateOutput.php
+++ b/src/Analytics/GetAccessStatsByDateOutput.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+final readonly class GetAccessStatsByDateOutput
+{
+    /**
+     * @param list<AccessStatsDayItem> $items
+     */
+    public function __construct(
+        public string $from,
+        public string $to,
+        public array $items,
+    ) {
+    }
+}

--- a/src/Analytics/GetAccessStatsByDateUseCase.php
+++ b/src/Analytics/GetAccessStatsByDateUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+final readonly class GetAccessStatsByDateUseCase implements GetAccessStatsByDateUseCaseInterface
+{
+    public function __construct(
+        private AccessLogRepositoryInterface $accessLogs,
+    ) {
+    }
+
+    public function execute(GetAccessStatsByDateInput $input): GetAccessStatsByDateOutput
+    {
+        $items = $this->accessLogs->aggregateByDate($input->from, $input->to);
+
+        return new GetAccessStatsByDateOutput(
+            from: $input->from->format('Y-m-d'),
+            to: $input->to->format('Y-m-d'),
+            items: $items,
+        );
+    }
+}

--- a/src/Analytics/GetAccessStatsByDateUseCaseInterface.php
+++ b/src/Analytics/GetAccessStatsByDateUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+interface GetAccessStatsByDateUseCaseInterface
+{
+    public function execute(GetAccessStatsByDateInput $input): GetAccessStatsByDateOutput;
+}

--- a/src/Analytics/PdoAccessLogRepository.php
+++ b/src/Analytics/PdoAccessLogRepository.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+use DateTimeImmutable;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoAccessLogRepository implements AccessLogRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function insert(AccessLogEntry $entry): void
+    {
+        $this->query->execute(
+            'INSERT INTO access_logs (request_id, method, path, status_code, duration_ms, accessed_at, access_date) VALUES (?, ?, ?, ?, ?, ?, ?)',
+            [
+                $entry->requestId,
+                $entry->method,
+                $entry->path,
+                $entry->statusCode,
+                $entry->durationMs,
+                $entry->accessedAt->format(DateTimeImmutable::ATOM),
+                $entry->accessedAt->format('Y-m-d'),
+            ],
+        );
+    }
+
+    public function aggregateByDate(DateTimeImmutable $from, DateTimeImmutable $to): array
+    {
+        $rows = $this->query->fetchAll(
+            <<<'SQL'
+            SELECT access_date AS date, COUNT(*) AS request_count, AVG(duration_ms) AS avg_duration_ms
+            FROM access_logs
+            WHERE access_date >= ? AND access_date <= ?
+            GROUP BY access_date
+            ORDER BY access_date ASC
+            SQL,
+            [
+                $from->format('Y-m-d'),
+                $to->format('Y-m-d'),
+            ],
+        );
+
+        return array_map(
+            static fn (array $row): AccessStatsDayItem => new AccessStatsDayItem(
+                date: (string) $row['date'],
+                requestCount: (int) $row['request_count'],
+                avgDurationMs: round((float) $row['avg_duration_ms'], 3),
+            ),
+            $rows,
+        );
+    }
+}

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -8,6 +8,7 @@ use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\DomainExceptionHandlerInterface;
+use NeNeRecords\Analytics\AnalyticsServiceProvider;
 use NeNeRecords\BoolField\BoolFieldNotFoundExceptionHandler;
 use NeNeRecords\BoolField\BoolFieldServiceProvider;
 use NeNeRecords\BoolField\FieldKeyNotRegisteredExceptionHandler as BoolFieldKeyNotRegisteredExceptionHandler;
@@ -69,7 +70,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new DateTimeFieldServiceProvider())
             ->addProvider(new TagServiceProvider())
             ->addProvider(new EntityTagServiceProvider())
-            ->addProvider(new EntityRelationServiceProvider());
+            ->addProvider(new EntityRelationServiceProvider())
+            ->addProvider(new AnalyticsServiceProvider());
 
         $builder
             ->set(
@@ -86,6 +88,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $tag = $container->get('nene-records.route_registrar.tag');
                     $entityTag = $container->get('nene-records.route_registrar.entity_tag');
                     $entityRelation = $container->get('nene-records.route_registrar.entity_relation');
+                    $analytics = $container->get('nene-records.route_registrar.analytics');
 
                     if (
                         !is_callable($entityType)
@@ -99,6 +102,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !is_callable($tag)
                         || !is_callable($entityTag)
                         || !is_callable($entityRelation)
+                        || !is_callable($analytics)
                     ) {
                         throw new LogicException('Route registrar service is invalid.');
                     }
@@ -115,6 +119,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $tag,
                         $entityTag,
                         $entityRelation,
+                        $analytics,
                     ];
                 },
             )

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -24,6 +24,7 @@ use Nene2\Http\ResponseEmitter;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Log\MonologLoggerFactory;
 use Nene2\Log\RequestIdHolder;
+use NeNeRecords\Analytics\AccessLogMiddleware;
 use NeNeRecords\ApplicationServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
@@ -218,7 +219,13 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('RequestIdHolder service is invalid.');
                     }
 
-                    $bearerMiddleware = null;
+                    $accessLogMiddleware = $container->get(AccessLogMiddleware::class);
+
+                    if (!$accessLogMiddleware instanceof AccessLogMiddleware) {
+                        throw new LogicException('Access log middleware service is invalid.');
+                    }
+
+                    $authMiddleware = [$accessLogMiddleware];
 
                     if ($config->localJwtSecret !== null) {
                         $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
@@ -227,7 +234,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                             throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
                         }
 
-                        $bearerMiddleware = new BearerTokenMiddleware(
+                        $authMiddleware[] = new BearerTokenMiddleware(
                             $problemDetails,
                             new LocalBearerTokenVerifier($config->localJwtSecret),
                             [],
@@ -242,7 +249,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         $exceptionHandlers,
                         $requestIdHolder,
                         $routeRegistrars,
-                        $bearerMiddleware,
+                        $authMiddleware,
                         [],
                         null,
                         $config->debug,

--- a/tests/Analytics/AccessLogMiddlewareTest.php
+++ b/tests/Analytics/AccessLogMiddlewareTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Analytics;
+
+use DateTimeImmutable;
+use NeNeRecords\Analytics\AccessLogMiddleware;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\NullLogger;
+
+final class AccessLogMiddlewareTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryAccessLogRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->repository = new InMemoryAccessLogRepository();
+    }
+
+    public function testPersistsAccessLogForApiRequest(): void
+    {
+        $middleware = new AccessLogMiddleware($this->repository, new NullLogger(), excludedPaths: ['/health']);
+
+        $response = $middleware->process(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/tags')
+                ->withAttribute('nene2.request_id', 'req-abc'),
+            new readonly class ($this->factory) implements RequestHandlerInterface {
+                public function __construct(private Psr17Factory $factory)
+                {
+                }
+
+                public function handle(ServerRequestInterface $request): ResponseInterface
+                {
+                    return $this->factory->createResponse(200);
+                }
+            },
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertCount(1, $this->repository->all());
+
+        $entry = $this->repository->all()[0];
+        self::assertSame('req-abc', $entry->requestId);
+        self::assertSame('GET', $entry->method);
+        self::assertSame('/api/v1/tags', $entry->path);
+        self::assertSame(200, $entry->statusCode);
+        self::assertGreaterThanOrEqual(0.0, $entry->durationMs);
+    }
+
+    public function testSkipsExcludedPaths(): void
+    {
+        $middleware = new AccessLogMiddleware($this->repository, new NullLogger());
+
+        $middleware->process(
+            $this->factory->createServerRequest('GET', 'https://example.test/health'),
+            new readonly class ($this->factory) implements RequestHandlerInterface {
+                public function __construct(private Psr17Factory $factory)
+                {
+                }
+
+                public function handle(ServerRequestInterface $request): ResponseInterface
+                {
+                    return $this->factory->createResponse(200);
+                }
+            },
+        );
+
+        self::assertSame([], $this->repository->all());
+    }
+
+    public function testDoesNotFailRequestWhenInsertFails(): void
+    {
+        $middleware = new AccessLogMiddleware(
+            new readonly class () implements \NeNeRecords\Analytics\AccessLogRepositoryInterface {
+                public function insert(\NeNeRecords\Analytics\AccessLogEntry $entry): void
+                {
+                    throw new \RuntimeException('db down');
+                }
+
+                public function aggregateByDate(DateTimeImmutable $from, DateTimeImmutable $to): array
+                {
+                    return [];
+                }
+            },
+            new NullLogger(),
+            excludedPaths: ['/health'],
+        );
+
+        $response = $middleware->process(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/tags'),
+            new readonly class ($this->factory) implements RequestHandlerInterface {
+                public function __construct(private Psr17Factory $factory)
+                {
+                }
+
+                public function handle(ServerRequestInterface $request): ResponseInterface
+                {
+                    return $this->factory->createResponse(200);
+                }
+            },
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+}

--- a/tests/Analytics/AccessStatsDateRangeParserTest.php
+++ b/tests/Analytics/AccessStatsDateRangeParserTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Analytics;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Nene2\Validation\ValidationException;
+use NeNeRecords\Analytics\AccessStatsDateRangeParser;
+use NeNeRecords\Analytics\GetAccessStatsByDateInput;
+use NeNeRecords\Analytics\GetAccessStatsByDateUseCase;
+use PHPUnit\Framework\TestCase;
+
+final class AccessStatsDateRangeParserTest extends TestCase
+{
+    public function testParseValidRange(): void
+    {
+        $range = AccessStatsDateRangeParser::parse([
+            'from' => '2026-05-01',
+            'to' => '2026-05-03',
+        ]);
+
+        self::assertSame('2026-05-01', $range->from->format('Y-m-d'));
+        self::assertSame('2026-05-03', $range->to->format('Y-m-d'));
+    }
+
+    public function testFromAfterToThrowsValidationException(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        AccessStatsDateRangeParser::parse([
+            'from' => '2026-05-10',
+            'to' => '2026-05-01',
+        ]);
+    }
+
+    public function testUseCaseReturnsEmptyItemsWhenNoLogs(): void
+    {
+        $repository = new InMemoryAccessLogRepository();
+        $useCase = new GetAccessStatsByDateUseCase($repository);
+        $utc = new DateTimeZone('UTC');
+
+        $output = $useCase->execute(new GetAccessStatsByDateInput(
+            from: new DateTimeImmutable('2026-05-01', $utc),
+            to: new DateTimeImmutable('2026-05-02', $utc),
+        ));
+
+        self::assertSame([], $output->items);
+    }
+}

--- a/tests/Analytics/AnalyticsHttpTest.php
+++ b/tests/Analytics/AnalyticsHttpTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Analytics;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Analytics\AccessLogEntry;
+use NeNeRecords\Analytics\AnalyticsRouteRegistrar;
+use NeNeRecords\Analytics\GetAccessStatsByDateHandler;
+use NeNeRecords\Analytics\GetAccessStatsByDateUseCase;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class AnalyticsHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryAccessLogRepository $repository;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->repository = new InMemoryAccessLogRepository();
+
+        $utc = new DateTimeZone('UTC');
+        $this->repository->insert(new AccessLogEntry(
+            requestId: null,
+            method: 'GET',
+            path: '/api/v1/tags',
+            statusCode: 200,
+            durationMs: 10.0,
+            accessedAt: new DateTimeImmutable('2026-05-01T12:00:00+00:00', $utc),
+        ));
+        $this->repository->insert(new AccessLogEntry(
+            requestId: null,
+            method: 'GET',
+            path: '/api/v1/entities',
+            statusCode: 200,
+            durationMs: 30.0,
+            accessedAt: new DateTimeImmutable('2026-05-02T08:00:00+00:00', $utc),
+        ));
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $registrar = new AnalyticsRouteRegistrar(
+            new GetAccessStatsByDateHandler(
+                new GetAccessStatsByDateUseCase($this->repository),
+                $jsonResponse,
+            ),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            routeRegistrars: [$registrar],
+        ))->create();
+    }
+
+    public function testGetAccessStatsByDateReturnsAggregatedItems(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest(
+                'GET',
+                'https://example.test/api/v1/analytics/access-stats?from=2026-05-01&to=2026-05-02',
+            ),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('2026-05-01', $payload['from']);
+        self::assertSame('2026-05-02', $payload['to']);
+        self::assertCount(2, $payload['items']);
+        self::assertSame('2026-05-01', $payload['items'][0]['date']);
+        self::assertSame(1, $payload['items'][0]['request_count']);
+        self::assertSame(10.0, $payload['items'][0]['avg_duration_ms']);
+    }
+
+    public function testMissingFromReturns422(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest(
+                'GET',
+                'https://example.test/api/v1/analytics/access-stats?to=2026-05-02',
+            ),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringEndsWith('validation-failed', (string) $payload['type']);
+    }
+
+    public function testInvalidDateFormatReturns422(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest(
+                'GET',
+                'https://example.test/api/v1/analytics/access-stats?from=2026/05/01&to=2026-05-02',
+            ),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/tests/Analytics/InMemoryAccessLogRepository.php
+++ b/tests/Analytics/InMemoryAccessLogRepository.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Analytics;
+
+use DateTimeImmutable;
+use NeNeRecords\Analytics\AccessLogEntry;
+use NeNeRecords\Analytics\AccessLogRepositoryInterface;
+use NeNeRecords\Analytics\AccessStatsDayItem;
+
+final class InMemoryAccessLogRepository implements AccessLogRepositoryInterface
+{
+    /** @var list<AccessLogEntry> */
+    private array $entries = [];
+
+    public function insert(AccessLogEntry $entry): void
+    {
+        $this->entries[] = $entry;
+    }
+
+    /** @return list<AccessLogEntry> */
+    public function all(): array
+    {
+        return $this->entries;
+    }
+
+    public function aggregateByDate(DateTimeImmutable $from, DateTimeImmutable $to): array
+    {
+        /** @var array<string, list<float>> $byDate */
+        $byDate = [];
+
+        foreach ($this->entries as $entry) {
+            $date = $entry->accessedAt->format('Y-m-d');
+
+            if ($date < $from->format('Y-m-d') || $date > $to->format('Y-m-d')) {
+                continue;
+            }
+
+            $byDate[$date] ??= [];
+            $byDate[$date][] = $entry->durationMs;
+        }
+
+        ksort($byDate);
+
+        $items = [];
+
+        foreach ($byDate as $date => $durations) {
+            $items[] = new AccessStatsDayItem(
+                date: $date,
+                requestCount: count($durations),
+                avgDurationMs: round(array_sum($durations) / count($durations), 3),
+            );
+        }
+
+        return $items;
+    }
+}

--- a/tests/Analytics/PdoAccessLogRepositoryTest.php
+++ b/tests/Analytics/PdoAccessLogRepositoryTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Analytics;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeNeRecords\Analytics\AccessLogEntry;
+use NeNeRecords\Analytics\PdoAccessLogRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PdoAccessLogRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+    private PdoAccessLogRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene-records-test',
+            '',
+            'utf8',
+        )));
+
+        foreach ($this->schemaStatements() as $statement) {
+            $this->executor->execute($statement);
+        }
+
+        $this->repository = new PdoAccessLogRepository($this->executor);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function schemaStatements(): array
+    {
+        $path = dirname(__DIR__, 2) . '/database/schema/access_logs.sql';
+        self::assertFileExists($path);
+        $raw = trim((string) file_get_contents($path));
+        $statements = [];
+
+        foreach (preg_split('/;\R/s', $raw) ?: [] as $chunk) {
+            $statement = trim($chunk);
+            if ($statement !== '') {
+                $statements[] = $statement;
+            }
+        }
+
+        return $statements;
+    }
+
+    public function testInsertAndAggregateByDate(): void
+    {
+        $utc = new DateTimeZone('UTC');
+
+        $this->repository->insert(new AccessLogEntry(
+            requestId: 'req-1',
+            method: 'GET',
+            path: '/api/v1/tags',
+            statusCode: 200,
+            durationMs: 10.0,
+            accessedAt: new DateTimeImmutable('2026-05-01T10:00:00+00:00', $utc),
+        ));
+        $this->repository->insert(new AccessLogEntry(
+            requestId: 'req-2',
+            method: 'POST',
+            path: '/api/v1/tags',
+            statusCode: 201,
+            durationMs: 20.0,
+            accessedAt: new DateTimeImmutable('2026-05-01T11:00:00+00:00', $utc),
+        ));
+        $this->repository->insert(new AccessLogEntry(
+            requestId: 'req-3',
+            method: 'GET',
+            path: '/api/v1/entities',
+            statusCode: 200,
+            durationMs: 30.0,
+            accessedAt: new DateTimeImmutable('2026-05-02T09:00:00+00:00', $utc),
+        ));
+
+        $items = $this->repository->aggregateByDate(
+            new DateTimeImmutable('2026-05-01', $utc),
+            new DateTimeImmutable('2026-05-02', $utc),
+        );
+
+        self::assertCount(2, $items);
+        self::assertSame('2026-05-01', $items[0]->date);
+        self::assertSame(2, $items[0]->requestCount);
+        self::assertSame(15.0, $items[0]->avgDurationMs);
+        self::assertSame('2026-05-02', $items[1]->date);
+        self::assertSame(1, $items[1]->requestCount);
+        self::assertSame(30.0, $items[1]->avgDurationMs);
+    }
+}

--- a/tools/generate-mcp-tools.php
+++ b/tools/generate-mcp-tools.php
@@ -434,6 +434,28 @@ $tools = [
         ['entityId', 'field_key', 'target_entity_id'],
     ),
     readTool(
+        'getAccessStatsByDate',
+        'Access Stats By Date',
+        'Return daily HTTP access counts and average duration for an inclusive date range (YYYY-MM-DD).',
+        'getAccessStatsByDate',
+        'GET',
+        '/api/v1/analytics/access-stats',
+        [
+            'from' => [
+                'type' => 'string',
+                'format' => 'date',
+                'description' => 'Start date (inclusive), YYYY-MM-DD.',
+            ],
+            'to' => [
+                'type' => 'string',
+                'format' => 'date',
+                'description' => 'End date (inclusive), YYYY-MM-DD. Range must not exceed 366 days.',
+            ],
+        ],
+        '#/components/schemas/AccessStatsByDateResponse',
+        ['from', 'to'],
+    ),
+    readTool(
         'listFieldDefs',
         'List Field Definitions',
         'List registered field definitions, optionally filtered by entity type.',


### PR DESCRIPTION
## Summary

- `access_logs` テーブル + Phinx migration / test schema
- `AccessLogMiddleware` — API リクエスト完了後に method/path/status/duration を DB 記録（health 等は除外）
- `GET /api/v1/analytics/access-stats?from=&to=` — 日次 request_count / avg_duration_ms 集計
- OpenAPI + MCP `getAccessStatsByDate`（54 tools）
- テスト 10 件追加（154 tests total）

## Test plan

- [x] `composer check`（154 tests + phpstan + cs + openapi + mcp）
- [ ] migration 適用後、API 呼び出し → stats 取得を手動確認

## 関連

Closes #69

使用チェックリスト: `docs/review/backend-api.md`


Made with [Cursor](https://cursor.com)