### PR TITLE
feat(frontend): Consumer Views Phase 6 強化 (#72)

### DIFF
--- a/docs/examples/consumer-api.md
+++ b/docs/examples/consumer-api.md
@@ -1,0 +1,157 @@
+# Consumer API Examples
+
+API-only patterns for building public list/detail experiences without the NeNe Records React SPA.
+
+The JSON API is the only persistence boundary. Consumer sites — static sites, mobile apps, or alternate frontends — use the same endpoints as the bundled `/view/*` routes.
+
+Base URL in examples: `http://localhost:8080` (local API). Adjust for your deployment.
+
+## 1. Discover entity types
+
+List registered content types (equivalent to `/view` index):
+
+```bash
+curl -s 'http://localhost:8080/api/v1/entity-types?limit=100&offset=0'
+```
+
+Example response:
+
+```json
+{
+  "items": [
+    { "id": 1, "name": "Article", "slug": "article" }
+  ],
+  "limit": 100,
+  "offset": 0
+}
+```
+
+Use `slug` to build public URLs: `/view/article`, `/view/article/42`, or your own routing scheme.
+
+## 2. List records for a type
+
+Resolve the type slug to `entity_type_id`, then list entities:
+
+```bash
+# entity_type_id=1 for slug "article"
+curl -s 'http://localhost:8080/api/v1/entities?entity_type_id=1&limit=20&offset=0'
+```
+
+Response includes pagination metadata:
+
+```json
+{
+  "items": [
+    { "id": 1, "entity_type_id": 1, "is_deleted": false, "deleted_at": null }
+  ],
+  "limit": 20,
+  "offset": 0,
+  "total": 1
+}
+```
+
+Optional filters (same as admin list API):
+
+```bash
+# Tag filter
+curl -s 'http://localhost:8080/api/v1/entities?entity_type_id=1&tags=featured'
+
+# Relation filter (field_key → target entity id)
+curl -s 'http://localhost:8080/api/v1/entities?entity_type_id=1&relation.author=5'
+```
+
+## 3. Resolve list labels (title field)
+
+The SPA uses the first `text` field named `title` when present. Fetch text fields for the type:
+
+```bash
+curl -s 'http://localhost:8080/api/v1/text-fields?entity_type_id=1&limit=100&offset=0'
+```
+
+Join `entity_id` with list items client-side to build card labels.
+
+## 4. Record detail — schema and values
+
+### Field definitions (display order + types)
+
+```bash
+curl -s 'http://localhost:8080/api/v1/field-defs?entity_type_id=1&limit=100&offset=0'
+```
+
+### Scalar values (per entity)
+
+```bash
+curl -s 'http://localhost:8080/api/v1/text-fields?entity_id=42&limit=100&offset=0'
+curl -s 'http://localhost:8080/api/v1/int-fields?entity_id=42&limit=100&offset=0'
+curl -s 'http://localhost:8080/api/v1/enum-fields?entity_id=42&limit=100&offset=0'
+curl -s 'http://localhost:8080/api/v1/bool-fields?entity_id=42&limit=100&offset=0'
+curl -s 'http://localhost:8080/api/v1/datetime-fields?entity_id=42&limit=100&offset=0'
+```
+
+### Relation fields
+
+```bash
+curl -s 'http://localhost:8080/api/v1/entities/42/relations?field_key=author'
+```
+
+Response:
+
+```json
+{
+  "items": [
+    { "field_key": "author", "target_entity_id": 5 }
+  ]
+}
+```
+
+Resolve target labels with additional entity/text-field fetches, or link to `/view/{targetTypeSlug}/{targetEntityId}`.
+
+## 5. Minimal fetch workflow (JavaScript)
+
+```javascript
+const API = 'http://localhost:8080'
+
+async function listPublicRecords(entityTypeSlug) {
+  const types = await fetch(`${API}/api/v1/entity-types?limit=100`).then((r) => r.json())
+  const type = types.items.find((t) => t.slug === entityTypeSlug)
+  if (!type) return null
+
+  const [entities, textFields] = await Promise.all([
+    fetch(`${API}/api/v1/entities?entity_type_id=${type.id}&limit=20&offset=0`).then((r) =>
+      r.json(),
+    ),
+    fetch(`${API}/api/v1/text-fields?entity_type_id=${type.id}&limit=100`).then((r) => r.json()),
+  ])
+
+  return entities.items.map((entity) => ({
+    id: entity.id,
+    label:
+      textFields.items.find(
+        (f) => f.entity_id === entity.id && f.field_key === 'title',
+      )?.value ?? `Record #${entity.id}`,
+  }))
+}
+```
+
+## 6. Contract references
+
+| Resource | OpenAPI tag |
+| --- | --- |
+| Entity types | `EntityTypes` |
+| Entities | `Entities` |
+| Field defs | `FieldDefs` |
+| Typed fields | `TextFields`, `IntFields`, … |
+| Relations | `EntityRelations` |
+| Tags | `Tags`, `EntityTags` |
+
+Full contract: [`docs/openapi/openapi.yaml`](../openapi/openapi.yaml)
+
+MCP tools mirror the same HTTP operations: [`docs/mcp/tools.json`](../mcp/tools.json)
+
+## 7. Replaceable presentation
+
+- **Bundled SPA:** `/view/*` routes in `frontend/` (React consumer shell + theme).
+- **Custom consumer:** any HTTP client; no admin-only bypass endpoints.
+- **Auth:** public read assumes API is reachable; protect writes with NENE2 middleware (Bearer / API key) as configured in deployment.
+
+See also: [`product-vision.md`](../explanation/product-vision.md), [`frontend-standards.md`](../development/frontend-standards.md) (Admin vs consumer).

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -12,7 +12,7 @@ Last updated: 2026-05-24
 
 | Issue | Summary |
 | --- | --- |
-| — | （なし） |
+| #72 | Consumer Views Phase 6 強化 |
 
 ## Recently Completed
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,9 +16,13 @@ npm run check        # type-check, lint, format, test, build-storybook
 ## Structure
 
 - `src/app/` — providers, router, auth shell
-- `src/pages/` — route wiring
-- `src/features/` — user workflows
+- `src/pages/` — route wiring (`pages/consumer/` = public `/view/*` shell)
+- `src/features/` — user workflows (`public-browse-*`, `public-view-*` = consumer-only)
 - `src/entities/` — API resource slices (TanStack Query)
 - `src/shared/ui/` — theme tokens, primitives, Storybook catalog
 
-Theme swap: edit `src/shared/ui/theme/active.css` import only.
+Public consumer routes: `/view` (type index), `/view/:slug` (list), `/view/:slug/:id` (detail).
+
+Theme swap: edit `src/shared/ui/theme/active.css` import only. Consumer shell uses `themes/consumer-brand.css` via `pages/consumer/consumer-theme.css` (`data-theme="consumer"`).
+
+API-only consumer patterns: [`docs/examples/consumer-api.md`](../docs/examples/consumer-api.md).

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -56,6 +56,10 @@ const importZones = [
     from: './src/shared/api',
   },
   {
+    target: './src/features/public-browse-index',
+    from: './src/features/manage-*',
+  },
+  {
     target: './src/features/public-browse-entity-records',
     from: './src/features/manage-*',
   },

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { PublicBrowsePage } from '@/pages/consumer/PublicBrowsePage'
+import { PublicIndexPage } from '@/pages/consumer/PublicIndexPage'
 import { PublicRecordDetailPage } from '@/pages/consumer/PublicRecordDetailPage'
 import { PublicShell } from '@/pages/consumer/PublicShell'
 import { EntityRecordPage } from '@/pages/entity-record/EntityRecordPage'
@@ -27,6 +28,7 @@ const router = createBrowserRouter([
     path: '/view',
     element: <PublicShell />,
     children: [
+      { index: true, element: <PublicIndexPage /> },
       { path: ':entityTypeSlug', element: <PublicBrowsePage /> },
       { path: ':entityTypeSlug/:entityId', element: <PublicRecordDetailPage /> },
     ],

--- a/frontend/src/entities/entity/queries.ts
+++ b/frontend/src/entities/entity/queries.ts
@@ -52,11 +52,13 @@ export function defaultEntityListParams(
   entityTypeId: number,
   tagSlugs: string[] = [],
   relationFilters: EntityListParams['relationFilters'] = {},
+  offset = 0,
 ): EntityListParams {
   return {
     entityTypeId,
     tagSlugs,
     relationFilters,
-    ...DEFAULT_LIST_PARAMS,
+    limit: DEFAULT_LIST_PARAMS.limit,
+    offset,
   }
 }

--- a/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.ts
+++ b/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.ts
@@ -4,13 +4,14 @@ import { useEntityTypeList } from '@/entities/entity-type'
 import { defaultTextFieldListParamsForEntityType, useTextFieldList } from '@/entities/text-field'
 import { findEntityTypeBySlug } from '@/shared/lib/find-entity-type-by-slug'
 import { getRecordDisplayLabel } from '@/shared/lib/get-record-display-label'
+import { PUBLIC_BROWSE_PAGE_SIZE } from '../lib/public-browse-pagination'
 
 export interface PublicRecordListItem {
   id: number
   label: string
 }
 
-export function usePublicBrowseEntityRecordsPage(entityTypeSlug: string) {
+export function usePublicBrowseEntityRecordsPage(entityTypeSlug: string, offset: number) {
   const entityTypeQuery = useEntityTypeList()
   const entityType = useMemo(
     () => findEntityTypeBySlug(entityTypeQuery.data?.items ?? [], entityTypeSlug),
@@ -18,7 +19,10 @@ export function usePublicBrowseEntityRecordsPage(entityTypeSlug: string) {
   )
 
   const entityTypeId = entityType !== undefined ? Number(entityType.id) : 0
-  const listParams = defaultEntityListParams(entityTypeId)
+  const listParams = useMemo(
+    () => defaultEntityListParams(entityTypeId, [], {}, offset),
+    [entityTypeId, offset],
+  )
   const entityListQuery = useEntityList(listParams, { enabled: entityTypeId > 0 })
   const textFieldListParams = useMemo(
     () => defaultTextFieldListParamsForEntityType(entityTypeId),
@@ -47,11 +51,20 @@ export function usePublicBrowseEntityRecordsPage(entityTypeSlug: string) {
     textFieldQuery.error?.title ??
     null
 
+  const total = entityListQuery.data?.total ?? 0
+  const pageSize = PUBLIC_BROWSE_PAGE_SIZE
+  const hasPreviousPage = offset > 0
+  const hasNextPage = offset + pageSize < total
+
   return {
     entityType,
     entityTypeSlug,
     items,
-    total: entityListQuery.data?.total ?? 0,
+    total,
+    offset,
+    pageSize,
+    hasPreviousPage,
+    hasNextPage,
     isLoading,
     isError,
     errorTitle,

--- a/frontend/src/features/public-browse-entity-records/lib/public-browse-pagination.ts
+++ b/frontend/src/features/public-browse-entity-records/lib/public-browse-pagination.ts
@@ -1,0 +1,11 @@
+export const PUBLIC_BROWSE_PAGE_SIZE = 20
+
+export function parsePublicBrowseOffset(raw: string | null): number {
+  const parsed = Number(raw ?? '0')
+
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    return 0
+  }
+
+  return parsed
+}

--- a/frontend/src/features/public-browse-entity-records/ui/PublicRecordListView.tsx
+++ b/frontend/src/features/public-browse-entity-records/ui/PublicRecordListView.tsx
@@ -7,6 +7,12 @@ export interface PublicRecordListViewProps {
   entityTypeName: string | null
   items: PublicRecordListItem[]
   total: number
+  offset: number
+  pageSize: number
+  hasPreviousPage: boolean
+  hasNextPage: boolean
+  onPreviousPage: () => void
+  onNextPage: () => void
   isLoading: boolean
   isError: boolean
   isUnknownType: boolean
@@ -19,6 +25,12 @@ export function PublicRecordListView({
   entityTypeName,
   items,
   total,
+  offset,
+  pageSize,
+  hasPreviousPage,
+  hasNextPage,
+  onPreviousPage,
+  onNextPage,
   isLoading,
   isError,
   isUnknownType,
@@ -63,6 +75,9 @@ export function PublicRecordListView({
     <Stack gap="md">
       <Text as="p" muted>
         {total} record{total === 1 ? '' : 's'}
+        {total > pageSize
+          ? ` · showing ${String(offset + 1)}–${String(Math.min(offset + items.length, total))}`
+          : ''}
       </Text>
       <ul className="flex flex-col gap-stack-sm">
         {items.map((item) => (
@@ -79,6 +94,21 @@ export function PublicRecordListView({
           </li>
         ))}
       </ul>
+      {(hasPreviousPage || hasNextPage) && (
+        <Stack direction="horizontal" gap="sm">
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={!hasPreviousPage}
+            onClick={onPreviousPage}
+          >
+            Previous
+          </Button>
+          <Button variant="secondary" size="sm" disabled={!hasNextPage} onClick={onNextPage}>
+            Next
+          </Button>
+        </Stack>
+      )}
     </Stack>
   )
 }

--- a/frontend/src/features/public-browse-index/hooks/use-public-browse-index-page.ts
+++ b/frontend/src/features/public-browse-index/hooks/use-public-browse-index-page.ts
@@ -1,0 +1,27 @@
+import { useEntityTypeList } from '@/entities/entity-type'
+
+export interface PublicEntityTypeListItem {
+  id: number
+  slug: string
+  name: string
+}
+
+export function usePublicBrowseIndexPage() {
+  const entityTypeQuery = useEntityTypeList({ limit: 100, offset: 0 })
+
+  const items: PublicEntityTypeListItem[] = (entityTypeQuery.data?.items ?? []).map((item) => ({
+    id: Number(item.id),
+    slug: item.slug,
+    name: item.name,
+  }))
+
+  return {
+    items,
+    isLoading: entityTypeQuery.isLoading,
+    isError: entityTypeQuery.isError,
+    errorTitle: entityTypeQuery.error?.title ?? null,
+    refetch: async () => {
+      await entityTypeQuery.refetch()
+    },
+  }
+}

--- a/frontend/src/features/public-browse-index/index.ts
+++ b/frontend/src/features/public-browse-index/index.ts
@@ -1,0 +1,3 @@
+export { usePublicBrowseIndexPage } from './hooks/use-public-browse-index-page'
+export type { PublicEntityTypeListItem } from './hooks/use-public-browse-index-page'
+export { PublicEntityTypeListView } from './ui/PublicEntityTypeListView'

--- a/frontend/src/features/public-browse-index/ui/PublicEntityTypeListView.tsx
+++ b/frontend/src/features/public-browse-index/ui/PublicEntityTypeListView.tsx
@@ -1,0 +1,65 @@
+import { Link } from 'react-router-dom'
+import { Button, EmptyState, Stack, Text } from '@/shared/ui'
+import type { PublicEntityTypeListItem } from '../hooks/use-public-browse-index-page'
+
+export interface PublicEntityTypeListViewProps {
+  items: PublicEntityTypeListItem[]
+  isLoading: boolean
+  isError: boolean
+  errorTitle: string | null
+  onRetry: () => void
+}
+
+export function PublicEntityTypeListView({
+  items,
+  isLoading,
+  isError,
+  errorTitle,
+  onRetry,
+}: PublicEntityTypeListViewProps) {
+  if (isLoading) {
+    return <Text muted>Loading…</Text>
+  }
+
+  if (isError) {
+    return (
+      <Stack gap="sm">
+        <Text variant="heading-sm">Could not load content types</Text>
+        <Text muted>{errorTitle ?? 'Unknown error'}</Text>
+        <Button variant="secondary" onClick={onRetry}>
+          Retry
+        </Button>
+      </Stack>
+    )
+  }
+
+  if (items.length === 0) {
+    return (
+      <EmptyState
+        title="No content types yet"
+        description="Entity types will appear here when they are registered in the API."
+      />
+    )
+  }
+
+  return (
+    <ul className="flex flex-col gap-stack-sm">
+      {items.map((item) => (
+        <li
+          key={String(item.id)}
+          className="rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm shadow-sm"
+        >
+          <Link
+            to={`/view/${item.slug}`}
+            className="font-sans text-heading-sm font-semibold text-text-primary hover:text-accent"
+          >
+            {item.name}
+          </Link>
+          <Text as="p" muted className="mt-stack-xs">
+            /view/{item.slug}
+          </Text>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/frontend/src/pages/consumer/PublicBrowsePage.test.tsx
+++ b/frontend/src/pages/consumer/PublicBrowsePage.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { PublicBrowsePage } from '@/pages/consumer/PublicBrowsePage'
+import { PublicIndexPage } from '@/pages/consumer/PublicIndexPage'
 import { PublicRecordDetailPage } from '@/pages/consumer/PublicRecordDetailPage'
 import { resetEntityStore, seedEntities } from '@tests/msw/handlers/entity'
 import { resetEntityTypeStore, seedEntityTypes } from '@tests/msw/handlers/entity-type'
@@ -10,10 +11,11 @@ import { resetTextFieldStore, seedTextFields } from '@tests/msw/handlers/text-fi
 import { mswServer } from '@tests/msw/server'
 import { renderWithProviders } from '@tests/render/render-with-providers'
 
-function renderBrowsePage(slug = 'article') {
+function renderBrowsePage(initialEntry = '/view/article') {
   return renderWithProviders(
-    <MemoryRouter initialEntries={[`/view/${slug}`]}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
+        <Route path="/view" element={<PublicIndexPage />} />
         <Route path="/view/:entityTypeSlug" element={<PublicBrowsePage />} />
         <Route path="/view/:entityTypeSlug/:entityId" element={<PublicRecordDetailPage />} />
       </Routes>
@@ -83,7 +85,7 @@ describe('PublicBrowsePage', () => {
   })
 
   it('shows empty state for unknown entity type slug', async () => {
-    renderBrowsePage('missing-type')
+    renderBrowsePage('/view/missing-type')
 
     expect(await screen.findByText('Entity type not found')).toBeInTheDocument()
     expect(screen.getByText('No public content for "missing-type".')).toBeInTheDocument()
@@ -116,5 +118,39 @@ describe('PublicBrowsePage', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Back to Article' })).toBeInTheDocument()
     })
+  })
+
+  it('paginates records with offset query param', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    seedEntities(
+      Array.from({ length: 21 }, (_, index) => ({
+        id: index + 1,
+        entity_type_id: 1,
+        is_deleted: false,
+        deleted_at: null,
+      })),
+    )
+    seedTextFields(
+      Array.from({ length: 21 }, (_, index) => ({
+        id: index + 1,
+        entity_id: index + 1,
+        field_key: 'title',
+        value: `Post ${String(index + 1)}`,
+      })),
+    )
+
+    const user = userEvent.setup()
+    renderBrowsePage('/view/article')
+
+    expect(await screen.findByText('21 records · showing 1–20')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Post 1' })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Post 21' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Next' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('21 records · showing 21–21')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('link', { name: 'Post 21' })).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/consumer/PublicBrowsePage.tsx
+++ b/frontend/src/pages/consumer/PublicBrowsePage.tsx
@@ -1,25 +1,70 @@
-import { useParams } from 'react-router-dom'
+import { Link, useParams, useSearchParams } from 'react-router-dom'
+import {
+  parsePublicBrowseOffset,
+  PUBLIC_BROWSE_PAGE_SIZE,
+} from '@/features/public-browse-entity-records/lib/public-browse-pagination'
 import {
   PublicRecordListView,
   usePublicBrowseEntityRecordsPage,
 } from '@/features/public-browse-entity-records'
-import { Stack, Text } from '@/shared/ui'
+import { Button, Stack, Text } from '@/shared/ui'
 
 export function PublicBrowsePage() {
   const { entityTypeSlug = '' } = useParams()
-  const { entityType, items, total, isLoading, isError, isUnknownType, errorTitle, refetch } =
-    usePublicBrowseEntityRecordsPage(entityTypeSlug)
+  const [searchParams, setSearchParams] = useSearchParams()
+  const offset = parsePublicBrowseOffset(searchParams.get('offset'))
+
+  const {
+    entityType,
+    items,
+    total,
+    pageSize,
+    hasPreviousPage,
+    hasNextPage,
+    isLoading,
+    isError,
+    isUnknownType,
+    errorTitle,
+    refetch,
+  } = usePublicBrowseEntityRecordsPage(entityTypeSlug, offset)
+
+  const goToOffset = (nextOffset: number) => {
+    const params = new URLSearchParams(searchParams)
+    if (nextOffset <= 0) {
+      params.delete('offset')
+    } else {
+      params.set('offset', String(nextOffset))
+    }
+    setSearchParams(params)
+  }
 
   return (
     <Stack gap="md">
-      <Text as="h1" variant="heading-md">
-        {entityType?.name ?? entityTypeSlug}
-      </Text>
+      <Stack gap="sm">
+        <Link to="/view">
+          <Button variant="secondary" size="sm">
+            All types
+          </Button>
+        </Link>
+        <Text as="h1" variant="heading-md">
+          {entityType?.name ?? entityTypeSlug}
+        </Text>
+      </Stack>
       <PublicRecordListView
         entityTypeSlug={entityTypeSlug}
         entityTypeName={entityType?.name ?? null}
         items={items}
         total={total}
+        offset={offset}
+        pageSize={pageSize}
+        hasPreviousPage={hasPreviousPage}
+        hasNextPage={hasNextPage}
+        onPreviousPage={() => {
+          goToOffset(Math.max(0, offset - PUBLIC_BROWSE_PAGE_SIZE))
+        }}
+        onNextPage={() => {
+          goToOffset(offset + PUBLIC_BROWSE_PAGE_SIZE)
+        }}
         isLoading={isLoading}
         isError={isError}
         isUnknownType={isUnknownType}

--- a/frontend/src/pages/consumer/PublicIndexPage.test.tsx
+++ b/frontend/src/pages/consumer/PublicIndexPage.test.tsx
@@ -1,0 +1,55 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { cleanup, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { PublicIndexPage } from '@/pages/consumer/PublicIndexPage'
+import { resetEntityTypeStore, seedEntityTypes } from '@tests/msw/handlers/entity-type'
+import { mswServer } from '@tests/msw/server'
+import { renderWithProviders } from '@tests/render/render-with-providers'
+
+function renderIndexPage() {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={['/view']}>
+      <Routes>
+        <Route path="/view" element={<PublicIndexPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('PublicIndexPage', () => {
+  beforeAll(() => {
+    mswServer.listen()
+  })
+
+  afterEach(() => {
+    mswServer.resetHandlers()
+    resetEntityTypeStore()
+    cleanup()
+  })
+
+  afterAll(() => {
+    mswServer.close()
+  })
+
+  it('lists entity types with links to public browse routes', async () => {
+    seedEntityTypes([
+      { id: 1, name: 'Article', slug: 'article' },
+      { id: 2, name: 'Product', slug: 'product' },
+    ])
+
+    renderIndexPage()
+
+    expect(await screen.findByRole('link', { name: 'Article' })).toHaveAttribute(
+      'href',
+      '/view/article',
+    )
+    expect(screen.getByRole('link', { name: 'Product' })).toHaveAttribute('href', '/view/product')
+    expect(screen.getByText('/view/article')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no entity types exist', async () => {
+    renderIndexPage()
+
+    expect(await screen.findByText('No content types yet')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/consumer/PublicIndexPage.tsx
+++ b/frontend/src/pages/consumer/PublicIndexPage.tsx
@@ -1,0 +1,26 @@
+import { PublicEntityTypeListView, usePublicBrowseIndexPage } from '@/features/public-browse-index'
+import { Stack, Text } from '@/shared/ui'
+
+export function PublicIndexPage() {
+  const { items, isLoading, isError, errorTitle, refetch } = usePublicBrowseIndexPage()
+
+  return (
+    <Stack gap="md">
+      <Stack gap="sm">
+        <Text as="h1" variant="heading-md">
+          Browse
+        </Text>
+        <Text muted>Public records grouped by entity type.</Text>
+      </Stack>
+      <PublicEntityTypeListView
+        items={items}
+        isLoading={isLoading}
+        isError={isError}
+        errorTitle={errorTitle}
+        onRetry={() => {
+          void refetch()
+        }}
+      />
+    </Stack>
+  )
+}

--- a/frontend/src/pages/consumer/PublicShell.tsx
+++ b/frontend/src/pages/consumer/PublicShell.tsx
@@ -1,12 +1,13 @@
+import './consumer-theme.css'
 import { Link, Outlet } from 'react-router-dom'
 import { Text } from '@/shared/ui'
 
 export function PublicShell() {
   return (
-    <div className="min-h-screen bg-surface font-sans text-text-primary">
+    <div data-theme="consumer" className="min-h-screen bg-surface font-sans text-text-primary">
       <header className="border-b border-border bg-surface-raised shadow-sm">
         <div className="mx-auto max-w-3xl px-inline-md py-stack-md">
-          <Link to="/">
+          <Link to="/view">
             <Text as="span" variant="heading-sm">
               NeNe Records
             </Text>

--- a/frontend/src/pages/consumer/consumer-theme.css
+++ b/frontend/src/pages/consumer/consumer-theme.css
@@ -1,0 +1,1 @@
+@import '../../shared/ui/theme/themes/consumer-brand.css';

--- a/frontend/src/pages/home/HomePage.tsx
+++ b/frontend/src/pages/home/HomePage.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom'
 import { Stack, Text } from '@/shared/ui'
 
 export function HomePage() {
@@ -9,6 +10,9 @@ export function HomePage() {
       <Text muted>
         Phase 4 scaffold is running. Use Entity types to verify API integration via TanStack Query.
       </Text>
+      <Link to="/view" className="text-body font-medium text-accent hover:text-accent-hover">
+        Open public site →
+      </Link>
     </Stack>
   )
 }

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -26,6 +26,9 @@ export function AppShell() {
               <NavLink to="/tags" className={navLinkClass}>
                 Tags
               </NavLink>
+              <NavLink to="/view" className={navLinkClass}>
+                Public site
+              </NavLink>
             </Stack>
           </nav>
         </div>

--- a/frontend/src/shared/ui/theme/themes/consumer-brand.css
+++ b/frontend/src/shared/ui/theme/themes/consumer-brand.css
@@ -1,0 +1,14 @@
+[data-theme='consumer'] {
+  --color-surface: oklch(97.5% 0.012 75);
+  --color-surface-raised: oklch(99.5% 0.008 75);
+  --color-surface-overlay: oklch(94% 0.02 75);
+  --color-text-primary: oklch(24% 0.03 55);
+  --color-text-muted: oklch(48% 0.03 55);
+  --color-text-inverse: oklch(99% 0 0);
+  --color-border: oklch(86% 0.02 75);
+  --color-accent: oklch(58% 0.14 45);
+  --color-accent-hover: oklch(52% 0.14 45);
+  --color-danger: oklch(52% 0.2 25);
+  --color-danger-hover: oklch(46% 0.2 25);
+  --color-focus-ring: oklch(68% 0.12 45);
+}

--- a/frontend/tests/unit/public-browse-pagination.test.ts
+++ b/frontend/tests/unit/public-browse-pagination.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parsePublicBrowseOffset,
+  PUBLIC_BROWSE_PAGE_SIZE,
+} from '@/features/public-browse-entity-records/lib/public-browse-pagination'
+
+describe('public-browse-pagination', () => {
+  it('defaults invalid offset to zero', () => {
+    expect(parsePublicBrowseOffset(null)).toBe(0)
+    expect(parsePublicBrowseOffset('-1')).toBe(0)
+    expect(parsePublicBrowseOffset('abc')).toBe(0)
+  })
+
+  it('parses valid integer offset', () => {
+    expect(parsePublicBrowseOffset('20')).toBe(20)
+  })
+
+  it('exposes page size constant aligned with entity list default', () => {
+    expect(PUBLIC_BROWSE_PAGE_SIZE).toBe(20)
+  })
+})


### PR DESCRIPTION
## Summary

- `/view` — entity type 一覧（公開サイト入口）
- `/view/:slug?offset=` — ページネーション（Previous / Next）
- Consumer テーマ `consumer-brand.css`（PublicShell `data-theme="consumer"`）
- `docs/examples/consumer-api.md` — curl / fetch の API-only 例
- Admin から Public site リンク

## Test plan

- [x] `npm run check --prefix frontend` — 68 tests green

Closes #72

使用チェックリスト: frontend-self-review


Made with [Cursor](https://cursor.com)