### PR TITLE
feat(public-record): 公開詳細の集約 API と HTML bootstrap (#75)

### DIFF
--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -347,6 +347,39 @@
             "responseSchemaRef": "#/components/schemas/EntityResponse"
         },
         {
+            "name": "getPublicRecordView",
+            "title": "Get Public Record View",
+            "description": "Aggregated bootstrap payload for a public consumer record detail page.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "getPublicRecordView",
+                "method": "GET",
+                "path": "/api/v1/public/entity-types/{slug}/records/{entityId}"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "slug": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Entity type slug."
+                    },
+                    "entityId": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Entity instance id."
+                    }
+                },
+                "required": [
+                    "slug",
+                    "entityId"
+                ],
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/PublicRecordViewResponse"
+        },
+        {
             "name": "updateEntityById",
             "title": "Update Entity",
             "description": "Update an entity record entity type id.",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -34,6 +34,8 @@ tags:
     description: Typed relation links between entity instances.
   - name: Analytics
     description: HTTP access log aggregation and reporting.
+  - name: PublicConsumer
+    description: Aggregated read-only views for public consumer pages and MCP.
 paths:
   /health:
     get:
@@ -1590,6 +1592,42 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/public/entity-types/{slug}/records/{entityId}:
+    get:
+      tags:
+        - PublicConsumer
+      summary: Get aggregated public record view
+      description: >
+        Returns a single JSON payload with entity type list, entity, field definitions,
+        typed field values, and relation data — aligned with the consumer detail page
+        TanStack Query cache keys.
+      operationId: getPublicRecordView
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          description: Entity type slug.
+          schema:
+            type: string
+            minLength: 1
+        - name: entityId
+          in: path
+          required: true
+          description: Entity instance id.
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: Aggregated public record view bootstrap payload.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicRecordViewResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /api/v1/analytics/access-stats:
     get:
       tags:
@@ -2545,4 +2583,69 @@ components:
         avg_duration_ms:
           type: number
           minimum: 0
+      additionalProperties: false
+    PublicRecordViewResponse:
+      type: object
+      required:
+        - entityTypeSlug
+        - entityTypeId
+        - entityId
+        - entityTypes
+        - entity
+        - fieldDefs
+        - textFields
+        - intFields
+        - enumFields
+        - boolFields
+        - dateTimeFields
+        - entityRelations
+        - relationTextFieldsByEntityTypeId
+      properties:
+        entityTypeSlug:
+          type: string
+          minLength: 1
+        entityTypeId:
+          type: integer
+          minimum: 1
+        entityId:
+          type: integer
+          minimum: 1
+        entityTypes:
+          $ref: '#/components/schemas/EntityTypeListResponse'
+        entity:
+          $ref: '#/components/schemas/EntityResponse'
+        fieldDefs:
+          $ref: '#/components/schemas/FieldDefListResponse'
+        textFields:
+          $ref: '#/components/schemas/TextFieldListResponse'
+        intFields:
+          $ref: '#/components/schemas/IntFieldListResponse'
+        enumFields:
+          $ref: '#/components/schemas/EnumFieldListResponse'
+        boolFields:
+          $ref: '#/components/schemas/BoolFieldListResponse'
+        dateTimeFields:
+          $ref: '#/components/schemas/DateTimeFieldListResponse'
+        entityRelations:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicRecordRelationQuery'
+        relationTextFieldsByEntityTypeId:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/TextFieldListResponse'
+      additionalProperties: false
+    PublicRecordRelationQuery:
+      type: object
+      required:
+        - fieldKey
+        - items
+      properties:
+        fieldKey:
+          type: string
+          minLength: 1
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntityRelationItemResponse'
       additionalProperties: false

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -1,11 +1,12 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useState, type ReactNode } from 'react'
+import { seedPublicRecordViewCache } from '@/shared/lib/seed-public-record-view-cache'
 import { AppError } from '@/shared/api/client'
 import { AuthGate } from './auth-gate'
 import { RootErrorBoundary } from './root-error-boundary'
 
 function createAppQueryClient(): QueryClient {
-  return new QueryClient({
+  const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
         staleTime: 30_000,
@@ -18,6 +19,10 @@ function createAppQueryClient(): QueryClient {
       },
     },
   })
+
+  seedPublicRecordViewCache(queryClient)
+
+  return queryClient
 }
 
 export function AppProviders({ children }: { children: ReactNode }) {

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
@@ -55,7 +55,7 @@ export function PublicRecordDetailPage() {
   const { entityTypeSlug = '', entityId: entityIdParam = '' } = useParams()
   const entityId = Number(entityIdParam)
 
-  const entityTypeQuery = useEntityTypeList()
+  const entityTypeQuery = useEntityTypeList({ limit: 100, offset: 0 })
   const entityType = useMemo(
     () => findEntityTypeBySlug(entityTypeQuery.data?.items ?? [], entityTypeSlug),
     [entityTypeQuery.data?.items, entityTypeSlug],

--- a/frontend/src/shared/lib/public-record-bootstrap.ts
+++ b/frontend/src/shared/lib/public-record-bootstrap.ts
@@ -1,0 +1,57 @@
+const BOOTSTRAP_SCRIPT_ID = 'nene-records-public-record-bootstrap'
+
+export interface PublicRecordBootstrapFieldListDto {
+  items: unknown[]
+  limit: number
+  offset: number
+}
+
+export interface PublicRecordBootstrapRelationQuery {
+  fieldKey: string
+  items: Array<{ field_key: string; target_entity_id: number }>
+}
+
+export interface PublicRecordBootstrapDto {
+  entityTypeSlug: string
+  entityTypeId: number
+  entityId: number
+  entityTypes: PublicRecordBootstrapFieldListDto
+  entity: {
+    id: number
+    entity_type_id: number
+    is_deleted: boolean
+    deleted_at: string | null
+  }
+  fieldDefs: PublicRecordBootstrapFieldListDto
+  textFields: PublicRecordBootstrapFieldListDto
+  intFields: PublicRecordBootstrapFieldListDto
+  enumFields: PublicRecordBootstrapFieldListDto
+  boolFields: PublicRecordBootstrapFieldListDto
+  dateTimeFields: PublicRecordBootstrapFieldListDto
+  entityRelations: PublicRecordBootstrapRelationQuery[]
+  relationTextFieldsByEntityTypeId: Record<string, PublicRecordBootstrapFieldListDto>
+}
+
+export function readPublicRecordBootstrap(): PublicRecordBootstrapDto | null {
+  if (typeof document === 'undefined') {
+    return null
+  }
+
+  const element = document.getElementById(BOOTSTRAP_SCRIPT_ID)
+
+  if (element === null) {
+    return null
+  }
+
+  const raw = element.textContent.trim()
+
+  if (raw === '') {
+    return null
+  }
+
+  try {
+    return JSON.parse(raw) as PublicRecordBootstrapDto
+  } catch {
+    return null
+  }
+}

--- a/frontend/src/shared/lib/seed-public-record-view-cache.ts
+++ b/frontend/src/shared/lib/seed-public-record-view-cache.ts
@@ -1,0 +1,104 @@
+import type { QueryClient } from '@tanstack/react-query'
+import type { BoolFieldListDto } from '@/entities/bool-field/api-types'
+import { mapBoolFieldListDtoToModel } from '@/entities/bool-field/mapper'
+import { boolFieldKeys } from '@/entities/bool-field/query-keys'
+import type { DateTimeFieldListDto } from '@/entities/datetime-field/api-types'
+import { mapDateTimeFieldListDtoToModel } from '@/entities/datetime-field/mapper'
+import { dateTimeFieldKeys } from '@/entities/datetime-field/query-keys'
+import type { EnumFieldListDto } from '@/entities/enum-field/api-types'
+import { mapEnumFieldListDtoToModel } from '@/entities/enum-field/mapper'
+import { enumFieldKeys } from '@/entities/enum-field/query-keys'
+import { mapEntityDtoToModel } from '@/entities/entity/mapper'
+import { toEntityId } from '@/entities/entity/ids'
+import { entityKeys } from '@/entities/entity/query-keys'
+import { mapEntityRelationListDtoToModel } from '@/entities/entity-relation/mapper'
+import { entityRelationKeys } from '@/entities/entity-relation/query-keys'
+import type { EntityTypeListDto } from '@/entities/entity-type/api-types'
+import { mapEntityTypeListDtoToModel } from '@/entities/entity-type/mapper'
+import { entityTypeKeys } from '@/entities/entity-type/query-keys'
+import type { FieldDefListDto } from '@/entities/field-def/api-types'
+import { mapFieldDefListDtoToModel } from '@/entities/field-def/mapper'
+import { fieldDefKeys } from '@/entities/field-def/query-keys'
+import type { IntFieldListDto } from '@/entities/int-field/api-types'
+import { mapIntFieldListDtoToModel } from '@/entities/int-field/mapper'
+import { intFieldKeys } from '@/entities/int-field/query-keys'
+import type { TextFieldListDto } from '@/entities/text-field/api-types'
+import { mapTextFieldListDtoToModel } from '@/entities/text-field/mapper'
+import { textFieldKeys } from '@/entities/text-field/query-keys'
+import {
+  readPublicRecordBootstrap,
+  type PublicRecordBootstrapDto,
+} from '@/shared/lib/public-record-bootstrap'
+
+const ENTITY_TYPE_LIST_PARAMS = { limit: 100, offset: 0 } as const
+const FIELD_DEF_LIST_PARAMS = { limit: 20, offset: 0 } as const
+const FIELD_VALUE_LIST_PARAMS = { limit: 100, offset: 0 } as const
+
+export function seedPublicRecordViewCache(
+  queryClient: QueryClient,
+  bootstrap: PublicRecordBootstrapDto | null = readPublicRecordBootstrap(),
+): void {
+  if (bootstrap === null) {
+    return
+  }
+
+  queryClient.setQueryData(
+    entityTypeKeys.list(ENTITY_TYPE_LIST_PARAMS),
+    mapEntityTypeListDtoToModel(bootstrap.entityTypes as EntityTypeListDto),
+  )
+
+  queryClient.setQueryData(
+    entityKeys.detail(toEntityId(bootstrap.entityId)),
+    mapEntityDtoToModel(bootstrap.entity),
+  )
+
+  queryClient.setQueryData(
+    fieldDefKeys.list({
+      entityTypeId: bootstrap.entityTypeId,
+      ...FIELD_DEF_LIST_PARAMS,
+    }),
+    mapFieldDefListDtoToModel(bootstrap.fieldDefs as FieldDefListDto),
+  )
+
+  const fieldListParams = { ...FIELD_VALUE_LIST_PARAMS, entityId: bootstrap.entityId }
+
+  queryClient.setQueryData(
+    textFieldKeys.list(fieldListParams),
+    mapTextFieldListDtoToModel(bootstrap.textFields as TextFieldListDto),
+  )
+  queryClient.setQueryData(
+    intFieldKeys.list(fieldListParams),
+    mapIntFieldListDtoToModel(bootstrap.intFields as IntFieldListDto),
+  )
+  queryClient.setQueryData(
+    enumFieldKeys.list(fieldListParams),
+    mapEnumFieldListDtoToModel(bootstrap.enumFields as EnumFieldListDto),
+  )
+  queryClient.setQueryData(
+    boolFieldKeys.list(fieldListParams),
+    mapBoolFieldListDtoToModel(bootstrap.boolFields as BoolFieldListDto),
+  )
+  queryClient.setQueryData(
+    dateTimeFieldKeys.list(fieldListParams),
+    mapDateTimeFieldListDtoToModel(bootstrap.dateTimeFields as DateTimeFieldListDto),
+  )
+
+  for (const relation of bootstrap.entityRelations) {
+    queryClient.setQueryData(
+      entityRelationKeys.list(bootstrap.entityId, relation.fieldKey),
+      mapEntityRelationListDtoToModel({ items: relation.items }),
+    )
+  }
+
+  for (const [entityTypeId, payload] of Object.entries(
+    bootstrap.relationTextFieldsByEntityTypeId,
+  )) {
+    queryClient.setQueryData(
+      textFieldKeys.list({
+        entityTypeId: Number(entityTypeId),
+        ...FIELD_VALUE_LIST_PARAMS,
+      }),
+      mapTextFieldListDtoToModel(payload as TextFieldListDto),
+    )
+  }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -24,6 +24,10 @@ export default defineConfig({
         target: 'http://localhost:8080',
         changeOrigin: true,
       },
+      '/view': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
     },
   },
 })

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -42,6 +42,9 @@ use NeNeRecords\IntField\FieldKeyNotRegisteredExceptionHandler as IntFieldKeyNot
 use NeNeRecords\IntField\FieldTypeMismatchExceptionHandler as IntFieldTypeMismatchExceptionHandler;
 use NeNeRecords\IntField\IntFieldNotFoundExceptionHandler;
 use NeNeRecords\IntField\IntFieldServiceProvider;
+use NeNeRecords\PublicRecord\PublicEntityTypeNotFoundExceptionHandler;
+use NeNeRecords\PublicRecord\PublicRecordNotFoundExceptionHandler;
+use NeNeRecords\PublicRecord\PublicRecordServiceProvider;
 use NeNeRecords\Tag\TagNotFoundExceptionHandler;
 use NeNeRecords\Tag\TagServiceProvider;
 use NeNeRecords\Tag\TagSlugConflictExceptionHandler;
@@ -71,7 +74,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new TagServiceProvider())
             ->addProvider(new EntityTagServiceProvider())
             ->addProvider(new EntityRelationServiceProvider())
-            ->addProvider(new AnalyticsServiceProvider());
+            ->addProvider(new AnalyticsServiceProvider())
+            ->addProvider(new PublicRecordServiceProvider());
 
         $builder
             ->set(
@@ -89,6 +93,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $entityTag = $container->get('nene-records.route_registrar.entity_tag');
                     $entityRelation = $container->get('nene-records.route_registrar.entity_relation');
                     $analytics = $container->get('nene-records.route_registrar.analytics');
+                    $publicRecord = $container->get('nene-records.route_registrar.public_record');
 
                     if (
                         !is_callable($entityType)
@@ -103,6 +108,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !is_callable($entityTag)
                         || !is_callable($entityRelation)
                         || !is_callable($analytics)
+                        || !is_callable($publicRecord)
                     ) {
                         throw new LogicException('Route registrar service is invalid.');
                     }
@@ -120,6 +126,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $entityTag,
                         $entityRelation,
                         $analytics,
+                        $publicRecord,
                     ];
                 },
             )
@@ -155,6 +162,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $relationTargetTypeMismatch = $container->get(RelationTargetTypeMismatchExceptionHandler::class);
                     $relationAlreadyAttached = $container->get(RelationAlreadyAttachedExceptionHandler::class);
                     $relationNotAttached = $container->get(RelationNotAttachedExceptionHandler::class);
+                    $publicEntityTypeNotFound = $container->get(PublicEntityTypeNotFoundExceptionHandler::class);
+                    $publicRecordNotFound = $container->get(PublicRecordNotFoundExceptionHandler::class);
 
                     foreach ([
                         $entityTypeNotFound,
@@ -186,6 +195,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $relationTargetTypeMismatch,
                         $relationAlreadyAttached,
                         $relationNotAttached,
+                        $publicEntityTypeNotFound,
+                        $publicRecordNotFound,
                     ] as $handler) {
                         if (!$handler instanceof DomainExceptionHandlerInterface) {
                             throw new LogicException('Exception handler service is invalid.');
@@ -222,6 +233,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $relationTargetTypeMismatch,
                         $relationAlreadyAttached,
                         $relationNotAttached,
+                        $publicEntityTypeNotFound,
+                        $publicRecordNotFound,
                     ];
                 },
             );

--- a/src/PublicRecord/GetPublicRecordViewHandler.php
+++ b/src/PublicRecord/GetPublicRecordViewHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetPublicRecordViewHandler
+{
+    public function __construct(
+        private GetPublicRecordViewUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $slug = trim((string) ($parameters['slug'] ?? ''));
+        $entityId = (int) ($parameters['entityId'] ?? 0);
+
+        if ($slug === '' || $entityId <= 0) {
+            throw new PublicRecordNotFoundException($slug !== '' ? $slug : 'unknown', max(0, $entityId));
+        }
+
+        $output = $this->useCase->execute(new GetPublicRecordViewInput($slug, $entityId));
+
+        return $this->response->create($output->bootstrap);
+    }
+}

--- a/src/PublicRecord/GetPublicRecordViewInput.php
+++ b/src/PublicRecord/GetPublicRecordViewInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+final readonly class GetPublicRecordViewInput
+{
+    public function __construct(
+        public string $entityTypeSlug,
+        public int $entityId,
+    ) {
+    }
+}

--- a/src/PublicRecord/GetPublicRecordViewOutput.php
+++ b/src/PublicRecord/GetPublicRecordViewOutput.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+final readonly class GetPublicRecordViewOutput
+{
+    /**
+     * @param array<string, mixed> $bootstrap
+     * @param list<PublicRecordViewDisplayField> $displayFields
+     */
+    public function __construct(
+        public string $entityTypeSlug,
+        public string $entityTypeName,
+        public int $entityId,
+        public string $pageTitle,
+        public array $bootstrap,
+        public array $displayFields,
+    ) {
+    }
+}

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -1,0 +1,339 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use NeNeRecords\BoolField\BoolField;
+use NeNeRecords\BoolField\BoolFieldRepositoryInterface;
+use NeNeRecords\DateTimeField\DateTimeField;
+use NeNeRecords\DateTimeField\DateTimeFieldRepositoryInterface;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\EntityRelation\EntityRelationRepositoryInterface;
+use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
+use NeNeRecords\EnumField\EnumField;
+use NeNeRecords\EnumField\EnumFieldRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+use NeNeRecords\IntField\IntField;
+use NeNeRecords\IntField\IntFieldRepositoryInterface;
+use NeNeRecords\TextField\TextField;
+use NeNeRecords\TextField\TextFieldRepositoryInterface;
+
+final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUseCaseInterface
+{
+    private const FIELD_DEF_LIMIT = 20;
+    private const FIELD_VALUE_LIMIT = 100;
+    private const ENTITY_TYPE_LIMIT = 100;
+
+    public function __construct(
+        private EntityTypeRepositoryInterface $entityTypes,
+        private EntityRepositoryInterface $entities,
+        private FieldDefRepositoryInterface $fieldDefs,
+        private TextFieldRepositoryInterface $textFields,
+        private IntFieldRepositoryInterface $intFields,
+        private EnumFieldRepositoryInterface $enumFields,
+        private BoolFieldRepositoryInterface $boolFields,
+        private DateTimeFieldRepositoryInterface $dateTimeFields,
+        private EntityRelationRepositoryInterface $entityRelations,
+    ) {
+    }
+
+    public function execute(GetPublicRecordViewInput $input): GetPublicRecordViewOutput
+    {
+        $entityType = $this->entityTypes->findBySlug($input->entityTypeSlug);
+
+        if ($entityType === null || $entityType->id === null) {
+            throw new PublicEntityTypeNotFoundException($input->entityTypeSlug);
+        }
+
+        $entity = $this->entities->findById($input->entityId);
+
+        if (
+            $entity === null
+            || $entity->id === null
+            || $entity->isDeleted
+            || $entity->entityTypeId !== $entityType->id
+        ) {
+            throw new PublicRecordNotFoundException($input->entityTypeSlug, $input->entityId);
+        }
+
+        $entityTypeId = $entityType->id;
+        $entityId = $entity->id;
+
+        $fieldDefRows = $this->fieldDefs->findAll($entityTypeId, self::FIELD_DEF_LIMIT, 0);
+        $dataTypes = array_values(array_unique(array_map(
+            static fn (FieldDef $fieldDef): string => $fieldDef->dataType,
+            $fieldDefRows,
+        )));
+
+        $textFieldRows = in_array('text', $dataTypes, true)
+            ? $this->textFields->findByEntityId($entityId, self::FIELD_VALUE_LIMIT, 0)
+            : [];
+        $intFieldRows = in_array('int', $dataTypes, true)
+            ? $this->intFields->findByEntityId($entityId, self::FIELD_VALUE_LIMIT, 0)
+            : [];
+        $enumFieldRows = in_array('enum', $dataTypes, true)
+            ? $this->enumFields->findByEntityId($entityId, self::FIELD_VALUE_LIMIT, 0)
+            : [];
+        $boolFieldRows = in_array('bool', $dataTypes, true)
+            ? $this->boolFields->findByEntityId($entityId, self::FIELD_VALUE_LIMIT, 0)
+            : [];
+        $dateTimeFieldRows = in_array('datetime', $dataTypes, true)
+            ? $this->dateTimeFields->findByEntityId($entityId, self::FIELD_VALUE_LIMIT, 0)
+            : [];
+
+        $allEntityTypes = $this->entityTypes->findAll(self::ENTITY_TYPE_LIMIT, 0);
+        $entityTypeSlugById = [];
+
+        foreach ($allEntityTypes as $listedType) {
+            if ($listedType->id !== null) {
+                $entityTypeSlugById[$listedType->id] = $listedType->slug;
+            }
+        }
+
+        $relationTextFieldsByEntityTypeId = [];
+        $targetEntityTypeIds = [];
+
+        foreach ($fieldDefRows as $fieldDef) {
+            if ($fieldDef->dataType === 'relation' && $fieldDef->targetEntityTypeId !== null) {
+                $targetEntityTypeIds[$fieldDef->targetEntityTypeId] = true;
+            }
+        }
+
+        foreach (array_keys($targetEntityTypeIds) as $targetEntityTypeId) {
+            $relationTextFieldsByEntityTypeId[$targetEntityTypeId] = $this->textFields->findByEntityTypeId(
+                $targetEntityTypeId,
+                self::FIELD_VALUE_LIMIT,
+                0,
+            );
+        }
+
+        $displayFields = $this->buildDisplayFields(
+            $fieldDefRows,
+            $textFieldRows,
+            $intFieldRows,
+            $enumFieldRows,
+            $boolFieldRows,
+            $dateTimeFieldRows,
+            $entityId,
+            $entityTypeSlugById,
+            $relationTextFieldsByEntityTypeId,
+        );
+
+        $pageTitle = $this->resolvePageTitle($textFieldRows, $entityId);
+
+        $bootstrap = PublicRecordViewHttpMapper::toBootstrap(
+            entityTypeSlug: $input->entityTypeSlug,
+            entityType: $entityType,
+            entity: $entity,
+            allEntityTypes: $allEntityTypes,
+            fieldDefRows: $fieldDefRows,
+            textFieldRows: $textFieldRows,
+            intFieldRows: $intFieldRows,
+            enumFieldRows: $enumFieldRows,
+            boolFieldRows: $boolFieldRows,
+            dateTimeFieldRows: $dateTimeFieldRows,
+            entityId: $entityId,
+            entityTypeId: $entityTypeId,
+            relationQueries: $this->buildRelationQueries($fieldDefRows, $entityId),
+            relationTextFieldRowsByEntityTypeId: $relationTextFieldsByEntityTypeId,
+        );
+
+        return new GetPublicRecordViewOutput(
+            entityTypeSlug: $input->entityTypeSlug,
+            entityTypeName: $entityType->name,
+            entityId: $entityId,
+            pageTitle: $pageTitle,
+            bootstrap: $bootstrap,
+            displayFields: $displayFields,
+        );
+    }
+
+    /**
+     * @param list<FieldDef> $fieldDefRows
+     * @param list<TextField> $textFieldRows
+     * @param list<IntField> $intFieldRows
+     * @param list<EnumField> $enumFieldRows
+     * @param list<BoolField> $boolFieldRows
+     * @param list<DateTimeField> $dateTimeFieldRows
+     * @param array<int, string> $entityTypeSlugById
+     * @param array<int, list<TextField>> $relationTextFieldsByEntityTypeId
+     * @return list<PublicRecordViewDisplayField>
+     */
+    private function buildDisplayFields(
+        array $fieldDefRows,
+        array $textFieldRows,
+        array $intFieldRows,
+        array $enumFieldRows,
+        array $boolFieldRows,
+        array $dateTimeFieldRows,
+        int $entityId,
+        array $entityTypeSlugById,
+        array $relationTextFieldsByEntityTypeId,
+    ): array {
+        $displayFields = [];
+
+        foreach ($fieldDefRows as $fieldDef) {
+            if ($fieldDef->dataType === 'relation') {
+                $targetEntityTypeId = $fieldDef->targetEntityTypeId;
+
+                if ($targetEntityTypeId === null) {
+                    continue;
+                }
+
+                $targetSlug = $entityTypeSlugById[$targetEntityTypeId] ?? (string) $targetEntityTypeId;
+                $labelFields = $relationTextFieldsByEntityTypeId[$targetEntityTypeId] ?? [];
+                $relations = $this->entityRelations->findByEntityIdAndFieldKey($entityId, $fieldDef->fieldKey);
+                $links = [];
+
+                foreach ($relations as $relation) {
+                    $links[] = [
+                        'label' => $this->resolveRecordLabel($relation->targetEntityId, $labelFields),
+                        'href' => '/view/' . $targetSlug . '/' . $relation->targetEntityId,
+                    ];
+                }
+
+                $displayFields[] = new PublicRecordViewDisplayField(
+                    fieldKey: $fieldDef->fieldKey,
+                    dataType: 'relation',
+                    displayValue: $links === [] ? '—' : implode(', ', array_column($links, 'label')),
+                    relationLinks: $links,
+                );
+
+                continue;
+            }
+
+            $raw = match ($fieldDef->dataType) {
+                'text' => $this->findTextValue($textFieldRows, $fieldDef->fieldKey),
+                'int' => $this->findIntValue($intFieldRows, $fieldDef->fieldKey),
+                'enum' => $this->findEnumValue($enumFieldRows, $fieldDef->fieldKey),
+                'bool' => $this->findBoolValue($boolFieldRows, $fieldDef->fieldKey),
+                'datetime' => $this->findDateTimeValue($dateTimeFieldRows, $fieldDef->fieldKey),
+                default => null,
+            };
+
+            $displayFields[] = new PublicRecordViewDisplayField(
+                fieldKey: $fieldDef->fieldKey,
+                dataType: $fieldDef->dataType,
+                displayValue: PublicFieldDisplayFormatter::format($fieldDef->dataType, $raw),
+            );
+        }
+
+        return $displayFields;
+    }
+
+    /**
+     * @param list<FieldDef> $fieldDefRows
+     * @return list<array{fieldKey: string, items: list<array{field_key: string, target_entity_id: int}>}>
+     */
+    private function buildRelationQueries(array $fieldDefRows, int $entityId): array
+    {
+        $queries = [];
+
+        foreach ($fieldDefRows as $fieldDef) {
+            if ($fieldDef->dataType !== 'relation') {
+                continue;
+            }
+
+            $items = array_map(
+                static fn ($relation) => [
+                    'field_key' => $relation->fieldKey,
+                    'target_entity_id' => $relation->targetEntityId,
+                ],
+                $this->entityRelations->findByEntityIdAndFieldKey($entityId, $fieldDef->fieldKey),
+            );
+
+            $queries[] = [
+                'fieldKey' => $fieldDef->fieldKey,
+                'items' => $items,
+            ];
+        }
+
+        return $queries;
+    }
+
+    /** @param list<TextField> $textFieldRows */
+    private function resolvePageTitle(array $textFieldRows, int $entityId): string
+    {
+        return $this->resolveRecordLabel($entityId, $textFieldRows);
+    }
+
+    /** @param list<TextField> $textFieldRows */
+    private function resolveRecordLabel(int $entityId, array $textFieldRows): string
+    {
+        foreach ($textFieldRows as $textField) {
+            if ($textField->entityId === $entityId && $textField->fieldKey === 'title' && trim($textField->value) !== '') {
+                return $textField->value;
+            }
+        }
+
+        foreach ($textFieldRows as $textField) {
+            if ($textField->entityId === $entityId && trim($textField->value) !== '') {
+                return $textField->value;
+            }
+        }
+
+        return 'Record #' . $entityId;
+    }
+
+    /** @param list<TextField> $rows */
+    private function findTextValue(array $rows, string $fieldKey): ?string
+    {
+        foreach ($rows as $row) {
+            if ($row->fieldKey === $fieldKey) {
+                return $row->value;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param list<IntField> $rows */
+    private function findIntValue(array $rows, string $fieldKey): ?int
+    {
+        foreach ($rows as $row) {
+            if ($row->fieldKey === $fieldKey) {
+                return $row->value;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param list<EnumField> $rows */
+    private function findEnumValue(array $rows, string $fieldKey): ?string
+    {
+        foreach ($rows as $row) {
+            if ($row->fieldKey === $fieldKey) {
+                return $row->value;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param list<BoolField> $rows */
+    private function findBoolValue(array $rows, string $fieldKey): ?bool
+    {
+        foreach ($rows as $row) {
+            if ($row->fieldKey === $fieldKey) {
+                return $row->value;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param list<DateTimeField> $rows */
+    private function findDateTimeValue(array $rows, string $fieldKey): ?string
+    {
+        foreach ($rows as $row) {
+            if ($row->fieldKey === $fieldKey) {
+                return $row->value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/PublicRecord/GetPublicRecordViewUseCaseInterface.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+interface GetPublicRecordViewUseCaseInterface
+{
+    public function execute(GetPublicRecordViewInput $input): GetPublicRecordViewOutput;
+}

--- a/src/PublicRecord/PublicEntityTypeNotFoundException.php
+++ b/src/PublicRecord/PublicEntityTypeNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use RuntimeException;
+
+final class PublicEntityTypeNotFoundException extends RuntimeException
+{
+    public function __construct(public readonly string $slug)
+    {
+        parent::__construct("Entity type with slug \"{$slug}\" was not found.");
+    }
+}

--- a/src/PublicRecord/PublicEntityTypeNotFoundExceptionHandler.php
+++ b/src/PublicRecord/PublicEntityTypeNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class PublicEntityTypeNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof PublicEntityTypeNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'not-found',
+            'Not Found',
+            404,
+            'The requested entity type was not found.',
+        );
+    }
+}

--- a/src/PublicRecord/PublicFieldDisplayFormatter.php
+++ b/src/PublicRecord/PublicFieldDisplayFormatter.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use DateTimeImmutable;
+
+final readonly class PublicFieldDisplayFormatter
+{
+    public static function format(string $dataType, string|int|bool|null $raw): string
+    {
+        if ($raw === null) {
+            return '—';
+        }
+
+        return match ($dataType) {
+            'bool' => $raw === true || $raw === 'true' || $raw === 1 || $raw === '1' ? 'Yes' : 'No',
+            'int' => (string) $raw,
+            'datetime' => self::formatDateTime((string) $raw),
+            default => trim((string) $raw) === '' ? '—' : (string) $raw,
+        };
+    }
+
+    private static function formatDateTime(string $iso): string
+    {
+        if (trim($iso) === '') {
+            return '—';
+        }
+
+        $parsed = DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $iso)
+            ?: DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', $iso)
+            ?: DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $iso);
+
+        if ($parsed === false) {
+            return $iso;
+        }
+
+        return $parsed->format('Y-m-d H:i:s') . ' UTC';
+    }
+}

--- a/src/PublicRecord/PublicRecordNotFoundException.php
+++ b/src/PublicRecord/PublicRecordNotFoundException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use RuntimeException;
+
+final class PublicRecordNotFoundException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $entityTypeSlug,
+        public readonly int $entityId,
+    ) {
+        parent::__construct(
+            "Public record \"{$entityTypeSlug}/{$entityId}\" was not found.",
+        );
+    }
+}

--- a/src/PublicRecord/PublicRecordNotFoundExceptionHandler.php
+++ b/src/PublicRecord/PublicRecordNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class PublicRecordNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof PublicRecordNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'not-found',
+            'Not Found',
+            404,
+            'The requested public record was not found.',
+        );
+    }
+}

--- a/src/PublicRecord/PublicRecordRouteRegistrar.php
+++ b/src/PublicRecord/PublicRecordRouteRegistrar.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class PublicRecordRouteRegistrar
+{
+    public function __construct(
+        private GetPublicRecordViewHandler $getPublicRecordViewHandler,
+        private RenderPublicRecordViewHandler $renderPublicRecordViewHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $getPublicRecordViewHandler = $this->getPublicRecordViewHandler;
+        $renderPublicRecordViewHandler = $this->renderPublicRecordViewHandler;
+
+        $router->get(
+            '/api/v1/public/entity-types/{slug}/records/{entityId}',
+            static fn (ServerRequestInterface $request) => $getPublicRecordViewHandler->handle($request),
+        );
+
+        $router->get(
+            '/view/{slug}/{entityId}',
+            static fn (ServerRequestInterface $request) => $renderPublicRecordViewHandler->handle($request),
+        );
+    }
+}

--- a/src/PublicRecord/PublicRecordServiceProvider.php
+++ b/src/PublicRecord/PublicRecordServiceProvider.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use LogicException;
+use Nene2\Config\AppConfig;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\View\HtmlResponseFactory;
+use Nene2\View\NativePhpViewRenderer;
+use NeNeRecords\BoolField\BoolFieldRepositoryInterface;
+use NeNeRecords\DateTimeField\DateTimeFieldRepositoryInterface;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\EntityRelation\EntityRelationRepositoryInterface;
+use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
+use NeNeRecords\EnumField\EnumFieldRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+use NeNeRecords\Http\RuntimeServiceProvider;
+use NeNeRecords\IntField\IntFieldRepositoryInterface;
+use NeNeRecords\TextField\TextFieldRepositoryInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class PublicRecordServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                NativePhpViewRenderer::class,
+                static function (ContainerInterface $container): NativePhpViewRenderer {
+                    $projectRoot = $container->get(RuntimeServiceProvider::PROJECT_ROOT);
+
+                    if (!is_string($projectRoot) || $projectRoot === '') {
+                        throw new LogicException('Project root service is invalid.');
+                    }
+
+                    return new NativePhpViewRenderer($projectRoot . '/templates');
+                },
+            )
+            ->set(
+                HtmlResponseFactory::class,
+                static function (ContainerInterface $container): HtmlResponseFactory {
+                    $responseFactory = $container->get(ResponseFactoryInterface::class);
+                    $streamFactory = $container->get(StreamFactoryInterface::class);
+                    $renderer = $container->get(NativePhpViewRenderer::class);
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    if (!$streamFactory instanceof StreamFactoryInterface) {
+                        throw new LogicException('Stream factory service is invalid.');
+                    }
+
+                    if (!$renderer instanceof NativePhpViewRenderer) {
+                        throw new LogicException('Native PHP view renderer service is invalid.');
+                    }
+
+                    return new HtmlResponseFactory($responseFactory, $streamFactory, $renderer);
+                },
+            )
+            ->set(
+                GetPublicRecordViewUseCaseInterface::class,
+                static function (ContainerInterface $container): GetPublicRecordViewUseCaseInterface {
+                    $entityTypes = $container->get(EntityTypeRepositoryInterface::class);
+                    $entities = $container->get(EntityRepositoryInterface::class);
+                    $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
+                    $textFields = $container->get(TextFieldRepositoryInterface::class);
+                    $intFields = $container->get(IntFieldRepositoryInterface::class);
+                    $enumFields = $container->get(EnumFieldRepositoryInterface::class);
+                    $boolFields = $container->get(BoolFieldRepositoryInterface::class);
+                    $dateTimeFields = $container->get(DateTimeFieldRepositoryInterface::class);
+                    $entityRelations = $container->get(EntityRelationRepositoryInterface::class);
+
+                    if (!$entityTypes instanceof EntityTypeRepositoryInterface) {
+                        throw new LogicException('Entity type repository service is invalid.');
+                    }
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field def repository service is invalid.');
+                    }
+
+                    if (!$textFields instanceof TextFieldRepositoryInterface) {
+                        throw new LogicException('Text field repository service is invalid.');
+                    }
+
+                    if (!$intFields instanceof IntFieldRepositoryInterface) {
+                        throw new LogicException('Int field repository service is invalid.');
+                    }
+
+                    if (!$enumFields instanceof EnumFieldRepositoryInterface) {
+                        throw new LogicException('Enum field repository service is invalid.');
+                    }
+
+                    if (!$boolFields instanceof BoolFieldRepositoryInterface) {
+                        throw new LogicException('Bool field repository service is invalid.');
+                    }
+
+                    if (!$dateTimeFields instanceof DateTimeFieldRepositoryInterface) {
+                        throw new LogicException('DateTime field repository service is invalid.');
+                    }
+
+                    if (!$entityRelations instanceof EntityRelationRepositoryInterface) {
+                        throw new LogicException('Entity relation repository service is invalid.');
+                    }
+
+                    return new GetPublicRecordViewUseCase(
+                        $entityTypes,
+                        $entities,
+                        $fieldDefs,
+                        $textFields,
+                        $intFields,
+                        $enumFields,
+                        $boolFields,
+                        $dateTimeFields,
+                        $entityRelations,
+                    );
+                },
+            )
+            ->set(
+                GetPublicRecordViewHandler::class,
+                static function (ContainerInterface $container): GetPublicRecordViewHandler {
+                    $useCase = $container->get(GetPublicRecordViewUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof GetPublicRecordViewUseCaseInterface) {
+                        throw new LogicException('GetPublicRecordView use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new GetPublicRecordViewHandler($useCase, $response);
+                },
+            )
+            ->set(
+                RenderPublicRecordViewHandler::class,
+                static function (ContainerInterface $container): RenderPublicRecordViewHandler {
+                    $useCase = $container->get(GetPublicRecordViewUseCaseInterface::class);
+                    $html = $container->get(HtmlResponseFactory::class);
+                    $config = $container->get(AppConfig::class);
+
+                    if (!$useCase instanceof GetPublicRecordViewUseCaseInterface) {
+                        throw new LogicException('GetPublicRecordView use case service is invalid.');
+                    }
+
+                    if (!$html instanceof HtmlResponseFactory) {
+                        throw new LogicException('HTML response factory service is invalid.');
+                    }
+
+                    if (!$config instanceof AppConfig) {
+                        throw new LogicException('Application config service is invalid.');
+                    }
+
+                    return new RenderPublicRecordViewHandler($useCase, $html, $config);
+                },
+            )
+            ->set(
+                PublicEntityTypeNotFoundExceptionHandler::class,
+                static function (ContainerInterface $container): PublicEntityTypeNotFoundExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new PublicEntityTypeNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                PublicRecordNotFoundExceptionHandler::class,
+                static function (ContainerInterface $container): PublicRecordNotFoundExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new PublicRecordNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.public_record',
+                static function (ContainerInterface $container): PublicRecordRouteRegistrar {
+                    $getHandler = $container->get(GetPublicRecordViewHandler::class);
+                    $renderHandler = $container->get(RenderPublicRecordViewHandler::class);
+
+                    if (!$getHandler instanceof GetPublicRecordViewHandler) {
+                        throw new LogicException('GetPublicRecordView handler service is invalid.');
+                    }
+
+                    if (!$renderHandler instanceof RenderPublicRecordViewHandler) {
+                        throw new LogicException('RenderPublicRecordView handler service is invalid.');
+                    }
+
+                    return new PublicRecordRouteRegistrar($getHandler, $renderHandler);
+                },
+            );
+    }
+}

--- a/src/PublicRecord/PublicRecordViewDisplayField.php
+++ b/src/PublicRecord/PublicRecordViewDisplayField.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+final readonly class PublicRecordViewDisplayField
+{
+    /**
+     * @param list<array{label: string, href: string}> $relationLinks
+     */
+    public function __construct(
+        public string $fieldKey,
+        public string $dataType,
+        public string $displayValue,
+        public array $relationLinks = [],
+    ) {
+    }
+}

--- a/src/PublicRecord/PublicRecordViewHttpMapper.php
+++ b/src/PublicRecord/PublicRecordViewHttpMapper.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use NeNeRecords\BoolField\BoolField;
+use NeNeRecords\DateTimeField\DateTimeField;
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\EntityType\EntityType;
+use NeNeRecords\EnumField\EnumField;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\FieldDef\FieldDefHttpMapper;
+use NeNeRecords\IntField\IntField;
+use NeNeRecords\TextField\TextField;
+
+final readonly class PublicRecordViewHttpMapper
+{
+    private const FIELD_DEF_LIMIT = 20;
+    private const FIELD_VALUE_LIMIT = 100;
+    private const ENTITY_TYPE_LIMIT = 100;
+
+    /**
+     * @param list<EntityType> $allEntityTypes
+     * @param list<FieldDef> $fieldDefRows
+     * @param list<TextField> $textFieldRows
+     * @param list<IntField> $intFieldRows
+     * @param list<EnumField> $enumFieldRows
+     * @param list<BoolField> $boolFieldRows
+     * @param list<DateTimeField> $dateTimeFieldRows
+     * @param list<array{fieldKey: string, items: list<array{field_key: string, target_entity_id: int}>}> $relationQueries
+     * @param array<int, list<TextField>> $relationTextFieldRowsByEntityTypeId
+     * @return array<string, mixed>
+     */
+    public static function toBootstrap(
+        string $entityTypeSlug,
+        EntityType $entityType,
+        Entity $entity,
+        array $allEntityTypes,
+        array $fieldDefRows,
+        array $textFieldRows,
+        array $intFieldRows,
+        array $enumFieldRows,
+        array $boolFieldRows,
+        array $dateTimeFieldRows,
+        int $entityId,
+        int $entityTypeId,
+        array $relationQueries,
+        array $relationTextFieldRowsByEntityTypeId,
+    ): array {
+        $entityTypesPayload = [
+            'items' => array_map(
+                static fn (EntityType $item) => [
+                    'id' => $item->id,
+                    'name' => $item->name,
+                    'slug' => $item->slug,
+                ],
+                $allEntityTypes,
+            ),
+            'limit' => self::ENTITY_TYPE_LIMIT,
+            'offset' => 0,
+        ];
+
+        return [
+            'entityTypeSlug' => $entityTypeSlug,
+            'entityTypeId' => $entityTypeId,
+            'entityId' => $entityId,
+            'entityTypes' => $entityTypesPayload,
+            'entity' => [
+                'id' => $entity->id,
+                'entity_type_id' => $entity->entityTypeId,
+                'is_deleted' => $entity->isDeleted,
+                'deleted_at' => $entity->deletedAt?->format(\DateTimeInterface::ATOM),
+            ],
+            'fieldDefs' => [
+                'items' => array_map(
+                    static fn (FieldDef $fieldDef) => FieldDefHttpMapper::fromFieldDef($fieldDef),
+                    $fieldDefRows,
+                ),
+                'limit' => self::FIELD_DEF_LIMIT,
+                'offset' => 0,
+            ],
+            'textFields' => self::textFieldListPayload($textFieldRows),
+            'intFields' => self::intFieldListPayload($intFieldRows),
+            'enumFields' => self::enumFieldListPayload($enumFieldRows),
+            'boolFields' => self::boolFieldListPayload($boolFieldRows),
+            'dateTimeFields' => self::dateTimeFieldListPayload($dateTimeFieldRows),
+            'entityRelations' => $relationQueries,
+            'relationTextFieldsByEntityTypeId' => array_map(
+                self::textFieldListPayload(...),
+                $relationTextFieldRowsByEntityTypeId,
+            ),
+        ];
+    }
+
+    /**
+     * @param list<TextField> $rows
+     * @return array{items: list<array<string, mixed>>, limit: int, offset: int}
+     */
+    private static function textFieldListPayload(array $rows): array
+    {
+        return [
+            'items' => array_map(
+                static fn (TextField $item) => [
+                    'id' => $item->id,
+                    'entity_id' => $item->entityId,
+                    'field_key' => $item->fieldKey,
+                    'value' => $item->value,
+                ],
+                $rows,
+            ),
+            'limit' => self::FIELD_VALUE_LIMIT,
+            'offset' => 0,
+        ];
+    }
+
+    /**
+     * @param list<IntField> $rows
+     * @return array{items: list<array<string, mixed>>, limit: int, offset: int}
+     */
+    private static function intFieldListPayload(array $rows): array
+    {
+        return [
+            'items' => array_map(
+                static fn (IntField $item) => [
+                    'id' => $item->id,
+                    'entity_id' => $item->entityId,
+                    'field_key' => $item->fieldKey,
+                    'value' => $item->value,
+                ],
+                $rows,
+            ),
+            'limit' => self::FIELD_VALUE_LIMIT,
+            'offset' => 0,
+        ];
+    }
+
+    /**
+     * @param list<EnumField> $rows
+     * @return array{items: list<array<string, mixed>>, limit: int, offset: int}
+     */
+    private static function enumFieldListPayload(array $rows): array
+    {
+        return [
+            'items' => array_map(
+                static fn (EnumField $item) => [
+                    'id' => $item->id,
+                    'entity_id' => $item->entityId,
+                    'field_key' => $item->fieldKey,
+                    'value' => $item->value,
+                ],
+                $rows,
+            ),
+            'limit' => self::FIELD_VALUE_LIMIT,
+            'offset' => 0,
+        ];
+    }
+
+    /**
+     * @param list<BoolField> $rows
+     * @return array{items: list<array<string, mixed>>, limit: int, offset: int}
+     */
+    private static function boolFieldListPayload(array $rows): array
+    {
+        return [
+            'items' => array_map(
+                static fn (BoolField $item) => [
+                    'id' => $item->id,
+                    'entity_id' => $item->entityId,
+                    'field_key' => $item->fieldKey,
+                    'value' => $item->value,
+                ],
+                $rows,
+            ),
+            'limit' => self::FIELD_VALUE_LIMIT,
+            'offset' => 0,
+        ];
+    }
+
+    /**
+     * @param list<DateTimeField> $rows
+     * @return array{items: list<array<string, mixed>>, limit: int, offset: int}
+     */
+    private static function dateTimeFieldListPayload(array $rows): array
+    {
+        return [
+            'items' => array_map(
+                static fn (DateTimeField $item) => [
+                    'id' => $item->id,
+                    'entity_id' => $item->entityId,
+                    'field_key' => $item->fieldKey,
+                    'value' => $item->value,
+                ],
+                $rows,
+            ),
+            'limit' => self::FIELD_VALUE_LIMIT,
+            'offset' => 0,
+        ];
+    }
+}

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use Nene2\Config\AppConfig;
+use Nene2\Routing\Router;
+use Nene2\View\HtmlResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class RenderPublicRecordViewHandler
+{
+    public function __construct(
+        private GetPublicRecordViewUseCaseInterface $useCase,
+        private HtmlResponseFactory $html,
+        private AppConfig $config,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $slug = trim((string) ($parameters['slug'] ?? ''));
+        $entityId = (int) ($parameters['entityId'] ?? 0);
+
+        if ($slug === '' || $entityId <= 0) {
+            throw new PublicRecordNotFoundException($slug !== '' ? $slug : 'unknown', max(0, $entityId));
+        }
+
+        $output = $this->useCase->execute(new GetPublicRecordViewInput($slug, $entityId));
+
+        $bootstrapJson = json_encode(
+            $output->bootstrap,
+            JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE,
+        );
+
+        $viteUrl = getenv('NENE_RECORDS_VITE_URL');
+
+        if (!is_string($viteUrl) || $viteUrl === '') {
+            $viteUrl = 'http://localhost:5173';
+        }
+
+        return $this->html->create('public/record-detail.php', [
+            'pageTitle' => $output->pageTitle,
+            'entityTypeSlug' => $output->entityTypeSlug,
+            'entityTypeName' => $output->entityTypeName,
+            'entityId' => $output->entityId,
+            'displayFields' => $output->displayFields,
+            'bootstrapJson' => $bootstrapJson,
+            'includeViteClient' => $this->config->debug,
+            'viteUrl' => rtrim($viteUrl, '/'),
+        ]);
+    }
+}

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><?= $e($pageTitle) ?> — <?= $e($entityTypeName) ?></title>
+    <?php if ($includeViteClient): ?>
+      <script type="module" src="<?= $e($viteUrl) ?>/@vite/client"></script>
+    <?php endif; ?>
+  </head>
+  <body>
+    <header>
+      <p><a href="/view/<?= $e($entityTypeSlug) ?>">← <?= $e($entityTypeName) ?></a></p>
+      <h1><?= $e($pageTitle) ?></h1>
+    </header>
+    <article>
+      <?php foreach ($displayFields as $field): ?>
+        <?php if ($field->dataType === 'relation'): ?>
+          <section>
+            <h2><?= $e($field->fieldKey) ?></h2>
+            <?php if ($field->relationLinks === []): ?>
+              <p>—</p>
+            <?php else: ?>
+              <ul>
+                <?php foreach ($field->relationLinks as $link): ?>
+                  <li><a href="<?= $e($link['href']) ?>"><?= $e($link['label']) ?></a></li>
+                <?php endforeach; ?>
+              </ul>
+            <?php endif; ?>
+          </section>
+        <?php elseif ($field->fieldKey === 'body'): ?>
+          <section>
+            <h2><?= $e($field->fieldKey) ?></h2>
+            <div><?= nl2br($e($field->displayValue)) ?></div>
+          </section>
+        <?php else: ?>
+          <section>
+            <h2><?= $e($field->fieldKey) ?></h2>
+            <p><?= $e($field->displayValue) ?></p>
+          </section>
+        <?php endif; ?>
+      <?php endforeach; ?>
+    </article>
+    <script
+      id="nene-records-public-record-bootstrap"
+      type="application/json"
+    ><?= $bootstrapJson ?></script>
+    <?php if ($includeViteClient): ?>
+      <div id="root"></div>
+      <script type="module" src="<?= $e($viteUrl) ?>/src/main.tsx"></script>
+    <?php endif; ?>
+  </body>
+</html>

--- a/tests/PublicRecord/GetPublicRecordViewUseCaseTest.php
+++ b/tests/PublicRecord/GetPublicRecordViewUseCaseTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\EntityType\EntityType;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\PublicRecord\GetPublicRecordViewInput;
+use NeNeRecords\PublicRecord\GetPublicRecordViewUseCase;
+use NeNeRecords\PublicRecord\PublicEntityTypeNotFoundException;
+use NeNeRecords\PublicRecord\PublicRecordNotFoundException;
+use NeNeRecords\Tests\BoolField\InMemoryBoolFieldRepository;
+use NeNeRecords\Tests\DateTimeField\InMemoryDateTimeFieldRepository;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\EntityRelation\InMemoryEntityRelationRepository;
+use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use NeNeRecords\Tests\EnumField\InMemoryEnumFieldRepository;
+use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use NeNeRecords\Tests\IntField\InMemoryIntFieldRepository;
+use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
+use NeNeRecords\TextField\TextField;
+use PHPUnit\Framework\TestCase;
+
+final class GetPublicRecordViewUseCaseTest extends TestCase
+{
+    public function testReturnsBootstrapWithScalarFields(): void
+    {
+        $entityTypes = new InMemoryEntityTypeRepository([
+            new EntityType(name: 'Article', slug: 'article', id: 1),
+        ]);
+        $entities = new InMemoryEntityRepository([
+            new Entity(id: 10, entityTypeId: 1),
+        ]);
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'title', dataType: 'text', id: 1),
+            new FieldDef(entityTypeId: 1, fieldKey: 'views', dataType: 'int', id: 2),
+        ]);
+        $textFields = new InMemoryTextFieldRepository([
+            new TextField(entityId: 10, fieldKey: 'title', value: 'Hello', id: 1),
+        ], $entities);
+        $intFields = new InMemoryIntFieldRepository([
+            new \NeNeRecords\IntField\IntField(entityId: 10, fieldKey: 'views', value: 42, id: 1),
+        ]);
+
+        $useCase = new GetPublicRecordViewUseCase(
+            $entityTypes,
+            $entities,
+            $fieldDefs,
+            $textFields,
+            $intFields,
+            new InMemoryEnumFieldRepository(),
+            new InMemoryBoolFieldRepository(),
+            new InMemoryDateTimeFieldRepository(),
+            new InMemoryEntityRelationRepository(),
+        );
+
+        $output = $useCase->execute(new GetPublicRecordViewInput('article', 10));
+
+        self::assertSame('article', $output->entityTypeSlug);
+        self::assertSame('Hello', $output->pageTitle);
+        self::assertSame('article', $output->bootstrap['entityTypeSlug']);
+        self::assertSame(10, $output->bootstrap['entityId']);
+        self::assertSame('Hello', $output->bootstrap['textFields']['items'][0]['value']);
+        self::assertSame(42, $output->bootstrap['intFields']['items'][0]['value']);
+    }
+
+    public function testThrowsWhenEntityTypeMissing(): void
+    {
+        $useCase = new GetPublicRecordViewUseCase(
+            new InMemoryEntityTypeRepository(),
+            new InMemoryEntityRepository(),
+            new InMemoryFieldDefRepository(),
+            new InMemoryTextFieldRepository(),
+            new InMemoryIntFieldRepository(),
+            new InMemoryEnumFieldRepository(),
+            new InMemoryBoolFieldRepository(),
+            new InMemoryDateTimeFieldRepository(),
+            new InMemoryEntityRelationRepository(),
+        );
+
+        $this->expectException(PublicEntityTypeNotFoundException::class);
+        $useCase->execute(new GetPublicRecordViewInput('missing', 1));
+    }
+
+    public function testThrowsWhenRecordMissing(): void
+    {
+        $entityTypes = new InMemoryEntityTypeRepository([
+            new EntityType(name: 'Article', slug: 'article', id: 1),
+        ]);
+
+        $useCase = new GetPublicRecordViewUseCase(
+            $entityTypes,
+            new InMemoryEntityRepository(),
+            new InMemoryFieldDefRepository(),
+            new InMemoryTextFieldRepository(),
+            new InMemoryIntFieldRepository(),
+            new InMemoryEnumFieldRepository(),
+            new InMemoryBoolFieldRepository(),
+            new InMemoryDateTimeFieldRepository(),
+            new InMemoryEntityRelationRepository(),
+        );
+
+        $this->expectException(PublicRecordNotFoundException::class);
+        $useCase->execute(new GetPublicRecordViewInput('article', 99));
+    }
+}

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use Nene2\Config\AppConfig;
+use Nene2\Config\AppEnvironment;
+use Nene2\Config\DatabaseConfig;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\View\HtmlResponseFactory;
+use Nene2\View\NativePhpViewRenderer;
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\EntityType\EntityType;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\PublicRecord\GetPublicRecordViewHandler;
+use NeNeRecords\PublicRecord\GetPublicRecordViewUseCase;
+use NeNeRecords\PublicRecord\PublicEntityTypeNotFoundExceptionHandler;
+use NeNeRecords\PublicRecord\PublicRecordNotFoundExceptionHandler;
+use NeNeRecords\PublicRecord\PublicRecordRouteRegistrar;
+use NeNeRecords\PublicRecord\RenderPublicRecordViewHandler;
+use NeNeRecords\Tests\BoolField\InMemoryBoolFieldRepository;
+use NeNeRecords\Tests\DateTimeField\InMemoryDateTimeFieldRepository;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\EntityRelation\InMemoryEntityRelationRepository;
+use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use NeNeRecords\Tests\EnumField\InMemoryEnumFieldRepository;
+use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use NeNeRecords\Tests\IntField\InMemoryIntFieldRepository;
+use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
+use NeNeRecords\TextField\TextField;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class PublicRecordHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private RequestHandlerInterface $application;
+    private string $projectRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->projectRoot = dirname(__DIR__, 2);
+
+        $entityTypes = new InMemoryEntityTypeRepository([
+            new EntityType(name: 'Article', slug: 'article', id: 1),
+        ]);
+        $entities = new InMemoryEntityRepository([
+            new Entity(id: 10, entityTypeId: 1),
+        ]);
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'title', dataType: 'text', id: 1),
+            new FieldDef(entityTypeId: 1, fieldKey: 'body', dataType: 'text', id: 2),
+        ]);
+        $textFields = new InMemoryTextFieldRepository([
+            new TextField(entityId: 10, fieldKey: 'title', value: 'Hello world', id: 1),
+            new TextField(entityId: 10, fieldKey: 'body', value: "Line one\nLine two", id: 2),
+        ], $entities);
+
+        $useCase = new GetPublicRecordViewUseCase(
+            $entityTypes,
+            $entities,
+            $fieldDefs,
+            $textFields,
+            new InMemoryIntFieldRepository(),
+            new InMemoryEnumFieldRepository(),
+            new InMemoryBoolFieldRepository(),
+            new InMemoryDateTimeFieldRepository(),
+            new InMemoryEntityRelationRepository(),
+        );
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+        $renderer = new NativePhpViewRenderer($this->projectRoot . '/templates');
+        $htmlResponse = new HtmlResponseFactory($this->factory, $this->factory, $renderer);
+        $config = new AppConfig(
+            environment: AppEnvironment::Test,
+            debug: true,
+            name: 'NeNe Records',
+            database: new DatabaseConfig(
+                url: null,
+                environment: 'test',
+                adapter: 'sqlite',
+                host: '',
+                port: 1,
+                name: ':memory:',
+                user: '',
+                password: '',
+                charset: '',
+            ),
+            machineApiKey: null,
+        );
+
+        $registrar = new PublicRecordRouteRegistrar(
+            new GetPublicRecordViewHandler($useCase, $jsonResponse),
+            new RenderPublicRecordViewHandler($useCase, $htmlResponse, $config),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [
+                new PublicEntityTypeNotFoundExceptionHandler($problemDetails),
+                new PublicRecordNotFoundExceptionHandler($problemDetails),
+            ],
+            routeRegistrars: [$registrar],
+        ))->create();
+    }
+
+    public function testGetPublicRecordViewReturnsAggregatedJson(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest(
+                'GET',
+                'https://example.test/api/v1/public/entity-types/article/records/10',
+            ),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('article', $payload['entityTypeSlug']);
+        self::assertSame(10, $payload['entityId']);
+        self::assertSame('Hello world', $payload['textFields']['items'][0]['value']);
+    }
+
+    public function testGetPublicRecordViewReturns404ForUnknownSlug(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest(
+                'GET',
+                'https://example.test/api/v1/public/entity-types/missing/records/10',
+            ),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testRenderPublicRecordViewReturnsHtmlWithBootstrapAndArticleContent(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest(
+                'GET',
+                'https://example.test/view/article/10',
+            ),
+        );
+        $html = (string) $response->getBody();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
+        self::assertStringContainsString('<h1>Hello world</h1>', $html);
+        self::assertStringContainsString('id="nene-records-public-record-bootstrap"', $html);
+        self::assertStringContainsString('"entityTypeSlug":"article"', $html);
+        self::assertStringContainsString('Line one', $html);
+    }
+
+    /** @return array<string, mixed> */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($payload)) {
+            self::fail('Expected JSON object response.');
+        }
+
+        return $payload;
+    }
+}

--- a/tools/generate-mcp-tools.php
+++ b/tools/generate-mcp-tools.php
@@ -295,6 +295,28 @@ $tools = [
         ['id'],
         'Get an entity record by id.',
     ),
+    readTool(
+        'getPublicRecordView',
+        'Get Public Record View',
+        'Aggregated bootstrap payload for a public consumer record detail page.',
+        'getPublicRecordView',
+        'GET',
+        '/api/v1/public/entity-types/{slug}/records/{entityId}',
+        [
+            'slug' => [
+                'type' => 'string',
+                'minLength' => 1,
+                'description' => 'Entity type slug.',
+            ],
+            'entityId' => [
+                'type' => 'integer',
+                'minimum' => 1,
+                'description' => 'Entity instance id.',
+            ],
+        ],
+        '#/components/schemas/PublicRecordViewResponse',
+        ['slug', 'entityId'],
+    ),
     idTool(
         'updateEntityById',
         'Update Entity',


### PR DESCRIPTION
## Summary

- Consumer 公開詳細向けに `GET /api/v1/public/entity-types/{slug}/records/{entityId}` を追加し、entity types / entity / field defs / typed fields / relations を1本の bootstrap JSON に集約
- `GET /view/{slug}/{entityId}` で PHP HTML を返し、本文を escape した `<article>` と `<script id="nene-records-public-record-bootstrap">` を出力（crawler/AI 可読 + React ハイドレーション）
- Frontend は bootstrap を TanStack Query に seed し初回 API フェッチを省略。Vite dev では `/view` を `:8080` に proxy

## Changes

**Backend**
- `src/PublicRecord/` — use case、JSON/HTML handlers、route registrar、service provider
- `templates/public/record-detail.php` — SSR テンプレート
- OpenAPI `PublicConsumer` tag + `PublicRecordViewResponse` schema
- MCP `getPublicRecordView` tool

**Frontend**
- `public-record-bootstrap.ts` / `seed-public-record-view-cache.ts`
- `providers.tsx` で起動時 seed
- `PublicRecordDetailPage` の entity type list を `limit: 100` に統一
- `vite.config.ts` に `/view` proxy

**Tests**
- `tests/PublicRecord/` — use case + HTTP (JSON/HTML)

## Test plan

- [x] `composer test` — 160 tests OK
- [x] PHPStan (`src/PublicRecord`, `tests/PublicRecord`) — OK
- [x] `npm run check --prefix frontend` — OK
- [x] `curl http://localhost:8080/view/blog/4` — 200、HTML 本文 + bootstrap script
- [x] `curl http://localhost:8080/api/v1/public/entity-types/blog/records/4` — 集約 JSON

## Self-review checklists

- `docs/review/backend-api.md`
- `docs/review/openapi-contract.md`
- `docs/review/frontend.md`

Closes #75


Made with [Cursor](https://cursor.com)