### PR TITLE
feat(setting): Site Settings API と管理 UI (#80)

### DIFF
--- a/database/migrations/20260524000013_create_settings_tables.php
+++ b/database/migrations/20260524000013_create_settings_tables.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateSettingsTables extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('setting_defs')
+            ->addColumn('setting_key', 'string', ['limit' => 191, 'null' => false])
+            ->addColumn('data_type', 'string', ['limit' => 32, 'null' => false])
+            ->addColumn('default_value', 'text', ['null' => true, 'default' => null])
+            ->addColumn('is_public', 'boolean', ['default' => false, 'null' => false])
+            ->addColumn('label', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['setting_key'], ['unique' => true])
+            ->create();
+
+        $this->table('setting_values')
+            ->addColumn('setting_key', 'string', ['limit' => 191, 'null' => false])
+            ->addColumn('value', 'text', ['null' => true, 'default' => null])
+            ->addColumn('is_deleted', 'boolean', ['default' => false, 'null' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true, 'default' => null])
+            ->addColumn('created_by', 'integer', ['null' => true, 'signed' => false])
+            ->addColumn('updated_by', 'integer', ['null' => true, 'signed' => false])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['setting_key'], ['unique' => true])
+            ->addForeignKey('setting_key', 'setting_defs', 'setting_key', [
+                'delete' => 'RESTRICT',
+                'update' => 'CASCADE',
+            ])
+            ->create();
+
+        $this->table('setting_revisions')
+            ->addColumn('setting_key', 'string', ['limit' => 191, 'null' => false])
+            ->addColumn('value', 'text', ['null' => true, 'default' => null])
+            ->addColumn('previous_value', 'text', ['null' => true, 'default' => null])
+            ->addColumn('action', 'string', ['limit' => 32, 'null' => false])
+            ->addColumn('actor_user_id', 'integer', ['null' => true, 'signed' => false])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addIndex(['setting_key', 'created_at'])
+            ->addForeignKey('setting_key', 'setting_defs', 'setting_key', [
+                'delete' => 'RESTRICT',
+                'update' => 'CASCADE',
+            ])
+            ->create();
+
+        $now = date('Y-m-d H:i:s');
+        $rows = [
+            [
+                'setting_key' => 'site_name',
+                'data_type' => 'text',
+                'default_value' => 'NeNe Records',
+                'is_public' => 1,
+                'label' => 'Site name',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'setting_key' => 'tagline',
+                'data_type' => 'text',
+                'default_value' => 'API-first flexible entity platform',
+                'is_public' => 1,
+                'label' => 'Tagline',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'setting_key' => 'default_meta_description',
+                'data_type' => 'text',
+                'default_value' => '',
+                'is_public' => 1,
+                'label' => 'Default meta description',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'setting_key' => 'footer_markdown',
+                'data_type' => 'markdown',
+                'default_value' => '',
+                'is_public' => 1,
+                'label' => 'Footer',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+        ];
+
+        $this->table('setting_defs')->insert($rows)->saveData();
+    }
+}

--- a/database/schema/settings.sql
+++ b/database/schema/settings.sql
@@ -1,0 +1,37 @@
+CREATE TABLE setting_defs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    setting_key TEXT NOT NULL,
+    data_type TEXT NOT NULL,
+    default_value TEXT NULL,
+    is_public BOOLEAN NOT NULL DEFAULT 0,
+    label TEXT NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+);
+CREATE UNIQUE INDEX setting_defs_setting_key ON setting_defs (setting_key);
+
+CREATE TABLE setting_values (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    setting_key TEXT NOT NULL,
+    value TEXT NULL,
+    is_deleted BOOLEAN NOT NULL DEFAULT 0,
+    deleted_at DATETIME NULL,
+    created_by INTEGER NULL,
+    updated_by INTEGER NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    FOREIGN KEY (setting_key) REFERENCES setting_defs (setting_key) ON DELETE RESTRICT ON UPDATE CASCADE
+);
+CREATE UNIQUE INDEX setting_values_setting_key ON setting_values (setting_key);
+
+CREATE TABLE setting_revisions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    setting_key TEXT NOT NULL,
+    value TEXT NULL,
+    previous_value TEXT NULL,
+    action TEXT NOT NULL,
+    actor_user_id INTEGER NULL,
+    created_at DATETIME NOT NULL,
+    FOREIGN KEY (setting_key) REFERENCES setting_defs (setting_key) ON DELETE RESTRICT ON UPDATE CASCADE
+);
+CREATE INDEX setting_revisions_setting_key_created_at ON setting_revisions (setting_key, created_at);

--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -992,6 +992,109 @@
             "responseSchemaRef": null
         },
         {
+            "name": "listSettings",
+            "title": "List Settings",
+            "description": "List all site settings with effective values for admin use.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "listSettings",
+                "method": "GET",
+                "path": "/api/v1/settings"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": [],
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/SettingListResponse"
+        },
+        {
+            "name": "listPublicSettings",
+            "title": "List Public Settings",
+            "description": "List public site settings for consumer pages.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "listPublicSettings",
+                "method": "GET",
+                "path": "/api/v1/public/settings"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": [],
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/PublicSettingListResponse"
+        },
+        {
+            "name": "updateSettingByKey",
+            "title": "Update Setting",
+            "description": "Update a site setting value by key.",
+            "safety": "write",
+            "source": {
+                "type": "openapi",
+                "operationId": "updateSettingByKey",
+                "method": "PUT",
+                "path": "/api/v1/settings/{key}"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_]*$",
+                        "description": "Setting key."
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "key",
+                    "value"
+                ],
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/SettingValueResponse"
+        },
+        {
+            "name": "listSettingRevisions",
+            "title": "List Setting Revisions",
+            "description": "List paginated revision history for a setting key.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "listSettingRevisions",
+                "method": "GET",
+                "path": "/api/v1/settings/{key}/revisions"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_]*$",
+                        "description": "Setting key."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "minimum": 0
+                    }
+                },
+                "required": [
+                    "key"
+                ],
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/SettingRevisionListResponse"
+        },
+        {
             "name": "listTextFields",
             "title": "List Text Fields",
             "description": "List text field values with optional entity or entity type filters.",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -36,6 +36,8 @@ tags:
     description: HTTP access log aggregation and reporting.
   - name: PublicConsumer
     description: Aggregated read-only views for public consumer pages and MCP.
+  - name: Settings
+    description: Site-wide settings registry with revision history.
 paths:
   /health:
     get:
@@ -1592,6 +1594,90 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/settings:
+    get:
+      tags:
+        - Settings
+      summary: List settings
+      description: Returns all registered settings with effective values for admin use.
+      operationId: listSettings
+      responses:
+        '200':
+          description: Setting list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SettingListResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/settings/{key}:
+    put:
+      tags:
+        - Settings
+      summary: Update setting value
+      description: Updates a setting value and appends a revision record atomically.
+      operationId: updateSettingByKey
+      parameters:
+        - $ref: '#/components/parameters/SettingKeyPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateSettingRequest'
+      responses:
+        '200':
+          description: Updated setting value.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SettingValueResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/settings/{key}/revisions:
+    get:
+      tags:
+        - Settings
+      summary: List setting revisions
+      description: Returns paginated revision history for a setting key.
+      operationId: listSettingRevisions
+      parameters:
+        - $ref: '#/components/parameters/SettingKeyPath'
+        - $ref: '#/components/parameters/LimitQuery'
+        - $ref: '#/components/parameters/OffsetQuery'
+      responses:
+        '200':
+          description: Paginated revision list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SettingRevisionListResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/public/settings:
+    get:
+      tags:
+        - Settings
+      summary: List public settings
+      description: Returns effective values for settings marked as public.
+      operationId: listPublicSettings
+      responses:
+        '200':
+          description: Public setting list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicSettingListResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /api/v1/public/entity-types/{slug}/records/{entityId}:
     get:
       tags:
@@ -1768,6 +1854,14 @@ components:
         format: int64
         minimum: 1
       example: 1
+    SettingKeyPath:
+      name: key
+      in: path
+      required: true
+      schema:
+        type: string
+        pattern: '^[a-z][a-z0-9_]*$'
+      example: site_name
   responses:
     NotFound:
       description: Resource not found.
@@ -2584,6 +2678,137 @@ components:
           type: number
           minimum: 0
       additionalProperties: false
+    SettingListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SettingAdminItemResponse'
+      additionalProperties: false
+    SettingAdminItemResponse:
+      type: object
+      required:
+        - setting_key
+        - label
+        - data_type
+        - is_public
+        - value
+      properties:
+        setting_key:
+          type: string
+          pattern: '^[a-z][a-z0-9_]*$'
+        label:
+          type: string
+        data_type:
+          type: string
+          enum: [text, markdown, bool, url]
+        default_value:
+          type: string
+          nullable: true
+        is_public:
+          type: boolean
+        value:
+          type: string
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+      additionalProperties: false
+    PublicSettingListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicSettingItemResponse'
+      additionalProperties: false
+    PublicSettingItemResponse:
+      type: object
+      required:
+        - setting_key
+        - value
+      properties:
+        setting_key:
+          type: string
+          pattern: '^[a-z][a-z0-9_]*$'
+        value:
+          type: string
+      additionalProperties: false
+    UpdateSettingRequest:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          type: string
+      additionalProperties: false
+    SettingValueResponse:
+      type: object
+      required:
+        - setting_key
+        - value
+        - updated_at
+      properties:
+        setting_key:
+          type: string
+          pattern: '^[a-z][a-z0-9_]*$'
+        value:
+          type: string
+        updated_at:
+          type: string
+          format: date-time
+      additionalProperties: false
+    SettingRevisionListResponse:
+      type: object
+      required:
+        - items
+        - limit
+        - offset
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SettingRevisionResponse'
+        limit:
+          type: integer
+        offset:
+          type: integer
+      additionalProperties: false
+    SettingRevisionResponse:
+      type: object
+      required:
+        - id
+        - setting_key
+        - action
+        - created_at
+      properties:
+        id:
+          type: integer
+          minimum: 1
+        setting_key:
+          type: string
+          pattern: '^[a-z][a-z0-9_]*$'
+        value:
+          type: string
+          nullable: true
+        previous_value:
+          type: string
+          nullable: true
+        action:
+          type: string
+          enum: [created, updated, deleted, restored]
+        actor_user_id:
+          type: integer
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+      additionalProperties: false
     PublicRecordViewResponse:
       type: object
       required:
@@ -2600,6 +2825,7 @@ components:
         - dateTimeFields
         - entityRelations
         - relationTextFieldsByEntityTypeId
+        - publicSettings
       properties:
         entityTypeSlug:
           type: string
@@ -2634,6 +2860,8 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/TextFieldListResponse'
+        publicSettings:
+          $ref: '#/components/schemas/PublicSettingListResponse'
       additionalProperties: false
     PublicRecordRelationQuery:
       type: object

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -9,6 +9,7 @@ import { EntityTypesPage } from '@/pages/entity-types/EntityTypesPage'
 import { FieldDefsPage } from '@/pages/field-defs/FieldDefsPage'
 import { HomePage } from '@/pages/home/HomePage'
 import { AppShell } from '@/pages/layout/AppShell'
+import { SiteSettingsPage } from '@/pages/settings/SiteSettingsPage'
 import { TagsPage } from '@/pages/tags/TagsPage'
 
 const router = createBrowserRouter([
@@ -19,6 +20,7 @@ const router = createBrowserRouter([
       { index: true, element: <HomePage /> },
       { path: 'entity-types', element: <EntityTypesPage /> },
       { path: 'tags', element: <TagsPage /> },
+      { path: 'settings', element: <SiteSettingsPage /> },
       { path: 'entity-types/:entityTypeId/fields', element: <FieldDefsPage /> },
       { path: 'entity-types/:entityTypeId/entities', element: <EntityRecordsPage /> },
       { path: 'entity-types/:entityTypeId/entities/:entityId', element: <EntityRecordPage /> },

--- a/frontend/src/entities/setting/api-types.ts
+++ b/frontend/src/entities/setting/api-types.ts
@@ -1,0 +1,48 @@
+export interface SettingAdminItemDto {
+  setting_key: string
+  label: string
+  data_type: 'text' | 'markdown' | 'bool' | 'url'
+  default_value: string | null
+  is_public: boolean
+  value: string
+  updated_at: string | null
+}
+
+export interface SettingListDto {
+  items: SettingAdminItemDto[]
+}
+
+export interface PublicSettingItemDto {
+  setting_key: string
+  value: string
+}
+
+export interface PublicSettingListDto {
+  items: PublicSettingItemDto[]
+}
+
+export interface SettingValueDto {
+  setting_key: string
+  value: string
+  updated_at: string
+}
+
+export interface SettingRevisionDto {
+  id: number
+  setting_key: string
+  value: string | null
+  previous_value: string | null
+  action: 'created' | 'updated' | 'deleted' | 'restored'
+  actor_user_id: number | null
+  created_at: string
+}
+
+export interface SettingRevisionListDto {
+  items: SettingRevisionDto[]
+  limit: number
+  offset: number
+}
+
+export interface UpdateSettingRequestDto {
+  value: string
+}

--- a/frontend/src/entities/setting/index.ts
+++ b/frontend/src/entities/setting/index.ts
@@ -1,0 +1,14 @@
+export type {
+  PublicSettingItem,
+  PublicSettingList,
+  SettingDataType,
+  SettingItem,
+  SettingKey,
+  SettingList,
+  SettingRevision,
+  SettingRevisionList,
+  UpdateSettingInput,
+} from './model'
+export { useUpdateSetting } from './mutations'
+export { publicSettingsToMap } from './mapper'
+export { usePublicSettings, useSettingList, useSettingRevisions } from './queries'

--- a/frontend/src/entities/setting/mapper.ts
+++ b/frontend/src/entities/setting/mapper.ts
@@ -1,0 +1,88 @@
+import type {
+  PublicSettingItemDto,
+  PublicSettingListDto,
+  SettingAdminItemDto,
+  SettingListDto,
+  SettingRevisionDto,
+  SettingRevisionListDto,
+  SettingValueDto,
+  UpdateSettingRequestDto,
+} from './api-types'
+import type {
+  PublicSettingItem,
+  PublicSettingList,
+  SettingItem,
+  SettingList,
+  SettingRevision,
+  SettingRevisionList,
+  UpdateSettingInput,
+} from './model'
+
+export function mapSettingAdminItemDtoToModel(dto: SettingAdminItemDto): SettingItem {
+  return {
+    settingKey: dto.setting_key,
+    label: dto.label,
+    dataType: dto.data_type,
+    defaultValue: dto.default_value,
+    isPublic: dto.is_public,
+    value: dto.value,
+    updatedAt: dto.updated_at,
+  }
+}
+
+export function mapSettingListDtoToModel(dto: SettingListDto): SettingList {
+  return {
+    items: dto.items.map(mapSettingAdminItemDtoToModel),
+  }
+}
+
+export function mapPublicSettingItemDtoToModel(dto: PublicSettingItemDto): PublicSettingItem {
+  return {
+    settingKey: dto.setting_key,
+    value: dto.value,
+  }
+}
+
+export function mapPublicSettingListDtoToModel(dto: PublicSettingListDto): PublicSettingList {
+  return {
+    items: dto.items.map(mapPublicSettingItemDtoToModel),
+  }
+}
+
+export function mapSettingRevisionDtoToModel(dto: SettingRevisionDto): SettingRevision {
+  return {
+    id: dto.id,
+    settingKey: dto.setting_key,
+    value: dto.value,
+    previousValue: dto.previous_value,
+    action: dto.action,
+    actorUserId: dto.actor_user_id,
+    createdAt: dto.created_at,
+  }
+}
+
+export function mapSettingRevisionListDtoToModel(dto: SettingRevisionListDto): SettingRevisionList {
+  return {
+    items: dto.items.map(mapSettingRevisionDtoToModel),
+    limit: dto.limit,
+    offset: dto.offset,
+  }
+}
+
+export function mapUpdateSettingInputToDto(input: UpdateSettingInput): UpdateSettingRequestDto {
+  return { value: input.value }
+}
+
+export function mapSettingValueDtoToModel(
+  dto: SettingValueDto,
+): Pick<SettingItem, 'settingKey' | 'value' | 'updatedAt'> {
+  return {
+    settingKey: dto.setting_key,
+    value: dto.value,
+    updatedAt: dto.updated_at,
+  }
+}
+
+export function publicSettingsToMap(items: PublicSettingItem[]): Record<string, string> {
+  return Object.fromEntries(items.map((item) => [item.settingKey, item.value]))
+}

--- a/frontend/src/entities/setting/model.ts
+++ b/frontend/src/entities/setting/model.ts
@@ -1,0 +1,46 @@
+export type SettingKey = string
+
+export type SettingDataType = 'text' | 'markdown' | 'bool' | 'url'
+
+export interface SettingItem {
+  settingKey: SettingKey
+  label: string
+  dataType: SettingDataType
+  defaultValue: string | null
+  isPublic: boolean
+  value: string
+  updatedAt: string | null
+}
+
+export interface SettingList {
+  items: SettingItem[]
+}
+
+export interface PublicSettingItem {
+  settingKey: SettingKey
+  value: string
+}
+
+export interface PublicSettingList {
+  items: PublicSettingItem[]
+}
+
+export interface SettingRevision {
+  id: number
+  settingKey: SettingKey
+  value: string | null
+  previousValue: string | null
+  action: 'created' | 'updated' | 'deleted' | 'restored'
+  actorUserId: number | null
+  createdAt: string
+}
+
+export interface SettingRevisionList {
+  items: SettingRevision[]
+  limit: number
+  offset: number
+}
+
+export interface UpdateSettingInput {
+  value: string
+}

--- a/frontend/src/entities/setting/mutations.ts
+++ b/frontend/src/entities/setting/mutations.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { SettingValueDto } from './api-types'
+import { mapSettingValueDtoToModel, mapUpdateSettingInputToDto } from './mapper'
+import type { SettingKey, UpdateSettingInput } from './model'
+import { settingKeys } from './query-keys'
+
+export function useUpdateSetting(): UseMutationResult<
+  { settingKey: SettingKey; value: string; updatedAt: string | null },
+  AppError,
+  { settingKey: SettingKey; input: UpdateSettingInput }
+> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ settingKey, input }) => {
+      const dto = await apiClient.put<SettingValueDto>(
+        `/api/v1/settings/${encodeURIComponent(settingKey)}`,
+        mapUpdateSettingInputToDto(input),
+      )
+      return mapSettingValueDtoToModel(dto)
+    },
+    onSuccess: async (_data, variables) => {
+      await queryClient.invalidateQueries({ queryKey: settingKeys.adminList() })
+      await queryClient.invalidateQueries({ queryKey: settingKeys.publicList() })
+      await queryClient.invalidateQueries({ queryKey: settingKeys.revisions(variables.settingKey) })
+    },
+  })
+}

--- a/frontend/src/entities/setting/queries.ts
+++ b/frontend/src/entities/setting/queries.ts
@@ -1,0 +1,53 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { PublicSettingListDto, SettingListDto, SettingRevisionListDto } from './api-types'
+import {
+  mapPublicSettingListDtoToModel,
+  mapSettingListDtoToModel,
+  mapSettingRevisionListDtoToModel,
+} from './mapper'
+import type { PublicSettingList, SettingList, SettingRevisionList } from './model'
+import { settingKeys } from './query-keys'
+
+const DEFAULT_REVISION_PARAMS = { limit: 20, offset: 0 } as const
+
+export function useSettingList(): UseQueryResult<SettingList, AppError> {
+  return useQuery({
+    queryKey: settingKeys.adminList(),
+    queryFn: async ({ signal }) => {
+      const dto = await apiClient.get<SettingListDto>('/api/v1/settings', signal)
+      return mapSettingListDtoToModel(dto)
+    },
+  })
+}
+
+export function usePublicSettings(): UseQueryResult<PublicSettingList, AppError> {
+  return useQuery({
+    queryKey: settingKeys.publicList(),
+    queryFn: async ({ signal }) => {
+      const dto = await apiClient.get<PublicSettingListDto>('/api/v1/public/settings', signal)
+      return mapPublicSettingListDtoToModel(dto)
+    },
+  })
+}
+
+export function useSettingRevisions(
+  settingKey: string,
+  params: { limit: number; offset: number } = DEFAULT_REVISION_PARAMS,
+): UseQueryResult<SettingRevisionList, AppError> {
+  return useQuery({
+    queryKey: [...settingKeys.revisions(settingKey), params],
+    queryFn: async ({ signal }) => {
+      const search = new URLSearchParams({
+        limit: String(params.limit),
+        offset: String(params.offset),
+      })
+      const dto = await apiClient.get<SettingRevisionListDto>(
+        `/api/v1/settings/${encodeURIComponent(settingKey)}/revisions?${search.toString()}`,
+        signal,
+      )
+      return mapSettingRevisionListDtoToModel(dto)
+    },
+    enabled: settingKey !== '',
+  })
+}

--- a/frontend/src/entities/setting/query-keys.ts
+++ b/frontend/src/entities/setting/query-keys.ts
@@ -1,0 +1,6 @@
+export const settingKeys = {
+  all: ['settings'] as const,
+  adminList: () => [...settingKeys.all, 'admin-list'] as const,
+  publicList: () => [...settingKeys.all, 'public-list'] as const,
+  revisions: (settingKey: string) => [...settingKeys.all, 'revisions', settingKey] as const,
+}

--- a/frontend/src/features/manage-settings/index.ts
+++ b/frontend/src/features/manage-settings/index.ts
@@ -1,0 +1,1 @@
+export { ManageSiteSettingsView } from './ui/ManageSiteSettingsView'

--- a/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.tsx
+++ b/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.tsx
@@ -1,0 +1,158 @@
+import { useCallback, useMemo, useState } from 'react'
+import {
+  useSettingList,
+  useSettingRevisions,
+  useUpdateSetting,
+  type SettingItem,
+} from '@/entities/setting'
+import { Button, Input, Stack, Text } from '@/shared/ui'
+
+function SettingField({
+  item,
+  isSaving,
+  onSave,
+}: {
+  item: SettingItem
+  isSaving: boolean
+  onSave: (settingKey: string, value: string) => Promise<void>
+}) {
+  const [value, setValue] = useState(item.value)
+
+  const inputId = `setting-${item.settingKey}`
+
+  return (
+    <Stack gap="sm">
+      {item.dataType === 'markdown' ? (
+        <div className="flex flex-col gap-stack-xs">
+          <label htmlFor={inputId} className="font-sans text-body font-medium text-text-primary">
+            {item.label}
+          </label>
+          <textarea
+            id={inputId}
+            value={value}
+            disabled={isSaving}
+            rows={4}
+            onChange={(event) => {
+              setValue(event.target.value)
+            }}
+            className="rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm font-sans text-body text-text-primary shadow-sm focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-50"
+          />
+          <Text muted variant="caption">
+            Markdown · {item.isPublic ? 'Public' : 'Admin only'}
+          </Text>
+        </div>
+      ) : (
+        <Input
+          id={inputId}
+          label={item.label}
+          value={value}
+          disabled={isSaving}
+          onChange={(event) => {
+            setValue(event.target.value)
+          }}
+        />
+      )}
+      <Button
+        variant="secondary"
+        size="sm"
+        disabled={isSaving || value === item.value}
+        onClick={() => {
+          void onSave(item.settingKey, value)
+        }}
+      >
+        {isSaving ? 'Saving…' : 'Save'}
+      </Button>
+    </Stack>
+  )
+}
+
+function SettingRevisionsPanel({ settingKey }: { settingKey: string }) {
+  const revisionsQuery = useSettingRevisions(settingKey)
+
+  if (revisionsQuery.isLoading) {
+    return <Text muted>Loading history…</Text>
+  }
+
+  if (revisionsQuery.isError) {
+    return <Text muted>Could not load revision history.</Text>
+  }
+
+  const items = revisionsQuery.data?.items ?? []
+
+  if (items.length === 0) {
+    return <Text muted>No revisions yet.</Text>
+  }
+
+  return (
+    <Stack gap="xs">
+      {items.map((revision) => (
+        <Text key={revision.id} muted variant="caption">
+          {revision.createdAt} · {revision.action}
+          {revision.previousValue !== null ? ` · from "${revision.previousValue}"` : ''}
+        </Text>
+      ))}
+    </Stack>
+  )
+}
+
+export function ManageSiteSettingsView() {
+  const listQuery = useSettingList()
+  const updateMutation = useUpdateSetting()
+  const [expandedKey, setExpandedKey] = useState<string | null>(null)
+
+  const saveSetting = useCallback(
+    async (settingKey: string, value: string) => {
+      await updateMutation.mutateAsync({ settingKey, input: { value } })
+    },
+    [updateMutation],
+  )
+
+  const items = useMemo(() => listQuery.data?.items ?? [], [listQuery.data?.items])
+
+  if (listQuery.isLoading) {
+    return <Text muted>Loading settings…</Text>
+  }
+
+  if (listQuery.isError) {
+    return (
+      <Stack gap="sm">
+        <Text muted>Could not load site settings.</Text>
+        <Button variant="secondary" size="sm" onClick={() => void listQuery.refetch()}>
+          Retry
+        </Button>
+      </Stack>
+    )
+  }
+
+  return (
+    <Stack gap="lg">
+      {items.map((item) => (
+        <section
+          key={item.settingKey}
+          className="rounded-md border border-border bg-surface-raised p-inline-md shadow-sm"
+        >
+          <Stack gap="md">
+            <SettingField
+              key={`${item.settingKey}:${item.updatedAt ?? 'default'}`}
+              item={item}
+              isSaving={updateMutation.isPending}
+              onSave={saveSetting}
+            />
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                setExpandedKey((current) => (current === item.settingKey ? null : item.settingKey))
+              }}
+            >
+              {expandedKey === item.settingKey ? 'Hide history' : 'Show history'}
+            </Button>
+            {expandedKey === item.settingKey ? (
+              <SettingRevisionsPanel settingKey={item.settingKey} />
+            ) : null}
+          </Stack>
+        </section>
+      ))}
+    </Stack>
+  )
+}

--- a/frontend/src/pages/consumer/PublicShell.tsx
+++ b/frontend/src/pages/consumer/PublicShell.tsx
@@ -1,22 +1,79 @@
+import { useEffect, useMemo } from 'react'
 import './consumer-theme.css'
 import { Link, Outlet } from 'react-router-dom'
-import { Text } from '@/shared/ui'
+import { publicSettingsToMap, usePublicSettings } from '@/entities/setting'
+import { Stack, Text } from '@/shared/ui'
+
+function useSiteDocumentMeta(siteName: string, metaDescription: string): void {
+  useEffect(() => {
+    if (siteName !== '') {
+      document.title = siteName
+    }
+
+    let meta = document.querySelector('meta[name="description"]')
+
+    if (metaDescription === '') {
+      meta?.remove()
+      return
+    }
+
+    if (meta === null) {
+      meta = document.createElement('meta')
+      meta.setAttribute('name', 'description')
+      document.head.appendChild(meta)
+    }
+
+    meta.setAttribute('content', metaDescription)
+  }, [siteName, metaDescription])
+}
 
 export function PublicShell() {
+  const publicSettingsQuery = usePublicSettings()
+  const settings = useMemo(
+    () => publicSettingsToMap(publicSettingsQuery.data?.items ?? []),
+    [publicSettingsQuery.data?.items],
+  )
+
+  const siteName = settings.site_name ?? 'NeNe Records'
+  const tagline = settings.tagline ?? ''
+  const metaDescription = settings.default_meta_description ?? ''
+  const footerMarkdown = settings.footer_markdown ?? ''
+
+  useSiteDocumentMeta(siteName, metaDescription)
+
   return (
-    <div data-theme="consumer" className="min-h-screen bg-surface font-sans text-text-primary">
+    <div
+      data-theme="consumer"
+      className="flex min-h-screen flex-col bg-surface font-sans text-text-primary"
+    >
       <header className="border-b border-border bg-surface-raised shadow-sm">
         <div className="mx-auto max-w-3xl px-inline-md py-stack-md">
           <Link to="/view">
-            <Text as="span" variant="heading-sm">
-              NeNe Records
-            </Text>
+            <Stack gap="xs">
+              <Text as="span" variant="heading-sm">
+                {siteName}
+              </Text>
+              {tagline !== '' ? (
+                <Text as="span" muted variant="caption">
+                  {tagline}
+                </Text>
+              ) : null}
+            </Stack>
           </Link>
         </div>
       </header>
-      <main className="mx-auto max-w-3xl px-inline-md py-stack-lg">
-        <Outlet />
+      <main className="mx-auto w-full max-w-3xl flex-1 px-inline-md py-stack-lg">
+        <Outlet context={{ siteName, metaDescription }} />
       </main>
+      {footerMarkdown !== '' ? (
+        <footer className="border-t border-border bg-surface-raised">
+          <div className="mx-auto max-w-3xl px-inline-md py-stack-md">
+            <div className="whitespace-pre-wrap font-sans text-body text-text-muted">
+              {footerMarkdown}
+            </div>
+          </div>
+        </footer>
+      ) : null}
     </div>
   )
 }

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -26,6 +26,9 @@ export function AppShell() {
               <NavLink to="/tags" className={navLinkClass}>
                 Tags
               </NavLink>
+              <NavLink to="/settings" className={navLinkClass}>
+                Settings
+              </NavLink>
               <NavLink to="/view" className={navLinkClass}>
                 Public site
               </NavLink>

--- a/frontend/src/pages/settings/SiteSettingsPage.tsx
+++ b/frontend/src/pages/settings/SiteSettingsPage.tsx
@@ -1,0 +1,16 @@
+import { ManageSiteSettingsView } from '@/features/manage-settings'
+import { Stack, Text } from '@/shared/ui'
+
+export function SiteSettingsPage() {
+  return (
+    <Stack gap="md">
+      <Text as="h1" variant="heading-md">
+        Site settings
+      </Text>
+      <Text muted>
+        Configure site name, tagline, default meta description, and footer content for public pages.
+      </Text>
+      <ManageSiteSettingsView />
+    </Stack>
+  )
+}

--- a/frontend/src/shared/lib/public-record-bootstrap.ts
+++ b/frontend/src/shared/lib/public-record-bootstrap.ts
@@ -1,3 +1,5 @@
+import type { PublicSettingListDto } from '@/entities/setting/api-types'
+
 const BOOTSTRAP_SCRIPT_ID = 'nene-records-public-record-bootstrap'
 
 export interface PublicRecordBootstrapFieldListDto {
@@ -30,6 +32,7 @@ export interface PublicRecordBootstrapDto {
   dateTimeFields: PublicRecordBootstrapFieldListDto
   entityRelations: PublicRecordBootstrapRelationQuery[]
   relationTextFieldsByEntityTypeId: Record<string, PublicRecordBootstrapFieldListDto>
+  publicSettings?: PublicSettingListDto
 }
 
 export function readPublicRecordBootstrap(): PublicRecordBootstrapDto | null {

--- a/frontend/src/shared/lib/seed-public-record-view-cache.ts
+++ b/frontend/src/shared/lib/seed-public-record-view-cache.ts
@@ -22,6 +22,8 @@ import { fieldDefKeys } from '@/entities/field-def/query-keys'
 import type { IntFieldListDto } from '@/entities/int-field/api-types'
 import { mapIntFieldListDtoToModel } from '@/entities/int-field/mapper'
 import { intFieldKeys } from '@/entities/int-field/query-keys'
+import { mapPublicSettingListDtoToModel } from '@/entities/setting/mapper'
+import { settingKeys } from '@/entities/setting/query-keys'
 import type { TextFieldListDto } from '@/entities/text-field/api-types'
 import { mapTextFieldListDtoToModel } from '@/entities/text-field/mapper'
 import { textFieldKeys } from '@/entities/text-field/query-keys'
@@ -99,6 +101,13 @@ export function seedPublicRecordViewCache(
         ...FIELD_VALUE_LIST_PARAMS,
       }),
       mapTextFieldListDtoToModel(payload as TextFieldListDto),
+    )
+  }
+
+  if (bootstrap.publicSettings !== undefined) {
+    queryClient.setQueryData(
+      settingKeys.publicList(),
+      mapPublicSettingListDtoToModel(bootstrap.publicSettings),
     )
   }
 }

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -45,6 +45,9 @@ use NeNeRecords\IntField\IntFieldServiceProvider;
 use NeNeRecords\PublicRecord\PublicEntityTypeNotFoundExceptionHandler;
 use NeNeRecords\PublicRecord\PublicRecordNotFoundExceptionHandler;
 use NeNeRecords\PublicRecord\PublicRecordServiceProvider;
+use NeNeRecords\Setting\SettingKeyNotFoundExceptionHandler;
+use NeNeRecords\Setting\SettingServiceProvider;
+use NeNeRecords\Setting\SettingValueInvalidExceptionHandler;
 use NeNeRecords\Tag\TagNotFoundExceptionHandler;
 use NeNeRecords\Tag\TagServiceProvider;
 use NeNeRecords\Tag\TagSlugConflictExceptionHandler;
@@ -75,7 +78,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new EntityTagServiceProvider())
             ->addProvider(new EntityRelationServiceProvider())
             ->addProvider(new AnalyticsServiceProvider())
-            ->addProvider(new PublicRecordServiceProvider());
+            ->addProvider(new PublicRecordServiceProvider())
+            ->addProvider(new SettingServiceProvider());
 
         $builder
             ->set(
@@ -94,6 +98,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $entityRelation = $container->get('nene-records.route_registrar.entity_relation');
                     $analytics = $container->get('nene-records.route_registrar.analytics');
                     $publicRecord = $container->get('nene-records.route_registrar.public_record');
+                    $setting = $container->get('nene-records.route_registrar.setting');
 
                     if (
                         !is_callable($entityType)
@@ -109,6 +114,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !is_callable($entityRelation)
                         || !is_callable($analytics)
                         || !is_callable($publicRecord)
+                        || !is_callable($setting)
                     ) {
                         throw new LogicException('Route registrar service is invalid.');
                     }
@@ -127,6 +133,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $entityRelation,
                         $analytics,
                         $publicRecord,
+                        $setting,
                     ];
                 },
             )
@@ -164,6 +171,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $relationNotAttached = $container->get(RelationNotAttachedExceptionHandler::class);
                     $publicEntityTypeNotFound = $container->get(PublicEntityTypeNotFoundExceptionHandler::class);
                     $publicRecordNotFound = $container->get(PublicRecordNotFoundExceptionHandler::class);
+                    $settingKeyNotFound = $container->get(SettingKeyNotFoundExceptionHandler::class);
+                    $settingValueInvalid = $container->get(SettingValueInvalidExceptionHandler::class);
 
                     foreach ([
                         $entityTypeNotFound,
@@ -197,6 +206,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $relationNotAttached,
                         $publicEntityTypeNotFound,
                         $publicRecordNotFound,
+                        $settingKeyNotFound,
+                        $settingValueInvalid,
                     ] as $handler) {
                         if (!$handler instanceof DomainExceptionHandlerInterface) {
                             throw new LogicException('Exception handler service is invalid.');
@@ -235,6 +246,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $relationNotAttached,
                         $publicEntityTypeNotFound,
                         $publicRecordNotFound,
+                        $settingKeyNotFound,
+                        $settingValueInvalid,
                     ];
                 },
             );

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -17,6 +17,9 @@ use NeNeRecords\FieldDef\FieldDef;
 use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
 use NeNeRecords\IntField\IntField;
 use NeNeRecords\IntField\IntFieldRepositoryInterface;
+use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
+use NeNeRecords\Setting\SettingEntry;
+use NeNeRecords\Setting\SettingHttpMapper;
 use NeNeRecords\TextField\TextField;
 use NeNeRecords\TextField\TextFieldRepositoryInterface;
 
@@ -36,6 +39,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
         private BoolFieldRepositoryInterface $boolFields,
         private DateTimeFieldRepositoryInterface $dateTimeFields,
         private EntityRelationRepositoryInterface $entityRelations,
+        private ListPublicSettingsUseCaseInterface $publicSettings,
     ) {
     }
 
@@ -139,6 +143,14 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             relationQueries: $this->buildRelationQueries($fieldDefRows, $entityId),
             relationTextFieldRowsByEntityTypeId: $relationTextFieldsByEntityTypeId,
         );
+
+        $publicSettingsOutput = $this->publicSettings->execute();
+        $bootstrap['publicSettings'] = [
+            'items' => array_map(
+                static fn (SettingEntry $entry) => SettingHttpMapper::entryToPublicArray($entry),
+                $publicSettingsOutput->items,
+            ),
+        ];
 
         return new GetPublicRecordViewOutput(
             entityTypeSlug: $input->entityTypeSlug,

--- a/src/PublicRecord/PublicRecordServiceProvider.php
+++ b/src/PublicRecord/PublicRecordServiceProvider.php
@@ -21,6 +21,7 @@ use NeNeRecords\EnumField\EnumFieldRepositoryInterface;
 use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
 use NeNeRecords\Http\RuntimeServiceProvider;
 use NeNeRecords\IntField\IntFieldRepositoryInterface;
+use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
 use NeNeRecords\TextField\TextFieldRepositoryInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -77,6 +78,7 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                     $boolFields = $container->get(BoolFieldRepositoryInterface::class);
                     $dateTimeFields = $container->get(DateTimeFieldRepositoryInterface::class);
                     $entityRelations = $container->get(EntityRelationRepositoryInterface::class);
+                    $publicSettings = $container->get(ListPublicSettingsUseCaseInterface::class);
 
                     if (!$entityTypes instanceof EntityTypeRepositoryInterface) {
                         throw new LogicException('Entity type repository service is invalid.');
@@ -114,6 +116,10 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                         throw new LogicException('Entity relation repository service is invalid.');
                     }
 
+                    if (!$publicSettings instanceof ListPublicSettingsUseCaseInterface) {
+                        throw new LogicException('ListPublicSettings use case service is invalid.');
+                    }
+
                     return new GetPublicRecordViewUseCase(
                         $entityTypes,
                         $entities,
@@ -124,6 +130,7 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                         $boolFields,
                         $dateTimeFields,
                         $entityRelations,
+                        $publicSettings,
                     );
                 },
             )
@@ -148,11 +155,16 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                 RenderPublicRecordViewHandler::class,
                 static function (ContainerInterface $container): RenderPublicRecordViewHandler {
                     $useCase = $container->get(GetPublicRecordViewUseCaseInterface::class);
+                    $publicSettings = $container->get(ListPublicSettingsUseCaseInterface::class);
                     $html = $container->get(HtmlResponseFactory::class);
                     $config = $container->get(AppConfig::class);
 
                     if (!$useCase instanceof GetPublicRecordViewUseCaseInterface) {
                         throw new LogicException('GetPublicRecordView use case service is invalid.');
+                    }
+
+                    if (!$publicSettings instanceof ListPublicSettingsUseCaseInterface) {
+                        throw new LogicException('ListPublicSettings use case service is invalid.');
                     }
 
                     if (!$html instanceof HtmlResponseFactory) {
@@ -163,7 +175,7 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                         throw new LogicException('Application config service is invalid.');
                     }
 
-                    return new RenderPublicRecordViewHandler($useCase, $html, $config);
+                    return new RenderPublicRecordViewHandler($useCase, $publicSettings, $html, $config);
                 },
             )
             ->set(

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\PublicRecord;
 use Nene2\Config\AppConfig;
 use Nene2\Routing\Router;
 use Nene2\View\HtmlResponseFactory;
+use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -14,6 +15,7 @@ final readonly class RenderPublicRecordViewHandler
 {
     public function __construct(
         private GetPublicRecordViewUseCaseInterface $useCase,
+        private ListPublicSettingsUseCaseInterface $publicSettings,
         private HtmlResponseFactory $html,
         private AppConfig $config,
     ) {
@@ -30,6 +32,7 @@ final readonly class RenderPublicRecordViewHandler
         }
 
         $output = $this->useCase->execute(new GetPublicRecordViewInput($slug, $entityId));
+        $siteSettings = $this->resolveSiteSettings();
 
         $bootstrapJson = json_encode(
             $output->bootstrap,
@@ -48,9 +51,28 @@ final readonly class RenderPublicRecordViewHandler
             'entityTypeName' => $output->entityTypeName,
             'entityId' => $output->entityId,
             'displayFields' => $output->displayFields,
+            'siteName' => $siteSettings['site_name'],
+            'metaDescription' => $siteSettings['default_meta_description'],
             'bootstrapJson' => $bootstrapJson,
             'includeViteClient' => $this->config->debug,
             'viteUrl' => rtrim($viteUrl, '/'),
         ]);
+    }
+
+    /** @return array{site_name: string, default_meta_description: string} */
+    private function resolveSiteSettings(): array
+    {
+        $settings = [
+            'site_name' => 'NeNe Records',
+            'default_meta_description' => '',
+        ];
+
+        foreach ($this->publicSettings->execute()->items as $entry) {
+            if (array_key_exists($entry->def->settingKey, $settings)) {
+                $settings[$entry->def->settingKey] = $entry->effectiveValue;
+            }
+        }
+
+        return $settings;
     }
 }

--- a/src/Setting/ListPublicSettingsHandler.php
+++ b/src/Setting/ListPublicSettingsHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListPublicSettingsHandler
+{
+    public function __construct(
+        private ListPublicSettingsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $output = $this->useCase->execute();
+
+        return $this->response->create([
+            'items' => array_map(
+                static fn (SettingEntry $entry) => SettingHttpMapper::entryToPublicArray($entry),
+                $output->items,
+            ),
+        ]);
+    }
+}

--- a/src/Setting/ListPublicSettingsOutput.php
+++ b/src/Setting/ListPublicSettingsOutput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+final readonly class ListPublicSettingsOutput
+{
+    /** @param list<SettingEntry> $items */
+    public function __construct(
+        public array $items,
+    ) {
+    }
+}

--- a/src/Setting/ListPublicSettingsUseCase.php
+++ b/src/Setting/ListPublicSettingsUseCase.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+final readonly class ListPublicSettingsUseCase implements ListPublicSettingsUseCaseInterface
+{
+    public function __construct(
+        private SettingRepositoryInterface $settings,
+    ) {
+    }
+
+    public function execute(): ListPublicSettingsOutput
+    {
+        return new ListPublicSettingsOutput(items: $this->settings->findPublicEntries());
+    }
+}

--- a/src/Setting/ListPublicSettingsUseCaseInterface.php
+++ b/src/Setting/ListPublicSettingsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+interface ListPublicSettingsUseCaseInterface
+{
+    public function execute(): ListPublicSettingsOutput;
+}

--- a/src/Setting/ListSettingRevisionsHandler.php
+++ b/src/Setting/ListSettingRevisionsHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListSettingRevisionsHandler
+{
+    private const KEY_PATTERN = '/^[a-z][a-z0-9_]*$/';
+
+    public function __construct(
+        private ListSettingRevisionsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $settingKey = trim((string) ($parameters['key'] ?? ''));
+
+        if ($settingKey === '' || preg_match(self::KEY_PATTERN, $settingKey) !== 1) {
+            throw new SettingKeyNotFoundException($settingKey !== '' ? $settingKey : 'unknown');
+        }
+
+        $pagination = PaginationQueryParser::parse($request);
+
+        $output = $this->useCase->execute(new ListSettingRevisionsInput(
+            settingKey: $settingKey,
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+        ));
+
+        return $this->response->create(
+            (new PaginationResponse(
+                items: array_map(
+                    static fn (SettingRevision $revision) => SettingHttpMapper::revisionToArray($revision),
+                    $output->items,
+                ),
+                limit: $output->limit,
+                offset: $output->offset,
+            ))->toArray(),
+        );
+    }
+}

--- a/src/Setting/ListSettingRevisionsInput.php
+++ b/src/Setting/ListSettingRevisionsInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+final readonly class ListSettingRevisionsInput
+{
+    public function __construct(
+        public string $settingKey,
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/Setting/ListSettingRevisionsOutput.php
+++ b/src/Setting/ListSettingRevisionsOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+final readonly class ListSettingRevisionsOutput
+{
+    /** @param list<SettingRevision> $items */
+    public function __construct(
+        public array $items,
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/Setting/ListSettingRevisionsUseCase.php
+++ b/src/Setting/ListSettingRevisionsUseCase.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+final readonly class ListSettingRevisionsUseCase implements ListSettingRevisionsUseCaseInterface
+{
+    public function __construct(
+        private SettingRepositoryInterface $settings,
+    ) {
+    }
+
+    public function execute(ListSettingRevisionsInput $input): ListSettingRevisionsOutput
+    {
+        if ($this->settings->findDefByKey($input->settingKey) === null) {
+            throw new SettingKeyNotFoundException($input->settingKey);
+        }
+
+        return new ListSettingRevisionsOutput(
+            items: $this->settings->findRevisionsByKey($input->settingKey, $input->limit, $input->offset),
+            limit: $input->limit,
+            offset: $input->offset,
+        );
+    }
+}

--- a/src/Setting/ListSettingRevisionsUseCaseInterface.php
+++ b/src/Setting/ListSettingRevisionsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+interface ListSettingRevisionsUseCaseInterface
+{
+    public function execute(ListSettingRevisionsInput $input): ListSettingRevisionsOutput;
+}

--- a/src/Setting/ListSettingsHandler.php
+++ b/src/Setting/ListSettingsHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListSettingsHandler
+{
+    public function __construct(
+        private ListSettingsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $output = $this->useCase->execute();
+
+        return $this->response->create([
+            'items' => array_map(
+                static fn (SettingEntry $entry) => SettingHttpMapper::entryToAdminArray($entry),
+                $output->items,
+            ),
+        ]);
+    }
+}

--- a/src/Setting/ListSettingsOutput.php
+++ b/src/Setting/ListSettingsOutput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+final readonly class ListSettingsOutput
+{
+    /** @param list<SettingEntry> $items */
+    public function __construct(
+        public array $items,
+    ) {
+    }
+}

--- a/src/Setting/ListSettingsUseCase.php
+++ b/src/Setting/ListSettingsUseCase.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+final readonly class ListSettingsUseCase implements ListSettingsUseCaseInterface
+{
+    public function __construct(
+        private SettingRepositoryInterface $settings,
+    ) {
+    }
+
+    public function execute(): ListSettingsOutput
+    {
+        return new ListSettingsOutput(items: $this->settings->findAllEntries());
+    }
+}

--- a/src/Setting/ListSettingsUseCaseInterface.php
+++ b/src/Setting/ListSettingsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+interface ListSettingsUseCaseInterface
+{
+    public function execute(): ListSettingsOutput;
+}

--- a/src/Setting/PdoSettingRepository.php
+++ b/src/Setting/PdoSettingRepository.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoSettingRepository implements SettingRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    /** @return list<SettingDef> */
+    public function findAllDefs(): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, setting_key, data_type, default_value, is_public, label
+             FROM setting_defs
+             ORDER BY id ASC',
+        );
+
+        return array_map($this->mapDef(...), $rows);
+    }
+
+    public function findDefByKey(string $settingKey): ?SettingDef
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, setting_key, data_type, default_value, is_public, label
+             FROM setting_defs
+             WHERE setting_key = ?',
+            [$settingKey],
+        );
+
+        return $row === null ? null : $this->mapDef($row);
+    }
+
+    public function findValueByKey(string $settingKey): ?SettingValue
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, setting_key, value, is_deleted, deleted_at, created_by, updated_by, created_at, updated_at
+             FROM setting_values
+             WHERE setting_key = ?',
+            [$settingKey],
+        );
+
+        return $row === null ? null : $this->mapValue($row);
+    }
+
+    /** @return list<SettingEntry> */
+    public function findAllEntries(): array
+    {
+        return $this->buildEntries($this->findAllDefs());
+    }
+
+    /** @return list<SettingEntry> */
+    public function findPublicEntries(): array
+    {
+        $defs = array_values(array_filter(
+            $this->findAllDefs(),
+            static fn (SettingDef $def): bool => $def->isPublic,
+        ));
+
+        return $this->buildEntries($defs);
+    }
+
+    /** @return list<SettingRevision> */
+    public function findRevisionsByKey(string $settingKey, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, setting_key, value, previous_value, action, actor_user_id, created_at
+             FROM setting_revisions
+             WHERE setting_key = ?
+             ORDER BY id DESC
+             LIMIT ? OFFSET ?',
+            [$settingKey, $limit, $offset],
+        );
+
+        return array_map($this->mapRevision(...), $rows);
+    }
+
+    public function applyValue(string $settingKey, string $value, ?int $actorUserId): SettingValue
+    {
+        $def = $this->findDefByKey($settingKey);
+
+        if ($def === null) {
+            throw new SettingKeyNotFoundException($settingKey);
+        }
+
+        $normalized = SettingValueValidator::normalize($def->dataType, $value);
+        SettingValueValidator::validate($def->dataType, $normalized);
+
+        $existing = $this->findValueByKey($settingKey);
+        $previousEffective = $this->resolveEffectiveValue($def, $existing);
+        $action = $existing === null || $existing->isDeleted
+            ? SettingRevisionAction::CREATED
+            : SettingRevisionAction::UPDATED;
+        $now = date('Y-m-d H:i:s');
+
+        $this->query->execute(
+            'INSERT INTO setting_revisions (setting_key, value, previous_value, action, actor_user_id, created_at)
+             VALUES (?, ?, ?, ?, ?, ?)',
+            [
+                $settingKey,
+                $normalized,
+                $previousEffective === $normalized ? null : $previousEffective,
+                $action,
+                $actorUserId,
+                $now,
+            ],
+        );
+
+        if ($existing === null) {
+            $this->query->execute(
+                'INSERT INTO setting_values (setting_key, value, is_deleted, deleted_at, created_by, updated_by, created_at, updated_at)
+                 VALUES (?, ?, 0, NULL, ?, ?, ?, ?)',
+                [$settingKey, $normalized, $actorUserId, $actorUserId, $now, $now],
+            );
+        } else {
+            $this->query->execute(
+                'UPDATE setting_values
+                 SET value = ?, is_deleted = 0, deleted_at = NULL, updated_by = ?, updated_at = ?
+                 WHERE setting_key = ?',
+                [$normalized, $actorUserId, $now, $settingKey],
+            );
+        }
+
+        $stored = $this->findValueByKey($settingKey);
+
+        if ($stored === null) {
+            throw new SettingValueInvalidException('Failed to persist setting value.');
+        }
+
+        return $stored;
+    }
+
+    /** @param list<SettingDef> $defs
+     * @return list<SettingEntry>
+     */
+    private function buildEntries(array $defs): array
+    {
+        $entries = [];
+
+        foreach ($defs as $def) {
+            $stored = $this->findValueByKey($def->settingKey);
+            $entries[] = new SettingEntry(
+                def: $def,
+                effectiveValue: $this->resolveEffectiveValue($def, $stored),
+                storedValue: $stored,
+            );
+        }
+
+        return $entries;
+    }
+
+    private function resolveEffectiveValue(SettingDef $def, ?SettingValue $stored): string
+    {
+        if ($stored !== null && !$stored->isDeleted) {
+            return $stored->value ?? '';
+        }
+
+        return $def->defaultValue ?? '';
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapDef(array $row): SettingDef
+    {
+        return new SettingDef(
+            settingKey: (string) $row['setting_key'],
+            dataType: (string) $row['data_type'],
+            defaultValue: $row['default_value'] !== null ? (string) $row['default_value'] : null,
+            isPublic: (bool) $row['is_public'],
+            label: (string) $row['label'],
+            id: (int) $row['id'],
+        );
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapValue(array $row): SettingValue
+    {
+        return new SettingValue(
+            settingKey: (string) $row['setting_key'],
+            value: $row['value'] !== null ? (string) $row['value'] : null,
+            isDeleted: (bool) $row['is_deleted'],
+            deletedAt: $row['deleted_at'] !== null ? (string) $row['deleted_at'] : null,
+            createdBy: $row['created_by'] !== null ? (int) $row['created_by'] : null,
+            updatedBy: $row['updated_by'] !== null ? (int) $row['updated_by'] : null,
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+            id: (int) $row['id'],
+        );
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRevision(array $row): SettingRevision
+    {
+        return new SettingRevision(
+            settingKey: (string) $row['setting_key'],
+            value: $row['value'] !== null ? (string) $row['value'] : null,
+            previousValue: $row['previous_value'] !== null ? (string) $row['previous_value'] : null,
+            action: (string) $row['action'],
+            actorUserId: $row['actor_user_id'] !== null ? (int) $row['actor_user_id'] : null,
+            createdAt: (string) $row['created_at'],
+            id: (int) $row['id'],
+        );
+    }
+}

--- a/src/Setting/SettingDef.php
+++ b/src/Setting/SettingDef.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+final readonly class SettingDef
+{
+    public function __construct(
+        public string $settingKey,
+        public string $dataType,
+        public ?string $defaultValue,
+        public bool $isPublic,
+        public string $label,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/Setting/SettingEntry.php
+++ b/src/Setting/SettingEntry.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+final readonly class SettingEntry
+{
+    public function __construct(
+        public SettingDef $def,
+        public string $effectiveValue,
+        public ?SettingValue $storedValue,
+    ) {
+    }
+}

--- a/src/Setting/SettingHttpMapper.php
+++ b/src/Setting/SettingHttpMapper.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+final readonly class SettingHttpMapper
+{
+    /** @return array<string, mixed> */
+    public static function entryToAdminArray(SettingEntry $entry): array
+    {
+        $stored = $entry->storedValue;
+
+        return [
+            'setting_key' => $entry->def->settingKey,
+            'label' => $entry->def->label,
+            'data_type' => $entry->def->dataType,
+            'default_value' => $entry->def->defaultValue,
+            'is_public' => $entry->def->isPublic,
+            'value' => $entry->effectiveValue,
+            'updated_at' => $stored !== null && !$stored->isDeleted ? $stored->updatedAt : null,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    public static function entryToPublicArray(SettingEntry $entry): array
+    {
+        return [
+            'setting_key' => $entry->def->settingKey,
+            'value' => $entry->effectiveValue,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    public static function valueToArray(SettingValue $value): array
+    {
+        return [
+            'setting_key' => $value->settingKey,
+            'value' => $value->value ?? '',
+            'updated_at' => $value->updatedAt,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    public static function revisionToArray(SettingRevision $revision): array
+    {
+        return [
+            'id' => $revision->id,
+            'setting_key' => $revision->settingKey,
+            'value' => $revision->value,
+            'previous_value' => $revision->previousValue,
+            'action' => $revision->action,
+            'actor_user_id' => $revision->actorUserId,
+            'created_at' => $revision->createdAt,
+        ];
+    }
+}

--- a/src/Setting/SettingKeyNotFoundException.php
+++ b/src/Setting/SettingKeyNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+use RuntimeException;
+
+final class SettingKeyNotFoundException extends RuntimeException
+{
+    public function __construct(string $settingKey)
+    {
+        parent::__construct("Setting with key {$settingKey} was not found.");
+    }
+}

--- a/src/Setting/SettingKeyNotFoundExceptionHandler.php
+++ b/src/Setting/SettingKeyNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class SettingKeyNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof SettingKeyNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'not-found',
+            'Not Found',
+            404,
+            'The requested setting was not found.',
+        );
+    }
+}

--- a/src/Setting/SettingRepositoryInterface.php
+++ b/src/Setting/SettingRepositoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+interface SettingRepositoryInterface
+{
+    /** @return list<SettingDef> */
+    public function findAllDefs(): array;
+
+    public function findDefByKey(string $settingKey): ?SettingDef;
+
+    public function findValueByKey(string $settingKey): ?SettingValue;
+
+    /** @return list<SettingEntry> */
+    public function findAllEntries(): array;
+
+    /** @return list<SettingEntry> */
+    public function findPublicEntries(): array;
+
+    /** @return list<SettingRevision> */
+    public function findRevisionsByKey(string $settingKey, int $limit, int $offset): array;
+
+    public function applyValue(string $settingKey, string $value, ?int $actorUserId): SettingValue;
+}

--- a/src/Setting/SettingRevision.php
+++ b/src/Setting/SettingRevision.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+final readonly class SettingRevision
+{
+    public function __construct(
+        public string $settingKey,
+        public ?string $value,
+        public ?string $previousValue,
+        public string $action,
+        public ?int $actorUserId,
+        public string $createdAt,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/Setting/SettingRevisionAction.php
+++ b/src/Setting/SettingRevisionAction.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+final class SettingRevisionAction
+{
+    public const CREATED = 'created';
+
+    public const UPDATED = 'updated';
+
+    public const DELETED = 'deleted';
+
+    public const RESTORED = 'restored';
+}

--- a/src/Setting/SettingRouteRegistrar.php
+++ b/src/Setting/SettingRouteRegistrar.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class SettingRouteRegistrar
+{
+    public function __construct(
+        private ListSettingsHandler $listHandler,
+        private ListPublicSettingsHandler $listPublicHandler,
+        private UpdateSettingHandler $updateHandler,
+        private ListSettingRevisionsHandler $listRevisionsHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $listHandler = $this->listHandler;
+        $listPublicHandler = $this->listPublicHandler;
+        $updateHandler = $this->updateHandler;
+        $listRevisionsHandler = $this->listRevisionsHandler;
+
+        $router->get('/api/v1/settings', static fn (ServerRequestInterface $request) => $listHandler->handle($request));
+        $router->put('/api/v1/settings/{key}', static fn (ServerRequestInterface $request) => $updateHandler->handle($request));
+        $router->get(
+            '/api/v1/settings/{key}/revisions',
+            static fn (ServerRequestInterface $request) => $listRevisionsHandler->handle($request),
+        );
+        $router->get(
+            '/api/v1/public/settings',
+            static fn (ServerRequestInterface $request) => $listPublicHandler->handle($request),
+        );
+    }
+}

--- a/src/Setting/SettingServiceProvider.php
+++ b/src/Setting/SettingServiceProvider.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Container\ContainerInterface;
+
+final readonly class SettingServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                SettingRepositoryInterface::class,
+                static function (ContainerInterface $container): SettingRepositoryInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoSettingRepository($query);
+                },
+            )
+            ->set(
+                ListSettingsUseCaseInterface::class,
+                static function (ContainerInterface $container): ListSettingsUseCaseInterface {
+                    $settings = $container->get(SettingRepositoryInterface::class);
+
+                    if (!$settings instanceof SettingRepositoryInterface) {
+                        throw new LogicException('Setting repository service is invalid.');
+                    }
+
+                    return new ListSettingsUseCase($settings);
+                },
+            )
+            ->set(
+                ListPublicSettingsUseCaseInterface::class,
+                static function (ContainerInterface $container): ListPublicSettingsUseCaseInterface {
+                    $settings = $container->get(SettingRepositoryInterface::class);
+
+                    if (!$settings instanceof SettingRepositoryInterface) {
+                        throw new LogicException('Setting repository service is invalid.');
+                    }
+
+                    return new ListPublicSettingsUseCase($settings);
+                },
+            )
+            ->set(
+                UpdateSettingUseCaseInterface::class,
+                static function (ContainerInterface $container): UpdateSettingUseCaseInterface {
+                    $transactions = $container->get(DatabaseTransactionManagerInterface::class);
+
+                    if (!$transactions instanceof DatabaseTransactionManagerInterface) {
+                        throw new LogicException('Database transaction manager service is invalid.');
+                    }
+
+                    return new UpdateSettingUseCase($transactions);
+                },
+            )
+            ->set(
+                ListSettingRevisionsUseCaseInterface::class,
+                static function (ContainerInterface $container): ListSettingRevisionsUseCaseInterface {
+                    $settings = $container->get(SettingRepositoryInterface::class);
+
+                    if (!$settings instanceof SettingRepositoryInterface) {
+                        throw new LogicException('Setting repository service is invalid.');
+                    }
+
+                    return new ListSettingRevisionsUseCase($settings);
+                },
+            )
+            ->set(
+                ListSettingsHandler::class,
+                static function (ContainerInterface $container): ListSettingsHandler {
+                    $useCase = $container->get(ListSettingsUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListSettingsUseCaseInterface) {
+                        throw new LogicException('ListSettings use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListSettingsHandler($useCase, $response);
+                },
+            )
+            ->set(
+                ListPublicSettingsHandler::class,
+                static function (ContainerInterface $container): ListPublicSettingsHandler {
+                    $useCase = $container->get(ListPublicSettingsUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListPublicSettingsUseCaseInterface) {
+                        throw new LogicException('ListPublicSettings use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListPublicSettingsHandler($useCase, $response);
+                },
+            )
+            ->set(
+                UpdateSettingHandler::class,
+                static function (ContainerInterface $container): UpdateSettingHandler {
+                    $useCase = $container->get(UpdateSettingUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof UpdateSettingUseCaseInterface) {
+                        throw new LogicException('UpdateSetting use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new UpdateSettingHandler($useCase, $response);
+                },
+            )
+            ->set(
+                ListSettingRevisionsHandler::class,
+                static function (ContainerInterface $container): ListSettingRevisionsHandler {
+                    $useCase = $container->get(ListSettingRevisionsUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListSettingRevisionsUseCaseInterface) {
+                        throw new LogicException('ListSettingRevisions use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListSettingRevisionsHandler($useCase, $response);
+                },
+            )
+            ->set(
+                SettingKeyNotFoundExceptionHandler::class,
+                static function (ContainerInterface $container): SettingKeyNotFoundExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new SettingKeyNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                SettingValueInvalidExceptionHandler::class,
+                static function (ContainerInterface $container): SettingValueInvalidExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new SettingValueInvalidExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.setting',
+                static function (ContainerInterface $container): SettingRouteRegistrar {
+                    $list = $container->get(ListSettingsHandler::class);
+                    $listPublic = $container->get(ListPublicSettingsHandler::class);
+                    $update = $container->get(UpdateSettingHandler::class);
+                    $listRevisions = $container->get(ListSettingRevisionsHandler::class);
+
+                    if (!$list instanceof ListSettingsHandler) {
+                        throw new LogicException('ListSettings handler service is invalid.');
+                    }
+
+                    if (!$listPublic instanceof ListPublicSettingsHandler) {
+                        throw new LogicException('ListPublicSettings handler service is invalid.');
+                    }
+
+                    if (!$update instanceof UpdateSettingHandler) {
+                        throw new LogicException('UpdateSetting handler service is invalid.');
+                    }
+
+                    if (!$listRevisions instanceof ListSettingRevisionsHandler) {
+                        throw new LogicException('ListSettingRevisions handler service is invalid.');
+                    }
+
+                    return new SettingRouteRegistrar($list, $listPublic, $update, $listRevisions);
+                },
+            );
+    }
+}

--- a/src/Setting/SettingValue.php
+++ b/src/Setting/SettingValue.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+final readonly class SettingValue
+{
+    public function __construct(
+        public string $settingKey,
+        public ?string $value,
+        public bool $isDeleted,
+        public ?string $deletedAt,
+        public ?int $createdBy,
+        public ?int $updatedBy,
+        public string $createdAt,
+        public string $updatedAt,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/Setting/SettingValueInvalidException.php
+++ b/src/Setting/SettingValueInvalidException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+use RuntimeException;
+
+final class SettingValueInvalidException extends RuntimeException
+{
+}

--- a/src/Setting/SettingValueInvalidExceptionHandler.php
+++ b/src/Setting/SettingValueInvalidExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class SettingValueInvalidExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof SettingValueInvalidException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'validation-failed',
+            'Validation Failed',
+            422,
+            $exception->getMessage(),
+        );
+    }
+}

--- a/src/Setting/SettingValueValidator.php
+++ b/src/Setting/SettingValueValidator.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+final class SettingValueValidator
+{
+    /** @var list<string> */
+    private const SUPPORTED_DATA_TYPES = ['text', 'markdown', 'bool', 'url'];
+
+    public static function normalize(string $dataType, string $value): string
+    {
+        self::assertSupportedDataType($dataType);
+
+        return match ($dataType) {
+            'bool' => self::normalizeBool($value),
+            default => $value,
+        };
+    }
+
+    public static function validate(string $dataType, string $value): void
+    {
+        self::assertSupportedDataType($dataType);
+
+        match ($dataType) {
+            'bool' => self::validateBool($value),
+            'url' => self::validateUrl($value),
+            'text', 'markdown' => null,
+            default => self::assertSupportedDataType($dataType),
+        };
+    }
+
+    private static function assertSupportedDataType(string $dataType): void
+    {
+        if (!in_array($dataType, self::SUPPORTED_DATA_TYPES, true)) {
+            throw new SettingValueInvalidException("Unsupported setting data type: {$dataType}.");
+        }
+    }
+
+    private static function normalizeBool(string $value): string
+    {
+        $normalized = strtolower(trim($value));
+
+        return match ($normalized) {
+            '1', 'true' => 'true',
+            '0', 'false' => 'false',
+            default => throw new SettingValueInvalidException('Boolean setting value must be true or false.'),
+        };
+    }
+
+    private static function validateBool(string $value): void
+    {
+        self::normalizeBool($value);
+    }
+
+    private static function validateUrl(string $value): void
+    {
+        if ($value === '') {
+            return;
+        }
+
+        if (filter_var($value, FILTER_VALIDATE_URL) === false) {
+            throw new SettingValueInvalidException('URL setting value must be a valid URL.');
+        }
+    }
+}

--- a/src/Setting/UpdateSettingHandler.php
+++ b/src/Setting/UpdateSettingHandler.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateSettingHandler
+{
+    private const KEY_PATTERN = '/^[a-z][a-z0-9_]*$/';
+
+    public function __construct(
+        private UpdateSettingUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $settingKey = trim((string) ($parameters['key'] ?? ''));
+
+        if ($settingKey === '' || preg_match(self::KEY_PATTERN, $settingKey) !== 1) {
+            throw new SettingKeyNotFoundException($settingKey !== '' ? $settingKey : 'unknown');
+        }
+
+        $body = JsonRequestBodyParser::parse($request);
+
+        if (!array_key_exists('value', $body)) {
+            throw new ValidationException([
+                new ValidationError('value', 'Value is required.', 'required'),
+            ]);
+        }
+
+        if (!is_string($body['value'])) {
+            throw new ValidationException([
+                new ValidationError('value', 'Value must be a string.', 'type'),
+            ]);
+        }
+
+        $output = $this->useCase->execute(new UpdateSettingInput(
+            settingKey: $settingKey,
+            value: $body['value'],
+        ));
+
+        return $this->response->create([
+            'setting_key' => $output->settingKey,
+            'value' => $output->value,
+            'updated_at' => $output->updatedAt,
+        ]);
+    }
+}

--- a/src/Setting/UpdateSettingInput.php
+++ b/src/Setting/UpdateSettingInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+final readonly class UpdateSettingInput
+{
+    public function __construct(
+        public string $settingKey,
+        public string $value,
+        public ?int $actorUserId = null,
+    ) {
+    }
+}

--- a/src/Setting/UpdateSettingOutput.php
+++ b/src/Setting/UpdateSettingOutput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+final readonly class UpdateSettingOutput
+{
+    public function __construct(
+        public string $settingKey,
+        public string $value,
+        public string $updatedAt,
+    ) {
+    }
+}

--- a/src/Setting/UpdateSettingUseCase.php
+++ b/src/Setting/UpdateSettingUseCase.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+
+final readonly class UpdateSettingUseCase implements UpdateSettingUseCaseInterface
+{
+    public function __construct(
+        private DatabaseTransactionManagerInterface $transactions,
+    ) {
+    }
+
+    public function execute(UpdateSettingInput $input): UpdateSettingOutput
+    {
+        $stored = $this->transactions->transactional(
+            function (DatabaseQueryExecutorInterface $query) use ($input): SettingValue {
+                $repository = new PdoSettingRepository($query);
+
+                return $repository->applyValue($input->settingKey, $input->value, $input->actorUserId);
+            },
+        );
+
+        return new UpdateSettingOutput(
+            settingKey: $stored->settingKey,
+            value: $stored->value ?? '',
+            updatedAt: $stored->updatedAt,
+        );
+    }
+}

--- a/src/Setting/UpdateSettingUseCaseInterface.php
+++ b/src/Setting/UpdateSettingUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+interface UpdateSettingUseCaseInterface
+{
+    public function execute(UpdateSettingInput $input): UpdateSettingOutput;
+}

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -3,7 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title><?= $e($pageTitle) ?> — <?= $e($entityTypeName) ?></title>
+    <?php if ($metaDescription !== ''): ?>
+      <meta name="description" content="<?= $e($metaDescription) ?>" />
+    <?php endif; ?>
+    <title><?= $e($pageTitle) ?> — <?= $e($siteName) ?></title>
     <?php if ($includeViteClient): ?>
       <script type="module" src="<?= $e($viteUrl) ?>/@vite/client"></script>
     <?php endif; ?>

--- a/tests/PublicRecord/GetPublicRecordViewUseCaseTest.php
+++ b/tests/PublicRecord/GetPublicRecordViewUseCaseTest.php
@@ -11,6 +11,7 @@ use NeNeRecords\PublicRecord\GetPublicRecordViewInput;
 use NeNeRecords\PublicRecord\GetPublicRecordViewUseCase;
 use NeNeRecords\PublicRecord\PublicEntityTypeNotFoundException;
 use NeNeRecords\PublicRecord\PublicRecordNotFoundException;
+use NeNeRecords\Setting\ListPublicSettingsUseCase;
 use NeNeRecords\Tests\BoolField\InMemoryBoolFieldRepository;
 use NeNeRecords\Tests\DateTimeField\InMemoryDateTimeFieldRepository;
 use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
@@ -19,6 +20,7 @@ use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
 use NeNeRecords\Tests\EnumField\InMemoryEnumFieldRepository;
 use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
 use NeNeRecords\Tests\IntField\InMemoryIntFieldRepository;
+use NeNeRecords\Tests\Setting\InMemorySettingRepository;
 use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
 use NeNeRecords\TextField\TextField;
 use PHPUnit\Framework\TestCase;
@@ -54,6 +56,7 @@ final class GetPublicRecordViewUseCaseTest extends TestCase
             new InMemoryBoolFieldRepository(),
             new InMemoryDateTimeFieldRepository(),
             new InMemoryEntityRelationRepository(),
+            new ListPublicSettingsUseCase(new InMemorySettingRepository()),
         );
 
         $output = $useCase->execute(new GetPublicRecordViewInput('article', 10));
@@ -64,6 +67,7 @@ final class GetPublicRecordViewUseCaseTest extends TestCase
         self::assertSame(10, $output->bootstrap['entityId']);
         self::assertSame('Hello', $output->bootstrap['textFields']['items'][0]['value']);
         self::assertSame(42, $output->bootstrap['intFields']['items'][0]['value']);
+        self::assertArrayHasKey('publicSettings', $output->bootstrap);
     }
 
     public function testThrowsWhenEntityTypeMissing(): void
@@ -78,6 +82,7 @@ final class GetPublicRecordViewUseCaseTest extends TestCase
             new InMemoryBoolFieldRepository(),
             new InMemoryDateTimeFieldRepository(),
             new InMemoryEntityRelationRepository(),
+            new ListPublicSettingsUseCase(new InMemorySettingRepository()),
         );
 
         $this->expectException(PublicEntityTypeNotFoundException::class);
@@ -100,6 +105,7 @@ final class GetPublicRecordViewUseCaseTest extends TestCase
             new InMemoryBoolFieldRepository(),
             new InMemoryDateTimeFieldRepository(),
             new InMemoryEntityRelationRepository(),
+            new ListPublicSettingsUseCase(new InMemorySettingRepository()),
         );
 
         $this->expectException(PublicRecordNotFoundException::class);

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -21,6 +21,7 @@ use NeNeRecords\PublicRecord\PublicEntityTypeNotFoundExceptionHandler;
 use NeNeRecords\PublicRecord\PublicRecordNotFoundExceptionHandler;
 use NeNeRecords\PublicRecord\PublicRecordRouteRegistrar;
 use NeNeRecords\PublicRecord\RenderPublicRecordViewHandler;
+use NeNeRecords\Setting\ListPublicSettingsUseCase;
 use NeNeRecords\Tests\BoolField\InMemoryBoolFieldRepository;
 use NeNeRecords\Tests\DateTimeField\InMemoryDateTimeFieldRepository;
 use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
@@ -29,6 +30,7 @@ use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
 use NeNeRecords\Tests\EnumField\InMemoryEnumFieldRepository;
 use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
 use NeNeRecords\Tests\IntField\InMemoryIntFieldRepository;
+use NeNeRecords\Tests\Setting\InMemorySettingRepository;
 use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
 use NeNeRecords\TextField\TextField;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -64,6 +66,8 @@ final class PublicRecordHttpTest extends TestCase
             new TextField(entityId: 10, fieldKey: 'body', value: "Line one\nLine two", id: 2),
         ], $entities);
 
+        $publicSettings = new ListPublicSettingsUseCase(new InMemorySettingRepository());
+
         $useCase = new GetPublicRecordViewUseCase(
             $entityTypes,
             $entities,
@@ -74,6 +78,7 @@ final class PublicRecordHttpTest extends TestCase
             new InMemoryBoolFieldRepository(),
             new InMemoryDateTimeFieldRepository(),
             new InMemoryEntityRelationRepository(),
+            $publicSettings,
         );
 
         $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
@@ -100,7 +105,7 @@ final class PublicRecordHttpTest extends TestCase
 
         $registrar = new PublicRecordRouteRegistrar(
             new GetPublicRecordViewHandler($useCase, $jsonResponse),
-            new RenderPublicRecordViewHandler($useCase, $htmlResponse, $config),
+            new RenderPublicRecordViewHandler($useCase, $publicSettings, $htmlResponse, $config),
         );
 
         $this->application = (new RuntimeApplicationFactory(

--- a/tests/Setting/InMemorySettingRepository.php
+++ b/tests/Setting/InMemorySettingRepository.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Setting;
+
+use NeNeRecords\Setting\SettingDef;
+use NeNeRecords\Setting\SettingEntry;
+use NeNeRecords\Setting\SettingRepositoryInterface;
+use NeNeRecords\Setting\SettingRevision;
+use NeNeRecords\Setting\SettingRevisionAction;
+use NeNeRecords\Setting\SettingValue;
+
+final class InMemorySettingRepository implements SettingRepositoryInterface
+{
+    /** @var array<string, SettingDef> */
+    private array $defs = [];
+
+    /** @var array<string, SettingValue> */
+    private array $values = [];
+
+    /** @var list<SettingRevision> */
+    private array $revisions = [];
+
+    private int $revisionId = 0;
+
+    private int $valueId = 0;
+
+    /** @param list<SettingDef> $defs */
+    public function __construct(array $defs = [])
+    {
+        foreach ($defs as $def) {
+            $this->defs[$def->settingKey] = $def;
+        }
+    }
+
+    /** @return list<SettingDef> */
+    public function findAllDefs(): array
+    {
+        return array_values($this->defs);
+    }
+
+    public function findDefByKey(string $settingKey): ?SettingDef
+    {
+        return $this->defs[$settingKey] ?? null;
+    }
+
+    public function findValueByKey(string $settingKey): ?SettingValue
+    {
+        return $this->values[$settingKey] ?? null;
+    }
+
+    /** @return list<SettingEntry> */
+    public function findAllEntries(): array
+    {
+        return $this->buildEntries($this->findAllDefs());
+    }
+
+    /** @return list<SettingEntry> */
+    public function findPublicEntries(): array
+    {
+        $defs = array_values(array_filter(
+            $this->findAllDefs(),
+            static fn (SettingDef $def): bool => $def->isPublic,
+        ));
+
+        return $this->buildEntries($defs);
+    }
+
+    /** @return list<SettingRevision> */
+    public function findRevisionsByKey(string $settingKey, int $limit, int $offset): array
+    {
+        $rows = array_values(array_filter(
+            $this->revisions,
+            static fn (SettingRevision $revision): bool => $revision->settingKey === $settingKey,
+        ));
+        usort($rows, static fn (SettingRevision $a, SettingRevision $b): int => ($b->id ?? 0) <=> ($a->id ?? 0));
+
+        return array_slice($rows, $offset, $limit);
+    }
+
+    public function applyValue(string $settingKey, string $value, ?int $actorUserId): SettingValue
+    {
+        return $this->applyValueDirect($settingKey, $value, $actorUserId);
+    }
+
+    public function applyValueDirect(string $settingKey, string $value, ?int $actorUserId): SettingValue
+    {
+        $def = $this->findDefByKey($settingKey);
+
+        if ($def === null) {
+            throw new \NeNeRecords\Setting\SettingKeyNotFoundException($settingKey);
+        }
+
+        $normalized = \NeNeRecords\Setting\SettingValueValidator::normalize($def->dataType, $value);
+        \NeNeRecords\Setting\SettingValueValidator::validate($def->dataType, $normalized);
+
+        $existing = $this->findValueByKey($settingKey);
+        $previousEffective = $this->resolveEffectiveValue($def, $existing);
+        $action = $existing === null || $existing->isDeleted
+            ? SettingRevisionAction::CREATED
+            : SettingRevisionAction::UPDATED;
+        $now = date('Y-m-d H:i:s');
+
+        $this->revisions[] = new SettingRevision(
+            settingKey: $settingKey,
+            value: $normalized,
+            previousValue: $previousEffective === $normalized ? null : $previousEffective,
+            action: $action,
+            actorUserId: $actorUserId,
+            createdAt: $now,
+            id: ++$this->revisionId,
+        );
+
+        if ($existing === null) {
+            $stored = new SettingValue(
+                settingKey: $settingKey,
+                value: $normalized,
+                isDeleted: false,
+                deletedAt: null,
+                createdBy: $actorUserId,
+                updatedBy: $actorUserId,
+                createdAt: $now,
+                updatedAt: $now,
+                id: ++$this->valueId,
+            );
+            $this->values[$settingKey] = $stored;
+
+            return $stored;
+        }
+
+        $stored = new SettingValue(
+            settingKey: $settingKey,
+            value: $normalized,
+            isDeleted: false,
+            deletedAt: null,
+            createdBy: $existing->createdBy,
+            updatedBy: $actorUserId,
+            createdAt: $existing->createdAt,
+            updatedAt: $now,
+            id: $existing->id,
+        );
+        $this->values[$settingKey] = $stored;
+
+        return $stored;
+    }
+
+    /** @param list<SettingDef> $defs
+     * @return list<SettingEntry>
+     */
+    private function buildEntries(array $defs): array
+    {
+        $entries = [];
+
+        foreach ($defs as $def) {
+            $stored = $this->findValueByKey($def->settingKey);
+            $entries[] = new SettingEntry(
+                def: $def,
+                effectiveValue: $this->resolveEffectiveValue($def, $stored),
+                storedValue: $stored,
+            );
+        }
+
+        return $entries;
+    }
+
+    private function resolveEffectiveValue(SettingDef $def, ?SettingValue $stored): string
+    {
+        if ($stored !== null && !$stored->isDeleted) {
+            return $stored->value ?? '';
+        }
+
+        return $def->defaultValue ?? '';
+    }
+}

--- a/tests/Setting/InMemoryUpdateSettingUseCase.php
+++ b/tests/Setting/InMemoryUpdateSettingUseCase.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Setting;
+
+use NeNeRecords\Setting\UpdateSettingInput;
+use NeNeRecords\Setting\UpdateSettingOutput;
+use NeNeRecords\Setting\UpdateSettingUseCaseInterface;
+
+final readonly class InMemoryUpdateSettingUseCase implements UpdateSettingUseCaseInterface
+{
+    public function __construct(
+        private InMemorySettingRepository $settings,
+    ) {
+    }
+
+    public function execute(UpdateSettingInput $input): UpdateSettingOutput
+    {
+        $stored = $this->settings->applyValueDirect(
+            $input->settingKey,
+            $input->value,
+            $input->actorUserId,
+        );
+
+        return new UpdateSettingOutput(
+            settingKey: $stored->settingKey,
+            value: $stored->value ?? '',
+            updatedAt: $stored->updatedAt,
+        );
+    }
+}

--- a/tests/Setting/PdoSettingRepositoryTest.php
+++ b/tests/Setting/PdoSettingRepositoryTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Setting;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeNeRecords\Setting\PdoSettingRepository;
+use NeNeRecords\Setting\SettingRevisionAction;
+use PHPUnit\Framework\TestCase;
+
+final class PdoSettingRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $factory = new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene-records-test',
+            '',
+            'utf8',
+        ));
+
+        $this->executor = new PdoDatabaseQueryExecutor($factory);
+
+        foreach ($this->schemaStatements() as $statement) {
+            $this->executor->execute($statement);
+        }
+
+        $now = date('Y-m-d H:i:s');
+        $this->executor->execute(
+            'INSERT INTO setting_defs (setting_key, data_type, default_value, is_public, label, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?)',
+            ['site_name', 'text', 'NeNe Records', 1, 'Site name', $now, $now],
+        );
+    }
+
+    /** @return list<string> */
+    private function schemaStatements(): array
+    {
+        $path = dirname(__DIR__, 2) . '/database/schema/settings.sql';
+        self::assertFileExists($path);
+        $raw = trim((string) file_get_contents($path));
+        $statements = [];
+
+        foreach (preg_split('/;\R/s', $raw) ?: [] as $chunk) {
+            $statement = trim($chunk);
+            if ($statement !== '') {
+                $statements[] = $statement;
+            }
+        }
+
+        return $statements;
+    }
+
+    public function testApplyValueCreatesRevisionAndStoredValue(): void
+    {
+        $repository = new PdoSettingRepository($this->executor);
+        $stored = $repository->applyValue('site_name', 'Updated Site', null);
+
+        self::assertSame('Updated Site', $stored->value);
+
+        $revisions = $repository->findRevisionsByKey('site_name', 10, 0);
+        self::assertCount(1, $revisions);
+        self::assertSame(SettingRevisionAction::CREATED, $revisions[0]->action);
+    }
+}

--- a/tests/Setting/SettingHttpTest.php
+++ b/tests/Setting/SettingHttpTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Setting;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Setting\ListPublicSettingsHandler;
+use NeNeRecords\Setting\ListPublicSettingsUseCase;
+use NeNeRecords\Setting\ListSettingRevisionsHandler;
+use NeNeRecords\Setting\ListSettingRevisionsUseCase;
+use NeNeRecords\Setting\ListSettingsHandler;
+use NeNeRecords\Setting\ListSettingsUseCase;
+use NeNeRecords\Setting\SettingDef;
+use NeNeRecords\Setting\SettingKeyNotFoundExceptionHandler;
+use NeNeRecords\Setting\SettingRouteRegistrar;
+use NeNeRecords\Setting\SettingValueInvalidExceptionHandler;
+use NeNeRecords\Setting\UpdateSettingHandler;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class SettingHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemorySettingRepository $repository;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->repository = new InMemorySettingRepository([
+            new SettingDef(
+                settingKey: 'site_name',
+                dataType: 'text',
+                defaultValue: 'NeNe Records',
+                isPublic: true,
+                label: 'Site name',
+                id: 1,
+            ),
+            new SettingDef(
+                settingKey: 'tagline',
+                dataType: 'text',
+                defaultValue: 'Demo tagline',
+                isPublic: true,
+                label: 'Tagline',
+                id: 2,
+            ),
+        ]);
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+
+        $registrar = new SettingRouteRegistrar(
+            new ListSettingsHandler(new ListSettingsUseCase($this->repository), $jsonResponse),
+            new ListPublicSettingsHandler(new ListPublicSettingsUseCase($this->repository), $jsonResponse),
+            new UpdateSettingHandler(new InMemoryUpdateSettingUseCase($this->repository), $jsonResponse),
+            new ListSettingRevisionsHandler(new ListSettingRevisionsUseCase($this->repository), $jsonResponse),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [
+                new SettingKeyNotFoundExceptionHandler($problemDetails),
+                new SettingValueInvalidExceptionHandler($problemDetails),
+            ],
+            routeRegistrars: [$registrar],
+        ))->create();
+    }
+
+    public function testListSettingsReturnsDefinitionsWithDefaults(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/settings'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertCount(2, $payload['items']);
+        self::assertSame('site_name', $payload['items'][0]['setting_key']);
+        self::assertSame('NeNe Records', $payload['items'][0]['value']);
+    }
+
+    public function testListPublicSettingsReturnsPublicKeysOnly(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/public/settings'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertCount(2, $payload['items']);
+        self::assertSame(['site_name', 'tagline'], array_column($payload['items'], 'setting_key'));
+    }
+
+    public function testPutSettingUpdatesValueAndCreatesRevision(): void
+    {
+        $body = $this->factory->createStream(json_encode(['value' => 'My Site'], JSON_THROW_ON_ERROR));
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('PUT', 'https://example.test/api/v1/settings/site_name')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('My Site', $payload['value']);
+
+        $revisions = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/settings/site_name/revisions'),
+        );
+        $revisionPayload = $this->decodeJson($revisions);
+
+        self::assertSame('created', $revisionPayload['items'][0]['action']);
+        self::assertSame('My Site', $revisionPayload['items'][0]['value']);
+    }
+
+    public function testPutUnknownSettingReturns404(): void
+    {
+        $body = $this->factory->createStream(json_encode(['value' => 'x'], JSON_THROW_ON_ERROR));
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('PUT', 'https://example.test/api/v1/settings/missing_key')->withBody($body),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    /** @return array<string, mixed> */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/tools/generate-mcp-tools.php
+++ b/tools/generate-mcp-tools.php
@@ -624,6 +624,63 @@ $tools = [
         ['id'],
         'Permanently delete a tag.',
     ),
+    readTool(
+        'listSettings',
+        'List Settings',
+        'List all site settings with effective values for admin use.',
+        'listSettings',
+        'GET',
+        '/api/v1/settings',
+        [],
+        '#/components/schemas/SettingListResponse',
+    ),
+    readTool(
+        'listPublicSettings',
+        'List Public Settings',
+        'List public site settings for consumer pages.',
+        'listPublicSettings',
+        'GET',
+        '/api/v1/public/settings',
+        [],
+        '#/components/schemas/PublicSettingListResponse',
+    ),
+    readTool(
+        'updateSettingByKey',
+        'Update Setting',
+        'Update a site setting value by key.',
+        'updateSettingByKey',
+        'PUT',
+        '/api/v1/settings/{key}',
+        [
+            'key' => [
+                'type' => 'string',
+                'pattern' => '^[a-z][a-z0-9_]*$',
+                'description' => 'Setting key.',
+            ],
+            'value' => ['type' => 'string'],
+        ],
+        '#/components/schemas/SettingValueResponse',
+        ['key', 'value'],
+    ),
+    readTool(
+        'listSettingRevisions',
+        'List Setting Revisions',
+        'List paginated revision history for a setting key.',
+        'listSettingRevisions',
+        'GET',
+        '/api/v1/settings/{key}/revisions',
+        [
+            'key' => [
+                'type' => 'string',
+                'pattern' => '^[a-z][a-z0-9_]*$',
+                'description' => 'Setting key.',
+            ],
+            'limit' => ['type' => 'integer', 'minimum' => 1, 'maximum' => 100],
+            'offset' => ['type' => 'integer', 'minimum' => 0],
+        ],
+        '#/components/schemas/SettingRevisionListResponse',
+        ['key'],
+    ),
 ];
 
 /** @return list<array<string, mixed>> */


### PR DESCRIPTION
## Summary

- `setting_defs` / `setting_values` / `setting_revisions` の3テーブルで Site Settings を実装（key-value + 型定義 + 追記専用履歴）
- Admin API: `GET /api/v1/settings`, `PUT /api/v1/settings/{key}`, `GET /api/v1/settings/{key}/revisions`
- Public API: `GET /api/v1/public/settings`（`is_public=true` のみ）
- 更新時は `DatabaseTransactionManagerInterface::transactional()` で revision INSERT + value UPSERT を原子的に実行
- フロント: `/settings` 管理ページ、`PublicShell` への site name / tagline / meta / footer 反映、public record bootstrap に `publicSettings` を同梱

## Test plan

- [x] `composer check`（PHPUnit / PHPStan / CS / OpenAPI / MCP）
- [x] `npm run check --prefix frontend`
- [ ] ローカル migration 実行: `docker compose exec app vendor/bin/phinx migrate`
- [ ] Admin `/settings` で site_name 等を更新し、public `/view` ヘッダー・フッターに反映されること
- [ ] `GET /api/v1/settings/site_name/revisions` で履歴が追記されること

Closes #80


Made with [Cursor](https://cursor.com)