### PR TITLE
feat(entity): Publish status + published_at（draft/published/archived ワークフロー）(#84)

### DIFF
--- a/database/migrations/20260524000014_add_publish_status_to_entities.php
+++ b/database/migrations/20260524000014_add_publish_status_to_entities.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddPublishStatusToEntities extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('entities')
+            ->addColumn('status', 'string', [
+                'limit' => 16,
+                'null' => false,
+                'default' => 'draft',
+                'after' => 'entity_type_id',
+            ])
+            ->addColumn('published_at', 'datetime', [
+                'null' => true,
+                'default' => null,
+                'after' => 'status',
+            ])
+            ->addIndex(['status'])
+            ->save();
+    }
+}

--- a/database/schema/entities.sql
+++ b/database/schema/entities.sql
@@ -1,8 +1,11 @@
 CREATE TABLE entities (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     entity_type_id INTEGER UNSIGNED NOT NULL,
+    status VARCHAR(16) NOT NULL DEFAULT 'draft',
+    published_at DATETIME NULL,
     is_deleted BOOLEAN NOT NULL DEFAULT 0,
     deleted_at DATETIME NULL,
     FOREIGN KEY (entity_type_id) REFERENCES entity_types (id) ON DELETE RESTRICT ON UPDATE NO ACTION
 );
 CREATE INDEX entities_entity_type_id ON entities (entity_type_id);
+CREATE INDEX entities_status ON entities (status);

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -209,12 +209,18 @@ paths:
       tags:
         - Entities
       summary: List entities
-      description: Returns non-deleted entities, optionally filtered by entity type, tags, and relation fields.
+      description: Returns non-deleted entities, optionally filtered by entity type, status, tags, and relation fields.
       operationId: listEntities
       parameters:
         - $ref: '#/components/parameters/LimitQuery'
         - $ref: '#/components/parameters/OffsetQuery'
         - $ref: '#/components/parameters/EntityTypeIdQuery'
+        - name: status
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/EntityStatus'
+          description: Filter by publish status.
         - $ref: '#/components/parameters/TagsQuery'
         - $ref: '#/components/parameters/TagQuery'
         - $ref: '#/components/parameters/RelationFilterQuery'
@@ -264,6 +270,8 @@ paths:
                   value:
                     id: 1
                     entity_type_id: 1
+                    status: draft
+                    published_at: null
                     is_deleted: false
                     deleted_at: null
         '404':
@@ -292,6 +300,8 @@ paths:
                   value:
                     id: 1
                     entity_type_id: 1
+                    status: draft
+                    published_at: null
                     is_deleted: false
                     deleted_at: null
         '404':
@@ -327,6 +337,8 @@ paths:
                   value:
                     id: 1
                     entity_type_id: 2
+                    status: published
+                    published_at: '2026-05-24T10:00:00+00:00'
                     is_deleted: false
                     deleted_at: null
         '404':
@@ -2080,11 +2092,19 @@ components:
           type: integer
         offset:
           type: integer
+    EntityStatus:
+      type: string
+      enum:
+        - draft
+        - published
+        - archived
     EntityResponse:
       type: object
       required:
         - id
         - entity_type_id
+        - status
+        - published_at
         - is_deleted
         - deleted_at
       properties:
@@ -2094,6 +2114,13 @@ components:
         entity_type_id:
           type: integer
           format: int64
+        status:
+          $ref: '#/components/schemas/EntityStatus'
+        published_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
         is_deleted:
           type: boolean
         deleted_at:
@@ -2110,6 +2137,8 @@ components:
           type: integer
           format: int64
           minimum: 1
+        status:
+          $ref: '#/components/schemas/EntityStatus'
       additionalProperties: false
     UpdateEntityRequest:
       type: object
@@ -2120,6 +2149,13 @@ components:
           type: integer
           format: int64
           minimum: 1
+        status:
+          $ref: '#/components/schemas/EntityStatus'
+        published_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
       additionalProperties: false
     EntityListResponse:
       type: object

--- a/frontend/src/entities/entity/api-types.ts
+++ b/frontend/src/entities/entity/api-types.ts
@@ -1,6 +1,10 @@
+export type EntityStatusDto = 'draft' | 'published' | 'archived'
+
 export interface EntityDto {
   id: number
   entity_type_id: number
+  status: EntityStatusDto
+  published_at: string | null
   is_deleted: boolean
   deleted_at: string | null
 }
@@ -14,4 +18,11 @@ export interface EntityListDto {
 
 export interface CreateEntityDto {
   entity_type_id: number
+  status?: EntityStatusDto
+}
+
+export interface UpdateEntityDto {
+  entity_type_id: number
+  status: EntityStatusDto
+  published_at?: string | null
 }

--- a/frontend/src/entities/entity/index.ts
+++ b/frontend/src/entities/entity/index.ts
@@ -1,7 +1,13 @@
 export type { EntityId } from './ids'
 export { toEntityId } from './ids'
-export type { CreateEntityInput, Entity, EntityList } from './model'
+export type {
+  CreateEntityInput,
+  Entity,
+  EntityList,
+  EntityStatus,
+  UpdateEntityInput,
+} from './model'
 export { entityKeys } from './query-keys'
 export type { EntityListParams, EntityRelationFilters } from './query-keys'
-export { useCreateEntity, useDeleteEntity } from './mutations'
+export { useCreateEntity, useDeleteEntity, useUpdateEntity } from './mutations'
 export { defaultEntityListParams, useEntity, useEntityList } from './queries'

--- a/frontend/src/entities/entity/mapper.ts
+++ b/frontend/src/entities/entity/mapper.ts
@@ -1,11 +1,13 @@
-import type { CreateEntityDto, EntityDto, EntityListDto } from './api-types'
+import type { CreateEntityDto, EntityDto, EntityListDto, UpdateEntityDto } from './api-types'
 import { toEntityId } from './ids'
-import type { CreateEntityInput, Entity, EntityList } from './model'
+import type { CreateEntityInput, Entity, EntityList, UpdateEntityInput } from './model'
 
 export function mapEntityDtoToModel(dto: EntityDto): Entity {
   return {
     id: toEntityId(dto.id),
     entityTypeId: dto.entity_type_id,
+    status: dto.status,
+    publishedAt: dto.published_at,
     isDeleted: dto.is_deleted,
     deletedAt: dto.deleted_at,
   }
@@ -23,5 +25,14 @@ export function mapEntityListDtoToModel(dto: EntityListDto): EntityList {
 export function mapCreateInputToDto(input: CreateEntityInput): CreateEntityDto {
   return {
     entity_type_id: input.entityTypeId,
+    ...(input.status !== undefined ? { status: input.status } : {}),
+  }
+}
+
+export function mapUpdateInputToDto(input: UpdateEntityInput): UpdateEntityDto {
+  return {
+    entity_type_id: input.entityTypeId,
+    status: input.status,
+    ...(input.publishedAt !== undefined ? { published_at: input.publishedAt } : {}),
   }
 }

--- a/frontend/src/entities/entity/model.ts
+++ b/frontend/src/entities/entity/model.ts
@@ -1,8 +1,12 @@
 import type { EntityId } from './ids'
 
+export type EntityStatus = 'draft' | 'published' | 'archived'
+
 export interface Entity {
   id: EntityId
   entityTypeId: number
+  status: EntityStatus
+  publishedAt: string | null
   isDeleted: boolean
   deletedAt: string | null
 }
@@ -16,4 +20,12 @@ export interface EntityList {
 
 export interface CreateEntityInput {
   entityTypeId: number
+  status?: EntityStatus
+}
+
+export interface UpdateEntityInput {
+  id: number
+  entityTypeId: number
+  status: EntityStatus
+  publishedAt?: string | null
 }

--- a/frontend/src/entities/entity/mutations.ts
+++ b/frontend/src/entities/entity/mutations.ts
@@ -2,8 +2,8 @@ import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/r
 import { apiClient, AppError } from '@/shared/api/client'
 import type { EntityDto } from './api-types'
 import type { EntityId } from './ids'
-import { mapCreateInputToDto, mapEntityDtoToModel } from './mapper'
-import type { CreateEntityInput, Entity } from './model'
+import { mapCreateInputToDto, mapEntityDtoToModel, mapUpdateInputToDto } from './mapper'
+import type { CreateEntityInput, Entity, UpdateEntityInput } from './model'
 import { entityKeys } from './query-keys'
 
 export function useCreateEntity(): UseMutationResult<Entity, AppError, CreateEntityInput> {
@@ -27,6 +27,24 @@ export function useCreateEntity(): UseMutationResult<Entity, AppError, CreateEnt
           )
         },
       })
+    },
+  })
+}
+
+export function useUpdateEntity(): UseMutationResult<Entity, AppError, UpdateEntityInput> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input) => {
+      const dto = await apiClient.put<EntityDto>(
+        `/api/v1/entities/${String(input.id)}`,
+        mapUpdateInputToDto(input),
+      )
+      return mapEntityDtoToModel(dto)
+    },
+    onSuccess: async (data) => {
+      queryClient.setQueryData(entityKeys.detail(data.id), data)
+      await queryClient.invalidateQueries({ queryKey: entityKeys.lists() })
     },
   })
 }

--- a/frontend/src/entities/entity/queries.ts
+++ b/frontend/src/entities/entity/queries.ts
@@ -21,6 +21,9 @@ export function useEntityList(
         offset: String(params.offset),
         entity_type_id: String(params.entityTypeId),
       })
+      if (params.status !== undefined) {
+        search.set('status', params.status)
+      }
       if (params.tagSlugs !== undefined && params.tagSlugs.length > 0) {
         search.set('tags', params.tagSlugs.join(','))
       }

--- a/frontend/src/entities/entity/query-keys.ts
+++ b/frontend/src/entities/entity/query-keys.ts
@@ -1,4 +1,5 @@
 import type { EntityId } from './ids'
+import type { EntityStatus } from './model'
 
 export type EntityRelationFilters = Record<string, number>
 
@@ -6,6 +7,7 @@ export interface EntityListParams {
   entityTypeId: number
   limit: number
   offset: number
+  status?: EntityStatus
   tagSlugs?: string[]
   relationFilters?: EntityRelationFilters
 }

--- a/frontend/src/features/manage-entities/ui/EntityListPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityListPanel.tsx
@@ -1,6 +1,15 @@
 import { Link } from 'react-router-dom'
-import type { Entity } from '@/entities/entity'
+import type { Entity, EntityStatus } from '@/entities/entity'
 import { Button, EmptyState, Stack, Text } from '@/shared/ui'
+
+const STATUS_BADGE_CLASS: Record<EntityStatus, string> = {
+  draft:
+    'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-yellow-100 text-yellow-800',
+  published:
+    'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-green-100 text-green-800',
+  archived:
+    'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600',
+}
 
 export interface EntityListPanelProps {
   entityTypeId: number
@@ -64,9 +73,12 @@ export function EntityListPanel({
           className="flex items-center justify-between gap-inline-md rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm shadow-sm"
         >
           <Stack gap="xs">
-            <Text as="span" variant="heading-sm">
-              {recordLabels[String(item.id)] ?? `Record #${String(item.id)}`}
-            </Text>
+            <div className="flex items-center gap-inline-sm">
+              <Text as="span" variant="heading-sm">
+                {recordLabels[String(item.id)] ?? `Record #${String(item.id)}`}
+              </Text>
+              <span className={STATUS_BADGE_CLASS[item.status]}>{item.status}</span>
+            </div>
             <Text as="span" muted>
               #{String(item.id)}
             </Text>

--- a/frontend/src/features/manage-entity-status/index.ts
+++ b/frontend/src/features/manage-entity-status/index.ts
@@ -1,0 +1,1 @@
+export { EntityStatusPanel } from './ui/EntityStatusPanel'

--- a/frontend/src/features/manage-entity-status/ui/EntityStatusPanel.tsx
+++ b/frontend/src/features/manage-entity-status/ui/EntityStatusPanel.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react'
+import type { Entity, EntityStatus } from '@/entities/entity'
+import { useUpdateEntity } from '@/entities/entity'
+import { Button, Stack, Text } from '@/shared/ui'
+
+const STATUS_LABELS: Record<EntityStatus, string> = {
+  draft: 'Draft',
+  published: 'Published',
+  archived: 'Archived',
+}
+
+const STATUS_BADGE_CLASS: Record<EntityStatus, string> = {
+  draft:
+    'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-yellow-100 text-yellow-800',
+  published:
+    'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-green-100 text-green-800',
+  archived:
+    'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-gray-100 text-gray-600',
+}
+
+const NEXT_STATUSES: Record<EntityStatus, EntityStatus[]> = {
+  draft: ['published', 'archived'],
+  published: ['draft', 'archived'],
+  archived: ['draft', 'published'],
+}
+
+interface EntityStatusPanelProps {
+  entity: Entity
+}
+
+export function EntityStatusPanel({ entity }: EntityStatusPanelProps) {
+  const updateMutation = useUpdateEntity()
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const changeStatus = async (nextStatus: EntityStatus) => {
+    setErrorMessage(null)
+    try {
+      await updateMutation.mutateAsync({
+        id: Number(entity.id),
+        entityTypeId: entity.entityTypeId,
+        status: nextStatus,
+      })
+    } catch {
+      setErrorMessage('Failed to update status.')
+    }
+  }
+
+  const currentStatus = entity.status
+
+  return (
+    <Stack gap="sm">
+      <Text as="h2" variant="heading-sm">
+        Publish status
+      </Text>
+      <div className="flex flex-wrap items-center gap-inline-md">
+        <span className={STATUS_BADGE_CLASS[currentStatus]}>{STATUS_LABELS[currentStatus]}</span>
+        {entity.publishedAt !== null && (
+          <Text as="span" muted>
+            Published {new Date(entity.publishedAt).toLocaleDateString('ja-JP')}
+          </Text>
+        )}
+      </div>
+      <div className="flex flex-wrap gap-inline-sm">
+        {NEXT_STATUSES[currentStatus].map((nextStatus) => (
+          <Button
+            key={nextStatus}
+            variant="secondary"
+            size="sm"
+            disabled={updateMutation.isPending}
+            onClick={() => {
+              void changeStatus(nextStatus)
+            }}
+          >
+            {nextStatus === 'published' ? 'Publish' : STATUS_LABELS[nextStatus]}
+          </Button>
+        ))}
+      </div>
+      {errorMessage !== null && <Text muted>{errorMessage}</Text>}
+    </Stack>
+  )
+}

--- a/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.ts
+++ b/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.ts
@@ -20,7 +20,10 @@ export function usePublicBrowseEntityRecordsPage(entityTypeSlug: string, offset:
 
   const entityTypeId = entityType !== undefined ? Number(entityType.id) : 0
   const listParams = useMemo(
-    () => defaultEntityListParams(entityTypeId, [], {}, offset),
+    () => ({
+      ...defaultEntityListParams(entityTypeId, [], {}, offset),
+      status: 'published' as const,
+    }),
     [entityTypeId, offset],
   )
   const entityListQuery = useEntityList(listParams, { enabled: entityTypeId > 0 })

--- a/frontend/src/pages/consumer/PublicBrowsePage.test.tsx
+++ b/frontend/src/pages/consumer/PublicBrowsePage.test.tsx
@@ -46,12 +46,14 @@ describe('PublicBrowsePage', () => {
       {
         id: 1,
         entity_type_id: 1,
+        status: 'published',
         is_deleted: false,
         deleted_at: null,
       },
       {
         id: 2,
         entity_type_id: 1,
+        status: 'published',
         is_deleted: false,
         deleted_at: null,
       },
@@ -97,6 +99,7 @@ describe('PublicBrowsePage', () => {
       {
         id: 1,
         entity_type_id: 1,
+        status: 'published',
         is_deleted: false,
         deleted_at: null,
       },
@@ -126,6 +129,7 @@ describe('PublicBrowsePage', () => {
       Array.from({ length: 21 }, (_, index) => ({
         id: index + 1,
         entity_type_id: 1,
+        status: 'published' as const,
         is_deleted: false,
         deleted_at: null,
       })),

--- a/frontend/src/pages/entity-record/EntityRecordPage.tsx
+++ b/frontend/src/pages/entity-record/EntityRecordPage.tsx
@@ -4,6 +4,7 @@ import {
   EditEntityTextFieldsView,
   useEditEntityTextFieldsPage,
 } from '@/features/edit-entity-text-fields'
+import { EntityStatusPanel } from '@/features/manage-entity-status'
 import { ManageEntityTagsView, useManageEntityTagsPage } from '@/features/manage-entity-tags'
 import { ManageEntityRelationsView } from '@/features/manage-entity-relations'
 import { InverseEntityRelationsView } from '@/features/inverse-entity-relations'
@@ -56,6 +57,7 @@ export function EntityRecordPage() {
           {entityTypeQuery.data?.name ?? 'Record'}
         </Text>
       </Stack>
+      {entity !== null && <EntityStatusPanel entity={entity} />}
       <EditEntityTextFieldsView
         entity={entity}
         textFieldDefs={textFieldDefs}

--- a/frontend/tests/msw/handlers/entity.ts
+++ b/frontend/tests/msw/handlers/entity.ts
@@ -3,9 +3,13 @@ import { getEntityRelationLinks } from './entity-relation'
 import { getEntityTagLinks } from './entity-tag'
 import { getTagBySlug } from './tag'
 
+export type EntityStatusDto = 'draft' | 'published' | 'archived'
+
 interface EntityRecord {
   id: number
   entity_type_id: number
+  status: EntityStatusDto
+  published_at: string | null
   is_deleted: boolean
   deleted_at: string | null
 }
@@ -18,8 +22,21 @@ export function resetEntityStore(): void {
   items = []
 }
 
-export function seedEntities(seed: EntityRecord[]): void {
-  items = [...seed]
+export function seedEntities(
+  seed: Array<{
+    id: number
+    entity_type_id: number
+    status?: EntityStatusDto
+    published_at?: string | null
+    is_deleted: boolean
+    deleted_at: string | null
+  }>,
+): void {
+  items = seed.map((item) => ({
+    ...item,
+    status: item.status ?? 'draft',
+    published_at: item.published_at ?? null,
+  }))
   nextId = Math.max(0, ...seed.map((item) => item.id)) + 1
 }
 
@@ -105,6 +122,7 @@ export const entityHandlers = [
     const offset = Number(url.searchParams.get('offset') ?? '0')
     const entityTypeIdParam = url.searchParams.get('entity_type_id')
     const entityTypeId = entityTypeIdParam === null ? null : Number(entityTypeIdParam)
+    const statusParam = url.searchParams.get('status')
     const tagsParam = url.searchParams.get('tags')
     const tagSlugs =
       tagsParam === null
@@ -117,6 +135,10 @@ export const entityHandlers = [
     const active = items.filter((item) => !item.is_deleted)
     let filtered =
       entityTypeId === null ? active : active.filter((item) => item.entity_type_id === entityTypeId)
+
+    if (statusParam !== null) {
+      filtered = filtered.filter((item) => item.status === statusParam)
+    }
 
     if (tagSlugs.length > 0) {
       const matchingEntityIds = getEntityIdsMatchingTagSlugs(tagSlugs)
@@ -155,7 +177,7 @@ export const entityHandlers = [
     return HttpResponse.json(item)
   }),
   http.post('/api/v1/entities', async ({ request }) => {
-    const body = (await request.json()) as { entity_type_id?: number }
+    const body = (await request.json()) as { entity_type_id?: number; status?: EntityStatusDto }
 
     if (typeof body.entity_type_id !== 'number' || body.entity_type_id < 1) {
       return HttpResponse.json(
@@ -173,12 +195,57 @@ export const entityHandlers = [
     const created: EntityRecord = {
       id: nextId++,
       entity_type_id: body.entity_type_id,
+      status: body.status ?? 'draft',
+      published_at: null,
       is_deleted: false,
       deleted_at: null,
     }
     items = [...items, created]
 
     return HttpResponse.json(created, { status: 201 })
+  }),
+  http.put('/api/v1/entities/:id', async ({ params, request }) => {
+    const id = Number(params.id)
+    const body = (await request.json()) as {
+      entity_type_id?: number
+      status?: EntityStatusDto
+      published_at?: string | null
+    }
+    const index = items.findIndex((item) => item.id === id && !item.is_deleted)
+
+    if (index === -1) {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/not-found',
+          title: 'Not found',
+          status: 404,
+          instance: `/api/v1/entities/${String(id)}`,
+        },
+        { status: 404 },
+      )
+    }
+
+    const existing = items[index]
+    if (existing === undefined) {
+      return new HttpResponse(null, { status: 500 })
+    }
+    const newStatus = body.status ?? existing.status
+    const newPublishedAt =
+      body.published_at !== undefined
+        ? body.published_at
+        : newStatus === 'published' && existing.published_at === null
+          ? new Date().toISOString()
+          : existing.published_at
+
+    const updated: EntityRecord = {
+      ...existing,
+      entity_type_id: body.entity_type_id ?? existing.entity_type_id,
+      status: newStatus,
+      published_at: newPublishedAt,
+    }
+    items = items.map((item, i) => (i === index ? updated : item))
+
+    return HttpResponse.json(updated)
   }),
   http.delete('/api/v1/entities/:id', ({ params }) => {
     const id = Number(params.id)

--- a/src/Entity/CreateEntityHandler.php
+++ b/src/Entity/CreateEntityHandler.php
@@ -34,17 +34,25 @@ final readonly class CreateEntityHandler
             $errors[] = new ValidationError('entity_type_id', 'Entity type id is required and must be a positive integer.', 'required');
         }
 
+        $rawStatus = $body['status'] ?? null;
+        $status = is_string($rawStatus) && EntityStatus::isValid($rawStatus) ? $rawStatus : EntityStatus::DRAFT;
+
         if ($errors !== []) {
             throw new ValidationException($errors);
         }
 
         /** @var int $entityTypeId */
-        $output = $this->useCase->execute(new CreateEntityInput(entityTypeId: $entityTypeId));
+        $output = $this->useCase->execute(new CreateEntityInput(
+            entityTypeId: $entityTypeId,
+            status: $status,
+        ));
 
         return $this->response->create(
             [
                 'id' => $output->id,
                 'entity_type_id' => $output->entityTypeId,
+                'status' => $output->status,
+                'published_at' => $output->publishedAtIso,
                 'is_deleted' => $output->isDeleted,
                 'deleted_at' => $output->deletedAtIso,
             ],

--- a/src/Entity/CreateEntityInput.php
+++ b/src/Entity/CreateEntityInput.php
@@ -8,6 +8,7 @@ final readonly class CreateEntityInput
 {
     public function __construct(
         public int $entityTypeId,
+        public string $status = EntityStatus::DRAFT,
     ) {
     }
 }

--- a/src/Entity/CreateEntityOutput.php
+++ b/src/Entity/CreateEntityOutput.php
@@ -9,6 +9,8 @@ final readonly class CreateEntityOutput
     public function __construct(
         public int $id,
         public int $entityTypeId,
+        public string $status,
+        public ?string $publishedAtIso,
         public bool $isDeleted,
         public ?string $deletedAtIso,
     ) {

--- a/src/Entity/CreateEntityUseCase.php
+++ b/src/Entity/CreateEntityUseCase.php
@@ -21,11 +21,17 @@ final readonly class CreateEntityUseCase implements CreateEntityUseCaseInterface
             throw new EntityTypeNotFoundException($input->entityTypeId);
         }
 
-        $id = $this->entities->save(new Entity(id: null, entityTypeId: $input->entityTypeId));
+        $id = $this->entities->save(new Entity(
+            id: null,
+            entityTypeId: $input->entityTypeId,
+            status: $input->status,
+        ));
 
         return new CreateEntityOutput(
             id: $id,
             entityTypeId: $input->entityTypeId,
+            status: $input->status,
+            publishedAtIso: null,
             isDeleted: false,
             deletedAtIso: null,
         );

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -11,6 +11,8 @@ final readonly class Entity
     public function __construct(
         public ?int $id,
         public int $entityTypeId,
+        public string $status = EntityStatus::DRAFT,
+        public ?DateTimeImmutable $publishedAt = null,
         public bool $isDeleted = false,
         public ?DateTimeImmutable $deletedAt = null,
     ) {

--- a/src/Entity/EntityListCriteria.php
+++ b/src/Entity/EntityListCriteria.php
@@ -14,6 +14,7 @@ final readonly class EntityListCriteria
         public ?int $entityTypeId = null,
         public array $tagSlugs = [],
         public array $relationFilters = [],
+        public ?string $status = null,
     ) {
     }
 }

--- a/src/Entity/EntityStatus.php
+++ b/src/Entity/EntityStatus.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+final class EntityStatus
+{
+    public const DRAFT = 'draft';
+    public const PUBLISHED = 'published';
+    public const ARCHIVED = 'archived';
+
+    /** @return list<string> */
+    public static function values(): array
+    {
+        return [self::DRAFT, self::PUBLISHED, self::ARCHIVED];
+    }
+
+    public static function isValid(string $status): bool
+    {
+        return in_array($status, self::values(), true);
+    }
+}

--- a/src/Entity/GetEntityByIdHandler.php
+++ b/src/Entity/GetEntityByIdHandler.php
@@ -31,6 +31,8 @@ final readonly class GetEntityByIdHandler
         return $this->response->create([
             'id' => $output->id,
             'entity_type_id' => $output->entityTypeId,
+            'status' => $output->status,
+            'published_at' => $output->publishedAtIso,
             'is_deleted' => $output->isDeleted,
             'deleted_at' => $output->deletedAtIso,
         ]);

--- a/src/Entity/GetEntityByIdOutput.php
+++ b/src/Entity/GetEntityByIdOutput.php
@@ -9,6 +9,8 @@ final readonly class GetEntityByIdOutput
     public function __construct(
         public int $id,
         public int $entityTypeId,
+        public string $status,
+        public ?string $publishedAtIso,
         public bool $isDeleted,
         public ?string $deletedAtIso,
     ) {

--- a/src/Entity/GetEntityByIdUseCase.php
+++ b/src/Entity/GetEntityByIdUseCase.php
@@ -31,6 +31,8 @@ final readonly class GetEntityByIdUseCase implements GetEntityByIdUseCaseInterfa
         return new GetEntityByIdOutput(
             id: $entityId,
             entityTypeId: $entity->entityTypeId,
+            status: $entity->status,
+            publishedAtIso: $entity->publishedAt?->format(DateTimeInterface::ATOM),
             isDeleted: $entity->isDeleted,
             deletedAtIso: $entity->deletedAt?->format(DateTimeInterface::ATOM),
         );

--- a/src/Entity/ListEntitiesHandler.php
+++ b/src/Entity/ListEntitiesHandler.php
@@ -30,6 +30,9 @@ final readonly class ListEntitiesHandler
         $entityTypeId = QueryStringParser::int($request, 'entity_type_id');
         $relationFilters = EntityRelationQueryParser::parseRelationFilters($request->getQueryParams());
 
+        $rawStatus = $request->getQueryParams()['status'] ?? null;
+        $status = is_string($rawStatus) && EntityStatus::isValid($rawStatus) ? $rawStatus : null;
+
         $output = $this->useCase->execute(new ListEntitiesInput(
             limit: $pagination->limit,
             offset: $pagination->offset,
@@ -37,6 +40,7 @@ final readonly class ListEntitiesHandler
                 entityTypeId: $entityTypeId,
                 tagSlugs: $tagSlugs,
                 relationFilters: $relationFilters,
+                status: $status,
             ),
         ));
 
@@ -46,6 +50,8 @@ final readonly class ListEntitiesHandler
                     static fn (ListEntityItem $item) => [
                         'id' => $item->id,
                         'entity_type_id' => $item->entityTypeId,
+                        'status' => $item->status,
+                        'published_at' => $item->publishedAtIso,
                         'is_deleted' => $item->isDeleted,
                         'deleted_at' => $item->deletedAtIso,
                     ],

--- a/src/Entity/ListEntitiesUseCase.php
+++ b/src/Entity/ListEntitiesUseCase.php
@@ -29,6 +29,8 @@ final readonly class ListEntitiesUseCase implements ListEntitiesUseCaseInterface
             return new ListEntityItem(
                 id: $entityId,
                 entityTypeId: $entity->entityTypeId,
+                status: $entity->status,
+                publishedAtIso: $entity->publishedAt?->format(DateTimeInterface::ATOM),
                 isDeleted: $entity->isDeleted,
                 deletedAtIso: $entity->deletedAt?->format(DateTimeInterface::ATOM),
             );

--- a/src/Entity/ListEntityItem.php
+++ b/src/Entity/ListEntityItem.php
@@ -9,6 +9,8 @@ final readonly class ListEntityItem
     public function __construct(
         public int $id,
         public int $entityTypeId,
+        public string $status,
+        public ?string $publishedAtIso,
         public bool $isDeleted,
         public ?string $deletedAtIso,
     ) {

--- a/src/Entity/PdoEntityRepository.php
+++ b/src/Entity/PdoEntityRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Entity;
 
 use DateTimeImmutable;
+use DateTimeInterface;
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 
@@ -19,7 +20,7 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
     {
         $row = $this->query->fetchOne(
             <<<'SQL'
-                SELECT id, entity_type_id, is_deleted, deleted_at
+                SELECT id, entity_type_id, status, published_at, is_deleted, deleted_at
                 FROM entities
                 WHERE id = ? AND is_deleted = 0
                 SQL,
@@ -48,7 +49,7 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
 
         $rows = $this->query->fetchAll(
             <<<SQL
-                SELECT e.id, e.entity_type_id, e.is_deleted, e.deleted_at
+                SELECT e.id, e.entity_type_id, e.status, e.published_at, e.is_deleted, e.deleted_at
                 FROM entities e
                 WHERE {$where}
                 ORDER BY e.id ASC
@@ -89,6 +90,11 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
             $params[] = $criteria->entityTypeId;
         }
 
+        if ($criteria->status !== null) {
+            $conditions[] = 'e.status = ?';
+            $params[] = $criteria->status;
+        }
+
         if ($criteria->tagSlugs !== []) {
             $placeholders = implode(', ', array_fill(0, count($criteria->tagSlugs), '?'));
             $conditions[] = <<<SQL
@@ -123,9 +129,11 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
 
     public function save(Entity $entity): int
     {
+        $publishedAt = $entity->publishedAt?->format(DateTimeInterface::ATOM);
+
         $this->query->execute(
-            'INSERT INTO entities (entity_type_id) VALUES (?)',
-            [$entity->entityTypeId],
+            'INSERT INTO entities (entity_type_id, status, published_at) VALUES (?, ?, ?)',
+            [$entity->entityTypeId, $entity->status, $publishedAt],
         );
 
         return $this->query->lastInsertId();
@@ -139,13 +147,15 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
             throw new LogicException('Entity id must be set before update.');
         }
 
+        $publishedAt = $entity->publishedAt?->format(DateTimeInterface::ATOM);
+
         $this->query->execute(
             <<<'SQL'
                 UPDATE entities
-                SET entity_type_id = ?
+                SET entity_type_id = ?, status = ?, published_at = ?
                 WHERE id = ? AND is_deleted = 0
                 SQL,
-            [$entity->entityTypeId, $id],
+            [$entity->entityTypeId, $entity->status, $publishedAt, $id],
         );
     }
 
@@ -167,9 +177,14 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
         $deletedRaw = $row['deleted_at'] ?? null;
         $deletedAt = ($deletedRaw !== null && $deletedRaw !== '') ? new DateTimeImmutable((string) $deletedRaw) : null;
 
+        $publishedRaw = $row['published_at'] ?? null;
+        $publishedAt = ($publishedRaw !== null && $publishedRaw !== '') ? new DateTimeImmutable((string) $publishedRaw) : null;
+
         return new Entity(
             id: (int) $row['id'],
             entityTypeId: (int) $row['entity_type_id'],
+            status: (string) ($row['status'] ?? EntityStatus::DRAFT),
+            publishedAt: $publishedAt,
             isDeleted: (bool) (int) $row['is_deleted'],
             deletedAt: $deletedAt,
         );

--- a/src/Entity/UpdateEntityHandler.php
+++ b/src/Entity/UpdateEntityHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Entity;
 
+use DateTimeImmutable;
 use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
@@ -42,16 +43,29 @@ final readonly class UpdateEntityHandler
             $errors[] = new ValidationError('entity_type_id', 'Entity type id is required and must be a positive integer.', 'required');
         }
 
+        $rawStatus = $body['status'] ?? null;
+        $status = is_string($rawStatus) && EntityStatus::isValid($rawStatus) ? $rawStatus : EntityStatus::DRAFT;
+
+        $rawPublishedAt = $body['published_at'] ?? null;
+        $publishedAt = is_string($rawPublishedAt) ? (DateTimeImmutable::createFromFormat(DATE_ATOM, $rawPublishedAt) ?: null) : null;
+
         if ($errors !== []) {
             throw new ValidationException($errors);
         }
 
         /** @var int $entityTypeId */
-        $output = $this->useCase->execute(new UpdateEntityInput(id: $id, entityTypeId: $entityTypeId));
+        $output = $this->useCase->execute(new UpdateEntityInput(
+            id: $id,
+            entityTypeId: $entityTypeId,
+            status: $status,
+            publishedAt: $publishedAt,
+        ));
 
         return $this->response->create([
             'id' => $output->id,
             'entity_type_id' => $output->entityTypeId,
+            'status' => $output->status,
+            'published_at' => $output->publishedAtIso,
             'is_deleted' => $output->isDeleted,
             'deleted_at' => $output->deletedAtIso,
         ]);

--- a/src/Entity/UpdateEntityInput.php
+++ b/src/Entity/UpdateEntityInput.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Entity;
 
+use DateTimeImmutable;
+
 final readonly class UpdateEntityInput
 {
     public function __construct(
         public int $id,
         public int $entityTypeId,
+        public string $status = EntityStatus::DRAFT,
+        public ?DateTimeImmutable $publishedAt = null,
     ) {
     }
 }

--- a/src/Entity/UpdateEntityOutput.php
+++ b/src/Entity/UpdateEntityOutput.php
@@ -9,6 +9,8 @@ final readonly class UpdateEntityOutput
     public function __construct(
         public int $id,
         public int $entityTypeId,
+        public string $status,
+        public ?string $publishedAtIso,
         public bool $isDeleted,
         public ?string $deletedAtIso,
     ) {

--- a/src/Entity/UpdateEntityUseCase.php
+++ b/src/Entity/UpdateEntityUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Entity;
 
+use DateTimeImmutable;
 use DateTimeInterface;
 use LogicException;
 use NeNeRecords\EntityType\EntityTypeNotFoundException;
@@ -35,9 +36,17 @@ final readonly class UpdateEntityUseCase implements UpdateEntityUseCaseInterface
             throw new EntityTypeNotFoundException($input->entityTypeId);
         }
 
+        // Auto-set published_at when transitioning to published for the first time.
+        $publishedAt = $input->publishedAt ?? $existing->publishedAt;
+        if ($input->status === EntityStatus::PUBLISHED && $publishedAt === null) {
+            $publishedAt = new DateTimeImmutable();
+        }
+
         $updated = new Entity(
             id: $entityId,
             entityTypeId: $input->entityTypeId,
+            status: $input->status,
+            publishedAt: $publishedAt,
             isDeleted: $existing->isDeleted,
             deletedAt: $existing->deletedAt,
         );
@@ -47,6 +56,8 @@ final readonly class UpdateEntityUseCase implements UpdateEntityUseCaseInterface
         return new UpdateEntityOutput(
             id: $entityId,
             entityTypeId: $input->entityTypeId,
+            status: $input->status,
+            publishedAtIso: $publishedAt?->format(DateTimeInterface::ATOM),
             isDeleted: $existing->isDeleted,
             deletedAtIso: $existing->deletedAt?->format(DateTimeInterface::ATOM),
         );

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -9,6 +9,7 @@ use NeNeRecords\BoolField\BoolFieldRepositoryInterface;
 use NeNeRecords\DateTimeField\DateTimeField;
 use NeNeRecords\DateTimeField\DateTimeFieldRepositoryInterface;
 use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\Entity\EntityStatus;
 use NeNeRecords\EntityRelation\EntityRelationRepositoryInterface;
 use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
 use NeNeRecords\EnumField\EnumField;
@@ -58,6 +59,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             || $entity->id === null
             || $entity->isDeleted
             || $entity->entityTypeId !== $entityType->id
+            || $entity->status !== EntityStatus::PUBLISHED
         ) {
             throw new PublicRecordNotFoundException($input->entityTypeSlug, $input->entityId);
         }

--- a/tests/Entity/InMemoryEntityRepository.php
+++ b/tests/Entity/InMemoryEntityRepository.php
@@ -81,6 +81,10 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
                 continue;
             }
 
+            if ($criteria->status !== null && $entity->status !== $criteria->status) {
+                continue;
+            }
+
             if ($criteria->tagSlugs !== []) {
                 $entityId = $entity->id ?? 0;
                 $entityTagSlugs = $this->tagSlugsByEntityId[$entityId] ?? [];
@@ -130,6 +134,8 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
         $this->entities[$id] = new Entity(
             id: $id,
             entityTypeId: $entity->entityTypeId,
+            status: $entity->status,
+            publishedAt: $entity->publishedAt,
         );
 
         return $id;
@@ -157,6 +163,7 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
         $this->entities[$id] = new Entity(
             id: $id,
             entityTypeId: $entity->entityTypeId,
+            status: $entity->status,
             isDeleted: true,
             deletedAt: new DateTimeImmutable('@1700000000'),
         );

--- a/tests/PublicRecord/GetPublicRecordViewUseCaseTest.php
+++ b/tests/PublicRecord/GetPublicRecordViewUseCaseTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Tests\PublicRecord;
 
 use NeNeRecords\Entity\Entity;
+use NeNeRecords\Entity\EntityStatus;
 use NeNeRecords\EntityType\EntityType;
 use NeNeRecords\FieldDef\FieldDef;
 use NeNeRecords\PublicRecord\GetPublicRecordViewInput;
@@ -33,7 +34,7 @@ final class GetPublicRecordViewUseCaseTest extends TestCase
             new EntityType(name: 'Article', slug: 'article', id: 1),
         ]);
         $entities = new InMemoryEntityRepository([
-            new Entity(id: 10, entityTypeId: 1),
+            new Entity(id: 10, entityTypeId: 1, status: EntityStatus::PUBLISHED),
         ]);
         $fieldDefs = new InMemoryFieldDefRepository([
             new FieldDef(entityTypeId: 1, fieldKey: 'title', dataType: 'text', id: 1),

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -13,6 +13,7 @@ use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\View\HtmlResponseFactory;
 use Nene2\View\NativePhpViewRenderer;
 use NeNeRecords\Entity\Entity;
+use NeNeRecords\Entity\EntityStatus;
 use NeNeRecords\EntityType\EntityType;
 use NeNeRecords\FieldDef\FieldDef;
 use NeNeRecords\PublicRecord\GetPublicRecordViewHandler;
@@ -55,7 +56,7 @@ final class PublicRecordHttpTest extends TestCase
             new EntityType(name: 'Article', slug: 'article', id: 1),
         ]);
         $entities = new InMemoryEntityRepository([
-            new Entity(id: 10, entityTypeId: 1),
+            new Entity(id: 10, entityTypeId: 1, status: EntityStatus::PUBLISHED),
         ]);
         $fieldDefs = new InMemoryFieldDefRepository([
             new FieldDef(entityTypeId: 1, fieldKey: 'title', dataType: 'text', id: 1),

--- a/tools/generate-mcp-tools.php
+++ b/tools/generate-mcp-tools.php
@@ -202,7 +202,7 @@ $tools = [
     readTool(
         'listEntities',
         'List Entities',
-        'List entity records with optional entity_type_id, tag, and relation filters.',
+        'List entity records with optional entity_type_id, status, tag, and relation filters.',
         'listEntities',
         'GET',
         '/api/v1/entities',
@@ -212,6 +212,11 @@ $tools = [
                 'type' => 'integer',
                 'minimum' => 1,
                 'description' => 'Filter by entity type id.',
+            ],
+            'status' => [
+                'type' => 'string',
+                'enum' => ['draft', 'published', 'archived'],
+                'description' => 'Filter by publish status.',
             ],
             'tags' => [
                 'type' => 'string',
@@ -280,6 +285,11 @@ $tools = [
                 'type' => 'integer',
                 'minimum' => 1,
             ],
+            'status' => [
+                'type' => 'string',
+                'enum' => ['draft', 'published', 'archived'],
+                'description' => 'Initial publish status (default: draft).',
+            ],
         ],
         null,
         ['entity_type_id'],
@@ -329,10 +339,20 @@ $tools = [
                 'type' => 'integer',
                 'minimum' => 1,
             ],
+            'status' => [
+                'type' => 'string',
+                'enum' => ['draft', 'published', 'archived'],
+                'description' => 'Publish status.',
+            ],
+            'published_at' => [
+                'type' => 'string',
+                'format' => 'date-time',
+                'description' => 'Override published_at timestamp (ISO 8601). Auto-set on first publish if omitted.',
+            ],
         ],
         '#/components/schemas/EntityResponse',
         ['id', 'entity_type_id'],
-        'Update an entity record entity type id.',
+        'Update an entity record entity type id and publish status.',
     ),
     idTool(
         'deleteEntityById',

--- a/tools/seed-blog-demo.php
+++ b/tools/seed-blog-demo.php
@@ -23,6 +23,11 @@ $postCount = 50;
  * @param array<string, mixed>|null $body
  * @return array<string, mixed>
  */
+/**
+ * @param non-empty-string $method
+ * @param array<string, mixed>|null $body
+ * @return array<string, mixed>
+ */
 function api(string $method, string $path, ?array $body = null): array
 {
     global $baseUrl;


### PR DESCRIPTION
## Summary
- `entities` テーブルに `status`（draft/published/archived）と `published_at` を追加し、CMS の基本公開ワークフローを実装
- Public consumer view（`/view/{type}/{id}` および一覧）は `status=published` のエンティティのみ表示
- Admin UI に status バッジ（一覧）とステータス変更パネル（詳細ページ）を追加

## Changes
- Migration: `20260524000014_add_publish_status_to_entities.php`
- `EntityStatus` 定数クラス（draft / published / archived）
- `Entity` ドメイン・リポジトリ・ユースケース・ハンドラ全体に status/published_at を追加
- `UpdateEntityUseCase`: published への変更時に `published_at` を自動セット
- `GetPublicRecordViewUseCase`: 非公開レコードは 404
- 公開一覧 hook: `status=published` フィルタを追加
- Frontend: API types/model/mapper/queries/mutations 更新、`EntityStatusPanel` 追加、EntityListPanel にバッジ追加
- OpenAPI / MCP tools 更新
- PHPStan: `seed-blog-demo.php` の既存エラー（`non-empty-string` と iterable 型注釈欠如）を合わせて修正

## Test plan
- [x] `composer check` 通過（PHPUnit 168, PHPStan, CS Fixer, OpenAPI, MCP）
- [x] `npm run check` 通過（TypeScript, ESLint, Prettier, Vitest 71, Storybook build）
- [x] Migration 適用済み（local DB）

Closes #84

Made with [Cursor](https://cursor.com)