### PR TITLE
feat(auth): ユーザー認証・Admin ログイン・API Bearer auth (#86)

### DIFF
--- a/database/migrations/20260524000015_create_users_table.php
+++ b/database/migrations/20260524000015_create_users_table.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateUsersTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('users')
+            ->addColumn('email', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('password_hash', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('role', 'string', ['limit' => 32, 'null' => false, 'default' => 'admin'])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['email'], ['unique' => true])
+            ->create();
+    }
+}

--- a/database/schema/users.sql
+++ b/database/schema/users.sql
@@ -1,0 +1,9 @@
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email VARCHAR(255) NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    role VARCHAR(32) NOT NULL DEFAULT 'admin',
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+);
+CREATE UNIQUE INDEX users_email ON users (email);

--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -175,7 +175,7 @@
         {
             "name": "listEntities",
             "title": "List Entities",
-            "description": "List entity records with optional entity_type_id, tag, and relation filters.",
+            "description": "List entity records with optional entity_type_id, status, tag, and relation filters.",
             "safety": "read",
             "source": {
                 "type": "openapi",
@@ -201,6 +201,15 @@
                         "type": "integer",
                         "minimum": 1,
                         "description": "Filter by entity type id."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "draft",
+                            "published",
+                            "archived"
+                        ],
+                        "description": "Filter by publish status."
                     },
                     "tags": {
                         "type": "string",
@@ -310,6 +319,15 @@
                     "entity_type_id": {
                         "type": "integer",
                         "minimum": 1
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "draft",
+                            "published",
+                            "archived"
+                        ],
+                        "description": "Initial publish status (default: draft)."
                     }
                 },
                 "required": [
@@ -382,7 +400,7 @@
         {
             "name": "updateEntityById",
             "title": "Update Entity",
-            "description": "Update an entity record entity type id.",
+            "description": "Update an entity record entity type id and publish status.",
             "safety": "write",
             "source": {
                 "type": "openapi",
@@ -401,6 +419,20 @@
                     "entity_type_id": {
                         "type": "integer",
                         "minimum": 1
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "draft",
+                            "published",
+                            "archived"
+                        ],
+                        "description": "Publish status."
+                    },
+                    "published_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Override published_at timestamp (ISO 8601). Auto-set on first publish if omitted."
                     }
                 },
                 "required": [
@@ -1918,6 +1950,38 @@
                 "additionalProperties": false
             },
             "responseSchemaRef": null
+        },
+        {
+            "name": "login",
+            "title": "Login",
+            "description": "Authenticate with email/password and obtain an API bearer token.",
+            "safety": "write",
+            "source": {
+                "type": "openapi",
+                "operationId": "login",
+                "method": "POST",
+                "path": "/api/v1/auth/login"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "email": {
+                        "type": "string",
+                        "format": "email",
+                        "minLength": 1
+                    },
+                    "password": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                },
+                "required": [
+                    "email",
+                    "password"
+                ],
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/LoginResponse"
         }
     ]
 }

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -8,6 +8,8 @@ servers:
   - url: http://localhost:8080
     description: Local development server
 tags:
+  - name: Auth
+    description: Authentication endpoints.
   - name: System
     description: Runtime health endpoints.
   - name: EntityTypes
@@ -39,6 +41,36 @@ tags:
   - name: Settings
     description: Site-wide settings registry with revision history.
 paths:
+  /api/v1/auth/login:
+    post:
+      tags:
+        - Auth
+      summary: Admin login
+      description: Authenticates with email/password and returns a bearer token.
+      operationId: login
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+            example:
+              email: admin@example.com
+              password: secret
+      responses:
+        '200':
+          description: Token issued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+              example:
+                token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+                expires_at: '2026-05-25T00:00:00Z'
+                email: admin@example.com
+                role: admin
+        '401':
+          $ref: '#/components/responses/InvalidCredentials'
   /health:
     get:
       tags:
@@ -1875,6 +1907,19 @@ components:
         pattern: '^[a-z][a-z0-9_]*$'
       example: site_name
   responses:
+    InvalidCredentials:
+      description: Email or password is incorrect.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          examples:
+            invalidCredentials:
+              value:
+                type: https://nene-records.dev/problems/invalid-credentials
+                title: Invalid credentials
+                status: 401
+                detail: Email or password is incorrect.
     NotFound:
       description: Resource not found.
       content:
@@ -2912,4 +2957,39 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EntityRelationItemResponse'
+      additionalProperties: false
+    LoginRequest:
+      type: object
+      required:
+        - email
+        - password
+      properties:
+        email:
+          type: string
+          format: email
+          minLength: 1
+        password:
+          type: string
+          minLength: 1
+      additionalProperties: false
+    LoginResponse:
+      type: object
+      required:
+        - token
+        - expires_at
+        - email
+        - role
+      properties:
+        token:
+          type: string
+          minLength: 1
+        expires_at:
+          type: string
+          format: date-time
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+          minLength: 1
       additionalProperties: false

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -9,13 +9,27 @@ import { EntityTypesPage } from '@/pages/entity-types/EntityTypesPage'
 import { FieldDefsPage } from '@/pages/field-defs/FieldDefsPage'
 import { HomePage } from '@/pages/home/HomePage'
 import { AppShell } from '@/pages/layout/AppShell'
+import { LoginPage } from '@/pages/login/LoginPage'
 import { SiteSettingsPage } from '@/pages/settings/SiteSettingsPage'
 import { TagsPage } from '@/pages/tags/TagsPage'
+import { RequireAuth } from '@/shared/auth/RequireAuth'
+
+function AdminShell() {
+  return (
+    <RequireAuth>
+      <AppShell />
+    </RequireAuth>
+  )
+}
 
 const router = createBrowserRouter([
   {
+    path: '/login',
+    element: <LoginPage />,
+  },
+  {
     path: '/',
-    element: <AppShell />,
+    element: <AdminShell />,
     children: [
       { index: true, element: <HomePage /> },
       { path: 'entity-types', element: <EntityTypesPage /> },

--- a/frontend/src/entities/auth/api-types.ts
+++ b/frontend/src/entities/auth/api-types.ts
@@ -1,0 +1,11 @@
+export interface LoginRequestDto {
+  email: string
+  password: string
+}
+
+export interface LoginResponseDto {
+  token: string
+  expires_at: string
+  email: string
+  role: string
+}

--- a/frontend/src/entities/auth/index.ts
+++ b/frontend/src/entities/auth/index.ts
@@ -1,0 +1,3 @@
+export { authStore } from './model'
+export type { AuthSession } from './model'
+export { useLogin } from './mutations'

--- a/frontend/src/entities/auth/model.ts
+++ b/frontend/src/entities/auth/model.ts
@@ -1,0 +1,38 @@
+export interface AuthSession {
+  token: string
+  expiresAt: string
+  email: string
+  role: string
+}
+
+const STORAGE_KEY = 'nene_records_token'
+
+export const authStore = {
+  getSession(): AuthSession | null {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    try {
+      return JSON.parse(raw) as AuthSession
+    } catch {
+      return null
+    }
+  },
+
+  setSession(session: AuthSession): void {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(session))
+  },
+
+  clearSession(): void {
+    localStorage.removeItem(STORAGE_KEY)
+  },
+
+  getToken(): string | null {
+    return this.getSession()?.token ?? null
+  },
+
+  isAuthenticated(): boolean {
+    const session = this.getSession()
+    if (!session) return false
+    return new Date(session.expiresAt) > new Date()
+  },
+}

--- a/frontend/src/entities/auth/mutations.ts
+++ b/frontend/src/entities/auth/mutations.ts
@@ -1,0 +1,20 @@
+import { useMutation, type UseMutationResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { LoginRequestDto, LoginResponseDto } from './api-types'
+import { authStore, type AuthSession } from './model'
+
+export function useLogin(): UseMutationResult<AuthSession, AppError, LoginRequestDto> {
+  return useMutation({
+    mutationFn: async (input) => {
+      const dto = await apiClient.post<LoginResponseDto>('/api/v1/auth/login', input)
+      const session: AuthSession = {
+        token: dto.token,
+        expiresAt: dto.expires_at,
+        email: dto.email,
+        role: dto.role,
+      }
+      authStore.setSession(session)
+      return session
+    },
+  })
+}

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -1,5 +1,6 @@
-import { Outlet, NavLink } from 'react-router-dom'
-import { Stack, Text } from '@/shared/ui'
+import { Outlet, NavLink, useNavigate } from 'react-router-dom'
+import { authStore } from '@/entities/auth'
+import { Button, Stack, Text } from '@/shared/ui'
 
 const navLinkClass = ({ isActive }: { isActive: boolean }): string =>
   [
@@ -8,6 +9,15 @@ const navLinkClass = ({ isActive }: { isActive: boolean }): string =>
   ].join(' ')
 
 export function AppShell() {
+  const navigate = useNavigate()
+
+  const handleLogout = () => {
+    authStore.clearSession()
+    void navigate('/login')
+  }
+
+  const session = authStore.getSession()
+
   return (
     <div className="min-h-screen bg-surface font-sans text-text-primary">
       <header className="border-b border-border bg-surface-raised shadow-sm">
@@ -34,6 +44,16 @@ export function AppShell() {
               </NavLink>
             </Stack>
           </nav>
+          <Stack direction="horizontal" gap="sm">
+            {session && (
+              <Text muted className="hidden text-sm sm:block">
+                {session.email}
+              </Text>
+            )}
+            <Button variant="ghost" size="sm" onClick={handleLogout}>
+              ログアウト
+            </Button>
+          </Stack>
         </div>
       </header>
       <main className="mx-auto max-w-5xl px-inline-md py-stack-lg">

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -1,0 +1,87 @@
+import { useState, type SyntheticEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useLogin } from '@/entities/auth'
+import { Button, Input, Stack, Text } from '@/shared/ui'
+
+export function LoginPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const navigate = useNavigate()
+  const login = useLogin()
+
+  const handleSubmit = (e: SyntheticEvent) => {
+    e.preventDefault()
+    login.mutate(
+      { email, password },
+      {
+        onSuccess: () => {
+          void navigate('/')
+        },
+      },
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-surface px-inline-md">
+      <div className="w-full max-w-sm rounded-lg border border-border bg-surface-raised p-stack-lg shadow-sm">
+        <Stack gap="lg">
+          <Stack gap="xs">
+            <Text as="h1" variant="heading-md">
+              NeNe Records Admin
+            </Text>
+            <Text muted>サインインしてください</Text>
+          </Stack>
+
+          {login.isError && (
+            <div
+              role="alert"
+              className="rounded-md border border-red-200 bg-red-50 px-inline-sm py-stack-xs text-sm text-red-700"
+            >
+              メールアドレスまたはパスワードが正しくありません
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit}>
+            <Stack gap="md">
+              <Stack gap="xs">
+                <label htmlFor="email" className="text-sm font-medium text-text-primary">
+                  メールアドレス
+                </label>
+                <Input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => {
+                    setEmail(e.target.value)
+                  }}
+                  placeholder="admin@example.com"
+                  required
+                />
+              </Stack>
+
+              <Stack gap="xs">
+                <label htmlFor="password" className="text-sm font-medium text-text-primary">
+                  パスワード
+                </label>
+                <Input
+                  id="password"
+                  type="password"
+                  value={password}
+                  onChange={(e) => {
+                    setPassword(e.target.value)
+                  }}
+                  placeholder="••••••••"
+                  required
+                />
+              </Stack>
+
+              <Button type="submit" disabled={login.isPending} className="w-full">
+                {login.isPending ? 'サインイン中…' : 'サインイン'}
+              </Button>
+            </Stack>
+          </form>
+        </Stack>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -1,3 +1,4 @@
+import { authStore } from '@/entities/auth/model'
 import { env } from '@/shared/config/env'
 import { AppError, parseProblemDetails } from '@/shared/api/errors'
 
@@ -12,9 +13,13 @@ interface RequestOptions {
 async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
   const base = env.apiBaseUrl.replace(/\/$/, '')
   const url = `${base}${path}`
-  const headers: HeadersInit = {}
+  const headers: Record<string, string> = {}
   if (options.body !== undefined) {
     headers['Content-Type'] = 'application/json'
+  }
+  const token = authStore.getToken()
+  if (token !== null) {
+    headers['Authorization'] = `Bearer ${token}`
   }
 
   const response = await fetch(url, {

--- a/frontend/src/shared/auth/RequireAuth.tsx
+++ b/frontend/src/shared/auth/RequireAuth.tsx
@@ -1,0 +1,16 @@
+import { Navigate, useLocation } from 'react-router-dom'
+import { authStore } from '@/entities/auth'
+
+interface Props {
+  children: React.ReactNode
+}
+
+export function RequireAuth({ children }: Props) {
+  const location = useLocation()
+
+  if (!authStore.isAuthenticated()) {
+    return <Navigate to="/login" state={{ from: location }} replace />
+  }
+
+  return <>{children}</>
+}

--- a/frontend/src/shared/ui/primitives/Button.tsx
+++ b/frontend/src/shared/ui/primitives/Button.tsx
@@ -1,4 +1,4 @@
-export type ButtonVariant = 'primary' | 'secondary' | 'danger'
+export type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost'
 export type ButtonSize = 'sm' | 'md'
 
 export interface ButtonProps {
@@ -20,6 +20,8 @@ const variantClasses: Record<ButtonVariant, string> = {
     'bg-surface-raised text-text-primary hover:bg-surface-overlay border-border focus-visible:shadow-focus',
   danger:
     'bg-danger text-text-inverse hover:bg-danger-hover border-transparent focus-visible:shadow-focus',
+  ghost:
+    'bg-transparent text-text-muted hover:text-text-primary border-transparent focus-visible:shadow-focus',
 }
 
 const sizeClasses: Record<ButtonSize, string> = {

--- a/frontend/tests/msw/handlers/auth.ts
+++ b/frontend/tests/msw/handlers/auth.ts
@@ -1,0 +1,31 @@
+import { http, HttpResponse } from 'msw'
+
+interface LoginBody {
+  email?: unknown
+  password?: unknown
+}
+
+export const authHandlers = [
+  http.post('/api/v1/auth/login', async ({ request }) => {
+    const body = (await request.json()) as LoginBody
+
+    if (body.email === 'admin@example.com' && body.password === 'secret') {
+      return HttpResponse.json({
+        token: 'test-token',
+        expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+        email: 'admin@example.com',
+        role: 'admin',
+      })
+    }
+
+    return HttpResponse.json(
+      {
+        type: 'https://nene-records.dev/problems/invalid-credentials',
+        title: 'Invalid credentials',
+        status: 401,
+        detail: 'Email or password is incorrect.',
+      },
+      { status: 401 },
+    )
+  }),
+]

--- a/frontend/tests/msw/server.ts
+++ b/frontend/tests/msw/server.ts
@@ -1,4 +1,5 @@
 import { setupServer } from 'msw/node'
+import { authHandlers } from './handlers/auth'
 import { boolFieldHandlers } from './handlers/bool-field'
 import { dateTimeFieldHandlers } from './handlers/datetime-field'
 import { entityRelationHandlers } from './handlers/entity-relation'
@@ -12,6 +13,7 @@ import { tagHandlers } from './handlers/tag'
 import { textFieldHandlers } from './handlers/text-field'
 
 export const mswServer = setupServer(
+  ...authHandlers,
   ...entityTypeHandlers,
   ...entityHandlers,
   ...entityTagHandlers,

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\DomainExceptionHandlerInterface;
 use NeNeRecords\Analytics\AnalyticsServiceProvider;
+use NeNeRecords\Auth\InvalidCredentialsExceptionHandler;
 use NeNeRecords\BoolField\BoolFieldNotFoundExceptionHandler;
 use NeNeRecords\BoolField\BoolFieldServiceProvider;
 use NeNeRecords\BoolField\FieldKeyNotRegisteredExceptionHandler as BoolFieldKeyNotRegisteredExceptionHandler;
@@ -99,6 +100,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $analytics = $container->get('nene-records.route_registrar.analytics');
                     $publicRecord = $container->get('nene-records.route_registrar.public_record');
                     $setting = $container->get('nene-records.route_registrar.setting');
+                    $auth = $container->get('nene-records.route_registrar.auth');
 
                     if (
                         !is_callable($entityType)
@@ -115,11 +117,13 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !is_callable($analytics)
                         || !is_callable($publicRecord)
                         || !is_callable($setting)
+                        || !is_callable($auth)
                     ) {
                         throw new LogicException('Route registrar service is invalid.');
                     }
 
                     return [
+                        $auth,
                         $entityType,
                         $fieldDef,
                         $entity,
@@ -173,6 +177,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $publicRecordNotFound = $container->get(PublicRecordNotFoundExceptionHandler::class);
                     $settingKeyNotFound = $container->get(SettingKeyNotFoundExceptionHandler::class);
                     $settingValueInvalid = $container->get(SettingValueInvalidExceptionHandler::class);
+                    $invalidCredentials = $container->get(InvalidCredentialsExceptionHandler::class);
 
                     foreach ([
                         $entityTypeNotFound,
@@ -208,6 +213,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $publicRecordNotFound,
                         $settingKeyNotFound,
                         $settingValueInvalid,
+                        $invalidCredentials,
                     ] as $handler) {
                         if (!$handler instanceof DomainExceptionHandlerInterface) {
                             throw new LogicException('Exception handler service is invalid.');
@@ -248,6 +254,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $publicRecordNotFound,
                         $settingKeyNotFound,
                         $settingValueInvalid,
+                        $invalidCredentials,
                     ];
                 },
             );

--- a/src/Auth/AdminApiAuthMiddleware.php
+++ b/src/Auth/AdminApiAuthMiddleware.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+use Nene2\Auth\TokenVerificationException;
+use Nene2\Auth\TokenVerifierInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Method-aware API authentication middleware.
+ *
+ * Protection rules (first match wins):
+ *  1. Always open: /health, /api/v1/auth/*, paths starting with /api/v1/public/
+ *  2. Always protected (all HTTP methods): paths starting with /api/v1/settings
+ *  3. Protected for non-GET methods: all other /api/v1/ paths
+ *  4. Everything else: open (static assets, public HTML pages)
+ */
+final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
+{
+    /** @var list<string> */
+    private const ALWAYS_OPEN_PREFIXES = [
+        '/health',
+        '/api/v1/auth/',
+        '/api/v1/public/',
+    ];
+
+    /** @var list<string> */
+    private const ADMIN_ONLY_PREFIXES = [
+        '/api/v1/settings',
+    ];
+
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+        private TokenVerifierInterface $verifier,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if (!$this->requiresAuthentication($request)) {
+            return $handler->handle($request);
+        }
+
+        $authorization = $request->getHeaderLine('Authorization');
+
+        if ($authorization === '') {
+            return $this->unauthorized($request, 'missing_token', 'No Bearer token was provided.');
+        }
+
+        if (!str_starts_with($authorization, 'Bearer ')) {
+            return $this->unauthorized($request, 'invalid_token', 'Authorization header must use the Bearer scheme.');
+        }
+
+        $token = substr($authorization, 7);
+
+        try {
+            $claims = $this->verifier->verify($token);
+        } catch (TokenVerificationException $e) {
+            return $this->unauthorized($request, 'invalid_token', $e->getMessage());
+        }
+
+        return $handler->handle(
+            $request
+                ->withAttribute('nene2.auth.credential_type', 'bearer')
+                ->withAttribute('nene2.auth.claims', $claims),
+        );
+    }
+
+    private function requiresAuthentication(ServerRequestInterface $request): bool
+    {
+        $path = $request->getUri()->getPath() ?: '/';
+        $method = strtoupper($request->getMethod());
+
+        // 1. Always open paths
+        foreach (self::ALWAYS_OPEN_PREFIXES as $prefix) {
+            if (str_starts_with($path, $prefix)) {
+                return false;
+            }
+        }
+
+        // 2. Admin-only prefixes: protect for all methods
+        foreach (self::ADMIN_ONLY_PREFIXES as $prefix) {
+            if (str_starts_with($path, $prefix)) {
+                return true;
+            }
+        }
+
+        // 3. All /api/v1/* paths: protect non-GET methods
+        if (str_starts_with($path, '/api/v1/')) {
+            return $method !== 'GET' && $method !== 'HEAD' && $method !== 'OPTIONS';
+        }
+
+        // 4. Everything else: open (HTML pages, static assets)
+        return false;
+    }
+
+    private function unauthorized(ServerRequestInterface $request, string $error, string $description): ResponseInterface
+    {
+        return $this->problemDetails
+            ->create($request, 'unauthorized', 'Unauthorized', 401, $description)
+            ->withHeader(
+                'WWW-Authenticate',
+                sprintf(
+                    'Bearer realm="NeNe Records", error="%s", error_description="%s"',
+                    $error,
+                    $this->sanitizeHeaderParam($description),
+                ),
+            );
+    }
+
+    private function sanitizeHeaderParam(string $value): string
+    {
+        return str_replace('"', '\\"', preg_replace('/\r?\n|\r/', ' ', $value) ?? $value);
+    }
+}

--- a/src/Auth/AuthRouteRegistrar.php
+++ b/src/Auth/AuthRouteRegistrar.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class AuthRouteRegistrar
+{
+    public function __construct(
+        private LoginHandler $loginHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $loginHandler = $this->loginHandler;
+
+        $router->post('/api/v1/auth/login', static fn (ServerRequestInterface $request) => $loginHandler->handle($request));
+    }
+}

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+use LogicException;
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Container\ContainerInterface;
+
+final readonly class AuthServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                UserRepositoryInterface::class,
+                static function (ContainerInterface $container): UserRepositoryInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('DatabaseQueryExecutorInterface service is invalid.');
+                    }
+
+                    return new PdoUserRepository($query);
+                },
+            )
+            ->set(
+                LoginUseCase::class,
+                static function (ContainerInterface $container): LoginUseCase {
+                    $users = $container->get(UserRepositoryInterface::class);
+                    $tokenIssuer = $container->get('nene-records.token_issuer');
+
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('UserRepositoryInterface service is invalid.');
+                    }
+
+                    if (!$tokenIssuer instanceof TokenIssuerInterface) {
+                        throw new LogicException('TokenIssuerInterface service is invalid.');
+                    }
+
+                    /** @var TokenIssuerInterface $tokenIssuer */
+                    return new LoginUseCase($users, $tokenIssuer);
+                },
+            )
+            ->set(
+                LoginHandler::class,
+                static function (ContainerInterface $container): LoginHandler {
+                    $useCase = $container->get(LoginUseCase::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof LoginUseCase) {
+                        throw new LogicException('LoginUseCase service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory service is invalid.');
+                    }
+
+                    return new LoginHandler($useCase, $response);
+                },
+            )
+            ->set(
+                InvalidCredentialsExceptionHandler::class,
+                static function (ContainerInterface $container): InvalidCredentialsExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new InvalidCredentialsExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.auth',
+                static function (ContainerInterface $container): AuthRouteRegistrar {
+                    $loginHandler = $container->get(LoginHandler::class);
+
+                    if (!$loginHandler instanceof LoginHandler) {
+                        throw new LogicException('LoginHandler service is invalid.');
+                    }
+
+                    return new AuthRouteRegistrar($loginHandler);
+                },
+            );
+    }
+}

--- a/src/Auth/InvalidCredentialsException.php
+++ b/src/Auth/InvalidCredentialsException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+use DomainException;
+
+final class InvalidCredentialsException extends DomainException
+{
+    public function __construct()
+    {
+        parent::__construct('Invalid email or password.');
+    }
+}

--- a/src/Auth/InvalidCredentialsExceptionHandler.php
+++ b/src/Auth/InvalidCredentialsExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class InvalidCredentialsExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof InvalidCredentialsException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'invalid-credentials',
+            'Invalid credentials',
+            401,
+            'Email or password is incorrect.',
+        );
+    }
+}

--- a/src/Auth/LoginHandler.php
+++ b/src/Auth/LoginHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class LoginHandler
+{
+    public function __construct(
+        private LoginUseCase $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+
+        $email = isset($body['email']) && is_string($body['email']) ? trim($body['email']) : '';
+        $password = isset($body['password']) && is_string($body['password']) ? $body['password'] : '';
+
+        if ($email === '') {
+            $errors[] = new ValidationError('email', 'Email is required.', 'required');
+        }
+
+        if ($password === '') {
+            $errors[] = new ValidationError('password', 'Password is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new LoginInput(email: $email, password: $password));
+
+        return $this->response->create([
+            'token' => $output->token,
+            'expires_at' => $output->expiresAt,
+            'email' => $output->email,
+            'role' => $output->role,
+        ]);
+    }
+}

--- a/src/Auth/LoginInput.php
+++ b/src/Auth/LoginInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+final readonly class LoginInput
+{
+    public function __construct(
+        public string $email,
+        public string $password,
+    ) {
+    }
+}

--- a/src/Auth/LoginOutput.php
+++ b/src/Auth/LoginOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+final readonly class LoginOutput
+{
+    public function __construct(
+        public string $token,
+        public int $expiresAt,
+        public string $email,
+        public string $role,
+    ) {
+    }
+}

--- a/src/Auth/LoginUseCase.php
+++ b/src/Auth/LoginUseCase.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+use Nene2\Auth\TokenIssuerInterface;
+
+final readonly class LoginUseCase
+{
+    private const TOKEN_TTL_SECONDS = 86400; // 24 hours
+
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private TokenIssuerInterface $tokenIssuer,
+    ) {
+    }
+
+    public function execute(LoginInput $input): LoginOutput
+    {
+        $user = $this->users->findByEmail($input->email);
+
+        if ($user === null || !password_verify($input->password, $user->passwordHash)) {
+            throw new InvalidCredentialsException();
+        }
+
+        $expiresAt = time() + self::TOKEN_TTL_SECONDS;
+
+        $token = $this->tokenIssuer->issue([
+            'sub' => $user->email,
+            'role' => $user->role,
+            'iat' => time(),
+            'exp' => $expiresAt,
+        ]);
+
+        return new LoginOutput(
+            token: $token,
+            expiresAt: $expiresAt,
+            email: $user->email,
+            role: $user->role,
+        );
+    }
+}

--- a/src/Auth/PdoUserRepository.php
+++ b/src/Auth/PdoUserRepository.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoUserRepository implements UserRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findByEmail(string $email): ?User
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, email, password_hash, role FROM users WHERE email = ?',
+            [$email],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return new User(
+            id: (int) $row['id'],
+            email: (string) $row['email'],
+            passwordHash: (string) $row['password_hash'],
+            role: (string) $row['role'],
+        );
+    }
+}

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+final readonly class User
+{
+    public function __construct(
+        public int $id,
+        public string $email,
+        public string $passwordHash,
+        public string $role,
+    ) {
+    }
+}

--- a/src/Auth/UserRepositoryInterface.php
+++ b/src/Auth/UserRepositoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+interface UserRepositoryInterface
+{
+    public function findByEmail(string $email): ?User;
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace NeNeRecords\Http;
 
 use LogicException;
-use Nene2\Auth\BearerTokenMiddleware;
 use Nene2\Auth\LocalBearerTokenVerifier;
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Auth\TokenVerifierInterface;
 use Nene2\Config\AppConfig;
 use Nene2\Config\ConfigLoader;
 use Nene2\Database\DatabaseConnectionFactoryInterface;
@@ -26,6 +27,8 @@ use Nene2\Log\MonologLoggerFactory;
 use Nene2\Log\RequestIdHolder;
 use NeNeRecords\Analytics\AccessLogMiddleware;
 use NeNeRecords\ApplicationServiceProvider;
+use NeNeRecords\Auth\AdminApiAuthMiddleware;
+use NeNeRecords\Auth\AuthServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -40,6 +43,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
     public function register(ContainerBuilder $builder): void
     {
         $builder->addProvider(new ApplicationServiceProvider());
+        $builder->addProvider(new AuthServiceProvider());
 
         $builder
             ->set(
@@ -168,6 +172,48 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
             )
             ->set(RequestIdHolder::class, static fn (ContainerInterface $container): RequestIdHolder => new RequestIdHolder())
             ->set(
+                LocalBearerTokenVerifier::class,
+                static function (ContainerInterface $container): LocalBearerTokenVerifier {
+                    $config = $container->get(AppConfig::class);
+
+                    if (!$config instanceof AppConfig) {
+                        throw new LogicException('Application config service is invalid.');
+                    }
+
+                    return new LocalBearerTokenVerifier($config->localJwtSecret ?? 'nene-records-dev-secret');
+                },
+            )
+            ->set(
+                TokenVerifierInterface::class,
+                static function (ContainerInterface $container): TokenVerifierInterface {
+                    $verifier = $container->get(LocalBearerTokenVerifier::class);
+
+                    if (!$verifier instanceof TokenVerifierInterface) {
+                        throw new LogicException('LocalBearerTokenVerifier service is invalid.');
+                    }
+
+                    return $verifier;
+                },
+            )
+            ->set(
+                TokenIssuerInterface::class,
+                static function (ContainerInterface $container): TokenIssuerInterface {
+                    $issuer = $container->get(LocalBearerTokenVerifier::class);
+
+                    if (!$issuer instanceof TokenIssuerInterface) {
+                        throw new LogicException('LocalBearerTokenVerifier service is invalid.');
+                    }
+
+                    return $issuer;
+                },
+            )
+            ->set(
+                'nene-records.token_issuer',
+                static function (ContainerInterface $container): TokenIssuerInterface {
+                    return $container->get(TokenIssuerInterface::class);
+                },
+            )
+            ->set(
                 LoggerInterface::class,
                 static function (ContainerInterface $container): LoggerInterface {
                     $config = $container->get(AppConfig::class);
@@ -227,19 +273,18 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
 
                     $authMiddleware = [$accessLogMiddleware];
 
-                    if ($config->localJwtSecret !== null) {
-                        $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+                    $tokenVerifier = $container->get(TokenVerifierInterface::class);
 
-                        if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
-                            throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
-                        }
-
-                        $authMiddleware[] = new BearerTokenMiddleware(
-                            $problemDetails,
-                            new LocalBearerTokenVerifier($config->localJwtSecret),
-                            [],
-                        );
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
                     }
+
+                    if (!$tokenVerifier instanceof TokenVerifierInterface) {
+                        throw new LogicException('TokenVerifierInterface service is invalid.');
+                    }
+
+                    $authMiddleware[] = new AdminApiAuthMiddleware($problemDetails, $tokenVerifier);
 
                     return new RuntimeApplicationFactory(
                         $responseFactory,

--- a/tools/generate-mcp-tools.php
+++ b/tools/generate-mcp-tools.php
@@ -843,6 +843,22 @@ foreach (['text', 'int', 'enum', 'bool', 'datetime'] as $kind) {
     array_push($tools, ...fieldTools($kind));
 }
 
+// Auth
+$tools[] = readTool(
+    'login',
+    'Login',
+    'Authenticate with email/password and obtain an API bearer token.',
+    'login',
+    'POST',
+    '/api/v1/auth/login',
+    [
+        'email' => ['type' => 'string', 'format' => 'email', 'minLength' => 1],
+        'password' => ['type' => 'string', 'minLength' => 1],
+    ],
+    '#/components/schemas/LoginResponse',
+    ['email', 'password'],
+);
+
 $catalog = [
     'version' => 1,
     'source' => 'docs/openapi/openapi.yaml',


### PR DESCRIPTION
## Summary

- `users` テーブルマイグレーション（`email`, `password_hash`, `role`）と対応スキーマを追加
- `POST /api/v1/auth/login` エンドポイントをクリーンアーキテクチャで実装（LoginUseCase / LoginHandler / AuthRouteRegistrar）
- `AdminApiAuthMiddleware` でパス・メソッドベースの認証ガードを導入
  - 常にオープン: `/health`, `/api/v1/auth/`, `/api/v1/public/`
  - 常に認証必須: `/api/v1/settings`（admin only）
  - その他 `/api/v1/` の非 GET メソッドは Bearer token 必須
- `AuthServiceProvider` → `RuntimeServiceProvider` → `ApplicationServiceProvider` に DI を統合
- OpenAPI に `LoginRequest`/`LoginResponse` スキーマ・MCP に `login` ツールを追加
- フロントエンド: `authStore`（localStorage）+ `useLogin` mutation + API クライアントへの Bearer 自動付与
- `LoginPage`（メール/パスワードフォーム）・`RequireAuth` ルートガード・`AppShell` ログアウトボタンを実装
- `Button` に `ghost` variant を追加、MSW に `authHandlers` を追加

## Test plan

- [x] PHPUnit 168 tests all pass
- [x] PHPStan no errors
- [x] PHP-CS-Fixer no changes needed
- [x] OpenAPI contract valid
- [x] MCP tool catalog valid
- [x] TypeScript type check pass
- [x] ESLint 0 errors/warnings
- [x] Prettier formatted
- [x] Vitest pass
- [x] Storybook build pass

## Checklist

セルフレビューチェックリスト: `docs/review/backend.md` + `docs/review/frontend.md`

Closes #86

Made with [Cursor](https://cursor.com)