### PR TITLE
feat(entity): Public slug routing + entity slug フィールドを追加 (#87)

### DIFF
--- a/database/migrations/20260524000016_add_slug_to_entities.php
+++ b/database/migrations/20260524000016_add_slug_to_entities.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddSlugToEntities extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('entities')
+            ->addColumn('slug', 'string', [
+                'limit' => 255,
+                'null' => true,
+                'default' => null,
+                'after' => 'entity_type_id',
+            ])
+            ->addIndex(['entity_type_id', 'slug'], ['unique' => true, 'name' => 'entities_entity_type_id_slug'])
+            ->save();
+    }
+}

--- a/database/schema/entities.sql
+++ b/database/schema/entities.sql
@@ -1,6 +1,7 @@
 CREATE TABLE entities (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     entity_type_id INTEGER UNSIGNED NOT NULL,
+    slug VARCHAR(255) NULL,
     status VARCHAR(16) NOT NULL DEFAULT 'draft',
     published_at DATETIME NULL,
     is_deleted BOOLEAN NOT NULL DEFAULT 0,
@@ -9,3 +10,4 @@ CREATE TABLE entities (
 );
 CREATE INDEX entities_entity_type_id ON entities (entity_type_id);
 CREATE INDEX entities_status ON entities (status);
+CREATE UNIQUE INDEX entities_entity_type_id_slug ON entities (entity_type_id, slug);

--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -320,6 +320,11 @@
                         "type": "integer",
                         "minimum": 1
                     },
+                    "slug": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "URL slug (unique per entity type)."
+                    },
                     "status": {
                         "type": "string",
                         "enum": [
@@ -373,7 +378,7 @@
                 "type": "openapi",
                 "operationId": "getPublicRecordView",
                 "method": "GET",
-                "path": "/api/v1/public/entity-types/{slug}/records/{entityId}"
+                "path": "/api/v1/public/entity-types/{slug}/records/{entitySlug}"
             },
             "inputSchema": {
                 "type": "object",
@@ -383,15 +388,15 @@
                         "minLength": 1,
                         "description": "Entity type slug."
                     },
-                    "entityId": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "description": "Entity instance id."
+                    "entitySlug": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Entity slug."
                     }
                 },
                 "required": [
                     "slug",
-                    "entityId"
+                    "entitySlug"
                 ],
                 "additionalProperties": false
             },
@@ -419,6 +424,11 @@
                     "entity_type_id": {
                         "type": "integer",
                         "minimum": 1
+                    },
+                    "slug": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "URL slug (unique per entity type)."
                     },
                     "status": {
                         "type": "string",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1722,7 +1722,7 @@ paths:
                 $ref: '#/components/schemas/PublicSettingListResponse'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /api/v1/public/entity-types/{slug}/records/{entityId}:
+  /api/v1/public/entity-types/{slug}/records/{entitySlug}:
     get:
       tags:
         - PublicConsumer
@@ -1740,13 +1740,13 @@ paths:
           schema:
             type: string
             minLength: 1
-        - name: entityId
+        - name: entitySlug
           in: path
           required: true
-          description: Entity instance id.
+          description: Entity slug.
           schema:
-            type: integer
-            minimum: 1
+            type: string
+            minLength: 1
       responses:
         '200':
           description: Aggregated public record view bootstrap payload.
@@ -2148,6 +2148,7 @@ components:
       required:
         - id
         - entity_type_id
+        - slug
         - status
         - published_at
         - is_deleted
@@ -2159,6 +2160,11 @@ components:
         entity_type_id:
           type: integer
           format: int64
+        slug:
+          type:
+            - string
+            - 'null'
+          minLength: 1
         status:
           $ref: '#/components/schemas/EntityStatus'
         published_at:
@@ -2182,6 +2188,9 @@ components:
           type: integer
           format: int64
           minimum: 1
+        slug:
+          type: string
+          minLength: 1
         status:
           $ref: '#/components/schemas/EntityStatus'
       additionalProperties: false
@@ -2194,6 +2203,9 @@ components:
           type: integer
           format: int64
           minimum: 1
+        slug:
+          type: string
+          minLength: 1
         status:
           $ref: '#/components/schemas/EntityStatus'
         published_at:

--- a/frontend/src/entities/entity/api-types.ts
+++ b/frontend/src/entities/entity/api-types.ts
@@ -3,6 +3,7 @@ export type EntityStatusDto = 'draft' | 'published' | 'archived'
 export interface EntityDto {
   id: number
   entity_type_id: number
+  slug: string | null
   status: EntityStatusDto
   published_at: string | null
   is_deleted: boolean
@@ -18,11 +19,13 @@ export interface EntityListDto {
 
 export interface CreateEntityDto {
   entity_type_id: number
+  slug?: string | null
   status?: EntityStatusDto
 }
 
 export interface UpdateEntityDto {
   entity_type_id: number
+  slug?: string | null
   status: EntityStatusDto
   published_at?: string | null
 }

--- a/frontend/src/entities/entity/mapper.ts
+++ b/frontend/src/entities/entity/mapper.ts
@@ -6,6 +6,7 @@ export function mapEntityDtoToModel(dto: EntityDto): Entity {
   return {
     id: toEntityId(dto.id),
     entityTypeId: dto.entity_type_id,
+    slug: dto.slug,
     status: dto.status,
     publishedAt: dto.published_at,
     isDeleted: dto.is_deleted,
@@ -25,6 +26,7 @@ export function mapEntityListDtoToModel(dto: EntityListDto): EntityList {
 export function mapCreateInputToDto(input: CreateEntityInput): CreateEntityDto {
   return {
     entity_type_id: input.entityTypeId,
+    ...(input.slug !== undefined ? { slug: input.slug } : {}),
     ...(input.status !== undefined ? { status: input.status } : {}),
   }
 }
@@ -32,6 +34,7 @@ export function mapCreateInputToDto(input: CreateEntityInput): CreateEntityDto {
 export function mapUpdateInputToDto(input: UpdateEntityInput): UpdateEntityDto {
   return {
     entity_type_id: input.entityTypeId,
+    ...(input.slug !== undefined ? { slug: input.slug } : {}),
     status: input.status,
     ...(input.publishedAt !== undefined ? { published_at: input.publishedAt } : {}),
   }

--- a/frontend/src/entities/entity/model.ts
+++ b/frontend/src/entities/entity/model.ts
@@ -5,6 +5,7 @@ export type EntityStatus = 'draft' | 'published' | 'archived'
 export interface Entity {
   id: EntityId
   entityTypeId: number
+  slug: string | null
   status: EntityStatus
   publishedAt: string | null
   isDeleted: boolean
@@ -20,12 +21,14 @@ export interface EntityList {
 
 export interface CreateEntityInput {
   entityTypeId: number
+  slug?: string | null
   status?: EntityStatus
 }
 
 export interface UpdateEntityInput {
   id: number
   entityTypeId: number
+  slug?: string | null
   status: EntityStatus
   publishedAt?: string | null
 }

--- a/frontend/src/features/manage-entity-status/ui/EntityStatusPanel.tsx
+++ b/frontend/src/features/manage-entity-status/ui/EntityStatusPanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import type { Entity, EntityStatus } from '@/entities/entity'
 import { useUpdateEntity } from '@/entities/entity'
-import { Button, Stack, Text } from '@/shared/ui'
+import { Button, Input, Stack, Text } from '@/shared/ui'
 
 const STATUS_LABELS: Record<EntityStatus, string> = {
   draft: 'Draft',
@@ -26,18 +26,23 @@ const NEXT_STATUSES: Record<EntityStatus, EntityStatus[]> = {
 
 interface EntityStatusPanelProps {
   entity: Entity
+  entityTypeSlug?: string
 }
 
-export function EntityStatusPanel({ entity }: EntityStatusPanelProps) {
+export function EntityStatusPanel({ entity, entityTypeSlug }: EntityStatusPanelProps) {
   const updateMutation = useUpdateEntity()
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [slugInput, setSlugInput] = useState(entity.slug ?? '')
+  const [slugSaved, setSlugSaved] = useState(false)
 
   const changeStatus = async (nextStatus: EntityStatus) => {
     setErrorMessage(null)
+    setSlugSaved(false)
     try {
       await updateMutation.mutateAsync({
         id: Number(entity.id),
         entityTypeId: entity.entityTypeId,
+        slug: slugInput !== '' ? slugInput : null,
         status: nextStatus,
       })
     } catch {
@@ -45,7 +50,27 @@ export function EntityStatusPanel({ entity }: EntityStatusPanelProps) {
     }
   }
 
+  const saveSlug = async () => {
+    setErrorMessage(null)
+    setSlugSaved(false)
+    try {
+      await updateMutation.mutateAsync({
+        id: Number(entity.id),
+        entityTypeId: entity.entityTypeId,
+        slug: slugInput !== '' ? slugInput : null,
+        status: entity.status,
+      })
+      setSlugSaved(true)
+    } catch {
+      setErrorMessage('Failed to save slug. It may already be used by another record.')
+    }
+  }
+
   const currentStatus = entity.status
+  const publicUrl =
+    entityTypeSlug !== undefined && (entity.slug ?? slugInput) !== ''
+      ? `/view/${entityTypeSlug}/${entity.slug ?? slugInput}`
+      : null
 
   return (
     <Stack gap="sm">
@@ -60,6 +85,38 @@ export function EntityStatusPanel({ entity }: EntityStatusPanelProps) {
           </Text>
         )}
       </div>
+
+      <Stack gap="xs">
+        <label htmlFor="entity-slug" className="text-sm font-medium text-text-primary">
+          Slug
+        </label>
+        <div className="flex items-center gap-inline-sm">
+          <Input
+            id="entity-slug"
+            value={slugInput}
+            onChange={(e) => {
+              setSlugInput(e.target.value)
+              setSlugSaved(false)
+            }}
+            placeholder="e.g. hello-world"
+          />
+          <Button variant="secondary" size="sm" onClick={() => void saveSlug()}>
+            Save slug
+          </Button>
+        </div>
+        {slugSaved && <Text muted>Saved.</Text>}
+        {publicUrl !== null && (
+          <a
+            href={publicUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-blue-600 underline hover:text-blue-800"
+          >
+            {publicUrl}
+          </a>
+        )}
+      </Stack>
+
       <div className="flex flex-wrap gap-inline-sm">
         {NEXT_STATUSES[currentStatus].map((nextStatus) => (
           <Button

--- a/frontend/src/pages/entity-record/EntityRecordPage.tsx
+++ b/frontend/src/pages/entity-record/EntityRecordPage.tsx
@@ -57,7 +57,9 @@ export function EntityRecordPage() {
           {entityTypeQuery.data?.name ?? 'Record'}
         </Text>
       </Stack>
-      {entity !== null && <EntityStatusPanel entity={entity} />}
+      {entity !== null && (
+        <EntityStatusPanel entity={entity} entityTypeSlug={entityTypeQuery.data?.slug} />
+      )}
       <EditEntityTextFieldsView
         entity={entity}
         textFieldDefs={textFieldDefs}

--- a/frontend/tests/msw/handlers/entity.ts
+++ b/frontend/tests/msw/handlers/entity.ts
@@ -8,6 +8,7 @@ export type EntityStatusDto = 'draft' | 'published' | 'archived'
 interface EntityRecord {
   id: number
   entity_type_id: number
+  slug: string | null
   status: EntityStatusDto
   published_at: string | null
   is_deleted: boolean
@@ -26,6 +27,7 @@ export function seedEntities(
   seed: Array<{
     id: number
     entity_type_id: number
+    slug?: string | null
     status?: EntityStatusDto
     published_at?: string | null
     is_deleted: boolean
@@ -34,6 +36,7 @@ export function seedEntities(
 ): void {
   items = seed.map((item) => ({
     ...item,
+    slug: item.slug ?? null,
     status: item.status ?? 'draft',
     published_at: item.published_at ?? null,
   }))
@@ -177,7 +180,11 @@ export const entityHandlers = [
     return HttpResponse.json(item)
   }),
   http.post('/api/v1/entities', async ({ request }) => {
-    const body = (await request.json()) as { entity_type_id?: number; status?: EntityStatusDto }
+    const body = (await request.json()) as {
+      entity_type_id?: number
+      slug?: string | null
+      status?: EntityStatusDto
+    }
 
     if (typeof body.entity_type_id !== 'number' || body.entity_type_id < 1) {
       return HttpResponse.json(
@@ -195,6 +202,7 @@ export const entityHandlers = [
     const created: EntityRecord = {
       id: nextId++,
       entity_type_id: body.entity_type_id,
+      slug: body.slug ?? null,
       status: body.status ?? 'draft',
       published_at: null,
       is_deleted: false,
@@ -208,6 +216,7 @@ export const entityHandlers = [
     const id = Number(params.id)
     const body = (await request.json()) as {
       entity_type_id?: number
+      slug?: string | null
       status?: EntityStatusDto
       published_at?: string | null
     }
@@ -240,6 +249,7 @@ export const entityHandlers = [
     const updated: EntityRecord = {
       ...existing,
       entity_type_id: body.entity_type_id ?? existing.entity_type_id,
+      slug: body.slug !== undefined ? body.slug : existing.slug,
       status: newStatus,
       published_at: newPublishedAt,
     }

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -18,6 +18,7 @@ use NeNeRecords\DateTimeField\DateTimeFieldNotFoundExceptionHandler;
 use NeNeRecords\DateTimeField\DateTimeFieldServiceProvider;
 use NeNeRecords\DateTimeField\FieldKeyNotRegisteredExceptionHandler as DateTimeFieldKeyNotRegisteredExceptionHandler;
 use NeNeRecords\DateTimeField\FieldTypeMismatchExceptionHandler as DateTimeFieldTypeMismatchExceptionHandler;
+use NeNeRecords\Entity\DuplicateEntitySlugExceptionHandler;
 use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
 use NeNeRecords\Entity\EntityServiceProvider;
 use NeNeRecords\EntityRelation\EntityRelationServiceProvider;
@@ -149,6 +150,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $fieldDefNotFound = $container->get(FieldDefNotFoundExceptionHandler::class);
                     $fieldDefConflict = $container->get(FieldDefConflictExceptionHandler::class);
                     $entityNotFound = $container->get(EntityNotFoundExceptionHandler::class);
+                    $duplicateEntitySlug = $container->get(DuplicateEntitySlugExceptionHandler::class);
                     $textFieldNotFound = $container->get(TextFieldNotFoundExceptionHandler::class);
                     $textFieldKeyNotRegistered = $container->get(TextFieldKeyNotRegisteredExceptionHandler::class);
                     $textFieldTypeMismatch = $container->get(TextFieldTypeMismatchExceptionHandler::class);
@@ -185,6 +187,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $fieldDefNotFound,
                         $fieldDefConflict,
                         $entityNotFound,
+                        $duplicateEntitySlug,
                         $textFieldNotFound,
                         $textFieldKeyNotRegistered,
                         $textFieldTypeMismatch,
@@ -226,6 +229,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $fieldDefNotFound,
                         $fieldDefConflict,
                         $entityNotFound,
+                        $duplicateEntitySlug,
                         $textFieldNotFound,
                         $textFieldKeyNotRegistered,
                         $textFieldTypeMismatch,

--- a/src/Entity/CreateEntityHandler.php
+++ b/src/Entity/CreateEntityHandler.php
@@ -34,6 +34,9 @@ final readonly class CreateEntityHandler
             $errors[] = new ValidationError('entity_type_id', 'Entity type id is required and must be a positive integer.', 'required');
         }
 
+        $rawSlug = $body['slug'] ?? null;
+        $slug = is_string($rawSlug) && trim($rawSlug) !== '' ? trim($rawSlug) : null;
+
         $rawStatus = $body['status'] ?? null;
         $status = is_string($rawStatus) && EntityStatus::isValid($rawStatus) ? $rawStatus : EntityStatus::DRAFT;
 
@@ -44,6 +47,7 @@ final readonly class CreateEntityHandler
         /** @var int $entityTypeId */
         $output = $this->useCase->execute(new CreateEntityInput(
             entityTypeId: $entityTypeId,
+            slug: $slug,
             status: $status,
         ));
 
@@ -51,6 +55,7 @@ final readonly class CreateEntityHandler
             [
                 'id' => $output->id,
                 'entity_type_id' => $output->entityTypeId,
+                'slug' => $output->slug,
                 'status' => $output->status,
                 'published_at' => $output->publishedAtIso,
                 'is_deleted' => $output->isDeleted,

--- a/src/Entity/CreateEntityInput.php
+++ b/src/Entity/CreateEntityInput.php
@@ -8,6 +8,7 @@ final readonly class CreateEntityInput
 {
     public function __construct(
         public int $entityTypeId,
+        public ?string $slug = null,
         public string $status = EntityStatus::DRAFT,
     ) {
     }

--- a/src/Entity/CreateEntityOutput.php
+++ b/src/Entity/CreateEntityOutput.php
@@ -9,6 +9,7 @@ final readonly class CreateEntityOutput
     public function __construct(
         public int $id,
         public int $entityTypeId,
+        public ?string $slug,
         public string $status,
         public ?string $publishedAtIso,
         public bool $isDeleted,

--- a/src/Entity/CreateEntityUseCase.php
+++ b/src/Entity/CreateEntityUseCase.php
@@ -21,19 +21,38 @@ final readonly class CreateEntityUseCase implements CreateEntityUseCaseInterface
             throw new EntityTypeNotFoundException($input->entityTypeId);
         }
 
+        $slug = $this->normalizeSlug($input->slug);
+
+        if ($slug !== null && $this->entities->existsBySlug($slug, $input->entityTypeId)) {
+            throw new DuplicateEntitySlugException($slug);
+        }
+
         $id = $this->entities->save(new Entity(
             id: null,
             entityTypeId: $input->entityTypeId,
+            slug: $slug,
             status: $input->status,
         ));
 
         return new CreateEntityOutput(
             id: $id,
             entityTypeId: $input->entityTypeId,
+            slug: $slug,
             status: $input->status,
             publishedAtIso: null,
             isDeleted: false,
             deletedAtIso: null,
         );
+    }
+
+    private function normalizeSlug(?string $slug): ?string
+    {
+        if ($slug === null) {
+            return null;
+        }
+
+        $normalized = trim($slug);
+
+        return $normalized !== '' ? $normalized : null;
     }
 }

--- a/src/Entity/DuplicateEntitySlugException.php
+++ b/src/Entity/DuplicateEntitySlugException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+use RuntimeException;
+
+final class DuplicateEntitySlugException extends RuntimeException
+{
+    public function __construct(string $slug)
+    {
+        parent::__construct("Entity slug \"{$slug}\" already exists in this entity type.");
+    }
+}

--- a/src/Entity/DuplicateEntitySlugExceptionHandler.php
+++ b/src/Entity/DuplicateEntitySlugExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class DuplicateEntitySlugExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof DuplicateEntitySlugException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'duplicate-entity-slug',
+            'Duplicate slug',
+            422,
+            $exception->getMessage(),
+        );
+    }
+}

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -11,6 +11,7 @@ final readonly class Entity
     public function __construct(
         public ?int $id,
         public int $entityTypeId,
+        public ?string $slug = null,
         public string $status = EntityStatus::DRAFT,
         public ?DateTimeImmutable $publishedAt = null,
         public bool $isDeleted = false,

--- a/src/Entity/EntityRepositoryInterface.php
+++ b/src/Entity/EntityRepositoryInterface.php
@@ -8,6 +8,10 @@ interface EntityRepositoryInterface
 {
     public function findById(int $id): ?Entity;
 
+    public function findBySlug(string $slug, int $entityTypeId): ?Entity;
+
+    public function existsBySlug(string $slug, int $entityTypeId, ?int $excludeId = null): bool;
+
     /** @return list<Entity> */
     public function findAll(int $limit, int $offset): array;
 

--- a/src/Entity/EntityServiceProvider.php
+++ b/src/Entity/EntityServiceProvider.php
@@ -187,6 +187,18 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                DuplicateEntitySlugExceptionHandler::class,
+                static function (ContainerInterface $c): DuplicateEntitySlugExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new DuplicateEntitySlugExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
                 EntityNotFoundExceptionHandler::class,
                 static function (ContainerInterface $c): EntityNotFoundExceptionHandler {
                     $problemDetails = $c->get(ProblemDetailsResponseFactory::class);

--- a/src/Entity/GetEntityByIdHandler.php
+++ b/src/Entity/GetEntityByIdHandler.php
@@ -31,6 +31,7 @@ final readonly class GetEntityByIdHandler
         return $this->response->create([
             'id' => $output->id,
             'entity_type_id' => $output->entityTypeId,
+            'slug' => $output->slug,
             'status' => $output->status,
             'published_at' => $output->publishedAtIso,
             'is_deleted' => $output->isDeleted,

--- a/src/Entity/GetEntityByIdOutput.php
+++ b/src/Entity/GetEntityByIdOutput.php
@@ -9,6 +9,7 @@ final readonly class GetEntityByIdOutput
     public function __construct(
         public int $id,
         public int $entityTypeId,
+        public ?string $slug,
         public string $status,
         public ?string $publishedAtIso,
         public bool $isDeleted,

--- a/src/Entity/GetEntityByIdUseCase.php
+++ b/src/Entity/GetEntityByIdUseCase.php
@@ -31,6 +31,7 @@ final readonly class GetEntityByIdUseCase implements GetEntityByIdUseCaseInterfa
         return new GetEntityByIdOutput(
             id: $entityId,
             entityTypeId: $entity->entityTypeId,
+            slug: $entity->slug,
             status: $entity->status,
             publishedAtIso: $entity->publishedAt?->format(DateTimeInterface::ATOM),
             isDeleted: $entity->isDeleted,

--- a/src/Entity/ListEntitiesHandler.php
+++ b/src/Entity/ListEntitiesHandler.php
@@ -50,6 +50,7 @@ final readonly class ListEntitiesHandler
                     static fn (ListEntityItem $item) => [
                         'id' => $item->id,
                         'entity_type_id' => $item->entityTypeId,
+                        'slug' => $item->slug,
                         'status' => $item->status,
                         'published_at' => $item->publishedAtIso,
                         'is_deleted' => $item->isDeleted,

--- a/src/Entity/ListEntitiesUseCase.php
+++ b/src/Entity/ListEntitiesUseCase.php
@@ -29,6 +29,7 @@ final readonly class ListEntitiesUseCase implements ListEntitiesUseCaseInterface
             return new ListEntityItem(
                 id: $entityId,
                 entityTypeId: $entity->entityTypeId,
+                slug: $entity->slug,
                 status: $entity->status,
                 publishedAtIso: $entity->publishedAt?->format(DateTimeInterface::ATOM),
                 isDeleted: $entity->isDeleted,

--- a/src/Entity/ListEntityItem.php
+++ b/src/Entity/ListEntityItem.php
@@ -9,6 +9,7 @@ final readonly class ListEntityItem
     public function __construct(
         public int $id,
         public int $entityTypeId,
+        public ?string $slug,
         public string $status,
         public ?string $publishedAtIso,
         public bool $isDeleted,

--- a/src/Entity/PdoEntityRepository.php
+++ b/src/Entity/PdoEntityRepository.php
@@ -20,7 +20,7 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
     {
         $row = $this->query->fetchOne(
             <<<'SQL'
-                SELECT id, entity_type_id, status, published_at, is_deleted, deleted_at
+                SELECT id, entity_type_id, slug, status, published_at, is_deleted, deleted_at
                 FROM entities
                 WHERE id = ? AND is_deleted = 0
                 SQL,
@@ -32,6 +32,41 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
         }
 
         return $this->mapRow($row);
+    }
+
+    public function findBySlug(string $slug, int $entityTypeId): ?Entity
+    {
+        $row = $this->query->fetchOne(
+            <<<'SQL'
+                SELECT id, entity_type_id, slug, status, published_at, is_deleted, deleted_at
+                FROM entities
+                WHERE slug = ? AND entity_type_id = ? AND is_deleted = 0
+                SQL,
+            [$slug, $entityTypeId],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return $this->mapRow($row);
+    }
+
+    public function existsBySlug(string $slug, int $entityTypeId, ?int $excludeId = null): bool
+    {
+        if ($excludeId !== null) {
+            $row = $this->query->fetchOne(
+                'SELECT id FROM entities WHERE slug = ? AND entity_type_id = ? AND id != ? AND is_deleted = 0',
+                [$slug, $entityTypeId, $excludeId],
+            );
+        } else {
+            $row = $this->query->fetchOne(
+                'SELECT id FROM entities WHERE slug = ? AND entity_type_id = ? AND is_deleted = 0',
+                [$slug, $entityTypeId],
+            );
+        }
+
+        return $row !== null;
     }
 
     /** @return list<Entity> */
@@ -49,7 +84,7 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
 
         $rows = $this->query->fetchAll(
             <<<SQL
-                SELECT e.id, e.entity_type_id, e.status, e.published_at, e.is_deleted, e.deleted_at
+                SELECT e.id, e.entity_type_id, e.slug, e.status, e.published_at, e.is_deleted, e.deleted_at
                 FROM entities e
                 WHERE {$where}
                 ORDER BY e.id ASC
@@ -132,8 +167,8 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
         $publishedAt = $entity->publishedAt?->format(DateTimeInterface::ATOM);
 
         $this->query->execute(
-            'INSERT INTO entities (entity_type_id, status, published_at) VALUES (?, ?, ?)',
-            [$entity->entityTypeId, $entity->status, $publishedAt],
+            'INSERT INTO entities (entity_type_id, slug, status, published_at) VALUES (?, ?, ?, ?)',
+            [$entity->entityTypeId, $entity->slug, $entity->status, $publishedAt],
         );
 
         return $this->query->lastInsertId();
@@ -152,10 +187,10 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
         $this->query->execute(
             <<<'SQL'
                 UPDATE entities
-                SET entity_type_id = ?, status = ?, published_at = ?
+                SET entity_type_id = ?, slug = ?, status = ?, published_at = ?
                 WHERE id = ? AND is_deleted = 0
                 SQL,
-            [$entity->entityTypeId, $entity->status, $publishedAt, $id],
+            [$entity->entityTypeId, $entity->slug, $entity->status, $publishedAt, $id],
         );
     }
 
@@ -180,9 +215,13 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
         $publishedRaw = $row['published_at'] ?? null;
         $publishedAt = ($publishedRaw !== null && $publishedRaw !== '') ? new DateTimeImmutable((string) $publishedRaw) : null;
 
+        $slugRaw = $row['slug'] ?? null;
+        $slug = ($slugRaw !== null && $slugRaw !== '') ? (string) $slugRaw : null;
+
         return new Entity(
             id: (int) $row['id'],
             entityTypeId: (int) $row['entity_type_id'],
+            slug: $slug,
             status: (string) ($row['status'] ?? EntityStatus::DRAFT),
             publishedAt: $publishedAt,
             isDeleted: (bool) (int) $row['is_deleted'],

--- a/src/Entity/UpdateEntityHandler.php
+++ b/src/Entity/UpdateEntityHandler.php
@@ -43,6 +43,9 @@ final readonly class UpdateEntityHandler
             $errors[] = new ValidationError('entity_type_id', 'Entity type id is required and must be a positive integer.', 'required');
         }
 
+        $rawSlug = $body['slug'] ?? null;
+        $slug = is_string($rawSlug) && trim($rawSlug) !== '' ? trim($rawSlug) : null;
+
         $rawStatus = $body['status'] ?? null;
         $status = is_string($rawStatus) && EntityStatus::isValid($rawStatus) ? $rawStatus : EntityStatus::DRAFT;
 
@@ -57,6 +60,7 @@ final readonly class UpdateEntityHandler
         $output = $this->useCase->execute(new UpdateEntityInput(
             id: $id,
             entityTypeId: $entityTypeId,
+            slug: $slug,
             status: $status,
             publishedAt: $publishedAt,
         ));
@@ -64,6 +68,7 @@ final readonly class UpdateEntityHandler
         return $this->response->create([
             'id' => $output->id,
             'entity_type_id' => $output->entityTypeId,
+            'slug' => $output->slug,
             'status' => $output->status,
             'published_at' => $output->publishedAtIso,
             'is_deleted' => $output->isDeleted,

--- a/src/Entity/UpdateEntityInput.php
+++ b/src/Entity/UpdateEntityInput.php
@@ -11,6 +11,7 @@ final readonly class UpdateEntityInput
     public function __construct(
         public int $id,
         public int $entityTypeId,
+        public ?string $slug = null,
         public string $status = EntityStatus::DRAFT,
         public ?DateTimeImmutable $publishedAt = null,
     ) {

--- a/src/Entity/UpdateEntityOutput.php
+++ b/src/Entity/UpdateEntityOutput.php
@@ -9,6 +9,7 @@ final readonly class UpdateEntityOutput
     public function __construct(
         public int $id,
         public int $entityTypeId,
+        public ?string $slug,
         public string $status,
         public ?string $publishedAtIso,
         public bool $isDeleted,

--- a/src/Entity/UpdateEntityUseCase.php
+++ b/src/Entity/UpdateEntityUseCase.php
@@ -36,6 +36,12 @@ final readonly class UpdateEntityUseCase implements UpdateEntityUseCaseInterface
             throw new EntityTypeNotFoundException($input->entityTypeId);
         }
 
+        $slug = $this->normalizeSlug($input->slug);
+
+        if ($slug !== null && $this->entities->existsBySlug($slug, $input->entityTypeId, $entityId)) {
+            throw new DuplicateEntitySlugException($slug);
+        }
+
         // Auto-set published_at when transitioning to published for the first time.
         $publishedAt = $input->publishedAt ?? $existing->publishedAt;
         if ($input->status === EntityStatus::PUBLISHED && $publishedAt === null) {
@@ -45,6 +51,7 @@ final readonly class UpdateEntityUseCase implements UpdateEntityUseCaseInterface
         $updated = new Entity(
             id: $entityId,
             entityTypeId: $input->entityTypeId,
+            slug: $slug,
             status: $input->status,
             publishedAt: $publishedAt,
             isDeleted: $existing->isDeleted,
@@ -56,10 +63,22 @@ final readonly class UpdateEntityUseCase implements UpdateEntityUseCaseInterface
         return new UpdateEntityOutput(
             id: $entityId,
             entityTypeId: $input->entityTypeId,
+            slug: $slug,
             status: $input->status,
             publishedAtIso: $publishedAt?->format(DateTimeInterface::ATOM),
             isDeleted: $existing->isDeleted,
             deletedAtIso: $existing->deletedAt?->format(DateTimeInterface::ATOM),
         );
+    }
+
+    private function normalizeSlug(?string $slug): ?string
+    {
+        if ($slug === null) {
+            return null;
+        }
+
+        $normalized = trim($slug);
+
+        return $normalized !== '' ? $normalized : null;
     }
 }

--- a/src/PublicRecord/GetPublicRecordViewHandler.php
+++ b/src/PublicRecord/GetPublicRecordViewHandler.php
@@ -20,14 +20,17 @@ final readonly class GetPublicRecordViewHandler
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
-        $slug = trim((string) ($parameters['slug'] ?? ''));
-        $entityId = (int) ($parameters['entityId'] ?? 0);
+        $typeSlug = trim((string) ($parameters['slug'] ?? ''));
+        $entitySlug = trim((string) ($parameters['entitySlug'] ?? ''));
 
-        if ($slug === '' || $entityId <= 0) {
-            throw new PublicRecordNotFoundException($slug !== '' ? $slug : 'unknown', max(0, $entityId));
+        if ($typeSlug === '' || $entitySlug === '') {
+            throw new PublicRecordNotFoundException(
+                $typeSlug !== '' ? $typeSlug : 'unknown',
+                $entitySlug !== '' ? $entitySlug : 'unknown',
+            );
         }
 
-        $output = $this->useCase->execute(new GetPublicRecordViewInput($slug, $entityId));
+        $output = $this->useCase->execute(new GetPublicRecordViewInput($typeSlug, $entitySlug));
 
         return $this->response->create($output->bootstrap);
     }

--- a/src/PublicRecord/GetPublicRecordViewInput.php
+++ b/src/PublicRecord/GetPublicRecordViewInput.php
@@ -8,7 +8,7 @@ final readonly class GetPublicRecordViewInput
 {
     public function __construct(
         public string $entityTypeSlug,
-        public int $entityId,
+        public string $entitySlug,
     ) {
     }
 }

--- a/src/PublicRecord/GetPublicRecordViewOutput.php
+++ b/src/PublicRecord/GetPublicRecordViewOutput.php
@@ -14,6 +14,7 @@ final readonly class GetPublicRecordViewOutput
         public string $entityTypeSlug,
         public string $entityTypeName,
         public int $entityId,
+        public string $entitySlug,
         public string $pageTitle,
         public array $bootstrap,
         public array $displayFields,

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -52,16 +52,15 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             throw new PublicEntityTypeNotFoundException($input->entityTypeSlug);
         }
 
-        $entity = $this->entities->findById($input->entityId);
+        $entity = $this->entities->findBySlug($input->entitySlug, $entityType->id);
 
         if (
             $entity === null
             || $entity->id === null
             || $entity->isDeleted
-            || $entity->entityTypeId !== $entityType->id
             || $entity->status !== EntityStatus::PUBLISHED
         ) {
-            throw new PublicRecordNotFoundException($input->entityTypeSlug, $input->entityId);
+            throw new PublicRecordNotFoundException($input->entityTypeSlug, $input->entitySlug);
         }
 
         $entityTypeId = $entityType->id;
@@ -158,6 +157,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             entityTypeSlug: $input->entityTypeSlug,
             entityTypeName: $entityType->name,
             entityId: $entityId,
+            entitySlug: $input->entitySlug,
             pageTitle: $pageTitle,
             bootstrap: $bootstrap,
             displayFields: $displayFields,

--- a/src/PublicRecord/PublicRecordNotFoundException.php
+++ b/src/PublicRecord/PublicRecordNotFoundException.php
@@ -10,10 +10,10 @@ final class PublicRecordNotFoundException extends RuntimeException
 {
     public function __construct(
         public readonly string $entityTypeSlug,
-        public readonly int $entityId,
+        public readonly string $entitySlug,
     ) {
         parent::__construct(
-            "Public record \"{$entityTypeSlug}/{$entityId}\" was not found.",
+            "Public record \"{$entityTypeSlug}/{$entitySlug}\" was not found.",
         );
     }
 }

--- a/src/PublicRecord/PublicRecordRouteRegistrar.php
+++ b/src/PublicRecord/PublicRecordRouteRegistrar.php
@@ -21,12 +21,12 @@ final readonly class PublicRecordRouteRegistrar
         $renderPublicRecordViewHandler = $this->renderPublicRecordViewHandler;
 
         $router->get(
-            '/api/v1/public/entity-types/{slug}/records/{entityId}',
+            '/api/v1/public/entity-types/{slug}/records/{entitySlug}',
             static fn (ServerRequestInterface $request) => $getPublicRecordViewHandler->handle($request),
         );
 
         $router->get(
-            '/view/{slug}/{entityId}',
+            '/view/{slug}/{entitySlug}',
             static fn (ServerRequestInterface $request) => $renderPublicRecordViewHandler->handle($request),
         );
     }

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -24,14 +24,17 @@ final readonly class RenderPublicRecordViewHandler
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
-        $slug = trim((string) ($parameters['slug'] ?? ''));
-        $entityId = (int) ($parameters['entityId'] ?? 0);
+        $typeSlug = trim((string) ($parameters['slug'] ?? ''));
+        $entitySlug = trim((string) ($parameters['entitySlug'] ?? ''));
 
-        if ($slug === '' || $entityId <= 0) {
-            throw new PublicRecordNotFoundException($slug !== '' ? $slug : 'unknown', max(0, $entityId));
+        if ($typeSlug === '' || $entitySlug === '') {
+            throw new PublicRecordNotFoundException(
+                $typeSlug !== '' ? $typeSlug : 'unknown',
+                $entitySlug !== '' ? $entitySlug : 'unknown',
+            );
         }
 
-        $output = $this->useCase->execute(new GetPublicRecordViewInput($slug, $entityId));
+        $output = $this->useCase->execute(new GetPublicRecordViewInput($typeSlug, $entitySlug));
         $siteSettings = $this->resolveSiteSettings();
 
         $bootstrapJson = json_encode(

--- a/tests/Entity/InMemoryEntityRepository.php
+++ b/tests/Entity/InMemoryEntityRepository.php
@@ -61,6 +61,40 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
         return $entity;
     }
 
+    public function findBySlug(string $slug, int $entityTypeId): ?Entity
+    {
+        foreach ($this->entities as $entity) {
+            if ($entity->isDeleted) {
+                continue;
+            }
+
+            if ($entity->slug === $slug && $entity->entityTypeId === $entityTypeId) {
+                return $entity;
+            }
+        }
+
+        return null;
+    }
+
+    public function existsBySlug(string $slug, int $entityTypeId, ?int $excludeId = null): bool
+    {
+        foreach ($this->entities as $entity) {
+            if ($entity->isDeleted) {
+                continue;
+            }
+
+            if ($entity->slug === $slug && $entity->entityTypeId === $entityTypeId) {
+                if ($excludeId !== null && $entity->id === $excludeId) {
+                    continue;
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /** @return list<Entity> */
     public function findAll(int $limit, int $offset): array
     {
@@ -134,6 +168,7 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
         $this->entities[$id] = new Entity(
             id: $id,
             entityTypeId: $entity->entityTypeId,
+            slug: $entity->slug,
             status: $entity->status,
             publishedAt: $entity->publishedAt,
         );

--- a/tests/PublicRecord/GetPublicRecordViewUseCaseTest.php
+++ b/tests/PublicRecord/GetPublicRecordViewUseCaseTest.php
@@ -34,7 +34,7 @@ final class GetPublicRecordViewUseCaseTest extends TestCase
             new EntityType(name: 'Article', slug: 'article', id: 1),
         ]);
         $entities = new InMemoryEntityRepository([
-            new Entity(id: 10, entityTypeId: 1, status: EntityStatus::PUBLISHED),
+            new Entity(id: 10, entityTypeId: 1, slug: 'hello-world', status: EntityStatus::PUBLISHED),
         ]);
         $fieldDefs = new InMemoryFieldDefRepository([
             new FieldDef(entityTypeId: 1, fieldKey: 'title', dataType: 'text', id: 1),
@@ -60,7 +60,7 @@ final class GetPublicRecordViewUseCaseTest extends TestCase
             new ListPublicSettingsUseCase(new InMemorySettingRepository()),
         );
 
-        $output = $useCase->execute(new GetPublicRecordViewInput('article', 10));
+        $output = $useCase->execute(new GetPublicRecordViewInput('article', 'hello-world'));
 
         self::assertSame('article', $output->entityTypeSlug);
         self::assertSame('Hello', $output->pageTitle);
@@ -87,7 +87,7 @@ final class GetPublicRecordViewUseCaseTest extends TestCase
         );
 
         $this->expectException(PublicEntityTypeNotFoundException::class);
-        $useCase->execute(new GetPublicRecordViewInput('missing', 1));
+        $useCase->execute(new GetPublicRecordViewInput('missing', 'some-slug'));
     }
 
     public function testThrowsWhenRecordMissing(): void
@@ -110,6 +110,6 @@ final class GetPublicRecordViewUseCaseTest extends TestCase
         );
 
         $this->expectException(PublicRecordNotFoundException::class);
-        $useCase->execute(new GetPublicRecordViewInput('article', 99));
+        $useCase->execute(new GetPublicRecordViewInput('article', 'nonexistent'));
     }
 }

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -56,7 +56,7 @@ final class PublicRecordHttpTest extends TestCase
             new EntityType(name: 'Article', slug: 'article', id: 1),
         ]);
         $entities = new InMemoryEntityRepository([
-            new Entity(id: 10, entityTypeId: 1, status: EntityStatus::PUBLISHED),
+            new Entity(id: 10, entityTypeId: 1, slug: 'hello-world', status: EntityStatus::PUBLISHED),
         ]);
         $fieldDefs = new InMemoryFieldDefRepository([
             new FieldDef(entityTypeId: 1, fieldKey: 'title', dataType: 'text', id: 1),
@@ -125,7 +125,7 @@ final class PublicRecordHttpTest extends TestCase
         $response = $this->application->handle(
             $this->factory->createServerRequest(
                 'GET',
-                'https://example.test/api/v1/public/entity-types/article/records/10',
+                'https://example.test/api/v1/public/entity-types/article/records/hello-world',
             ),
         );
         $payload = $this->decodeJson($response);
@@ -141,7 +141,7 @@ final class PublicRecordHttpTest extends TestCase
         $response = $this->application->handle(
             $this->factory->createServerRequest(
                 'GET',
-                'https://example.test/api/v1/public/entity-types/missing/records/10',
+                'https://example.test/api/v1/public/entity-types/missing/records/some-slug',
             ),
         );
 
@@ -153,7 +153,7 @@ final class PublicRecordHttpTest extends TestCase
         $response = $this->application->handle(
             $this->factory->createServerRequest(
                 'GET',
-                'https://example.test/view/article/10',
+                'https://example.test/view/article/hello-world',
             ),
         );
         $html = (string) $response->getBody();

--- a/tools/generate-mcp-tools.php
+++ b/tools/generate-mcp-tools.php
@@ -285,6 +285,11 @@ $tools = [
                 'type' => 'integer',
                 'minimum' => 1,
             ],
+            'slug' => [
+                'type' => 'string',
+                'minLength' => 1,
+                'description' => 'URL slug (unique per entity type).',
+            ],
             'status' => [
                 'type' => 'string',
                 'enum' => ['draft', 'published', 'archived'],
@@ -311,21 +316,21 @@ $tools = [
         'Aggregated bootstrap payload for a public consumer record detail page.',
         'getPublicRecordView',
         'GET',
-        '/api/v1/public/entity-types/{slug}/records/{entityId}',
+        '/api/v1/public/entity-types/{slug}/records/{entitySlug}',
         [
             'slug' => [
                 'type' => 'string',
                 'minLength' => 1,
                 'description' => 'Entity type slug.',
             ],
-            'entityId' => [
-                'type' => 'integer',
-                'minimum' => 1,
-                'description' => 'Entity instance id.',
+            'entitySlug' => [
+                'type' => 'string',
+                'minLength' => 1,
+                'description' => 'Entity slug.',
             ],
         ],
         '#/components/schemas/PublicRecordViewResponse',
-        ['slug', 'entityId'],
+        ['slug', 'entitySlug'],
     ),
     idTool(
         'updateEntityById',
@@ -338,6 +343,11 @@ $tools = [
             'entity_type_id' => [
                 'type' => 'integer',
                 'minimum' => 1,
+            ],
+            'slug' => [
+                'type' => 'string',
+                'minLength' => 1,
+                'description' => 'URL slug (unique per entity type).',
             ],
             'status' => [
                 'type' => 'string',


### PR DESCRIPTION
## Summary

- `entities` テーブルに `slug` カラム（entity_type_id + slug の UNIQUE インデックス）を追加
- `DuplicateEntitySlugException`（422）で entity type 内の slug 重複を検出
- `EntityRepositoryInterface` に `findBySlug` / `existsBySlug` を追加し PDO・InMemory 実装を提供
- `CreateEntityUseCase` / `UpdateEntityUseCase` で slug バリデーション・永続化に対応
- 全 Entity Handler・UseCase・DTO に `slug` フィールドを追加
- Public ルートを ID ベースから **slug ベース** に変更
  - `GET /api/v1/public/entity-types/{slug}/records/{entitySlug}`
  - `GET /view/{typeSlug}/{entitySlug}`
- `GetPublicRecordViewInput` を `entityId: int → entitySlug: string` に変更
- OpenAPI スキーマ・MCP ツールを slug ベースに更新
- フロントエンド: Entity モデル / DTO / mapper / MSW handlers に `slug` を追加
- `EntityStatusPanel` に slug 編集フィールドと公開 URL リンクを追加
- `ApplicationServiceProvider` に `DuplicateEntitySlugExceptionHandler` を登録

## Test plan

- [x] PHPUnit 168 tests pass
- [x] PHPStan no errors
- [x] PHP-CS-Fixer no changes
- [x] OpenAPI contract valid
- [x] MCP tool catalog valid
- [x] TypeScript type check pass
- [x] ESLint 0 errors/warnings
- [x] Prettier formatted
- [x] Vitest pass
- [x] Storybook build pass

## Checklist

セルフレビューチェックリスト: `docs/review/backend.md` + `docs/review/frontend.md`

Closes #87

Made with [Cursor](https://cursor.com)