### PR TITLE
ci(backend): PHP バックエンド GitHub Actions CI を追加 (#90)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,47 @@
+name: Backend CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pdo, pdo_sqlite
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Prepare environment
+        run: cp .env.example .env
+
+      - name: Create var directory
+        run: mkdir -p var
+
+      - name: Run checks
+        run: composer check


### PR DESCRIPTION
## 目的

Issue #90 — PHP バックエンドの CI が存在しなかったため、GitHub Actions ワークフローを追加する。

## 変更点

- `.github/workflows/backend-ci.yml` を新規追加
- PR・main push のたびに `composer check` を自動実行
  - PHPUnit（168 tests）
  - PHPStan（Level Max）
  - PHP-CS-Fixer（--dry-run）
  - OpenAPI バリデーション
  - MCP ツールカタログバリデーション

## 技術的判断

- テストは全て SQLite インメモリで完結しているため MySQL サービス不要
- PHP 8.4 + `shivammathur/setup-php` でセットアップ
- Composer キャッシュで二回目以降の実行を高速化

## 検証結果

ローカルで `composer check` を実行し全チェック通過を確認。
```
OK (168 tests, 763 assertions)
No errors (PHPStan)
Found 0 of 529 files that can be fixed (PHP-CS-Fixer)
OpenAPI contract is valid.
MCP tool catalog is valid.
```

## セルフレビューチェックリスト: docs/development/coding-standards.md

Closes #90

Made with [Cursor](https://cursor.com)