### PR TITLE
fix(auth): expires_at を ISO 8601 文字列に修正（ログイン不能バグ）

### DIFF
--- a/src/Auth/LoginHandler.php
+++ b/src/Auth/LoginHandler.php
@@ -44,7 +44,7 @@ final readonly class LoginHandler
 
         return $this->response->create([
             'token' => $output->token,
-            'expires_at' => $output->expiresAt,
+            'expires_at' => (new \DateTimeImmutable('@' . $output->expiresAt))->format(\DateTimeInterface::ATOM),
             'email' => $output->email,
             'role' => $output->role,
         ]);


### PR DESCRIPTION
## 原因

`LoginUseCase` が `$expiresAt = time() + 86400` として UNIX タイムスタンプ整数を返していた。
フロントエンドの `authStore.isAuthenticated()` は `new Date(session.expiresAt) > new Date()` で判定するため、整数値だと `new Date("1779719622")` が `Invalid Date` になりログイン直後に未認証扱いされていた。

## 修正

`LoginHandler` で `DateTimeImmutable` を使い、ATOM 形式（ISO 8601）の文字列に変換してレスポンスを返すように修正。

```
"expires_at": "2026-05-25T14:34:29+00:00"  // 修正後
"expires_at": 1779719622                    // 修正前（整数）
```

OpenAPI の `LoginResponse.expires_at` は `type: string, format: date-time` で既に正しく定義されていた（実装のみが不一致）。

## 検証

- `curl` で `/api/v1/auth/login` を叩いて ISO 文字列が返ることを確認
- `composer check` 全通過（168 tests, PHPStan, CS-Fixer, OpenAPI, MCP）

## セルフレビューチェックリスト: docs/development/coding-standards.md

Closes #86

Made with [Cursor](https://cursor.com)