### PR TITLE
ci(backend): NENE2 をクローンしてローカルパス依存を解決 (#90)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -34,6 +34,9 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
+      - name: Clone NENE2 (local path dependency)
+        run: git clone --depth=1 https://github.com/hideyukiMORI/NENE2.git ../NENE2
+
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 


### PR DESCRIPTION
## 原因

`composer.json` が `../NENE2` のローカルパスで `hideyukimori/nene2` を参照しているため、
CI 環境（GitHub Actions）ではそのパスが存在せず `composer install` が以下のエラーで失敗していた。

```
Source path "../NENE2" is not found for package hideyukimori/nene2
```

## 修正

ワークフローに `git clone --depth=1 https://github.com/hideyukiMORI/NENE2.git ../NENE2` ステップを追加。
NENE2 はパブリックリポジトリのため認証不要。
`--depth=1` で履歴を省略し実行時間を最小化。

## ローカル開発への影響なし

`../NENE2` が存在するローカル環境では引き続き symlink によるパス参照が使われる。

Closes #90

Made with [Cursor](https://cursor.com)