### PR TITLE
fix(public-record): datetime 表示の UTC タイムゾーン変換バグを修正 (#91)

### DIFF
--- a/src/PublicRecord/PublicFieldDisplayFormatter.php
+++ b/src/PublicRecord/PublicFieldDisplayFormatter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\PublicRecord;
 
 use DateTimeImmutable;
+use DateTimeZone;
 
 final readonly class PublicFieldDisplayFormatter
 {
@@ -36,6 +37,6 @@ final readonly class PublicFieldDisplayFormatter
             return $iso;
         }
 
-        return $parsed->format('Y-m-d H:i:s') . ' UTC';
+        return $parsed->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s') . ' UTC';
     }
 }

--- a/tests/PublicRecord/PublicFieldDisplayFormatterTest.php
+++ b/tests/PublicRecord/PublicFieldDisplayFormatterTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use NeNeRecords\PublicRecord\PublicFieldDisplayFormatter;
+use PHPUnit\Framework\TestCase;
+
+final class PublicFieldDisplayFormatterTest extends TestCase
+{
+    public function testFormatDateTimeConvertsToUtc(): void
+    {
+        // JST (+09:00) → UTC 変換で 9 時間引かれることを確認
+        $result = PublicFieldDisplayFormatter::format('datetime', '2026-05-24T09:00:00+09:00');
+        self::assertSame('2026-05-24 00:00:00 UTC', $result);
+    }
+
+    public function testFormatDateTimeAlreadyUtc(): void
+    {
+        $result = PublicFieldDisplayFormatter::format('datetime', '2026-05-24T12:30:00+00:00');
+        self::assertSame('2026-05-24 12:30:00 UTC', $result);
+    }
+
+    public function testFormatDateTimeNegativeOffset(): void
+    {
+        // EST (-05:00) → UTC 変換で 5 時間足されることを確認
+        $result = PublicFieldDisplayFormatter::format('datetime', '2026-05-24T07:00:00-05:00');
+        self::assertSame('2026-05-24 12:00:00 UTC', $result);
+    }
+
+    public function testFormatDateTimeFallbackFormatWithoutTimezone(): void
+    {
+        // タイムゾーン情報なし → そのまま返す（パース失敗扱い）
+        $result = PublicFieldDisplayFormatter::format('datetime', '2026-05-24 12:30:00');
+        self::assertSame('2026-05-24 12:30:00 UTC', $result);
+    }
+
+    public function testFormatDateTimeEmpty(): void
+    {
+        $result = PublicFieldDisplayFormatter::format('datetime', '');
+        self::assertSame('—', $result);
+    }
+
+    public function testFormatDateTimeNull(): void
+    {
+        $result = PublicFieldDisplayFormatter::format('datetime', null);
+        self::assertSame('—', $result);
+    }
+
+    public function testFormatBool(): void
+    {
+        self::assertSame('Yes', PublicFieldDisplayFormatter::format('bool', 'true'));
+        self::assertSame('No', PublicFieldDisplayFormatter::format('bool', 'false'));
+        self::assertSame('Yes', PublicFieldDisplayFormatter::format('bool', '1'));
+        self::assertSame('No', PublicFieldDisplayFormatter::format('bool', '0'));
+    }
+
+    public function testFormatInt(): void
+    {
+        self::assertSame('42', PublicFieldDisplayFormatter::format('int', 42));
+    }
+
+    public function testFormatTextEmpty(): void
+    {
+        self::assertSame('—', PublicFieldDisplayFormatter::format('text', '   '));
+    }
+
+    public function testFormatText(): void
+    {
+        self::assertSame('hello', PublicFieldDisplayFormatter::format('text', 'hello'));
+    }
+}


### PR DESCRIPTION
## バグ

`PublicFieldDisplayFormatter::formatDateTime` が `setTimezone` を呼ばずに `format()` していたため、JST 等の offset を持つ datetime 値がタイムゾーン変換されずにそのまま「UTC」と表示されていた。

```
// 修正前（誤り）
"2026-05-24T09:00:00+09:00" → "2026-05-24 09:00:00 UTC"

// 修正後（正しい）
"2026-05-24T09:00:00+09:00" → "2026-05-24 00:00:00 UTC"
```

## 修正

`DateTimeImmutable::setTimezone(new DateTimeZone('UTC'))` を挟んで UTC 変換してから `format()` する。

## テスト

`PublicFieldDisplayFormatterTest` を新規追加（10 tests, 13 assertions）。
JST→UTC / EST→UTC / UTC / タイムゾーンなし / null / bool / int / text を網羅。

Closes #91

Made with [Cursor](https://cursor.com)