### PR TITLE
docs: OSS 公開準備 — CHANGELOG / SECURITY / llms.txt / README バッジ / 401 リダイレクト

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,105 @@
+# Changelog
+
+All notable changes to NeNe Records are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+NeNe Records does not yet follow Semantic Versioning — entries are grouped by milestone.
+
+---
+
+## [Unreleased]
+
+### Added
+- `CHANGELOG.md` — this file (#94)
+- `SECURITY.md` — vulnerability reporting policy (#97)
+- `llms.txt` — LLM crawler summary (#96)
+- README badges and OSS-ready copy (#98)
+
+---
+
+## [M1 Complete] — 2026-05-24
+
+### Added
+- PHP backend GitHub Actions CI (`composer check`: PHPUnit / PHPStan / CS-Fixer / OpenAPI / MCP) (#90, PR #99 #101)
+- User authentication, Admin login, API Bearer auth with JWT (#86, PR #88)
+- Public slug routing — `/view/{type}/{slug}` and `slug` field on entities (#87, PR #89)
+- Publish status workflow — `draft` / `published` / `archived` + `published_at` (#84, PR #85)
+- Site Settings API and Admin UI — 3-table design with atomic updates (#80, PR #81)
+
+### Fixed
+- `expires_at` returned as UNIX timestamp integer instead of ISO 8601 string (PR #100)
+- Backend CI failing due to missing local `../NENE2` path in GitHub Actions (PR #101)
+
+---
+
+## [Phase 7 — CMS Hardening] — 2026-05-24
+
+### Added
+- Public record aggregation API and HTML bootstrap (#75, PR #76)
+- Markdown rendering for `body` fields on public pages (#78, PR #79)
+- Blog demo seed script (`tools/seed-blog-demo.php`) (PR #77)
+- CMS mid-term milestone plan and TODO (PR #83)
+
+---
+
+## [Phase 6 — Consumer Views] — 2026-05-24
+
+### Added
+- Consumer views — public listing and detail pages (#38, PR #39)
+- Consumer view relation link display (#63, PR #64)
+- Public record detail: relations rendered as links (PR #64)
+- Access log persistence and daily analytics API (#69, PR #70)
+- Consumer Views Phase 6 enhancements — layout, field display (#72, PR #73)
+
+---
+
+## [Phase 5 — MCP Tools] — 2026-05-24
+
+### Added
+- Full API MCP tool catalog — 60 tools across all domains (#67, PR #68)
+- Entity relation tools added to MCP catalog (#65, PR #66)
+
+---
+
+## [Phase 4 — Entity Relations & Tags] — 2026-05-24
+
+### Added
+- Entity relations API and `relation` field type for field_defs (#51, PR #54)
+- ADR 0004: Entity Relations design (#51, PR #53)
+- Record relation attach/detach UI (#52, PR #56)
+- Records list: relation filter API and Admin UI (#57 #59, PR #58 #60)
+- Record detail: inverse relation (referenced-by) list (#61, PR #62)
+- Tag CRUD Admin UI (#44, PR #45)
+- Record tag attach/detach UI (#46, PR #47)
+- Records list: tag filter UI (#48, PR #49)
+- Records list: relation filter UI (#59, PR #60)
+- List API: relation filter (#57, PR #58)
+
+---
+
+## [Phase 3 — Field Types & Filters] — 2026-05-24
+
+### Added
+- All field type UIs: text, int, bool, enum, datetime (#36, PR #37)
+- List API field filters for all types (PR #37)
+- field_def edit UI (#40, PR #41)
+- text-fields: entity_type_id filter + list label optimisation (#42, PR #43)
+- Frontend CI (ESLint / TypeScript / Vitest) (PR #37)
+
+---
+
+## [Phase 2 — Core Admin UI] — 2026-05-24
+
+### Added
+- Entity type editor — create, list, delete (#24, PR #25)
+- Entity list, create, delete UI (#26, PR #27)
+- field_defs list, create, delete UI (#28, PR #29)
+- text_fields value edit UI (#30, PR #31)
+- Record list with title display (#32, PR #33)
+- int_fields value edit UI (#34, PR #35)
+
+---
+
+## [Phase 1 — Infrastructure] — 2026-05-24
+
+### Added
+- Local development Docker Compose stack (MySQL 8.4 + phpMyAdmin + Mailpit) (#22, PR #23)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # NeNe Records
 
+[![Backend CI](https://github.com/hideyukiMORI/nene-records/actions/workflows/backend-ci.yml/badge.svg)](https://github.com/hideyukiMORI/nene-records/actions/workflows/backend-ci.yml)
+[![Frontend CI](https://github.com/hideyukiMORI/nene-records/actions/workflows/frontend-ci.yml/badge.svg)](https://github.com/hideyukiMORI/nene-records/actions/workflows/frontend-ci.yml)
+[![PHP 8.4](https://img.shields.io/badge/PHP-8.4-777BB4?logo=php)](https://www.php.net/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
+[![OpenAPI](https://img.shields.io/badge/OpenAPI-3.1-85EA2D?logo=swagger)](./docs/openapi/openapi.yaml)
+
 API-first flexible entity platform built on [NENE2](https://github.com/hideyukiMORI/NENE2).
 
 NeNe Records lets you define entity types and typed fields from the admin frontend, persist them through a thin JSON API, and expose the same operations to humans, SPAs, and AI agents via OpenAPI and MCP.
@@ -10,14 +16,34 @@ NeNe Records lets you define entity types and typed fields from the admin fronte
 - **Readable**: explicit schema registry, typed value tables, OpenAPI contracts
 - **Secure**: auth and validation at the API boundary; MCP tools never touch the database directly
 - **Replaceable layers**: swap the API runtime, admin UI, or consumer views independently
+- **AI-native**: 60+ MCP tools expose every API operation to AI clients
+
+## Quick Start
+
+```bash
+git clone https://github.com/hideyukiMORI/nene-records.git
+cd nene-records
+cp .env.example .env
+docker compose up --build -d
+# Admin UI → http://localhost:8080
+```
+
+Default credentials (local only): `admin@nene-records.local` / `nene1234`
+
+> See [`docs/development/docker.md`](./docs/development/docker.md) for full setup details.
 
 ## Architecture
 
 ```
 Admin frontend (React)  ──┐
-Consumer views          ──┼──→  NeNe Records API (NENE2)  ──→  Database
+Consumer views          ──┼──→  NeNe Records API (NENE2)  ──→  MySQL / SQLite
 AI clients (MCP)        ──┘
 ```
+
+- **Backend**: PHP 8.4, NENE2 framework, Clean Architecture (Use Cases / Repositories)
+- **Frontend**: React 19, TypeScript, Vite, TailwindCSS v4, React Query
+- **API contract**: OpenAPI 3.1 ([`docs/openapi/openapi.yaml`](./docs/openapi/openapi.yaml))
+- **MCP**: 60+ tools auto-generated from OpenAPI
 
 ## Contributing
 
@@ -26,7 +52,6 @@ NeNe Records inherits NENE2 engineering discipline:
 | Topic | Document |
 | --- | --- |
 | **Product vision** | [`docs/explanation/product-vision.md`](./docs/explanation/product-vision.md) |
-| **Workspace handoff** | [`docs/todo/handoff-2026-05-24-workspace-switch.md`](./docs/todo/handoff-2026-05-24-workspace-switch.md) |
 | **Start here (agents)** | [`AGENTS.md`](./AGENTS.md) |
 | NENE2 inheritance map | [`docs/inheritance-from-nene2.md`](./docs/inheritance-from-nene2.md) |
 | Workflow | [`docs/workflow.md`](./docs/workflow.md) |
@@ -36,15 +61,6 @@ NeNe Records inherits NENE2 engineering discipline:
 | Full contributing guide | [`docs/CONTRIBUTING.md`](./docs/CONTRIBUTING.md) |
 
 **Rules in brief:** GitHub Issue-driven work, `type/issue-number-summary` branches, Conventional Commits (Japanese description, English type), PR with verification and self-review checklist, no direct commits to `main`.
-
-## Status
-
-Early planning. See [Issues](https://github.com/hideyukiMORI/nene-records/issues).
-
-Local development stack: **`docker compose up --build`** — see [`docs/development/docker.md`](./docs/development/docker.md).
-
-- [#1](https://github.com/hideyukiMORI/nene-records/issues/1) — MVP entity CRUD vertical slice
-- [#2](https://github.com/hideyukiMORI/nene-records/issues/2) — NENE2 governance inheritance
 
 ## Related
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| main    | ✅        |
+
+We currently support the latest `main` branch only. Older commits are not patched.
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub Issue for security vulnerabilities.**
+
+Use [GitHub Private Vulnerability Reporting](https://github.com/hideyukiMORI/nene-records/security/advisories/new) to report vulnerabilities confidentially.
+
+### What to include
+
+- A clear description of the vulnerability
+- Steps to reproduce (proof of concept if possible)
+- The potential impact and affected components
+- Any suggested mitigations
+
+### Response timeline
+
+| Stage | Target |
+| ----- | ------ |
+| Acknowledgement | Within 3 business days |
+| Initial assessment | Within 7 business days |
+| Fix or mitigation | Depends on severity (critical: ASAP, high: 30 days, others: 90 days) |
+| Public disclosure | After fix is available |
+
+## Scope
+
+This policy covers the NeNe Records application code in this repository.
+It does not cover the NENE2 framework (report to [hideyukiMORI/NENE2](https://github.com/hideyukiMORI/NENE2)) or third-party dependencies.

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -31,6 +31,10 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
   })
 
   if (!response.ok) {
+    if (response.status === 401 && !path.includes('/auth/login')) {
+      authStore.clearSession()
+      window.location.href = '/login'
+    }
     throw await parseProblemDetails(response)
   }
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,64 @@
+# NeNe Records
+
+> API-first flexible entity platform on NENE2. Define entity types and typed fields from an admin UI; persist via JSON API; expose to humans, SPAs, and AI agents through OpenAPI and MCP.
+
+## Project
+
+- Repository: https://github.com/hideyukiMORI/nene-records
+- Framework: NENE2 (https://github.com/hideyukiMORI/NENE2) — PHP 8.4 micro-framework
+- License: MIT
+
+## Documentation
+
+- [AGENTS.md](./AGENTS.md) — AI agent entry point and operating rules
+- [docs/explanation/product-vision.md](./docs/explanation/product-vision.md) — product direction
+- [docs/workflow.md](./docs/workflow.md) — contribution workflow
+- [docs/development/coding-standards.md](./docs/development/coding-standards.md) — coding standards
+- [docs/development/backend-standards.md](./docs/development/backend-standards.md) — backend patterns
+- [docs/development/frontend-standards.md](./docs/development/frontend-standards.md) — frontend patterns
+- [docs/inheritance-from-nene2.md](./docs/inheritance-from-nene2.md) — NENE2 inheritance map
+- [docs/roadmap.md](./docs/roadmap.md) — roadmap
+- [docs/todo/current.md](./docs/todo/current.md) — current tasks
+
+## API
+
+- OpenAPI 3.1 contract: [docs/openapi/openapi.yaml](./docs/openapi/openapi.yaml)
+- Base URL (local): http://localhost:8080
+- Auth: Bearer JWT via `POST /api/v1/auth/login`
+
+### Key endpoints
+
+- `GET  /api/v1/entity-types` — list entity types
+- `POST /api/v1/entity-types` — create entity type (Admin)
+- `GET  /api/v1/entity-types/{id}/entities` — list entities
+- `POST /api/v1/entity-types/{id}/entities` — create entity (Admin)
+- `GET  /api/v1/public/entity-types/{slug}/records` — public record list
+- `GET  /api/v1/public/entity-types/{slug}/records/{entitySlug}` — public record detail
+- `GET  /api/v1/settings` — site settings (public)
+- `PUT  /api/v1/admin/settings` — update site settings (Admin)
+
+## MCP Tools
+
+60+ MCP tools auto-generated from OpenAPI. Tool catalog: [tools/mcp-tools.json](./tools/mcp-tools.json)
+
+Categories: entity-types, entities, field-defs, text-fields, int-fields, bool-fields, enum-fields, datetime-fields, tags, entity-relations, settings, analytics, auth, public-records
+
+## Architecture
+
+```
+Admin frontend (React 19 + Vite)  ──┐
+Consumer views                    ──┼──→  NeNe Records API (NENE2)  ──→  MySQL / SQLite
+AI clients via MCP                ──┘
+```
+
+### Backend (src/)
+Clean Architecture: Use Cases → Repositories → PDO. One service provider per domain.
+Entity domains: Entity, EntityType, FieldDef, *Field, Tag, EntityRelation, Setting, PublicRecord, Analytics, Auth.
+
+### Frontend (frontend/src/)
+Feature-Sliced Design: app / pages / features / entities / shared.
+React Query for server state; TailwindCSS v4 design tokens.
+
+### Database
+MySQL 8.4 (production), SQLite (tests). Phinx migrations in `database/migrations/`.
+Schema snapshots in `database/schema/`.


### PR DESCRIPTION
## 変更点

### #94 CHANGELOG.md
Keep a Changelog 形式で Phase 1 から M1 完了までの全 PR 履歴を記録。

### #97 SECURITY.md
GitHub Private Vulnerability Reporting を使った脆弱性報告ポリシー。対応タイムライン明記。

### #96 llms.txt
[llmstxt.org](https://llmstxt.org) 標準。API エンドポイント / MCP ツール / アーキテクチャを機械可読形式で記述。

### #98 README バッジ
Backend CI / Frontend CI / PHP 8.4 / License MIT / OpenAPI 3.1 バッジを追加。Quick Start（5 ステップ）と Architecture セクションも強化。

### #93 フロントエンド 401 → ログインリダイレクト
`shared/api/client.ts` の `request` 関数で 401 レスポンス時に `authStore.clearSession()` してから `window.location.href = '/login'` にリダイレクト。ログイン API 自体（`/auth/login`）は除外し、認証情報誤りのエラー表示は従来通り動作する。

## 検証

- TypeScript: `tsc --noEmit` エラーなし
- 全変更はドキュメント or フロントエンドのみ（バックエンドの `composer check` 対象外）

Closes #93
Closes #94
Closes #96
Closes #97
Closes #98

Made with [Cursor](https://cursor.com)