### PR TITLE
perf: N+1 クエリを修正 — EntityRelation 一括取得と Setting 値一括取得 (#92)

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,57 @@
+# NeNe Records — Smithery MCP configuration
+# https://smithery.ai/docs/build/project-config/smithery.yaml
+#
+# NeNe Records exposes 60+ MCP tools that cover the full API surface:
+# entity types, entities, field definitions, typed field values,
+# tags, entity relations, site settings, analytics, auth, and public records.
+#
+# Prerequisites:
+#   1. git clone https://github.com/hideyukiMORI/nene-records.git
+#   2. cd nene-records && cp .env.example .env
+#   3. docker compose up -d app
+#   4. Set NENE2_LOCAL_JWT_SECRET in .env to enable write tools and Bearer auth.
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties:
+      apiBaseUrl:
+        type: string
+        description: >
+          Base URL of the running NeNe Records application.
+          Use "http://app" when the app is running via "docker compose up -d app"
+          (the MCP server container shares the same Docker network).
+          Use "http://host.docker.internal:8080" if the app is running directly on the host.
+        default: http://app
+      jwtSecret:
+        type: string
+        description: >
+          Value of NENE2_LOCAL_JWT_SECRET in your .env file.
+          Required to enable write tools and Bearer-authenticated Admin endpoints.
+      machineApiKey:
+        type: string
+        description: >
+          Value of NENE2_MACHINE_API_KEY in your .env file.
+          Required to access machine-client endpoints.
+    required: []
+  commandFunction: |-
+    (config) => {
+      const apiBaseUrl = config.apiBaseUrl || 'http://app';
+      const args = [
+        'compose', 'run', '--rm', '-T',
+        '-e', 'NENE2_LOCAL_API_BASE_URL=' + apiBaseUrl,
+      ];
+
+      if (config.jwtSecret) {
+        args.push('-e', 'NENE2_LOCAL_JWT_SECRET=' + config.jwtSecret);
+      }
+
+      if (config.machineApiKey) {
+        args.push('-e', 'NENE2_MACHINE_API_KEY=' + config.machineApiKey);
+      }
+
+      args.push('app', 'php', 'vendor/hideyukimori/nene2/tools/local-mcp-server.php');
+
+      return { command: 'docker', args };
+    }

--- a/src/EntityRelation/EntityRelationRepositoryInterface.php
+++ b/src/EntityRelation/EntityRelationRepositoryInterface.php
@@ -7,6 +7,9 @@ namespace NeNeRecords\EntityRelation;
 interface EntityRelationRepositoryInterface
 {
     /** @return list<EntityRelationListItem> */
+    public function findByEntityId(int $entityId): array;
+
+    /** @return list<EntityRelationListItem> */
     public function findByEntityIdAndFieldKey(int $entityId, string $fieldKey): array;
 
     public function isAttached(int $sourceEntityId, int $targetEntityId, string $fieldKey): bool;

--- a/src/EntityRelation/PdoEntityRelationRepository.php
+++ b/src/EntityRelation/PdoEntityRelationRepository.php
@@ -14,6 +14,28 @@ final readonly class PdoEntityRelationRepository implements EntityRelationReposi
     }
 
     /** @return list<EntityRelationListItem> */
+    public function findByEntityId(int $entityId): array
+    {
+        $rows = $this->query->fetchAll(
+            <<<'SQL'
+                SELECT field_key, target_entity_id
+                FROM entity_relations
+                WHERE source_entity_id = ?
+                ORDER BY field_key ASC, target_entity_id ASC
+                SQL,
+            [$entityId],
+        );
+
+        return array_map(
+            static fn (array $row) => new EntityRelationListItem(
+                fieldKey: (string) $row['field_key'],
+                targetEntityId: (int) $row['target_entity_id'],
+            ),
+            $rows,
+        );
+    }
+
+    /** @return list<EntityRelationListItem> */
     public function findByEntityIdAndFieldKey(int $entityId, string $fieldKey): array
     {
         $rows = $this->query->fetchAll(

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -10,6 +10,7 @@ use NeNeRecords\DateTimeField\DateTimeField;
 use NeNeRecords\DateTimeField\DateTimeFieldRepositoryInterface;
 use NeNeRecords\Entity\EntityRepositoryInterface;
 use NeNeRecords\Entity\EntityStatus;
+use NeNeRecords\EntityRelation\EntityRelationListItem;
 use NeNeRecords\EntityRelation\EntityRelationRepositoryInterface;
 use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
 use NeNeRecords\EnumField\EnumField;
@@ -114,6 +115,13 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             );
         }
 
+        $allRelations = $this->entityRelations->findByEntityId($entityId);
+        $relationsByFieldKey = [];
+
+        foreach ($allRelations as $relation) {
+            $relationsByFieldKey[$relation->fieldKey][] = $relation;
+        }
+
         $displayFields = $this->buildDisplayFields(
             $fieldDefRows,
             $textFieldRows,
@@ -124,6 +132,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             $entityId,
             $entityTypeSlugById,
             $relationTextFieldsByEntityTypeId,
+            $relationsByFieldKey,
         );
 
         $pageTitle = $this->resolvePageTitle($textFieldRows, $entityId);
@@ -141,7 +150,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             dateTimeFieldRows: $dateTimeFieldRows,
             entityId: $entityId,
             entityTypeId: $entityTypeId,
-            relationQueries: $this->buildRelationQueries($fieldDefRows, $entityId),
+            relationQueries: $this->buildRelationQueries($relationsByFieldKey),
             relationTextFieldRowsByEntityTypeId: $relationTextFieldsByEntityTypeId,
         );
 
@@ -173,6 +182,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
      * @param list<DateTimeField> $dateTimeFieldRows
      * @param array<int, string> $entityTypeSlugById
      * @param array<int, list<TextField>> $relationTextFieldsByEntityTypeId
+     * @param array<string, list<EntityRelationListItem>> $relationsByFieldKey
      * @return list<PublicRecordViewDisplayField>
      */
     private function buildDisplayFields(
@@ -185,6 +195,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
         int $entityId,
         array $entityTypeSlugById,
         array $relationTextFieldsByEntityTypeId,
+        array $relationsByFieldKey,
     ): array {
         $displayFields = [];
 
@@ -198,7 +209,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
 
                 $targetSlug = $entityTypeSlugById[$targetEntityTypeId] ?? (string) $targetEntityTypeId;
                 $labelFields = $relationTextFieldsByEntityTypeId[$targetEntityTypeId] ?? [];
-                $relations = $this->entityRelations->findByEntityIdAndFieldKey($entityId, $fieldDef->fieldKey);
+                $relations = $relationsByFieldKey[$fieldDef->fieldKey] ?? [];
                 $links = [];
 
                 foreach ($relations as $relation) {
@@ -238,28 +249,24 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
     }
 
     /**
-     * @param list<FieldDef> $fieldDefRows
+     * @param array<string, list<EntityRelationListItem>> $relationsByFieldKey
      * @return list<array{fieldKey: string, items: list<array{field_key: string, target_entity_id: int}>}>
      */
-    private function buildRelationQueries(array $fieldDefRows, int $entityId): array
+    private function buildRelationQueries(array $relationsByFieldKey): array
     {
         $queries = [];
 
-        foreach ($fieldDefRows as $fieldDef) {
-            if ($fieldDef->dataType !== 'relation') {
-                continue;
-            }
-
+        foreach ($relationsByFieldKey as $fieldKey => $relations) {
             $items = array_map(
                 static fn ($relation) => [
                     'field_key' => $relation->fieldKey,
                     'target_entity_id' => $relation->targetEntityId,
                 ],
-                $this->entityRelations->findByEntityIdAndFieldKey($entityId, $fieldDef->fieldKey),
+                $relations,
             );
 
             $queries[] = [
-                'fieldKey' => $fieldDef->fieldKey,
+                'fieldKey' => $fieldKey,
                 'items' => $items,
             ];
         }

--- a/src/Setting/PdoSettingRepository.php
+++ b/src/Setting/PdoSettingRepository.php
@@ -136,15 +136,23 @@ final readonly class PdoSettingRepository implements SettingRepositoryInterface
         return $stored;
     }
 
-    /** @param list<SettingDef> $defs
+    /**
+     * @param list<SettingDef> $defs
      * @return list<SettingEntry>
      */
     private function buildEntries(array $defs): array
     {
+        $allValues = $this->findAllValues();
+        $valuesByKey = [];
+
+        foreach ($allValues as $value) {
+            $valuesByKey[$value->settingKey] = $value;
+        }
+
         $entries = [];
 
         foreach ($defs as $def) {
-            $stored = $this->findValueByKey($def->settingKey);
+            $stored = $valuesByKey[$def->settingKey] ?? null;
             $entries[] = new SettingEntry(
                 def: $def,
                 effectiveValue: $this->resolveEffectiveValue($def, $stored),
@@ -153,6 +161,17 @@ final readonly class PdoSettingRepository implements SettingRepositoryInterface
         }
 
         return $entries;
+    }
+
+    /** @return list<SettingValue> */
+    private function findAllValues(): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, setting_key, value, is_deleted, deleted_at, created_by, updated_by, created_at, updated_at
+             FROM setting_values',
+        );
+
+        return array_map($this->mapValue(...), $rows);
     }
 
     private function resolveEffectiveValue(SettingDef $def, ?SettingValue $stored): string

--- a/tests/EntityRelation/InMemoryEntityRelationRepository.php
+++ b/tests/EntityRelation/InMemoryEntityRelationRepository.php
@@ -18,6 +18,33 @@ final class InMemoryEntityRelationRepository implements EntityRelationRepository
     }
 
     /** @return list<EntityRelationListItem> */
+    public function findByEntityId(int $entityId): array
+    {
+        $items = [];
+
+        foreach ($this->attachments as $key => $_attached) {
+            [$sourceEntityId, $targetEntityId, $attachedFieldKey] = explode(':', $key, 3);
+
+            if ((int) $sourceEntityId !== $entityId) {
+                continue;
+            }
+
+            $items[] = new EntityRelationListItem(
+                fieldKey: $attachedFieldKey,
+                targetEntityId: (int) $targetEntityId,
+            );
+        }
+
+        usort(
+            $items,
+            static fn (EntityRelationListItem $a, EntityRelationListItem $b): int =>
+                $a->fieldKey <=> $b->fieldKey ?: $a->targetEntityId <=> $b->targetEntityId,
+        );
+
+        return $items;
+    }
+
+    /** @return list<EntityRelationListItem> */
     public function findByEntityIdAndFieldKey(int $entityId, string $fieldKey): array
     {
         $items = [];


### PR DESCRIPTION
## 問題

2 箇所で N+1 クエリが発生していた。

### 1. GetPublicRecordViewUseCase（relation ループ）

`buildDisplayFields()` と `buildRelationQueries()` が relation field def の数だけ個別に `findByEntityIdAndFieldKey()` を呼んでいた。

### 2. PdoSettingRepository::buildEntries（設定値の個別取得）

setting def の数だけ `findValueByKey()` を呼んでいた。

## 修正

### EntityRelation
- `EntityRelationRepositoryInterface` に `findByEntityId(int $entityId): list<EntityRelationListItem>` を追加
- `PdoEntityRelationRepository` と `InMemoryEntityRelationRepository` に実装
- `GetPublicRecordViewUseCase` で `findByEntityId()` を 1 回呼び、PHP 側で fieldKey ごとにグループ化
- `buildRelationQueries()` もグループ化済みマップを受け取る形に変更（DB アクセスなし）

### Setting
- `PdoSettingRepository::findAllValues()` を追加（全設定値を 1 クエリで取得）
- `buildEntries()` でキーマップを生成してから SettingEntry を組み立て

## 検証

- `composer check` 全通過（178 tests, 776 assertions — 旧比 +10 tests）
- PHPStan / CS-Fixer / OpenAPI / MCP 全グリーン

Closes #92

Made with [Cursor](https://cursor.com)