### PR TITLE
fix(entity-type): レコードがある Entity Type を削除しようとすると 500 になるバグを修正 (#99)

### DIFF
--- a/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.ts
+++ b/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.ts
@@ -85,5 +85,6 @@ export function useManageEntityTypesPage() {
     cancelDelete,
     confirmDelete,
     isDeleting: deleteMutation.isPending,
+    deleteErrorDetail: deleteMutation.error?.detail ?? deleteMutation.error?.title ?? null,
   }
 }

--- a/frontend/src/features/manage-entity-types/ui/ManageEntityTypesView.tsx
+++ b/frontend/src/features/manage-entity-types/ui/ManageEntityTypesView.tsx
@@ -16,6 +16,7 @@ export interface ManageEntityTypesViewProps {
   updateErrorTitle: string | null
   deleteTarget: EntityType | null
   isDeleting: boolean
+  deleteErrorDetail: string | null
   onRetry: () => void
   onCreate: (values: { name: string; slug: string }) => Promise<void>
   onRequestEdit: (entityType: EntityType) => void
@@ -38,6 +39,7 @@ export function ManageEntityTypesView({
   updateErrorTitle,
   deleteTarget,
   isDeleting,
+  deleteErrorDetail,
   onRetry,
   onCreate,
   onRequestEdit,
@@ -88,6 +90,7 @@ export function ManageEntityTypesView({
             ? `"${deleteTarget.name}" will be removed. This cannot be undone.`
             : undefined
         }
+        errorDetail={deleteErrorDetail}
         confirmLabel={isDeleting ? 'Deleting…' : 'Delete'}
         isPending={isDeleting}
         onCancel={onCancelDelete}

--- a/frontend/src/pages/entity-types/EntityTypesPage.tsx
+++ b/frontend/src/pages/entity-types/EntityTypesPage.tsx
@@ -22,6 +22,7 @@ export function EntityTypesPage() {
     cancelDelete,
     confirmDelete,
     isDeleting,
+    deleteErrorDetail,
   } = useManageEntityTypesPage()
 
   return (
@@ -41,6 +42,7 @@ export function EntityTypesPage() {
         updateErrorTitle={updateErrorTitle}
         deleteTarget={deleteTarget}
         isDeleting={isDeleting}
+        deleteErrorDetail={deleteErrorDetail}
         onRetry={() => {
           void refetch()
         }}

--- a/frontend/src/shared/ui/components/ConfirmDialog.tsx
+++ b/frontend/src/shared/ui/components/ConfirmDialog.tsx
@@ -6,6 +6,7 @@ export interface ConfirmDialogProps {
   open: boolean
   title: string
   description?: string
+  errorDetail?: string | null
   confirmLabel?: string
   cancelLabel?: string
   isPending?: boolean
@@ -25,6 +26,7 @@ export function ConfirmDialog({
   open,
   title,
   description,
+  errorDetail = null,
   confirmLabel = 'Confirm',
   cancelLabel = 'Cancel',
   isPending = false,
@@ -56,6 +58,14 @@ export function ConfirmDialog({
             </Text>
             {description !== undefined ? <Text muted>{description}</Text> : null}
           </Stack>
+          {errorDetail !== null ? (
+            <div
+              role="alert"
+              className="rounded-md border border-red-200 bg-red-50 px-inline-sm py-stack-xs text-sm text-red-700"
+            >
+              {errorDetail}
+            </div>
+          ) : null}
           <Stack direction="horizontal" gap="sm">
             <Button variant="secondary" disabled={isPending} onClick={onCancel}>
               {cancelLabel}

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -30,6 +30,7 @@ use NeNeRecords\EntityRelation\RelationTargetTypeMismatchExceptionHandler;
 use NeNeRecords\EntityTag\EntityTagAlreadyAttachedExceptionHandler;
 use NeNeRecords\EntityTag\EntityTagNotAttachedExceptionHandler;
 use NeNeRecords\EntityTag\EntityTagServiceProvider;
+use NeNeRecords\EntityType\EntityTypeHasEntitiesExceptionHandler;
 use NeNeRecords\EntityType\EntityTypeNotFoundExceptionHandler;
 use NeNeRecords\EntityType\EntityTypeServiceProvider;
 use NeNeRecords\EntityType\EntityTypeSlugConflictExceptionHandler;
@@ -146,6 +147,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                 self::EXCEPTION_HANDLERS,
                 static function (ContainerInterface $container): array {
                     $entityTypeNotFound = $container->get(EntityTypeNotFoundExceptionHandler::class);
+                    $entityTypeHasEntities = $container->get(EntityTypeHasEntitiesExceptionHandler::class);
                     $entityTypeSlugConflict = $container->get(EntityTypeSlugConflictExceptionHandler::class);
                     $fieldDefNotFound = $container->get(FieldDefNotFoundExceptionHandler::class);
                     $fieldDefConflict = $container->get(FieldDefConflictExceptionHandler::class);
@@ -183,6 +185,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
 
                     foreach ([
                         $entityTypeNotFound,
+                        $entityTypeHasEntities,
                         $entityTypeSlugConflict,
                         $fieldDefNotFound,
                         $fieldDefConflict,
@@ -225,6 +228,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
 
                     return [
                         $entityTypeNotFound,
+                        $entityTypeHasEntities,
                         $entityTypeSlugConflict,
                         $fieldDefNotFound,
                         $fieldDefConflict,

--- a/src/EntityType/DeleteEntityTypeUseCase.php
+++ b/src/EntityType/DeleteEntityTypeUseCase.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace NeNeRecords\EntityType;
 
+use NeNeRecords\Entity\EntityListCriteria;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+
 final readonly class DeleteEntityTypeUseCase implements DeleteEntityTypeUseCaseInterface
 {
     public function __construct(
         private EntityTypeRepositoryInterface $entityTypes,
+        private EntityRepositoryInterface $entities,
     ) {
     }
 
@@ -17,6 +21,12 @@ final readonly class DeleteEntityTypeUseCase implements DeleteEntityTypeUseCaseI
 
         if ($entityType === null) {
             throw new EntityTypeNotFoundException($input->id);
+        }
+
+        $count = $this->entities->countByCriteria(new EntityListCriteria(entityTypeId: $input->id));
+
+        if ($count > 0) {
+            throw new EntityTypeHasEntitiesException($input->id, $count);
         }
 
         $this->entityTypes->delete($input->id);

--- a/src/EntityType/EntityTypeHasEntitiesException.php
+++ b/src/EntityType/EntityTypeHasEntitiesException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityType;
+
+use RuntimeException;
+
+final class EntityTypeHasEntitiesException extends RuntimeException
+{
+    public function __construct(int $entityTypeId, int $count)
+    {
+        parent::__construct(
+            "Entity type #{$entityTypeId} cannot be deleted because it has {$count} record(s). Delete all records first.",
+        );
+    }
+}

--- a/src/EntityType/EntityTypeHasEntitiesExceptionHandler.php
+++ b/src/EntityType/EntityTypeHasEntitiesExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityType;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class EntityTypeHasEntitiesExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof EntityTypeHasEntitiesException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'entity-type-has-entities',
+            'Cannot delete entity type with records',
+            409,
+            $exception->getMessage(),
+        );
+    }
+}

--- a/src/EntityType/EntityTypeServiceProvider.php
+++ b/src/EntityType/EntityTypeServiceProvider.php
@@ -10,6 +10,7 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Entity\EntityRepositoryInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 
@@ -92,12 +93,17 @@ final readonly class EntityTypeServiceProvider implements ServiceProviderInterfa
                 DeleteEntityTypeUseCaseInterface::class,
                 static function (ContainerInterface $c): DeleteEntityTypeUseCaseInterface {
                     $repository = $c->get(EntityTypeRepositoryInterface::class);
+                    $entities = $c->get(EntityRepositoryInterface::class);
 
                     if (!$repository instanceof EntityTypeRepositoryInterface) {
                         throw new LogicException('Entity type repository service is invalid.');
                     }
 
-                    return new DeleteEntityTypeUseCase($repository);
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    return new DeleteEntityTypeUseCase($repository, $entities);
                 },
             )
             ->set(
@@ -185,6 +191,18 @@ final readonly class EntityTypeServiceProvider implements ServiceProviderInterfa
                     }
 
                     return new EntityTypeNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                EntityTypeHasEntitiesExceptionHandler::class,
+                static function (ContainerInterface $c): EntityTypeHasEntitiesExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new EntityTypeHasEntitiesExceptionHandler($problemDetails);
                 },
             )
             ->set(

--- a/tests/EntityType/EntityTypeHttpTest.php
+++ b/tests/EntityType/EntityTypeHttpTest.php
@@ -12,6 +12,7 @@ use NeNeRecords\EntityType\CreateEntityTypeUseCase;
 use NeNeRecords\EntityType\DeleteEntityTypeHandler;
 use NeNeRecords\EntityType\DeleteEntityTypeUseCase;
 use NeNeRecords\EntityType\EntityType;
+use NeNeRecords\EntityType\EntityTypeHasEntitiesExceptionHandler;
 use NeNeRecords\EntityType\EntityTypeNotFoundExceptionHandler;
 use NeNeRecords\EntityType\EntityTypeRouteRegistrar;
 use NeNeRecords\EntityType\EntityTypeSlugConflictExceptionHandler;
@@ -21,6 +22,7 @@ use NeNeRecords\EntityType\ListEntityTypesHandler;
 use NeNeRecords\EntityType\ListEntityTypesUseCase;
 use NeNeRecords\EntityType\UpdateEntityTypeHandler;
 use NeNeRecords\EntityType\UpdateEntityTypeUseCase;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -42,11 +44,13 @@ final class EntityTypeHttpTest extends TestCase
         $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
         $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
 
+        $entityRepository = new InMemoryEntityRepository();
+
         $registrar = new EntityTypeRouteRegistrar(
             new GetEntityTypeByIdHandler(new GetEntityTypeByIdUseCase($this->repository), $jsonResponse),
             new CreateEntityTypeHandler(new CreateEntityTypeUseCase($this->repository), $jsonResponse),
             new UpdateEntityTypeHandler(new UpdateEntityTypeUseCase($this->repository), $jsonResponse),
-            new DeleteEntityTypeHandler(new DeleteEntityTypeUseCase($this->repository), $this->factory),
+            new DeleteEntityTypeHandler(new DeleteEntityTypeUseCase($this->repository, $entityRepository), $this->factory),
             new ListEntityTypesHandler(new ListEntityTypesUseCase($this->repository), $jsonResponse),
         );
 
@@ -55,6 +59,7 @@ final class EntityTypeHttpTest extends TestCase
             $this->factory,
             domainExceptionHandlers: [
                 new EntityTypeNotFoundExceptionHandler($problemDetails),
+                new EntityTypeHasEntitiesExceptionHandler($problemDetails),
                 new EntityTypeSlugConflictExceptionHandler($problemDetails),
             ],
             routeRegistrars: [$registrar],


### PR DESCRIPTION
## 目的

Entity Types ページで既存のタイプを Delete しようとすると 500 Internal Server Error になっていたバグを修正。

## 原因

`DeleteEntityTypeUseCase` がエンティティ件数を確認せずに `DELETE` を実行していた。
DB の外部キー制約が違反され、NENE2 フレームワークが汎用 500 として返していた。

## 変更点

### バックエンド
- `EntityTypeHasEntitiesException` を新規追加
- `EntityTypeHasEntitiesExceptionHandler` を新規追加（**409 Conflict** を返す）
- `DeleteEntityTypeUseCase` に `EntityRepositoryInterface` を注入し、削除前に `countByCriteria` で件数確認
- `EntityTypeServiceProvider` / `ApplicationServiceProvider` にハンドラーを登録

### フロントエンド
- `ConfirmDialog` に `errorDetail` prop を追加し、エラーメッセージをダイアログ内に表示
- `useManageEntityTypesPage` / `ManageEntityTypesView` / `EntityTypesPage` にエラー伝播を追加

### テスト
- `EntityTypeHttpTest` のセットアップに `InMemoryEntityRepository` を渡すように修正（引数不足エラー解消）

## 検証

```
composer check  → 全パス (178 tests, 750 assertions)
npm run check   → 全パス
```

API 動作確認:
- エンティティあり → **409 Conflict** + わかりやすいメッセージ
- エンティティなし → **204 No Content** で正常削除

## セルフレビューチェックリスト

- [x] 変更は依頼範囲に限定
- [x] composer check 全パス
- [x] npm run check 全パス
- [x] 秘密情報なし

Made with [Cursor](https://cursor.com)