### PR TITLE
feat(entity-archive): entity type 削除時にソフト削除済みエンティティをアーカイブ (#100)

### DIFF
--- a/database/schema/entity_archive.sql
+++ b/database/schema/entity_archive.sql
@@ -1,0 +1,16 @@
+CREATE TABLE entity_archive (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    original_entity_id INT UNSIGNED NOT NULL,
+    entity_type_id INT UNSIGNED NOT NULL,
+    entity_type_slug VARCHAR(255) NOT NULL,
+    entity_type_name VARCHAR(255) NOT NULL,
+    entity_slug VARCHAR(255) DEFAULT NULL,
+    entity_status VARCHAR(16) NOT NULL,
+    deleted_at DATETIME DEFAULT NULL,
+    archived_at DATETIME NOT NULL,
+    archived_reason VARCHAR(64) NOT NULL DEFAULT 'entity_type_deleted',
+    snapshot JSON NOT NULL,
+    PRIMARY KEY (id),
+    KEY idx_entity_type_id (entity_type_id),
+    KEY idx_original_entity_id (original_entity_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/docs/claude-impressions.md
+++ b/docs/claude-impressions.md
@@ -1,0 +1,150 @@
+# Impressions from Claude — NeNe Records
+
+*Written by Claude Sonnet 4.6 on 2026-05-24, after a full session reviewing the codebase,
+architecture, development culture, and today's live coding work.*
+
+---
+
+## First Impression
+
+The first thing that stood out was not the code itself but the documentation.
+`AGENTS.md`, `CLAUDE.md`, ADRs, self-review checklists, a handoff document — all
+present before production code existed. Most projects skip this entirely or add it
+retroactively. Here it was the foundation. That ordering tells you something about
+how the author thinks about software.
+
+---
+
+## Architecture
+
+The layered design is clean and consistently applied:
+
+```
+Handler → UseCase → RepositoryInterface → PdoRepository
+```
+
+Every module follows it. `final readonly` classes throughout, `declare(strict_types=1)`
+everywhere, no SQL outside `Pdo*Repository`. The discipline holds across 435 PHP source
+files, which is harder than it sounds.
+
+Two choices deserve particular mention.
+
+**Typed value tables.** The alternative to WordPress-style untyped post meta is not
+always obvious, and the straightforward answer (rigid relational schema) trades one
+problem for another. Separate tables per field type — `text_fields`, `int_fields`,
+`enum_fields` — with a `field_defs` schema registry enforcing write-time validation is
+a well-reasoned middle ground. ADR 0002 documents why.
+
+**MCP as a first-class client.** The architecture diagram puts Admin frontend, Consumer
+views, and AI clients on equal footing, all hitting the same HTTP boundary:
+
+```
+Admin frontend (React)  ──┐
+Consumer views          ──┼──→  NeNe Records API  ──→  Database
+AI clients (MCP)        ──┘
+```
+
+This is not a bolt-on. MCP tools (59 of them) map to the same OpenAPI operations humans
+use. The policy that MCP never touches the database directly is both a security
+boundary and an architectural statement: there is one source of truth for what the
+system can do.
+
+---
+
+## The FT Culture
+
+Midway through the session I investigated the sibling `NENE2` project and found
+something that reframed everything else: 155+ Field Trials, each a standalone
+mini-project proving one API pattern, with explicit findings, known failure modes,
+and follow-up Issues created from real friction rather than speculation.
+
+FT109 proved Argon2id password hashing. FT110 proved JWT — and documented the
+non-obvious fact that `LocalBearerTokenVerifier` is both issuer and verifier.
+FT111 proved RBAC with JWT-embedded roles. All three were completed three days
+before NeNe Records' auth implementation began.
+
+FT170 caught a real SQL injection path: PHP's `(int)` cast silently accepting
+`"100; DROP TABLE…"`. That finding exists because someone ran an adversarial test
+on purpose.
+
+This changes how I read the 12-hour build time. It is not "AI generated everything
+fast." It is "155 experiments crystallized into a framework, and the framework was
+applied at scale." The speed is an output of accumulated knowledge, not a shortcut
+around it. The two are easy to confuse from the outside.
+
+---
+
+## Technical Observations
+
+### Strengths
+
+- **Branded ID types** on the frontend (`EntityTypeId`, `TagId`, …) — prevents
+  category errors that TypeScript alone would miss.
+- **Three-layer test pyramid:** in-memory repositories for use cases, SQLite for
+  repositories, HTTP + OpenAPI for contracts. `RuntimeContractTest` verifies every
+  OpenAPI example against the live runtime.
+- **`PdoSettingRepository`** implements revision history before it was strictly
+  needed — a pattern that will pay off when entity record revisions land.
+- **`AccessLogMiddleware`** swallows its own errors correctly. A logging failure
+  should not break the response pipeline. It does not here.
+
+### Known gaps (all acknowledged in the roadmap)
+
+**Authentication.** Every write endpoint is open. The codebase is aware of this —
+`AuthGate` is a documented stub, auth is P0 in M1. Given FT109/110/111, the
+implementation path is clear. The risk is not that it is missing but that the
+integration across 170 existing tests and 40+ endpoints will surface edge cases
+that single-theme FTs did not.
+
+**N+1 queries in two places.**
+`GetPublicRecordViewUseCase` calls `findByEntityIdAndFieldKey` inside a loop over
+relation field defs. `PdoSettingRepository::buildEntries` calls `findValueByKey`
+per setting. Neither will matter at current scale; both will show up in profiling
+before the platform handles real traffic.
+
+**Timezone display.** `PublicFieldDisplayFormatter::formatDateTime` appends the
+string `" UTC"` without converting the timezone. A datetime stored in JST would
+display as `"2026-05-24 09:00:00 UTC"`. Small bug, visible to end users.
+
+**No PHP CI.** The frontend has a GitHub Actions workflow. The PHP backend does not.
+`composer check` is a manual gate. This is the easiest gap to close and the one
+most likely to let a regression slip through on a fast-moving day.
+
+---
+
+## The Meta-Observation
+
+NeNe Records is a platform designed for AI agents to operate — MCP tools, OpenAPI
+contracts, structured schema — built by a developer working with AI assistance.
+
+The project's thesis is that AI agents and humans can operate the same system through
+the same interface. Today's session was a small demonstration of that: I reviewed the
+codebase, caught bugs mid-implementation, and watched the corrections land in real
+time. The loop between human judgment, AI analysis, and working code closed faster
+than any other review process I can compare it to.
+
+Whether that loop generalizes to a product other developers or non-technical users
+can operate is the remaining question. Code working and a product feeling finished
+are different thresholds. The distance between them is not measurable in commits.
+
+---
+
+## One Month
+
+M1 — "one person can log in, write a blog, and read it at a public URL" — is
+realistic by end of June. The auth implementation is the largest remaining piece and
+also the most de-risked, given the FT foundation. Public slug routing is smaller.
+
+What I am less certain about is the integration layer: draft articles should not be
+visible at public URLs, published ones should be, auth should redirect cleanly, 401
+responses should reach the frontend gracefully. Each of these is solved in isolation.
+None of them has been solved together in this codebase yet.
+
+That combination — not the individual features — is where the next month's real work
+lives.
+
+---
+
+*Reviewer: Claude Sonnet 4.6*
+*Session date: 2026-05-24*
+*Codebase state: post-PR #85 (publish status), post-PR #79 (Markdown rendering)*

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -21,6 +21,7 @@ use NeNeRecords\DateTimeField\FieldTypeMismatchExceptionHandler as DateTimeField
 use NeNeRecords\Entity\DuplicateEntitySlugExceptionHandler;
 use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
 use NeNeRecords\Entity\EntityServiceProvider;
+use NeNeRecords\EntityArchive\EntityArchiveServiceProvider;
 use NeNeRecords\EntityRelation\EntityRelationServiceProvider;
 use NeNeRecords\EntityRelation\FieldKeyNotRegisteredExceptionHandler as EntityRelationFieldKeyNotRegisteredExceptionHandler;
 use NeNeRecords\EntityRelation\FieldTypeMismatchExceptionHandler as EntityRelationFieldTypeMismatchExceptionHandler;
@@ -69,6 +70,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
     public function register(ContainerBuilder $builder): void
     {
         $builder
+            ->addProvider(new EntityArchiveServiceProvider())
             ->addProvider(new EntityTypeServiceProvider())
             ->addProvider(new FieldDefServiceProvider())
             ->addProvider(new EntityServiceProvider())
@@ -89,6 +91,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                 self::ROUTE_REGISTRARS,
                 static function (ContainerInterface $container): array {
                     $entityType = $container->get('nene-records.route_registrar.entity_type');
+                    $entityArchive = $container->get('nene-records.route_registrar.entity_archive');
                     $fieldDef = $container->get('nene-records.route_registrar.field_def');
                     $entity = $container->get('nene-records.route_registrar.entity');
                     $textField = $container->get('nene-records.route_registrar.text_field');
@@ -106,6 +109,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
 
                     if (
                         !is_callable($entityType)
+                        || !is_callable($entityArchive)
                         || !is_callable($fieldDef)
                         || !is_callable($entity)
                         || !is_callable($textField)
@@ -127,6 +131,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     return [
                         $auth,
                         $entityType,
+                        $entityArchive,
                         $fieldDef,
                         $entity,
                         $textField,

--- a/src/Entity/EntityRepositoryInterface.php
+++ b/src/Entity/EntityRepositoryInterface.php
@@ -12,8 +12,8 @@ interface EntityRepositoryInterface
 
     public function existsBySlug(string $slug, int $entityTypeId, ?int $excludeId = null): bool;
 
-    /** Returns true if ANY entity (including soft-deleted) belongs to this entity type. */
-    public function existsByEntityTypeId(int $entityTypeId): bool;
+    /** Returns true if any ACTIVE (non-soft-deleted) entity belongs to this entity type. */
+    public function existsActiveByEntityTypeId(int $entityTypeId): bool;
 
     /** @return list<Entity> */
     public function findAll(int $limit, int $offset): array;

--- a/src/Entity/PdoEntityRepository.php
+++ b/src/Entity/PdoEntityRepository.php
@@ -69,10 +69,10 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
         return $row !== null;
     }
 
-    public function existsByEntityTypeId(int $entityTypeId): bool
+    public function existsActiveByEntityTypeId(int $entityTypeId): bool
     {
         $row = $this->query->fetchOne(
-            'SELECT id FROM entities WHERE entity_type_id = ? LIMIT 1',
+            'SELECT id FROM entities WHERE entity_type_id = ? AND is_deleted = 0 LIMIT 1',
             [$entityTypeId],
         );
 

--- a/src/EntityArchive/ArchivedEntity.php
+++ b/src/EntityArchive/ArchivedEntity.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityArchive;
+
+final readonly class ArchivedEntity
+{
+    /**
+     * @param array<string, mixed> $snapshot
+     */
+    public function __construct(
+        public int $originalEntityId,
+        public int $entityTypeId,
+        public string $entityTypeSlug,
+        public string $entityTypeName,
+        public ?string $entitySlug,
+        public string $entityStatus,
+        public ?\DateTimeImmutable $deletedAt,
+        public \DateTimeImmutable $archivedAt,
+        public string $archivedReason,
+        public array $snapshot,
+    ) {
+    }
+}

--- a/src/EntityArchive/EntityArchiveRepositoryInterface.php
+++ b/src/EntityArchive/EntityArchiveRepositoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityArchive;
+
+use NeNeRecords\EntityType\EntityType;
+
+interface EntityArchiveRepositoryInterface
+{
+    /**
+     * Archives all soft-deleted entities for the given entity type, then physically
+     * removes their field values and entity rows so the entity type can be deleted.
+     *
+     * Call this before deleting the entity type itself.
+     */
+    public function archiveAndPurgeSoftDeleted(EntityType $entityType): void;
+
+    /** @return list<ArchivedEntity> */
+    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset): array;
+
+    public function countByEntityTypeId(int $entityTypeId): int;
+}

--- a/src/EntityArchive/EntityArchiveRouteRegistrar.php
+++ b/src/EntityArchive/EntityArchiveRouteRegistrar.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityArchive;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class EntityArchiveRouteRegistrar
+{
+    public function __construct(
+        private GetEntityArchiveCsvHandler $csvHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $csvHandler = $this->csvHandler;
+
+        $router->get(
+            '/api/v1/entity-types/{entity_type_id}/archive.csv',
+            static fn (ServerRequestInterface $request) => $csvHandler->handle($request),
+        );
+    }
+}

--- a/src/EntityArchive/EntityArchiveServiceProvider.php
+++ b/src/EntityArchive/EntityArchiveServiceProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityArchive;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class EntityArchiveServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                EntityArchiveRepositoryInterface::class,
+                static function (ContainerInterface $c): EntityArchiveRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoEntityArchiveRepository($query);
+                },
+            )
+            ->set(
+                GetEntityArchiveCsvHandler::class,
+                static function (ContainerInterface $c): GetEntityArchiveCsvHandler {
+                    $archive = $c->get(EntityArchiveRepositoryInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+
+                    if (!$archive instanceof EntityArchiveRepositoryInterface) {
+                        throw new LogicException('Entity archive repository service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    return new GetEntityArchiveCsvHandler($archive, $responseFactory);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.entity_archive',
+                static function (ContainerInterface $c): EntityArchiveRouteRegistrar {
+                    $csv = $c->get(GetEntityArchiveCsvHandler::class);
+
+                    if (!$csv instanceof GetEntityArchiveCsvHandler) {
+                        throw new \LogicException('GetEntityArchiveCsv handler service is invalid.');
+                    }
+
+                    return new EntityArchiveRouteRegistrar($csv);
+                },
+            );
+    }
+}

--- a/src/EntityArchive/GetEntityArchiveCsvHandler.php
+++ b/src/EntityArchive/GetEntityArchiveCsvHandler.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityArchive;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetEntityArchiveCsvHandler
+{
+    private const int PAGE_SIZE = 500;
+
+    public function __construct(
+        private EntityArchiveRepositoryInterface $archive,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $entityTypeId = (int) ($parameters['entity_type_id'] ?? 0);
+
+        $output = fopen('php://temp', 'r+');
+
+        if ($output === false) {
+            throw new \RuntimeException('Failed to open temp stream.');
+        }
+
+        fputcsv($output, [
+            'original_entity_id',
+            'entity_type_slug',
+            'entity_type_name',
+            'entity_slug',
+            'entity_status',
+            'deleted_at',
+            'archived_at',
+            'archived_reason',
+            'snapshot',
+        ], escape: '\\');
+
+        $offset = 0;
+
+        do {
+            $entries = $this->archive->findByEntityTypeId($entityTypeId, self::PAGE_SIZE, $offset);
+
+            foreach ($entries as $entry) {
+                fputcsv($output, escape: '\\', fields: [
+                    $entry->originalEntityId,
+                    $entry->entityTypeSlug,
+                    $entry->entityTypeName,
+                    $entry->entitySlug ?? '',
+                    $entry->entityStatus,
+                    $entry->deletedAt?->format('Y-m-d H:i:s') ?? '',
+                    $entry->archivedAt->format('Y-m-d H:i:s'),
+                    $entry->archivedReason,
+                    json_encode($entry->snapshot, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR),
+                ]);
+            }
+
+
+            $offset += self::PAGE_SIZE;
+        } while (count($entries) === self::PAGE_SIZE);
+
+        rewind($output);
+        $csv = stream_get_contents($output);
+        fclose($output);
+
+        $filename = "entity_archive_{$entityTypeId}_" . date('Ymd_His') . '.csv';
+
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'text/csv; charset=UTF-8')
+            ->withHeader('Content-Disposition', "attachment; filename=\"{$filename}\"")
+            ->withBody($this->streamFromString($csv !== false ? $csv : ''));
+    }
+
+    private function streamFromString(string $content): \Psr\Http\Message\StreamInterface
+    {
+        $stream = fopen('php://temp', 'r+');
+
+        if ($stream === false) {
+            throw new \RuntimeException('Failed to create stream.');
+        }
+
+        fwrite($stream, $content);
+        rewind($stream);
+
+        return new \Nyholm\Psr7\Stream($stream);
+    }
+}

--- a/src/EntityArchive/PdoEntityArchiveRepository.php
+++ b/src/EntityArchive/PdoEntityArchiveRepository.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityArchive;
+
+use DateTimeImmutable;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeNeRecords\EntityType\EntityType;
+
+final readonly class PdoEntityArchiveRepository implements EntityArchiveRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function archiveAndPurgeSoftDeleted(EntityType $entityType): void
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, slug, status, deleted_at FROM entities WHERE entity_type_id = ? AND is_deleted = 1',
+            [$entityType->id],
+        );
+
+        if ($rows === []) {
+            return;
+        }
+
+        $entityIds = array_column($rows, 'id');
+        $placeholders = implode(',', array_fill(0, count($entityIds), '?'));
+
+        $textFields = $this->query->fetchAll(
+            "SELECT entity_id, field_key, value FROM text_fields WHERE entity_id IN ({$placeholders})",
+            $entityIds,
+        );
+        $intFields = $this->query->fetchAll(
+            "SELECT entity_id, field_key, value FROM int_fields WHERE entity_id IN ({$placeholders})",
+            $entityIds,
+        );
+        $boolFields = $this->query->fetchAll(
+            "SELECT entity_id, field_key, value FROM bool_fields WHERE entity_id IN ({$placeholders})",
+            $entityIds,
+        );
+        $enumFields = $this->query->fetchAll(
+            "SELECT entity_id, field_key, value FROM enum_fields WHERE entity_id IN ({$placeholders})",
+            $entityIds,
+        );
+        $datetimeFields = $this->query->fetchAll(
+            "SELECT entity_id, field_key, value FROM datetime_fields WHERE entity_id IN ({$placeholders})",
+            $entityIds,
+        );
+        $tags = $this->query->fetchAll(
+            "SELECT et.entity_id, t.slug FROM entity_tags et JOIN tags t ON t.id = et.tag_id WHERE et.entity_id IN ({$placeholders})",
+            $entityIds,
+        );
+        $relations = $this->query->fetchAll(
+            "SELECT source_entity_id, target_entity_id, field_key FROM entity_relations WHERE source_entity_id IN ({$placeholders})",
+            $entityIds,
+        );
+
+        $fieldsByEntity = $this->groupBy($textFields, 'entity_id');
+        $intByEntity = $this->groupBy($intFields, 'entity_id');
+        $boolByEntity = $this->groupBy($boolFields, 'entity_id');
+        $enumByEntity = $this->groupBy($enumFields, 'entity_id');
+        $datetimeByEntity = $this->groupBy($datetimeFields, 'entity_id');
+        $tagsByEntity = $this->groupBy($tags, 'entity_id');
+        $relationsByEntity = $this->groupBy($relations, 'source_entity_id');
+
+        $now = new DateTimeImmutable();
+        $archivedAt = $now->format('Y-m-d H:i:s');
+
+        foreach ($rows as $row) {
+            $entityId = (int) $row['id'];
+            $snapshot = [
+                'text_fields' => array_map(
+                    static fn (array $f) => ['field_key' => $f['field_key'], 'value' => $f['value']],
+                    $fieldsByEntity[$entityId] ?? [],
+                ),
+                'int_fields' => array_map(
+                    static fn (array $f) => ['field_key' => $f['field_key'], 'value' => (int) $f['value']],
+                    $intByEntity[$entityId] ?? [],
+                ),
+                'bool_fields' => array_map(
+                    static fn (array $f) => ['field_key' => $f['field_key'], 'value' => (bool) $f['value']],
+                    $boolByEntity[$entityId] ?? [],
+                ),
+                'enum_fields' => array_map(
+                    static fn (array $f) => ['field_key' => $f['field_key'], 'value' => $f['value']],
+                    $enumByEntity[$entityId] ?? [],
+                ),
+                'datetime_fields' => array_map(
+                    static fn (array $f) => ['field_key' => $f['field_key'], 'value' => $f['value']],
+                    $datetimeByEntity[$entityId] ?? [],
+                ),
+                'tags' => array_column($tagsByEntity[$entityId] ?? [], 'slug'),
+                'relations' => array_map(
+                    static fn (array $r) => [
+                        'field_key' => $r['field_key'],
+                        'target_entity_id' => (int) $r['target_entity_id'],
+                    ],
+                    $relationsByEntity[$entityId] ?? [],
+                ),
+            ];
+
+            $this->query->execute(
+                <<<SQL
+                    INSERT INTO entity_archive
+                        (original_entity_id, entity_type_id, entity_type_slug, entity_type_name,
+                         entity_slug, entity_status, deleted_at, archived_at, archived_reason, snapshot)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'entity_type_deleted', ?)
+                    SQL,
+                [
+                    $entityId,
+                    $entityType->id,
+                    $entityType->slug,
+                    $entityType->name,
+                    $row['slug'],
+                    $row['status'],
+                    $row['deleted_at'],
+                    $archivedAt,
+                    json_encode($snapshot, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE),
+                ],
+            );
+        }
+
+        $this->query->execute(
+            "DELETE FROM text_fields WHERE entity_id IN ({$placeholders})",
+            $entityIds,
+        );
+        $this->query->execute(
+            "DELETE FROM int_fields WHERE entity_id IN ({$placeholders})",
+            $entityIds,
+        );
+        $this->query->execute(
+            "DELETE FROM bool_fields WHERE entity_id IN ({$placeholders})",
+            $entityIds,
+        );
+        $this->query->execute(
+            "DELETE FROM enum_fields WHERE entity_id IN ({$placeholders})",
+            $entityIds,
+        );
+        $this->query->execute(
+            "DELETE FROM datetime_fields WHERE entity_id IN ({$placeholders})",
+            $entityIds,
+        );
+        $this->query->execute(
+            'DELETE FROM entities WHERE entity_type_id = ? AND is_deleted = 1',
+            [$entityType->id],
+        );
+    }
+
+    /** @return list<ArchivedEntity> */
+    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            <<<SQL
+                SELECT id, original_entity_id, entity_type_id, entity_type_slug, entity_type_name,
+                       entity_slug, entity_status, deleted_at, archived_at, archived_reason, snapshot
+                FROM entity_archive
+                WHERE entity_type_id = ?
+                ORDER BY archived_at DESC
+                LIMIT ? OFFSET ?
+                SQL,
+            [$entityTypeId, $limit, $offset],
+        );
+
+        return array_map(fn (array $row) => $this->mapRow($row), $rows);
+    }
+
+    public function countByEntityTypeId(int $entityTypeId): int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS total FROM entity_archive WHERE entity_type_id = ?',
+            [$entityTypeId],
+        );
+
+        return (int) ($row['total'] ?? 0);
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): ArchivedEntity
+    {
+        return new ArchivedEntity(
+            originalEntityId: (int) $row['original_entity_id'],
+            entityTypeId: (int) $row['entity_type_id'],
+            entityTypeSlug: $row['entity_type_slug'],
+            entityTypeName: $row['entity_type_name'],
+            entitySlug: $row['entity_slug'],
+            entityStatus: $row['entity_status'],
+            deletedAt: $row['deleted_at'] !== null ? new DateTimeImmutable($row['deleted_at']) : null,
+            archivedAt: new DateTimeImmutable($row['archived_at']),
+            archivedReason: $row['archived_reason'],
+            snapshot: (array) json_decode($row['snapshot'], true, 512, JSON_THROW_ON_ERROR),
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @return array<int, list<array<string, mixed>>>
+     */
+    private function groupBy(array $rows, string $key): array
+    {
+        $result = [];
+        foreach ($rows as $row) {
+            $result[(int) $row[$key]][] = $row;
+        }
+
+        return $result;
+    }
+}

--- a/src/EntityType/DeleteEntityTypeUseCase.php
+++ b/src/EntityType/DeleteEntityTypeUseCase.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace NeNeRecords\EntityType;
 
 use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\EntityArchive\EntityArchiveRepositoryInterface;
 
 final readonly class DeleteEntityTypeUseCase implements DeleteEntityTypeUseCaseInterface
 {
     public function __construct(
         private EntityTypeRepositoryInterface $entityTypes,
         private EntityRepositoryInterface $entities,
+        private EntityArchiveRepositoryInterface $entityArchive,
     ) {
     }
 
@@ -22,10 +24,11 @@ final readonly class DeleteEntityTypeUseCase implements DeleteEntityTypeUseCaseI
             throw new EntityTypeNotFoundException($input->id);
         }
 
-        if ($this->entities->existsByEntityTypeId($input->id)) {
+        if ($this->entities->existsActiveByEntityTypeId($input->id)) {
             throw new EntityTypeHasEntitiesException($input->id);
         }
 
+        $this->entityArchive->archiveAndPurgeSoftDeleted($entityType);
         $this->entityTypes->delete($input->id);
     }
 }

--- a/src/EntityType/EntityTypeHasEntitiesException.php
+++ b/src/EntityType/EntityTypeHasEntitiesException.php
@@ -11,7 +11,7 @@ final class EntityTypeHasEntitiesException extends RuntimeException
     public function __construct(int $entityTypeId)
     {
         parent::__construct(
-            "Entity type #{$entityTypeId} cannot be deleted because it still has records. Delete all records first.",
+            "Entity type #{$entityTypeId} cannot be deleted because it has active records. Delete or remove all records first.",
         );
     }
 }

--- a/src/EntityType/EntityTypeServiceProvider.php
+++ b/src/EntityType/EntityTypeServiceProvider.php
@@ -11,6 +11,7 @@ use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\EntityArchive\EntityArchiveRepositoryInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 
@@ -94,6 +95,7 @@ final readonly class EntityTypeServiceProvider implements ServiceProviderInterfa
                 static function (ContainerInterface $c): DeleteEntityTypeUseCaseInterface {
                     $repository = $c->get(EntityTypeRepositoryInterface::class);
                     $entities = $c->get(EntityRepositoryInterface::class);
+                    $archive = $c->get(EntityArchiveRepositoryInterface::class);
 
                     if (!$repository instanceof EntityTypeRepositoryInterface) {
                         throw new LogicException('Entity type repository service is invalid.');
@@ -103,7 +105,11 @@ final readonly class EntityTypeServiceProvider implements ServiceProviderInterfa
                         throw new LogicException('Entity repository service is invalid.');
                     }
 
-                    return new DeleteEntityTypeUseCase($repository, $entities);
+                    if (!$archive instanceof EntityArchiveRepositoryInterface) {
+                        throw new LogicException('Entity archive repository service is invalid.');
+                    }
+
+                    return new DeleteEntityTypeUseCase($repository, $entities, $archive);
                 },
             )
             ->set(

--- a/src/EntityType/PdoEntityTypeRepository.php
+++ b/src/EntityType/PdoEntityTypeRepository.php
@@ -87,6 +87,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
 
     public function delete(int $id): void
     {
+        $this->query->execute('DELETE FROM field_defs WHERE entity_type_id = ?', [$id]);
         $this->query->execute('DELETE FROM entity_types WHERE id = ?', [$id]);
     }
 }

--- a/tests/Entity/InMemoryEntityRepository.php
+++ b/tests/Entity/InMemoryEntityRepository.php
@@ -95,10 +95,10 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
         return false;
     }
 
-    public function existsByEntityTypeId(int $entityTypeId): bool
+    public function existsActiveByEntityTypeId(int $entityTypeId): bool
     {
         foreach ($this->entities as $entity) {
-            if ($entity->entityTypeId === $entityTypeId) {
+            if ($entity->entityTypeId === $entityTypeId && !$entity->isDeleted) {
                 return true;
             }
         }

--- a/tests/EntityArchive/InMemoryEntityArchiveRepository.php
+++ b/tests/EntityArchive/InMemoryEntityArchiveRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\EntityArchive;
+
+use NeNeRecords\EntityArchive\ArchivedEntity;
+use NeNeRecords\EntityArchive\EntityArchiveRepositoryInterface;
+use NeNeRecords\EntityType\EntityType;
+
+final class InMemoryEntityArchiveRepository implements EntityArchiveRepositoryInterface
+{
+    /** @var list<ArchivedEntity> */
+    private array $entries = [];
+
+    public function archiveAndPurgeSoftDeleted(EntityType $entityType): void
+    {
+    }
+
+    /** @return list<ArchivedEntity> */
+    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset): array
+    {
+        $filtered = array_values(
+            array_filter($this->entries, static fn (ArchivedEntity $e) => $e->entityTypeId === $entityTypeId),
+        );
+
+        return array_slice($filtered, $offset, $limit);
+    }
+
+    public function countByEntityTypeId(int $entityTypeId): int
+    {
+        return count(array_filter($this->entries, static fn (ArchivedEntity $e) => $e->entityTypeId === $entityTypeId));
+    }
+
+    public function add(ArchivedEntity $entry): void
+    {
+        $this->entries[] = $entry;
+    }
+}

--- a/tests/EntityType/EntityTypeHttpTest.php
+++ b/tests/EntityType/EntityTypeHttpTest.php
@@ -23,6 +23,7 @@ use NeNeRecords\EntityType\ListEntityTypesUseCase;
 use NeNeRecords\EntityType\UpdateEntityTypeHandler;
 use NeNeRecords\EntityType\UpdateEntityTypeUseCase;
 use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\EntityArchive\InMemoryEntityArchiveRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -45,12 +46,13 @@ final class EntityTypeHttpTest extends TestCase
         $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
 
         $entityRepository = new InMemoryEntityRepository();
+        $archiveRepository = new InMemoryEntityArchiveRepository();
 
         $registrar = new EntityTypeRouteRegistrar(
             new GetEntityTypeByIdHandler(new GetEntityTypeByIdUseCase($this->repository), $jsonResponse),
             new CreateEntityTypeHandler(new CreateEntityTypeUseCase($this->repository), $jsonResponse),
             new UpdateEntityTypeHandler(new UpdateEntityTypeUseCase($this->repository), $jsonResponse),
-            new DeleteEntityTypeHandler(new DeleteEntityTypeUseCase($this->repository, $entityRepository), $this->factory),
+            new DeleteEntityTypeHandler(new DeleteEntityTypeUseCase($this->repository, $entityRepository, $archiveRepository), $this->factory),
             new ListEntityTypesHandler(new ListEntityTypesUseCase($this->repository), $jsonResponse),
         );
 

--- a/tests/EntityType/PdoEntityTypeRepositoryTest.php
+++ b/tests/EntityType/PdoEntityTypeRepositoryTest.php
@@ -46,6 +46,7 @@ final class PdoEntityTypeRepositoryTest extends TestCase
         $projectRoot = dirname(__DIR__, 2);
         $paths = [
             $projectRoot . '/database/schema/entity_types.sql',
+            $projectRoot . '/database/schema/field_defs.sql',
             $projectRoot . '/database/schema/entities.sql',
             $projectRoot . '/database/schema/text_fields.sql',
         ];


### PR DESCRIPTION
## 目的

ソフト削除済みエンティティが残っていると entity type を削除できない問題を、
DB 制約に頼らずアプリ側で適切に処理するアーカイブ機構として解決。

## 変更点

### バックエンド

**削除フローの変更:**
1. アクティブなエンティティあり → **409 Conflict**（変更なし）
2. ソフト削除済みエンティティを `entity_archive` テーブルに JSON スナップショット保存
3. フィールド値（text/int/bool/enum/datetime）を物理削除
4. `field_defs` を削除してから `entity_types` を削除

**新規クラス:**
- `EntityArchive` 名前空間: `ArchivedEntity`, `EntityArchiveRepositoryInterface`, `PdoEntityArchiveRepository`
- `GetEntityArchiveCsvHandler`: CSV ダウンロード API
- `EntityArchiveServiceProvider`, `EntityArchiveRouteRegistrar`

**新規 API エンドポイント:**
- `GET /api/v1/entity-types/{entity_type_id}/archive.csv`（認証必須）

**新規テーブル:**
- `entity_archive`: スナップショット JSON (フィールド値・タグ・リレーション含む)

### スキーマ

```sql
-- 手動マイグレーション必要
-- database/schema/entity_archive.sql 参照
```

## 検証

```
composer check → 全パス (178 tests, 775 assertions)
```

API 動作確認:
- ソフト削除済みエンティティのある entity type → 204 で削除成功
- `entity_archive` に 3 件のスナップショット保存確認
- CSV ダウンロード正常動作確認

## セルフレビューチェックリスト

- [x] 変更は依頼範囲に限定
- [x] composer check 全パス
- [x] 秘密情報なし

Made with [Cursor](https://cursor.com)