### PR TITLE
feat(auth): admin/editor ロールと capability チェック (#108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ docker compose up --build -d
 # Admin UI → http://localhost:8080
 ```
 
-Default credentials (local only): `admin@nene-records.local` / `nene1234`
+Default credentials (local only):
+
+- Admin: `admin@nene-records.local` / `nene1234`
+- Editor: `editor@nene-records.local` / `nene1234`
 
 > See [`docs/development/docker.md`](./docs/development/docker.md) for full setup details.
 

--- a/database/migrations/20260525000000_seed_default_users.php
+++ b/database/migrations/20260525000000_seed_default_users.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class SeedDefaultUsers extends AbstractMigration
+{
+    public function up(): void
+    {
+        if (!$this->hasTable('users')) {
+            return;
+        }
+
+        $now = (new DateTimeImmutable())->format('Y-m-d H:i:s');
+        $passwordHash = password_hash('nene1234', PASSWORD_DEFAULT);
+        $pdo = $this->getAdapter()->getConnection();
+
+        $users = [
+            [
+                'email' => 'admin@nene-records.local',
+                'password_hash' => $passwordHash,
+                'role' => 'admin',
+            ],
+            [
+                'email' => 'editor@nene-records.local',
+                'password_hash' => $passwordHash,
+                'role' => 'editor',
+            ],
+        ];
+
+        foreach ($users as $user) {
+            $statement = $pdo->prepare('SELECT id FROM users WHERE email = ?');
+            $statement->execute([$user['email']]);
+
+            if ($statement->fetch() !== false) {
+                continue;
+            }
+
+            $this->table('users')->insert([
+                'email' => $user['email'],
+                'password_hash' => $user['password_hash'],
+                'role' => $user['role'],
+                'created_at' => $now,
+                'updated_at' => $now,
+            ])->saveData();
+        }
+    }
+
+    public function down(): void
+    {
+        if (!$this->hasTable('users')) {
+            return;
+        }
+
+        $this->execute(
+            "DELETE FROM users WHERE email IN ('admin@nene-records.local', 'editor@nene-records.local')",
+        );
+    }
+}

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-24
+Last updated: 2026-05-25
 
 ## 状態サマリー
 
@@ -34,16 +34,81 @@ Backend CI + Frontend CI (GitHub Actions) 稼働中。
 
 ## Up Next — M2（Team-Ready CMS）
 
-| 優先 | 項目 | 説明 |
-| --- | --- | --- |
-| P0 | Roles（admin / editor） | capability check on mutating routes |
-| P1 | Entity record revisions | API + Admin 履歴タブ（settings パターン踏襲） |
-| P1 | Image / file field + upload API | 最小メディア対応 |
-| P1 | Per-record SEO fields | meta override on public bootstrap |
-| P2 | Navigation settings | menu defs + PublicShell |
-| P2 | Admin Markdown editor UX | preview pane 付き textarea |
+| 優先 | Issue | 項目 | 説明 |
+| --- | --- | --- | --- |
+| **P0** | [#108](https://github.com/hideyukiMORI/nene-records/issues/108) | Roles（admin / editor） | capability check — **実装中** (`feat/108-roles`) |
+| **P0.5** | [#109](https://github.com/hideyukiMORI/nene-records/issues/109) | Admin i18n 基盤 | 13 言語メッセージカタログ・`t()`・locale 切替（#108 後） |
+| **P0.5** | [#110](https://github.com/hideyukiMORI/nene-records/issues/110) | Admin 全画面 i18n 移行 | ハードコード排除・13 locale 完全キー一致（#109 後） |
+| P1 | — | Entity record revisions | API + Admin 履歴タブ（settings パターン踏襲） |
+| P1 | — | Image / file field + upload API | 最小メディア対応 |
+| P1 | — | Per-record SEO fields | meta override on public bootstrap |
+| P2 | — | Navigation settings | menu defs + PublicShell |
+| P2 | — | Admin Markdown editor UX | preview pane 付き textarea |
+
+**Admin i18n 13 言語:** NENE2 VitePress 既存 6 locale（en, ja, fr, zh, pt-br, de）+ es, ko, it, ru, ar, hi, vi。API / Problem Details は NENE2 language policy どおり英語維持。
 
 詳細は [`docs/milestones/2026-06-cms-mid-term.md`](../milestones/2026-06-cms-mid-term.md)。
+
+---
+
+---
+
+## Ideas — Beyond M3
+
+将来のフェーズで検討するアイデア。Issue 未起票。
+
+### AI Consumer Chat（DB 問い合わせチャットシステム）
+
+> **⚠️ 設計原則: NeNe Records とは完全に分離した独立システムとして開発すること。**
+> この Chat System を NeNe Records に統合してはならない。
+
+自社の NeNe Records DB に対して自然言語で問い合わせ、回答を生成するコンシューマー向けチャット。
+
+#### なぜ分離か
+
+依存の方向が「Chat → NeNe Records API」であり、Chat は NeNe Records の **クライアント** である。クライアントをサーバーに同居させることは依存の方向を逆転させる。
+
+| 関心事 | NeNe Records | Chat System |
+| --- | --- | --- |
+| 役割 | コンテンツ管理 | 会話・推論・回答生成 |
+| 利用者 | 管理者・編集者 | エンドコンシューマー |
+| 認証 | JWT（管理者向け） | 匿名 or 別セッション |
+| 通信 | REST JSON | SSE / WebSocket が自然 |
+| 障害分離 | Chat が落ちても CMS は動く | NeNe が遅くても Chat はキャッシュで逃げられる |
+
+NENE2 を基盤とした **別の独立クライアントプロジェクト** として立てる。
+
+```
+NENE2（フレームワーク）
+  ├── NeNe Records（CMS）        ← ここ
+  └── Chat System（独立）        ← 別リポジトリで開発
+```
+
+#### アーキテクチャ
+
+```
+Consumer Chat UI
+    ↓
+Chat API（レート制限・認証・トークン計測）← Chat System の責務
+    ↓
+Claude API（tool_use / function calling）
+    ↓
+NeNe Records 読み取り専用 API           ← NeNe Records は API を提供するだけ
+    ↓
+DB
+```
+
+MCP プロトコル自体はコンシューマーに見せない。Claude が tool_use で NeNe Records の既存 API を叩く形。
+
+#### 着手タイミング
+
+NeNe Records M3（full-text search / export API）が成熟してから。Chat が必要とする「軽量な検索 API」が M3 で揃う。
+
+#### 検討が必要な課題
+- スコープ管理: DB で答えられない質問へのフォールバック
+- プロンプトインジェクション対策
+- レート制限の粒度（ユーザーごと推奨）
+- tool_use のレイテンシ（2〜3 回 DB 呼び出し = 5〜10 秒）
 
 ---
 

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -7,6 +7,7 @@ import { EntityRecordPage } from '@/pages/entity-record/EntityRecordPage'
 import { EntityRecordsPage } from '@/pages/entity-records/EntityRecordsPage'
 import { EntityTypesPage } from '@/pages/entity-types/EntityTypesPage'
 import { FieldDefsPage } from '@/pages/field-defs/FieldDefsPage'
+import { ForbiddenPage } from '@/pages/forbidden/ForbiddenPage'
 import { HomePage } from '@/pages/home/HomePage'
 import { AppShell } from '@/pages/layout/AppShell'
 import { LoginPage } from '@/pages/login/LoginPage'
@@ -26,6 +27,14 @@ const router = createBrowserRouter([
   {
     path: '/login',
     element: <LoginPage />,
+  },
+  {
+    path: '/forbidden',
+    element: (
+      <RequireAuth>
+        <ForbiddenPage />
+      </RequireAuth>
+    ),
   },
   {
     path: '/',

--- a/frontend/src/entities/auth/authorization.ts
+++ b/frontend/src/entities/auth/authorization.ts
@@ -1,0 +1,19 @@
+import { authStore } from './model'
+import { hasCapability, isAdmin, type Capability, type UserRole } from './capabilities'
+
+export function getCurrentRole(): UserRole | undefined {
+  const role = authStore.getSession()?.role
+  if (role === 'admin' || role === 'editor') {
+    return role
+  }
+
+  return undefined
+}
+
+export function currentUserHasCapability(capability: Capability): boolean {
+  return hasCapability(authStore.getSession()?.role, capability)
+}
+
+export function currentUserIsAdmin(): boolean {
+  return isAdmin(authStore.getSession()?.role)
+}

--- a/frontend/src/entities/auth/capabilities.ts
+++ b/frontend/src/entities/auth/capabilities.ts
@@ -1,0 +1,26 @@
+export type UserRole = 'admin' | 'editor'
+
+export type Capability =
+  | 'manage_schema'
+  | 'manage_settings'
+  | 'read_settings'
+  | 'manage_tags'
+  | 'edit_content'
+
+const EDITOR_CAPABILITIES: readonly Capability[] = ['read_settings', 'edit_content'] as const
+
+export function hasCapability(role: string | undefined, capability: Capability): boolean {
+  if (role === 'admin') {
+    return true
+  }
+
+  if (role === 'editor') {
+    return EDITOR_CAPABILITIES.includes(capability)
+  }
+
+  return false
+}
+
+export function isAdmin(role: string | undefined): boolean {
+  return role === 'admin'
+}

--- a/frontend/src/entities/auth/index.ts
+++ b/frontend/src/entities/auth/index.ts
@@ -1,3 +1,6 @@
 export { authStore } from './model'
 export type { AuthSession } from './model'
 export { useLogin } from './mutations'
+export { hasCapability, isAdmin } from './capabilities'
+export type { Capability, UserRole } from './capabilities'
+export { currentUserHasCapability, currentUserIsAdmin, getCurrentRole } from './authorization'

--- a/frontend/src/features/manage-entity-types/ui/EntityTypeListPanel.tsx
+++ b/frontend/src/features/manage-entity-types/ui/EntityTypeListPanel.tsx
@@ -4,6 +4,7 @@ import { Button, EmptyState, Stack, Text } from '@/shared/ui'
 
 export interface EntityTypeListPanelProps {
   items: EntityType[]
+  canManageSchema: boolean
   isLoading: boolean
   isError: boolean
   errorTitle: string | null
@@ -15,6 +16,7 @@ export interface EntityTypeListPanelProps {
 
 export function EntityTypeListPanel({
   items,
+  canManageSchema,
   isLoading,
   isError,
   errorTitle,
@@ -64,35 +66,41 @@ export function EntityTypeListPanel({
             </Text>
           </Stack>
           <div className="flex items-center gap-inline-sm">
-            <Link to={`/entity-types/${String(item.id)}/fields`}>
-              <Button variant="secondary" size="sm">
-                Fields
-              </Button>
-            </Link>
+            {canManageSchema ? (
+              <Link to={`/entity-types/${String(item.id)}/fields`}>
+                <Button variant="secondary" size="sm">
+                  Fields
+                </Button>
+              </Link>
+            ) : null}
             <Link to={`/entity-types/${String(item.id)}/entities`}>
               <Button variant="secondary" size="sm">
                 Records
               </Button>
             </Link>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => {
-                onEdit(item)
-              }}
-            >
-              Edit
-            </Button>
-            <Button
-              variant="danger"
-              size="sm"
-              disabled={isDeleting}
-              onClick={() => {
-                onDelete(item)
-              }}
-            >
-              Delete
-            </Button>
+            {canManageSchema ? (
+              <>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    onEdit(item)
+                  }}
+                >
+                  Edit
+                </Button>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  disabled={isDeleting}
+                  onClick={() => {
+                    onDelete(item)
+                  }}
+                >
+                  Delete
+                </Button>
+              </>
+            ) : null}
           </div>
         </li>
       ))}

--- a/frontend/src/features/manage-entity-types/ui/ManageEntityTypesView.tsx
+++ b/frontend/src/features/manage-entity-types/ui/ManageEntityTypesView.tsx
@@ -6,6 +6,7 @@ import { EntityTypeListPanel } from './EntityTypeListPanel'
 
 export interface ManageEntityTypesViewProps {
   items: EntityType[]
+  canManageSchema: boolean
   isLoading: boolean
   isError: boolean
   errorTitle: string | null
@@ -29,6 +30,7 @@ export interface ManageEntityTypesViewProps {
 
 export function ManageEntityTypesView({
   items,
+  canManageSchema,
   isLoading,
   isError,
   errorTitle,
@@ -52,12 +54,14 @@ export function ManageEntityTypesView({
   return (
     <>
       <Stack gap="lg">
-        <EntityTypeCreateForm
-          isSubmitting={isCreating}
-          serverErrorTitle={createErrorTitle}
-          onSubmit={onCreate}
-        />
-        {editTarget !== null ? (
+        {canManageSchema ? (
+          <EntityTypeCreateForm
+            isSubmitting={isCreating}
+            serverErrorTitle={createErrorTitle}
+            onSubmit={onCreate}
+          />
+        ) : null}
+        {canManageSchema && editTarget !== null ? (
           <EntityTypeEditForm
             entityType={editTarget}
             isSubmitting={isUpdating}
@@ -72,6 +76,7 @@ export function ManageEntityTypesView({
           </Text>
           <EntityTypeListPanel
             items={items}
+            canManageSchema={canManageSchema}
             isLoading={isLoading}
             isError={isError}
             errorTitle={errorTitle}

--- a/frontend/src/features/manage-field-defs/ui/FieldDefListPanel.tsx
+++ b/frontend/src/features/manage-field-defs/ui/FieldDefListPanel.tsx
@@ -11,6 +11,7 @@ const DATA_TYPE_LABELS: Record<FieldDef['dataType'], string> = {
 
 export interface FieldDefListPanelProps {
   items: FieldDef[]
+  canManageSchema: boolean
   isLoading: boolean
   isError: boolean
   errorTitle: string | null
@@ -22,6 +23,7 @@ export interface FieldDefListPanelProps {
 
 export function FieldDefListPanel({
   items,
+  canManageSchema,
   isLoading,
   isError,
   errorTitle,
@@ -71,25 +73,29 @@ export function FieldDefListPanel({
             </Text>
           </Stack>
           <div className="flex items-center gap-inline-sm">
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => {
-                onEdit(item)
-              }}
-            >
-              Edit
-            </Button>
-            <Button
-              variant="danger"
-              size="sm"
-              disabled={isDeleting}
-              onClick={() => {
-                onDelete(item)
-              }}
-            >
-              Delete
-            </Button>
+            {canManageSchema ? (
+              <>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    onEdit(item)
+                  }}
+                >
+                  Edit
+                </Button>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  disabled={isDeleting}
+                  onClick={() => {
+                    onDelete(item)
+                  }}
+                >
+                  Delete
+                </Button>
+              </>
+            ) : null}
           </div>
         </li>
       ))}

--- a/frontend/src/features/manage-field-defs/ui/ManageFieldDefsView.tsx
+++ b/frontend/src/features/manage-field-defs/ui/ManageFieldDefsView.tsx
@@ -6,6 +6,7 @@ import { FieldDefListPanel } from './FieldDefListPanel'
 
 export interface ManageFieldDefsViewProps {
   entityTypeSlug: string | null
+  canManageSchema: boolean
   items: FieldDef[]
   isLoading: boolean
   isError: boolean
@@ -29,6 +30,7 @@ export interface ManageFieldDefsViewProps {
 
 export function ManageFieldDefsView({
   entityTypeSlug,
+  canManageSchema,
   items,
   isLoading,
   isError,
@@ -57,12 +59,14 @@ export function ManageFieldDefsView({
             Schema for {entityTypeSlug}
           </Text>
         ) : null}
-        <FieldDefCreateForm
-          isSubmitting={isCreating}
-          serverErrorTitle={createErrorTitle}
-          onSubmit={onCreate}
-        />
-        {editTarget !== null ? (
+        {canManageSchema ? (
+          <FieldDefCreateForm
+            isSubmitting={isCreating}
+            serverErrorTitle={createErrorTitle}
+            onSubmit={onCreate}
+          />
+        ) : null}
+        {canManageSchema && editTarget !== null ? (
           <FieldDefEditForm
             fieldDef={editTarget}
             isSubmitting={isUpdating}
@@ -77,6 +81,7 @@ export function ManageFieldDefsView({
           </Text>
           <FieldDefListPanel
             items={items}
+            canManageSchema={canManageSchema}
             isLoading={isLoading}
             isError={isError}
             errorTitle={errorTitle}

--- a/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.tsx
+++ b/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.tsx
@@ -10,10 +10,12 @@ import { Button, Input, Stack, Text } from '@/shared/ui'
 function SettingField({
   item,
   isSaving,
+  canManageSettings,
   onSave,
 }: {
   item: SettingItem
   isSaving: boolean
+  canManageSettings: boolean
   onSave: (settingKey: string, value: string) => Promise<void>
 }) {
   const [value, setValue] = useState(item.value)
@@ -30,7 +32,7 @@ function SettingField({
           <textarea
             id={inputId}
             value={value}
-            disabled={isSaving}
+            disabled={isSaving || !canManageSettings}
             rows={4}
             onChange={(event) => {
               setValue(event.target.value)
@@ -46,22 +48,24 @@ function SettingField({
           id={inputId}
           label={item.label}
           value={value}
-          disabled={isSaving}
+          disabled={isSaving || !canManageSettings}
           onChange={(event) => {
             setValue(event.target.value)
           }}
         />
       )}
-      <Button
-        variant="secondary"
-        size="sm"
-        disabled={isSaving || value === item.value}
-        onClick={() => {
-          void onSave(item.settingKey, value)
-        }}
-      >
-        {isSaving ? 'Saving…' : 'Save'}
-      </Button>
+      {canManageSettings ? (
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={isSaving || value === item.value}
+          onClick={() => {
+            void onSave(item.settingKey, value)
+          }}
+        >
+          {isSaving ? 'Saving…' : 'Save'}
+        </Button>
+      ) : null}
     </Stack>
   )
 }
@@ -95,7 +99,7 @@ function SettingRevisionsPanel({ settingKey }: { settingKey: string }) {
   )
 }
 
-export function ManageSiteSettingsView() {
+export function ManageSiteSettingsView({ canManageSettings }: { canManageSettings: boolean }) {
   const listQuery = useSettingList()
   const updateMutation = useUpdateSetting()
   const [expandedKey, setExpandedKey] = useState<string | null>(null)
@@ -136,6 +140,7 @@ export function ManageSiteSettingsView() {
               key={`${item.settingKey}:${item.updatedAt ?? 'default'}`}
               item={item}
               isSaving={updateMutation.isPending}
+              canManageSettings={canManageSettings}
               onSave={saveSetting}
             />
             <Button

--- a/frontend/src/pages/entity-records/EntityRecordsPage.test.tsx
+++ b/frontend/src/pages/entity-records/EntityRecordsPage.test.tsx
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { cleanup, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
@@ -13,6 +13,7 @@ import { resetTagStore, seedTags } from '@tests/msw/handlers/tag'
 import { resetTextFieldStore, seedTextFields } from '@tests/msw/handlers/text-field'
 import { mswServer } from '@tests/msw/server'
 import { renderWithProviders } from '@tests/render/render-with-providers'
+import { clearAuthSession, seedAdminSession } from '@tests/helpers/auth-session'
 
 function renderRecordsPage(entityTypeId = 1) {
   return renderWithProviders(
@@ -29,6 +30,10 @@ describe('EntityRecordsPage', () => {
     mswServer.listen()
   })
 
+  beforeEach(() => {
+    seedAdminSession()
+  })
+
   afterEach(() => {
     mswServer.resetHandlers()
     resetEntityTypeStore()
@@ -38,6 +43,7 @@ describe('EntityRecordsPage', () => {
     resetFieldDefStore()
     resetTagStore()
     resetTextFieldStore()
+    clearAuthSession()
     cleanup()
   })
 

--- a/frontend/src/pages/entity-types/EntityTypesPage.test.tsx
+++ b/frontend/src/pages/entity-types/EntityTypesPage.test.tsx
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { cleanup, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
@@ -6,6 +6,7 @@ import { EntityTypesPage } from '@/pages/entity-types/EntityTypesPage'
 import { resetEntityTypeStore } from '@tests/msw/handlers/entity-type'
 import { mswServer } from '@tests/msw/server'
 import { renderWithProviders } from '@tests/render/render-with-providers'
+import { clearAuthSession, seedAdminSession } from '@tests/helpers/auth-session'
 
 function renderEntityTypesPage() {
   return renderWithProviders(
@@ -36,9 +37,14 @@ describe('EntityTypesPage', () => {
     mswServer.listen()
   })
 
+  beforeEach(() => {
+    seedAdminSession()
+  })
+
   afterEach(() => {
     mswServer.resetHandlers()
     resetEntityTypeStore()
+    clearAuthSession()
     cleanup()
   })
 

--- a/frontend/src/pages/entity-types/EntityTypesPage.tsx
+++ b/frontend/src/pages/entity-types/EntityTypesPage.tsx
@@ -1,7 +1,9 @@
 import { ManageEntityTypesView, useManageEntityTypesPage } from '@/features/manage-entity-types'
+import { currentUserHasCapability } from '@/entities/auth'
 import { Stack, Text } from '@/shared/ui'
 
 export function EntityTypesPage() {
+  const canManageSchema = currentUserHasCapability('manage_schema')
   const {
     items,
     isLoading,
@@ -32,6 +34,7 @@ export function EntityTypesPage() {
       </Text>
       <ManageEntityTypesView
         items={items}
+        canManageSchema={canManageSchema}
         isLoading={isLoading}
         isError={isError}
         errorTitle={errorTitle}

--- a/frontend/src/pages/field-defs/FieldDefsPage.test.tsx
+++ b/frontend/src/pages/field-defs/FieldDefsPage.test.tsx
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { cleanup, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
@@ -7,6 +7,7 @@ import { resetFieldDefStore, seedFieldDefs } from '@tests/msw/handlers/field-def
 import { resetEntityTypeStore, seedEntityTypes } from '@tests/msw/handlers/entity-type'
 import { mswServer } from '@tests/msw/server'
 import { renderWithProviders } from '@tests/render/render-with-providers'
+import { clearAuthSession, seedAdminSession } from '@tests/helpers/auth-session'
 
 function renderFieldDefsPage(entityTypeId = 1) {
   return renderWithProviders(
@@ -31,10 +32,15 @@ describe('FieldDefsPage', () => {
     mswServer.listen()
   })
 
+  beforeEach(() => {
+    seedAdminSession()
+  })
+
   afterEach(() => {
     mswServer.resetHandlers()
     resetEntityTypeStore()
     resetFieldDefStore()
+    clearAuthSession()
     cleanup()
   })
 

--- a/frontend/src/pages/field-defs/FieldDefsPage.tsx
+++ b/frontend/src/pages/field-defs/FieldDefsPage.tsx
@@ -1,11 +1,13 @@
-import { Link, useParams } from 'react-router-dom'
+import { Link, Navigate, useParams } from 'react-router-dom'
 import { toEntityTypeId, useEntityType } from '@/entities/entity-type'
+import { currentUserHasCapability } from '@/entities/auth'
 import { ManageFieldDefsView, useManageFieldDefsPage } from '@/features/manage-field-defs'
 import { Button, Stack, Text } from '@/shared/ui'
 
 export function FieldDefsPage() {
   const { entityTypeId: entityTypeIdParam } = useParams()
   const entityTypeId = Number(entityTypeIdParam)
+  const canManageSchema = currentUserHasCapability('manage_schema')
 
   const entityTypeQuery = useEntityType(toEntityTypeId(entityTypeId))
   const {
@@ -30,6 +32,10 @@ export function FieldDefsPage() {
     isDeleting,
   } = useManageFieldDefsPage(entityTypeId)
 
+  if (!canManageSchema) {
+    return <Navigate to="/forbidden" replace />
+  }
+
   return (
     <Stack gap="md">
       <Stack gap="sm">
@@ -44,6 +50,7 @@ export function FieldDefsPage() {
       </Stack>
       <ManageFieldDefsView
         entityTypeSlug={entityTypeQuery.data?.slug ?? null}
+        canManageSchema={canManageSchema}
         items={items}
         isLoading={isLoading}
         isError={isError}

--- a/frontend/src/pages/forbidden/ForbiddenPage.tsx
+++ b/frontend/src/pages/forbidden/ForbiddenPage.tsx
@@ -1,0 +1,20 @@
+import { Link } from 'react-router-dom'
+import { Button, Stack, Text } from '@/shared/ui'
+
+export function ForbiddenPage() {
+  return (
+    <Stack gap="md" className="py-stack-xl">
+      <Text as="h1" variant="heading-md">
+        Access denied
+      </Text>
+      <Text muted>
+        You are signed in, but your account does not have permission to perform this action.
+      </Text>
+      <Stack direction="horizontal" gap="sm">
+        <Link to="/">
+          <Button variant="secondary">Back to home</Button>
+        </Link>
+      </Stack>
+    </Stack>
+  )
+}

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -1,5 +1,5 @@
 import { Outlet, NavLink, useNavigate } from 'react-router-dom'
-import { authStore } from '@/entities/auth'
+import { authStore, currentUserHasCapability } from '@/entities/auth'
 import { Button, Stack, Text } from '@/shared/ui'
 
 const navLinkClass = ({ isActive }: { isActive: boolean }): string =>
@@ -17,6 +17,8 @@ export function AppShell() {
   }
 
   const session = authStore.getSession()
+  const canManageTags = currentUserHasCapability('manage_tags')
+  const canReadSettings = currentUserHasCapability('read_settings')
 
   return (
     <div className="min-h-screen bg-surface font-sans text-text-primary">
@@ -33,12 +35,16 @@ export function AppShell() {
               <NavLink to="/entity-types" className={navLinkClass}>
                 Entity types
               </NavLink>
-              <NavLink to="/tags" className={navLinkClass}>
-                Tags
-              </NavLink>
-              <NavLink to="/settings" className={navLinkClass}>
-                Settings
-              </NavLink>
+              {canManageTags ? (
+                <NavLink to="/tags" className={navLinkClass}>
+                  Tags
+                </NavLink>
+              ) : null}
+              {canReadSettings ? (
+                <NavLink to="/settings" className={navLinkClass}>
+                  Settings
+                </NavLink>
+              ) : null}
               <NavLink to="/view" className={navLinkClass}>
                 Public site
               </NavLink>

--- a/frontend/src/pages/settings/SiteSettingsPage.tsx
+++ b/frontend/src/pages/settings/SiteSettingsPage.tsx
@@ -1,7 +1,9 @@
 import { ManageSiteSettingsView } from '@/features/manage-settings'
+import { currentUserHasCapability } from '@/entities/auth'
 import { Stack, Text } from '@/shared/ui'
 
 export function SiteSettingsPage() {
+  const canManageSettings = currentUserHasCapability('manage_settings')
   return (
     <Stack gap="md">
       <Text as="h1" variant="heading-md">
@@ -10,7 +12,7 @@ export function SiteSettingsPage() {
       <Text muted>
         Configure site name, tagline, default meta description, and footer content for public pages.
       </Text>
-      <ManageSiteSettingsView />
+      <ManageSiteSettingsView canManageSettings={canManageSettings} />
     </Stack>
   )
 }

--- a/frontend/src/pages/tags/TagsPage.test.tsx
+++ b/frontend/src/pages/tags/TagsPage.test.tsx
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { cleanup, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
@@ -6,6 +6,7 @@ import { TagsPage } from '@/pages/tags/TagsPage'
 import { resetTagStore } from '@tests/msw/handlers/tag'
 import { mswServer } from '@tests/msw/server'
 import { renderWithProviders } from '@tests/render/render-with-providers'
+import { clearAuthSession, seedAdminSession } from '@tests/helpers/auth-session'
 
 function renderTagsPage() {
   return renderWithProviders(
@@ -36,9 +37,14 @@ describe('TagsPage', () => {
     mswServer.listen()
   })
 
+  beforeEach(() => {
+    seedAdminSession()
+  })
+
   afterEach(() => {
     mswServer.resetHandlers()
     resetTagStore()
+    clearAuthSession()
     cleanup()
   })
 

--- a/frontend/src/pages/tags/TagsPage.tsx
+++ b/frontend/src/pages/tags/TagsPage.tsx
@@ -1,7 +1,10 @@
+import { Navigate } from 'react-router-dom'
 import { ManageTagsView, useManageTagsPage } from '@/features/manage-tags'
+import { currentUserHasCapability } from '@/entities/auth'
 import { Stack, Text } from '@/shared/ui'
 
 export function TagsPage() {
+  const canManageTags = currentUserHasCapability('manage_tags')
   const {
     items,
     isLoading,
@@ -23,6 +26,10 @@ export function TagsPage() {
     confirmDelete,
     isDeleting,
   } = useManageTagsPage()
+
+  if (!canManageTags) {
+    return <Navigate to="/forbidden" replace />
+  }
 
   return (
     <Stack gap="md">

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -35,6 +35,9 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
       authStore.clearSession()
       window.location.href = '/login'
     }
+    if (response.status === 403) {
+      window.location.href = '/forbidden'
+    }
     throw await parseProblemDetails(response)
   }
 

--- a/frontend/tests/helpers/auth-session.ts
+++ b/frontend/tests/helpers/auth-session.ts
@@ -1,0 +1,23 @@
+import { authStore } from '@/entities/auth'
+
+export function seedAdminSession(): void {
+  authStore.setSession({
+    token: 'test-token',
+    expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+    email: 'admin@example.com',
+    role: 'admin',
+  })
+}
+
+export function seedEditorSession(): void {
+  authStore.setSession({
+    token: 'test-token',
+    expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+    email: 'editor@example.com',
+    role: 'editor',
+  })
+}
+
+export function clearAuthSession(): void {
+  authStore.clearSession()
+}

--- a/src/Auth/Capability.php
+++ b/src/Auth/Capability.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+enum Capability
+{
+    case ManageSchema;
+    case ManageSettings;
+    case ReadSettings;
+    case ManageTags;
+    case EditContent;
+}

--- a/src/Auth/CapabilityMiddleware.php
+++ b/src/Auth/CapabilityMiddleware.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Enforces role-based capabilities on authenticated API requests.
+ *
+ * Runs after AdminApiAuthMiddleware. Unauthenticated requests pass through unchanged.
+ */
+final readonly class CapabilityMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $claims = $request->getAttribute('nene2.auth.claims');
+
+        if (!is_array($claims)) {
+            return $handler->handle($request);
+        }
+
+        $path = $request->getUri()->getPath() ?: '/';
+        $required = CapabilityResolver::resolve($path, $request->getMethod());
+
+        if ($required === null) {
+            return $handler->handle($request);
+        }
+
+        $role = Role::tryFrom((string) ($claims['role'] ?? ''));
+
+        if ($role === null || !$role->hasCapability($required)) {
+            return $this->problemDetails->create(
+                $request,
+                'forbidden',
+                'Forbidden',
+                403,
+                'You do not have permission to perform this action.',
+            );
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/src/Auth/CapabilityResolver.php
+++ b/src/Auth/CapabilityResolver.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+final class CapabilityResolver
+{
+    /** @var list<string> */
+    private const CONTENT_MUTATION_PREFIXES = [
+        '/api/v1/entities',
+        '/api/v1/text-fields',
+        '/api/v1/int-fields',
+        '/api/v1/enum-fields',
+        '/api/v1/bool-fields',
+        '/api/v1/datetime-fields',
+    ];
+
+    public static function resolve(string $path, string $method): ?Capability
+    {
+        $method = strtoupper($method);
+
+        if (str_starts_with($path, '/api/v1/settings')) {
+            return match ($method) {
+                'PUT' => Capability::ManageSettings,
+                'GET', 'HEAD' => Capability::ReadSettings,
+                default => null,
+            };
+        }
+
+        if (str_starts_with($path, '/api/v1/entity-types')) {
+            if (str_contains($path, '/archive.csv')) {
+                return Capability::ManageSchema;
+            }
+
+            if (self::isMutationMethod($method)) {
+                return Capability::ManageSchema;
+            }
+        }
+
+        if (str_starts_with($path, '/api/v1/field-defs') && self::isMutationMethod($method)) {
+            return Capability::ManageSchema;
+        }
+
+        if (str_starts_with($path, '/api/v1/tags') && self::isMutationMethod($method)) {
+            return Capability::ManageTags;
+        }
+
+        foreach (self::CONTENT_MUTATION_PREFIXES as $prefix) {
+            if (str_starts_with($path, $prefix) && self::isMutationMethod($method)) {
+                return Capability::EditContent;
+            }
+        }
+
+        return null;
+    }
+
+    private static function isMutationMethod(string $method): bool
+    {
+        return !in_array($method, ['GET', 'HEAD', 'OPTIONS'], true);
+    }
+}

--- a/src/Auth/LoginUseCase.php
+++ b/src/Auth/LoginUseCase.php
@@ -24,11 +24,17 @@ final readonly class LoginUseCase
             throw new InvalidCredentialsException();
         }
 
+        $role = Role::tryFrom($user->role);
+
+        if ($role === null) {
+            throw new InvalidCredentialsException();
+        }
+
         $expiresAt = time() + self::TOKEN_TTL_SECONDS;
 
         $token = $this->tokenIssuer->issue([
             'sub' => $user->email,
-            'role' => $user->role,
+            'role' => $role->value,
             'iat' => time(),
             'exp' => $expiresAt,
         ]);
@@ -37,7 +43,7 @@ final readonly class LoginUseCase
             token: $token,
             expiresAt: $expiresAt,
             email: $user->email,
-            role: $user->role,
+            role: $role->value,
         );
     }
 }

--- a/src/Auth/Role.php
+++ b/src/Auth/Role.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+enum Role: string
+{
+    case Admin = 'admin';
+    case Editor = 'editor';
+
+    public function hasCapability(Capability $capability): bool
+    {
+        return match ($this) {
+            self::Admin => true,
+            self::Editor => match ($capability) {
+                Capability::ReadSettings,
+                Capability::EditContent => true,
+                Capability::ManageSchema,
+                Capability::ManageSettings,
+                Capability::ManageTags => false,
+            },
+        };
+    }
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -29,6 +29,7 @@ use NeNeRecords\Analytics\AccessLogMiddleware;
 use NeNeRecords\ApplicationServiceProvider;
 use NeNeRecords\Auth\AdminApiAuthMiddleware;
 use NeNeRecords\Auth\AuthServiceProvider;
+use NeNeRecords\Auth\CapabilityMiddleware;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -285,6 +286,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     }
 
                     $authMiddleware[] = new AdminApiAuthMiddleware($problemDetails, $tokenVerifier);
+                    $authMiddleware[] = new CapabilityMiddleware($problemDetails);
 
                     return new RuntimeApplicationFactory(
                         $responseFactory,

--- a/tests/Auth/CapabilityMiddlewareTest.php
+++ b/tests/Auth/CapabilityMiddlewareTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Auth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use NeNeRecords\Auth\CapabilityMiddleware;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class CapabilityMiddlewareTest extends TestCase
+{
+    private Psr17Factory $factory;
+
+    private CapabilityMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->middleware = new CapabilityMiddleware(
+            new ProblemDetailsResponseFactory($this->factory, $this->factory),
+        );
+    }
+
+    public function testUnauthenticatedRequestPassesThrough(): void
+    {
+        $request = $this->factory->createServerRequest('DELETE', 'https://example.test/api/v1/entity-types/1');
+
+        $response = $this->middleware->process($request, $this->createPassThroughHandler());
+
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testEditorDeletingEntityTypeReturns403(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('DELETE', 'https://example.test/api/v1/entity-types/1')
+            ->withAttribute('nene2.auth.claims', ['role' => 'editor', 'sub' => 'editor@example.com']);
+
+        $response = $this->middleware->process($request, $this->createPassThroughHandler());
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function testAdminDeletingEntityTypePassesThrough(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('DELETE', 'https://example.test/api/v1/entity-types/1')
+            ->withAttribute('nene2.auth.claims', ['role' => 'admin', 'sub' => 'admin@example.com']);
+
+        $response = $this->middleware->process($request, $this->createPassThroughHandler());
+
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testEditorCreatingEntityPassesThrough(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('POST', 'https://example.test/api/v1/entities')
+            ->withAttribute('nene2.auth.claims', ['role' => 'editor', 'sub' => 'editor@example.com']);
+
+        $response = $this->middleware->process($request, $this->createPassThroughHandler());
+
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testEditorUpdatingSettingsReturns403(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('PUT', 'https://example.test/api/v1/settings/site_name')
+            ->withAttribute('nene2.auth.claims', ['role' => 'editor', 'sub' => 'editor@example.com']);
+
+        $response = $this->middleware->process($request, $this->createPassThroughHandler());
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function testEditorReadingSettingsPassesThrough(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('GET', 'https://example.test/api/v1/settings')
+            ->withAttribute('nene2.auth.claims', ['role' => 'editor', 'sub' => 'editor@example.com']);
+
+        $response = $this->middleware->process($request, $this->createPassThroughHandler());
+
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    private function createPassThroughHandler(): RequestHandlerInterface
+    {
+        return new class () implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): Response
+            {
+                return new Response(204);
+            }
+        };
+    }
+}

--- a/tests/Auth/CapabilityResolverTest.php
+++ b/tests/Auth/CapabilityResolverTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Auth;
+
+use NeNeRecords\Auth\Capability;
+use NeNeRecords\Auth\CapabilityResolver;
+use PHPUnit\Framework\TestCase;
+
+final class CapabilityResolverTest extends TestCase
+{
+    public function testEntityTypeDeleteRequiresManageSchema(): void
+    {
+        self::assertSame(
+            Capability::ManageSchema,
+            CapabilityResolver::resolve('/api/v1/entity-types/1', 'DELETE'),
+        );
+    }
+
+    public function testEntityTypeGetDoesNotRequireCapability(): void
+    {
+        self::assertNull(CapabilityResolver::resolve('/api/v1/entity-types/1', 'GET'));
+    }
+
+    public function testSettingsPutRequiresManageSettings(): void
+    {
+        self::assertSame(
+            Capability::ManageSettings,
+            CapabilityResolver::resolve('/api/v1/settings/site_name', 'PUT'),
+        );
+    }
+
+    public function testSettingsGetRequiresReadSettings(): void
+    {
+        self::assertSame(
+            Capability::ReadSettings,
+            CapabilityResolver::resolve('/api/v1/settings', 'GET'),
+        );
+    }
+
+    public function testEntityCreateRequiresEditContent(): void
+    {
+        self::assertSame(
+            Capability::EditContent,
+            CapabilityResolver::resolve('/api/v1/entities', 'POST'),
+        );
+    }
+
+    public function testArchiveCsvRequiresManageSchema(): void
+    {
+        self::assertSame(
+            Capability::ManageSchema,
+            CapabilityResolver::resolve('/api/v1/entity-types/1/archive.csv', 'GET'),
+        );
+    }
+}

--- a/tests/Auth/RoleTest.php
+++ b/tests/Auth/RoleTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Auth;
+
+use NeNeRecords\Auth\Capability;
+use NeNeRecords\Auth\Role;
+use PHPUnit\Framework\TestCase;
+
+final class RoleTest extends TestCase
+{
+    public function testAdminHasAllCapabilities(): void
+    {
+        foreach (Capability::cases() as $capability) {
+            self::assertTrue(Role::Admin->hasCapability($capability));
+        }
+    }
+
+    public function testEditorCanEditContentAndReadSettings(): void
+    {
+        self::assertTrue(Role::Editor->hasCapability(Capability::EditContent));
+        self::assertTrue(Role::Editor->hasCapability(Capability::ReadSettings));
+    }
+
+    public function testEditorCannotManageSchemaOrSettings(): void
+    {
+        self::assertFalse(Role::Editor->hasCapability(Capability::ManageSchema));
+        self::assertFalse(Role::Editor->hasCapability(Capability::ManageSettings));
+        self::assertFalse(Role::Editor->hasCapability(Capability::ManageTags));
+    }
+}


### PR DESCRIPTION
## Summary

- JWT `role` に基づく capability チェックを `CapabilityMiddleware` で実装（NENE2 RBAC 準拠、401/403 分離）
- `admin`: 全 mutating 操作 / `editor`: コンテンツ編集 + settings 閲覧のみ
- デフォルトユーザー seed 追加（`admin@nene-records.local` / `editor@nene-records.local`、パスワード `nene1234`）
- Admin UI: ロールに応じた nav / ボタン制御、403 → `/forbidden` ページ

## 権限マトリクス

| Capability | admin | editor |
|---|---|---|
| entity types / field defs 変更 | ✅ | ❌ 403 |
| settings 閲覧 | ✅ | ✅ |
| settings 更新 | ✅ | ❌ 403 |
| tags CRUD | ✅ | ❌ 403 |
| records / field values 編集 | ✅ | ✅ |

## Test plan

- [x] `composer check` — 187 tests 全パス
- [x] `npm run check` — 全パス
- [x] Editor `DELETE /api/v1/entity-types/{id}` → 403
- [x] Editor `POST /api/v1/entities` → 201
- [x] Admin 全操作可能

## セルフレビューチェックリスト

- [x] 変更は Issue #108 範囲に限定
- [x] composer check / npm run check 全パス
- [x] 秘密情報なし

Closes #108

Made with [Cursor](https://cursor.com)