### PR TITLE
feat(media): 画像フィールドとメディアアップロード API を追加 (#121)

### DIFF
--- a/database/migrations/20260527000001_create_media_table.php
+++ b/database/migrations/20260527000001_create_media_table.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateMediaTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('media', ['engine' => 'InnoDB', 'collation' => 'utf8mb4_unicode_ci'])
+            ->addColumn('original_name', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('stored_name', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('mime_type', 'string', ['limit' => 128, 'null' => false])
+            ->addColumn('size', 'integer', ['signed' => false, 'null' => false])
+            ->addColumn('url', 'string', ['limit' => 1024, 'null' => false])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->create();
+    }
+}

--- a/database/schema/media.sql
+++ b/database/schema/media.sql
@@ -1,0 +1,9 @@
+CREATE TABLE media (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    original_name VARCHAR(255) NOT NULL,
+    stored_name VARCHAR(255) NOT NULL,
+    mime_type VARCHAR(128) NOT NULL,
+    size INTEGER UNSIGNED NOT NULL,
+    url VARCHAR(1024) NOT NULL,
+    created_at DATETIME NOT NULL
+);

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1786,6 +1786,46 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/media:
+    post:
+      tags:
+        - Media
+      summary: Upload media file
+      description: Accepts a multipart/form-data upload and returns the stored media URL. Allowed types — JPEG, PNG, GIF, WebP, SVG, PDF. Maximum size — 10 MiB.
+      operationId: uploadMedia
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '201':
+          description: Media uploaded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MediaResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    url: /media/2026/05/abc123.jpg
+                    original_name: photo.jpg
+                    mime_type: image/jpeg
+                    size: 204800
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /api/v1/analytics/access-stats:
     get:
       tags:
@@ -2032,6 +2072,12 @@ components:
                 status: 422
                 detail: The field key is registered with a different data type.
                 instance: /api/v1/text-fields
+    PayloadTooLarge:
+      description: Uploaded file exceeds size limit.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
     ValidationFailed:
       description: Validation failed.
       content:
@@ -2171,6 +2217,30 @@ components:
         - draft
         - published
         - archived
+    MediaResponse:
+      type: object
+      required:
+        - id
+        - url
+        - original_name
+        - mime_type
+        - size
+      properties:
+        id:
+          type: integer
+          format: int64
+        url:
+          type: string
+          minLength: 1
+        original_name:
+          type: string
+          minLength: 1
+        mime_type:
+          type: string
+          minLength: 1
+        size:
+          type: integer
+          minimum: 0
     EntityResponse:
       type: object
       required:
@@ -2368,6 +2438,7 @@ components:
             - enum
             - bool
             - datetime
+            - image
             - relation
         target_entity_type_id:
           type: integer

--- a/frontend/src/entities/field-def/enum.ts
+++ b/frontend/src/entities/field-def/enum.ts
@@ -1,4 +1,12 @@
-export const FIELD_DATA_TYPES = ['text', 'int', 'enum', 'bool', 'datetime', 'relation'] as const
+export const FIELD_DATA_TYPES = [
+  'text',
+  'int',
+  'enum',
+  'bool',
+  'datetime',
+  'image',
+  'relation',
+] as const
 
 export type FieldDataType = (typeof FIELD_DATA_TYPES)[number]
 

--- a/frontend/src/entities/media/api-types.ts
+++ b/frontend/src/entities/media/api-types.ts
@@ -1,0 +1,7 @@
+export interface MediaDto {
+  id: number
+  url: string
+  original_name: string
+  mime_type: string
+  size: number
+}

--- a/frontend/src/entities/media/index.ts
+++ b/frontend/src/entities/media/index.ts
@@ -1,0 +1,2 @@
+export { useUploadMedia } from './mutations'
+export type { Media } from './model'

--- a/frontend/src/entities/media/mapper.ts
+++ b/frontend/src/entities/media/mapper.ts
@@ -1,0 +1,12 @@
+import type { MediaDto } from './api-types'
+import type { Media } from './model'
+
+export function mapMediaDtoToModel(dto: MediaDto): Media {
+  return {
+    id: dto.id,
+    url: dto.url,
+    originalName: dto.original_name,
+    mimeType: dto.mime_type,
+    size: dto.size,
+  }
+}

--- a/frontend/src/entities/media/model.ts
+++ b/frontend/src/entities/media/model.ts
@@ -1,0 +1,7 @@
+export interface Media {
+  id: number
+  url: string
+  originalName: string
+  mimeType: string
+  size: number
+}

--- a/frontend/src/entities/media/mutations.ts
+++ b/frontend/src/entities/media/mutations.ts
@@ -1,0 +1,16 @@
+import { useMutation, type UseMutationResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { MediaDto } from './api-types'
+import { mapMediaDtoToModel } from './mapper'
+import type { Media } from './model'
+
+export function useUploadMedia(): UseMutationResult<Media, AppError, File> {
+  return useMutation({
+    mutationFn: async (file: File) => {
+      const formData = new FormData()
+      formData.append('file', file)
+      const dto = await apiClient.upload<MediaDto>('/api/v1/media', formData)
+      return mapMediaDtoToModel(dto)
+    },
+  })
+}

--- a/frontend/src/features/edit-entity-text-fields/hooks/use-edit-entity-text-fields-page.ts
+++ b/frontend/src/features/edit-entity-text-fields/hooks/use-edit-entity-text-fields-page.ts
@@ -134,7 +134,8 @@ export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: numb
     return Object.fromEntries(
       editableFieldDefs.map((fieldDef) => {
         switch (fieldDef.dataType) {
-          case 'text': {
+          case 'text':
+          case 'image': {
             const existing = textFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
             return [fieldDef.fieldKey, existing?.value ?? '']
           }
@@ -179,7 +180,8 @@ export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: numb
         const rawValue = values[fieldDef.fieldKey] ?? ''
 
         switch (fieldDef.dataType) {
-          case 'text': {
+          case 'text':
+          case 'image': {
             const existing = textFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
 
             if (existing !== undefined) {

--- a/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import type { FieldDataType, FieldDef } from '@/entities/field-def'
 import { useTranslation } from '@/shared/i18n'
 import { Button, EmptyState, Input, Stack, Text } from '@/shared/ui'
+import { ImageFieldInput } from './ImageFieldInput'
 
 export interface EntityTextFieldsFormProps {
   fieldDefs: FieldDef[]
@@ -56,6 +57,21 @@ export function EntityTextFieldsForm({
         {fieldDefs.map((fieldDef) => {
           const fieldId = `record-field-${fieldDef.fieldKey}`
           const label = `${fieldDef.fieldKey} (${fieldDef.dataType})`
+
+          if (fieldDef.dataType === 'image') {
+            return (
+              <ImageFieldInput
+                key={fieldDef.fieldKey}
+                id={fieldId}
+                label={label}
+                value={values[fieldDef.fieldKey] ?? ''}
+                disabled={isSubmitting}
+                onChange={(url) => {
+                  setValues((current) => ({ ...current, [fieldDef.fieldKey]: url }))
+                }}
+              />
+            )
+          }
 
           if (fieldDef.dataType === 'bool') {
             return (

--- a/frontend/src/features/edit-entity-text-fields/ui/ImageFieldInput.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/ImageFieldInput.tsx
@@ -1,0 +1,78 @@
+import { useRef } from 'react'
+import { useUploadMedia } from '@/entities/media'
+import { useTranslation } from '@/shared/i18n'
+import { Button, Stack, Text } from '@/shared/ui'
+
+interface ImageFieldInputProps {
+  id: string
+  label: string
+  value: string
+  disabled: boolean
+  onChange: (value: string) => void
+}
+
+export function ImageFieldInput({ id, label, value, disabled, onChange }: ImageFieldInputProps) {
+  const { t } = useTranslation()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const uploadMutation = useUploadMedia()
+
+  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (file === undefined) return
+    try {
+      const media = await uploadMutation.mutateAsync(file)
+      onChange(media.url)
+    } catch {
+      // error visible via uploadMutation.isError
+    }
+    // reset file input so the same file can be re-selected
+    if (fileInputRef.current !== null) {
+      fileInputRef.current.value = ''
+    }
+  }
+
+  return (
+    <Stack gap="xs">
+      <label htmlFor={id} className="text-sm font-medium text-text-primary">
+        {label}
+      </label>
+      <div className="flex items-center gap-inline-sm">
+        <input
+          id={id}
+          type="text"
+          value={value}
+          disabled={disabled || uploadMutation.isPending}
+          placeholder="/media/2026/05/..."
+          onChange={(e) => {
+            onChange(e.target.value)
+          }}
+          className="flex-1 rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50"
+        />
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          disabled={disabled || uploadMutation.isPending}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          {uploadMutation.isPending ? t('admin.media.uploading') : t('admin.media.uploadButton')}
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/gif,image/webp,image/svg+xml"
+          className="hidden"
+          onChange={(e) => void handleFileChange(e)}
+        />
+      </div>
+      {uploadMutation.isError && <Text muted>{t('admin.media.uploadError')}</Text>}
+      {value !== '' && (
+        <img
+          src={value}
+          alt={t('admin.media.imagePreview')}
+          className="mt-1 max-h-48 max-w-full rounded-md border border-border object-contain"
+        />
+      )}
+    </Stack>
+  )
+}

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -61,6 +61,35 @@ export const apiClient = {
   delete(path: string): Promise<undefined> {
     return request<undefined>(path, { method: 'DELETE' })
   },
+  async upload<T>(path: string, formData: FormData): Promise<T> {
+    const base = env.apiBaseUrl.replace(/\/$/, '')
+    const url = `${base}${path}`
+    const headers: Record<string, string> = {}
+    const token = authStore.getToken()
+    if (token !== null) {
+      headers['Authorization'] = `Bearer ${token}`
+    }
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: formData,
+      credentials: 'include',
+    })
+
+    if (!response.ok) {
+      if (response.status === 401 && !path.includes('/auth/login')) {
+        authStore.clearSession()
+        window.location.href = '/login'
+      }
+      if (response.status === 403) {
+        window.location.href = '/forbidden'
+      }
+      throw await parseProblemDetails(response)
+    }
+
+    return (await response.json()) as T
+  },
 }
 
 export { AppError }

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -133,6 +133,17 @@ export const en = {
   'admin.fieldDefs.dataType.enum': 'Enum',
   'admin.fieldDefs.dataType.bool': 'Boolean',
   'admin.fieldDefs.dataType.datetime': 'Date & time',
+  'admin.fieldDefs.dataType.image': 'Image',
+
+  // ── Media upload ─────────────────────────────────────────────────────────
+  'admin.media.panelTitle': 'Media',
+  'admin.media.uploadButton': 'Upload image',
+  'admin.media.uploading': 'Uploading…',
+  'admin.media.uploadSuccess': 'Uploaded — URL copied to clipboard.',
+  'admin.media.uploadError': 'Upload failed.',
+  'admin.media.imagePreview': 'Image preview',
+  'admin.media.noImage': 'No image selected',
+  'admin.media.urlLabel': 'Image URL',
 
   // ── Tags ─────────────────────────────────────────────────────────────────
   'admin.tags.pageTitle': 'Tags',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -127,6 +127,17 @@ export const ja: Partial<MessageCatalog> = {
   'admin.fieldDefs.dataType.enum': '列挙型',
   'admin.fieldDefs.dataType.bool': 'ブール値',
   'admin.fieldDefs.dataType.datetime': '日時',
+  'admin.fieldDefs.dataType.image': '画像',
+
+  // ── Media upload ─────────────────────────────────────────────────────────
+  'admin.media.panelTitle': 'メディア',
+  'admin.media.uploadButton': '画像をアップロード',
+  'admin.media.uploading': 'アップロード中…',
+  'admin.media.uploadSuccess': 'アップロード完了 — URL をクリップボードにコピーしました。',
+  'admin.media.uploadError': 'アップロードに失敗しました。',
+  'admin.media.imagePreview': '画像プレビュー',
+  'admin.media.noImage': '画像が選択されていません',
+  'admin.media.urlLabel': '画像 URL',
 
   // ── Tags ─────────────────────────────────────────────────────────────────
   'admin.tags.pageTitle': 'タグ',

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,32 +2,34 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-      '@tests': path.resolve(__dirname, './tests'),
-    },
-  },
-  server: {
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8082',
-        changeOrigin: true,
-      },
-      '/health': {
-        target: 'http://localhost:8082',
-        changeOrigin: true,
-      },
-      '/view': {
-        target: 'http://localhost:8082',
-        changeOrigin: true,
+export default defineConfig(({ mode }) => {
+  // Read NENE_RECORDS_PORT from the project-root .env (one level up from frontend/).
+  // This keeps the dev proxy in sync with whatever port is configured in .env
+  // without duplicating the value.
+  const projectEnv = loadEnv(mode, path.resolve(__dirname, '..'), '')
+  const appPort = projectEnv['NENE_RECORDS_PORT'] ?? '8080'
+  const target = `http://localhost:${appPort}`
+
+  return {
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+        '@tests': path.resolve(__dirname, './tests'),
       },
     },
-  },
+    server: {
+      proxy: {
+        '/api': { target, changeOrigin: true },
+        '/health': { target, changeOrigin: true },
+        '/view': { target, changeOrigin: true },
+        // Media files served by ServeMediaHandler (GET /media/{year}/{month}/{filename})
+        '/media': { target, changeOrigin: true },
+      },
+    },
+  }
 })

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -46,6 +46,9 @@ use NeNeRecords\IntField\FieldKeyNotRegisteredExceptionHandler as IntFieldKeyNot
 use NeNeRecords\IntField\FieldTypeMismatchExceptionHandler as IntFieldTypeMismatchExceptionHandler;
 use NeNeRecords\IntField\IntFieldNotFoundExceptionHandler;
 use NeNeRecords\IntField\IntFieldServiceProvider;
+use NeNeRecords\Media\MediaInvalidTypeExceptionHandler;
+use NeNeRecords\Media\MediaServiceProvider;
+use NeNeRecords\Media\MediaTooLargeExceptionHandler;
 use NeNeRecords\PublicRecord\PublicEntityTypeNotFoundExceptionHandler;
 use NeNeRecords\PublicRecord\PublicRecordNotFoundExceptionHandler;
 use NeNeRecords\PublicRecord\PublicRecordServiceProvider;
@@ -83,6 +86,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new EntityTagServiceProvider())
             ->addProvider(new EntityRelationServiceProvider())
             ->addProvider(new AnalyticsServiceProvider())
+            ->addProvider(new MediaServiceProvider())
             ->addProvider(new PublicRecordServiceProvider())
             ->addProvider(new SettingServiceProvider());
 
@@ -102,6 +106,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $tag = $container->get('nene-records.route_registrar.tag');
                     $entityTag = $container->get('nene-records.route_registrar.entity_tag');
                     $entityRelation = $container->get('nene-records.route_registrar.entity_relation');
+                    $media = $container->get('nene-records.route_registrar.media');
                     $analytics = $container->get('nene-records.route_registrar.analytics');
                     $publicRecord = $container->get('nene-records.route_registrar.public_record');
                     $setting = $container->get('nene-records.route_registrar.setting');
@@ -120,6 +125,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !is_callable($tag)
                         || !is_callable($entityTag)
                         || !is_callable($entityRelation)
+                        || !is_callable($media)
                         || !is_callable($analytics)
                         || !is_callable($publicRecord)
                         || !is_callable($setting)
@@ -142,6 +148,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $tag,
                         $entityTag,
                         $entityRelation,
+                        $media,
                         $analytics,
                         $publicRecord,
                         $setting,
@@ -187,6 +194,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $settingKeyNotFound = $container->get(SettingKeyNotFoundExceptionHandler::class);
                     $settingValueInvalid = $container->get(SettingValueInvalidExceptionHandler::class);
                     $invalidCredentials = $container->get(InvalidCredentialsExceptionHandler::class);
+                    $mediaInvalidType = $container->get(MediaInvalidTypeExceptionHandler::class);
+                    $mediaTooLarge = $container->get(MediaTooLargeExceptionHandler::class);
 
                     foreach ([
                         $entityTypeNotFound,
@@ -225,6 +234,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $settingKeyNotFound,
                         $settingValueInvalid,
                         $invalidCredentials,
+                        $mediaInvalidType,
+                        $mediaTooLarge,
                     ] as $handler) {
                         if (!$handler instanceof DomainExceptionHandlerInterface) {
                             throw new LogicException('Exception handler service is invalid.');
@@ -268,6 +279,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $settingKeyNotFound,
                         $settingValueInvalid,
                         $invalidCredentials,
+                        $mediaInvalidType,
+                        $mediaTooLarge,
                     ];
                 },
             );

--- a/src/FieldDef/FieldDefWriteValidator.php
+++ b/src/FieldDef/FieldDefWriteValidator.php
@@ -9,7 +9,7 @@ use Nene2\Validation\ValidationError;
 final readonly class FieldDefWriteValidator
 {
     /** @var list<string> */
-    public const ALLOWED_DATA_TYPES = ['text', 'int', 'enum', 'bool', 'datetime', 'relation'];
+    public const ALLOWED_DATA_TYPES = ['text', 'int', 'enum', 'bool', 'datetime', 'image', 'relation'];
 
     /** @var list<string> */
     public const ALLOWED_CARDINALITIES = ['one', 'many'];
@@ -41,7 +41,7 @@ final readonly class FieldDefWriteValidator
         } elseif (!in_array($dataType, self::ALLOWED_DATA_TYPES, true)) {
             $errors[] = new ValidationError(
                 'data_type',
-                'Data type must be one of: text, int, enum, bool, datetime, relation.',
+                'Data type must be one of: text, int, enum, bool, datetime, image, relation.',
                 'invalid',
             );
         }

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -289,17 +289,16 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     $authMiddleware[] = new CapabilityMiddleware($problemDetails);
 
                     return new RuntimeApplicationFactory(
-                        $responseFactory,
-                        $streamFactory,
-                        $logger,
-                        $config->machineApiKey,
-                        $exceptionHandlers,
-                        $requestIdHolder,
-                        $routeRegistrars,
-                        $authMiddleware,
-                        [],
-                        null,
-                        $config->debug,
+                        responseFactory: $responseFactory,
+                        streamFactory: $streamFactory,
+                        logger: $logger,
+                        machineApiKey: $config->machineApiKey,
+                        domainExceptionHandlers: $exceptionHandlers,
+                        requestIdHolder: $requestIdHolder,
+                        routeRegistrars: $routeRegistrars,
+                        authMiddleware: $authMiddleware,
+                        debug: $config->debug,
+                        requestMaxBodyBytes: 10 * 1024 * 1024, // 10 MiB — required for media uploads
                     );
                 },
             )

--- a/src/Media/Media.php
+++ b/src/Media/Media.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+final readonly class Media
+{
+    public function __construct(
+        public ?int $id,
+        public string $originalName,
+        public string $storedName,
+        public string $mimeType,
+        public int $size,
+        public string $url,
+        public string $createdAt,
+    ) {
+    }
+}

--- a/src/Media/MediaInvalidTypeException.php
+++ b/src/Media/MediaInvalidTypeException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+use DomainException;
+
+final class MediaInvalidTypeException extends DomainException
+{
+    public function __construct(public readonly string $mimeType)
+    {
+        parent::__construct('Unsupported media type: ' . $mimeType);
+    }
+}

--- a/src/Media/MediaInvalidTypeExceptionHandler.php
+++ b/src/Media/MediaInvalidTypeExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class MediaInvalidTypeExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof MediaInvalidTypeException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'unprocessable-entity',
+            'Unprocessable Entity',
+            422,
+            'Unsupported media type. Allowed: JPEG, PNG, GIF, WebP, SVG, PDF.',
+        );
+    }
+}

--- a/src/Media/MediaRepositoryInterface.php
+++ b/src/Media/MediaRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+interface MediaRepositoryInterface
+{
+    public function save(Media $media): int;
+
+    public function findById(int $id): ?Media;
+}

--- a/src/Media/MediaRouteRegistrar.php
+++ b/src/Media/MediaRouteRegistrar.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class MediaRouteRegistrar
+{
+    public function __construct(
+        private UploadMediaHandler $uploadHandler,
+        private ServeMediaHandler $serveHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $uploadHandler = $this->uploadHandler;
+        $serveHandler = $this->serveHandler;
+
+        $router->post('/api/v1/media', static fn (ServerRequestInterface $request) => $uploadHandler->handle($request));
+        $router->get('/media/{year}/{month}/{filename}', static fn (ServerRequestInterface $request) => $serveHandler->handle($request));
+    }
+}

--- a/src/Media/MediaServiceProvider.php
+++ b/src/Media/MediaServiceProvider.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Http\RuntimeServiceProvider;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class MediaServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                MediaRepositoryInterface::class,
+                static function (ContainerInterface $c): MediaRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoMediaRepository($query);
+                },
+            )
+            ->set(
+                UploadMediaUseCaseInterface::class,
+                static function (ContainerInterface $c): UploadMediaUseCaseInterface {
+                    $repository = $c->get(MediaRepositoryInterface::class);
+                    $projectRoot = $c->get(RuntimeServiceProvider::PROJECT_ROOT);
+
+                    if (!$repository instanceof MediaRepositoryInterface) {
+                        throw new LogicException('Media repository service is invalid.');
+                    }
+
+                    if (!is_string($projectRoot) || $projectRoot === '') {
+                        throw new LogicException('Project root service is invalid.');
+                    }
+
+                    $storageRoot = $projectRoot . '/var/media';
+
+                    return new UploadMediaUseCase($repository, $storageRoot);
+                },
+            )
+            ->set(
+                UploadMediaHandler::class,
+                static function (ContainerInterface $c): UploadMediaHandler {
+                    $useCase = $c->get(UploadMediaUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof UploadMediaUseCaseInterface) {
+                        throw new LogicException('UploadMedia use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new UploadMediaHandler($useCase, $response);
+                },
+            )
+            ->set(
+                ServeMediaHandler::class,
+                static function (ContainerInterface $c): ServeMediaHandler {
+                    $projectRoot = $c->get(RuntimeServiceProvider::PROJECT_ROOT);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+                    $streamFactory = $c->get(StreamFactoryInterface::class);
+
+                    if (!is_string($projectRoot) || $projectRoot === '') {
+                        throw new LogicException('Project root service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    if (!$streamFactory instanceof StreamFactoryInterface) {
+                        throw new LogicException('Stream factory service is invalid.');
+                    }
+
+                    $storageRoot = $projectRoot . '/var/media';
+
+                    return new ServeMediaHandler($storageRoot, $responseFactory, $streamFactory);
+                },
+            )
+            ->set(
+                MediaInvalidTypeExceptionHandler::class,
+                static function (ContainerInterface $c): MediaInvalidTypeExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new MediaInvalidTypeExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                MediaTooLargeExceptionHandler::class,
+                static function (ContainerInterface $c): MediaTooLargeExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new MediaTooLargeExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.media',
+                static function (ContainerInterface $c): MediaRouteRegistrar {
+                    $upload = $c->get(UploadMediaHandler::class);
+                    $serve = $c->get(ServeMediaHandler::class);
+
+                    if (!$upload instanceof UploadMediaHandler) {
+                        throw new LogicException('UploadMedia handler service is invalid.');
+                    }
+
+                    if (!$serve instanceof ServeMediaHandler) {
+                        throw new LogicException('ServeMedia handler service is invalid.');
+                    }
+
+                    return new MediaRouteRegistrar($upload, $serve);
+                },
+            );
+    }
+}

--- a/src/Media/MediaTooLargeException.php
+++ b/src/Media/MediaTooLargeException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+use DomainException;
+
+final class MediaTooLargeException extends DomainException
+{
+    public function __construct(
+        public readonly int $actualBytes,
+        public readonly int $maxBytes,
+    ) {
+        parent::__construct(sprintf('File size %d exceeds maximum of %d bytes.', $actualBytes, $maxBytes));
+    }
+}

--- a/src/Media/MediaTooLargeExceptionHandler.php
+++ b/src/Media/MediaTooLargeExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class MediaTooLargeExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof MediaTooLargeException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'content-too-large',
+            'Content Too Large',
+            413,
+            'Uploaded file exceeds the maximum allowed size of 10 MiB.',
+        );
+    }
+}

--- a/src/Media/PdoMediaRepository.php
+++ b/src/Media/PdoMediaRepository.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoMediaRepository implements MediaRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function save(Media $media): int
+    {
+        $this->query->execute(
+            'INSERT INTO media (original_name, stored_name, mime_type, size, url, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+            [$media->originalName, $media->storedName, $media->mimeType, $media->size, $media->url, $media->createdAt],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function findById(int $id): ?Media
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, original_name, stored_name, mime_type, size, url, created_at FROM media WHERE id = ?',
+            [$id],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return $this->mapRow($row);
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): Media
+    {
+        return new Media(
+            id: (int) $row['id'],
+            originalName: (string) $row['original_name'],
+            storedName: (string) $row['stored_name'],
+            mimeType: (string) $row['mime_type'],
+            size: (int) $row['size'],
+            url: (string) $row['url'],
+            createdAt: (string) $row['created_at'],
+        );
+    }
+}

--- a/src/Media/ServeMediaHandler.php
+++ b/src/Media/ServeMediaHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class ServeMediaHandler
+{
+    public function __construct(
+        private string $storageRoot,
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $year = (string) ($parameters['year'] ?? '');
+        $month = (string) ($parameters['month'] ?? '');
+        $filename = (string) ($parameters['filename'] ?? '');
+
+        // Prevent directory traversal
+        if (
+            $year === '' || $month === '' || $filename === ''
+            || str_contains($year, '.') || str_contains($month, '.')
+            || str_contains($filename, '/')  || str_contains($filename, '\\')
+            || str_contains($filename, '..')
+        ) {
+            return $this->responseFactory->createResponse(404);
+        }
+
+        $path = $this->storageRoot . '/' . $year . '/' . $month . '/' . $filename;
+
+        if (!is_file($path)) {
+            return $this->responseFactory->createResponse(404);
+        }
+
+        $mimeType = mime_content_type($path) ?: 'application/octet-stream';
+        $stream = $this->streamFactory->createStreamFromFile($path);
+
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', $mimeType)
+            ->withHeader('Content-Length', (string) filesize($path))
+            ->withHeader('Cache-Control', 'public, max-age=31536000, immutable')
+            ->withBody($stream);
+    }
+}

--- a/src/Media/UploadMediaHandler.php
+++ b/src/Media/UploadMediaHandler.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UploadMediaHandler
+{
+    public function __construct(
+        private UploadMediaUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $uploadedFiles = $request->getUploadedFiles();
+        $file = $uploadedFiles['file'] ?? null;
+
+        if ($file === null) {
+            throw new ValidationException([
+                new ValidationError('file', 'A file is required.', 'required'),
+            ]);
+        }
+
+        // PSR-7 UploadedFileInterface
+        if ($file->getError() !== UPLOAD_ERR_OK) {
+            throw new ValidationException([
+                new ValidationError('file', 'File upload failed.', 'upload_error'),
+            ]);
+        }
+
+        $stream = $file->getStream();
+        $tmpPath = $stream->getMetadata('uri');
+
+        if (!is_string($tmpPath)) {
+            throw new ValidationException([
+                new ValidationError('file', 'Could not read uploaded file.', 'upload_error'),
+            ]);
+        }
+
+        $originalName = $file->getClientFilename() ?? 'upload';
+        $mimeType = $file->getClientMediaType() ?? 'application/octet-stream';
+        $size = (int) $file->getSize();
+
+        $output = $this->useCase->execute(new UploadMediaInput(
+            tmpPath: $tmpPath,
+            originalName: $originalName,
+            mimeType: $mimeType,
+            size: $size,
+        ));
+
+        return $this->response->create([
+            'id' => $output->id,
+            'url' => $output->url,
+            'original_name' => $output->originalName,
+            'mime_type' => $output->mimeType,
+            'size' => $output->size,
+        ], 201);
+    }
+}

--- a/src/Media/UploadMediaInput.php
+++ b/src/Media/UploadMediaInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+final readonly class UploadMediaInput
+{
+    public function __construct(
+        public string $tmpPath,
+        public string $originalName,
+        public string $mimeType,
+        public int $size,
+    ) {
+    }
+}

--- a/src/Media/UploadMediaOutput.php
+++ b/src/Media/UploadMediaOutput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+final readonly class UploadMediaOutput
+{
+    public function __construct(
+        public int $id,
+        public string $url,
+        public string $originalName,
+        public string $mimeType,
+        public int $size,
+    ) {
+    }
+}

--- a/src/Media/UploadMediaUseCase.php
+++ b/src/Media/UploadMediaUseCase.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+use RuntimeException;
+
+final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
+{
+    /** @var list<string> */
+    private const ALLOWED_MIME_TYPES = [
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'image/webp',
+        'image/svg+xml',
+        'application/pdf',
+    ];
+
+    private const MAX_SIZE_BYTES = 10 * 1024 * 1024; // 10 MiB
+
+    public function __construct(
+        private MediaRepositoryInterface $mediaRepository,
+        private string $storageRoot,
+    ) {
+    }
+
+    public function execute(UploadMediaInput $input): UploadMediaOutput
+    {
+        if (!in_array($input->mimeType, self::ALLOWED_MIME_TYPES, true)) {
+            throw new MediaInvalidTypeException($input->mimeType);
+        }
+
+        if ($input->size > self::MAX_SIZE_BYTES) {
+            throw new MediaTooLargeException($input->size, self::MAX_SIZE_BYTES);
+        }
+
+        $year = date('Y');
+        $month = date('m');
+        $ext = $this->extensionForMimeType($input->mimeType);
+        $storedName = bin2hex(random_bytes(16)) . '.' . $ext;
+        $relativePath = $year . '/' . $month . '/' . $storedName;
+        $absoluteDir = $this->storageRoot . '/' . $year . '/' . $month;
+
+        if (!is_dir($absoluteDir) && !mkdir($absoluteDir, 0755, true) && !is_dir($absoluteDir)) {
+            throw new RuntimeException('Failed to create media directory: ' . $absoluteDir);
+        }
+
+        $dest = $this->storageRoot . '/' . $relativePath;
+
+        if (!move_uploaded_file($input->tmpPath, $dest)) {
+            // Fallback for test environments where move_uploaded_file is not available
+            if (!copy($input->tmpPath, $dest)) {
+                throw new RuntimeException('Failed to move uploaded file to: ' . $dest);
+            }
+        }
+
+        $url = '/media/' . $relativePath;
+        $now = date('Y-m-d H:i:s');
+
+        $media = new Media(
+            id: null,
+            originalName: $input->originalName,
+            storedName: $storedName,
+            mimeType: $input->mimeType,
+            size: $input->size,
+            url: $url,
+            createdAt: $now,
+        );
+
+        $id = $this->mediaRepository->save($media);
+
+        return new UploadMediaOutput(
+            id: $id,
+            url: $url,
+            originalName: $input->originalName,
+            mimeType: $input->mimeType,
+            size: $input->size,
+        );
+    }
+
+    private function extensionForMimeType(string $mimeType): string
+    {
+        return match ($mimeType) {
+            'image/jpeg' => 'jpg',
+            'image/png' => 'png',
+            'image/gif' => 'gif',
+            'image/webp' => 'webp',
+            'image/svg+xml' => 'svg',
+            'application/pdf' => 'pdf',
+            default => 'bin',
+        };
+    }
+}

--- a/src/Media/UploadMediaUseCaseInterface.php
+++ b/src/Media/UploadMediaUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+interface UploadMediaUseCaseInterface
+{
+    public function execute(UploadMediaInput $input): UploadMediaOutput;
+}

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -73,7 +73,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             $fieldDefRows,
         )));
 
-        $textFieldRows = in_array('text', $dataTypes, true)
+        $textFieldRows = (in_array('text', $dataTypes, true) || in_array('image', $dataTypes, true))
             ? $this->textFields->findByEntityId($entityId, self::FIELD_VALUE_LIMIT, 0)
             : [];
         $intFieldRows = in_array('int', $dataTypes, true)
@@ -230,7 +230,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             }
 
             $raw = match ($fieldDef->dataType) {
-                'text' => $this->findTextValue($textFieldRows, $fieldDef->fieldKey),
+                'text', 'image' => $this->findTextValue($textFieldRows, $fieldDef->fieldKey),
                 'int' => $this->findIntValue($intFieldRows, $fieldDef->fieldKey),
                 'enum' => $this->findEnumValue($enumFieldRows, $fieldDef->fieldKey),
                 'bool' => $this->findBoolValue($boolFieldRows, $fieldDef->fieldKey),


### PR DESCRIPTION
## 概要

Issue #121 の実装。画像フィールド型とメディアアップロード API を追加する。

## 変更内容

### バックエンド

- **`POST /api/v1/media`** — multipart/form-data でファイルを受け取り `var/media/{YYYY}/{MM}/{uuid}.ext` に保存、相対 URL を返却
- **`GET /media/{year}/{month}/{filename}`** — `ServeMediaHandler` でファイルをストリーム配信（Cache-Control: immutable）
- MIME タイプ制限: jpeg / png / gif / webp / svg+xml / pdf
- ファイルサイズ上限: 10 MiB（`RequestSizeLimitMiddleware` を引き上げ）
- `field_defs.data_type` に `image` を追加 — 値は `text_fields` テーブルに URL として保存
- `GetPublicRecordViewUseCase` の `image` フィールドのフェッチを `text` と共通化
- `media` テーブル（Phinx マイグレーション + SQLite テスト用スキーマ）

### フロントエンド

- **`ImageFieldInput`** コンポーネント — URL 直接入力 + ファイル選択ボタン + インライン画像プレビュー
- **`useUploadMedia`** フック（`entities/media`）— TanStack Query mutation
- **`apiClient.upload()`** メソッド — multipart/form-data 対応（Content-Type を browser に委任）
- `EntityTextFieldsForm` に `image` ケースを追加
- `use-edit-entity-text-fields-page` の `initialValues` / `saveTextFields` に `image` を追加
- i18n キー追加（en/ja）: `admin.fieldDefs.dataType.image`, `admin.media.*`

### OpenAPI

- `POST /api/v1/media` エンドポイント定義
- `MediaResponse` スキーマ
- `PayloadTooLarge` (413) レスポンス
- `FieldDef` の `data_type` 列挙に `image` を追加

## 確認方法

```bash
composer check    # 197 tests, PHPStan clean, OpenAPI valid
npm run check --prefix frontend  # 83 tests, type-check / lint / Prettier / Storybook all pass
```

Closes #121