### PR TITLE
feat(field-def): markdown フィールド型と管理 UI プレビューエディタを追加 (#124)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2434,6 +2434,7 @@ components:
           type: string
           enum:
             - text
+            - markdown
             - int
             - enum
             - bool
@@ -2467,6 +2468,7 @@ components:
           type: string
           enum:
             - text
+            - markdown
             - int
             - enum
             - bool

--- a/frontend/src/entities/field-def/enum.ts
+++ b/frontend/src/entities/field-def/enum.ts
@@ -1,5 +1,6 @@
 export const FIELD_DATA_TYPES = [
   'text',
+  'markdown',
   'int',
   'enum',
   'bool',

--- a/frontend/src/features/edit-entity-text-fields/hooks/use-edit-entity-text-fields-page.ts
+++ b/frontend/src/features/edit-entity-text-fields/hooks/use-edit-entity-text-fields-page.ts
@@ -135,6 +135,7 @@ export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: numb
       editableFieldDefs.map((fieldDef) => {
         switch (fieldDef.dataType) {
           case 'text':
+          case 'markdown':
           case 'image': {
             const existing = textFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
             return [fieldDef.fieldKey, existing?.value ?? '']
@@ -181,6 +182,7 @@ export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: numb
 
         switch (fieldDef.dataType) {
           case 'text':
+          case 'markdown':
           case 'image': {
             const existing = textFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
 

--- a/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
@@ -3,6 +3,7 @@ import type { FieldDataType, FieldDef } from '@/entities/field-def'
 import { useTranslation } from '@/shared/i18n'
 import { Button, EmptyState, Input, Stack, Text } from '@/shared/ui'
 import { ImageFieldInput } from './ImageFieldInput'
+import { MarkdownFieldInput } from './MarkdownFieldInput'
 
 export interface EntityTextFieldsFormProps {
   fieldDefs: FieldDef[]
@@ -68,6 +69,21 @@ export function EntityTextFieldsForm({
                 disabled={isSubmitting}
                 onChange={(url) => {
                   setValues((current) => ({ ...current, [fieldDef.fieldKey]: url }))
+                }}
+              />
+            )
+          }
+
+          if (fieldDef.dataType === 'markdown') {
+            return (
+              <MarkdownFieldInput
+                key={fieldDef.fieldKey}
+                id={fieldId}
+                label={label}
+                value={values[fieldDef.fieldKey] ?? ''}
+                disabled={isSubmitting}
+                onChange={(val) => {
+                  setValues((current) => ({ ...current, [fieldDef.fieldKey]: val }))
                 }}
               />
             )

--- a/frontend/src/features/edit-entity-text-fields/ui/MarkdownFieldInput.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/MarkdownFieldInput.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { useTranslation } from '@/shared/i18n'
+import { Stack, Text } from '@/shared/ui'
+
+interface MarkdownFieldInputProps {
+  id: string
+  label: string
+  value: string
+  disabled: boolean
+  onChange: (value: string) => void
+}
+
+export function MarkdownFieldInput({
+  id,
+  label,
+  value,
+  disabled,
+  onChange,
+}: MarkdownFieldInputProps) {
+  const { t } = useTranslation()
+  const [tab, setTab] = useState<'write' | 'preview'>('write')
+
+  return (
+    <Stack gap="xs">
+      <label htmlFor={id} className="font-sans text-body font-medium text-text-primary">
+        {label}
+      </label>
+
+      {/* Tab bar */}
+      <div className="flex gap-inline-sm border-b border-border">
+        <button
+          type="button"
+          onClick={() => {
+            setTab('write')
+          }}
+          className={`pb-1 text-sm font-medium transition-colors focus-visible:outline-none ${
+            tab === 'write'
+              ? 'border-b-2 border-blue-500 text-text-primary'
+              : 'text-text-muted hover:text-text-primary'
+          }`}
+        >
+          {t('admin.markdownEditor.write')}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setTab('preview')
+          }}
+          className={`pb-1 text-sm font-medium transition-colors focus-visible:outline-none ${
+            tab === 'preview'
+              ? 'border-b-2 border-blue-500 text-text-primary'
+              : 'text-text-muted hover:text-text-primary'
+          }`}
+        >
+          {t('admin.markdownEditor.preview')}
+        </button>
+      </div>
+
+      {/* Write pane */}
+      {tab === 'write' && (
+        <textarea
+          id={id}
+          value={value}
+          disabled={disabled}
+          rows={10}
+          onChange={(e) => {
+            onChange(e.target.value)
+          }}
+          className="w-full rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm font-mono text-sm text-text-primary shadow-sm focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-50"
+        />
+      )}
+
+      {/* Preview pane */}
+      {tab === 'preview' && (
+        <div className="min-h-40 rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm shadow-sm">
+          {value.trim() === '' ? (
+            <Text muted>{t('admin.markdownEditor.empty')}</Text>
+          ) : (
+            <div className="prose prose-sm max-w-none text-text-primary">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{value}</ReactMarkdown>
+            </div>
+          )}
+        </div>
+      )}
+    </Stack>
+  )
+}

--- a/frontend/src/features/manage-field-defs/ui/FieldDefCreateForm.tsx
+++ b/frontend/src/features/manage-field-defs/ui/FieldDefCreateForm.tsx
@@ -7,10 +7,12 @@ import { useCreateFieldDefForm } from '../hooks/use-create-field-def-form'
 
 const DATA_TYPE_LABEL_KEYS: Record<FieldDataType, MessageKey> = {
   text: 'admin.fieldDefs.dataType.text',
+  markdown: 'admin.fieldDefs.dataType.markdown',
   int: 'admin.fieldDefs.dataType.int',
   enum: 'admin.fieldDefs.dataType.enum',
   bool: 'admin.fieldDefs.dataType.bool',
   datetime: 'admin.fieldDefs.dataType.datetime',
+  relation: 'admin.fieldDefs.dataType.relation',
 }
 
 export interface FieldDefCreateFormProps {

--- a/frontend/src/features/manage-field-defs/ui/FieldDefEditForm.tsx
+++ b/frontend/src/features/manage-field-defs/ui/FieldDefEditForm.tsx
@@ -7,10 +7,12 @@ import { useEditFieldDefForm } from '../hooks/use-create-field-def-form'
 
 const DATA_TYPE_LABEL_KEYS: Record<FieldDataType, MessageKey> = {
   text: 'admin.fieldDefs.dataType.text',
+  markdown: 'admin.fieldDefs.dataType.markdown',
   int: 'admin.fieldDefs.dataType.int',
   enum: 'admin.fieldDefs.dataType.enum',
   bool: 'admin.fieldDefs.dataType.bool',
   datetime: 'admin.fieldDefs.dataType.datetime',
+  relation: 'admin.fieldDefs.dataType.relation',
 }
 
 export interface FieldDefEditFormProps {

--- a/frontend/src/features/manage-field-defs/ui/FieldDefListPanel.tsx
+++ b/frontend/src/features/manage-field-defs/ui/FieldDefListPanel.tsx
@@ -6,10 +6,12 @@ import { Button, EmptyState, Stack, Text } from '@/shared/ui'
 
 const DATA_TYPE_LABEL_KEYS: Record<FieldDataType, MessageKey> = {
   text: 'admin.fieldDefs.dataType.text',
+  markdown: 'admin.fieldDefs.dataType.markdown',
   int: 'admin.fieldDefs.dataType.int',
   enum: 'admin.fieldDefs.dataType.enum',
   bool: 'admin.fieldDefs.dataType.bool',
   datetime: 'admin.fieldDefs.dataType.datetime',
+  relation: 'admin.fieldDefs.dataType.relation',
 }
 
 export interface FieldDefListPanelProps {

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -129,11 +129,13 @@ export const en = {
   'admin.fieldDefs.delete.title': 'Delete field?',
   'admin.fieldDefs.delete.description': '"{{fieldKey}}" will be removed from the schema.',
   'admin.fieldDefs.dataType.text': 'Text',
+  'admin.fieldDefs.dataType.markdown': 'Markdown',
   'admin.fieldDefs.dataType.int': 'Integer',
   'admin.fieldDefs.dataType.enum': 'Enum',
   'admin.fieldDefs.dataType.bool': 'Boolean',
   'admin.fieldDefs.dataType.datetime': 'Date & time',
   'admin.fieldDefs.dataType.image': 'Image',
+  'admin.fieldDefs.dataType.relation': 'Relation',
 
   // ── Media upload ─────────────────────────────────────────────────────────
   'admin.media.panelTitle': 'Media',
@@ -144,6 +146,11 @@ export const en = {
   'admin.media.imagePreview': 'Image preview',
   'admin.media.noImage': 'No image selected',
   'admin.media.urlLabel': 'Image URL',
+
+  // ── Markdown editor ───────────────────────────────────────────────────────
+  'admin.markdownEditor.preview': 'Preview',
+  'admin.markdownEditor.write': 'Write',
+  'admin.markdownEditor.empty': 'Nothing to preview.',
 
   // ── Tags ─────────────────────────────────────────────────────────────────
   'admin.tags.pageTitle': 'Tags',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -123,11 +123,13 @@ export const ja: Partial<MessageCatalog> = {
   'admin.fieldDefs.delete.title': 'フィールドを削除しますか？',
   'admin.fieldDefs.delete.description': '「{{fieldKey}}」がスキーマから削除されます。',
   'admin.fieldDefs.dataType.text': 'テキスト',
+  'admin.fieldDefs.dataType.markdown': 'Markdown',
   'admin.fieldDefs.dataType.int': '整数',
   'admin.fieldDefs.dataType.enum': '列挙型',
   'admin.fieldDefs.dataType.bool': 'ブール値',
   'admin.fieldDefs.dataType.datetime': '日時',
   'admin.fieldDefs.dataType.image': '画像',
+  'admin.fieldDefs.dataType.relation': 'リレーション',
 
   // ── Media upload ─────────────────────────────────────────────────────────
   'admin.media.panelTitle': 'メディア',
@@ -138,6 +140,11 @@ export const ja: Partial<MessageCatalog> = {
   'admin.media.imagePreview': '画像プレビュー',
   'admin.media.noImage': '画像が選択されていません',
   'admin.media.urlLabel': '画像 URL',
+
+  // ── Markdown editor ───────────────────────────────────────────────────────
+  'admin.markdownEditor.preview': 'プレビュー',
+  'admin.markdownEditor.write': '編集',
+  'admin.markdownEditor.empty': 'プレビューする内容がありません。',
 
   // ── Tags ─────────────────────────────────────────────────────────────────
   'admin.tags.pageTitle': 'タグ',

--- a/src/FieldDef/FieldDefWriteValidator.php
+++ b/src/FieldDef/FieldDefWriteValidator.php
@@ -9,7 +9,7 @@ use Nene2\Validation\ValidationError;
 final readonly class FieldDefWriteValidator
 {
     /** @var list<string> */
-    public const ALLOWED_DATA_TYPES = ['text', 'int', 'enum', 'bool', 'datetime', 'image', 'relation'];
+    public const ALLOWED_DATA_TYPES = ['text', 'markdown', 'int', 'enum', 'bool', 'datetime', 'image', 'relation'];
 
     /** @var list<string> */
     public const ALLOWED_CARDINALITIES = ['one', 'many'];
@@ -41,7 +41,7 @@ final readonly class FieldDefWriteValidator
         } elseif (!in_array($dataType, self::ALLOWED_DATA_TYPES, true)) {
             $errors[] = new ValidationError(
                 'data_type',
-                'Data type must be one of: text, int, enum, bool, datetime, image, relation.',
+                'Data type must be one of: text, markdown, int, enum, bool, datetime, image, relation.',
                 'invalid',
             );
         }

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -73,7 +73,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             $fieldDefRows,
         )));
 
-        $textFieldRows = (in_array('text', $dataTypes, true) || in_array('image', $dataTypes, true))
+        $textFieldRows = (in_array('text', $dataTypes, true) || in_array('markdown', $dataTypes, true) || in_array('image', $dataTypes, true))
             ? $this->textFields->findByEntityId($entityId, self::FIELD_VALUE_LIMIT, 0)
             : [];
         $intFieldRows = in_array('int', $dataTypes, true)
@@ -230,7 +230,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             }
 
             $raw = match ($fieldDef->dataType) {
-                'text', 'image' => $this->findTextValue($textFieldRows, $fieldDef->fieldKey),
+                'text', 'markdown', 'image' => $this->findTextValue($textFieldRows, $fieldDef->fieldKey),
                 'int' => $this->findIntValue($intFieldRows, $fieldDef->fieldKey),
                 'enum' => $this->findEnumValue($enumFieldRows, $fieldDef->fieldKey),
                 'bool' => $this->findBoolValue($boolFieldRows, $fieldDef->fieldKey),


### PR DESCRIPTION
## 概要

Issue #124 の実装。フィールド定義に `markdown` データ型を追加し、管理画面で Markdown プレビュー付きエディタを使えるようにする。

## 変更内容

### バックエンド

- **`FieldDefWriteValidator`** — `'markdown'` を `ALLOWED_DATA_TYPES` に追加
- **`GetPublicRecordViewUseCase`** — `'markdown'` フィールドを `'text'` と同様に `text_fields` テーブルから取得
- **OpenAPI** — `FieldDefResponse` / `CreateFieldDefRequest` の `data_type` enum に `'markdown'` を追加
- DB 変更・マイグレーション不要（値は既存の `text_fields` テーブルに保存）

### フロントエンド

- **`FIELD_DATA_TYPES`** enum に `'markdown'` を追加
- **`MarkdownFieldInput`** コンポーネント（新規）
  - 「編集」/「プレビュー」のタブ切り替え UI
  - 編集タブ: monospace textarea（10行）
  - プレビュータブ: `react-markdown` + `remark-gfm` によるリアルタイム Markdown レンダリング
  - 空の場合は「プレビューする内容がありません。」を表示
- **`EntityTextFieldsForm`** に `'markdown'` ケースを追加 → `MarkdownFieldInput` を使用
- **`use-edit-entity-text-fields-page`** の `initialValues` / `saveTextFields` に `'markdown'` ケースを追加
- **i18n**（en/ja）
  - `admin.fieldDefs.dataType.markdown` / `admin.fieldDefs.dataType.relation` を追加
  - `admin.markdownEditor.preview` / `admin.markdownEditor.write` / `admin.markdownEditor.empty` を追加
- **`DATA_TYPE_LABEL_KEYS`** を全 `FieldDataType` 完全網羅に修正（`markdown` + `relation` を補完）

## 確認方法

```bash
composer check    # 197 tests, PHPStan clean, OpenAPI valid
npm run check --prefix frontend  # 83 tests, type-check / lint / Prettier / Storybook all pass
```

**使い方**: フィールド定義で data_type = markdown のフィールドを作成すると、レコード編集画面で編集/プレビュータブ付きの Markdown エディタが表示される。

Closes #124