### PR TITLE
docs: 2026-05-27 開発日報を追加

### DIFF
--- a/docs/daily-reports/2026-05-27.md
+++ b/docs/daily-reports/2026-05-27.md
@@ -1,0 +1,113 @@
+# NeNe Records 開発日報
+
+**日付:** 2026-05-27（水）  
+**プロジェクト:** NeNe Records（NENE2 ベース API-first CMS）  
+**フェーズ:** **M2 完了 → M3 計画へ**
+
+---
+
+## 本日の概要
+
+昨日積み上げた 5 本の OPEN PR（#112 / #120 / #122 / #123 / #124）をすべてマージし、M2 を完全クローズ。  
+並行して Navigation 層の PHPUnit テスト（16 テスト）を追加し、`LAST_INSERT_ID()` バグも修正。  
+テスト数は 197 → **213** に増加。
+
+---
+
+## 完了した作業
+
+### 1. OPEN PR のトリアージとマージ ✅
+
+| PR | 内容 | 処理 |
+| --- | --- | --- |
+| #112 | docs: ドキュメント鮮度更新 | main 既取込のためクローズ |
+| #120 | feat: SEO フィールド | ✅ マージ |
+| #122 | feat: メディアアップロード | ✅ リベース後マージ |
+| #123 | feat: Markdown フィールド | ✅ リベース後マージ |
+| #124 | feat: Navigation 設定 | ✅ リベース後マージ（テスト含む） |
+
+**コンフリクト解消対応:**
+
+- `frontend/vite.config.ts`: `localhost:8082` ハードコード vs `NENE_RECORDS_PORT` 動的解決 → 動的解決を採用
+- `frontend/src/entities/field-def/enum.ts`: `image` vs `markdown` → 両方を含む配列に統合
+- `frontend/src/features/edit-entity-text-fields/`: image と markdown の分岐を両立
+- `frontend/src/shared/i18n/messages/en.ts` / `ja.ts`: media 節と markdown editor 節を両立
+- `src/FieldDef/FieldDefWriteValidator.php`: `ALLOWED_DATA_TYPES` に `text, markdown, int, enum, bool, datetime, image, relation` を統合
+- `src/PublicRecord/GetPublicRecordViewUseCase.php`: `text_fields` フェッチ条件に `markdown` と `image` を両立
+- `docs/openapi/openapi.yaml`: media エンドポイントと navigation エンドポイントを両立
+- `src/ApplicationServiceProvider.php`: Media と NavigationItem の例外ハンドラー登録を統合
+
+---
+
+### 2. Navigation 層 PHPUnit テスト追加 ✅
+
+**バグ修正（PR #124 に同梱）:**
+- `PdoNavigationItemRepository::save()` が `SELECT LAST_INSERT_ID() AS id`（MySQL 専用）を使用
+  → `$this->query->lastInsertId()` に統一（SQLite :memory: テスト互換）
+
+**新規テストファイル:**
+
+| ファイル | テスト数 | 内容 |
+| --- | --- | --- |
+| `tests/NavigationItem/InMemoryNavigationItemRepository.php` | — | インメモリ実装 |
+| `tests/NavigationItem/NavigationItemHttpTest.php` | 8 | HTTP ハンドラー統合テスト |
+| `tests/NavigationItem/PdoNavigationItemRepositoryTest.php` | 5 | SQLite リポジトリテスト |
+
+**テストカバレッジ:**
+- 一覧（空 / ソート順）・作成 201・バリデーション 422・更新 200・存在しない場合 404・削除 204・公開エンドポイント
+
+---
+
+### 3. ドキュメント更新 ✅
+
+- `docs/todo/current.md`: M2 完了テーブルに全 PR を記録、テスト数 213 に更新、Up Next を M3 ロードマップに差し替え
+
+---
+
+## マイルストーン進捗
+
+```
+M1 Usable Blog CMS     ████████████████████ 100% ✅（マージ済み）
+M2 Team-Ready CMS      ████████████████████ 100% ✅（本日完了）
+M3（未着手）            ░░░░░░░░░░░░░░░░░░░░   0%
+```
+
+---
+
+## 数値サマリー
+
+| 指標 | 値 |
+| --- | --- |
+| PHPUnit tests | **213**（全パス）|
+| PHPStan | ✅ エラー 0 |
+| CS-Fixer | ✅ |
+| OpenAPI | ✅ valid |
+| MCP | ✅ valid |
+| 本日マージ PR | 5 本（#120 / #122 / #123 / #124 / #125） |
+| 本日クローズ PR | 1 本（#112） |
+| 新規テスト | 16（Navigation 層） |
+
+---
+
+## 課題・所感
+
+- **コンフリクト地雷の連鎖:** 5 本が同じファイルを触っていたため、一本マージするたびに次がコンフリクト。順序管理が大切。
+- **LAST_INSERT_ID() のバグ:** PHPUnit で発見できたのは SQLite :memory: テスト戦略のおかげ。テストを書くことの価値を再確認。
+- **git stash の落とし穴:** untracked ファイルは `git stash` に含まれないため、ブランチ切り替え中に誤コミットされかけた。テストファイルが markdown PR に混入する事故が発生 → 発見して修正。
+
+---
+
+## 明日以降の予定
+
+| 優先 | 内容 |
+| --- | --- |
+| P1 | M3 計画のドラフト（Full-text search / Export API） |
+| P1 | CHANGELOG.md の M2 セクション追記 |
+| P2 | README のバッジ・機能リスト更新 |
+
+---
+
+## 参照
+
+- 正本: [`docs/todo/current.md`](../todo/current.md)
+- Milestone: [`docs/milestones/2026-06-cms-mid-term.md`](../milestones/2026-06-cms-mid-term.md)


### PR DESCRIPTION
M2 完了日の開発日報。PR マージ・コンフリクト解消・Navigation テスト追加の記録。

🤖 Generated with [Claude Code](https://claude.com/claude-code)