### PR TITLE
feat(ui): Admin UI リデザイン — サイドバーレイアウト＋ダークテーマ (#127)

### DIFF
--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -3,6 +3,7 @@ import { useState, type ReactNode } from 'react'
 import { seedPublicRecordViewCache } from '@/shared/lib/seed-public-record-view-cache'
 import { AppError } from '@/shared/api/client'
 import { I18nProvider } from '@/shared/i18n'
+import { ThemeProvider } from '@/shared/theme'
 import { AuthGate } from './auth-gate'
 import { RootErrorBoundary } from './root-error-boundary'
 
@@ -30,12 +31,14 @@ export function AppProviders({ children }: { children: ReactNode }) {
   const [queryClient] = useState(createAppQueryClient)
 
   return (
-    <I18nProvider>
-      <QueryClientProvider client={queryClient}>
-        <RootErrorBoundary>
-          <AuthGate>{children}</AuthGate>
-        </RootErrorBoundary>
-      </QueryClientProvider>
-    </I18nProvider>
+    <ThemeProvider>
+      <I18nProvider>
+        <QueryClientProvider client={queryClient}>
+          <RootErrorBoundary>
+            <AuthGate>{children}</AuthGate>
+          </RootErrorBoundary>
+        </QueryClientProvider>
+      </I18nProvider>
+    </ThemeProvider>
   )
 }

--- a/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.tsx
+++ b/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.tsx
@@ -6,74 +6,7 @@ import {
   type SettingItem,
 } from '@/entities/setting'
 import { useTranslation } from '@/shared/i18n'
-import { Button, Input, Stack, Text } from '@/shared/ui'
-
-function SettingField({
-  item,
-  isSaving,
-  canManageSettings,
-  onSave,
-}: {
-  item: SettingItem
-  isSaving: boolean
-  canManageSettings: boolean
-  onSave: (settingKey: string, value: string) => Promise<void>
-}) {
-  const { t } = useTranslation()
-  const [value, setValue] = useState(item.value)
-
-  const inputId = `setting-${item.settingKey}`
-
-  return (
-    <Stack gap="sm">
-      {item.dataType === 'markdown' ? (
-        <div className="flex flex-col gap-stack-xs">
-          <label htmlFor={inputId} className="font-sans text-body font-medium text-text-primary">
-            {item.label}
-          </label>
-          <textarea
-            id={inputId}
-            value={value}
-            disabled={isSaving || !canManageSettings}
-            rows={4}
-            onChange={(event) => {
-              setValue(event.target.value)
-            }}
-            className="rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm font-sans text-body text-text-primary shadow-sm focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-50"
-          />
-          <Text muted variant="caption">
-            Markdown ·{' '}
-            {item.isPublic
-              ? t('admin.settings.visibility.public')
-              : t('admin.settings.visibility.adminOnly')}
-          </Text>
-        </div>
-      ) : (
-        <Input
-          id={inputId}
-          label={item.label}
-          value={value}
-          disabled={isSaving || !canManageSettings}
-          onChange={(event) => {
-            setValue(event.target.value)
-          }}
-        />
-      )}
-      {canManageSettings ? (
-        <Button
-          variant="secondary"
-          size="sm"
-          disabled={isSaving || value === item.value}
-          onClick={() => {
-            void onSave(item.settingKey, value)
-          }}
-        >
-          {isSaving ? t('admin.settings.saving') : t('admin.settings.save')}
-        </Button>
-      ) : null}
-    </Stack>
-  )
-}
+import { Button, Stack, Text } from '@/shared/ui'
 
 function SettingRevisionsPanel({ settingKey }: { settingKey: string }) {
   const { t } = useTranslation()
@@ -102,6 +35,118 @@ function SettingRevisionsPanel({ settingKey }: { settingKey: string }) {
         </Text>
       ))}
     </Stack>
+  )
+}
+
+function SettingCard({
+  item,
+  isSaving,
+  canManageSettings,
+  onSave,
+  isExpanded,
+  onToggle,
+}: {
+  item: SettingItem
+  isSaving: boolean
+  canManageSettings: boolean
+  onSave: (settingKey: string, value: string) => Promise<void>
+  isExpanded: boolean
+  onToggle: () => void
+}) {
+  const { t } = useTranslation()
+  const [value, setValue] = useState(item.value)
+  const inputId = `setting-${item.settingKey}`
+  const dirty = value !== item.value
+
+  const inputClass =
+    'rounded-md border border-border bg-surface px-inline-sm py-stack-sm font-sans text-body text-text-primary shadow-sm focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-50'
+
+  return (
+    <section className="rounded-md border border-border bg-surface-raised p-inline-md shadow-sm">
+      {/* ── Header row: label + history toggle ── */}
+      <div className="mb-stack-sm flex items-center justify-between gap-inline-md">
+        <label htmlFor={inputId} className="font-sans text-body font-medium text-text-primary">
+          {item.label}
+        </label>
+        <button
+          type="button"
+          onClick={onToggle}
+          className="shrink-0 font-sans text-caption text-text-muted transition-colors hover:text-text-primary"
+        >
+          {isExpanded ? t('admin.settings.history.hide') : t('admin.settings.history.show')}
+        </button>
+      </div>
+
+      {/* ── Field ── */}
+      {item.dataType === 'markdown' ? (
+        /* Markdown: textarea stacked, save right-aligned below */
+        <div className="flex flex-col gap-stack-sm">
+          <Text muted variant="caption">
+            Markdown ·{' '}
+            {item.isPublic
+              ? t('admin.settings.visibility.public')
+              : t('admin.settings.visibility.adminOnly')}
+          </Text>
+          <textarea
+            id={inputId}
+            value={value}
+            disabled={isSaving || !canManageSettings}
+            rows={4}
+            onChange={(e) => {
+              setValue(e.target.value)
+            }}
+            className={`w-full resize-y ${inputClass}`}
+          />
+          {canManageSettings ? (
+            <div className="flex justify-end">
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={isSaving || !dirty}
+                onClick={() => {
+                  void onSave(item.settingKey, value)
+                }}
+              >
+                {isSaving ? t('admin.settings.saving') : t('admin.settings.save')}
+              </Button>
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        /* Text: input + save button inline */
+        <div className="flex items-center gap-stack-sm">
+          <input
+            id={inputId}
+            type="text"
+            value={value}
+            disabled={isSaving || !canManageSettings}
+            onChange={(e) => {
+              setValue(e.target.value)
+            }}
+            className={`flex-1 ${inputClass}`}
+          />
+          {canManageSettings ? (
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={isSaving || !dirty}
+              onClick={() => {
+                void onSave(item.settingKey, value)
+              }}
+            >
+              {isSaving ? t('admin.settings.saving') : t('admin.settings.save')}
+            </Button>
+          ) : null}
+        </div>
+      )}
+
+      {/* ── History panel ── */}
+      {isExpanded ? (
+        <div className="mt-stack-md border-t border-border pt-stack-sm">
+          <SettingRevisionsPanel settingKey={item.settingKey} />
+        </div>
+      ) : null}
+    </section>
   )
 }
 
@@ -136,36 +181,19 @@ export function ManageSiteSettingsView({ canManageSettings }: { canManageSetting
   }
 
   return (
-    <Stack gap="lg">
+    <Stack gap="md">
       {items.map((item) => (
-        <section
-          key={item.settingKey}
-          className="rounded-md border border-border bg-surface-raised p-inline-md shadow-sm"
-        >
-          <Stack gap="md">
-            <SettingField
-              key={`${item.settingKey}:${item.updatedAt ?? 'default'}`}
-              item={item}
-              isSaving={updateMutation.isPending}
-              canManageSettings={canManageSettings}
-              onSave={saveSetting}
-            />
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => {
-                setExpandedKey((current) => (current === item.settingKey ? null : item.settingKey))
-              }}
-            >
-              {expandedKey === item.settingKey
-                ? t('admin.settings.history.hide')
-                : t('admin.settings.history.show')}
-            </Button>
-            {expandedKey === item.settingKey ? (
-              <SettingRevisionsPanel settingKey={item.settingKey} />
-            ) : null}
-          </Stack>
-        </section>
+        <SettingCard
+          key={`${item.settingKey}:${item.updatedAt ?? 'default'}`}
+          item={item}
+          isSaving={updateMutation.isPending}
+          canManageSettings={canManageSettings}
+          onSave={saveSetting}
+          isExpanded={expandedKey === item.settingKey}
+          onToggle={() => {
+            setExpandedKey((cur) => (cur === item.settingKey ? null : item.settingKey))
+          }}
+        />
       ))}
     </Stack>
   )

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -1,17 +1,50 @@
 import { Outlet, NavLink, useNavigate } from 'react-router-dom'
 import { authStore, currentUserHasCapability } from '@/entities/auth'
 import { LOCALES, SUPPORTED_LOCALE_IDS, useTranslation } from '@/shared/i18n'
-import { Button, Stack, Text } from '@/shared/ui'
+import { useTheme } from '@/shared/theme'
+import {
+  IconHome,
+  IconLayers,
+  IconTag,
+  IconLink,
+  IconSettings,
+  IconGlobe,
+  IconSun,
+  IconMoon,
+  IconLogOut,
+} from '@/shared/ui/icons/Icons'
 
-const navLinkClass = ({ isActive }: { isActive: boolean }): string =>
-  [
-    'rounded-md px-inline-sm py-stack-xs text-body font-medium transition-colors duration-fast',
-    isActive ? 'bg-surface-overlay text-text-primary' : 'text-text-muted hover:text-text-primary',
-  ].join(' ')
+interface NavItemProps {
+  to: string
+  end?: boolean
+  icon: React.ReactNode
+  label: string
+}
+
+function NavItem({ to, end, icon, label }: NavItemProps) {
+  return (
+    <NavLink
+      to={to}
+      end={end}
+      className={({ isActive }) =>
+        [
+          'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors duration-fast',
+          isActive
+            ? 'bg-sidebar-active-bg text-sidebar-active-text'
+            : 'text-sidebar-text hover:bg-sidebar-hover-bg hover:text-sidebar-active-text',
+        ].join(' ')
+      }
+    >
+      <span className="shrink-0 opacity-75">{icon}</span>
+      <span>{label}</span>
+    </NavLink>
+  )
+}
 
 export function AppShell() {
   const navigate = useNavigate()
   const { t, locale, setLocale } = useTranslation()
+  const { theme, toggleTheme } = useTheme()
 
   const handleLogout = () => {
     authStore.clearSession()
@@ -24,53 +57,90 @@ export function AppShell() {
   const canManageSettings = currentUserHasCapability('manage_settings')
 
   return (
-    <div className="min-h-screen bg-surface font-sans text-text-primary">
-      <header className="border-b border-border bg-surface-raised shadow-sm">
-        <div className="mx-auto flex max-w-5xl items-center justify-between px-inline-md py-stack-md">
-          <Text as="span" variant="heading-sm">
-            NeNe Records Admin
-          </Text>
-          <nav aria-label="Main">
-            <Stack direction="horizontal" gap="sm">
-              <NavLink to="/" className={navLinkClass} end>
-                {t('admin.nav.home')}
-              </NavLink>
-              <NavLink to="/entity-types" className={navLinkClass}>
-                {t('admin.nav.entityTypes')}
-              </NavLink>
-              {canManageTags ? (
-                <NavLink to="/tags" className={navLinkClass}>
-                  {t('admin.nav.tags')}
-                </NavLink>
-              ) : null}
-              {canManageSettings ? (
-                <NavLink to="/navigation" className={navLinkClass}>
-                  {t('admin.nav.navigation')}
-                </NavLink>
-              ) : null}
-              {canReadSettings ? (
-                <NavLink to="/settings" className={navLinkClass}>
-                  {t('admin.nav.settings')}
-                </NavLink>
-              ) : null}
-              <NavLink to="/view" className={navLinkClass}>
-                {t('admin.nav.publicSite')}
-              </NavLink>
-            </Stack>
-          </nav>
-          <Stack direction="horizontal" gap="sm">
-            {session && (
-              <Text muted className="hidden text-sm sm:block">
-                {session.email}
-              </Text>
-            )}
+    <div className="flex min-h-screen bg-surface font-sans text-text-primary">
+      {/* ── Sidebar ────────────────────────────────────────────────────── */}
+      <aside
+        className="fixed inset-y-0 left-0 flex w-60 flex-col border-r border-sidebar-border bg-sidebar-bg"
+        aria-label="Sidebar"
+      >
+        {/* Brand */}
+        <div className="flex h-14 shrink-0 items-center gap-2 border-b border-sidebar-border px-4">
+          <span className="text-sm font-semibold tracking-wide text-sidebar-active-text">
+            NeNe Records
+          </span>
+          <span className="rounded bg-accent px-1.5 py-0.5 text-caption font-semibold uppercase tracking-wider text-white">
+            Admin
+          </span>
+        </div>
+
+        {/* Nav links */}
+        <nav className="flex-1 overflow-y-auto px-3 py-4" aria-label="Main">
+          <ul className="space-y-0.5">
+            <li>
+              <NavItem to="/" end icon={<IconHome size={16} />} label={t('admin.nav.home')} />
+            </li>
+            <li>
+              <NavItem
+                to="/entity-types"
+                icon={<IconLayers size={16} />}
+                label={t('admin.nav.entityTypes')}
+              />
+            </li>
+            {canManageTags ? (
+              <li>
+                <NavItem to="/tags" icon={<IconTag size={16} />} label={t('admin.nav.tags')} />
+              </li>
+            ) : null}
+            {canManageSettings ? (
+              <li>
+                <NavItem
+                  to="/navigation"
+                  icon={<IconLink size={16} />}
+                  label={t('admin.nav.navigation')}
+                />
+              </li>
+            ) : null}
+            {canReadSettings ? (
+              <li>
+                <NavItem
+                  to="/settings"
+                  icon={<IconSettings size={16} />}
+                  label={t('admin.nav.settings')}
+                />
+              </li>
+            ) : null}
+          </ul>
+
+          <div className="my-4 border-t border-sidebar-border" />
+
+          <ul className="space-y-0.5">
+            <li>
+              <NavItem
+                to="/view"
+                icon={<IconGlobe size={16} />}
+                label={t('admin.nav.publicSite')}
+              />
+            </li>
+          </ul>
+        </nav>
+
+        {/* Bottom: user info + controls */}
+        <div className="shrink-0 space-y-2 border-t border-sidebar-border p-3">
+          {session && (
+            <div className="truncate px-1 text-xs text-sidebar-text-muted" title={session.email}>
+              {session.email}
+            </div>
+          )}
+
+          <div className="flex items-center gap-1">
+            {/* Language selector */}
             <select
               aria-label="Language"
               value={locale}
               onChange={(e) => {
                 setLocale(e.target.value as typeof locale)
               }}
-              className="rounded-md border border-border bg-surface-raised px-inline-sm py-stack-xs font-sans text-caption text-text-primary shadow-sm focus-visible:outline-none focus-visible:shadow-focus"
+              className="min-w-0 flex-1 rounded-md border border-sidebar-border bg-sidebar-active-bg px-2 py-1.5 text-xs text-sidebar-text focus:outline-none focus:ring-1 focus:ring-accent"
             >
               {SUPPORTED_LOCALE_IDS.map((id) => (
                 <option key={id} value={id}>
@@ -78,14 +148,38 @@ export function AppShell() {
                 </option>
               ))}
             </select>
-            <Button variant="ghost" size="sm" onClick={handleLogout}>
-              {t('admin.nav.logout')}
-            </Button>
-          </Stack>
+
+            {/* Theme toggle */}
+            <button
+              type="button"
+              onClick={toggleTheme}
+              aria-label={
+                theme === 'dark' ? t('admin.theme.toggleLight') : t('admin.theme.toggleDark')
+              }
+              className="flex shrink-0 items-center justify-center rounded-md border border-sidebar-border bg-sidebar-active-bg p-1.5 text-sidebar-text transition-colors hover:bg-sidebar-hover-bg hover:text-sidebar-active-text"
+            >
+              {theme === 'dark' ? <IconSun size={15} /> : <IconMoon size={15} />}
+            </button>
+
+            {/* Logout */}
+            <button
+              type="button"
+              onClick={handleLogout}
+              aria-label={t('admin.nav.logout')}
+              title={t('admin.nav.logout')}
+              className="flex shrink-0 items-center justify-center rounded-md border border-sidebar-border bg-sidebar-active-bg p-1.5 text-sidebar-text transition-colors hover:border-red-800 hover:bg-red-950/60 hover:text-red-300"
+            >
+              <IconLogOut size={15} />
+            </button>
+          </div>
         </div>
-      </header>
-      <main className="mx-auto max-w-5xl px-inline-md py-stack-lg">
-        <Outlet />
+      </aside>
+
+      {/* ── Main content ───────────────────────────────────────────────── */}
+      <main className="ml-60 min-w-0 flex-1">
+        <div className="mx-auto max-w-5xl px-6 py-8">
+          <Outlet />
+        </div>
       </main>
     </div>
   )

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { Outlet, NavLink, useNavigate } from 'react-router-dom'
 import { authStore, currentUserHasCapability } from '@/entities/auth'
 import { LOCALES, SUPPORTED_LOCALE_IDS, useTranslation } from '@/shared/i18n'
@@ -12,6 +13,8 @@ import {
   IconSun,
   IconMoon,
   IconLogOut,
+  IconMenu,
+  IconX,
 } from '@/shared/ui/icons/Icons'
 
 interface NavItemProps {
@@ -19,13 +22,15 @@ interface NavItemProps {
   end?: boolean
   icon: React.ReactNode
   label: string
+  onClick?: () => void
 }
 
-function NavItem({ to, end, icon, label }: NavItemProps) {
+function NavItem({ to, end, icon, label, onClick }: NavItemProps) {
   return (
     <NavLink
       to={to}
       end={end}
+      onClick={onClick}
       className={({ isActive }) =>
         [
           'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors duration-fast',
@@ -45,6 +50,19 @@ export function AppShell() {
   const navigate = useNavigate()
   const { t, locale, setLocale } = useTranslation()
   const { theme, toggleTheme } = useTheme()
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+
+  // Prevent body scroll when drawer is open
+  useEffect(() => {
+    if (sidebarOpen) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = ''
+    }
+    return () => {
+      document.body.style.overflow = ''
+    }
+  }, [sidebarOpen])
 
   const handleLogout = () => {
     authStore.clearSession()
@@ -56,39 +74,98 @@ export function AppShell() {
   const canReadSettings = currentUserHasCapability('read_settings')
   const canManageSettings = currentUserHasCapability('manage_settings')
 
+  const closeSidebar = () => {
+    setSidebarOpen(false)
+  }
+
   return (
     <div className="flex min-h-screen bg-surface font-sans text-text-primary">
-      {/* ── Sidebar ────────────────────────────────────────────────────── */}
+      {/* ── Mobile top bar (hidden on lg+) ─────────────────────────────── */}
+      <header className="fixed inset-x-0 top-0 z-10 flex h-14 items-center gap-3 border-b border-sidebar-border bg-sidebar-bg px-4 lg:hidden">
+        <button
+          type="button"
+          onClick={() => {
+            setSidebarOpen(true)
+          }}
+          aria-label={t('admin.nav.openMenu')}
+          className="flex items-center justify-center rounded-md p-1.5 text-sidebar-text transition-colors hover:bg-sidebar-hover-bg hover:text-sidebar-active-text"
+        >
+          <IconMenu size={20} />
+        </button>
+        <span className="text-sm font-semibold tracking-wide text-sidebar-active-text">
+          NeNe Records
+        </span>
+        <span className="rounded bg-accent px-1.5 py-0.5 text-caption font-semibold uppercase tracking-wider text-white">
+          Admin
+        </span>
+      </header>
+
+      {/* ── Overlay backdrop (mobile only) ──────────────────────────────── */}
+      {sidebarOpen ? (
+        <div
+          className="fixed inset-0 z-20 bg-black/50 lg:hidden"
+          aria-hidden="true"
+          onClick={closeSidebar}
+        />
+      ) : null}
+
+      {/* ── Sidebar ─────────────────────────────────────────────────────── */}
       <aside
-        className="fixed inset-y-0 left-0 flex w-60 flex-col border-r border-sidebar-border bg-sidebar-bg"
+        className={[
+          'fixed inset-y-0 left-0 z-30 flex w-64 flex-col border-r border-sidebar-border bg-sidebar-bg',
+          'transition-transform duration-200',
+          'lg:w-60 lg:translate-x-0',
+          sidebarOpen ? 'translate-x-0' : '-translate-x-full',
+        ].join(' ')}
         aria-label="Sidebar"
       >
         {/* Brand */}
         <div className="flex h-14 shrink-0 items-center gap-2 border-b border-sidebar-border px-4">
-          <span className="text-sm font-semibold tracking-wide text-sidebar-active-text">
+          <span className="flex-1 text-sm font-semibold tracking-wide text-sidebar-active-text">
             NeNe Records
           </span>
           <span className="rounded bg-accent px-1.5 py-0.5 text-caption font-semibold uppercase tracking-wider text-white">
             Admin
           </span>
+          {/* Close button — mobile only */}
+          <button
+            type="button"
+            onClick={closeSidebar}
+            aria-label={t('admin.nav.closeMenu')}
+            className="ml-1 flex items-center justify-center rounded-md p-1 text-sidebar-text transition-colors hover:bg-sidebar-hover-bg hover:text-sidebar-active-text lg:hidden"
+          >
+            <IconX size={18} />
+          </button>
         </div>
 
         {/* Nav links */}
         <nav className="flex-1 overflow-y-auto px-3 py-4" aria-label="Main">
           <ul className="space-y-0.5">
             <li>
-              <NavItem to="/" end icon={<IconHome size={16} />} label={t('admin.nav.home')} />
+              <NavItem
+                to="/"
+                end
+                icon={<IconHome size={16} />}
+                label={t('admin.nav.home')}
+                onClick={closeSidebar}
+              />
             </li>
             <li>
               <NavItem
                 to="/entity-types"
                 icon={<IconLayers size={16} />}
                 label={t('admin.nav.entityTypes')}
+                onClick={closeSidebar}
               />
             </li>
             {canManageTags ? (
               <li>
-                <NavItem to="/tags" icon={<IconTag size={16} />} label={t('admin.nav.tags')} />
+                <NavItem
+                  to="/tags"
+                  icon={<IconTag size={16} />}
+                  label={t('admin.nav.tags')}
+                  onClick={closeSidebar}
+                />
               </li>
             ) : null}
             {canManageSettings ? (
@@ -97,6 +174,7 @@ export function AppShell() {
                   to="/navigation"
                   icon={<IconLink size={16} />}
                   label={t('admin.nav.navigation')}
+                  onClick={closeSidebar}
                 />
               </li>
             ) : null}
@@ -106,6 +184,7 @@ export function AppShell() {
                   to="/settings"
                   icon={<IconSettings size={16} />}
                   label={t('admin.nav.settings')}
+                  onClick={closeSidebar}
                 />
               </li>
             ) : null}
@@ -119,6 +198,7 @@ export function AppShell() {
                 to="/view"
                 icon={<IconGlobe size={16} />}
                 label={t('admin.nav.publicSite')}
+                onClick={closeSidebar}
               />
             </li>
           </ul>
@@ -175,9 +255,9 @@ export function AppShell() {
         </div>
       </aside>
 
-      {/* ── Main content ───────────────────────────────────────────────── */}
-      <main className="ml-60 min-w-0 flex-1">
-        <div className="mx-auto max-w-5xl px-6 py-8">
+      {/* ── Main content ────────────────────────────────────────────────── */}
+      <main className="min-w-0 flex-1 pt-14 lg:ml-60 lg:pt-0">
+        <div className="mx-auto max-w-5xl px-4 py-6 sm:px-6 sm:py-8">
           <Outlet />
         </div>
       </main>

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -46,6 +46,8 @@ export const en = {
   'admin.nav.settings': 'Settings',
   'admin.nav.publicSite': 'Public site',
   'admin.nav.logout': 'Log out',
+  'admin.theme.toggleDark': 'Switch to dark mode',
+  'admin.theme.toggleLight': 'Switch to light mode',
 
   // ── Auth (Login page) ────────────────────────────────────────────────────
   'admin.auth.appTitle': 'NeNe Records Admin',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -48,6 +48,8 @@ export const en = {
   'admin.nav.logout': 'Log out',
   'admin.theme.toggleDark': 'Switch to dark mode',
   'admin.theme.toggleLight': 'Switch to light mode',
+  'admin.nav.openMenu': 'Open navigation menu',
+  'admin.nav.closeMenu': 'Close navigation menu',
 
   // ── Auth (Login page) ────────────────────────────────────────────────────
   'admin.auth.appTitle': 'NeNe Records Admin',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -39,6 +39,8 @@ export const ja: Partial<MessageCatalog> = {
   'admin.nav.settings': '設定',
   'admin.nav.publicSite': 'パブリックサイト',
   'admin.nav.logout': 'ログアウト',
+  'admin.theme.toggleDark': 'ダークモードに切り替え',
+  'admin.theme.toggleLight': 'ライトモードに切り替え',
 
   // ── Auth ─────────────────────────────────────────────────────────────────
   'admin.auth.appTitle': 'NeNe Records Admin',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -41,6 +41,8 @@ export const ja: Partial<MessageCatalog> = {
   'admin.nav.logout': 'ログアウト',
   'admin.theme.toggleDark': 'ダークモードに切り替え',
   'admin.theme.toggleLight': 'ライトモードに切り替え',
+  'admin.nav.openMenu': 'ナビゲーションメニューを開く',
+  'admin.nav.closeMenu': 'ナビゲーションメニューを閉じる',
 
   // ── Auth ─────────────────────────────────────────────────────────────────
   'admin.auth.appTitle': 'NeNe Records Admin',

--- a/frontend/src/shared/theme/index.ts
+++ b/frontend/src/shared/theme/index.ts
@@ -1,0 +1,3 @@
+export { ThemeProvider } from './theme-context'
+export type { Theme } from './theme-context'
+export { useTheme } from './use-theme'

--- a/frontend/src/shared/theme/theme-context.tsx
+++ b/frontend/src/shared/theme/theme-context.tsx
@@ -1,0 +1,58 @@
+import { createContext, useCallback, useEffect, useState, type ReactNode } from 'react'
+
+export type Theme = 'light' | 'dark'
+
+interface ThemeContextValue {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+const STORAGE_KEY = 'nene-theme'
+
+function detectTheme(): Theme {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === 'dark' || stored === 'light') return stored
+  } catch {
+    // localStorage blocked
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function applyTheme(theme: Theme): void {
+  document.documentElement.setAttribute('data-theme', theme)
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(detectTheme)
+
+  const setTheme = useCallback((next: Theme) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, next)
+    } catch {
+      // ignore
+    }
+    setThemeState(next)
+    applyTheme(next)
+  }, [])
+
+  const toggleTheme = useCallback(() => {
+    setTheme(theme === 'light' ? 'dark' : 'light')
+  }, [theme, setTheme])
+
+  useEffect(() => {
+    applyTheme(theme)
+  }, [theme])
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export { ThemeContext }
+export type { ThemeContextValue }

--- a/frontend/src/shared/theme/use-theme.ts
+++ b/frontend/src/shared/theme/use-theme.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react'
+import { ThemeContext, type ThemeContextValue } from './theme-context'
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext)
+  if (ctx === null) throw new Error('useTheme must be used inside ThemeProvider')
+  return ctx
+}

--- a/frontend/src/shared/ui/icons/Icons.tsx
+++ b/frontend/src/shared/ui/icons/Icons.tsx
@@ -111,3 +111,22 @@ export function IconChevronRight({ size = 16, className }: IconProps) {
     </svg>
   )
 }
+
+export function IconMenu({ size = 16, className }: IconProps) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <line x1="3" y1="6" x2="21" y2="6" />
+      <line x1="3" y1="12" x2="21" y2="12" />
+      <line x1="3" y1="18" x2="21" y2="18" />
+    </svg>
+  )
+}
+
+export function IconX({ size = 16, className }: IconProps) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  )
+}

--- a/frontend/src/shared/ui/icons/Icons.tsx
+++ b/frontend/src/shared/ui/icons/Icons.tsx
@@ -1,0 +1,113 @@
+interface IconProps {
+  className?: string
+  size?: number
+}
+
+const base = (size: number): React.SVGProps<SVGSVGElement> => ({
+  width: size,
+  height: size,
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.75,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+})
+
+export function IconHome({ size = 16, className }: IconProps) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <path d="M3 9.5L12 3l9 6.5V20a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9.5z" />
+      <path d="M9 21V12h6v9" />
+    </svg>
+  )
+}
+
+export function IconLayers({ size = 16, className }: IconProps) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <polygon points="12 2 2 7 12 12 22 7 12 2" />
+      <polyline points="2 17 12 22 22 17" />
+      <polyline points="2 12 12 17 22 12" />
+    </svg>
+  )
+}
+
+export function IconTag({ size = 16, className }: IconProps) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" />
+      <line x1="7" y1="7" x2="7.01" y2="7" />
+    </svg>
+  )
+}
+
+export function IconLink({ size = 16, className }: IconProps) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  )
+}
+
+export function IconSettings({ size = 16, className }: IconProps) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </svg>
+  )
+}
+
+export function IconGlobe({ size = 16, className }: IconProps) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <circle cx="12" cy="12" r="10" />
+      <line x1="2" y1="12" x2="22" y2="12" />
+      <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+    </svg>
+  )
+}
+
+export function IconSun({ size = 16, className }: IconProps) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  )
+}
+
+export function IconMoon({ size = 16, className }: IconProps) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  )
+}
+
+export function IconLogOut({ size = 16, className }: IconProps) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+      <polyline points="16 17 21 12 16 7" />
+      <line x1="21" y1="12" x2="9" y2="12" />
+    </svg>
+  )
+}
+
+export function IconChevronRight({ size = 16, className }: IconProps) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <polyline points="9 18 15 12 9 6" />
+    </svg>
+  )
+}

--- a/frontend/src/shared/ui/theme/active.css
+++ b/frontend/src/shared/ui/theme/active.css
@@ -1,1 +1,2 @@
 @import './themes/default.css';
+@import './themes/dark.css';

--- a/frontend/src/shared/ui/theme/themes/dark.css
+++ b/frontend/src/shared/ui/theme/themes/dark.css
@@ -1,0 +1,39 @@
+/* Dark theme overrides — applied when <html data-theme="dark"> */
+[data-theme='dark'] {
+  /* ── Surfaces ──────────────────────────────────────────────────────────── */
+  --color-surface: oklch(13% 0.01 265);
+  --color-surface-raised: oklch(17% 0.01 265);
+  --color-surface-overlay: oklch(22% 0.015 265);
+
+  /* ── Sidebar ─────────────────────────────────────────────────────────── */
+  --color-sidebar-bg: oklch(10% 0.01 265);
+  --color-sidebar-text: oklch(78% 0.01 265);
+  --color-sidebar-text-muted: oklch(50% 0.01 265);
+  --color-sidebar-active-bg: oklch(22% 0.02 265);
+  --color-sidebar-active-text: oklch(96% 0.005 75);
+  --color-sidebar-hover-bg: oklch(17% 0.015 265);
+  --color-sidebar-border: oklch(22% 0.01 265);
+
+  /* ── Text ─────────────────────────────────────────────────────────────── */
+  --color-text-primary: oklch(93% 0.008 75);
+  --color-text-muted: oklch(60% 0.01 265);
+  --color-text-inverse: oklch(12% 0.01 265);
+
+  /* ── Border ──────────────────────────────────────────────────────────── */
+  --color-border: oklch(28% 0.01 265);
+
+  /* ── Accent (brighter for dark bg) ───────────────────────────────────── */
+  --color-accent: oklch(72% 0.17 72);
+  --color-accent-hover: oklch(66% 0.17 72);
+
+  /* ── Danger ──────────────────────────────────────────────────────────── */
+  --color-danger: oklch(62% 0.2 25);
+  --color-danger-hover: oklch(56% 0.2 25);
+
+  /* ── Focus ring ──────────────────────────────────────────────────────── */
+  --color-focus-ring: oklch(74% 0.14 72);
+
+  /* ── Shadows (subtler in dark) ───────────────────────────────────────── */
+  --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.2);
+  --shadow-md: 0 4px 12px oklch(0% 0 0 / 0.4);
+}

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -1,19 +1,38 @@
 @theme {
-  /* Color */
-  --color-surface: oklch(98.5% 0.005 260);
+  /* ── Surfaces ──────────────────────────────────────────────────────────── */
+  --color-surface: oklch(97% 0.006 75);
   --color-surface-raised: oklch(100% 0 0);
-  --color-surface-overlay: oklch(96% 0.01 260);
-  --color-text-primary: oklch(22% 0.02 260);
-  --color-text-muted: oklch(52% 0.02 260);
+  --color-surface-overlay: oklch(94% 0.008 75);
+
+  /* ── Sidebar (dark even in light mode — WordPress style) ──────────────── */
+  --color-sidebar-bg: oklch(19% 0.015 265);
+  --color-sidebar-text: oklch(80% 0.01 265);
+  --color-sidebar-text-muted: oklch(55% 0.01 265);
+  --color-sidebar-active-bg: oklch(28% 0.02 265);
+  --color-sidebar-active-text: oklch(94% 0.005 75);
+  --color-sidebar-hover-bg: oklch(24% 0.015 265);
+  --color-sidebar-border: oklch(27% 0.015 265);
+
+  /* ── Text ────────────────────────────────────────────────────────────── */
+  --color-text-primary: oklch(18% 0.02 75);
+  --color-text-muted: oklch(50% 0.02 75);
   --color-text-inverse: oklch(99% 0 0);
-  --color-border: oklch(88% 0.01 260);
-  --color-accent: oklch(52% 0.16 250);
-  --color-accent-hover: oklch(46% 0.16 250);
+
+  /* ── Border ─────────────────────────────────────────────────────────── */
+  --color-border: oklch(88% 0.01 75);
+
+  /* ── Accent (warm amber-gold — Claude.ai ひねり版) ──────────────────── */
+  --color-accent: oklch(62% 0.17 72);
+  --color-accent-hover: oklch(56% 0.17 72);
+
+  /* ── Danger ─────────────────────────────────────────────────────────── */
   --color-danger: oklch(52% 0.2 25);
   --color-danger-hover: oklch(46% 0.2 25);
-  --color-focus-ring: oklch(62% 0.14 250);
 
-  /* Spacing */
+  /* ── Focus ring ─────────────────────────────────────────────────────── */
+  --color-focus-ring: oklch(70% 0.14 72);
+
+  /* ── Spacing ─────────────────────────────────────────────────────────── */
   --spacing-inline-xs: 0.25rem;
   --spacing-inline-sm: 0.5rem;
   --spacing-inline-md: 1rem;
@@ -25,7 +44,7 @@
   --spacing-stack-lg: 1.5rem;
   --spacing-stack-xl: 2rem;
 
-  /* Typography */
+  /* ── Typography ──────────────────────────────────────────────────────── */
   --font-family-sans: 'Inter', system-ui, sans-serif;
   --font-family-mono: ui-monospace, 'Cascadia Code', monospace;
   --font-size-body: 0.875rem;
@@ -38,25 +57,25 @@
   --font-weight-medium: 500;
   --font-weight-semibold: 600;
 
-  /* Radius */
+  /* ── Radius ──────────────────────────────────────────────────────────── */
   --radius-sm: 0.25rem;
   --radius-md: 0.5rem;
   --radius-full: 9999px;
 
-  /* Shadow */
+  /* ── Shadow ──────────────────────────────────────────────────────────── */
   --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.06);
   --shadow-md: 0 4px 12px oklch(0% 0 0 / 0.08);
   --shadow-focus: 0 0 0 3px color-mix(in oklch, var(--color-focus-ring) 35%, transparent);
 
-  /* Border */
+  /* ── Border width ────────────────────────────────────────────────────── */
   --border-width-default: 1px;
 
-  /* Motion */
+  /* ── Motion ──────────────────────────────────────────────────────────── */
   --duration-fast: 120ms;
   --duration-normal: 200ms;
   --ease-default: cubic-bezier(0.4, 0, 0.2, 1);
 
-  /* Z-index */
+  /* ── Z-index ─────────────────────────────────────────────────────────── */
   --z-dropdown: 100;
   --z-modal: 200;
   --z-toast: 300;


### PR DESCRIPTION
## 目的

管理画面UIをWordPress風のサイドバーレイアウトに刷新し、ダーク/ライトテーマ切り替えを実装する。

## 変更内容

### レイアウト

- `AppShell.tsx` をフラットヘッダーから固定サイドバー (240px) に完全書き換え
  - アイコン + ラベルのナビゲーションリンク
  - ブランドバー（NeNe Records + Admin バッジ）
  - 下部: ユーザーメール・言語セレクター・テーマトグル・ログアウト
  - メインコンテンツ領域は `ml-60` で右側を占有

### テーマシステム

- `ThemeProvider` / `useTheme` フック（`shared/theme/`）
  - `localStorage` に `nene-theme` キーで永続化
  - システム設定 (`prefers-color-scheme`) をフォールバックとして使用
  - `<html data-theme="dark">` 属性で CSS 変数を切り替え
- `dark.css`: ダークモード CSS 変数オーバーライド（oklch）
- `AppProviders` に `ThemeProvider` を追加

### デザイントークン

- アクセントカラー: 暖かいアンバーゴールド `oklch(62% 0.17 72)`（従来の青からひねり）
- サイドバー専用トークン: `sidebar-bg / text / active-bg / hover-bg / border`
  - ライトモードでも暗いサイドバー（WordPress スタイル）

### その他

- `Icons.tsx`: SVG アイコンコンポーネント一式（Home/Layers/Tag/Link/Settings/Globe/Sun/Moon/LogOut/ChevronRight）
- i18n: `admin.theme.toggleDark` / `toggleLight` キーを en/ja に追加

## 動作確認

```
npm run check --prefix frontend
# 21 test files, 83 tests — all passed
# type-check / lint (0 warnings) / format / storybook — all clean
```

## チェックリスト

- [x] 型チェック通過
- [x] lint 通過（warnings 0）
- [x] フォーマット通過
- [x] テスト全通過
- [x] Storybook ビルド成功

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)