### PR TITLE
feat(search): エンティティレコード全文検索 API (#129)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -243,7 +243,7 @@ paths:
       tags:
         - Entities
       summary: List entities
-      description: Returns non-deleted entities, optionally filtered by entity type, status, tags, and relation fields.
+      description: Returns non-deleted entities, optionally filtered by entity type, status, tags, relation fields, and full-text search.
       operationId: listEntities
       parameters:
         - $ref: '#/components/parameters/LimitQuery'
@@ -258,6 +258,13 @@ paths:
         - $ref: '#/components/parameters/TagsQuery'
         - $ref: '#/components/parameters/TagQuery'
         - $ref: '#/components/parameters/RelationFilterQuery'
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+            minLength: 1
+          description: Full-text search across slug and text field values (partial match).
       responses:
         '200':
           description: Paginated entity list.

--- a/frontend/src/entities/entity/queries.ts
+++ b/frontend/src/entities/entity/queries.ts
@@ -31,6 +31,9 @@ export function useEntityList(
       if (params.tagSlugs !== undefined && params.tagSlugs.length > 0) {
         search.set('tags', params.tagSlugs.join(','))
       }
+      if (params.q !== undefined && params.q !== '') {
+        search.set('q', params.q)
+      }
       if (params.relationFilters !== undefined) {
         for (const [fieldKey, targetEntityId] of Object.entries(params.relationFilters)) {
           search.set(`relation.${fieldKey}`, String(targetEntityId))
@@ -83,6 +86,7 @@ export function defaultEntityListParams(
   tagSlugs: string[] = [],
   relationFilters: EntityListParams['relationFilters'] = {},
   offset = 0,
+  q?: string,
 ): EntityListParams {
   return {
     entityTypeId,
@@ -90,5 +94,6 @@ export function defaultEntityListParams(
     relationFilters,
     limit: DEFAULT_LIST_PARAMS.limit,
     offset,
+    q: q !== '' ? q : undefined,
   }
 }

--- a/frontend/src/entities/entity/query-keys.ts
+++ b/frontend/src/entities/entity/query-keys.ts
@@ -10,6 +10,7 @@ export interface EntityListParams {
   status?: EntityStatus
   tagSlugs?: string[]
   relationFilters?: EntityRelationFilters
+  q?: string
 }
 
 export const entityKeys = {

--- a/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
+++ b/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
@@ -21,9 +21,17 @@ import { getRecordDisplayLabel } from '@/shared/lib/get-record-display-label'
 export function useManageEntitiesPage(entityTypeId: number) {
   const [selectedTagSlugs, setSelectedTagSlugs] = useState<string[]>([])
   const [selectedRelationFilters, setSelectedRelationFilters] = useState<EntityRelationFilters>({})
+  const [searchQuery, setSearchQuery] = useState('')
   const listParams = useMemo(
-    () => defaultEntityListParams(entityTypeId, selectedTagSlugs, selectedRelationFilters),
-    [entityTypeId, selectedRelationFilters, selectedTagSlugs],
+    () =>
+      defaultEntityListParams(
+        entityTypeId,
+        selectedTagSlugs,
+        selectedRelationFilters,
+        0,
+        searchQuery,
+      ),
+    [entityTypeId, selectedRelationFilters, selectedTagSlugs, searchQuery],
   )
   const listQuery = useEntityList(listParams)
   const tagListQuery = useTagList({ limit: 100, offset: 0 })
@@ -109,11 +117,16 @@ export function useManageEntitiesPage(entityTypeId: number) {
     relationFieldDefs,
     selectedTagSlugs,
     selectedRelationFilters,
+    searchQuery,
+    setSearchQuery,
     toggleTagSlug,
     clearTagFilter,
     setRelationFilter,
     clearRelationFilters,
-    isFilterActive: selectedTagSlugs.length > 0 || Object.keys(selectedRelationFilters).length > 0,
+    isFilterActive:
+      selectedTagSlugs.length > 0 ||
+      Object.keys(selectedRelationFilters).length > 0 ||
+      searchQuery !== '',
     isLoading,
     isError,
     errorTitle,

--- a/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
+++ b/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
@@ -19,6 +19,7 @@ export interface ManageEntitiesViewProps {
   relationFieldDefs: RelationFieldDef[]
   selectedTagSlugs: string[]
   selectedRelationFilters: EntityRelationFilters
+  searchQuery: string
   isFilterActive: boolean
   isLoading: boolean
   isError: boolean
@@ -32,6 +33,7 @@ export interface ManageEntitiesViewProps {
   onClearTagFilter: () => void
   onSelectRelationFilter: (fieldKey: string, targetEntityId: number | undefined) => void
   onClearRelationFilters: () => void
+  onSearchChange: (q: string) => void
   onCreate: () => Promise<void>
   onRequestDelete: (entity: Entity) => void
   onCancelDelete: () => void
@@ -49,6 +51,7 @@ export function ManageEntitiesView({
   relationFieldDefs,
   selectedTagSlugs,
   selectedRelationFilters,
+  searchQuery,
   isFilterActive,
   isLoading,
   isError,
@@ -62,6 +65,7 @@ export function ManageEntitiesView({
   onClearTagFilter,
   onSelectRelationFilter,
   onClearRelationFilters,
+  onSearchChange,
   onCreate,
   onRequestDelete,
   onCancelDelete,
@@ -88,6 +92,33 @@ export function ManageEntitiesView({
           serverErrorTitle={createErrorTitle}
           onCreate={onCreate}
         />
+
+        {/* ── Search ── */}
+        <div className="relative">
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={(e) => {
+              onSearchChange(e.target.value)
+            }}
+            placeholder={t('admin.entityRecords.search.placeholder')}
+            aria-label={t('admin.entityRecords.search.placeholder')}
+            className="w-full rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm font-sans text-body text-text-primary shadow-sm focus-visible:outline-none focus-visible:shadow-focus"
+          />
+          {searchQuery !== '' ? (
+            <button
+              type="button"
+              onClick={() => {
+                onSearchChange('')
+              }}
+              aria-label={t('admin.entityRecords.search.clear')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-text-muted hover:text-text-primary"
+            >
+              ✕
+            </button>
+          ) : null}
+        </div>
+
         <EntityTagFilterPanel
           tags={availableTags}
           selectedTagSlugs={selectedTagSlugs}

--- a/frontend/src/pages/entity-records/EntityRecordsPage.tsx
+++ b/frontend/src/pages/entity-records/EntityRecordsPage.tsx
@@ -18,6 +18,8 @@ export function EntityRecordsPage() {
     relationFieldDefs,
     selectedTagSlugs,
     selectedRelationFilters,
+    searchQuery,
+    setSearchQuery,
     isFilterActive,
     isLoading,
     isError,
@@ -60,6 +62,7 @@ export function EntityRecordsPage() {
         relationFieldDefs={relationFieldDefs}
         selectedTagSlugs={selectedTagSlugs}
         selectedRelationFilters={selectedRelationFilters}
+        searchQuery={searchQuery}
         isFilterActive={isFilterActive}
         isLoading={isLoading}
         isError={isError}
@@ -71,6 +74,7 @@ export function EntityRecordsPage() {
         onRetry={() => {
           void refetch()
         }}
+        onSearchChange={setSearchQuery}
         onToggleTagSlug={toggleTagSlug}
         onClearTagFilter={clearTagFilter}
         onSelectRelationFilter={setRelationFilter}

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -107,6 +107,8 @@ export const en = {
   'admin.entityRecords.list.emptyFiltered.title': 'No matching records',
   'admin.entityRecords.list.emptyFiltered.description':
     'Try clearing the filters or selecting different criteria.',
+  'admin.entityRecords.search.placeholder': 'Search records…',
+  'admin.entityRecords.search.clear': 'Clear search',
   'admin.entityRecords.create.title': 'Create record',
   'admin.entityRecords.create.description':
     'Records are created for this entity type. Field values will be editable in a later phase.',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -100,6 +100,8 @@ export const ja: Partial<MessageCatalog> = {
   'admin.entityRecords.list.emptyFiltered.title': '一致するレコードがありません',
   'admin.entityRecords.list.emptyFiltered.description':
     'フィルターをクリアするか、別の条件を選択してください。',
+  'admin.entityRecords.search.placeholder': 'レコードを検索…',
+  'admin.entityRecords.search.clear': '検索をクリア',
   'admin.entityRecords.create.title': 'レコードを作成',
   'admin.entityRecords.create.description':
     'このエンティティタイプのレコードを作成します。フィールド値は後のフェーズで編集できます。',

--- a/src/Entity/EntityListCriteria.php
+++ b/src/Entity/EntityListCriteria.php
@@ -15,6 +15,7 @@ final readonly class EntityListCriteria
         public array $tagSlugs = [],
         public array $relationFilters = [],
         public ?EntityStatus $status = null,
+        public ?string $q = null,
     ) {
     }
 }

--- a/src/Entity/ListEntitiesHandler.php
+++ b/src/Entity/ListEntitiesHandler.php
@@ -33,6 +33,9 @@ final readonly class ListEntitiesHandler
         $rawStatus = $request->getQueryParams()['status'] ?? null;
         $status = is_string($rawStatus) ? EntityStatus::tryFrom($rawStatus) : null;
 
+        $rawQ = $request->getQueryParams()['q'] ?? null;
+        $q = (is_string($rawQ) && $rawQ !== '') ? $rawQ : null;
+
         $output = $this->useCase->execute(new ListEntitiesInput(
             limit: $pagination->limit,
             offset: $pagination->offset,
@@ -41,6 +44,7 @@ final readonly class ListEntitiesHandler
                 tagSlugs: $tagSlugs,
                 relationFilters: $relationFilters,
                 status: $status,
+                q: $q,
             ),
         ));
 

--- a/src/Entity/PdoEntityRepository.php
+++ b/src/Entity/PdoEntityRepository.php
@@ -169,6 +169,23 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
             $params[] = $targetEntityId;
         }
 
+        if ($criteria->q !== null && $criteria->q !== '') {
+            $like = '%' . $criteria->q . '%';
+            $conditions[] = <<<'SQL'
+                (
+                    e.slug LIKE ?
+                    OR EXISTS (
+                        SELECT 1 FROM text_fields tf
+                        WHERE tf.entity_id = e.id
+                          AND tf.is_deleted = 0
+                          AND tf.value LIKE ?
+                    )
+                )
+                SQL;
+            $params[] = $like;
+            $params[] = $like;
+        }
+
         return [implode(' AND ', $conditions), $params];
     }
 

--- a/tests/Entity/PdoEntityRepositoryTest.php
+++ b/tests/Entity/PdoEntityRepositoryTest.php
@@ -251,4 +251,76 @@ final class PdoEntityRepositoryTest extends TestCase
         self::assertSame($entityA, $andList[0]->id);
         self::assertSame(1, $repository->countByCriteria($andFilter));
     }
+
+    public function testFindByCriteriaSearchBySlug(): void
+    {
+        $typeId = $this->insertEntityTypeId();
+        $repository = new PdoEntityRepository($this->executor);
+
+        $entityA = $repository->save(new Entity(id: null, entityTypeId: $typeId, slug: 'hello-world'));
+        $repository->save(new Entity(id: null, entityTypeId: $typeId, slug: 'another-post'));
+
+        $list = $repository->findByCriteria(new EntityListCriteria(q: 'hello'), 10, 0);
+
+        self::assertCount(1, $list);
+        self::assertSame($entityA, $list[0]->id);
+        self::assertSame(1, $repository->countByCriteria(new EntityListCriteria(q: 'hello')));
+    }
+
+    public function testFindByCriteriaSearchByTextField(): void
+    {
+        $typeId = $this->insertEntityTypeId();
+        $repository = new PdoEntityRepository($this->executor);
+
+        $entityA = $repository->save(new Entity(id: null, entityTypeId: $typeId));
+        $entityB = $repository->save(new Entity(id: null, entityTypeId: $typeId));
+
+        $this->executor->execute(
+            'INSERT INTO text_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$entityA, 'title', 'Welcome to NeNe Records'],
+        );
+        $this->executor->execute(
+            'INSERT INTO text_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
+            [$entityB, 'title', 'Another article'],
+        );
+
+        $list = $repository->findByCriteria(new EntityListCriteria(q: 'NeNe'), 10, 0);
+
+        self::assertCount(1, $list);
+        self::assertSame($entityA, $list[0]->id);
+        self::assertSame(1, $repository->countByCriteria(new EntityListCriteria(q: 'NeNe')));
+    }
+
+    public function testFindByCriteriaSearchReturnsEmptyWhenNoMatch(): void
+    {
+        $typeId = $this->insertEntityTypeId();
+        $repository = new PdoEntityRepository($this->executor);
+
+        $repository->save(new Entity(id: null, entityTypeId: $typeId, slug: 'hello-world'));
+
+        $list = $repository->findByCriteria(new EntityListCriteria(q: 'zzznomatch'), 10, 0);
+
+        self::assertCount(0, $list);
+        self::assertSame(0, $repository->countByCriteria(new EntityListCriteria(q: 'zzznomatch')));
+    }
+
+    public function testFindByCriteriaSearchCombinesWithEntityTypeId(): void
+    {
+        $typeId = $this->insertEntityTypeId();
+        $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('Other', 'other')");
+        $otherTypeId = $this->executor->lastInsertId();
+
+        $repository = new PdoEntityRepository($this->executor);
+        $entityA = $repository->save(new Entity(id: null, entityTypeId: $typeId, slug: 'hello-world'));
+        $repository->save(new Entity(id: null, entityTypeId: $otherTypeId, slug: 'hello-other'));
+
+        $list = $repository->findByCriteria(
+            new EntityListCriteria(entityTypeId: $typeId, q: 'hello'),
+            10,
+            0,
+        );
+
+        self::assertCount(1, $list);
+        self::assertSame($entityA, $list[0]->id);
+    }
 }


### PR DESCRIPTION
## 目的

エンティティレコードを slug・テキストフィールド値で横断検索できる API とフロントエンド UI を追加する。

## 変更内容

### バックエンド

- `EntityListCriteria` に `q` フィールドを追加
- `PdoEntityRepository::buildCriteriaWhere`: `q` が指定された場合に  
  `e.slug LIKE ?` または `text_fields.value LIKE ?`（EXISTS サブクエリ）条件を追加
- `ListEntitiesHandler`: `?q=` クエリパラメータを読み取り Criteria に渡す
- `openapi.yaml`: `GET /api/v1/entities` の `q` パラメータを文書化
- PHPUnit テスト 4 件追加（slug 検索・フィールド検索・不一致・entityTypeId との組み合わせ）

### フロントエンド

- `EntityListParams` / `defaultEntityListParams` に `q` を追加
- `useEntityList`: `q` パラメータを URLSearchParams に含める
- `useManageEntitiesPage`: `searchQuery` ステートと `isFilterActive` への反映
- `ManageEntitiesView`: 検索ボックス UI（入力中にクリアボタン表示）
- `EntityRecordsPage`: 新 props を伝播
- i18n: `admin.entityRecords.search.placeholder / clear` を en/ja に追加

## 動作確認

```
composer check  → 217 tests / PHPStan Max / CS-Fixer / OpenAPI — 全グリーン
npm run check   → 21 files / 83 tests — 全グリーン
```

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)