### PR TITLE
feat(file-field): ファイルフィールド型とファイルアップロード対応 (#133)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1851,7 +1851,7 @@ paths:
       tags:
         - Media
       summary: Upload media file
-      description: Accepts a multipart/form-data upload and returns the stored media URL. Allowed types — JPEG, PNG, GIF, WebP, SVG, PDF. Maximum size — 10 MiB.
+      description: "Accepts a multipart/form-data upload and returns the stored media URL. Allowed types — images (JPEG, PNG, GIF, WebP, SVG), documents (PDF, DOC, DOCX, XLS, XLSX, PPT, PPTX), video (MP4, WebM), audio (MP3, WAV, OGG), archives (ZIP), text (TXT, CSV). Maximum size — 10 MiB."
       operationId: uploadMedia
       requestBody:
         required: true
@@ -2606,6 +2606,7 @@ components:
             - bool
             - datetime
             - image
+            - file
             - relation
         target_entity_type_id:
           type: integer
@@ -2639,6 +2640,8 @@ components:
             - enum
             - bool
             - datetime
+            - image
+            - file
             - relation
         target_entity_type_id:
           type: integer

--- a/frontend/src/entities/field-def/enum.ts
+++ b/frontend/src/entities/field-def/enum.ts
@@ -6,6 +6,7 @@ export const FIELD_DATA_TYPES = [
   'bool',
   'datetime',
   'image',
+  'file',
   'relation',
 ] as const
 

--- a/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import type { FieldDataType, FieldDef } from '@/entities/field-def'
 import { useTranslation } from '@/shared/i18n'
 import { Button, EmptyState, Input, Stack, Text } from '@/shared/ui'
+import { FileFieldInput } from './FileFieldInput'
 import { ImageFieldInput } from './ImageFieldInput'
 import { MarkdownFieldInput } from './MarkdownFieldInput'
 
@@ -62,6 +63,21 @@ export function EntityTextFieldsForm({
           if (fieldDef.dataType === 'image') {
             return (
               <ImageFieldInput
+                key={fieldDef.fieldKey}
+                id={fieldId}
+                label={label}
+                value={values[fieldDef.fieldKey] ?? ''}
+                disabled={isSubmitting}
+                onChange={(url) => {
+                  setValues((current) => ({ ...current, [fieldDef.fieldKey]: url }))
+                }}
+              />
+            )
+          }
+
+          if (fieldDef.dataType === 'file') {
+            return (
+              <FileFieldInput
                 key={fieldDef.fieldKey}
                 id={fieldId}
                 label={label}

--- a/frontend/src/features/edit-entity-text-fields/ui/FileFieldInput.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/FileFieldInput.tsx
@@ -1,0 +1,151 @@
+import { useRef } from 'react'
+import { useUploadMedia } from '@/entities/media'
+import { useTranslation } from '@/shared/i18n'
+import { Button, Stack, Text } from '@/shared/ui'
+
+interface FileFieldInputProps {
+  id: string
+  label: string
+  value: string
+  disabled: boolean
+  onChange: (value: string) => void
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${String(bytes)} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function FileIcon({ mimeType }: { mimeType: string }) {
+  if (mimeType.startsWith('image/')) {
+    return <span aria-hidden="true">🖼</span>
+  }
+  if (mimeType === 'application/pdf') {
+    return <span aria-hidden="true">📄</span>
+  }
+  if (
+    mimeType === 'application/msword' ||
+    mimeType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+  ) {
+    return <span aria-hidden="true">📝</span>
+  }
+  if (
+    mimeType === 'application/vnd.ms-excel' ||
+    mimeType === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  ) {
+    return <span aria-hidden="true">📊</span>
+  }
+  if (
+    mimeType === 'application/vnd.ms-powerpoint' ||
+    mimeType === 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+  ) {
+    return <span aria-hidden="true">📽</span>
+  }
+  if (mimeType.startsWith('video/')) {
+    return <span aria-hidden="true">🎬</span>
+  }
+  if (mimeType.startsWith('audio/')) {
+    return <span aria-hidden="true">🎵</span>
+  }
+  if (mimeType === 'application/zip') {
+    return <span aria-hidden="true">🗜</span>
+  }
+  return <span aria-hidden="true">📎</span>
+}
+
+export function FileFieldInput({ id, label, value, disabled, onChange }: FileFieldInputProps) {
+  const { t } = useTranslation()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const uploadMutation = useUploadMedia()
+
+  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (file === undefined) return
+    try {
+      const media = await uploadMutation.mutateAsync(file)
+      onChange(media.url)
+    } catch {
+      // error visible via uploadMutation.isError
+    }
+    if (fileInputRef.current !== null) {
+      fileInputRef.current.value = ''
+    }
+  }
+
+  const uploadedMedia = uploadMutation.isSuccess ? uploadMutation.data : null
+
+  return (
+    <Stack gap="xs">
+      <label htmlFor={id} className="text-sm font-medium text-text-primary">
+        {label}
+      </label>
+      <div className="flex items-center gap-inline-sm">
+        <input
+          id={id}
+          type="text"
+          value={value}
+          disabled={disabled || uploadMutation.isPending}
+          placeholder="/media/2026/05/..."
+          onChange={(e) => {
+            onChange(e.target.value)
+          }}
+          className="flex-1 rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50"
+        />
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          disabled={disabled || uploadMutation.isPending}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          {uploadMutation.isPending
+            ? t('admin.media.uploading')
+            : t('admin.media.fileUploadButton')}
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/gif,image/webp,image/svg+xml,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,video/mp4,video/webm,audio/mpeg,audio/wav,audio/ogg,application/zip,text/plain,text/csv"
+          className="hidden"
+          onChange={(e) => void handleFileChange(e)}
+        />
+      </div>
+      {uploadMutation.isError && <Text muted>{t('admin.media.uploadError')}</Text>}
+      {value !== '' && (
+        <div className="mt-1 flex items-center gap-2 rounded-md border border-border bg-surface px-3 py-2 text-sm">
+          {uploadedMedia !== null ? (
+            <>
+              <FileIcon mimeType={uploadedMedia.mimeType} />
+              <span className="min-w-0 flex-1 truncate text-text-primary">
+                {uploadedMedia.originalName}
+              </span>
+              <span className="shrink-0 text-text-muted">{formatBytes(uploadedMedia.size)}</span>
+              <span className="shrink-0 text-text-muted">{uploadedMedia.mimeType}</span>
+              <a
+                href={value}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="shrink-0 text-blue-600 hover:underline dark:text-blue-400"
+              >
+                {t('admin.media.fileDownload')}
+              </a>
+            </>
+          ) : (
+            <>
+              <span aria-hidden="true">📎</span>
+              <a
+                href={value}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="min-w-0 flex-1 truncate text-blue-600 hover:underline dark:text-blue-400"
+              >
+                {value}
+              </a>
+            </>
+          )}
+        </div>
+      )}
+    </Stack>
+  )
+}

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -142,17 +142,20 @@ export const en = {
   'admin.fieldDefs.dataType.bool': 'Boolean',
   'admin.fieldDefs.dataType.datetime': 'Date & time',
   'admin.fieldDefs.dataType.image': 'Image',
+  'admin.fieldDefs.dataType.file': 'File',
   'admin.fieldDefs.dataType.relation': 'Relation',
 
   // ── Media upload ─────────────────────────────────────────────────────────
   'admin.media.panelTitle': 'Media',
   'admin.media.uploadButton': 'Upload image',
+  'admin.media.fileUploadButton': 'Upload file',
   'admin.media.uploading': 'Uploading…',
   'admin.media.uploadSuccess': 'Uploaded — URL copied to clipboard.',
   'admin.media.uploadError': 'Upload failed.',
   'admin.media.imagePreview': 'Image preview',
   'admin.media.noImage': 'No image selected',
   'admin.media.urlLabel': 'Image URL',
+  'admin.media.fileDownload': 'Download',
 
   // ── Markdown editor ───────────────────────────────────────────────────────
   'admin.markdownEditor.preview': 'Preview',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -136,17 +136,20 @@ export const ja: Partial<MessageCatalog> = {
   'admin.fieldDefs.dataType.bool': 'ブール値',
   'admin.fieldDefs.dataType.datetime': '日時',
   'admin.fieldDefs.dataType.image': '画像',
+  'admin.fieldDefs.dataType.file': 'ファイル',
   'admin.fieldDefs.dataType.relation': 'リレーション',
 
   // ── Media upload ─────────────────────────────────────────────────────────
   'admin.media.panelTitle': 'メディア',
   'admin.media.uploadButton': '画像をアップロード',
+  'admin.media.fileUploadButton': 'ファイルをアップロード',
   'admin.media.uploading': 'アップロード中…',
   'admin.media.uploadSuccess': 'アップロード完了 — URL をクリップボードにコピーしました。',
   'admin.media.uploadError': 'アップロードに失敗しました。',
   'admin.media.imagePreview': '画像プレビュー',
   'admin.media.noImage': '画像が選択されていません',
   'admin.media.urlLabel': '画像 URL',
+  'admin.media.fileDownload': 'ダウンロード',
 
   // ── Markdown editor ───────────────────────────────────────────────────────
   'admin.markdownEditor.preview': 'プレビュー',

--- a/src/FieldDef/FieldDefWriteValidator.php
+++ b/src/FieldDef/FieldDefWriteValidator.php
@@ -9,7 +9,7 @@ use Nene2\Validation\ValidationError;
 final readonly class FieldDefWriteValidator
 {
     /** @var list<string> */
-    public const ALLOWED_DATA_TYPES = ['text', 'markdown', 'int', 'enum', 'bool', 'datetime', 'image', 'relation'];
+    public const ALLOWED_DATA_TYPES = ['text', 'markdown', 'int', 'enum', 'bool', 'datetime', 'image', 'file', 'relation'];
 
     /** @var list<string> */
     public const ALLOWED_CARDINALITIES = ['one', 'many'];
@@ -41,7 +41,7 @@ final readonly class FieldDefWriteValidator
         } elseif (!in_array($dataType, self::ALLOWED_DATA_TYPES, true)) {
             $errors[] = new ValidationError(
                 'data_type',
-                'Data type must be one of: text, markdown, int, enum, bool, datetime, image, relation.',
+                'Data type must be one of: text, markdown, int, enum, bool, datetime, image, file, relation.',
                 'invalid',
             );
         }

--- a/src/Media/UploadMediaUseCase.php
+++ b/src/Media/UploadMediaUseCase.php
@@ -10,12 +10,31 @@ final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
 {
     /** @var list<string> */
     private const ALLOWED_MIME_TYPES = [
+        // Images
         'image/jpeg',
         'image/png',
         'image/gif',
         'image/webp',
         'image/svg+xml',
+        // Documents
         'application/pdf',
+        'application/msword',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'application/vnd.ms-excel',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'application/vnd.ms-powerpoint',
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        // Video
+        'video/mp4',
+        'video/webm',
+        // Audio
+        'audio/mpeg',
+        'audio/wav',
+        'audio/ogg',
+        // Archives / Text
+        'application/zip',
+        'text/plain',
+        'text/csv',
     ];
 
     private const MAX_SIZE_BYTES = 10 * 1024 * 1024; // 10 MiB
@@ -89,6 +108,20 @@ final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
             'image/webp' => 'webp',
             'image/svg+xml' => 'svg',
             'application/pdf' => 'pdf',
+            'application/msword' => 'doc',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'docx',
+            'application/vnd.ms-excel' => 'xls',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'xlsx',
+            'application/vnd.ms-powerpoint' => 'ppt',
+            'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'pptx',
+            'video/mp4' => 'mp4',
+            'video/webm' => 'webm',
+            'audio/mpeg' => 'mp3',
+            'audio/wav' => 'wav',
+            'audio/ogg' => 'ogg',
+            'application/zip' => 'zip',
+            'text/plain' => 'txt',
+            'text/csv' => 'csv',
             default => 'bin',
         };
     }

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -73,7 +73,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             $fieldDefRows,
         )));
 
-        $textFieldRows = (in_array('text', $dataTypes, true) || in_array('markdown', $dataTypes, true) || in_array('image', $dataTypes, true))
+        $textFieldRows = (in_array('text', $dataTypes, true) || in_array('markdown', $dataTypes, true) || in_array('image', $dataTypes, true) || in_array('file', $dataTypes, true))
             ? $this->textFields->findByEntityId($entityId, self::FIELD_VALUE_LIMIT, 0)
             : [];
         $intFieldRows = in_array('int', $dataTypes, true)
@@ -230,7 +230,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             }
 
             $raw = match ($fieldDef->dataType) {
-                'text', 'markdown', 'image' => $this->findTextValue($textFieldRows, $fieldDef->fieldKey),
+                'text', 'markdown', 'image', 'file' => $this->findTextValue($textFieldRows, $fieldDef->fieldKey),
                 'int' => $this->findIntValue($intFieldRows, $fieldDef->fieldKey),
                 'enum' => $this->findEnumValue($enumFieldRows, $fieldDef->fieldKey),
                 'bool' => $this->findBoolValue($boolFieldRows, $fieldDef->fieldKey),


### PR DESCRIPTION
## 概要

`data_type = 'file'` を新規追加し、画像以外のファイル（PDF・Word・Excel・動画・音声・ZIP 等）をアップロード・管理できるようにする。

## 変更内容

### バックエンド
- **`FieldDefWriteValidator`**: `'file'` を許可 `data_type` に追加
- **`UploadMediaUseCase`**: 許可 MIME 型を大幅拡張
  - Documents: PDF, DOC, DOCX, XLS, XLSX, PPT, PPTX
  - Video: MP4, WebM
  - Audio: MP3, WAV, OGG
  - Archives: ZIP
  - Text: TXT, CSV
- **`GetPublicRecordViewUseCase`**: `'file'` を text_fields フェッチ対象に追加
- **OpenAPI**: `data_type` enum と `uploadMedia` 説明を更新

### フロントエンド
- **`FileFieldInput` コンポーネント（新規）**
  - ファイル選択 → アップロード → URL 保存
  - アップロード後: ファイル名・サイズ・MIME type + ダウンロードリンク表示
  - MIME type 別アイコン（📄 PDF / 📝 Word / 📊 Excel / 🎬 動画 / 🎵 音声 / 🗜 ZIP / 📎 その他）
  - 既存 URL のみある場合: リンク表示
- **`EntityTextFieldsForm`**: `'file'` 分岐を追加
- **`FieldDataType` enum**: `'file'` を追加
- **i18n**: en/ja に `admin.fieldDefs.dataType.file`・`admin.media.fileUploadButton`・`admin.media.fileDownload` を追加

## 検証

```bash
composer check     # 217 tests — OK
npm run check      # 83 tests — OK
```

## チェックリスト

- [x] `composer check` グリーン（217 tests）
- [x] `npm run check` グリーン（83 tests）
- [x] OpenAPI valid
- [x] MCP valid
- [x] 既存 `image` フィールドへの後方互換あり
- [x] `image` フィールドは変更なし

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)