### PR TITLE
chore: CHANGELOG M2/M3 更新 + 予約公開 cron サービス追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,36 @@ NeNe Records does not yet follow Semantic Versioning — entries are grouped by 
 
 ---
 
-## [Unreleased]
+## [M3 Complete — Headless CMS Platform] — 2026-05-26
+
+### Added
+- Admin UI redesign — sidebar layout, dark theme, responsive mobile drawer (#127, PR #128)
+- Full-text search API — `/api/v1/entities/search?q=` with entity type scoping (#129, PR #131)
+- Export API — CSV / JSON download per entity type with field columns (#130, PR #132)
+- File field type — non-image file upload support extending the media upload API (#133, PR #134)
+- Webhook / event hooks — CRUD for webhook subscriptions; HMAC-SHA256 signed POST on `entity.created` / `.updated` / `.deleted` (#135, PR #136)
+- Scheduled publish — `scheduled_at` + `status: scheduled`; `POST /api/v1/entities/process-scheduled` batch transition (#137, PR #138)
+- Draft preview token — 64-char hex token URL for non-published record preview; 24-hour TTL with rotation (#139, PR #141)
+- Public cache headers — `Cache-Control` / `ETag` / `304 Not Modified` on public consumer endpoints (#142, PR #143)
+- Docker Compose `cron` service — calls `process-scheduled` every minute via busybox crond
+
+---
+
+## [M2 Complete — Team-Ready CMS] — 2026-05-26
 
 ### Added
 - Admin / editor roles with JWT-embedded `role` and `CapabilityMiddleware` on mutating routes (#108, PR #111)
 - Entity archive before entity type purge — JSON snapshot + CSV download API (PR #107)
 - Default user seed migration — `admin@nene-records.local` / `editor@nene-records.local` (#108)
 - Admin UI role-based nav and button visibility; 403 → `/forbidden` page (#108)
+- PHP / TypeScript naming convention document; renamed all files to match (#113, PR #114)
+- Admin i18n foundation — 6-language message catalog (`ja` / `en` / `zh` / `ko` / `fr` / `de`) and locale switcher (#109, PR #115)
+- Admin full-screen i18n migration — all hardcoded strings moved to `t()` calls (#110, PR #116)
+- Entity record revision history — action log snapshot on create / update / delete (#117, PR #118)
+- Per-record SEO fields — `meta_title` / `meta_description` on entity records (#119, PR #120)
+- Image field type and media upload API — multipart POST, type/size validation, local storage (#121, PR #122)
+- Markdown field type and Admin preview editor (#124, PR #123)
+- Navigation settings CRUD API and Admin management screen (#125, PR #124)
 - `CHANGELOG.md` — this file (#94)
 - `SECURITY.md` — vulnerability reporting policy (#97)
 - `llms.txt` — LLM crawler summary (#96)

--- a/compose.yaml
+++ b/compose.yaml
@@ -65,6 +65,15 @@ services:
     ports:
       - "${NENE_RECORDS_PHPMYADMIN_PORT:-8081}:80"
 
+  cron:
+    image: alpine:3.21
+    depends_on:
+      - app
+    volumes:
+      - ./docker/cron/crontab:/etc/crontabs/root:ro
+    command: crond -f -l 6
+    restart: unless-stopped
+
   mailpit:
     image: axllent/mailpit:latest
     ports:

--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -1,0 +1,3 @@
+# NeNe Records scheduled publish processor
+# Runs every minute — transitions scheduled entities to published when scheduled_at has passed.
+* * * * * wget -q -O- --post-data="" http://app/api/v1/entities/process-scheduled


### PR DESCRIPTION
## 変更内容

### CHANGELOG.md

**`[M3 Complete — Headless CMS Platform] — 2026-05-26`** セクションを追加:
- Admin UI リデザイン（#127, #128）
- 全文検索 API（#129, #131）
- CSV/JSON エクスポート（#130, #132）
- ファイルフィールド（#133, #134）
- Webhook / イベントフック（#135, #136）
- 予約公開（#137, #138）
- Draft プレビュートークン（#139, #141）
- Public cache / ETag（#142, #143）

**`[M2 Complete — Team-Ready CMS] — 2026-05-26`** セクションを追加:
- 既存の `[Unreleased]` 内容を統合
- i18n 基盤・全画面移行（#109–#110）
- entity revisions、SEO fields、media upload、Markdown field、navigation（#117–#125）

### compose.yaml — cron サービス追加

```yaml
cron:
  image: alpine:3.21
  depends_on:
    - app
  volumes:
    - ./docker/cron/crontab:/etc/crontabs/root:ro
  command: crond -f -l 6
  restart: unless-stopped
```

### docker/cron/crontab

毎分 `POST /api/v1/entities/process-scheduled` を呼び出し、`scheduled_at` 超過レコードを自動公開遷移する。

```cron
* * * * * wget -q -O- --post-data="" http://app/api/v1/entities/process-scheduled
```

## 確認

- `composer check` 253 tests — OK
- `docker compose config` — YAML valid