### PR TITLE
feat(dashboard): 管理ダッシュボード API とフロントエンド統計表示を追加 (#145)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2286,6 +2286,40 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/dashboard:
+    get:
+      tags:
+        - Dashboard
+      summary: Get dashboard summary
+      description: Returns an aggregated summary for the admin dashboard — recent published entities, today/month access counts, and published/draft counts per entity type.
+      operationId: getDashboardSummary
+      responses:
+        '200':
+          description: Dashboard summary.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DashboardSummaryResponse'
+              examples:
+                ok:
+                  value:
+                    recent_published:
+                      - id: 10
+                        entity_type_id: 1
+                        entity_type_name: Article
+                        entity_type_slug: article
+                        slug: hello-world
+                        published_at: '2026-05-25T10:00:00+00:00'
+                    today_access_count: 42
+                    this_month_access_count: 1234
+                    entity_type_summary:
+                      - entity_type_id: 1
+                        entity_type_name: Article
+                        entity_type_slug: article
+                        published_count: 5
+                        draft_count: 2
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /api/v1/analytics/access-stats:
     get:
       tags:
@@ -3878,6 +3912,83 @@ components:
           nullable: true
         is_active:
           type: boolean
+      additionalProperties: false
+    DashboardSummaryResponse:
+      type: object
+      required:
+        - recent_published
+        - today_access_count
+        - this_month_access_count
+        - entity_type_summary
+      properties:
+        recent_published:
+          type: array
+          items:
+            $ref: '#/components/schemas/DashboardRecentEntity'
+        today_access_count:
+          type: integer
+          minimum: 0
+        this_month_access_count:
+          type: integer
+          minimum: 0
+        entity_type_summary:
+          type: array
+          items:
+            $ref: '#/components/schemas/DashboardEntityTypeSummary'
+      additionalProperties: false
+    DashboardRecentEntity:
+      type: object
+      required:
+        - id
+        - entity_type_id
+        - entity_type_name
+        - entity_type_slug
+        - slug
+        - published_at
+      properties:
+        id:
+          type: integer
+          format: int64
+          minimum: 1
+        entity_type_id:
+          type: integer
+          format: int64
+          minimum: 1
+        entity_type_name:
+          type: string
+        entity_type_slug:
+          type: string
+        slug:
+          type: string
+          nullable: true
+        published_at:
+          type: string
+          format: date-time
+          nullable: true
+      additionalProperties: false
+    DashboardEntityTypeSummary:
+      type: object
+      required:
+        - entity_type_id
+        - entity_type_name
+        - entity_type_slug
+        - published_count
+        - draft_count
+      properties:
+        entity_type_id:
+          type: integer
+          format: int64
+          minimum: 1
+        entity_type_name:
+          type: string
+        entity_type_slug:
+          type: string
+        published_count:
+          type: integer
+          minimum: 0
+        draft_count:
+          type: integer
+          minimum: 0
       additionalProperties: false
     GeneratePreviewTokenResponse:
       type: object

--- a/frontend/src/entities/dashboard/api-types.ts
+++ b/frontend/src/entities/dashboard/api-types.ts
@@ -1,0 +1,23 @@
+export interface DashboardRecentEntityDto {
+  id: number
+  entity_type_id: number
+  entity_type_name: string
+  entity_type_slug: string
+  slug: string | null
+  published_at: string | null
+}
+
+export interface DashboardEntityTypeSummaryDto {
+  entity_type_id: number
+  entity_type_name: string
+  entity_type_slug: string
+  published_count: number
+  draft_count: number
+}
+
+export interface DashboardSummaryDto {
+  recent_published: DashboardRecentEntityDto[]
+  today_access_count: number
+  this_month_access_count: number
+  entity_type_summary: DashboardEntityTypeSummaryDto[]
+}

--- a/frontend/src/entities/dashboard/index.ts
+++ b/frontend/src/entities/dashboard/index.ts
@@ -1,0 +1,2 @@
+export type { DashboardEntityTypeSummary, DashboardRecentEntity, DashboardSummary } from './model'
+export { useDashboardSummary } from './queries'

--- a/frontend/src/entities/dashboard/mapper.ts
+++ b/frontend/src/entities/dashboard/mapper.ts
@@ -1,0 +1,38 @@
+import type {
+  DashboardEntityTypeSummaryDto,
+  DashboardRecentEntityDto,
+  DashboardSummaryDto,
+} from './api-types'
+import type { DashboardEntityTypeSummary, DashboardRecentEntity, DashboardSummary } from './model'
+
+function mapRecentEntityDtoToModel(dto: DashboardRecentEntityDto): DashboardRecentEntity {
+  return {
+    id: dto.id,
+    entityTypeId: dto.entity_type_id,
+    entityTypeName: dto.entity_type_name,
+    entityTypeSlug: dto.entity_type_slug,
+    slug: dto.slug,
+    publishedAt: dto.published_at,
+  }
+}
+
+function mapEntityTypeSummaryDtoToModel(
+  dto: DashboardEntityTypeSummaryDto,
+): DashboardEntityTypeSummary {
+  return {
+    entityTypeId: dto.entity_type_id,
+    entityTypeName: dto.entity_type_name,
+    entityTypeSlug: dto.entity_type_slug,
+    publishedCount: dto.published_count,
+    draftCount: dto.draft_count,
+  }
+}
+
+export function mapDashboardSummaryDtoToModel(dto: DashboardSummaryDto): DashboardSummary {
+  return {
+    recentPublished: dto.recent_published.map(mapRecentEntityDtoToModel),
+    todayAccessCount: dto.today_access_count,
+    thisMonthAccessCount: dto.this_month_access_count,
+    entityTypeSummary: dto.entity_type_summary.map(mapEntityTypeSummaryDtoToModel),
+  }
+}

--- a/frontend/src/entities/dashboard/model.ts
+++ b/frontend/src/entities/dashboard/model.ts
@@ -1,0 +1,23 @@
+export interface DashboardRecentEntity {
+  id: number
+  entityTypeId: number
+  entityTypeName: string
+  entityTypeSlug: string
+  slug: string | null
+  publishedAt: string | null
+}
+
+export interface DashboardEntityTypeSummary {
+  entityTypeId: number
+  entityTypeName: string
+  entityTypeSlug: string
+  publishedCount: number
+  draftCount: number
+}
+
+export interface DashboardSummary {
+  recentPublished: DashboardRecentEntity[]
+  todayAccessCount: number
+  thisMonthAccessCount: number
+  entityTypeSummary: DashboardEntityTypeSummary[]
+}

--- a/frontend/src/entities/dashboard/queries.ts
+++ b/frontend/src/entities/dashboard/queries.ts
@@ -1,0 +1,16 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { DashboardSummaryDto } from './api-types'
+import { mapDashboardSummaryDtoToModel } from './mapper'
+import type { DashboardSummary } from './model'
+import { dashboardKeys } from './query-keys'
+
+export function useDashboardSummary(): UseQueryResult<DashboardSummary, AppError> {
+  return useQuery({
+    queryKey: dashboardKeys.summary(),
+    queryFn: async ({ signal }) => {
+      const dto = await apiClient.get<DashboardSummaryDto>('/api/v1/dashboard', signal)
+      return mapDashboardSummaryDtoToModel(dto)
+    },
+  })
+}

--- a/frontend/src/entities/dashboard/query-keys.ts
+++ b/frontend/src/entities/dashboard/query-keys.ts
@@ -1,0 +1,4 @@
+export const dashboardKeys = {
+  all: ['dashboard'] as const,
+  summary: () => [...dashboardKeys.all, 'summary'] as const,
+}

--- a/frontend/src/pages/home/HomePage.tsx
+++ b/frontend/src/pages/home/HomePage.tsx
@@ -1,16 +1,98 @@
 import { Link } from 'react-router-dom'
+import { useDashboardSummary } from '@/entities/dashboard'
 import { useTranslation } from '@/shared/i18n'
 import { Stack, Text } from '@/shared/ui'
 
 export function HomePage() {
   const { t } = useTranslation()
+  const { data, isLoading, isError } = useDashboardSummary()
 
   return (
     <Stack gap="md">
       <Text as="h1" variant="heading-md">
         {t('admin.home.title')}
       </Text>
-      <Text muted>{t('admin.home.description')}</Text>
+
+      {isLoading && <Text muted>{t('admin.home.dashboard.loading')}</Text>}
+
+      {isError && <Text muted>{t('admin.home.dashboard.error')}</Text>}
+
+      {data && (
+        <Stack gap="md">
+          {/* Access count cards */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="rounded border border-border bg-surface-raised p-4">
+              <Text muted>{t('admin.home.dashboard.todayAccess')}</Text>
+              <Text as="p" variant="heading-md">
+                {data.todayAccessCount.toLocaleString()}
+              </Text>
+            </div>
+            <div className="rounded border border-border bg-surface-raised p-4">
+              <Text muted>{t('admin.home.dashboard.monthAccess')}</Text>
+              <Text as="p" variant="heading-md">
+                {data.thisMonthAccessCount.toLocaleString()}
+              </Text>
+            </div>
+          </div>
+
+          {/* Entity type summary */}
+          {data.entityTypeSummary.length > 0 && (
+            <div>
+              <Text as="h2" variant="heading-sm">
+                {t('admin.home.dashboard.entityTypeSummary')}
+              </Text>
+              <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                {data.entityTypeSummary.map((summary) => (
+                  <div
+                    key={summary.entityTypeId}
+                    className="rounded border border-border bg-surface-raised p-3"
+                  >
+                    <Text as="p">{summary.entityTypeName}</Text>
+                    <div className="mt-1 flex gap-4">
+                      <Text muted>
+                        {t('admin.home.dashboard.published')}: {summary.publishedCount}
+                      </Text>
+                      <Text muted>
+                        {t('admin.home.dashboard.draft')}: {summary.draftCount}
+                      </Text>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Recent published */}
+          <div>
+            <Text as="h2" variant="heading-sm">
+              {t('admin.home.dashboard.recentPublished')}
+            </Text>
+            {data.recentPublished.length === 0 ? (
+              <Text muted>{t('admin.home.dashboard.noRecentPublished')}</Text>
+            ) : (
+              <ul className="mt-2 space-y-1">
+                {data.recentPublished.map((entity) => (
+                  <li key={entity.id}>
+                    <Link
+                      to={`/entity-types/${entity.entityTypeSlug}/entities/${String(entity.id)}`}
+                      className="text-body text-accent hover:text-accent-hover"
+                    >
+                      {entity.entityTypeName} / {entity.slug ?? String(entity.id)}
+                    </Link>
+                    {entity.publishedAt && (
+                      <Text as="span" muted>
+                        {' '}
+                        — {new Date(entity.publishedAt).toLocaleDateString()}
+                      </Text>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </Stack>
+      )}
+
       <Link to="/view" className="text-body font-medium text-accent hover:text-accent-hover">
         {t('admin.home.openPublicSite')}
       </Link>

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -73,6 +73,15 @@ export const en = {
   'admin.home.description':
     'Phase 4 scaffold is running. Use Entity types to verify API integration via TanStack Query.',
   'admin.home.openPublicSite': 'Open public site →',
+  'admin.home.dashboard.todayAccess': "Today's accesses",
+  'admin.home.dashboard.monthAccess': "This month's accesses",
+  'admin.home.dashboard.recentPublished': 'Recently published',
+  'admin.home.dashboard.entityTypeSummary': 'Content summary',
+  'admin.home.dashboard.published': 'Published',
+  'admin.home.dashboard.draft': 'Draft',
+  'admin.home.dashboard.loading': 'Loading dashboard…',
+  'admin.home.dashboard.error': 'Could not load dashboard',
+  'admin.home.dashboard.noRecentPublished': 'No recently published content.',
 
   // ── Entity types ─────────────────────────────────────────────────────────
   'admin.entityTypes.pageTitle': 'Entity types',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -66,6 +66,15 @@ export const ja: Partial<MessageCatalog> = {
   'admin.home.description':
     'Phase 4 スキャフォールドが実行中です。エンティティタイプを使用して TanStack Query 経由の API 連携を確認してください。',
   'admin.home.openPublicSite': 'パブリックサイトを開く →',
+  'admin.home.dashboard.todayAccess': '本日のアクセス数',
+  'admin.home.dashboard.monthAccess': '今月のアクセス数',
+  'admin.home.dashboard.recentPublished': '最近公開されたコンテンツ',
+  'admin.home.dashboard.entityTypeSummary': 'コンテンツ集計',
+  'admin.home.dashboard.published': '公開済み',
+  'admin.home.dashboard.draft': '下書き',
+  'admin.home.dashboard.loading': 'ダッシュボードを読み込み中…',
+  'admin.home.dashboard.error': 'ダッシュボードを読み込めませんでした',
+  'admin.home.dashboard.noRecentPublished': '最近公開されたコンテンツはありません。',
 
   // ── Entity types ─────────────────────────────────────────────────────────
   'admin.entityTypes.pageTitle': 'エンティティタイプ',

--- a/src/Analytics/AccessLogRepositoryInterface.php
+++ b/src/Analytics/AccessLogRepositoryInterface.php
@@ -14,4 +14,8 @@ interface AccessLogRepositoryInterface
      * @return list<AccessStatsDayItem>
      */
     public function aggregateByDate(DateTimeImmutable $from, DateTimeImmutable $to): array;
+
+    public function countByDate(DateTimeImmutable $date): int;
+
+    public function countByYearMonth(int $year, int $month): int;
 }

--- a/src/Analytics/PdoAccessLogRepository.php
+++ b/src/Analytics/PdoAccessLogRepository.php
@@ -30,6 +30,30 @@ final readonly class PdoAccessLogRepository implements AccessLogRepositoryInterf
         );
     }
 
+    public function countByDate(DateTimeImmutable $date): int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS cnt FROM access_logs WHERE access_date = ?',
+            [$date->format('Y-m-d')],
+        );
+
+        return (int) ($row['cnt'] ?? 0);
+    }
+
+    public function countByYearMonth(int $year, int $month): int
+    {
+        $from = sprintf('%04d-%02d-01', $year, $month);
+        $lastDay = (int) date('t', (int) mktime(0, 0, 0, $month, 1, $year));
+        $to   = sprintf('%04d-%02d-%02d', $year, $month, $lastDay);
+
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS cnt FROM access_logs WHERE access_date >= ? AND access_date <= ?',
+            [$from, $to],
+        );
+
+        return (int) ($row['cnt'] ?? 0);
+    }
+
     public function aggregateByDate(DateTimeImmutable $from, DateTimeImmutable $to): array
     {
         $rows = $this->query->fetchAll(

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -14,6 +14,7 @@ use NeNeRecords\BoolField\BoolFieldNotFoundExceptionHandler;
 use NeNeRecords\BoolField\BoolFieldServiceProvider;
 use NeNeRecords\BoolField\FieldKeyNotRegisteredExceptionHandler as BoolFieldKeyNotRegisteredExceptionHandler;
 use NeNeRecords\BoolField\FieldTypeMismatchExceptionHandler as BoolFieldTypeMismatchExceptionHandler;
+use NeNeRecords\Dashboard\DashboardServiceProvider;
 use NeNeRecords\DateTimeField\DateTimeFieldNotFoundExceptionHandler;
 use NeNeRecords\DateTimeField\DateTimeFieldServiceProvider;
 use NeNeRecords\DateTimeField\FieldKeyNotRegisteredExceptionHandler as DateTimeFieldKeyNotRegisteredExceptionHandler;
@@ -97,7 +98,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new SettingServiceProvider())
             ->addProvider(new NavigationItemServiceProvider())
             ->addProvider(new WebhookServiceProvider())
-            ->addProvider(new PreviewTokenServiceProvider());
+            ->addProvider(new PreviewTokenServiceProvider())
+            ->addProvider(new DashboardServiceProvider());
 
         $builder
             ->set(
@@ -122,6 +124,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $navigationItem = $container->get('nene-records.route_registrar.navigation_item');
                     $webhook = $container->get('nene-records.route_registrar.webhook');
                     $previewToken = $container->get('nene-records.route_registrar.preview_token');
+                    $dashboard = $container->get('nene-records.route_registrar.dashboard');
                     $auth = $container->get('nene-records.route_registrar.auth');
 
                     if (
@@ -144,6 +147,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !is_callable($navigationItem)
                         || !is_callable($webhook)
                         || !is_callable($previewToken)
+                        || !is_callable($dashboard)
                         || !is_callable($auth)
                     ) {
                         throw new LogicException('Route registrar service is invalid.');
@@ -170,6 +174,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $navigationItem,
                         $webhook,
                         $previewToken,
+                        $dashboard,
                     ];
                 },
             )

--- a/src/Dashboard/DashboardEntityTypeSummary.php
+++ b/src/Dashboard/DashboardEntityTypeSummary.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Dashboard;
+
+final readonly class DashboardEntityTypeSummary
+{
+    public function __construct(
+        public int $entityTypeId,
+        public string $entityTypeName,
+        public string $entityTypeSlug,
+        public int $publishedCount,
+        public int $draftCount,
+    ) {
+    }
+}

--- a/src/Dashboard/DashboardRecentEntity.php
+++ b/src/Dashboard/DashboardRecentEntity.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Dashboard;
+
+final readonly class DashboardRecentEntity
+{
+    public function __construct(
+        public int $id,
+        public int $entityTypeId,
+        public string $entityTypeName,
+        public string $entityTypeSlug,
+        public ?string $slug,
+        public ?string $publishedAtIso,
+    ) {
+    }
+}

--- a/src/Dashboard/DashboardRouteRegistrar.php
+++ b/src/Dashboard/DashboardRouteRegistrar.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Dashboard;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DashboardRouteRegistrar
+{
+    public function __construct(
+        private GetDashboardSummaryHandler $handler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $handler = $this->handler;
+
+        $router->get(
+            '/api/v1/dashboard',
+            static fn (ServerRequestInterface $request) => $handler->handle($request),
+        );
+    }
+}

--- a/src/Dashboard/DashboardServiceProvider.php
+++ b/src/Dashboard/DashboardServiceProvider.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Dashboard;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Analytics\AccessLogRepositoryInterface;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class DashboardServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                GetDashboardSummaryUseCaseInterface::class,
+                static function (ContainerInterface $container): GetDashboardSummaryUseCaseInterface {
+                    $entities = $container->get(EntityRepositoryInterface::class);
+                    $entityTypes = $container->get(EntityTypeRepositoryInterface::class);
+                    $accessLogs = $container->get(AccessLogRepositoryInterface::class);
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$entityTypes instanceof EntityTypeRepositoryInterface) {
+                        throw new LogicException('EntityType repository service is invalid.');
+                    }
+
+                    if (!$accessLogs instanceof AccessLogRepositoryInterface) {
+                        throw new LogicException('Access log repository service is invalid.');
+                    }
+
+                    return new GetDashboardSummaryUseCase($entities, $entityTypes, $accessLogs);
+                },
+            )
+            ->set(
+                GetDashboardSummaryHandler::class,
+                static function (ContainerInterface $container): GetDashboardSummaryHandler {
+                    $useCase = $container->get(GetDashboardSummaryUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof GetDashboardSummaryUseCaseInterface) {
+                        throw new LogicException('GetDashboardSummary use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new GetDashboardSummaryHandler($useCase, $response);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.dashboard',
+                static function (ContainerInterface $container): DashboardRouteRegistrar {
+                    $handler = $container->get(GetDashboardSummaryHandler::class);
+
+                    if (!$handler instanceof GetDashboardSummaryHandler) {
+                        throw new LogicException('GetDashboardSummary handler service is invalid.');
+                    }
+
+                    return new DashboardRouteRegistrar($handler);
+                },
+            );
+    }
+}

--- a/src/Dashboard/GetDashboardSummaryHandler.php
+++ b/src/Dashboard/GetDashboardSummaryHandler.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Dashboard;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetDashboardSummaryHandler
+{
+    public function __construct(
+        private GetDashboardSummaryUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $output = $this->useCase->execute();
+
+        return $this->response->create([
+            'recent_published' => array_map(
+                static fn (DashboardRecentEntity $e): array => [
+                    'id'               => $e->id,
+                    'entity_type_id'   => $e->entityTypeId,
+                    'entity_type_name' => $e->entityTypeName,
+                    'entity_type_slug' => $e->entityTypeSlug,
+                    'slug'             => $e->slug,
+                    'published_at'     => $e->publishedAtIso,
+                ],
+                $output->recentPublished,
+            ),
+            'today_access_count'      => $output->todayAccessCount,
+            'this_month_access_count' => $output->thisMonthAccessCount,
+            'entity_type_summary' => array_map(
+                static fn (DashboardEntityTypeSummary $s): array => [
+                    'entity_type_id'   => $s->entityTypeId,
+                    'entity_type_name' => $s->entityTypeName,
+                    'entity_type_slug' => $s->entityTypeSlug,
+                    'published_count'  => $s->publishedCount,
+                    'draft_count'      => $s->draftCount,
+                ],
+                $output->entityTypeSummary,
+            ),
+        ]);
+    }
+}

--- a/src/Dashboard/GetDashboardSummaryOutput.php
+++ b/src/Dashboard/GetDashboardSummaryOutput.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Dashboard;
+
+final readonly class GetDashboardSummaryOutput
+{
+    /**
+     * @param list<DashboardRecentEntity>      $recentPublished
+     * @param list<DashboardEntityTypeSummary> $entityTypeSummary
+     */
+    public function __construct(
+        public array $recentPublished,
+        public int $todayAccessCount,
+        public int $thisMonthAccessCount,
+        public array $entityTypeSummary,
+    ) {
+    }
+}

--- a/src/Dashboard/GetDashboardSummaryUseCase.php
+++ b/src/Dashboard/GetDashboardSummaryUseCase.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Dashboard;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use NeNeRecords\Analytics\AccessLogRepositoryInterface;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
+
+final readonly class GetDashboardSummaryUseCase implements GetDashboardSummaryUseCaseInterface
+{
+    private const RECENT_PUBLISHED_LIMIT = 5;
+
+    private const ENTITY_TYPE_PAGE_SIZE = 100;
+
+    public function __construct(
+        private EntityRepositoryInterface $entities,
+        private EntityTypeRepositoryInterface $entityTypes,
+        private AccessLogRepositoryInterface $accessLogs,
+    ) {
+    }
+
+    public function execute(): GetDashboardSummaryOutput
+    {
+        $now = new DateTimeImmutable();
+
+        // ── Recent published entities ──────────────────────────────────────
+        $recentEntities = $this->entities->findRecentPublished(self::RECENT_PUBLISHED_LIMIT);
+
+        // Pre-load entity types for name/slug lookup
+        $entityTypeRows = $this->entityTypes->findAll(self::ENTITY_TYPE_PAGE_SIZE, 0);
+        $entityTypeMap = [];
+        foreach ($entityTypeRows as $et) {
+            if ($et->id !== null) {
+                $entityTypeMap[$et->id] = $et;
+            }
+        }
+
+        $recentPublished = array_map(
+            static function (\NeNeRecords\Entity\Entity $entity) use ($entityTypeMap): DashboardRecentEntity {
+                $et = $entityTypeMap[$entity->entityTypeId] ?? null;
+
+                return new DashboardRecentEntity(
+                    id: (int) $entity->id,
+                    entityTypeId: $entity->entityTypeId,
+                    entityTypeName: $et !== null ? $et->name : '',
+                    entityTypeSlug: $et !== null ? $et->slug : '',
+                    slug: $entity->slug,
+                    publishedAtIso: $entity->publishedAt?->format(DateTimeInterface::ATOM),
+                );
+            },
+            $recentEntities,
+        );
+
+        // ── Access counts ──────────────────────────────────────────────────
+        $todayAccessCount = $this->accessLogs->countByDate($now);
+        $thisMonthAccessCount = $this->accessLogs->countByYearMonth(
+            (int) $now->format('Y'),
+            (int) $now->format('n'),
+        );
+
+        // ── Entity type summary ────────────────────────────────────────────
+        $publishedByType = $this->entities->countPublishedGroupedByEntityType();
+        $draftByType     = $this->entities->countDraftGroupedByEntityType();
+
+        $entityTypeSummary = array_map(
+            static function (\NeNeRecords\EntityType\EntityType $et) use ($publishedByType, $draftByType): DashboardEntityTypeSummary {
+                $typeId = (int) $et->id;
+
+                return new DashboardEntityTypeSummary(
+                    entityTypeId: $typeId,
+                    entityTypeName: $et->name,
+                    entityTypeSlug: $et->slug,
+                    publishedCount: $publishedByType[$typeId] ?? 0,
+                    draftCount: $draftByType[$typeId] ?? 0,
+                );
+            },
+            $entityTypeRows,
+        );
+
+        return new GetDashboardSummaryOutput(
+            recentPublished: $recentPublished,
+            todayAccessCount: $todayAccessCount,
+            thisMonthAccessCount: $thisMonthAccessCount,
+            entityTypeSummary: $entityTypeSummary,
+        );
+    }
+}

--- a/src/Dashboard/GetDashboardSummaryUseCaseInterface.php
+++ b/src/Dashboard/GetDashboardSummaryUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Dashboard;
+
+interface GetDashboardSummaryUseCaseInterface
+{
+    public function execute(): GetDashboardSummaryOutput;
+}

--- a/src/Entity/EntityRepositoryInterface.php
+++ b/src/Entity/EntityRepositoryInterface.php
@@ -26,6 +26,15 @@ interface EntityRepositoryInterface
     /** @return list<Entity> */
     public function findDueScheduled(): array;
 
+    /** @return list<Entity> Most recently published entities, ordered by published_at DESC. */
+    public function findRecentPublished(int $limit): array;
+
+    /** @return array<int, int> entityTypeId => published count */
+    public function countPublishedGroupedByEntityType(): array;
+
+    /** @return array<int, int> entityTypeId => draft count */
+    public function countDraftGroupedByEntityType(): array;
+
     /** @return list<EntityRevision> */
     public function findRevisionsByEntityId(int $entityId, int $limit, int $offset): array;
 

--- a/src/Entity/PdoEntityRepository.php
+++ b/src/Entity/PdoEntityRepository.php
@@ -325,6 +325,62 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
         return array_map(fn (array $row) => $this->mapRow($row), $rows);
     }
 
+    public function findRecentPublished(int $limit): array
+    {
+        $rows = $this->query->fetchAll(
+            <<<SQL
+                SELECT id, entity_type_id, slug, status, published_at, scheduled_at, is_deleted, deleted_at, meta_title, meta_description
+                FROM entities
+                WHERE status = 'published' AND is_deleted = 0
+                ORDER BY published_at DESC
+                LIMIT ?
+                SQL,
+            [$limit],
+        );
+
+        return array_map(fn (array $row) => $this->mapRow($row), $rows);
+    }
+
+    public function countPublishedGroupedByEntityType(): array
+    {
+        $rows = $this->query->fetchAll(
+            <<<'SQL'
+                SELECT entity_type_id, COUNT(*) AS cnt
+                FROM entities
+                WHERE status = 'published' AND is_deleted = 0
+                GROUP BY entity_type_id
+                SQL,
+            [],
+        );
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[(int) $row['entity_type_id']] = (int) $row['cnt'];
+        }
+
+        return $result;
+    }
+
+    public function countDraftGroupedByEntityType(): array
+    {
+        $rows = $this->query->fetchAll(
+            <<<'SQL'
+                SELECT entity_type_id, COUNT(*) AS cnt
+                FROM entities
+                WHERE status = 'draft' AND is_deleted = 0
+                GROUP BY entity_type_id
+                SQL,
+            [],
+        );
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[(int) $row['entity_type_id']] = (int) $row['cnt'];
+        }
+
+        return $result;
+    }
+
     /** @param array<string, mixed> $row */
     private function mapRow(array $row): Entity
     {

--- a/tests/Analytics/AccessLogMiddlewareTest.php
+++ b/tests/Analytics/AccessLogMiddlewareTest.php
@@ -86,6 +86,16 @@ final class AccessLogMiddlewareTest extends TestCase
                     throw new \RuntimeException('db down');
                 }
 
+                public function countByDate(DateTimeImmutable $date): int
+                {
+                    return 0;
+                }
+
+                public function countByYearMonth(int $year, int $month): int
+                {
+                    return 0;
+                }
+
                 public function aggregateByDate(DateTimeImmutable $from, DateTimeImmutable $to): array
                 {
                     return [];

--- a/tests/Analytics/InMemoryAccessLogRepository.php
+++ b/tests/Analytics/InMemoryAccessLogRepository.php
@@ -25,6 +25,34 @@ final class InMemoryAccessLogRepository implements AccessLogRepositoryInterface
         return $this->entries;
     }
 
+    public function countByDate(DateTimeImmutable $date): int
+    {
+        $target = $date->format('Y-m-d');
+        $count = 0;
+
+        foreach ($this->entries as $entry) {
+            if ($entry->accessedAt->format('Y-m-d') === $target) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+
+    public function countByYearMonth(int $year, int $month): int
+    {
+        $prefix = sprintf('%04d-%02d', $year, $month);
+        $count = 0;
+
+        foreach ($this->entries as $entry) {
+            if (str_starts_with($entry->accessedAt->format('Y-m-d'), $prefix)) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+
     public function aggregateByDate(DateTimeImmutable $from, DateTimeImmutable $to): array
     {
         /** @var array<string, list<float>> $byDate */

--- a/tests/Dashboard/DashboardHttpTest.php
+++ b/tests/Dashboard/DashboardHttpTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Dashboard;
+
+use DateTimeImmutable;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Dashboard\DashboardRouteRegistrar;
+use NeNeRecords\Dashboard\GetDashboardSummaryHandler;
+use NeNeRecords\Dashboard\GetDashboardSummaryUseCase;
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\Entity\EntityStatus;
+use NeNeRecords\EntityType\EntityType;
+use NeNeRecords\Tests\Analytics\InMemoryAccessLogRepository;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class DashboardHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryEntityRepository $entities;
+    private InMemoryEntityTypeRepository $entityTypes;
+    private InMemoryAccessLogRepository $accessLogs;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->entities = new InMemoryEntityRepository();
+        $this->entityTypes = new InMemoryEntityTypeRepository();
+        $this->accessLogs = new InMemoryAccessLogRepository();
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+
+        $useCase = new GetDashboardSummaryUseCase(
+            $this->entities,
+            $this->entityTypes,
+            $this->accessLogs,
+        );
+
+        $registrar = new DashboardRouteRegistrar(
+            new GetDashboardSummaryHandler($useCase, $jsonResponse),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [],
+            routeRegistrars: [$registrar],
+        ))->create();
+    }
+
+    public function testReturnsEmptyDashboardWhenNoData(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/dashboard'),
+        );
+
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame([], $payload['recent_published']);
+        self::assertSame(0, $payload['today_access_count']);
+        self::assertSame(0, $payload['this_month_access_count']);
+        self::assertSame([], $payload['entity_type_summary']);
+    }
+
+    public function testReturnsRecentPublishedEntities(): void
+    {
+        $articleType = new EntityType(name: 'Article', slug: 'article', id: 1);
+        $this->entityTypes = new InMemoryEntityTypeRepository([$articleType]);
+
+        $publishedAt = new DateTimeImmutable('2026-05-25T10:00:00+00:00');
+
+        $entity = new Entity(
+            id: 1,
+            entityTypeId: 1,
+            slug: 'hello-world',
+            status: EntityStatus::Published,
+            publishedAt: $publishedAt,
+        );
+        $this->entities = new InMemoryEntityRepository([$entity]);
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $useCase = new GetDashboardSummaryUseCase($this->entities, $this->entityTypes, $this->accessLogs);
+        $registrar = new DashboardRouteRegistrar(
+            new GetDashboardSummaryHandler($useCase, $jsonResponse),
+        );
+
+        $application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [],
+            routeRegistrars: [$registrar],
+        ))->create();
+
+        $response = $application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/dashboard'),
+        );
+
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertCount(1, $payload['recent_published']);
+
+        $recent = $payload['recent_published'][0];
+        self::assertSame(1, $recent['id']);
+        self::assertSame(1, $recent['entity_type_id']);
+        self::assertSame('Article', $recent['entity_type_name']);
+        self::assertSame('article', $recent['entity_type_slug']);
+        self::assertSame('hello-world', $recent['slug']);
+        self::assertNotNull($recent['published_at']);
+    }
+
+    public function testCountsAccessLogs(): void
+    {
+        $now = new DateTimeImmutable();
+
+        $entry1 = new \NeNeRecords\Analytics\AccessLogEntry(
+            requestId: null,
+            method: 'GET',
+            path: '/api/v1/entities',
+            statusCode: 200,
+            durationMs: 12.5,
+            accessedAt: $now,
+        );
+        $entry2 = new \NeNeRecords\Analytics\AccessLogEntry(
+            requestId: null,
+            method: 'GET',
+            path: '/api/v1/entities',
+            statusCode: 200,
+            durationMs: 8.0,
+            accessedAt: $now,
+        );
+        $this->accessLogs->insert($entry1);
+        $this->accessLogs->insert($entry2);
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $useCase = new GetDashboardSummaryUseCase($this->entities, $this->entityTypes, $this->accessLogs);
+        $registrar = new DashboardRouteRegistrar(
+            new GetDashboardSummaryHandler($useCase, $jsonResponse),
+        );
+
+        $application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [],
+            routeRegistrars: [$registrar],
+        ))->create();
+
+        $response = $application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/dashboard'),
+        );
+
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(2, $payload['today_access_count']);
+        self::assertSame(2, $payload['this_month_access_count']);
+    }
+
+    public function testEntityTypeSummaryShowsPublishedAndDraftCounts(): void
+    {
+        $articleType = new EntityType(name: 'Article', slug: 'article', id: 1);
+        $this->entityTypes = new InMemoryEntityTypeRepository([$articleType]);
+
+        $published1 = new Entity(id: 1, entityTypeId: 1, slug: 'p1', status: EntityStatus::Published, publishedAt: new DateTimeImmutable());
+        $published2 = new Entity(id: 2, entityTypeId: 1, slug: 'p2', status: EntityStatus::Published, publishedAt: new DateTimeImmutable());
+        $draft = new Entity(id: 3, entityTypeId: 1, slug: 'd1', status: EntityStatus::Draft);
+        $this->entities = new InMemoryEntityRepository([$published1, $published2, $draft]);
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $useCase = new GetDashboardSummaryUseCase($this->entities, $this->entityTypes, $this->accessLogs);
+        $registrar = new DashboardRouteRegistrar(
+            new GetDashboardSummaryHandler($useCase, $jsonResponse),
+        );
+
+        $application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [],
+            routeRegistrars: [$registrar],
+        ))->create();
+
+        $response = $application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/dashboard'),
+        );
+
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertCount(1, $payload['entity_type_summary']);
+
+        $summary = $payload['entity_type_summary'][0];
+        self::assertSame(1, $summary['entity_type_id']);
+        self::assertSame('Article', $summary['entity_type_name']);
+        self::assertSame('article', $summary['entity_type_slug']);
+        self::assertSame(2, $summary['published_count']);
+        self::assertSame(1, $summary['draft_count']);
+    }
+}

--- a/tests/Entity/InMemoryEntityRepository.php
+++ b/tests/Entity/InMemoryEntityRepository.php
@@ -201,6 +201,52 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
         return $result;
     }
 
+    /** @return list<Entity> */
+    public function findRecentPublished(int $limit): array
+    {
+        $published = array_values(array_filter(
+            $this->entities,
+            static fn (Entity $e): bool => !$e->isDeleted && $e->status === \NeNeRecords\Entity\EntityStatus::Published,
+        ));
+
+        usort(
+            $published,
+            static fn (Entity $a, Entity $b): int => ($b->publishedAt <=> $a->publishedAt),
+        );
+
+        return array_slice($published, 0, $limit);
+    }
+
+    /** @return array<int, int> */
+    public function countPublishedGroupedByEntityType(): array
+    {
+        $result = [];
+        foreach ($this->entities as $entity) {
+            if ($entity->isDeleted || $entity->status !== \NeNeRecords\Entity\EntityStatus::Published) {
+                continue;
+            }
+            $typeId = $entity->entityTypeId;
+            $result[$typeId] = ($result[$typeId] ?? 0) + 1;
+        }
+
+        return $result;
+    }
+
+    /** @return array<int, int> */
+    public function countDraftGroupedByEntityType(): array
+    {
+        $result = [];
+        foreach ($this->entities as $entity) {
+            if ($entity->isDeleted || $entity->status !== \NeNeRecords\Entity\EntityStatus::Draft) {
+                continue;
+            }
+            $typeId = $entity->entityTypeId;
+            $result[$typeId] = ($result[$typeId] ?? 0) + 1;
+        }
+
+        return $result;
+    }
+
     /** @return list<\NeNeRecords\Entity\EntityRevision> */
     public function findRevisionsByEntityId(int $entityId, int $limit, int $offset): array
     {


### PR DESCRIPTION
## 目的

管理画面のホームページにダッシュボード統計を表示する。

## 変更内容

### バックエンド

- `GET /api/v1/dashboard` エンドポイントを追加
  - 最近公開されたエンティティ（最大5件）
  - 本日のアクセス数
  - 今月のアクセス数
  - エンティティタイプ別公開/下書き件数サマリー
- `EntityRepositoryInterface` に3メソッドを追加
  - `findRecentPublished(int $limit)`
  - `countPublishedGroupedByEntityType()`
  - `countDraftGroupedByEntityType()`
- `AccessLogRepositoryInterface` に2メソッドを追加
  - `countByDate(DateTimeImmutable $date)`
  - `countByYearMonth(int $year, int $month)`
- DashboardServiceProvider / DashboardRouteRegistrar を追加
- PHPUnit テスト 4件追加

### フロントエンド

- `frontend/src/entities/dashboard/` スライスを追加（model/api-types/mapper/queries/query-keys/index）
- `HomePage.tsx` をダッシュボード表示に更新
  - アクセス数カード（本日・今月）
  - エンティティタイプ別集計
  - 最近公開されたコンテンツ一覧
- i18n メッセージ追加（ja/en）

### OpenAPI

- `/api/v1/dashboard` パスを追加
- `DashboardSummaryResponse`・`DashboardRecentEntity`・`DashboardEntityTypeSummary` スキーマを追加

## 検証

```bash
composer check   # 257 tests, 1062 assertions — OK, PHPStan OK, CS-Fixer OK, OpenAPI OK
npm run check --prefix frontend  # type-check OK, lint OK, test OK, storybook OK
```

## チェックリスト

- [x] テスト追加済み
- [x] OpenAPI 更新済み
- [x] i18n 対応済み（ja/en）
- [x] 静的解析パス済み

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)