### PR TITLE
feat(i18n): text_fields に locale 列を追加し多言語コンテンツに対応 (#147)

### DIFF
--- a/database/migrations/20260530000001_add_locale_to_text_fields.php
+++ b/database/migrations/20260530000001_add_locale_to_text_fields.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddLocaleToTextFields extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('text_fields')
+            ->addColumn('locale', 'string', [
+                'limit'   => 10,
+                'null'    => true,
+                'default' => null,
+                'after'   => 'field_key',
+            ])
+            ->addIndex(['entity_id', 'locale'])
+            ->update();
+    }
+}

--- a/database/schema/text_fields.sql
+++ b/database/schema/text_fields.sql
@@ -2,9 +2,11 @@ CREATE TABLE text_fields (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     entity_id INTEGER UNSIGNED NOT NULL,
     field_key VARCHAR(255) NOT NULL,
+    locale VARCHAR(10) NULL DEFAULT NULL,
     value TEXT NOT NULL,
     is_deleted BOOLEAN NOT NULL DEFAULT 0,
     deleted_at DATETIME NULL,
     FOREIGN KEY (entity_id) REFERENCES entities (id) ON DELETE RESTRICT ON UPDATE NO ACTION
 );
 CREATE INDEX text_fields_entity_id ON text_fields (entity_id);
+CREATE INDEX text_fields_entity_locale ON text_fields (entity_id, locale);

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -887,6 +887,13 @@ paths:
         - $ref: '#/components/parameters/OffsetQuery'
         - $ref: '#/components/parameters/EntityIdQuery'
         - $ref: '#/components/parameters/EntityTypeIdQuery'
+        - name: locale
+          in: query
+          required: false
+          description: Filter by locale code (e.g. "ja", "en"). When omitted, rows of all locales are returned.
+          schema:
+            type: string
+            maxLength: 10
       responses:
         '200':
           description: Paginated text field list.
@@ -922,6 +929,12 @@ paths:
                   entity_id: 1
                   field_key: title
                   value: Hello world
+              withLocale:
+                value:
+                  entity_id: 1
+                  field_key: title
+                  value: こんにちは
+                  locale: ja
       responses:
         '201':
           description: Text field created.
@@ -3093,6 +3106,7 @@ components:
         - entity_id
         - field_key
         - value
+        - locale
       properties:
         id:
           type: integer
@@ -3104,6 +3118,10 @@ components:
           type: string
         value:
           type: string
+        locale:
+          type: string
+          nullable: true
+          description: BCP-47 locale code (e.g. "ja", "en-US"). Null indicates the default/global value.
     CreateTextFieldRequest:
       type: object
       required:
@@ -3120,6 +3138,11 @@ components:
           minLength: 1
         value:
           type: string
+        locale:
+          type: string
+          nullable: true
+          maxLength: 10
+          description: BCP-47 locale code. Omit for the default/global value.
       additionalProperties: false
     UpdateTextFieldRequest:
       type: object
@@ -3132,6 +3155,11 @@ components:
           minLength: 1
         value:
           type: string
+        locale:
+          type: string
+          nullable: true
+          maxLength: 10
+          description: BCP-47 locale code. Omit to keep as the default/global value.
       additionalProperties: false
     TextFieldListResponse:
       type: object

--- a/frontend/src/entities/text-field/api-types.ts
+++ b/frontend/src/entities/text-field/api-types.ts
@@ -3,6 +3,7 @@ export interface TextFieldDto {
   entity_id: number
   field_key: string
   value: string
+  locale: string | null
 }
 
 export interface TextFieldListDto {
@@ -15,9 +16,11 @@ export interface CreateTextFieldDto {
   entity_id: number
   field_key: string
   value: string
+  locale?: string | null
 }
 
 export interface UpdateTextFieldDto {
   field_key: string
   value: string
+  locale?: string | null
 }

--- a/frontend/src/entities/text-field/mapper.ts
+++ b/frontend/src/entities/text-field/mapper.ts
@@ -13,6 +13,7 @@ export function mapTextFieldDtoToModel(dto: TextFieldDto): TextField {
     entityId: dto.entity_id,
     fieldKey: dto.field_key,
     value: dto.value,
+    locale: dto.locale,
   }
 }
 
@@ -29,6 +30,7 @@ export function mapCreateInputToDto(input: CreateTextFieldInput): CreateTextFiel
     entity_id: input.entityId,
     field_key: input.fieldKey,
     value: input.value,
+    locale: input.locale,
   }
 }
 
@@ -36,5 +38,6 @@ export function mapUpdateInputToDto(input: UpdateTextFieldInput): UpdateTextFiel
   return {
     field_key: input.fieldKey,
     value: input.value,
+    locale: input.locale,
   }
 }

--- a/frontend/src/entities/text-field/model.ts
+++ b/frontend/src/entities/text-field/model.ts
@@ -5,6 +5,7 @@ export interface TextField {
   entityId: number
   fieldKey: string
   value: string
+  locale: string | null
 }
 
 export interface TextFieldList {
@@ -17,9 +18,11 @@ export interface CreateTextFieldInput {
   entityId: number
   fieldKey: string
   value: string
+  locale?: string | null
 }
 
 export interface UpdateTextFieldInput {
   fieldKey: string
   value: string
+  locale?: string | null
 }

--- a/frontend/src/entities/text-field/queries.ts
+++ b/frontend/src/entities/text-field/queries.ts
@@ -32,6 +32,9 @@ export function useTextFieldList(
       } else if (params.entityTypeId !== undefined) {
         search.set('entity_type_id', String(params.entityTypeId))
       }
+      if (params.locale != null) {
+        search.set('locale', params.locale)
+      }
       const dto = await apiClient.get<TextFieldListDto>(
         `/api/v1/text-fields?${search.toString()}`,
         signal,

--- a/frontend/src/entities/text-field/query-keys.ts
+++ b/frontend/src/entities/text-field/query-keys.ts
@@ -5,6 +5,7 @@ export interface TextFieldListParams {
   offset: number
   entityId?: number
   entityTypeId?: number
+  locale?: string | null
 }
 
 export const textFieldKeys = {

--- a/src/TextField/CreateTextFieldHandler.php
+++ b/src/TextField/CreateTextFieldHandler.php
@@ -46,10 +46,15 @@ final readonly class CreateTextFieldHandler
             throw new ValidationException($errors);
         }
 
+        $localeRaw = isset($body['locale']) && is_string($body['locale']) && $body['locale'] !== ''
+            ? $body['locale']
+            : null;
+
         $output = $this->useCase->execute(new CreateTextFieldInput(
             entityId: $entityId,
             fieldKey: $fieldKey,
             value: $valueRaw,
+            locale: $localeRaw,
         ));
 
         return $this->response->create(
@@ -58,6 +63,7 @@ final readonly class CreateTextFieldHandler
                 'entity_id'  => $output->entityId,
                 'field_key'  => $output->fieldKey,
                 'value'      => $output->value,
+                'locale'     => $output->locale,
             ],
             201,
             ['Location' => '/api/v1/text-fields/' . $output->id],

--- a/src/TextField/CreateTextFieldInput.php
+++ b/src/TextField/CreateTextFieldInput.php
@@ -10,6 +10,7 @@ final readonly class CreateTextFieldInput
         public int $entityId,
         public string $fieldKey,
         public string $value,
+        public ?string $locale = null,
     ) {
     }
 }

--- a/src/TextField/CreateTextFieldOutput.php
+++ b/src/TextField/CreateTextFieldOutput.php
@@ -11,6 +11,7 @@ final readonly class CreateTextFieldOutput
         public int $entityId,
         public string $fieldKey,
         public string $value,
+        public ?string $locale = null,
     ) {
     }
 }

--- a/src/TextField/CreateTextFieldUseCase.php
+++ b/src/TextField/CreateTextFieldUseCase.php
@@ -33,6 +33,7 @@ final readonly class CreateTextFieldUseCase implements CreateTextFieldUseCaseInt
             entityId: $input->entityId,
             fieldKey: $input->fieldKey,
             value: $input->value,
+            locale: $input->locale,
         ));
 
         return new CreateTextFieldOutput(
@@ -40,6 +41,7 @@ final readonly class CreateTextFieldUseCase implements CreateTextFieldUseCaseInt
             entityId: $input->entityId,
             fieldKey: $input->fieldKey,
             value: $input->value,
+            locale: $input->locale,
         );
     }
 

--- a/src/TextField/GetTextFieldByIdHandler.php
+++ b/src/TextField/GetTextFieldByIdHandler.php
@@ -33,6 +33,7 @@ final readonly class GetTextFieldByIdHandler
             'entity_id' => $output->entityId,
             'field_key' => $output->fieldKey,
             'value'     => $output->value,
+            'locale'    => $output->locale,
         ]);
     }
 }

--- a/src/TextField/GetTextFieldByIdOutput.php
+++ b/src/TextField/GetTextFieldByIdOutput.php
@@ -11,6 +11,7 @@ final readonly class GetTextFieldByIdOutput
         public int $entityId,
         public string $fieldKey,
         public string $value,
+        public ?string $locale = null,
     ) {
     }
 }

--- a/src/TextField/GetTextFieldByIdUseCase.php
+++ b/src/TextField/GetTextFieldByIdUseCase.php
@@ -24,6 +24,7 @@ final readonly class GetTextFieldByIdUseCase implements GetTextFieldByIdUseCaseI
             entityId: $textField->entityId,
             fieldKey: $textField->fieldKey,
             value: $textField->value,
+            locale: $textField->locale,
         );
     }
 }

--- a/src/TextField/ListTextFieldItem.php
+++ b/src/TextField/ListTextFieldItem.php
@@ -11,6 +11,7 @@ final readonly class ListTextFieldItem
         public int $entityId,
         public string $fieldKey,
         public string $value,
+        public ?string $locale = null,
     ) {
     }
 }

--- a/src/TextField/ListTextFieldsHandler.php
+++ b/src/TextField/ListTextFieldsHandler.php
@@ -39,11 +39,17 @@ final readonly class ListTextFieldsHandler
             }
         }
 
+        $locale = null;
+        if (isset($query['locale']) && is_string($query['locale']) && $query['locale'] !== '') {
+            $locale = $query['locale'];
+        }
+
         $output = $this->useCase->execute(new ListTextFieldsInput(
             entityId: $entityId,
             entityTypeId: $entityTypeId,
             limit: $pagination->limit,
             offset: $pagination->offset,
+            locale: $locale,
         ));
 
         return $this->response->create(
@@ -54,6 +60,7 @@ final readonly class ListTextFieldsHandler
                         'entity_id' => $item->entityId,
                         'field_key' => $item->fieldKey,
                         'value'     => $item->value,
+                        'locale'    => $item->locale,
                     ],
                     $output->items,
                 ),

--- a/src/TextField/ListTextFieldsInput.php
+++ b/src/TextField/ListTextFieldsInput.php
@@ -11,6 +11,7 @@ final readonly class ListTextFieldsInput
         public ?int $entityTypeId = null,
         public int $limit = 20,
         public int $offset = 0,
+        public ?string $locale = null,
     ) {
     }
 }

--- a/src/TextField/ListTextFieldsUseCase.php
+++ b/src/TextField/ListTextFieldsUseCase.php
@@ -18,13 +18,15 @@ final readonly class ListTextFieldsUseCase implements ListTextFieldsUseCaseInter
                 $input->entityId,
                 $input->limit,
                 $input->offset,
+                $input->locale,
             ),
             $input->entityTypeId !== null => $this->textFields->findByEntityTypeId(
                 $input->entityTypeId,
                 $input->limit,
                 $input->offset,
+                $input->locale,
             ),
-            default => $this->textFields->findAll($input->limit, $input->offset),
+            default => $this->textFields->findAll($input->limit, $input->offset, $input->locale),
         };
 
         $items = array_map(
@@ -33,6 +35,7 @@ final readonly class ListTextFieldsUseCase implements ListTextFieldsUseCaseInter
                 entityId: $textField->entityId,
                 fieldKey: $textField->fieldKey,
                 value: $textField->value,
+                locale: $textField->locale,
             ),
             $rows,
         );

--- a/src/TextField/PdoTextFieldRepository.php
+++ b/src/TextField/PdoTextFieldRepository.php
@@ -17,7 +17,7 @@ final readonly class PdoTextFieldRepository implements TextFieldRepositoryInterf
     public function findById(int $id): ?TextField
     {
         $row = $this->query->fetchOne(
-            'SELECT id, entity_id, field_key, value FROM text_fields WHERE id = ? AND is_deleted = 0',
+            'SELECT id, entity_id, field_key, locale, value FROM text_fields WHERE id = ? AND is_deleted = 0',
             [$id],
         );
 
@@ -25,78 +25,80 @@ final readonly class PdoTextFieldRepository implements TextFieldRepositoryInterf
             return null;
         }
 
-        return new TextField(
-            entityId: (int) $row['entity_id'],
-            fieldKey: (string) $row['field_key'],
-            value: (string) $row['value'],
-            id: (int) $row['id'],
-        );
+        return $this->mapRow($row);
     }
 
     /** @return list<TextField> */
-    public function findAll(int $limit, int $offset): array
+    public function findAll(int $limit, int $offset, ?string $locale = null): array
     {
-        $rows = $this->query->fetchAll(
-            'SELECT id, entity_id, field_key, value FROM text_fields WHERE is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
-            [$limit, $offset],
-        );
+        if ($locale !== null) {
+            $rows = $this->query->fetchAll(
+                'SELECT id, entity_id, field_key, locale, value FROM text_fields WHERE is_deleted = 0 AND locale = ? ORDER BY id ASC LIMIT ? OFFSET ?',
+                [$locale, $limit, $offset],
+            );
+        } else {
+            $rows = $this->query->fetchAll(
+                'SELECT id, entity_id, field_key, locale, value FROM text_fields WHERE is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
+                [$limit, $offset],
+            );
+        }
 
-        return array_map(
-            static fn (array $row) => new TextField(
-                entityId: (int) $row['entity_id'],
-                fieldKey: (string) $row['field_key'],
-                value: (string) $row['value'],
-                id: (int) $row['id'],
-            ),
-            $rows,
-        );
+        return array_map(fn (array $row) => $this->mapRow($row), $rows);
     }
 
     /** @return list<TextField> */
-    public function findByEntityId(int $entityId, int $limit, int $offset): array
+    public function findByEntityId(int $entityId, int $limit, int $offset, ?string $locale = null): array
     {
-        $rows = $this->query->fetchAll(
-            'SELECT id, entity_id, field_key, value FROM text_fields WHERE entity_id = ? AND is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
-            [$entityId, $limit, $offset],
-        );
+        if ($locale !== null) {
+            $rows = $this->query->fetchAll(
+                'SELECT id, entity_id, field_key, locale, value FROM text_fields WHERE entity_id = ? AND locale = ? AND is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
+                [$entityId, $locale, $limit, $offset],
+            );
+        } else {
+            $rows = $this->query->fetchAll(
+                'SELECT id, entity_id, field_key, locale, value FROM text_fields WHERE entity_id = ? AND is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
+                [$entityId, $limit, $offset],
+            );
+        }
 
-        return array_map(
-            static fn (array $row) => new TextField(
-                entityId: (int) $row['entity_id'],
-                fieldKey: (string) $row['field_key'],
-                value: (string) $row['value'],
-                id: (int) $row['id'],
-            ),
-            $rows,
-        );
+        return array_map(fn (array $row) => $this->mapRow($row), $rows);
     }
 
     /** @return list<TextField> */
-    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset): array
+    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset, ?string $locale = null): array
     {
-        $rows = $this->query->fetchAll(
-            <<<'SQL'
-            SELECT tf.id, tf.entity_id, tf.field_key, tf.value
-            FROM text_fields tf
-            INNER JOIN entities e ON e.id = tf.entity_id
-            WHERE tf.is_deleted = 0
-              AND e.is_deleted = 0
-              AND e.entity_type_id = ?
-            ORDER BY tf.id ASC
-            LIMIT ? OFFSET ?
-            SQL,
-            [$entityTypeId, $limit, $offset],
-        );
+        if ($locale !== null) {
+            $rows = $this->query->fetchAll(
+                <<<'SQL'
+                SELECT tf.id, tf.entity_id, tf.field_key, tf.locale, tf.value
+                FROM text_fields tf
+                INNER JOIN entities e ON e.id = tf.entity_id
+                WHERE tf.is_deleted = 0
+                  AND e.is_deleted = 0
+                  AND e.entity_type_id = ?
+                  AND tf.locale = ?
+                ORDER BY tf.id ASC
+                LIMIT ? OFFSET ?
+                SQL,
+                [$entityTypeId, $locale, $limit, $offset],
+            );
+        } else {
+            $rows = $this->query->fetchAll(
+                <<<'SQL'
+                SELECT tf.id, tf.entity_id, tf.field_key, tf.locale, tf.value
+                FROM text_fields tf
+                INNER JOIN entities e ON e.id = tf.entity_id
+                WHERE tf.is_deleted = 0
+                  AND e.is_deleted = 0
+                  AND e.entity_type_id = ?
+                ORDER BY tf.id ASC
+                LIMIT ? OFFSET ?
+                SQL,
+                [$entityTypeId, $limit, $offset],
+            );
+        }
 
-        return array_map(
-            static fn (array $row) => new TextField(
-                entityId: (int) $row['entity_id'],
-                fieldKey: (string) $row['field_key'],
-                value: (string) $row['value'],
-                id: (int) $row['id'],
-            ),
-            $rows,
-        );
+        return array_map(fn (array $row) => $this->mapRow($row), $rows);
     }
 
     /** @param list<int> $entityIds @return list<TextField> */
@@ -108,26 +110,18 @@ final readonly class PdoTextFieldRepository implements TextFieldRepositoryInterf
 
         $placeholders = implode(', ', array_fill(0, count($entityIds), '?'));
         $rows = $this->query->fetchAll(
-            "SELECT id, entity_id, field_key, value FROM text_fields WHERE entity_id IN ({$placeholders}) AND is_deleted = 0 ORDER BY entity_id ASC, id ASC",
+            "SELECT id, entity_id, field_key, locale, value FROM text_fields WHERE entity_id IN ({$placeholders}) AND is_deleted = 0 ORDER BY entity_id ASC, id ASC",
             $entityIds,
         );
 
-        return array_map(
-            static fn (array $row) => new TextField(
-                entityId: (int) $row['entity_id'],
-                fieldKey: (string) $row['field_key'],
-                value: (string) $row['value'],
-                id: (int) $row['id'],
-            ),
-            $rows,
-        );
+        return array_map(fn (array $row) => $this->mapRow($row), $rows);
     }
 
     public function save(TextField $textField): int
     {
         $this->query->execute(
-            'INSERT INTO text_fields (entity_id, field_key, value) VALUES (?, ?, ?)',
-            [$textField->entityId, $textField->fieldKey, $textField->value],
+            'INSERT INTO text_fields (entity_id, field_key, locale, value) VALUES (?, ?, ?, ?)',
+            [$textField->entityId, $textField->fieldKey, $textField->locale, $textField->value],
         );
 
         return $this->query->lastInsertId();
@@ -140,8 +134,8 @@ final readonly class PdoTextFieldRepository implements TextFieldRepositoryInterf
         }
 
         $affected = $this->query->execute(
-            'UPDATE text_fields SET field_key = ?, value = ? WHERE id = ? AND is_deleted = 0',
-            [$textField->fieldKey, $textField->value, $textField->id],
+            'UPDATE text_fields SET field_key = ?, locale = ?, value = ? WHERE id = ? AND is_deleted = 0',
+            [$textField->fieldKey, $textField->locale, $textField->value, $textField->id],
         );
 
         if ($affected === 0) {
@@ -159,5 +153,19 @@ final readonly class PdoTextFieldRepository implements TextFieldRepositoryInterf
         if ($affected === 0) {
             throw new TextFieldNotFoundException($id);
         }
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): TextField
+    {
+        $localeRaw = $row['locale'] ?? null;
+
+        return new TextField(
+            entityId: (int) $row['entity_id'],
+            fieldKey: (string) $row['field_key'],
+            value: (string) $row['value'],
+            id: (int) $row['id'],
+            locale: ($localeRaw !== null && $localeRaw !== '') ? (string) $localeRaw : null,
+        );
     }
 }

--- a/src/TextField/TextField.php
+++ b/src/TextField/TextField.php
@@ -11,6 +11,7 @@ final readonly class TextField
         public string $fieldKey,
         public string $value,
         public ?int $id = null,
+        public ?string $locale = null,
     ) {
     }
 }

--- a/src/TextField/TextFieldRepositoryInterface.php
+++ b/src/TextField/TextFieldRepositoryInterface.php
@@ -10,24 +10,27 @@ interface TextFieldRepositoryInterface
 
     /**
      * Active (non-soft-deleted) rows only.
+     * When $locale is given, only rows with that locale are returned.
      *
      * @return list<TextField>
      */
-    public function findAll(int $limit, int $offset): array;
+    public function findAll(int $limit, int $offset, ?string $locale = null): array;
 
     /**
      * Active (non-soft-deleted) rows for the given entity only.
+     * When $locale is given, only rows with that locale are returned.
      *
      * @return list<TextField>
      */
-    public function findByEntityId(int $entityId, int $limit, int $offset): array;
+    public function findByEntityId(int $entityId, int $limit, int $offset, ?string $locale = null): array;
 
     /**
      * Active (non-soft-deleted) rows for entities belonging to the given entity type.
+     * When $locale is given, only rows with that locale are returned.
      *
      * @return list<TextField>
      */
-    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset): array;
+    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset, ?string $locale = null): array;
 
     /**
      * Active (non-soft-deleted) rows for a batch of entity ids (no limit).

--- a/src/TextField/UpdateTextFieldHandler.php
+++ b/src/TextField/UpdateTextFieldHandler.php
@@ -49,13 +49,23 @@ final readonly class UpdateTextFieldHandler
             throw new ValidationException($errors);
         }
 
-        $output = $this->useCase->execute(new UpdateTextFieldInput(id: $id, fieldKey: $fieldKey, value: $valueRaw));
+        $localeRaw = isset($body['locale']) && is_string($body['locale']) && $body['locale'] !== ''
+            ? $body['locale']
+            : null;
+
+        $output = $this->useCase->execute(new UpdateTextFieldInput(
+            id: $id,
+            fieldKey: $fieldKey,
+            value: $valueRaw,
+            locale: $localeRaw,
+        ));
 
         return $this->response->create([
             'id'        => $output->id,
             'entity_id' => $output->entityId,
             'field_key' => $output->fieldKey,
             'value'     => $output->value,
+            'locale'    => $output->locale,
         ]);
     }
 }

--- a/src/TextField/UpdateTextFieldInput.php
+++ b/src/TextField/UpdateTextFieldInput.php
@@ -10,6 +10,7 @@ final readonly class UpdateTextFieldInput
         public int $id,
         public string $fieldKey,
         public string $value,
+        public ?string $locale = null,
     ) {
     }
 }

--- a/src/TextField/UpdateTextFieldOutput.php
+++ b/src/TextField/UpdateTextFieldOutput.php
@@ -11,6 +11,7 @@ final readonly class UpdateTextFieldOutput
         public int $entityId,
         public string $fieldKey,
         public string $value,
+        public ?string $locale = null,
     ) {
     }
 }

--- a/src/TextField/UpdateTextFieldUseCase.php
+++ b/src/TextField/UpdateTextFieldUseCase.php
@@ -40,6 +40,7 @@ final readonly class UpdateTextFieldUseCase implements UpdateTextFieldUseCaseInt
             fieldKey: $input->fieldKey,
             value: $input->value,
             id: $input->id,
+            locale: $input->locale,
         );
         $this->textFields->update($updated);
 
@@ -48,6 +49,7 @@ final readonly class UpdateTextFieldUseCase implements UpdateTextFieldUseCaseInt
             entityId: $existing->entityId,
             fieldKey: $input->fieldKey,
             value: $input->value,
+            locale: $input->locale,
         );
     }
 

--- a/tests/TextField/InMemoryTextFieldRepository.php
+++ b/tests/TextField/InMemoryTextFieldRepository.php
@@ -49,12 +49,16 @@ final class InMemoryTextFieldRepository implements TextFieldRepositoryInterface
     }
 
     /** @return list<TextField> */
-    public function findAll(int $limit, int $offset): array
+    public function findAll(int $limit, int $offset, ?string $locale = null): array
     {
         $active = [];
 
         foreach ($this->fields as $id => $textField) {
             if (!isset($this->deletedIds[$id])) {
+                if ($locale !== null && $textField->locale !== $locale) {
+                    continue;
+                }
+
                 $active[] = $textField;
             }
         }
@@ -65,12 +69,16 @@ final class InMemoryTextFieldRepository implements TextFieldRepositoryInterface
     }
 
     /** @return list<TextField> */
-    public function findByEntityId(int $entityId, int $limit, int $offset): array
+    public function findByEntityId(int $entityId, int $limit, int $offset, ?string $locale = null): array
     {
         $active = [];
 
         foreach ($this->fields as $id => $textField) {
             if (!isset($this->deletedIds[$id]) && $textField->entityId === $entityId) {
+                if ($locale !== null && $textField->locale !== $locale) {
+                    continue;
+                }
+
                 $active[] = $textField;
             }
         }
@@ -81,7 +89,7 @@ final class InMemoryTextFieldRepository implements TextFieldRepositoryInterface
     }
 
     /** @return list<TextField> */
-    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset): array
+    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset, ?string $locale = null): array
     {
         $active = [];
 
@@ -97,6 +105,10 @@ final class InMemoryTextFieldRepository implements TextFieldRepositoryInterface
             $entity = $this->entities->findById($textField->entityId);
 
             if ($entity !== null && $entity->entityTypeId === $entityTypeId) {
+                if ($locale !== null && $textField->locale !== $locale) {
+                    continue;
+                }
+
                 $active[] = $textField;
             }
         }
@@ -137,6 +149,7 @@ final class InMemoryTextFieldRepository implements TextFieldRepositoryInterface
             fieldKey: $textField->fieldKey,
             value: $textField->value,
             id: $id,
+            locale: $textField->locale,
         );
 
         return $id;

--- a/tests/TextField/TextFieldHttpTest.php
+++ b/tests/TextField/TextFieldHttpTest.php
@@ -311,6 +311,81 @@ final class TextFieldHttpTest extends TestCase
         self::assertSame('Type A title', $payload['items'][0]['value']);
     }
 
+    public function testCreateTextFieldWithLocaleStoresLocale(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Article', slug: 'article'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'title', dataType: 'text'));
+        $entityId = $this->createEntity($typeId);
+
+        $body = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'title',
+            'value' => 'こんにちは',
+            'locale' => 'ja',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/text-fields')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame('ja', $payload['locale']);
+    }
+
+    public function testListTextFieldsFiltersByLocale(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Article', slug: 'article'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'title', dataType: 'text'));
+        $entityId = $this->createEntity($typeId);
+
+        // Create default (null locale) and Japanese versions
+        $this->createTextField($entityId, 'title', 'Hello');
+
+        $bodyJa = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'title',
+            'value' => 'こんにちは',
+            'locale' => 'ja',
+        ], JSON_THROW_ON_ERROR));
+        $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/text-fields')->withBody($bodyJa),
+        );
+
+        // Filter by locale=ja → should return only the Japanese version
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/text-fields?entity_id={$entityId}&locale=ja"),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertCount(1, $payload['items']);
+        self::assertSame('こんにちは', $payload['items'][0]['value']);
+        self::assertSame('ja', $payload['items'][0]['locale']);
+    }
+
+    public function testResponseIncludesLocaleField(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Article', slug: 'article'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'body', dataType: 'text'));
+        $entityId = $this->createEntity($typeId);
+
+        $body = $this->factory->createStream(json_encode([
+            'entity_id' => $entityId,
+            'field_key' => 'body',
+            'value' => 'Content',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/text-fields')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertArrayHasKey('locale', $payload);
+        self::assertNull($payload['locale']);
+    }
+
     private function createEntity(int $entityTypeId): int
     {
         $bodyEntity = $this->factory->createStream(json_encode(['entity_type_id' => $entityTypeId], JSON_THROW_ON_ERROR));


### PR DESCRIPTION
## 目的

テキストフィールドの値を言語ごとに保存できるようにし、多言語コンテンツ管理を実現する。

## 変更内容

### バックエンド

- **マイグレーション**: `text_fields` に `locale VARCHAR(10) NULL` 列を追加（`NULL` = デフォルト/グローバル値）
- **`TextField` モデル**: `locale: ?string` を追加
- **入力クラス**: `CreateTextFieldInput`, `UpdateTextFieldInput`, `ListTextFieldsInput` に `locale` を追加
- **`TextFieldRepositoryInterface`**: `findAll`, `findByEntityId`, `findByEntityTypeId` に `?string $locale = null` を追加
- **`PdoTextFieldRepository`**: ロケール対応の SQL（SELECT / INSERT / UPDATE）
- **ハンドラ**: リクエストから locale を取得・レスポンスに locale を含める

### API 変更

**GET /api/v1/text-fields** に新しいクエリパラメータ:

```
?locale=ja  → ja ロケールの値のみ返す
?locale=en  → en ロケールの値のみ返す
(省略)      → 全ロケールの値を返す（後方互換）
```

**POST / PUT** に任意の `locale` フィールド:

```json
{
  "entity_id": 1,
  "field_key": "title",
  "value": "こんにちは",
  "locale": "ja"
}
```

**レスポンス** に `locale` フィールドが追加:

```json
{
  "id": 1,
  "entity_id": 1,
  "field_key": "title",
  "value": "Hello world",
  "locale": null
}
```

### フロントエンド

- `TextField` model / api-types / mapper に `locale` を追加
- `TextFieldListParams` に `locale` オプションを追加
- `useTextFieldList` クエリで `?locale=` パラメータをサポート

## 検証

```bash
composer check   # 264 tests, 1090 assertions — OK, PHPStan OK, CS-Fixer OK, OpenAPI OK
npm run check --prefix frontend  # type-check OK, lint OK, test OK, storybook OK
```

## チェックリスト

- [x] テスト追加済み（3件）
- [x] マイグレーション追加済み
- [x] テスト用スキーマ更新済み
- [x] OpenAPI 更新済み
- [x] フロントエンド更新済み
- [x] 後方互換性あり（locale 省略時は全ロケール返す）

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)