### PR TITLE
feat(ux): エンティティ一覧ステータスフィルター＋テキストフィールドロケール切替 (#151 #152)

### DIFF
--- a/frontend/src/entities/entity/queries.ts
+++ b/frontend/src/entities/entity/queries.ts
@@ -7,7 +7,7 @@ import {
   mapEntityListDtoToModel,
   mapEntityRevisionListDtoToModel,
 } from './mapper'
-import type { Entity, EntityList, EntityRevisionList } from './model'
+import type { Entity, EntityList, EntityRevisionList, EntityStatus } from './model'
 import { entityKeys, type EntityListParams } from './query-keys'
 
 const DEFAULT_LIST_PARAMS = { limit: 20, offset: 0 } as const
@@ -87,6 +87,7 @@ export function defaultEntityListParams(
   relationFilters: EntityListParams['relationFilters'] = {},
   offset = 0,
   q?: string,
+  status?: EntityStatus,
 ): EntityListParams {
   return {
     entityTypeId,
@@ -95,5 +96,6 @@ export function defaultEntityListParams(
     limit: DEFAULT_LIST_PARAMS.limit,
     offset,
     q: q !== '' ? q : undefined,
+    status,
   }
 }

--- a/frontend/src/features/edit-entity-text-fields/hooks/use-edit-entity-text-fields-page.ts
+++ b/frontend/src/features/edit-entity-text-fields/hooks/use-edit-entity-text-fields-page.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { FIELD_DATA_TYPES, type FieldDataType } from '@/entities/field-def'
 import { defaultFieldDefListParams, useFieldDefList } from '@/entities/field-def'
 import { toEntityId, useEntity } from '@/entities/entity'
@@ -82,6 +82,8 @@ function datetimeLocalToIso(local: string): string {
 }
 
 export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: number) {
+  const [selectedLocale, setSelectedLocale] = useState<string | null>(null)
+
   const listParams = useMemo(() => ({ ...FIELD_LIST_PARAMS, entityId }), [entityId])
 
   const entityQuery = useEntity(toEntityId(entityId))
@@ -114,6 +116,20 @@ export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: numb
     return textFieldQuery.data?.items ?? []
   }, [textFieldQuery.data?.items])
 
+  // Text fields filtered to the currently selected locale
+  const textFieldsForLocale = useMemo(
+    () => textFieldsForEntity.filter((f) => f.locale === selectedLocale),
+    [textFieldsForEntity, selectedLocale],
+  )
+
+  // Unique locales present in the fetched text fields (excluding null = default)
+  const availableLocales = useMemo(() => {
+    const locales = new Set(textFieldsForEntity.map((f) => f.locale))
+    return Array.from(locales)
+      .filter((l): l is string => l !== null)
+      .sort()
+  }, [textFieldsForEntity])
+
   const intFieldsForEntity = useMemo((): IntField[] => {
     return intFieldQuery.data?.items ?? []
   }, [intFieldQuery.data?.items])
@@ -137,7 +153,7 @@ export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: numb
           case 'text':
           case 'markdown':
           case 'image': {
-            const existing = textFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
+            const existing = textFieldsForLocale.find((item) => item.fieldKey === fieldDef.fieldKey)
             return [fieldDef.fieldKey, existing?.value ?? '']
           }
           case 'int': {
@@ -172,7 +188,7 @@ export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: numb
     editableFieldDefs,
     enumFieldsForEntity,
     intFieldsForEntity,
-    textFieldsForEntity,
+    textFieldsForLocale,
   ])
 
   const saveTextFields = useCallback(
@@ -184,18 +200,19 @@ export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: numb
           case 'text':
           case 'markdown':
           case 'image': {
-            const existing = textFieldsForEntity.find((item) => item.fieldKey === fieldDef.fieldKey)
+            const existing = textFieldsForLocale.find((item) => item.fieldKey === fieldDef.fieldKey)
 
             if (existing !== undefined) {
               await updateTextMutation.mutateAsync({
                 id: existing.id,
-                input: { fieldKey: fieldDef.fieldKey, value: rawValue },
+                input: { fieldKey: fieldDef.fieldKey, value: rawValue, locale: selectedLocale },
               })
             } else {
               await createTextMutation.mutateAsync({
                 entityId,
                 fieldKey: fieldDef.fieldKey,
                 value: rawValue,
+                locale: selectedLocale,
               })
             }
             break
@@ -288,7 +305,8 @@ export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: numb
       entityId,
       enumFieldsForEntity,
       intFieldsForEntity,
-      textFieldsForEntity,
+      selectedLocale,
+      textFieldsForLocale,
       updateBoolMutation,
       updateDateTimeMutation,
       updateEnumMutation,
@@ -327,6 +345,9 @@ export function useEditEntityTextFieldsPage(entityTypeId: number, entityId: numb
     entity: entityQuery.data ?? null,
     textFieldDefs: editableFieldDefs,
     initialValues,
+    selectedLocale,
+    availableLocales,
+    setLocale: setSelectedLocale,
     isLoading,
     isError,
     errorTitle,

--- a/frontend/src/features/edit-entity-text-fields/ui/EditEntityTextFieldsView.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/EditEntityTextFieldsView.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { FieldDef } from '@/entities/field-def'
 import type { Entity } from '@/entities/entity'
 import { useTranslation } from '@/shared/i18n'
@@ -8,11 +9,14 @@ export interface EditEntityTextFieldsViewProps {
   entity: Entity | null
   textFieldDefs: FieldDef[]
   initialValues: Record<string, string>
+  selectedLocale: string | null
+  availableLocales: string[]
   isLoading: boolean
   isError: boolean
   errorTitle: string | null
   isSaving: boolean
   saveErrorTitle: string | null
+  onLocaleChange: (locale: string | null) => void
   onRetry: () => void
   onSave: (values: Record<string, string>) => Promise<void>
 }
@@ -21,15 +25,19 @@ export function EditEntityTextFieldsView({
   entity,
   textFieldDefs,
   initialValues,
+  selectedLocale,
+  availableLocales,
   isLoading,
   isError,
   errorTitle,
   isSaving,
   saveErrorTitle,
+  onLocaleChange,
   onRetry,
   onSave,
 }: EditEntityTextFieldsViewProps) {
   const { t } = useTranslation()
+  const [customLocaleInput, setCustomLocaleInput] = useState('')
 
   if (isLoading) {
     return <Text muted>{t('admin.entityRecord.loading')}</Text>
@@ -51,13 +59,84 @@ export function EditEntityTextFieldsView({
     return <Text muted>{t('admin.entityRecord.notFound')}</Text>
   }
 
+  const handleCustomLocaleSwitch = () => {
+    const trimmed = customLocaleInput.trim()
+    if (trimmed !== '') {
+      onLocaleChange(trimmed)
+      setCustomLocaleInput('')
+    }
+  }
+
   return (
     <Stack gap="lg">
       <Text as="p" muted>
         {t('admin.entityRecord.id', { id: entity.id })}
       </Text>
+
+      {/* ── Locale Switcher ── */}
+      <Stack gap="sm">
+        <Text as="h2" variant="heading-sm">
+          {t('admin.entityRecord.locale.label')}
+        </Text>
+        <div className="flex flex-wrap gap-inline-sm">
+          <Button
+            variant={selectedLocale === null ? 'primary' : 'secondary'}
+            size="sm"
+            aria-pressed={selectedLocale === null}
+            onClick={() => {
+              onLocaleChange(null)
+            }}
+          >
+            {t('admin.entityRecord.locale.default')}
+          </Button>
+          {availableLocales.map((locale) => (
+            <Button
+              key={locale}
+              variant={selectedLocale === locale ? 'primary' : 'secondary'}
+              size="sm"
+              aria-pressed={selectedLocale === locale}
+              onClick={() => {
+                onLocaleChange(locale)
+              }}
+            >
+              {locale}
+            </Button>
+          ))}
+        </div>
+        <div className="flex items-center gap-inline-sm">
+          <input
+            type="text"
+            value={customLocaleInput}
+            onChange={(e) => {
+              setCustomLocaleInput(e.target.value)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleCustomLocaleSwitch()
+              }
+            }}
+            placeholder={t('admin.entityRecord.locale.inputPlaceholder')}
+            aria-label={t('admin.entityRecord.locale.inputPlaceholder')}
+            className="w-32 rounded-md border border-border bg-surface-raised px-inline-sm py-stack-xs font-sans text-caption text-text-primary shadow-sm focus-visible:outline-none focus-visible:shadow-focus"
+          />
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleCustomLocaleSwitch}
+            disabled={customLocaleInput.trim() === ''}
+          >
+            {t('admin.entityRecord.locale.switch')}
+          </Button>
+        </div>
+        {selectedLocale !== null ? (
+          <Text muted>{t('admin.entityRecord.locale.editing', { locale: selectedLocale })}</Text>
+        ) : (
+          <Text muted>{t('admin.entityRecord.locale.editingDefault')}</Text>
+        )}
+      </Stack>
+
       <EntityTextFieldsForm
-        key={JSON.stringify(initialValues)}
+        key={`${selectedLocale ?? 'default'}-${JSON.stringify(initialValues)}`}
         fieldDefs={textFieldDefs}
         defaultValues={initialValues}
         isSubmitting={isSaving}

--- a/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
+++ b/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
@@ -7,6 +7,7 @@ import {
   type Entity,
   type EntityId,
   type EntityRelationFilters,
+  type EntityStatus,
 } from '@/entities/entity'
 import {
   defaultFieldDefListParams,
@@ -22,6 +23,7 @@ export function useManageEntitiesPage(entityTypeId: number) {
   const [selectedTagSlugs, setSelectedTagSlugs] = useState<string[]>([])
   const [selectedRelationFilters, setSelectedRelationFilters] = useState<EntityRelationFilters>({})
   const [searchQuery, setSearchQuery] = useState('')
+  const [selectedStatus, setSelectedStatus] = useState<EntityStatus | undefined>(undefined)
   const listParams = useMemo(
     () =>
       defaultEntityListParams(
@@ -30,8 +32,9 @@ export function useManageEntitiesPage(entityTypeId: number) {
         selectedRelationFilters,
         0,
         searchQuery,
+        selectedStatus,
       ),
-    [entityTypeId, selectedRelationFilters, selectedTagSlugs, searchQuery],
+    [entityTypeId, selectedRelationFilters, selectedTagSlugs, searchQuery, selectedStatus],
   )
   const listQuery = useEntityList(listParams)
   const tagListQuery = useTagList({ limit: 100, offset: 0 })
@@ -117,6 +120,8 @@ export function useManageEntitiesPage(entityTypeId: number) {
     relationFieldDefs,
     selectedTagSlugs,
     selectedRelationFilters,
+    selectedStatus,
+    setStatus: setSelectedStatus,
     searchQuery,
     setSearchQuery,
     toggleTagSlug,
@@ -126,7 +131,8 @@ export function useManageEntitiesPage(entityTypeId: number) {
     isFilterActive:
       selectedTagSlugs.length > 0 ||
       Object.keys(selectedRelationFilters).length > 0 ||
-      searchQuery !== '',
+      searchQuery !== '' ||
+      selectedStatus !== undefined,
     isLoading,
     isError,
     errorTitle,

--- a/frontend/src/features/manage-entities/ui/EntityListPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityListPanel.tsx
@@ -10,6 +10,8 @@ const STATUS_BADGE_CLASS: Record<EntityStatus, string> = {
     'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-green-100 text-green-800',
   archived:
     'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600',
+  scheduled:
+    'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-800',
 }
 
 export interface EntityListPanelProps {

--- a/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
+++ b/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
@@ -1,13 +1,15 @@
-import type { Entity, EntityRelationFilters } from '@/entities/entity'
+import type { Entity, EntityRelationFilters, EntityStatus } from '@/entities/entity'
 import type { RelationFieldDef } from '@/entities/field-def'
 import type { Tag } from '@/entities/tag'
 import { useTranslation } from '@/shared/i18n'
-import { ConfirmDialog, Stack, Text } from '@/shared/ui'
+import { Button, ConfirmDialog, Stack, Text } from '@/shared/ui'
 import { buildExportUrl } from '../lib/build-export-url'
 import { EntityCreatePanel } from './EntityCreatePanel'
 import { EntityListPanel } from './EntityListPanel'
 import { EntityRelationFilterPanel } from './EntityRelationFilterPanel'
 import { EntityTagFilterPanel } from './EntityTagFilterPanel'
+
+const ENTITY_STATUSES: EntityStatus[] = ['draft', 'published', 'scheduled', 'archived']
 
 export interface ManageEntitiesViewProps {
   entityTypeId: number
@@ -20,6 +22,7 @@ export interface ManageEntitiesViewProps {
   relationFieldDefs: RelationFieldDef[]
   selectedTagSlugs: string[]
   selectedRelationFilters: EntityRelationFilters
+  selectedStatus: EntityStatus | undefined
   searchQuery: string
   isFilterActive: boolean
   isLoading: boolean
@@ -34,6 +37,7 @@ export interface ManageEntitiesViewProps {
   onClearTagFilter: () => void
   onSelectRelationFilter: (fieldKey: string, targetEntityId: number | undefined) => void
   onClearRelationFilters: () => void
+  onStatusChange: (status: EntityStatus | undefined) => void
   onSearchChange: (q: string) => void
   onCreate: () => Promise<void>
   onRequestDelete: (entity: Entity) => void
@@ -52,6 +56,7 @@ export function ManageEntitiesView({
   relationFieldDefs,
   selectedTagSlugs,
   selectedRelationFilters,
+  selectedStatus,
   searchQuery,
   isFilterActive,
   isLoading,
@@ -66,6 +71,7 @@ export function ManageEntitiesView({
   onClearTagFilter,
   onSelectRelationFilter,
   onClearRelationFilters,
+  onStatusChange,
   onSearchChange,
   onCreate,
   onRequestDelete,
@@ -137,6 +143,38 @@ export function ManageEntitiesView({
             </button>
           ) : null}
         </div>
+
+        {/* ── Status Filter ── */}
+        <Stack gap="sm">
+          <Text as="h2" variant="heading-sm">
+            {t('admin.entityRecords.statusFilter.label')}
+          </Text>
+          <div className="flex flex-wrap gap-inline-sm">
+            <Button
+              variant={selectedStatus === undefined ? 'primary' : 'secondary'}
+              size="sm"
+              aria-pressed={selectedStatus === undefined}
+              onClick={() => {
+                onStatusChange(undefined)
+              }}
+            >
+              {t('admin.entityRecords.statusFilter.all')}
+            </Button>
+            {ENTITY_STATUSES.map((status) => (
+              <Button
+                key={status}
+                variant={selectedStatus === status ? 'primary' : 'secondary'}
+                size="sm"
+                aria-pressed={selectedStatus === status}
+                onClick={() => {
+                  onStatusChange(status)
+                }}
+              >
+                {t(`admin.entityStatus.status.${status}`)}
+              </Button>
+            ))}
+          </div>
+        </Stack>
 
         <EntityTagFilterPanel
           tags={availableTags}

--- a/frontend/src/pages/entity-record/EntityRecordPage.tsx
+++ b/frontend/src/pages/entity-record/EntityRecordPage.tsx
@@ -26,6 +26,9 @@ export function EntityRecordPage() {
     entity,
     textFieldDefs,
     initialValues,
+    selectedLocale,
+    availableLocales,
+    setLocale,
     isLoading,
     isError,
     errorTitle,
@@ -70,11 +73,14 @@ export function EntityRecordPage() {
         entity={entity}
         textFieldDefs={textFieldDefs}
         initialValues={initialValues}
+        selectedLocale={selectedLocale}
+        availableLocales={availableLocales}
         isLoading={isLoading}
         isError={isError}
         errorTitle={errorTitle}
         isSaving={isSaving}
         saveErrorTitle={saveErrorTitle}
+        onLocaleChange={setLocale}
         onRetry={() => {
           void refetch()
         }}

--- a/frontend/src/pages/entity-records/EntityRecordsPage.tsx
+++ b/frontend/src/pages/entity-records/EntityRecordsPage.tsx
@@ -18,6 +18,8 @@ export function EntityRecordsPage() {
     relationFieldDefs,
     selectedTagSlugs,
     selectedRelationFilters,
+    selectedStatus,
+    setStatus,
     searchQuery,
     setSearchQuery,
     isFilterActive,
@@ -62,6 +64,7 @@ export function EntityRecordsPage() {
         relationFieldDefs={relationFieldDefs}
         selectedTagSlugs={selectedTagSlugs}
         selectedRelationFilters={selectedRelationFilters}
+        selectedStatus={selectedStatus}
         searchQuery={searchQuery}
         isFilterActive={isFilterActive}
         isLoading={isLoading}
@@ -74,6 +77,7 @@ export function EntityRecordsPage() {
         onRetry={() => {
           void refetch()
         }}
+        onStatusChange={setStatus}
         onSearchChange={setSearchQuery}
         onToggleTagSlug={toggleTagSlug}
         onClearTagFilter={clearTagFilter}

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -126,6 +126,8 @@ export const en = {
   'admin.entityRecords.create.submitting': 'Creating…',
   'admin.entityRecords.delete.title': 'Delete record?',
   'admin.entityRecords.delete.description': 'Record #{{id}} will be soft-deleted.',
+  'admin.entityRecords.statusFilter.label': 'Filter by status',
+  'admin.entityRecords.statusFilter.all': 'All',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Fields',
@@ -213,6 +215,12 @@ export const en = {
     'Add field definitions for this entity type first.',
   'admin.entityRecord.textFields.saving': 'Saving…',
   'admin.entityRecord.textFields.save': 'Save values',
+  'admin.entityRecord.locale.label': 'Language',
+  'admin.entityRecord.locale.default': 'Default',
+  'admin.entityRecord.locale.switch': 'Switch',
+  'admin.entityRecord.locale.inputPlaceholder': 'e.g. ja, en, fr…',
+  'admin.entityRecord.locale.editing': 'Editing locale: {{locale}}',
+  'admin.entityRecord.locale.editingDefault': 'Editing default (no locale)',
 
   // ── Entity status panel ───────────────────────────────────────────────────
   'admin.entityStatus.panelTitle': 'Publish status',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -119,6 +119,8 @@ export const ja: Partial<MessageCatalog> = {
   'admin.entityRecords.create.submitting': '作成中…',
   'admin.entityRecords.delete.title': 'レコードを削除しますか？',
   'admin.entityRecords.delete.description': 'レコード #{{id}} がソフト削除されます。',
+  'admin.entityRecords.statusFilter.label': 'ステータスで絞り込む',
+  'admin.entityRecords.statusFilter.all': 'すべて',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'フィールド',
@@ -207,6 +209,12 @@ export const ja: Partial<MessageCatalog> = {
     'まずこのエンティティタイプのフィールド定義を追加してください。',
   'admin.entityRecord.textFields.saving': '保存中…',
   'admin.entityRecord.textFields.save': '値を保存',
+  'admin.entityRecord.locale.label': '言語',
+  'admin.entityRecord.locale.default': 'デフォルト',
+  'admin.entityRecord.locale.switch': '切替',
+  'admin.entityRecord.locale.inputPlaceholder': '例: ja、en、fr…',
+  'admin.entityRecord.locale.editing': '編集中のロケール: {{locale}}',
+  'admin.entityRecord.locale.editingDefault': 'デフォルト（ロケールなし）を編集中',
 
   // ── Entity status panel ───────────────────────────────────────────────────
   'admin.entityStatus.panelTitle': '公開ステータス',


### PR DESCRIPTION
## 目的
使い勝手の改善として、エンティティ一覧のステータスフィルターとテキストフィールド編集画面のロケール切替を追加。

## 変更内容

### #151 — ステータスフィルター（エンティティ一覧）
- `All / Draft / Published / Scheduled / Archived` のフィルターボタンを一覧画面に追加
- `useManageEntitiesPage` に `selectedStatus` ステートと `setStatus` ハンドラーを追加
- `defaultEntityListParams` に `status` パラメーターを追加
- `EntityListPanel` に `scheduled` ステータスバッジ（青）を追加（以前は欠落）
- `isFilterActive` に status フィルターが含まれるよう修正

### #152 — ロケール切替（フィールド値編集）
- フィールド値編集画面にロケール切替 UI を追加
  - Default ボタン（locale=null）
  - 既存ロケールのボタン（取得済みテキストフィールドから自動生成）
  - テキスト入力で任意ロケールへの切替
- `useEditEntityTextFieldsPage` に `selectedLocale / availableLocales / setLocale` を追加
- `textFieldsForLocale` を locale でフィルタリングして `initialValues` に反映
- create/update ミューテーションに `locale` を渡すよう対応

### i18n
- `admin.entityRecords.statusFilter.*` キーを en/ja に追加
- `admin.entityRecord.locale.*` キーを en/ja に追加

## 検証
- `npm run check --prefix frontend` — 21 test files, 83 tests, 全グリーン ✅
- `composer check` — 264 tests, PHPStan Max, CS-Fixer, OpenAPI, MCP — 全グリーン ✅

## チェックリスト
- [x] Issue #151, #152 対応済み
- [x] 型エラーなし（TypeScript strict）
- [x] Prettier フォーマット済み
- [x] i18n キー en/ja 両方追加済み
- [x] 既存テスト全グリーン

Closes #151
Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)