### PR TITLE
feat(ux): タグフィルター i18n・エクスポート URL status 反映・ページネーション UI・CHANGELOG M4 (#154 #155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ NeNe Records does not yet follow Semantic Versioning — entries are grouped by 
 
 ---
 
+## [M4 — 機能拡充・使い勝手改善] — 2026-05-26
+
+### Added
+- Admin dashboard — `/api/v1/dashboard` returning recent published entities, today / month access counts, entity type summary (#145, PR #148)
+- IP-based API rate limiting — `ThrottleMiddleware` + `PdoRateLimitStorage`; 120 req/60s default; `429 Too Many Requests` + `Retry-After` / `X-RateLimit-*` headers (#146, PR #149)
+- Multi-language content — `locale` column on `text_fields`; locale filtering on list / create / update APIs (#147, PR #150)
+- Entity list status filter — All / Draft / Published / Scheduled / Archived toggle buttons on the records management screen (#151, PR #153)
+- Locale switcher on field edit screen — Default + per-locale buttons; free-text locale input; locale-aware create / update mutations (#152, PR #153)
+- `scheduled` status badge (blue) on entity list items — previously missing
+
+---
+
 ## [M3 Complete — Headless CMS Platform] — 2026-05-26
 
 ### Added

--- a/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
+++ b/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
@@ -19,22 +19,25 @@ import { useTagList } from '@/entities/tag'
 import { defaultTextFieldListParamsForEntityType, useTextFieldList } from '@/entities/text-field'
 import { getRecordDisplayLabel } from '@/shared/lib/get-record-display-label'
 
+const PAGE_LIMIT = 20
+
 export function useManageEntitiesPage(entityTypeId: number) {
   const [selectedTagSlugs, setSelectedTagSlugs] = useState<string[]>([])
   const [selectedRelationFilters, setSelectedRelationFilters] = useState<EntityRelationFilters>({})
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedStatus, setSelectedStatus] = useState<EntityStatus | undefined>(undefined)
+  const [page, setPage] = useState(0)
   const listParams = useMemo(
     () =>
       defaultEntityListParams(
         entityTypeId,
         selectedTagSlugs,
         selectedRelationFilters,
-        0,
+        page * PAGE_LIMIT,
         searchQuery,
         selectedStatus,
       ),
-    [entityTypeId, selectedRelationFilters, selectedTagSlugs, searchQuery, selectedStatus],
+    [entityTypeId, page, selectedRelationFilters, selectedTagSlugs, searchQuery, selectedStatus],
   )
   const listQuery = useEntityList(listParams)
   const tagListQuery = useTagList({ limit: 100, offset: 0 })
@@ -65,10 +68,12 @@ export function useManageEntitiesPage(entityTypeId: number) {
     setSelectedTagSlugs((current) =>
       current.includes(slug) ? current.filter((item) => item !== slug) : [...current, slug],
     )
+    setPage(0)
   }, [])
 
   const clearTagFilter = useCallback(() => {
     setSelectedTagSlugs([])
+    setPage(0)
   }, [])
 
   const setRelationFilter = useCallback((fieldKey: string, targetEntityId: number | undefined) => {
@@ -79,10 +84,22 @@ export function useManageEntitiesPage(entityTypeId: number) {
 
       return { ...current, [fieldKey]: targetEntityId }
     })
+    setPage(0)
   }, [])
 
   const clearRelationFilters = useCallback(() => {
     setSelectedRelationFilters({})
+    setPage(0)
+  }, [])
+
+  const setStatus = useCallback((status: EntityStatus | undefined) => {
+    setSelectedStatus(status)
+    setPage(0)
+  }, [])
+
+  const setSearch = useCallback((q: string) => {
+    setSearchQuery(q)
+    setPage(0)
   }, [])
 
   const createEntity = useCallback(async () => {
@@ -112,18 +129,35 @@ export function useManageEntitiesPage(entityTypeId: number) {
   const errorTitle =
     listQuery.error?.title ?? textFieldQuery.error?.title ?? fieldDefQuery.error?.title ?? null
 
+  const total = listQuery.data?.total ?? 0
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_LIMIT))
+
   return {
     items,
     recordLabels,
-    total: listQuery.data?.total ?? 0,
+    total,
+    page,
+    totalPages,
+    prevPage:
+      page > 0
+        ? () => {
+            setPage((p) => p - 1)
+          }
+        : undefined,
+    nextPage:
+      page < totalPages - 1
+        ? () => {
+            setPage((p) => p + 1)
+          }
+        : undefined,
     availableTags: tagListQuery.data?.items ?? [],
     relationFieldDefs,
     selectedTagSlugs,
     selectedRelationFilters,
     selectedStatus,
-    setStatus: setSelectedStatus,
+    setStatus,
     searchQuery,
-    setSearchQuery,
+    setSearchQuery: setSearch,
     toggleTagSlug,
     clearTagFilter,
     setRelationFilter,

--- a/frontend/src/features/manage-entities/lib/build-export-url.ts
+++ b/frontend/src/features/manage-entities/lib/build-export-url.ts
@@ -1,10 +1,20 @@
-export function buildExportUrl(entityTypeId: number, format: 'csv' | 'json', q?: string): string {
+import type { EntityStatus } from '@/entities/entity'
+
+export function buildExportUrl(
+  entityTypeId: number,
+  format: 'csv' | 'json',
+  q?: string,
+  status?: EntityStatus,
+): string {
   const params = new URLSearchParams({
     entity_type_id: String(entityTypeId),
     format,
   })
   if (q !== undefined && q !== '') {
     params.set('q', q)
+  }
+  if (status !== undefined) {
+    params.set('status', status)
   }
   return `/api/v1/entities/export?${params.toString()}`
 }

--- a/frontend/src/features/manage-entities/ui/EntityTagFilterPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityTagFilterPanel.tsx
@@ -1,4 +1,5 @@
 import type { Tag } from '@/entities/tag'
+import { useTranslation } from '@/shared/i18n'
 import { Button, Stack, Text } from '@/shared/ui'
 
 export interface EntityTagFilterPanelProps {
@@ -14,6 +15,8 @@ export function EntityTagFilterPanel({
   onToggleTagSlug,
   onClear,
 }: EntityTagFilterPanelProps) {
+  const { t } = useTranslation()
+
   if (tags.length === 0) {
     return null
   }
@@ -22,11 +25,11 @@ export function EntityTagFilterPanel({
     <Stack gap="sm">
       <Stack direction="horizontal" gap="sm">
         <Text as="h2" variant="heading-sm">
-          Filter by tag
+          {t('admin.entityRecords.tagFilter.label')}
         </Text>
         {selectedTagSlugs.length > 0 ? (
           <Button variant="secondary" size="sm" onClick={onClear}>
-            Clear
+            {t('admin.entityRecords.tagFilter.clear')}
           </Button>
         ) : null}
       </Stack>
@@ -50,7 +53,7 @@ export function EntityTagFilterPanel({
         })}
       </div>
       {selectedTagSlugs.length > 0 ? (
-        <Text muted>Showing records with any selected tag.</Text>
+        <Text muted>{t('admin.entityRecords.tagFilter.hint')}</Text>
       ) : null}
     </Stack>
   )

--- a/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
+++ b/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
@@ -18,6 +18,8 @@ export interface ManageEntitiesViewProps {
   items: Entity[]
   recordLabels: Record<string, string>
   total: number
+  page: number
+  totalPages: number
   availableTags: Tag[]
   relationFieldDefs: RelationFieldDef[]
   selectedTagSlugs: string[]
@@ -39,6 +41,8 @@ export interface ManageEntitiesViewProps {
   onClearRelationFilters: () => void
   onStatusChange: (status: EntityStatus | undefined) => void
   onSearchChange: (q: string) => void
+  onPrevPage: (() => void) | undefined
+  onNextPage: (() => void) | undefined
   onCreate: () => Promise<void>
   onRequestDelete: (entity: Entity) => void
   onCancelDelete: () => void
@@ -52,6 +56,8 @@ export function ManageEntitiesView({
   items,
   recordLabels,
   total,
+  page,
+  totalPages,
   availableTags,
   relationFieldDefs,
   selectedTagSlugs,
@@ -73,6 +79,8 @@ export function ManageEntitiesView({
   onClearRelationFilters,
   onStatusChange,
   onSearchChange,
+  onPrevPage,
+  onNextPage,
   onCreate,
   onRequestDelete,
   onCancelDelete,
@@ -97,14 +105,14 @@ export function ManageEntitiesView({
           </Stack>
           <div className="flex shrink-0 gap-2">
             <a
-              href={buildExportUrl(entityTypeId, 'csv', searchQuery)}
+              href={buildExportUrl(entityTypeId, 'csv', searchQuery, selectedStatus)}
               download="records.csv"
               className="inline-flex items-center gap-1.5 rounded-md border border-border bg-surface-raised px-inline-sm py-stack-xs font-sans text-caption text-text-muted shadow-sm transition-colors hover:text-text-primary"
             >
               ↓ CSV
             </a>
             <a
-              href={buildExportUrl(entityTypeId, 'json', searchQuery)}
+              href={buildExportUrl(entityTypeId, 'json', searchQuery, selectedStatus)}
               download="records.json"
               className="inline-flex items-center gap-1.5 rounded-md border border-border bg-surface-raised px-inline-sm py-stack-xs font-sans text-caption text-text-muted shadow-sm transition-colors hover:text-text-primary"
             >
@@ -206,6 +214,32 @@ export function ManageEntitiesView({
             onRetry={onRetry}
             onDelete={onRequestDelete}
           />
+          {totalPages > 1 || page > 0 ? (
+            <div className="flex items-center justify-between gap-inline-md pt-stack-xs">
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={onPrevPage === undefined}
+                onClick={onPrevPage}
+              >
+                {t('admin.entityRecords.pagination.prev')}
+              </Button>
+              <Text muted>
+                {t('admin.entityRecords.pagination.page', {
+                  page: page + 1,
+                  total: totalPages,
+                })}
+              </Text>
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={onNextPage === undefined}
+                onClick={onNextPage}
+              >
+                {t('admin.entityRecords.pagination.next')}
+              </Button>
+            </div>
+          ) : null}
         </Stack>
       </Stack>
       <ConfirmDialog

--- a/frontend/src/pages/entity-records/EntityRecordsPage.tsx
+++ b/frontend/src/pages/entity-records/EntityRecordsPage.tsx
@@ -14,6 +14,10 @@ export function EntityRecordsPage() {
     items,
     recordLabels,
     total,
+    page,
+    totalPages,
+    prevPage,
+    nextPage,
     availableTags,
     relationFieldDefs,
     selectedTagSlugs,
@@ -60,6 +64,8 @@ export function EntityRecordsPage() {
         items={items}
         recordLabels={recordLabels}
         total={total}
+        page={page}
+        totalPages={totalPages}
         availableTags={availableTags}
         relationFieldDefs={relationFieldDefs}
         selectedTagSlugs={selectedTagSlugs}
@@ -79,6 +85,8 @@ export function EntityRecordsPage() {
         }}
         onStatusChange={setStatus}
         onSearchChange={setSearchQuery}
+        onPrevPage={prevPage}
+        onNextPage={nextPage}
         onToggleTagSlug={toggleTagSlug}
         onClearTagFilter={clearTagFilter}
         onSelectRelationFilter={setRelationFilter}

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -128,6 +128,12 @@ export const en = {
   'admin.entityRecords.delete.description': 'Record #{{id}} will be soft-deleted.',
   'admin.entityRecords.statusFilter.label': 'Filter by status',
   'admin.entityRecords.statusFilter.all': 'All',
+  'admin.entityRecords.tagFilter.label': 'Filter by tag',
+  'admin.entityRecords.tagFilter.clear': 'Clear',
+  'admin.entityRecords.tagFilter.hint': 'Showing records with any selected tag.',
+  'admin.entityRecords.pagination.prev': '← Prev',
+  'admin.entityRecords.pagination.next': 'Next →',
+  'admin.entityRecords.pagination.page': 'Page {{page}} / {{total}}',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Fields',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -121,6 +121,12 @@ export const ja: Partial<MessageCatalog> = {
   'admin.entityRecords.delete.description': 'レコード #{{id}} がソフト削除されます。',
   'admin.entityRecords.statusFilter.label': 'ステータスで絞り込む',
   'admin.entityRecords.statusFilter.all': 'すべて',
+  'admin.entityRecords.tagFilter.label': 'タグで絞り込む',
+  'admin.entityRecords.tagFilter.clear': 'クリア',
+  'admin.entityRecords.tagFilter.hint': '選択中のいずれかのタグを持つレコードを表示しています。',
+  'admin.entityRecords.pagination.prev': '← 前へ',
+  'admin.entityRecords.pagination.next': '次へ →',
+  'admin.entityRecords.pagination.page': '{{page}} / {{total}} ページ',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'フィールド',


### PR DESCRIPTION
## 目的
細かい UX 負債の解消と CHANGELOG の更新。

## 変更内容

### #154 — EntityTagFilterPanel i18n 化・エクスポート URL 修正
- `EntityTagFilterPanel` の「Filter by tag」「Clear」「Showing records with any selected tag.」を `t()` に置換
- `buildExportUrl` に `status?: EntityStatus` を追加
- `ManageEntitiesView` の CSV/JSON リンクに `selectedStatus` を渡す → ステータスフィルター中のエクスポートに `?status=draft` 等が反映される

### #155 — エンティティ一覧ページネーション UI
- `useManageEntitiesPage` に `page` ステート（0-indexed）を追加
- `offset = page × 20` で API リクエスト
- フィルター・検索・ステータス変更時にページを自動リセット
- `ManageEntitiesView` リスト下部に「← Prev / Page X / Y / Next →」バーを追加（2 ページ以上のときのみ表示）

### CHANGELOG
- M4 完了分（#145–#153）を CHANGELOG.md に追記

## 検証
- `npm run check --prefix frontend` — 21 test files / 83 tests 全グリーン ✅
- `composer check` — 264 tests / PHPStan / CS-Fixer / OpenAPI / MCP 全グリーン ✅

## チェックリスト
- [x] Issue #154, #155 対応済み
- [x] TypeScript strict エラーなし
- [x] Prettier フォーマット済み
- [x] i18n キー en/ja 両方追加済み

Closes #154
Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)