### PR TITLE
feat(content): entity_types に is_pinned フラグを追加（動的ナビゲーション基盤）(#159)

### DIFF
--- a/database/migrations/20260531000000_add_is_pinned_to_entity_types.php
+++ b/database/migrations/20260531000000_add_is_pinned_to_entity_types.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddIsPinnedToEntityTypes extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('entity_types')
+            ->addColumn('is_pinned', 'boolean', ['null' => false, 'default' => false, 'after' => 'slug'])
+            ->update();
+    }
+}

--- a/database/schema/entity_types.sql
+++ b/database/schema/entity_types.sql
@@ -1,6 +1,7 @@
 CREATE TABLE entity_types (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name VARCHAR(255) NOT NULL,
-    slug VARCHAR(255) NOT NULL
+    slug VARCHAR(255) NOT NULL,
+    is_pinned BOOLEAN NOT NULL DEFAULT 0
 );
 CREATE UNIQUE INDEX entity_types_slug ON entity_types (slug);

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2680,6 +2680,7 @@ components:
         - id
         - name
         - slug
+        - is_pinned
       properties:
         id:
           type: integer
@@ -2688,6 +2689,8 @@ components:
           type: string
         slug:
           type: string
+        is_pinned:
+          type: boolean
     CreateEntityTypeRequest:
       type: object
       required:
@@ -2700,6 +2703,8 @@ components:
         slug:
           type: string
           pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
+        is_pinned:
+          type: boolean
       additionalProperties: false
     UpdateEntityTypeRequest:
       $ref: '#/components/schemas/CreateEntityTypeRequest'

--- a/frontend/src/entities/entity-type/api-types.ts
+++ b/frontend/src/entities/entity-type/api-types.ts
@@ -2,6 +2,7 @@ export interface EntityTypeDto {
   id: number
   name: string
   slug: string
+  is_pinned: boolean
 }
 
 export interface EntityTypeListDto {
@@ -13,6 +14,7 @@ export interface EntityTypeListDto {
 export interface CreateEntityTypeDto {
   name: string
   slug: string
+  is_pinned?: boolean
 }
 
 export type UpdateEntityTypeDto = CreateEntityTypeDto

--- a/frontend/src/entities/entity-type/mapper.test.ts
+++ b/frontend/src/entities/entity-type/mapper.test.ts
@@ -4,31 +4,42 @@ import { toEntityTypeId } from './ids'
 
 describe('entity-type mapper', () => {
   it('maps entity type dto to model', () => {
-    const model = mapEntityTypeDtoToModel({ id: 1, name: 'Article', slug: 'article' })
+    const model = mapEntityTypeDtoToModel({ id: 1, name: 'Article', slug: 'article', is_pinned: true })
 
     expect(model).toEqual({
       id: toEntityTypeId(1),
       name: 'Article',
       slug: 'article',
+      isPinned: true,
     })
   })
 
   it('maps list dto to model', () => {
     const model = mapEntityTypeListDtoToModel({
-      items: [{ id: 2, name: 'Page', slug: 'page' }],
+      items: [{ id: 2, name: 'Page', slug: 'page', is_pinned: false }],
       limit: 20,
       offset: 0,
     })
 
     expect(model.items).toHaveLength(1)
     expect(model.items[0]?.slug).toBe('page')
+    expect(model.items[0]?.isPinned).toBe(false)
     expect(model.limit).toBe(20)
   })
 
   it('maps create input to dto', () => {
+    expect(mapCreateInputToDto({ name: 'Blog', slug: 'blog', isPinned: true })).toEqual({
+      name: 'Blog',
+      slug: 'blog',
+      is_pinned: true,
+    })
+  })
+
+  it('defaults is_pinned to false when not provided', () => {
     expect(mapCreateInputToDto({ name: 'Blog', slug: 'blog' })).toEqual({
       name: 'Blog',
       slug: 'blog',
+      is_pinned: false,
     })
   })
 })

--- a/frontend/src/entities/entity-type/mapper.ts
+++ b/frontend/src/entities/entity-type/mapper.ts
@@ -17,6 +17,7 @@ export function mapEntityTypeDtoToModel(dto: EntityTypeDto): EntityType {
     id: toEntityTypeId(dto.id),
     name: dto.name,
     slug: dto.slug,
+    isPinned: dto.is_pinned,
   }
 }
 
@@ -32,6 +33,7 @@ export function mapCreateInputToDto(input: CreateEntityTypeInput): CreateEntityT
   return {
     name: input.name,
     slug: input.slug,
+    is_pinned: input.isPinned ?? false,
   }
 }
 

--- a/frontend/src/entities/entity-type/model.ts
+++ b/frontend/src/entities/entity-type/model.ts
@@ -4,6 +4,7 @@ export interface EntityType {
   id: EntityTypeId
   name: string
   slug: string
+  isPinned: boolean
 }
 
 export interface EntityTypeList {
@@ -15,6 +16,7 @@ export interface EntityTypeList {
 export interface CreateEntityTypeInput {
   name: string
   slug: string
+  isPinned?: boolean
 }
 
 export type UpdateEntityTypeInput = CreateEntityTypeInput

--- a/frontend/src/features/manage-entity-types/hooks/use-create-entity-type-form.ts
+++ b/frontend/src/features/manage-entity-types/hooks/use-create-entity-type-form.ts
@@ -8,6 +8,7 @@ export const createEntityTypeFormSchema = z.object({
     .string()
     .trim()
     .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Use lowercase letters, numbers, and hyphens'),
+  isPinned: z.boolean().default(false),
 })
 
 export type CreateEntityTypeFormValues = z.infer<typeof createEntityTypeFormSchema>
@@ -18,6 +19,7 @@ export function useCreateEntityTypeForm() {
     defaultValues: {
       name: '',
       slug: '',
+      isPinned: false,
     },
   })
 }

--- a/frontend/src/features/manage-entity-types/ui/EntityTypeCreateForm.tsx
+++ b/frontend/src/features/manage-entity-types/ui/EntityTypeCreateForm.tsx
@@ -1,12 +1,13 @@
 import { Controller } from 'react-hook-form'
 import { useTranslation } from '@/shared/i18n'
 import { Button, Input, Stack, Text } from '@/shared/ui'
+import type { CreateEntityTypeFormValues } from '../hooks/use-create-entity-type-form'
 import { useCreateEntityTypeForm } from '../hooks/use-create-entity-type-form'
 
 export interface EntityTypeCreateFormProps {
   isSubmitting: boolean
   serverErrorTitle: string | null
-  onSubmit: (values: { name: string; slug: string }) => Promise<void>
+  onSubmit: (values: CreateEntityTypeFormValues) => Promise<void>
 }
 
 export function EntityTypeCreateForm({

--- a/frontend/src/features/manage-entity-types/ui/EntityTypeEditForm.tsx
+++ b/frontend/src/features/manage-entity-types/ui/EntityTypeEditForm.tsx
@@ -3,12 +3,13 @@ import type { EntityType } from '@/entities/entity-type'
 import { useTranslation } from '@/shared/i18n'
 import { Button, Input, Stack, Text } from '@/shared/ui'
 import { useEditEntityTypeForm } from '../hooks/use-create-entity-type-form'
+import type { CreateEntityTypeFormValues } from '../hooks/use-create-entity-type-form'
 
 export interface EntityTypeEditFormProps {
   entityType: EntityType
   isSubmitting: boolean
   serverErrorTitle: string | null
-  onSubmit: (values: { name: string; slug: string }) => Promise<void>
+  onSubmit: (values: CreateEntityTypeFormValues) => Promise<void>
   onCancel: () => void
 }
 
@@ -27,6 +28,7 @@ export function EntityTypeEditForm({
   } = useEditEntityTypeForm({
     name: entityType.name,
     slug: entityType.slug,
+    isPinned: entityType.isPinned,
   })
 
   return (
@@ -73,6 +75,30 @@ export function EntityTypeEditForm({
               onChange={field.onChange}
               onBlur={field.onBlur}
             />
+          )}
+        />
+        <Controller
+          name="isPinned"
+          control={control}
+          render={({ field }) => (
+            <label className="flex cursor-pointer items-start gap-3">
+              <input
+                type="checkbox"
+                id="entity-type-edit-is-pinned"
+                checked={field.value}
+                onChange={field.onChange}
+                disabled={isSubmitting}
+                className="mt-0.5 h-4 w-4 shrink-0 accent-accent"
+              />
+              <span className="flex flex-col gap-0.5">
+                <span className="text-sm font-medium text-text-primary">
+                  {t('admin.entityTypes.editForm.isPinned')}
+                </span>
+                <span className="text-xs text-text-muted">
+                  {t('admin.entityTypes.editForm.isPinnedDescription')}
+                </span>
+              </span>
+            </label>
           )}
         />
         {serverErrorTitle !== null ? <Text muted>{serverErrorTitle}</Text> : null}

--- a/frontend/src/features/manage-entity-types/ui/ManageEntityTypesView.tsx
+++ b/frontend/src/features/manage-entity-types/ui/ManageEntityTypesView.tsx
@@ -1,6 +1,7 @@
 import type { EntityType } from '@/entities/entity-type'
 import { useTranslation } from '@/shared/i18n'
 import { ConfirmDialog, Stack, Text } from '@/shared/ui'
+import type { CreateEntityTypeFormValues } from '../hooks/use-create-entity-type-form'
 import { EntityTypeCreateForm } from './EntityTypeCreateForm'
 import { EntityTypeEditForm } from './EntityTypeEditForm'
 import { EntityTypeListPanel } from './EntityTypeListPanel'
@@ -20,10 +21,10 @@ export interface ManageEntityTypesViewProps {
   isDeleting: boolean
   deleteErrorDetail: string | null
   onRetry: () => void
-  onCreate: (values: { name: string; slug: string }) => Promise<void>
+  onCreate: (values: CreateEntityTypeFormValues) => Promise<void>
   onRequestEdit: (entityType: EntityType) => void
   onCancelEdit: () => void
-  onUpdate: (values: { name: string; slug: string }) => Promise<void>
+  onUpdate: (values: CreateEntityTypeFormValues) => Promise<void>
   onRequestDelete: (entityType: EntityType) => void
   onCancelDelete: () => void
   onConfirmDelete: () => Promise<void>

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -98,6 +98,8 @@ export const en = {
   'admin.entityTypes.editForm.title': 'Edit content type',
   'admin.entityTypes.editForm.save': 'Save changes',
   'admin.entityTypes.editForm.saving': 'Saving…',
+  'admin.entityTypes.editForm.isPinned': 'Show in sidebar',
+  'admin.entityTypes.editForm.isPinnedDescription': 'Pin this content type to the navigation sidebar for quick access.',
   'admin.entityTypes.delete.title': 'Delete content type?',
   'admin.entityTypes.delete.description': '"{{name}}" will be removed. This cannot be undone.',
   'admin.entityTypes.actions.fields': 'Fields',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -91,6 +91,8 @@ export const ja: Partial<MessageCatalog> = {
   'admin.entityTypes.editForm.title': 'コンテンツタイプを編集',
   'admin.entityTypes.editForm.save': '変更を保存',
   'admin.entityTypes.editForm.saving': '保存中…',
+  'admin.entityTypes.editForm.isPinned': 'サイドバーに表示',
+  'admin.entityTypes.editForm.isPinnedDescription': 'サイドバーにピン留めして、すぐアクセスできるようにします。',
   'admin.entityTypes.delete.title': 'コンテンツタイプを削除しますか？',
   'admin.entityTypes.delete.description': '「{{name}}」が削除されます。この操作は元に戻せません。',
   'admin.entityTypes.actions.fields': 'フィールド',

--- a/frontend/tests/msw/handlers/entity-type.ts
+++ b/frontend/tests/msw/handlers/entity-type.ts
@@ -4,6 +4,7 @@ interface EntityTypeRecord {
   id: number
   name: string
   slug: string
+  is_pinned: boolean
 }
 
 let nextId = 1
@@ -14,8 +15,8 @@ export function resetEntityTypeStore(): void {
   items = []
 }
 
-export function seedEntityTypes(seed: EntityTypeRecord[]): void {
-  items = [...seed]
+export function seedEntityTypes(seed: { id: number; name: string; slug: string; is_pinned?: boolean }[]): void {
+  items = seed.map((item) => ({ ...item, is_pinned: item.is_pinned ?? false }))
   nextId = Math.max(0, ...seed.map((item) => item.id)) + 1
 }
 
@@ -32,7 +33,7 @@ export const entityTypeHandlers = [
     })
   }),
   http.post('/api/v1/entity-types', async ({ request }) => {
-    const body = (await request.json()) as { name?: string; slug?: string }
+    const body = (await request.json()) as { name?: string; slug?: string; is_pinned?: boolean }
 
     if (typeof body.name !== 'string' || body.name.trim() === '') {
       return HttpResponse.json(
@@ -59,10 +60,11 @@ export const entityTypeHandlers = [
       )
     }
 
-    const created = {
+    const created: EntityTypeRecord = {
       id: nextId++,
       name: body.name,
       slug: body.slug ?? '',
+      is_pinned: body.is_pinned ?? false,
     }
     items = [...items, created]
 
@@ -102,7 +104,7 @@ export const entityTypeHandlers = [
       )
     }
 
-    const body = (await request.json()) as { name?: string; slug?: string }
+    const body = (await request.json()) as { name?: string; slug?: string; is_pinned?: boolean }
 
     if (typeof body.name !== 'string' || body.name.trim() === '') {
       return HttpResponse.json(
@@ -129,10 +131,11 @@ export const entityTypeHandlers = [
       )
     }
 
-    const updated = {
+    const updated: EntityTypeRecord = {
       id,
       name: body.name,
       slug: body.slug ?? '',
+      is_pinned: body.is_pinned ?? false,
     }
     items = [...items.slice(0, index), updated, ...items.slice(index + 1)]
 

--- a/src/EntityType/CreateEntityTypeHandler.php
+++ b/src/EntityType/CreateEntityTypeHandler.php
@@ -29,6 +29,7 @@ final readonly class CreateEntityTypeHandler
 
         $name = trim((string) ($body['name'] ?? ''));
         $slug = trim((string) ($body['slug'] ?? ''));
+        $isPinned = (bool) ($body['is_pinned'] ?? false);
 
         if ($name === '') {
             $errors[] = new ValidationError('name', 'Name is required.', 'required');
@@ -44,10 +45,10 @@ final readonly class CreateEntityTypeHandler
             throw new ValidationException($errors);
         }
 
-        $output = $this->useCase->execute(new CreateEntityTypeInput(name: $name, slug: $slug));
+        $output = $this->useCase->execute(new CreateEntityTypeInput(name: $name, slug: $slug, isPinned: $isPinned));
 
         return $this->response->create(
-            ['id' => $output->id, 'name' => $output->name, 'slug' => $output->slug],
+            ['id' => $output->id, 'name' => $output->name, 'slug' => $output->slug, 'is_pinned' => $output->isPinned],
             201,
             ['Location' => '/api/v1/entity-types/' . $output->id],
         );

--- a/src/EntityType/CreateEntityTypeInput.php
+++ b/src/EntityType/CreateEntityTypeInput.php
@@ -9,6 +9,7 @@ final readonly class CreateEntityTypeInput
     public function __construct(
         public string $name,
         public string $slug,
+        public bool $isPinned = false,
     ) {
     }
 }

--- a/src/EntityType/CreateEntityTypeOutput.php
+++ b/src/EntityType/CreateEntityTypeOutput.php
@@ -10,6 +10,7 @@ final readonly class CreateEntityTypeOutput
         public int $id,
         public string $name,
         public string $slug,
+        public bool $isPinned,
     ) {
     }
 }

--- a/src/EntityType/CreateEntityTypeUseCase.php
+++ b/src/EntityType/CreateEntityTypeUseCase.php
@@ -19,8 +19,8 @@ final readonly class CreateEntityTypeUseCase implements CreateEntityTypeUseCaseI
             throw new EntityTypeSlugConflictException($input->slug);
         }
 
-        $id = $this->entityTypes->save(new EntityType(name: $input->name, slug: $input->slug));
+        $id = $this->entityTypes->save(new EntityType(name: $input->name, slug: $input->slug, isPinned: $input->isPinned));
 
-        return new CreateEntityTypeOutput(id: $id, name: $input->name, slug: $input->slug);
+        return new CreateEntityTypeOutput(id: $id, name: $input->name, slug: $input->slug, isPinned: $input->isPinned);
     }
 }

--- a/src/EntityType/EntityType.php
+++ b/src/EntityType/EntityType.php
@@ -9,6 +9,7 @@ final readonly class EntityType
     public function __construct(
         public string $name,
         public string $slug,
+        public bool $isPinned = false,
         public ?int $id = null,
     ) {
     }

--- a/src/EntityType/GetEntityTypeByIdHandler.php
+++ b/src/EntityType/GetEntityTypeByIdHandler.php
@@ -32,6 +32,7 @@ final readonly class GetEntityTypeByIdHandler
             'id' => $output->id,
             'name' => $output->name,
             'slug' => $output->slug,
+            'is_pinned' => $output->isPinned,
         ]);
     }
 }

--- a/src/EntityType/GetEntityTypeByIdOutput.php
+++ b/src/EntityType/GetEntityTypeByIdOutput.php
@@ -10,6 +10,7 @@ final readonly class GetEntityTypeByIdOutput
         public int $id,
         public string $name,
         public string $slug,
+        public bool $isPinned,
     ) {
     }
 }

--- a/src/EntityType/GetEntityTypeByIdUseCase.php
+++ b/src/EntityType/GetEntityTypeByIdUseCase.php
@@ -23,6 +23,7 @@ final readonly class GetEntityTypeByIdUseCase implements GetEntityTypeByIdUseCas
             id: $entityType->id ?? $input->id,
             name: $entityType->name,
             slug: $entityType->slug,
+            isPinned: $entityType->isPinned,
         );
     }
 }

--- a/src/EntityType/ListEntityTypeItem.php
+++ b/src/EntityType/ListEntityTypeItem.php
@@ -10,6 +10,7 @@ final readonly class ListEntityTypeItem
         public int $id,
         public string $name,
         public string $slug,
+        public bool $isPinned,
     ) {
     }
 }

--- a/src/EntityType/ListEntityTypesHandler.php
+++ b/src/EntityType/ListEntityTypesHandler.php
@@ -31,6 +31,7 @@ final readonly class ListEntityTypesHandler
                         'id' => $item->id,
                         'name' => $item->name,
                         'slug' => $item->slug,
+                        'is_pinned' => $item->isPinned,
                     ],
                     $output->items,
                 ),

--- a/src/EntityType/ListEntityTypesUseCase.php
+++ b/src/EntityType/ListEntityTypesUseCase.php
@@ -20,6 +20,7 @@ final readonly class ListEntityTypesUseCase implements ListEntityTypesUseCaseInt
                 id: (int) $entityType->id,
                 name: $entityType->name,
                 slug: $entityType->slug,
+                isPinned: $entityType->isPinned,
             ),
             $rows,
         );

--- a/src/EntityType/PdoEntityTypeRepository.php
+++ b/src/EntityType/PdoEntityTypeRepository.php
@@ -16,7 +16,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function findById(int $id): ?EntityType
     {
         $row = $this->query->fetchOne(
-            'SELECT id, name, slug FROM entity_types WHERE id = ?',
+            'SELECT id, name, slug, is_pinned FROM entity_types WHERE id = ?',
             [$id],
         );
 
@@ -27,6 +27,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
         return new EntityType(
             name: (string) $row['name'],
             slug: (string) $row['slug'],
+            isPinned: (bool) $row['is_pinned'],
             id: (int) $row['id'],
         );
     }
@@ -34,7 +35,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function findBySlug(string $slug): ?EntityType
     {
         $row = $this->query->fetchOne(
-            'SELECT id, name, slug FROM entity_types WHERE slug = ?',
+            'SELECT id, name, slug, is_pinned FROM entity_types WHERE slug = ?',
             [$slug],
         );
 
@@ -45,6 +46,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
         return new EntityType(
             name: (string) $row['name'],
             slug: (string) $row['slug'],
+            isPinned: (bool) $row['is_pinned'],
             id: (int) $row['id'],
         );
     }
@@ -53,7 +55,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function findAll(int $limit, int $offset): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT id, name, slug FROM entity_types ORDER BY id ASC LIMIT ? OFFSET ?',
+            'SELECT id, name, slug, is_pinned FROM entity_types ORDER BY id ASC LIMIT ? OFFSET ?',
             [$limit, $offset],
         );
 
@@ -61,6 +63,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
             static fn (array $row) => new EntityType(
                 name: (string) $row['name'],
                 slug: (string) $row['slug'],
+                isPinned: (bool) $row['is_pinned'],
                 id: (int) $row['id'],
             ),
             $rows,
@@ -70,8 +73,8 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function save(EntityType $entityType): int
     {
         $this->query->execute(
-            'INSERT INTO entity_types (name, slug) VALUES (?, ?)',
-            [$entityType->name, $entityType->slug],
+            'INSERT INTO entity_types (name, slug, is_pinned) VALUES (?, ?, ?)',
+            [$entityType->name, $entityType->slug, $entityType->isPinned ? 1 : 0],
         );
 
         return $this->query->lastInsertId();
@@ -80,8 +83,8 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function update(EntityType $entityType): void
     {
         $this->query->execute(
-            'UPDATE entity_types SET name = ?, slug = ? WHERE id = ?',
-            [$entityType->name, $entityType->slug, $entityType->id],
+            'UPDATE entity_types SET name = ?, slug = ?, is_pinned = ? WHERE id = ?',
+            [$entityType->name, $entityType->slug, $entityType->isPinned ? 1 : 0, $entityType->id],
         );
     }
 

--- a/src/EntityType/UpdateEntityTypeHandler.php
+++ b/src/EntityType/UpdateEntityTypeHandler.php
@@ -37,6 +37,7 @@ final readonly class UpdateEntityTypeHandler
 
         $name = trim((string) ($body['name'] ?? ''));
         $slug = trim((string) ($body['slug'] ?? ''));
+        $isPinned = (bool) ($body['is_pinned'] ?? false);
 
         if ($name === '') {
             $errors[] = new ValidationError('name', 'Name is required.', 'required');
@@ -52,8 +53,8 @@ final readonly class UpdateEntityTypeHandler
             throw new ValidationException($errors);
         }
 
-        $output = $this->useCase->execute(new UpdateEntityTypeInput(id: $id, name: $name, slug: $slug));
+        $output = $this->useCase->execute(new UpdateEntityTypeInput(id: $id, name: $name, slug: $slug, isPinned: $isPinned));
 
-        return $this->response->create(['id' => $output->id, 'name' => $output->name, 'slug' => $output->slug]);
+        return $this->response->create(['id' => $output->id, 'name' => $output->name, 'slug' => $output->slug, 'is_pinned' => $output->isPinned]);
     }
 }

--- a/src/EntityType/UpdateEntityTypeInput.php
+++ b/src/EntityType/UpdateEntityTypeInput.php
@@ -10,6 +10,7 @@ final readonly class UpdateEntityTypeInput
         public int $id,
         public string $name,
         public string $slug,
+        public bool $isPinned = false,
     ) {
     }
 }

--- a/src/EntityType/UpdateEntityTypeOutput.php
+++ b/src/EntityType/UpdateEntityTypeOutput.php
@@ -10,6 +10,7 @@ final readonly class UpdateEntityTypeOutput
         public int $id,
         public string $name,
         public string $slug,
+        public bool $isPinned,
     ) {
     }
 }

--- a/src/EntityType/UpdateEntityTypeUseCase.php
+++ b/src/EntityType/UpdateEntityTypeUseCase.php
@@ -27,9 +27,9 @@ final readonly class UpdateEntityTypeUseCase implements UpdateEntityTypeUseCaseI
             }
         }
 
-        $updated = new EntityType(name: $input->name, slug: $input->slug, id: $input->id);
+        $updated = new EntityType(name: $input->name, slug: $input->slug, isPinned: $input->isPinned, id: $input->id);
         $this->entityTypes->update($updated);
 
-        return new UpdateEntityTypeOutput(id: $input->id, name: $input->name, slug: $input->slug);
+        return new UpdateEntityTypeOutput(id: $input->id, name: $input->name, slug: $input->slug, isPinned: $input->isPinned);
     }
 }

--- a/tests/EntityType/InMemoryEntityTypeRepository.php
+++ b/tests/EntityType/InMemoryEntityTypeRepository.php
@@ -27,7 +27,7 @@ final class InMemoryEntityTypeRepository implements EntityTypeRepositoryInterfac
         foreach ($seed as $entityType) {
             if ($entityType->id !== null) {
                 $id = $entityType->id;
-                $stored = new EntityType(name: $entityType->name, slug: $entityType->slug, id: $id);
+                $stored = new EntityType(name: $entityType->name, slug: $entityType->slug, isPinned: $entityType->isPinned, id: $id);
                 $this->byId[$id] = $stored;
                 $this->slugToId[$stored->slug] = $id;
                 $this->nextId = max($this->nextId, $id + 1);
@@ -63,7 +63,7 @@ final class InMemoryEntityTypeRepository implements EntityTypeRepositoryInterfac
     public function save(EntityType $entityType): int
     {
         $id = $this->nextId++;
-        $stored = new EntityType(name: $entityType->name, slug: $entityType->slug, id: $id);
+        $stored = new EntityType(name: $entityType->name, slug: $entityType->slug, isPinned: $entityType->isPinned, id: $id);
         $this->byId[$id] = $stored;
         $this->slugToId[$stored->slug] = $id;
 


### PR DESCRIPTION
## 目的
動的サイドバーナビゲーション（Step 5）の基盤として、entity_types に `is_pinned` フラグを追加する。

## 変更内容
**Backend:**
- マイグレーション追加: `is_pinned BOOLEAN NOT NULL DEFAULT 0`
- `EntityType` モデル・全 DTO・リポジトリ・ユースケース・ハンドラに `is_pinned / isPinned` を追加
- OpenAPI: `EntityTypeResponse` に required の `is_pinned` 追加

**Frontend:**
- `model.ts / api-types.ts / mapper.ts` に `isPinned / is_pinned` を追加
- MSW ハンドラを更新（テスト対応）
- 編集フォームに「サイドバーに表示」チェックボックス追加（英・日両対応）

## 検証
```
composer check  # 264 tests / PHPStan / CS-Fixer / OpenAPI — all pass
npm run check --prefix frontend  # 21 files / 84 tests — all pass
```

Closes #159