### PR TITLE
feat(ux): ピン留めエンティティタイプをサイドバーに動的表示・ダッシュボード改修 (#161)

### DIFF
--- a/frontend/src/entities/entity-type/index.ts
+++ b/frontend/src/entities/entity-type/index.ts
@@ -8,4 +8,4 @@ export type {
 } from './model'
 export { entityTypeKeys } from './query-keys'
 export { useCreateEntityType, useDeleteEntityType, useUpdateEntityType } from './mutations'
-export { useEntityType, useEntityTypeList } from './queries'
+export { useEntityType, useEntityTypeList, usePinnedEntityTypes } from './queries'

--- a/frontend/src/entities/entity-type/queries.ts
+++ b/frontend/src/entities/entity-type/queries.ts
@@ -8,6 +8,7 @@ import type { EntityType, EntityTypeList } from './model'
 import { entityTypeKeys } from './query-keys'
 
 const DEFAULT_LIST_PARAMS = { limit: 20, offset: 0 } as const
+const PINNED_LIST_PARAMS = { limit: 100, offset: 0 } as const
 
 export function useEntityTypeList(
   params: { limit: number; offset: number } = DEFAULT_LIST_PARAMS,
@@ -25,6 +26,25 @@ export function useEntityTypeList(
       )
       return mapEntityTypeListDtoToModel(dto)
     },
+  })
+}
+
+export function usePinnedEntityTypes(): UseQueryResult<EntityType[], AppError> {
+  return useQuery({
+    queryKey: [...entityTypeKeys.list(PINNED_LIST_PARAMS), 'pinned'],
+    queryFn: async ({ signal }) => {
+      const search = new URLSearchParams({
+        limit: String(PINNED_LIST_PARAMS.limit),
+        offset: String(PINNED_LIST_PARAMS.offset),
+      })
+      const dto = await apiClient.get<EntityTypeListDto>(
+        `/api/v1/entity-types?${search.toString()}`,
+        signal,
+      )
+      const list = mapEntityTypeListDtoToModel(dto)
+      return list.items.filter((item) => item.isPinned)
+    },
+    staleTime: 5 * 60 * 1000, // 5 minutes — sidebar nav doesn't need frequent refresh
   })
 }
 

--- a/frontend/src/pages/home/HomePage.tsx
+++ b/frontend/src/pages/home/HomePage.tsx
@@ -1,20 +1,55 @@
 import { Link } from 'react-router-dom'
 import { useDashboardSummary } from '@/entities/dashboard'
+import { usePinnedEntityTypes } from '@/entities/entity-type'
 import { useTranslation } from '@/shared/i18n'
 import { Stack, Text } from '@/shared/ui'
+import { IconFileText } from '@/shared/ui/icons/Icons'
 
 export function HomePage() {
   const { t } = useTranslation()
   const { data, isLoading, isError } = useDashboardSummary()
+  const pinnedQuery = usePinnedEntityTypes()
+  const pinnedTypes = pinnedQuery.data ?? []
 
   return (
-    <Stack gap="md">
+    <Stack gap="lg">
       <Text as="h1" variant="heading-md">
         {t('admin.home.title')}
       </Text>
 
-      {isLoading && <Text muted>{t('admin.home.dashboard.loading')}</Text>}
+      {/* ── Quick access ── */}
+      <section>
+        <Text as="h2" variant="heading-sm">
+          {t('admin.home.quickAccess')}
+        </Text>
+        {pinnedTypes.length === 0 && !pinnedQuery.isLoading ? (
+          <Text muted>{t('admin.home.quickAccess.empty')}</Text>
+        ) : (
+          <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {pinnedTypes.map((entityType) => (
+              <Link
+                key={entityType.id}
+                to={`/entity-types/${String(entityType.id)}/entities`}
+                className="group flex items-center gap-3 rounded-lg border border-border bg-surface-raised p-4 shadow-sm transition-colors hover:border-accent hover:bg-surface"
+              >
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-accent/10 text-accent transition-colors group-hover:bg-accent/20">
+                  <IconFileText size={18} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate font-medium text-text-primary">
+                    {entityType.name}
+                  </span>
+                  <span className="block text-xs text-text-muted">
+                    {t('admin.home.quickAccess.manage')}
+                  </span>
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </section>
 
+      {isLoading && <Text muted>{t('admin.home.dashboard.loading')}</Text>}
       {isError && <Text muted>{t('admin.home.dashboard.error')}</Text>}
 
       {data && (

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Outlet, NavLink, useNavigate } from 'react-router-dom'
 import { authStore, currentUserHasCapability } from '@/entities/auth'
+import { usePinnedEntityTypes } from '@/entities/entity-type'
 import { LOCALES, SUPPORTED_LOCALE_IDS, useTranslation } from '@/shared/i18n'
 import { useTheme } from '@/shared/theme'
 import {
@@ -17,6 +18,7 @@ import {
   IconMenu,
   IconX,
   IconChevronRight,
+  IconFileText,
 } from '@/shared/ui/icons/Icons'
 
 interface NavItemProps {
@@ -77,6 +79,8 @@ export function AppShell() {
   const canManageSettings = currentUserHasCapability('manage_settings')
 
   const [advancedOpen, setAdvancedOpen] = useState(false)
+  const pinnedEntityTypesQuery = usePinnedEntityTypes()
+  const pinnedEntityTypes = pinnedEntityTypesQuery.data ?? []
 
   const closeSidebar = () => {
     setSidebarOpen(false)
@@ -155,6 +159,20 @@ export function AppShell() {
                 onClick={closeSidebar}
               />
             </li>
+            {/* ── Pinned content types (dynamic) ── */}
+            {pinnedEntityTypes.map((entityType) => (
+              <li key={entityType.id}>
+                <NavItem
+                  to={`/entity-types/${String(entityType.id)}/entities`}
+                  icon={<IconFileText size={16} />}
+                  label={entityType.name}
+                  onClick={closeSidebar}
+                />
+              </li>
+            ))}
+            {pinnedEntityTypes.length > 0 && (
+              <li aria-hidden="true" className="my-2 border-t border-sidebar-border opacity-50" />
+            )}
             <li>
               <NavItem
                 to="/entity-types"

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -70,10 +70,13 @@ export const en = {
     'You are signed in, but your account does not have permission to perform this action.',
 
   // ── Home page ────────────────────────────────────────────────────────────
-  'admin.home.title': 'Admin dashboard',
-  'admin.home.description':
-    'Phase 4 scaffold is running. Use Entity types to verify API integration via TanStack Query.',
+  'admin.home.title': 'Dashboard',
+  'admin.home.description': 'Welcome to NeNe Records.',
   'admin.home.openPublicSite': 'Open public site →',
+  'admin.home.quickAccess': 'Quick access',
+  'admin.home.quickAccess.description': 'Manage your content',
+  'admin.home.quickAccess.manage': 'Manage',
+  'admin.home.quickAccess.empty': 'No pinned content types yet. Pin a content type from the Content types settings to get started.',
   'admin.home.dashboard.todayAccess': "Today's accesses",
   'admin.home.dashboard.monthAccess': "This month's accesses",
   'admin.home.dashboard.recentPublished': 'Recently published',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -63,10 +63,13 @@ export const ja: Partial<MessageCatalog> = {
     'サインインしていますが、このアクションを実行する権限がありません。',
 
   // ── Home ─────────────────────────────────────────────────────────────────
-  'admin.home.title': '管理ダッシュボード',
-  'admin.home.description':
-    'Phase 4 スキャフォールドが実行中です。エンティティタイプを使用して TanStack Query 経由の API 連携を確認してください。',
+  'admin.home.title': 'ダッシュボード',
+  'admin.home.description': 'NeNe Records へようこそ。',
   'admin.home.openPublicSite': 'パブリックサイトを開く →',
+  'admin.home.quickAccess': 'クイックアクセス',
+  'admin.home.quickAccess.description': 'コンテンツを管理する',
+  'admin.home.quickAccess.manage': '管理する',
+  'admin.home.quickAccess.empty': 'ピン留めされたコンテンツタイプがありません。コンテンツタイプの設定からピン留めを有効にしてください。',
   'admin.home.dashboard.todayAccess': '本日のアクセス数',
   'admin.home.dashboard.monthAccess': '今月のアクセス数',
   'admin.home.dashboard.recentPublished': '最近公開されたコンテンツ',

--- a/frontend/src/shared/ui/icons/Icons.tsx
+++ b/frontend/src/shared/ui/icons/Icons.tsx
@@ -140,3 +140,15 @@ export function IconWebhook({ size = 16, className }: IconProps) {
     </svg>
   )
 }
+
+export function IconFileText({ size = 16, className }: IconProps) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <polyline points="14 2 14 8 20 8" />
+      <line x1="16" y1="13" x2="8" y2="13" />
+      <line x1="16" y1="17" x2="8" y2="17" />
+      <polyline points="10 9 9 9 8 9" />
+    </svg>
+  )
+}


### PR DESCRIPTION
## 目的
`is_pinned=true` のコンテンツタイプをサイドバーと HOME 画面に自動表示し、WP ライクな「すぐ触れる」操作感を実現する。

## 変更内容
**サイドバー（AppShell）:**
- `usePinnedEntityTypes` フック追加（limit:100 で取得し `isPinned` でフィルタ）
- Home の直下にピン留めタイプを動的リスト表示（`IconFileText` アイコン）
- ピン留めタイプがある場合、Content types との間にセパレーターを挿入

**ダッシュボード（HomePage）:**
- 「Quick access / クイックアクセス」セクションをページ上部に追加
- ピン留めタイプをカード形式で表示（タイプ名＋「Manage」リンク）
- ピン留めなし時はヒントテキストを表示
- ページタイトルを「Dashboard / ダッシュボード」に改訂
- スキャフォールド説明文を削除

**アイコン:**
- `IconFileText` (document icon) を Icons.tsx に追加

## 検証
```
npx tsc --noEmit     # エラーなし
npx vitest run       # 21 files / 84 tests pass
```

Closes #161