### PR TITLE
feat(routing): 管理画面を /admin/ 配下に移動・公開URLから /view/ プレフィックスを削除 (#168)

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -39,7 +39,7 @@ const router = createBrowserRouter([
     ),
   },
   {
-    path: '/',
+    path: '/admin',
     element: <AdminShell />,
     children: [
       { index: true, element: <HomePage /> },
@@ -52,14 +52,14 @@ const router = createBrowserRouter([
       // Legacy long-form routes kept for schema management links
       { path: 'entity-types/:entityTypeSlug/entities', element: <EntityRecordsPage /> },
       { path: 'entity-types/:entityTypeSlug/entities/:entityId', element: <EntityRecordPage /> },
-      // Short-form catch-all: /:slug and /:slug/:entityId
+      // Short-form catch-all: /admin/:slug and /admin/:slug/:entityId
       // Must be last — specific routes above take priority
       { path: ':entityTypeSlug', element: <EntityRecordsPage /> },
       { path: ':entityTypeSlug/:entityId', element: <EntityRecordPage /> },
     ],
   },
   {
-    path: '/view',
+    path: '/',
     element: <PublicShell />,
     children: [
       { index: true, element: <PublicIndexPage /> },

--- a/frontend/src/features/inverse-entity-relations/ui/InverseRelationPanel.tsx
+++ b/frontend/src/features/inverse-entity-relations/ui/InverseRelationPanel.tsx
@@ -69,8 +69,8 @@ export function InverseRelationPanel({ fieldDef, targetEntityId }: InverseRelati
               <Link
                 to={
                   sourceEntityTypeSlug !== null
-                    ? `/${sourceEntityTypeSlug}/${String(item.id)}`
-                    : `/entity-types/${String(fieldDef.entityTypeId)}/entities/${String(item.id)}`
+                    ? `/admin/${sourceEntityTypeSlug}/${String(item.id)}`
+                    : `/admin/entity-types/${String(fieldDef.entityTypeId)}/entities/${String(item.id)}`
                 }
               >
                 <Button variant="secondary" size="sm">

--- a/frontend/src/features/manage-entities/ui/EntityListPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityListPanel.tsx
@@ -95,7 +95,7 @@ export function EntityListPanel({
             </Text>
           </Stack>
           <div className="flex items-center gap-inline-sm">
-            <Link to={`/${entityTypeSlug}/${String(item.id)}`}>
+            <Link to={`/admin/${entityTypeSlug}/${String(item.id)}`}>
               <Button variant="secondary" size="sm">
                 {t('common.actions.edit')}
               </Button>

--- a/frontend/src/features/manage-entity-status/ui/EntityStatusPanel.tsx
+++ b/frontend/src/features/manage-entity-status/ui/EntityStatusPanel.tsx
@@ -143,7 +143,7 @@ export function EntityStatusPanel({ entity, entityTypeSlug }: EntityStatusPanelP
   const currentStatus = entity.status
   const publicUrl =
     entityTypeSlug !== undefined && (entity.slug ?? slugInput) !== ''
-      ? `/view/${entityTypeSlug}/${entity.slug ?? slugInput}`
+      ? `/${entityTypeSlug}/${entity.slug ?? slugInput}`
       : null
 
   return (

--- a/frontend/src/features/manage-entity-types/ui/EntityTypeListPanel.tsx
+++ b/frontend/src/features/manage-entity-types/ui/EntityTypeListPanel.tsx
@@ -70,13 +70,13 @@ export function EntityTypeListPanel({
           </Stack>
           <div className="flex items-center gap-inline-sm">
             {canManageSchema ? (
-              <Link to={`/entity-types/${item.slug}/fields`}>
+              <Link to={`/admin/entity-types/${item.slug}/fields`}>
                 <Button variant="secondary" size="sm">
                   {t('admin.entityTypes.actions.fields')}
                 </Button>
               </Link>
             ) : null}
-            <Link to={`/${item.slug}`}>
+            <Link to={`/admin/${item.slug}`}>
               <Button variant="secondary" size="sm">
                 {t('admin.entityTypes.actions.records')}
               </Button>

--- a/frontend/src/features/public-browse-entity-records/ui/PublicRecordListView.tsx
+++ b/frontend/src/features/public-browse-entity-records/ui/PublicRecordListView.tsx
@@ -86,7 +86,7 @@ export function PublicRecordListView({
             className="rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm shadow-sm"
           >
             <Link
-              to={`/view/${entityTypeSlug}/${String(item.id)}`}
+              to={`/${entityTypeSlug}/${String(item.id)}`}
               className="font-sans text-heading-sm font-semibold text-text-primary hover:text-accent"
             >
               {item.label}

--- a/frontend/src/features/public-browse-index/ui/PublicEntityTypeListView.tsx
+++ b/frontend/src/features/public-browse-index/ui/PublicEntityTypeListView.tsx
@@ -50,13 +50,13 @@ export function PublicEntityTypeListView({
           className="rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm shadow-sm"
         >
           <Link
-            to={`/view/${item.slug}`}
+            to={`/${item.slug}`}
             className="font-sans text-heading-sm font-semibold text-text-primary hover:text-accent"
           >
             {item.name}
           </Link>
           <Text as="p" muted className="mt-stack-xs">
-            /view/{item.slug}
+            /{item.slug}
           </Text>
         </li>
       ))}

--- a/frontend/src/features/public-view-entity-record/hooks/use-public-relation-field-display.ts
+++ b/frontend/src/features/public-view-entity-record/hooks/use-public-relation-field-display.ts
@@ -33,7 +33,7 @@ export function usePublicRelationFieldDisplay(
         textFields,
         `Record #${String(relation.targetEntityId)}`,
       ),
-      href: `/view/${targetSlug}/${String(relation.targetEntityId)}`,
+      href: `/${targetSlug}/${String(relation.targetEntityId)}`,
     }))
   }, [
     entityTypeSlugById,

--- a/frontend/src/pages/consumer/PublicBrowsePage.test.tsx
+++ b/frontend/src/pages/consumer/PublicBrowsePage.test.tsx
@@ -11,13 +11,13 @@ import { resetTextFieldStore, seedTextFields } from '@tests/msw/handlers/text-fi
 import { mswServer } from '@tests/msw/server'
 import { renderWithProviders } from '@tests/render/render-with-providers'
 
-function renderBrowsePage(initialEntry = '/view/article') {
+function renderBrowsePage(initialEntry = '/article') {
   return renderWithProviders(
     <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
-        <Route path="/view" element={<PublicIndexPage />} />
-        <Route path="/view/:entityTypeSlug" element={<PublicBrowsePage />} />
-        <Route path="/view/:entityTypeSlug/:entityId" element={<PublicRecordDetailPage />} />
+        <Route path="/" element={<PublicIndexPage />} />
+        <Route path="/:entityTypeSlug" element={<PublicBrowsePage />} />
+        <Route path="/:entityTypeSlug/:entityId" element={<PublicRecordDetailPage />} />
       </Routes>
     </MemoryRouter>,
   )
@@ -76,18 +76,12 @@ describe('PublicBrowsePage', () => {
     renderBrowsePage()
 
     expect(await screen.findByText('2 records')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'First post' })).toHaveAttribute(
-      'href',
-      '/view/article/1',
-    )
-    expect(screen.getByRole('link', { name: 'Second post' })).toHaveAttribute(
-      'href',
-      '/view/article/2',
-    )
+    expect(screen.getByRole('link', { name: 'First post' })).toHaveAttribute('href', '/article/1')
+    expect(screen.getByRole('link', { name: 'Second post' })).toHaveAttribute('href', '/article/2')
   })
 
   it('shows empty state for unknown entity type slug', async () => {
-    renderBrowsePage('/view/missing-type')
+    renderBrowsePage('/missing-type')
 
     expect(await screen.findByText('Entity type not found')).toBeInTheDocument()
     expect(screen.getByText('No public content for "missing-type".')).toBeInTheDocument()
@@ -144,7 +138,7 @@ describe('PublicBrowsePage', () => {
     )
 
     const user = userEvent.setup()
-    renderBrowsePage('/view/article')
+    renderBrowsePage('/article')
 
     expect(await screen.findByText('21 records · showing 1–20')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Post 1' })).toBeInTheDocument()

--- a/frontend/src/pages/consumer/PublicBrowsePage.tsx
+++ b/frontend/src/pages/consumer/PublicBrowsePage.tsx
@@ -41,7 +41,7 @@ export function PublicBrowsePage() {
   return (
     <Stack gap="md">
       <Stack gap="sm">
-        <Link to="/view">
+        <Link to="/">
           <Button variant="secondary" size="sm">
             All types
           </Button>

--- a/frontend/src/pages/consumer/PublicIndexPage.test.tsx
+++ b/frontend/src/pages/consumer/PublicIndexPage.test.tsx
@@ -8,9 +8,9 @@ import { renderWithProviders } from '@tests/render/render-with-providers'
 
 function renderIndexPage() {
   return renderWithProviders(
-    <MemoryRouter initialEntries={['/view']}>
+    <MemoryRouter initialEntries={['/']}>
       <Routes>
-        <Route path="/view" element={<PublicIndexPage />} />
+        <Route path="/" element={<PublicIndexPage />} />
       </Routes>
     </MemoryRouter>,
   )
@@ -39,12 +39,9 @@ describe('PublicIndexPage', () => {
 
     renderIndexPage()
 
-    expect(await screen.findByRole('link', { name: 'Article' })).toHaveAttribute(
-      'href',
-      '/view/article',
-    )
-    expect(screen.getByRole('link', { name: 'Product' })).toHaveAttribute('href', '/view/product')
-    expect(screen.getByText('/view/article')).toBeInTheDocument()
+    expect(await screen.findByRole('link', { name: 'Article' })).toHaveAttribute('href', '/article')
+    expect(screen.getByRole('link', { name: 'Product' })).toHaveAttribute('href', '/product')
+    expect(screen.getByText('/article')).toBeInTheDocument()
   })
 
   it('shows empty state when no entity types exist', async () => {

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.test.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.test.tsx
@@ -14,9 +14,9 @@ import { renderWithProviders } from '@tests/render/render-with-providers'
 
 function renderDetailPage(entityTypeSlug = 'article', entityId = 1) {
   return renderWithProviders(
-    <MemoryRouter initialEntries={[`/view/${entityTypeSlug}/${String(entityId)}`]}>
+    <MemoryRouter initialEntries={[`/${entityTypeSlug}/${String(entityId)}`]}>
       <Routes>
-        <Route path="/view/:entityTypeSlug/:entityId" element={<PublicRecordDetailPage />} />
+        <Route path="/:entityTypeSlug/:entityId" element={<PublicRecordDetailPage />} />
       </Routes>
     </MemoryRouter>,
   )
@@ -126,7 +126,7 @@ describe('PublicRecordDetailPage', () => {
     expect(await screen.findByText('author')).toBeInTheDocument()
 
     const authorLink = screen.getByRole('link', { name: 'Alice' })
-    expect(authorLink).toHaveAttribute('href', '/view/author/2')
+    expect(authorLink).toHaveAttribute('href', '/author/2')
   })
 
   it('renders body text fields as markdown', async () => {

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
@@ -27,7 +27,7 @@ function PublicRecordDetailContent({
   return (
     <Stack gap="md">
       <Stack gap="sm">
-        <Link to={`/view/${entityTypeSlug}`}>
+        <Link to={`/${entityTypeSlug}`}>
           <Button variant="secondary" size="sm">
             Back to {entityTypeName}
           </Button>

--- a/frontend/src/pages/consumer/PublicShell.tsx
+++ b/frontend/src/pages/consumer/PublicShell.tsx
@@ -51,7 +51,7 @@ export function PublicShell() {
     >
       <header className="border-b border-border bg-surface-raised shadow-sm">
         <div className="mx-auto flex max-w-3xl items-center justify-between px-inline-md py-stack-md">
-          <Link to="/view">
+          <Link to="/">
             <Stack gap="xs">
               <Text as="span" variant="heading-sm">
                 {siteName}

--- a/frontend/src/pages/entity-record/EntityRecordPage.test.tsx
+++ b/frontend/src/pages/entity-record/EntityRecordPage.test.tsx
@@ -19,9 +19,9 @@ import { renderWithProviders } from '@tests/render/render-with-providers'
 
 function renderEntityRecordPage(entityTypeSlug = 'article', entityId = 1) {
   return renderWithProviders(
-    <MemoryRouter initialEntries={[`/${entityTypeSlug}/${String(entityId)}`]}>
+    <MemoryRouter initialEntries={[`/admin/${entityTypeSlug}/${String(entityId)}`]}>
       <Routes>
-        <Route path="/:entityTypeSlug/:entityId" element={<EntityRecordPage />} />
+        <Route path="/admin/:entityTypeSlug/:entityId" element={<EntityRecordPage />} />
       </Routes>
     </MemoryRouter>,
   )
@@ -351,6 +351,6 @@ describe('EntityRecordPage', () => {
     expect(await screen.findByText('Article · author')).toBeInTheDocument()
     expect(await screen.findByText('My article')).toBeInTheDocument()
     expect(screen.queryByText('Other article')).not.toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Open' })).toHaveAttribute('href', '/article/1')
+    expect(screen.getByRole('link', { name: 'Open' })).toHaveAttribute('href', '/admin/article/1')
   })
 })

--- a/frontend/src/pages/entity-record/EntityRecordPage.tsx
+++ b/frontend/src/pages/entity-record/EntityRecordPage.tsx
@@ -81,7 +81,7 @@ function EntityRecordContent({
   return (
     <Stack gap="md">
       <Stack gap="sm">
-        <Link to={`/${entityType.slug}`}>
+        <Link to={`/admin/${entityType.slug}`}>
           <Button variant="secondary" size="sm">
             {t('admin.entityRecord.backToRecords')}
           </Button>

--- a/frontend/src/pages/entity-records/EntityRecordsPage.test.tsx
+++ b/frontend/src/pages/entity-records/EntityRecordsPage.test.tsx
@@ -17,11 +17,11 @@ import { clearAuthSession, seedAdminSession } from '@tests/helpers/auth-session'
 
 function renderRecordsPage(entityTypeSlug = 'article') {
   return renderWithProviders(
-    <MemoryRouter initialEntries={[`/${entityTypeSlug}`]}>
+    <MemoryRouter initialEntries={[`/admin/${entityTypeSlug}`]}>
       <Routes>
-        <Route path="/:entityTypeSlug" element={<EntityRecordsPage />} />
+        <Route path="/admin/:entityTypeSlug" element={<EntityRecordsPage />} />
         <Route
-          path="/:entityTypeSlug/:entityId"
+          path="/admin/:entityTypeSlug/:entityId"
           element={<div data-testid="entity-edit-page">Edit page</div>}
         />
       </Routes>
@@ -258,10 +258,10 @@ describe('EntityRecordsPage', () => {
   it('links from entity types page to records', async () => {
     const user = userEvent.setup()
     renderWithProviders(
-      <MemoryRouter initialEntries={['/entity-types']}>
+      <MemoryRouter initialEntries={['/admin/entity-types']}>
         <Routes>
-          <Route path="/entity-types" element={<EntityTypesPage />} />
-          <Route path="/:entityTypeSlug" element={<EntityRecordsPage />} />
+          <Route path="/admin/entity-types" element={<EntityTypesPage />} />
+          <Route path="/admin/:entityTypeSlug" element={<EntityRecordsPage />} />
         </Routes>
       </MemoryRouter>,
     )

--- a/frontend/src/pages/entity-records/EntityRecordsPage.tsx
+++ b/frontend/src/pages/entity-records/EntityRecordsPage.tsx
@@ -64,7 +64,7 @@ function EntityRecordsContent({ entityType }: { entityType: EntityType }) {
 
   const handleCreate = async () => {
     const newEntity = await createEntity()
-    void navigate(`/${entityType.slug}/${String(newEntity.id)}`)
+    void navigate(`/admin/${entityType.slug}/${String(newEntity.id)}`)
   }
 
   const localizedName = getLocalizedEntityTypeName(entityType, locale)
@@ -75,7 +75,7 @@ function EntityRecordsContent({ entityType }: { entityType: EntityType }) {
         {/* ── Breadcrumb ── */}
         <nav aria-label="breadcrumb">
           <Link
-            to="/entity-types"
+            to="/admin/entity-types"
             className="inline-flex items-center gap-1 text-xs text-text-muted transition-colors duration-fast hover:text-text-primary"
           >
             <IconChevronLeft size={12} />

--- a/frontend/src/pages/field-defs/FieldDefsPage.test.tsx
+++ b/frontend/src/pages/field-defs/FieldDefsPage.test.tsx
@@ -11,9 +11,9 @@ import { clearAuthSession, seedAdminSession } from '@tests/helpers/auth-session'
 
 function renderFieldDefsPage(entityTypeSlug = 'article') {
   return renderWithProviders(
-    <MemoryRouter initialEntries={[`/entity-types/${entityTypeSlug}/fields`]}>
+    <MemoryRouter initialEntries={[`/admin/entity-types/${entityTypeSlug}/fields`]}>
       <Routes>
-        <Route path="/entity-types/:entityTypeSlug/fields" element={<FieldDefsPage />} />
+        <Route path="/admin/entity-types/:entityTypeSlug/fields" element={<FieldDefsPage />} />
       </Routes>
     </MemoryRouter>,
   )

--- a/frontend/src/pages/field-defs/FieldDefsPage.tsx
+++ b/frontend/src/pages/field-defs/FieldDefsPage.tsx
@@ -59,7 +59,7 @@ function FieldDefsContent({ entityType }: { entityType: EntityType }) {
   return (
     <Stack gap="md">
       <Stack gap="sm">
-        <Link to="/entity-types">
+        <Link to="/admin/entity-types">
           <Button variant="secondary" size="sm">
             {t('admin.entityTypes.actions.backToTypes')}
           </Button>

--- a/frontend/src/pages/forbidden/ForbiddenPage.tsx
+++ b/frontend/src/pages/forbidden/ForbiddenPage.tsx
@@ -12,7 +12,7 @@ export function ForbiddenPage() {
       </Text>
       <Text muted>{t('admin.forbidden.description')}</Text>
       <Stack direction="horizontal" gap="sm">
-        <Link to="/">
+        <Link to="/admin">
           <Button variant="secondary">{t('common.actions.backToHome')}</Button>
         </Link>
       </Stack>

--- a/frontend/src/pages/home/HomePage.tsx
+++ b/frontend/src/pages/home/HomePage.tsx
@@ -35,7 +35,7 @@ export function HomePage() {
           <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
             {pinnedTypes.length > 0 ? (
               <Link
-                to={`/${pinnedTypes[0].slug}`}
+                to={`/admin/${pinnedTypes[0].slug}`}
                 className="group flex items-start gap-3 rounded-md border border-border bg-surface-raised p-4 transition-colors hover:border-accent"
               >
                 <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent/10 text-accent">
@@ -53,7 +53,7 @@ export function HomePage() {
             ) : null}
             {canManageSettings ? (
               <Link
-                to="/navigation"
+                to="/admin/navigation"
                 className="group flex items-start gap-3 rounded-md border border-border bg-surface-raised p-4 transition-colors hover:border-accent"
               >
                 <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent/10 text-accent">
@@ -85,7 +85,7 @@ export function HomePage() {
             {pinnedTypes.map((entityType) => (
               <Link
                 key={entityType.id}
-                to={`/${entityType.slug}`}
+                to={`/admin/${entityType.slug}`}
                 className="group flex items-center gap-3 rounded-lg border border-border bg-surface-raised p-4 shadow-sm transition-colors hover:border-accent hover:bg-surface"
               >
                 <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-accent/10 text-accent transition-colors group-hover:bg-accent/20">
@@ -165,7 +165,7 @@ export function HomePage() {
                 {data.recentPublished.map((entity) => (
                   <li key={entity.id}>
                     <Link
-                      to={`/entity-types/${entity.entityTypeSlug}/entities/${String(entity.id)}`}
+                      to={`/admin/entity-types/${entity.entityTypeSlug}/entities/${String(entity.id)}`}
                       className="text-body text-accent hover:text-accent-hover"
                     >
                       {entity.entityTypeName} / {entity.slug ?? String(entity.id)}
@@ -184,7 +184,7 @@ export function HomePage() {
         </Stack>
       )}
 
-      <Link to="/view" className="text-body font-medium text-accent hover:text-accent-hover">
+      <Link to="/" className="text-body font-medium text-accent hover:text-accent-hover">
         {t('admin.home.openPublicSite')}
       </Link>
     </Stack>

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -154,7 +154,7 @@ export function AppShell() {
           <ul className="space-y-0.5">
             <li>
               <NavItem
-                to="/"
+                to="/admin"
                 end
                 icon={<IconHome size={16} />}
                 label={t('admin.nav.home')}
@@ -165,7 +165,7 @@ export function AppShell() {
             {pinnedEntityTypes.map((entityType) => (
               <li key={entityType.id}>
                 <NavItem
-                  to={`/${entityType.slug}`}
+                  to={`/admin/${entityType.slug}`}
                   icon={<IconFileText size={16} />}
                   label={getLocalizedEntityTypeName(entityType, locale)}
                   onClick={closeSidebar}
@@ -178,7 +178,7 @@ export function AppShell() {
             {canManageTags ? (
               <li>
                 <NavItem
-                  to="/tags"
+                  to="/admin/tags"
                   icon={<IconTag size={16} />}
                   label={t('admin.nav.tags')}
                   onClick={closeSidebar}
@@ -188,7 +188,7 @@ export function AppShell() {
             {canReadSettings ? (
               <li>
                 <NavItem
-                  to="/settings"
+                  to="/admin/settings"
                   icon={<IconSettings size={16} />}
                   label={t('admin.nav.settings')}
                   onClick={closeSidebar}
@@ -224,7 +224,7 @@ export function AppShell() {
                   <ul className="mt-0.5 space-y-0.5">
                     <li>
                       <NavItem
-                        to="/navigation"
+                        to="/admin/navigation"
                         icon={<IconLink size={16} />}
                         label={t('admin.nav.navigation')}
                         onClick={closeSidebar}
@@ -262,7 +262,7 @@ export function AppShell() {
                   <ul className="mt-0.5 space-y-0.5">
                     <li>
                       <NavItem
-                        to="/entity-types"
+                        to="/admin/entity-types"
                         icon={<IconLayers size={16} />}
                         label={t('admin.nav.entityTypes')}
                         onClick={closeSidebar}
@@ -270,7 +270,7 @@ export function AppShell() {
                     </li>
                     <li>
                       <NavItem
-                        to="/webhooks"
+                        to="/admin/webhooks"
                         icon={<IconWebhook size={16} />}
                         label={t('admin.nav.webhooks')}
                         onClick={closeSidebar}
@@ -287,7 +287,7 @@ export function AppShell() {
           <ul className="space-y-0.5">
             <li>
               <NavItem
-                to="/view"
+                to="/"
                 icon={<IconGlobe size={16} />}
                 label={t('admin.nav.publicSite')}
                 onClick={closeSidebar}

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -17,7 +17,7 @@ export function LoginPage() {
       { email, password },
       {
         onSuccess: () => {
-          void navigate('/')
+          void navigate('/admin')
         },
       },
     )


### PR DESCRIPTION
## 目的

Phase 1 (#167) で導入した短縮URLを基盤に、管理画面と公開サイトのURL空間を完全に分離する。

## 変更内容

### 管理画面を /admin/ 配下へ
```
変更前: /, /entity-types, /tags, /settings, /posts, /pages ...
変更後: /admin, /admin/entity-types, /admin/tags, /admin/settings, /admin/posts, /admin/pages ...
```

### 公開サイトから /view/ を削除
```
変更前: /view/, /view/posts/my-article
変更後: /, /posts/my-article
```

### ルートのURL整理
- 管理画面ルート: `/` → `/admin`
- 公開サイトルート: `/view` → `/`
- `/login` および `/forbidden` はルート直下のまま維持

### 更新対象コンポーネント (16ファイル)
- `src/app/router.tsx` - ルート構造変更
- `src/pages/layout/AppShell.tsx` - サイドバー全ナビゲーションリンク
- `src/pages/home/HomePage.tsx` - クイックアクセスリンク
- `src/pages/login/LoginPage.tsx` - ログイン後リダイレクト先
- `src/pages/forbidden/ForbiddenPage.tsx` - ホームへのリンク
- `src/pages/entity-records/EntityRecordsPage.tsx` - 新規作成後リダイレクト、パンくずリンク
- `src/pages/entity-record/EntityRecordPage.tsx` - 戻るボタン
- `src/pages/field-defs/FieldDefsPage.tsx` - 戻るボタン
- `src/features/manage-entity-types/ui/EntityTypeListPanel.tsx` - フィールド・コンテンツリンク
- `src/features/manage-entities/ui/EntityListPanel.tsx` - 編集リンク
- `src/features/inverse-entity-relations/ui/InverseRelationPanel.tsx` - ソースレコードリンク
- `src/features/manage-entity-status/ui/EntityStatusPanel.tsx` - 公開URLプレビュー
- `src/pages/consumer/PublicShell.tsx` - ホームリンク
- `src/pages/consumer/PublicBrowsePage.tsx` - 戻るリンク
- `src/pages/consumer/PublicRecordDetailPage.tsx` - 戻るリンク
- `src/features/public-browse-index/ui/PublicEntityTypeListView.tsx` - 一覧リンク
- `src/features/public-browse-entity-records/ui/PublicRecordListView.tsx` - 詳細リンク
- `src/features/public-view-entity-record/hooks/use-public-relation-field-display.ts` - リレーション先リンク

## 検証

- ✅ 全84テスト通過
- ✅ TypeScript型チェック通過
- ✅ ESLint通過
- ✅ Storybook正常ビルド

## チェックリスト

- [x] テスト追加・更新
- [x] 型チェック通過
- [x] Lint通過

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)