### PR TITLE
feat(admin): フッター著作権表示を画面右下に固定表示

### DIFF
--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -348,16 +348,16 @@ export function AppShell() {
       </aside>
 
       {/* ── Main content ────────────────────────────────────────────────── */}
-      <main className="min-w-0 flex-1 pt-14 lg:ml-60 lg:pt-0">
+      <main className="min-w-0 flex-1 pb-8 pt-14 lg:ml-60 lg:pt-0">
         <div className="mx-auto max-w-5xl px-4 py-6 sm:px-6 sm:py-8">
           <Outlet />
         </div>
-        <footer className="border-t border-border px-4 py-3 sm:px-6">
-          <p className="text-center font-sans text-caption text-text-muted">
-            Powered by NENE2 · © 2026 AYANE
-          </p>
-        </footer>
       </main>
+
+      {/* ── Footer (fixed bottom-right) ─────────────────────────────────── */}
+      <footer className="fixed bottom-0 right-0 px-4 py-2">
+        <p className="font-sans text-caption text-text-muted">Powered by NENE2 · © 2026 AYANE</p>
+      </footer>
     </div>
   )
 }

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -356,7 +356,7 @@ export function AppShell() {
 
       {/* ── Footer (fixed bottom-right) ─────────────────────────────────── */}
       <footer className="fixed bottom-0 right-0 px-4 py-2">
-        <p className="font-sans text-caption text-text-muted">Powered by NENE2 · © 2026 AYANE</p>
+        <p className="font-sans text-tiny text-text-muted">Powered by NENE2 · © 2026 AYANE</p>
       </footer>
     </div>
   )

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -356,7 +356,7 @@ export function AppShell() {
 
       {/* ── Footer (fixed bottom-right) ─────────────────────────────────── */}
       <footer className="fixed bottom-0 right-0 pb-3 pl-4 pr-5 pt-2">
-        <p className="font-sans text-tiny text-text-muted">Powered by NENE2 · © 2026 AYANE</p>
+        <p className="font-sans text-caption text-text-muted">Powered by NENE2 · © 2026 AYANE</p>
       </footer>
     </div>
   )

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -355,7 +355,7 @@ export function AppShell() {
       </main>
 
       {/* ── Footer (fixed bottom-right) ─────────────────────────────────── */}
-      <footer className="fixed bottom-0 right-0 px-4 py-2">
+      <footer className="fixed bottom-0 right-0 pb-3 pl-4 pr-5 pt-2">
         <p className="font-sans text-tiny text-text-muted">Powered by NENE2 · © 2026 AYANE</p>
       </footer>
     </div>

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -48,6 +48,7 @@
   /* Tailwind v4 の font-sans ユーティリティが参照する変数を上書き */
   --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
   --font-mono: ui-monospace, 'Cascadia Code', monospace;
+  --font-size-tiny: 0.625rem;
   --font-size-body: 0.875rem;
   --font-size-caption: 0.75rem;
   --font-size-heading-sm: 1.125rem;

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -48,13 +48,15 @@
   /* Tailwind v4 の font-sans ユーティリティが参照する変数を上書き */
   --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
   --font-mono: ui-monospace, 'Cascadia Code', monospace;
-  --font-size-tiny: 0.625rem;
-  --font-size-body: 0.875rem;
-  --font-size-caption: 0.75rem;
-  --font-size-heading-sm: 1.125rem;
-  --font-size-heading-md: 1.5rem;
-  --line-height-body: 1.5;
-  --line-height-heading: 1.25;
+  /* font-size: Tailwind v4 は --text-* 命名規則を使用（--font-size-* は無効） */
+  --text-tiny: 0.625rem;
+  --text-caption: 0.75rem;
+  --text-body: 0.875rem;
+  --text-heading-sm: 1.125rem;
+  --text-heading-md: 1.5rem;
+  /* line-height: Tailwind v4 は --leading-* 命名規則を使用（--line-height-* は無効） */
+  --leading-body: 1.5;
+  --leading-heading: 1.25;
   --font-weight-normal: 400;
   --font-weight-medium: 500;
   --font-weight-semibold: 600;
@@ -81,9 +83,4 @@
   --z-dropdown: 100;
   --z-modal: 200;
   --z-toast: 300;
-}
-
-@utility text-tiny {
-  font-size: 0.625rem;
-  line-height: 1.25;
 }

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -82,3 +82,8 @@
   --z-modal: 200;
   --z-toast: 300;
 }
+
+@utility text-tiny {
+  font-size: 0.625rem;
+  line-height: 1.25;
+}


### PR DESCRIPTION
## 変更内容
- `<footer>` を `fixed bottom-0 right-0` に変更
- スクロール位置によらず常に画面右下に表示
- `main` に `pb-8` を追加してコンテンツとの重なりを防止

## 確認
- [x] `npm run check` — 全テスト通過

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)