### PR TITLE
feat(admin): 管理画面テーマセレクター（Default/GitHub/Solarized/Dracula/Monokai）

### DIFF
--- a/frontend/src/features/manage-appearance/index.ts
+++ b/frontend/src/features/manage-appearance/index.ts
@@ -1,0 +1,1 @@
+export { AppearanceView } from './ui/AppearanceView'

--- a/frontend/src/features/manage-appearance/ui/AppearanceView.tsx
+++ b/frontend/src/features/manage-appearance/ui/AppearanceView.tsx
@@ -1,0 +1,119 @@
+import { useTheme } from '@/shared/theme'
+import { ADMIN_THEME_DEFS, type ThemeVariant } from '@/shared/theme'
+import { useTranslation } from '@/shared/i18n'
+import { Stack, Text } from '@/shared/ui'
+import { IconSun, IconMoon } from '@/shared/ui/icons/Icons'
+
+interface ThemePreviewProps {
+  surface: string
+  sidebar: string
+  accent: string
+}
+
+function ThemePreview({ surface, sidebar, accent }: ThemePreviewProps) {
+  return (
+    <div className="flex h-14 overflow-hidden rounded-t-md border-b border-border">
+      {/* Sidebar strip */}
+      <div className="w-8 shrink-0" style={{ backgroundColor: sidebar }}>
+        <div
+          className="mx-auto mt-2 h-1 w-4 rounded-full opacity-60"
+          style={{ backgroundColor: accent }}
+        />
+        <div
+          className="mx-auto mt-1 h-1 w-4 rounded-full opacity-30"
+          style={{ backgroundColor: accent }}
+        />
+        <div
+          className="mx-auto mt-1 h-1 w-4 rounded-full opacity-30"
+          style={{ backgroundColor: accent }}
+        />
+      </div>
+      {/* Main area */}
+      <div className="flex-1 p-2" style={{ backgroundColor: surface }}>
+        <div className="mb-1.5 h-1.5 w-12 rounded-full" style={{ backgroundColor: accent }} />
+        <div
+          className="mb-1 h-1 w-full rounded-full opacity-20"
+          style={{ backgroundColor: sidebar }}
+        />
+        <div className="h-1 w-3/4 rounded-full opacity-20" style={{ backgroundColor: sidebar }} />
+      </div>
+    </div>
+  )
+}
+
+export function AppearanceView() {
+  const { t } = useTranslation()
+  const { adminThemeId, themeVariant, setAdminTheme } = useTheme()
+
+  return (
+    <Stack gap="sm">
+      <Text variant="heading-sm">{t('admin.settings.appearance.title')}</Text>
+      <div className="grid grid-cols-2 gap-stack-sm sm:grid-cols-3 lg:grid-cols-5">
+        {ADMIN_THEME_DEFS.map((def) => {
+          const isSelected = def.id === adminThemeId
+          // カード表示には現在のバリアントを優先、未選択テーマはデフォルトバリアントのプレビューを表示
+          const displayVariant: ThemeVariant = isSelected
+            ? themeVariant
+            : (def.variants[0] as ThemeVariant)
+          const previewColors = def.preview[displayVariant]
+
+          return (
+            <div
+              key={def.id}
+              role="button"
+              tabIndex={0}
+              aria-pressed={isSelected}
+              onClick={() => {
+                setAdminTheme(def.id)
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  setAdminTheme(def.id)
+                }
+              }}
+              className={[
+                'cursor-pointer rounded-md border-2 transition-colors duration-fast focus-visible:outline-none focus-visible:shadow-focus',
+                isSelected ? 'border-accent' : 'border-border hover:border-accent',
+              ].join(' ')}
+            >
+              {/* カラープレビュー */}
+              {previewColors !== undefined ? (
+                <ThemePreview
+                  surface={previewColors.surface}
+                  sidebar={previewColors.sidebar}
+                  accent={previewColors.accent}
+                />
+              ) : null}
+
+              {/* テーマ名 + バリアントトグル */}
+              <div className="flex items-center justify-between px-inline-sm py-stack-xs">
+                <Text as="span" variant="caption">
+                  {def.name}
+                </Text>
+                {isSelected && def.variants.length > 1 ? (
+                  <button
+                    type="button"
+                    aria-label={
+                      themeVariant === 'dark'
+                        ? t('admin.theme.toggleLight')
+                        : t('admin.theme.toggleDark')
+                    }
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      const next: ThemeVariant = themeVariant === 'light' ? 'dark' : 'light'
+                      setAdminTheme(def.id, next)
+                    }}
+                    className="flex items-center justify-center rounded p-0.5 text-text-muted transition-colors hover:text-text-primary"
+                  >
+                    {themeVariant === 'dark' ? <IconSun size={13} /> : <IconMoon size={13} />}
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </Stack>
+  )
+}

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -54,7 +54,7 @@ function NavItem({ to, end, icon, label, onClick }: NavItemProps) {
 export function AppShell() {
   const navigate = useNavigate()
   const { t, locale, setLocale } = useTranslation()
-  const { theme, toggleTheme } = useTheme()
+  const { themeVariant, toggleVariant, canToggleVariant } = useTheme()
   const [sidebarOpen, setSidebarOpen] = useState(false)
 
   // Prevent body scroll when drawer is open
@@ -321,17 +321,21 @@ export function AppShell() {
               ))}
             </select>
 
-            {/* Theme toggle */}
-            <button
-              type="button"
-              onClick={toggleTheme}
-              aria-label={
-                theme === 'dark' ? t('admin.theme.toggleLight') : t('admin.theme.toggleDark')
-              }
-              className="flex shrink-0 items-center justify-center rounded-md border border-sidebar-border bg-sidebar-active-bg p-1.5 text-sidebar-text transition-colors hover:bg-sidebar-hover-bg hover:text-sidebar-active-text"
-            >
-              {theme === 'dark' ? <IconSun size={15} /> : <IconMoon size={15} />}
-            </button>
+            {/* Theme toggle — both variants available のみ表示 */}
+            {canToggleVariant ? (
+              <button
+                type="button"
+                onClick={toggleVariant}
+                aria-label={
+                  themeVariant === 'dark'
+                    ? t('admin.theme.toggleLight')
+                    : t('admin.theme.toggleDark')
+                }
+                className="flex shrink-0 items-center justify-center rounded-md border border-sidebar-border bg-sidebar-active-bg p-1.5 text-sidebar-text transition-colors hover:bg-sidebar-hover-bg hover:text-sidebar-active-text"
+              >
+                {themeVariant === 'dark' ? <IconSun size={15} /> : <IconMoon size={15} />}
+              </button>
+            ) : null}
 
             {/* Logout */}
             <button

--- a/frontend/src/pages/settings/SiteSettingsPage.tsx
+++ b/frontend/src/pages/settings/SiteSettingsPage.tsx
@@ -1,4 +1,5 @@
 import { ManageSiteSettingsView } from '@/features/manage-settings'
+import { AppearanceView } from '@/features/manage-appearance'
 import { currentUserHasCapability } from '@/entities/auth'
 import { useTranslation } from '@/shared/i18n'
 import { Stack, Text } from '@/shared/ui'
@@ -7,11 +8,14 @@ export function SiteSettingsPage() {
   const { t } = useTranslation()
   const canManageSettings = currentUserHasCapability('manage_settings')
   return (
-    <Stack gap="md">
-      <Text as="h1" variant="heading-md">
-        {t('admin.settings.pageTitle')}
-      </Text>
-      <Text muted>{t('admin.settings.description')}</Text>
+    <Stack gap="lg">
+      <Stack gap="xs">
+        <Text as="h1" variant="heading-md">
+          {t('admin.settings.pageTitle')}
+        </Text>
+        <Text muted>{t('admin.settings.description')}</Text>
+      </Stack>
+      <AppearanceView />
       <ManageSiteSettingsView canManageSettings={canManageSettings} />
     </Stack>
   )

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -334,6 +334,8 @@ export const en = {
   'admin.entitySeo.saveSuccess': 'SEO settings saved.',
 
   // ── Settings ──────────────────────────────────────────────────────────────
+  'admin.settings.appearance.title': 'Appearance',
+
   'admin.settings.pageTitle': 'Site settings',
   'admin.settings.description':
     'Configure site name, tagline, default meta description, and footer content for public pages.',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -335,6 +335,8 @@ export const ja: Partial<MessageCatalog> = {
   'admin.entitySeo.saveSuccess': 'SEO 設定を保存しました。',
 
   // ── Settings ──────────────────────────────────────────────────────────────
+  'admin.settings.appearance.title': '外観',
+
   'admin.settings.pageTitle': 'サイト設定',
   'admin.settings.description':
     'パブリックページのサイト名、タグライン、デフォルトメタ説明、フッターコンテンツを設定します。',

--- a/frontend/src/shared/theme/admin-theme-config.ts
+++ b/frontend/src/shared/theme/admin-theme-config.ts
@@ -1,0 +1,75 @@
+export type AdminThemeId = 'default' | 'github' | 'solarized' | 'dracula' | 'monokai'
+export type ThemeVariant = 'light' | 'dark'
+
+export interface ThemePreviewColors {
+  surface: string
+  sidebar: string
+  accent: string
+}
+
+export interface AdminThemeDef {
+  readonly id: AdminThemeId
+  readonly name: string
+  readonly variants: readonly ThemeVariant[]
+  readonly preview: Partial<Record<ThemeVariant, ThemePreviewColors>>
+}
+
+export const ADMIN_THEME_DEFS: readonly AdminThemeDef[] = [
+  {
+    id: 'default',
+    name: 'Default',
+    variants: ['light', 'dark'],
+    preview: {
+      light: { surface: '#f7f3ee', sidebar: '#2d3147', accent: '#c8820a' },
+      dark: { surface: '#1a1d2e', sidebar: '#10121f', accent: '#d4970e' },
+    },
+  },
+  {
+    id: 'github',
+    name: 'GitHub',
+    variants: ['light', 'dark'],
+    preview: {
+      light: { surface: '#ffffff', sidebar: '#24292f', accent: '#0969da' },
+      dark: { surface: '#0d1117', sidebar: '#010409', accent: '#58a6ff' },
+    },
+  },
+  {
+    id: 'solarized',
+    name: 'Solarized',
+    variants: ['light', 'dark'],
+    preview: {
+      light: { surface: '#fdf6e3', sidebar: '#073642', accent: '#2aa198' },
+      dark: { surface: '#002b36', sidebar: '#001f29', accent: '#2aa198' },
+    },
+  },
+  {
+    id: 'dracula',
+    name: 'Dracula',
+    variants: ['dark'],
+    preview: {
+      dark: { surface: '#282a36', sidebar: '#21222c', accent: '#bd93f9' },
+    },
+  },
+  {
+    id: 'monokai',
+    name: 'Monokai',
+    variants: ['dark'],
+    preview: {
+      dark: { surface: '#272822', sidebar: '#1e1e1c', accent: '#a6e22e' },
+    },
+  },
+] as const
+
+export function getDataAttr(id: AdminThemeId, variant: ThemeVariant): string {
+  return `${id}-${variant}`
+}
+
+export function getDefaultVariant(id: AdminThemeId): ThemeVariant {
+  const def = ADMIN_THEME_DEFS.find((t) => t.id === id)
+  if (def?.variants.includes('light')) return 'light'
+  return 'dark'
+}
+
+export function canToggleVariant(id: AdminThemeId): boolean {
+  return (ADMIN_THEME_DEFS.find((t) => t.id === id)?.variants.length ?? 0) > 1
+}

--- a/frontend/src/shared/theme/index.ts
+++ b/frontend/src/shared/theme/index.ts
@@ -1,3 +1,4 @@
 export { ThemeProvider } from './theme-context'
-export type { Theme } from './theme-context'
+export type { AdminThemeId, ThemeVariant, ThemeContextValue } from './theme-context'
+export { ADMIN_THEME_DEFS, canToggleVariant } from './admin-theme-config'
 export { useTheme } from './use-theme'

--- a/frontend/src/shared/theme/theme-context.tsx
+++ b/frontend/src/shared/theme/theme-context.tsx
@@ -1,54 +1,106 @@
 import { createContext, useCallback, useEffect, useState, type ReactNode } from 'react'
+import {
+  ADMIN_THEME_DEFS,
+  canToggleVariant,
+  getDataAttr,
+  getDefaultVariant,
+  type AdminThemeId,
+  type ThemeVariant,
+} from './admin-theme-config'
 
-export type Theme = 'light' | 'dark'
+export type { AdminThemeId, ThemeVariant }
 
-interface ThemeContextValue {
-  theme: Theme
-  setTheme: (theme: Theme) => void
-  toggleTheme: () => void
+export interface ThemeContextValue {
+  adminThemeId: AdminThemeId
+  themeVariant: ThemeVariant
+  setAdminTheme: (id: AdminThemeId, variant?: ThemeVariant) => void
+  toggleVariant: () => void
+  canToggleVariant: boolean
 }
 
 const ThemeContext = createContext<ThemeContextValue | null>(null)
 
-const STORAGE_KEY = 'nene-theme'
+const STORAGE_KEY = 'nene-admin-theme'
+const LEGACY_STORAGE_KEY = 'nene-theme'
 
-function detectTheme(): Theme {
+function detectTheme(): { id: AdminThemeId; variant: ThemeVariant } {
   try {
     const stored = localStorage.getItem(STORAGE_KEY)
-    if (stored === 'dark' || stored === 'light') return stored
+    if (stored !== null) {
+      const lastDash = stored.lastIndexOf('-')
+      if (lastDash > 0) {
+        const id = stored.slice(0, lastDash) as AdminThemeId
+        const variant = stored.slice(lastDash + 1) as ThemeVariant
+        const def = ADMIN_THEME_DEFS.find((t) => t.id === id)
+        if (def !== undefined && (def.variants as readonly string[]).includes(variant)) {
+          return { id, variant }
+        }
+      }
+    }
+    // 旧キー (nene-theme) からマイグレーション
+    const legacy = localStorage.getItem(LEGACY_STORAGE_KEY)
+    if (legacy === 'dark') return { id: 'default', variant: 'dark' }
+    if (legacy === 'light') return { id: 'default', variant: 'light' }
   } catch {
     // localStorage blocked
   }
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+  return { id: 'default', variant: prefersDark ? 'dark' : 'light' }
 }
 
-function applyTheme(theme: Theme): void {
-  document.documentElement.setAttribute('data-theme', theme)
+function applyTheme(id: AdminThemeId, variant: ThemeVariant): void {
+  document.documentElement.setAttribute('data-admin-theme', getDataAttr(id, variant))
+  document.documentElement.removeAttribute('data-theme')
+}
+
+function saveTheme(id: AdminThemeId, variant: ThemeVariant): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, getDataAttr(id, variant))
+  } catch {
+    // ignore
+  }
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>(detectTheme)
+  const [{ id, variant }, setState] = useState<{ id: AdminThemeId; variant: ThemeVariant }>(
+    detectTheme,
+  )
 
-  const setTheme = useCallback((next: Theme) => {
-    try {
-      localStorage.setItem(STORAGE_KEY, next)
-    } catch {
-      // ignore
-    }
-    setThemeState(next)
-    applyTheme(next)
+  const setAdminTheme = useCallback((newId: AdminThemeId, newVariant?: ThemeVariant) => {
+    const def = ADMIN_THEME_DEFS.find((t) => t.id === newId)
+    const resolvedVariant: ThemeVariant =
+      def !== undefined &&
+      newVariant !== undefined &&
+      (def.variants as readonly string[]).includes(newVariant)
+        ? newVariant
+        : getDefaultVariant(newId)
+    setState({ id: newId, variant: resolvedVariant })
+    applyTheme(newId, resolvedVariant)
+    saveTheme(newId, resolvedVariant)
   }, [])
 
-  const toggleTheme = useCallback(() => {
-    setTheme(theme === 'light' ? 'dark' : 'light')
-  }, [theme, setTheme])
+  const toggleVariant = useCallback(() => {
+    if (!canToggleVariant(id)) return
+    const next: ThemeVariant = variant === 'light' ? 'dark' : 'light'
+    setState({ id, variant: next })
+    applyTheme(id, next)
+    saveTheme(id, next)
+  }, [id, variant])
 
   useEffect(() => {
-    applyTheme(theme)
-  }, [theme])
+    applyTheme(id, variant)
+  }, [id, variant])
 
   return (
-    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+    <ThemeContext.Provider
+      value={{
+        adminThemeId: id,
+        themeVariant: variant,
+        setAdminTheme,
+        toggleVariant,
+        canToggleVariant: canToggleVariant(id),
+      }}
+    >
       {children}
     </ThemeContext.Provider>
   )

--- a/frontend/src/shared/ui/theme/active.css
+++ b/frontend/src/shared/ui/theme/active.css
@@ -1,2 +1,3 @@
 @import './themes/default.css';
 @import './themes/dark.css';
+@import './themes/admin-themes.css';

--- a/frontend/src/shared/ui/theme/themes/admin-themes.css
+++ b/frontend/src/shared/ui/theme/themes/admin-themes.css
@@ -1,0 +1,197 @@
+/* ============================================================
+   Admin Theme Overrides
+   セレクター形式: [data-admin-theme='{id}-{variant}']
+   Default Light は @theme のデフォルト値をそのまま使用（上書き不要）
+   ============================================================ */
+
+/* ── GitHub Light ─────────────────────────────────────────── */
+[data-admin-theme='github-light'] {
+  --color-surface: oklch(100% 0 0);
+  --color-surface-raised: oklch(100% 0 0);
+  --color-surface-overlay: oklch(97% 0.005 240);
+
+  --color-sidebar-bg: oklch(20% 0.015 250);
+  --color-sidebar-text: oklch(92% 0.01 240);
+  --color-sidebar-text-muted: oklch(62% 0.015 240);
+  --color-sidebar-active-bg: oklch(26% 0.015 250);
+  --color-sidebar-active-text: oklch(96% 0.007 240);
+  --color-sidebar-hover-bg: oklch(22% 0.015 250);
+  --color-sidebar-border: oklch(26% 0.015 250);
+
+  --color-text-primary: oklch(18% 0.01 265);
+  --color-text-muted: oklch(46% 0.015 250);
+  --color-text-inverse: oklch(99% 0 0);
+
+  --color-border: oklch(86% 0.01 230);
+
+  --color-accent: oklch(46% 0.21 248);
+  --color-accent-hover: oklch(40% 0.21 248);
+
+  --color-danger: oklch(47% 0.21 25);
+  --color-danger-hover: oklch(41% 0.21 25);
+
+  --color-focus-ring: oklch(60% 0.18 248);
+
+  --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.06);
+  --shadow-md: 0 4px 12px oklch(0% 0 0 / 0.08);
+}
+
+/* ── GitHub Dark ──────────────────────────────────────────── */
+[data-admin-theme='github-dark'] {
+  --color-surface: oklch(9% 0.01 265);
+  --color-surface-raised: oklch(13% 0.015 265);
+  --color-surface-overlay: oklch(16% 0.015 265);
+
+  --color-sidebar-bg: oklch(5% 0.01 265);
+  --color-sidebar-text: oklch(62% 0.015 240);
+  --color-sidebar-text-muted: oklch(42% 0.015 250);
+  --color-sidebar-active-bg: oklch(18% 0.015 265);
+  --color-sidebar-active-text: oklch(96% 0.007 240);
+  --color-sidebar-hover-bg: oklch(13% 0.015 265);
+  --color-sidebar-border: oklch(18% 0.015 265);
+
+  --color-text-primary: oklch(92% 0.01 240);
+  --color-text-muted: oklch(62% 0.015 240);
+  --color-text-inverse: oklch(10% 0.01 265);
+
+  --color-border: oklch(26% 0.015 250);
+
+  --color-accent: oklch(66% 0.17 250);
+  --color-accent-hover: oklch(72% 0.17 250);
+
+  --color-danger: oklch(58% 0.22 25);
+  --color-danger-hover: oklch(64% 0.22 25);
+
+  --color-focus-ring: oklch(66% 0.17 250);
+
+  --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.3);
+  --shadow-md: 0 4px 12px oklch(0% 0 0 / 0.5);
+}
+
+/* ── Solarized Light ──────────────────────────────────────── */
+[data-admin-theme='solarized-light'] {
+  --color-surface: oklch(97% 0.03 88);
+  --color-surface-raised: oklch(92% 0.025 88);
+  --color-surface-overlay: oklch(89% 0.025 88);
+
+  --color-sidebar-bg: oklch(22% 0.05 215);
+  --color-sidebar-text: oklch(60% 0.03 200);
+  --color-sidebar-text-muted: oklch(46% 0.04 210);
+  --color-sidebar-active-bg: oklch(30% 0.05 215);
+  --color-sidebar-active-text: oklch(66% 0.025 200);
+  --color-sidebar-hover-bg: oklch(26% 0.05 215);
+  --color-sidebar-border: oklch(30% 0.05 215);
+
+  --color-text-primary: oklch(46% 0.04 210);
+  --color-text-muted: oklch(66% 0.025 200);
+  --color-text-inverse: oklch(97% 0.03 88);
+
+  --color-border: oklch(83% 0.04 88);
+
+  --color-accent: oklch(62% 0.11 185);
+  --color-accent-hover: oklch(56% 0.11 185);
+
+  --color-danger: oklch(52% 0.2 25);
+  --color-danger-hover: oklch(46% 0.2 25);
+
+  --color-focus-ring: oklch(62% 0.11 185);
+
+  --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.06);
+  --shadow-md: 0 4px 12px oklch(0% 0 0 / 0.08);
+}
+
+/* ── Solarized Dark ───────────────────────────────────────── */
+[data-admin-theme='solarized-dark'] {
+  --color-surface: oklch(15% 0.05 215);
+  --color-surface-raised: oklch(22% 0.05 215);
+  --color-surface-overlay: oklch(26% 0.06 215);
+
+  --color-sidebar-bg: oklch(12% 0.05 215);
+  --color-sidebar-text: oklch(60% 0.03 200);
+  --color-sidebar-text-muted: oklch(46% 0.04 210);
+  --color-sidebar-active-bg: oklch(22% 0.05 215);
+  --color-sidebar-active-text: oklch(66% 0.025 200);
+  --color-sidebar-hover-bg: oklch(15% 0.05 215);
+  --color-sidebar-border: oklch(22% 0.05 215);
+
+  --color-text-primary: oklch(60% 0.03 200);
+  --color-text-muted: oklch(46% 0.04 210);
+  --color-text-inverse: oklch(15% 0.05 215);
+
+  --color-border: oklch(26% 0.05 215);
+
+  --color-accent: oklch(62% 0.11 185);
+  --color-accent-hover: oklch(68% 0.11 185);
+
+  --color-danger: oklch(58% 0.22 25);
+  --color-danger-hover: oklch(64% 0.22 25);
+
+  --color-focus-ring: oklch(62% 0.11 185);
+
+  --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.3);
+  --shadow-md: 0 4px 12px oklch(0% 0 0 / 0.5);
+}
+
+/* ── Dracula (dark only) ──────────────────────────────────── */
+[data-admin-theme='dracula-dark'] {
+  --color-surface: oklch(20% 0.03 280);
+  --color-surface-raised: oklch(16% 0.025 275);
+  --color-surface-overlay: oklch(32% 0.04 275);
+
+  --color-sidebar-bg: oklch(16% 0.025 275);
+  --color-sidebar-text: oklch(97% 0.005 60);
+  --color-sidebar-text-muted: oklch(48% 0.08 270);
+  --color-sidebar-active-bg: oklch(32% 0.04 275);
+  --color-sidebar-active-text: oklch(97% 0.005 60);
+  --color-sidebar-hover-bg: oklch(27% 0.035 278);
+  --color-sidebar-border: oklch(32% 0.04 275);
+
+  --color-text-primary: oklch(97% 0.005 60);
+  --color-text-muted: oklch(48% 0.08 270);
+  --color-text-inverse: oklch(20% 0.03 280);
+
+  --color-border: oklch(32% 0.04 275);
+
+  --color-accent: oklch(72% 0.18 295);
+  --color-accent-hover: oklch(78% 0.18 295);
+
+  --color-danger: oklch(65% 0.22 25);
+  --color-danger-hover: oklch(71% 0.22 25);
+
+  --color-focus-ring: oklch(72% 0.18 295);
+
+  --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.3);
+  --shadow-md: 0 4px 12px oklch(0% 0 0 / 0.5);
+}
+
+/* ── Monokai (dark only) ──────────────────────────────────── */
+[data-admin-theme='monokai-dark'] {
+  --color-surface: oklch(19% 0.015 120);
+  --color-surface-raised: oklch(28% 0.015 95);
+  --color-surface-overlay: oklch(32% 0.015 95);
+
+  --color-sidebar-bg: oklch(14% 0.01 95);
+  --color-sidebar-text: oklch(97% 0.005 60);
+  --color-sidebar-text-muted: oklch(49% 0.03 85);
+  --color-sidebar-active-bg: oklch(32% 0.015 95);
+  --color-sidebar-active-text: oklch(84% 0.2 127);
+  --color-sidebar-hover-bg: oklch(28% 0.015 95);
+  --color-sidebar-border: oklch(32% 0.015 95);
+
+  --color-text-primary: oklch(97% 0.005 60);
+  --color-text-muted: oklch(49% 0.03 85);
+  --color-text-inverse: oklch(19% 0.015 120);
+
+  --color-border: oklch(32% 0.015 95);
+
+  --color-accent: oklch(84% 0.2 127);
+  --color-accent-hover: oklch(78% 0.2 127);
+
+  --color-danger: oklch(58% 0.22 355);
+  --color-danger-hover: oklch(64% 0.22 355);
+
+  --color-focus-ring: oklch(84% 0.2 127);
+
+  --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.3);
+  --shadow-md: 0 4px 12px oklch(0% 0 0 / 0.5);
+}

--- a/frontend/src/shared/ui/theme/themes/dark.css
+++ b/frontend/src/shared/ui/theme/themes/dark.css
@@ -1,5 +1,5 @@
-/* Dark theme overrides — applied when <html data-theme="dark"> */
-[data-theme='dark'] {
+/* Default Dark — applied when <html data-admin-theme="default-dark"> */
+[data-admin-theme='default-dark'] {
   /* ── Surfaces ──────────────────────────────────────────────────────────── */
   --color-surface: oklch(13% 0.01 265);
   --color-surface-raised: oklch(17% 0.01 265);


### PR DESCRIPTION
## 概要
設定ページ (/admin/settings) にテーマセレクターを追加。5テーマ・最大2バリアントから選択可能。

## テーマ一覧
| テーマ | Light | Dark |
|---|---|---|
| Default | ✅ | ✅ |
| GitHub | ✅ | ✅ |
| Solarized | ✅ | ✅ |
| Dracula | — | ✅ のみ |
| Monokai | — | ✅ のみ |

## 主な変更
- `admin-theme-config.ts`: テーマ定義（ID・名前・バリアント・プレビューカラー）
- `theme-context.tsx`: 多テーマ対応（`data-admin-theme="github-dark"` 形式）・旧キー自動マイグレーション
- `admin-themes.css`: 全テーマの CSS カスタムプロパティ上書き
- `AppearanceView.tsx`: ミニプレビュー付きカード型テーマピッカー
- `AppShell.tsx`: Dark のみテーマ選択時は Light/Dark トグルを非表示

## 確認
- [x] `npm run check` — 21 test files, 84 tests passed

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)