### PR TITLE
feat(editor): posts/pages body を markdown 型に変更・Markdown エディター改善

### DIFF
--- a/database/migrations/20260605000000_change_body_to_markdown_for_blog_posts_pages.php
+++ b/database/migrations/20260605000000_change_body_to_markdown_for_blog_posts_pages.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class ChangeBodyToMarkdownForBlogPostsPages extends AbstractMigration
+{
+    public function up(): void
+    {
+        // blog / posts / pages エンティティタイプの body フィールドを
+        // text → markdown 型に変更する
+        // entity_type_id: blog=2, posts=5, pages=6 (デフォルトシード値)
+        $this->execute(
+            "UPDATE field_defs
+             SET data_type = 'markdown'
+             WHERE field_key = 'body'
+               AND data_type = 'text'
+               AND entity_type_id IN (
+                   SELECT id FROM entity_types WHERE slug IN ('blog', 'posts', 'pages')
+               )"
+        );
+    }
+
+    public function down(): void
+    {
+        $this->execute(
+            "UPDATE field_defs
+             SET data_type = 'text'
+             WHERE field_key = 'body'
+               AND data_type = 'markdown'
+               AND entity_type_id IN (
+                   SELECT id FROM entity_types WHERE slug IN ('blog', 'posts', 'pages')
+               )"
+        );
+    }
+}

--- a/frontend/src/features/edit-entity-text-fields/ui/MarkdownFieldInput.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/MarkdownFieldInput.tsx
@@ -1,8 +1,7 @@
-import { useState } from 'react'
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
+import { useCallback, useRef, useState } from 'react'
 import { useTranslation } from '@/shared/i18n'
 import { Stack, Text } from '@/shared/ui'
+import { PublicMarkdownContent } from '@/shared/ui/markdown/PublicMarkdownContent'
 
 interface MarkdownFieldInputProps {
   id: string
@@ -11,6 +10,109 @@ interface MarkdownFieldInputProps {
   disabled: boolean
   onChange: (value: string) => void
 }
+
+interface ToolbarAction {
+  label: string
+  icon: string
+  action: (value: string, selStart: number, selEnd: number) => { text: string; cursor: number }
+}
+
+const TOOLBAR_ACTIONS: ToolbarAction[] = [
+  {
+    label: 'Bold',
+    icon: 'B',
+    action: (v, s, e) => {
+      const sel = v.slice(s, e) || 'テキスト'
+      return { text: v.slice(0, s) + `**${sel}**` + v.slice(e), cursor: s + sel.length + 4 }
+    },
+  },
+  {
+    label: 'Italic',
+    icon: 'I',
+    action: (v, s, e) => {
+      const sel = v.slice(s, e) || 'テキスト'
+      return { text: v.slice(0, s) + `*${sel}*` + v.slice(e), cursor: s + sel.length + 2 }
+    },
+  },
+  {
+    label: 'H2',
+    icon: 'H2',
+    action: (v, s, e) => {
+      const lineStart = v.lastIndexOf('\n', s - 1) + 1
+      const line = v.slice(lineStart, e) || 'Heading'
+      const before = v.slice(0, lineStart)
+      const after = v.slice(e)
+      const heading = line.startsWith('## ') ? line.slice(3) : `## ${line.replace(/^#+\s*/, '')}`
+      return { text: before + heading + after, cursor: lineStart + heading.length }
+    },
+  },
+  {
+    label: 'H3',
+    icon: 'H3',
+    action: (v, s, e) => {
+      const lineStart = v.lastIndexOf('\n', s - 1) + 1
+      const line = v.slice(lineStart, e) || 'Heading'
+      const before = v.slice(0, lineStart)
+      const after = v.slice(e)
+      const heading = line.startsWith('### ') ? line.slice(4) : `### ${line.replace(/^#+\s*/, '')}`
+      return { text: before + heading + after, cursor: lineStart + heading.length }
+    },
+  },
+  {
+    label: 'Unordered list',
+    icon: '≡',
+    action: (v, s) => {
+      const lineStart = v.lastIndexOf('\n', s - 1) + 1
+      const ins = '- '
+      return {
+        text: v.slice(0, lineStart) + ins + v.slice(lineStart),
+        cursor: s + ins.length,
+      }
+    },
+  },
+  {
+    label: 'Ordered list',
+    icon: '1.',
+    action: (v, s) => {
+      const lineStart = v.lastIndexOf('\n', s - 1) + 1
+      const ins = '1. '
+      return {
+        text: v.slice(0, lineStart) + ins + v.slice(lineStart),
+        cursor: s + ins.length,
+      }
+    },
+  },
+  {
+    label: 'Link',
+    icon: '🔗',
+    action: (v, s, e) => {
+      const sel = v.slice(s, e) || 'リンクテキスト'
+      const snippet = `[${sel}](url)`
+      return { text: v.slice(0, s) + snippet + v.slice(e), cursor: s + sel.length + 3 }
+    },
+  },
+  {
+    label: 'Code block',
+    icon: '</>',
+    action: (v, s, e) => {
+      const sel = v.slice(s, e) || 'code'
+      const snippet = `\`\`\`\n${sel}\n\`\`\``
+      return { text: v.slice(0, s) + snippet + v.slice(e), cursor: s + 4 + sel.length }
+    },
+  },
+  {
+    label: 'Blockquote',
+    icon: '❝',
+    action: (v, s) => {
+      const lineStart = v.lastIndexOf('\n', s - 1) + 1
+      const ins = '> '
+      return {
+        text: v.slice(0, lineStart) + ins + v.slice(lineStart),
+        cursor: s + ins.length,
+      }
+    },
+  },
+]
 
 export function MarkdownFieldInput({
   id,
@@ -21,6 +123,31 @@ export function MarkdownFieldInput({
 }: MarkdownFieldInputProps) {
   const { t } = useTranslation()
   const [tab, setTab] = useState<'write' | 'preview'>('write')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const applyToolbar = useCallback(
+    (action: ToolbarAction) => {
+      const ta = textareaRef.current
+      if (ta === null) return
+      const s = ta.selectionStart
+      const e = ta.selectionEnd
+      const { text, cursor } = action.action(value, s, e)
+      onChange(text)
+      requestAnimationFrame(() => {
+        ta.focus()
+        ta.setSelectionRange(cursor, cursor)
+      })
+    },
+    [value, onChange],
+  )
+
+  const tabClass = (active: boolean) =>
+    [
+      'pb-1.5 font-sans text-caption font-medium transition-colors focus-visible:outline-none',
+      active
+        ? 'border-b-2 border-accent text-text-primary'
+        : 'text-text-muted hover:text-text-primary',
+    ].join(' ')
 
   return (
     <Stack gap="xs">
@@ -28,62 +155,77 @@ export function MarkdownFieldInput({
         {label}
       </label>
 
-      {/* Tab bar */}
-      <div className="flex gap-inline-sm border-b border-border">
-        <button
-          type="button"
-          onClick={() => {
-            setTab('write')
-          }}
-          className={`pb-1 text-sm font-medium transition-colors focus-visible:outline-none ${
-            tab === 'write'
-              ? 'border-b-2 border-blue-500 text-text-primary'
-              : 'text-text-muted hover:text-text-primary'
-          }`}
-        >
-          {t('admin.markdownEditor.write')}
-        </button>
-        <button
-          type="button"
-          onClick={() => {
-            setTab('preview')
-          }}
-          className={`pb-1 text-sm font-medium transition-colors focus-visible:outline-none ${
-            tab === 'preview'
-              ? 'border-b-2 border-blue-500 text-text-primary'
-              : 'text-text-muted hover:text-text-primary'
-          }`}
-        >
-          {t('admin.markdownEditor.preview')}
-        </button>
-      </div>
-
-      {/* Write pane */}
-      {tab === 'write' && (
-        <textarea
-          id={id}
-          value={value}
-          disabled={disabled}
-          rows={10}
-          onChange={(e) => {
-            onChange(e.target.value)
-          }}
-          className="w-full rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm font-mono text-sm text-text-primary shadow-sm focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-50"
-        />
-      )}
-
-      {/* Preview pane */}
-      {tab === 'preview' && (
-        <div className="min-h-40 rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm shadow-sm">
-          {value.trim() === '' ? (
-            <Text muted>{t('admin.markdownEditor.empty')}</Text>
-          ) : (
-            <div className="prose prose-sm max-w-none text-text-primary">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{value}</ReactMarkdown>
-            </div>
-          )}
+      <div className="rounded-md border border-border shadow-sm">
+        {/* ── Tab bar ── */}
+        <div className="flex items-center justify-between border-b border-border px-inline-sm">
+          <div className="flex gap-inline-md">
+            <button
+              type="button"
+              onClick={() => {
+                setTab('write')
+              }}
+              className={tabClass(tab === 'write')}
+            >
+              {t('admin.markdownEditor.write')}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setTab('preview')
+              }}
+              className={tabClass(tab === 'preview')}
+            >
+              {t('admin.markdownEditor.preview')}
+            </button>
+          </div>
         </div>
-      )}
+
+        {/* ── Toolbar (write モードのみ) ── */}
+        {tab === 'write' && (
+          <div className="flex flex-wrap gap-0.5 border-b border-border bg-surface-overlay px-inline-sm py-stack-xs">
+            {TOOLBAR_ACTIONS.map((action) => (
+              <button
+                key={action.label}
+                type="button"
+                title={action.label}
+                disabled={disabled}
+                onClick={() => {
+                  applyToolbar(action)
+                }}
+                className="flex w-8 items-center justify-center rounded px-1.5 py-0.5 font-mono text-caption text-text-muted transition-colors hover:bg-surface-raised hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {action.icon}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* ── Write pane ── */}
+        {tab === 'write' && (
+          <textarea
+            ref={textareaRef}
+            id={id}
+            value={value}
+            disabled={disabled}
+            rows={16}
+            onChange={(e) => {
+              onChange(e.target.value)
+            }}
+            className="w-full rounded-b-md bg-surface-raised px-inline-md py-stack-sm font-mono text-body text-text-primary focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+          />
+        )}
+
+        {/* ── Preview pane ── */}
+        {tab === 'preview' && (
+          <div className="min-h-64 rounded-b-md bg-surface-raised px-inline-md py-stack-sm">
+            {value.trim() === '' ? (
+              <Text muted>{t('admin.markdownEditor.empty')}</Text>
+            ) : (
+              <PublicMarkdownContent markdown={value} />
+            )}
+          </div>
+        )}
+      </div>
     </Stack>
   )
 }


### PR DESCRIPTION
## 概要
posts / pages エンティティの body フィールドを `text` → `markdown` データ型に昇格させ、
管理画面の編集フォームを本格的な Markdown エディターにリニューアルします。

## 変更内容

### DBマイグレーション
- `database/migrations/20260605000000_change_body_to_markdown_for_blog_posts_pages.php`
  - `field_defs` の `body` フィールド (`data_type='text'`) を `markdown` に変更
  - 対象: entity_types.slug IN ('blog', 'posts', 'pages')

### フロントエンド
- `MarkdownFieldInput.tsx` フルリライト
  - **Write / Preview タブ**切り替えUI
  - **ツールバー**（9種）: Bold / Italic / H2 / H3 / UL / OL / Link / Code block / Blockquote
  - テキストエリア選択範囲を保持して記法挿入、`requestAnimationFrame` でカーソル位置を復元
  - Preview タブで `PublicMarkdownContent` によるレンダリング
  - テーマ対応カラー (`border-accent`)
  - rows=16・font-mono

## 将来のロードマップ（本PRは Phase 1）
- Phase 2: リッチテキスト / HTML エディター
- Phase 3: ビジュアルエディター（Elementor ライク）

## 確認方法
1. マイグレーション実行 (または済み: 直接MySQL で3行更新済み)
2. posts / pages のエンティティレコード編集画面を開く
3. body フィールドがツールバー付きのMarkdown エディターになっていることを確認
4. Write ↔ Preview タブ切り替えでプレビュー表示を確認

## チェックリスト
- [x] `npm run check --prefix frontend` パス（型チェック・lint・テスト・Storybook）
- [x] マイグレーション up/down 実装済み
- [x] ESLint・Prettier エラーなし

Closes #184

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)