### PR TITLE
feat(ui): 保存操作のトースト通知

### DIFF
--- a/frontend/src/features/edit-entity-text-fields/ui/EditEntityTextFieldsView.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/EditEntityTextFieldsView.tsx
@@ -45,7 +45,7 @@ export function EditEntityTextFieldsView({
       await onSave(values)
       showToast(t('admin.entityRecord.textFields.saved'), 'success')
     } catch {
-      showToast(t('common.error.unknown'), 'error')
+      // エラーは saveErrorTitle 経由で EntityTextFieldsForm 内に表示される
     }
   }
 

--- a/frontend/src/features/edit-entity-text-fields/ui/EditEntityTextFieldsView.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/EditEntityTextFieldsView.tsx
@@ -1,8 +1,8 @@
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import type { FieldDef } from '@/entities/field-def'
 import type { Entity } from '@/entities/entity'
 import { useTranslation } from '@/shared/i18n'
-import { Button, Stack, Text } from '@/shared/ui'
+import { Button, Stack, Text, useToast } from '@/shared/ui'
 import { EntityTextFieldsForm } from './EntityTextFieldsForm'
 
 export interface EditEntityTextFieldsViewProps {
@@ -37,17 +37,16 @@ export function EditEntityTextFieldsView({
   onSave,
 }: EditEntityTextFieldsViewProps) {
   const { t } = useTranslation()
+  const { showToast } = useToast()
   const [customLocaleInput, setCustomLocaleInput] = useState('')
-  const [isSaved, setIsSaved] = useState(false)
-  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const handleSave = async (values: Record<string, string>) => {
-    await onSave(values)
-    setIsSaved(true)
-    if (savedTimerRef.current !== null) clearTimeout(savedTimerRef.current)
-    savedTimerRef.current = setTimeout(() => {
-      setIsSaved(false)
-    }, 3000)
+    try {
+      await onSave(values)
+      showToast(t('admin.entityRecord.textFields.saved'), 'success')
+    } catch {
+      showToast(t('common.error.unknown'), 'error')
+    }
   }
 
   if (isLoading) {
@@ -151,7 +150,6 @@ export function EditEntityTextFieldsView({
         fieldDefs={textFieldDefs}
         defaultValues={initialValues}
         isSubmitting={isSaving}
-        isSaved={isSaved}
         serverErrorTitle={saveErrorTitle}
         onSubmit={handleSave}
       />

--- a/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
@@ -10,7 +10,6 @@ export interface EntityTextFieldsFormProps {
   fieldDefs: FieldDef[]
   defaultValues: Record<string, string>
   isSubmitting: boolean
-  isSaved: boolean
   serverErrorTitle: string | null
   onSubmit: (values: Record<string, string>) => Promise<void>
 }
@@ -30,7 +29,6 @@ export function EntityTextFieldsForm({
   fieldDefs,
   defaultValues,
   isSubmitting,
-  isSaved,
   serverErrorTitle,
   onSubmit,
 }: EntityTextFieldsFormProps) {
@@ -155,9 +153,6 @@ export function EntityTextFieldsForm({
               ? t('admin.entityRecord.textFields.saving')
               : t('admin.entityRecord.textFields.save')}
           </Button>
-          {isSaved && !isSubmitting ? (
-            <Text muted>{t('admin.entityRecord.textFields.saved')}</Text>
-          ) : null}
         </div>
       </Stack>
     </form>

--- a/frontend/src/features/manage-entity-status/ui/EntitySeoPanel.tsx
+++ b/frontend/src/features/manage-entity-status/ui/EntitySeoPanel.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import type { Entity } from '@/entities/entity'
 import { useUpdateEntity } from '@/entities/entity'
 import { useTranslation } from '@/shared/i18n'
-import { Button, Stack, Text } from '@/shared/ui'
+import { Button, Stack, Text, useToast } from '@/shared/ui'
 
 interface EntitySeoPanelProps {
   entity: Entity
@@ -10,16 +10,13 @@ interface EntitySeoPanelProps {
 
 export function EntitySeoPanel({ entity }: EntitySeoPanelProps) {
   const { t } = useTranslation()
+  const { showToast } = useToast()
   const updateMutation = useUpdateEntity()
 
   const [metaTitle, setMetaTitle] = useState(entity.metaTitle ?? '')
   const [metaDescription, setMetaDescription] = useState(entity.metaDescription ?? '')
-  const [saved, setSaved] = useState(false)
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   const save = async () => {
-    setErrorMessage(null)
-    setSaved(false)
     try {
       await updateMutation.mutateAsync({
         id: Number(entity.id),
@@ -29,9 +26,9 @@ export function EntitySeoPanel({ entity }: EntitySeoPanelProps) {
         metaTitle: metaTitle !== '' ? metaTitle : null,
         metaDescription: metaDescription !== '' ? metaDescription : null,
       })
-      setSaved(true)
+      showToast(t('admin.entitySeo.saveSuccess'), 'success')
     } catch {
-      setErrorMessage(t('common.error.serverError'))
+      showToast(t('common.error.serverError'), 'error')
     }
   }
 
@@ -52,7 +49,6 @@ export function EntitySeoPanel({ entity }: EntitySeoPanelProps) {
             value={metaTitle}
             onChange={(e) => {
               setMetaTitle(e.target.value)
-              setSaved(false)
             }}
             placeholder={t('admin.entitySeo.metaTitle.placeholder')}
             maxLength={255}
@@ -72,7 +68,6 @@ export function EntitySeoPanel({ entity }: EntitySeoPanelProps) {
             value={metaDescription}
             onChange={(e) => {
               setMetaDescription(e.target.value)
-              setSaved(false)
             }}
             placeholder={t('admin.entitySeo.metaDescription.placeholder')}
             rows={3}
@@ -89,14 +84,7 @@ export function EntitySeoPanel({ entity }: EntitySeoPanelProps) {
           >
             {updateMutation.isPending ? t('admin.entitySeo.saving') : t('admin.entitySeo.save')}
           </Button>
-          {saved && (
-            <Text as="span" muted>
-              {t('admin.entitySeo.saveSuccess')}
-            </Text>
-          )}
         </div>
-
-        {errorMessage !== null && <Text muted>{errorMessage}</Text>}
       </Stack>
     </section>
   )

--- a/frontend/src/features/manage-entity-status/ui/EntityStatusPanel.tsx
+++ b/frontend/src/features/manage-entity-status/ui/EntityStatusPanel.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/entities/entity'
 import { useTranslation } from '@/shared/i18n'
 import type { MessageKey } from '@/shared/i18n'
-import { Button, Input, Stack, Text } from '@/shared/ui'
+import { Button, Input, Stack, Text, useToast } from '@/shared/ui'
 
 const STATUS_BADGE_CLASS: Record<EntityStatus, string> = {
   draft:
@@ -43,14 +43,13 @@ interface EntityStatusPanelProps {
 
 export function EntityStatusPanel({ entity, entityTypeSlug }: EntityStatusPanelProps) {
   const { t } = useTranslation()
+  const { showToast } = useToast()
   const updateMutation = useUpdateEntity()
   const scheduleMutation = useScheduleEntity()
   const unscheduleMutation = useUnscheduleEntity()
   const generatePreviewMutation = useGeneratePreviewToken()
   const revokePreviewMutation = useRevokePreviewToken()
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [slugInput, setSlugInput] = useState(entity.slug ?? '')
-  const [slugSaved, setSlugSaved] = useState(false)
   const [showScheduleForm, setShowScheduleForm] = useState(false)
   const [scheduledAtInput, setScheduledAtInput] = useState('')
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
@@ -64,8 +63,6 @@ export function EntityStatusPanel({ entity, entityTypeSlug }: EntityStatusPanelP
     revokePreviewMutation.isPending
 
   const changeStatus = async (nextStatus: EntityStatus) => {
-    setErrorMessage(null)
-    setSlugSaved(false)
     try {
       await updateMutation.mutateAsync({
         id: Number(entity.id),
@@ -74,13 +71,11 @@ export function EntityStatusPanel({ entity, entityTypeSlug }: EntityStatusPanelP
         status: nextStatus,
       })
     } catch {
-      setErrorMessage(t('admin.entityStatus.updateError'))
+      showToast(t('admin.entityStatus.updateError'), 'error')
     }
   }
 
   const saveSlug = async () => {
-    setErrorMessage(null)
-    setSlugSaved(false)
     try {
       await updateMutation.mutateAsync({
         id: Number(entity.id),
@@ -88,15 +83,14 @@ export function EntityStatusPanel({ entity, entityTypeSlug }: EntityStatusPanelP
         slug: slugInput !== '' ? slugInput : null,
         status: entity.status,
       })
-      setSlugSaved(true)
+      showToast(t('admin.entityStatus.slugSaved'), 'success')
     } catch {
-      setErrorMessage(t('admin.entityStatus.slugError'))
+      showToast(t('admin.entityStatus.slugError'), 'error')
     }
   }
 
   const schedulePublish = async () => {
     if (scheduledAtInput === '') return
-    setErrorMessage(null)
     try {
       await scheduleMutation.mutateAsync({
         id: Number(entity.id),
@@ -105,38 +99,35 @@ export function EntityStatusPanel({ entity, entityTypeSlug }: EntityStatusPanelP
       setShowScheduleForm(false)
       setScheduledAtInput('')
     } catch {
-      setErrorMessage(t('admin.entityStatus.scheduleError'))
+      showToast(t('admin.entityStatus.scheduleError'), 'error')
     }
   }
 
   const cancelSchedule = async () => {
-    setErrorMessage(null)
     try {
       await unscheduleMutation.mutateAsync({ id: entity.id })
     } catch {
-      setErrorMessage(t('admin.entityStatus.updateError'))
+      showToast(t('admin.entityStatus.updateError'), 'error')
     }
   }
 
   const generatePreview = async () => {
-    setErrorMessage(null)
     try {
       const output = await generatePreviewMutation.mutateAsync({ id: Number(entity.id) })
       setPreviewUrl(output.previewUrl)
       setPreviewExpires(output.expiresAt)
     } catch {
-      setErrorMessage(t('admin.entityStatus.previewTokenError'))
+      showToast(t('admin.entityStatus.previewTokenError'), 'error')
     }
   }
 
   const revokePreview = async () => {
-    setErrorMessage(null)
     try {
       await revokePreviewMutation.mutateAsync({ id: Number(entity.id) })
       setPreviewUrl(null)
       setPreviewExpires(null)
     } catch {
-      setErrorMessage(t('admin.entityStatus.updateError'))
+      showToast(t('admin.entityStatus.updateError'), 'error')
     }
   }
 
@@ -181,7 +172,6 @@ export function EntityStatusPanel({ entity, entityTypeSlug }: EntityStatusPanelP
             value={slugInput}
             onChange={(e) => {
               setSlugInput(e.target.value)
-              setSlugSaved(false)
             }}
             placeholder={t('admin.entityStatus.slugPlaceholder')}
           />
@@ -189,7 +179,6 @@ export function EntityStatusPanel({ entity, entityTypeSlug }: EntityStatusPanelP
             {t('admin.entityStatus.saveSlug')}
           </Button>
         </div>
-        {slugSaved && <Text muted>{t('admin.entityStatus.slugSaved')}</Text>}
         {publicUrl !== null && (
           <a
             href={publicUrl}
@@ -309,8 +298,6 @@ export function EntityStatusPanel({ entity, entityTypeSlug }: EntityStatusPanelP
           </Stack>
         </div>
       )}
-
-      {errorMessage !== null && <Text muted>{errorMessage}</Text>}
     </Stack>
   )
 }

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -4,6 +4,7 @@ import { authStore, currentUserHasCapability } from '@/entities/auth'
 import { getLocalizedEntityTypeName, usePinnedEntityTypes } from '@/entities/entity-type'
 import { LOCALES, SUPPORTED_LOCALE_IDS, useTranslation } from '@/shared/i18n'
 import { useTheme } from '@/shared/theme'
+import { ToastProvider } from '@/shared/ui'
 import {
   IconHome,
   IconLayers,
@@ -89,279 +90,281 @@ export function AppShell() {
   }
 
   return (
-    <div className="flex min-h-screen bg-surface font-sans text-text-primary">
-      {/* ── Mobile top bar (hidden on lg+) ─────────────────────────────── */}
-      <header className="fixed inset-x-0 top-0 z-10 flex h-14 items-center gap-3 border-b border-sidebar-border bg-sidebar-bg px-4 lg:hidden">
-        <button
-          type="button"
-          onClick={() => {
-            setSidebarOpen(true)
-          }}
-          aria-label={t('admin.nav.openMenu')}
-          className="flex items-center justify-center rounded-md p-1.5 text-sidebar-text transition-colors hover:bg-sidebar-hover-bg hover:text-sidebar-active-text"
-        >
-          <IconMenu size={20} />
-        </button>
-        <span className="text-sm font-semibold tracking-wide text-sidebar-active-text">
-          NeNe Records
-        </span>
-        <span className="rounded bg-accent px-1.5 py-0.5 text-caption font-semibold uppercase tracking-wider text-white">
-          Admin
-        </span>
-      </header>
-
-      {/* ── Overlay backdrop (mobile only) ──────────────────────────────── */}
-      {sidebarOpen ? (
-        <div
-          className="fixed inset-0 z-20 bg-black/50 lg:hidden"
-          aria-hidden="true"
-          onClick={closeSidebar}
-        />
-      ) : null}
-
-      {/* ── Sidebar ─────────────────────────────────────────────────────── */}
-      <aside
-        className={[
-          'fixed inset-y-0 left-0 z-30 flex w-64 flex-col border-r border-sidebar-border bg-sidebar-bg',
-          'transition-transform duration-200',
-          'lg:w-60 lg:translate-x-0',
-          sidebarOpen ? 'translate-x-0' : '-translate-x-full',
-        ].join(' ')}
-        aria-label="Sidebar"
-      >
-        {/* Brand */}
-        <div className="flex h-14 shrink-0 items-center gap-2 border-b border-sidebar-border px-4">
-          <span className="flex-1 text-sm font-semibold tracking-wide text-sidebar-active-text">
+    <ToastProvider>
+      <div className="flex min-h-screen bg-surface font-sans text-text-primary">
+        {/* ── Mobile top bar (hidden on lg+) ─────────────────────────────── */}
+        <header className="fixed inset-x-0 top-0 z-10 flex h-14 items-center gap-3 border-b border-sidebar-border bg-sidebar-bg px-4 lg:hidden">
+          <button
+            type="button"
+            onClick={() => {
+              setSidebarOpen(true)
+            }}
+            aria-label={t('admin.nav.openMenu')}
+            className="flex items-center justify-center rounded-md p-1.5 text-sidebar-text transition-colors hover:bg-sidebar-hover-bg hover:text-sidebar-active-text"
+          >
+            <IconMenu size={20} />
+          </button>
+          <span className="text-sm font-semibold tracking-wide text-sidebar-active-text">
             NeNe Records
           </span>
           <span className="rounded bg-accent px-1.5 py-0.5 text-caption font-semibold uppercase tracking-wider text-white">
             Admin
           </span>
-          {/* Close button — mobile only */}
-          <button
-            type="button"
+        </header>
+
+        {/* ── Overlay backdrop (mobile only) ──────────────────────────────── */}
+        {sidebarOpen ? (
+          <div
+            className="fixed inset-0 z-20 bg-black/50 lg:hidden"
+            aria-hidden="true"
             onClick={closeSidebar}
-            aria-label={t('admin.nav.closeMenu')}
-            className="ml-1 flex items-center justify-center rounded-md p-1 text-sidebar-text transition-colors hover:bg-sidebar-hover-bg hover:text-sidebar-active-text lg:hidden"
-          >
-            <IconX size={18} />
-          </button>
-        </div>
+          />
+        ) : null}
 
-        {/* Nav links */}
-        <nav className="flex-1 overflow-y-auto px-3 py-4" aria-label="Main">
-          {/* ── Primary nav ── */}
-          <ul className="space-y-0.5">
-            <li>
-              <NavItem
-                to="/admin"
-                end
-                icon={<IconHome size={16} />}
-                label={t('admin.nav.home')}
-                onClick={closeSidebar}
-              />
-            </li>
-            {/* ── Pinned content types (dynamic) ── */}
-            {pinnedEntityTypes.map((entityType) => (
-              <li key={entityType.id}>
-                <NavItem
-                  to={`/admin/${entityType.slug}`}
-                  icon={<IconFileText size={16} />}
-                  label={getLocalizedEntityTypeName(entityType, locale)}
-                  onClick={closeSidebar}
-                />
-              </li>
-            ))}
-            {pinnedEntityTypes.length > 0 && (
-              <li aria-hidden="true" className="my-2 border-t border-sidebar-border opacity-50" />
-            )}
-            {canManageTags ? (
-              <li>
-                <NavItem
-                  to="/admin/tags"
-                  icon={<IconTag size={16} />}
-                  label={t('admin.nav.tags')}
-                  onClick={closeSidebar}
-                />
-              </li>
-            ) : null}
-            {canReadSettings ? (
-              <li>
-                <NavItem
-                  to="/admin/settings"
-                  icon={<IconSettings size={16} />}
-                  label={t('admin.nav.settings')}
-                  onClick={closeSidebar}
-                />
-              </li>
-            ) : null}
-          </ul>
-
-          {/* ── Appearance (collapsible, default open) ── */}
-          {canManageSettings ? (
-            <>
-              <div className="my-4 border-t border-sidebar-border" />
-              <div>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setAppearanceOpen((o) => !o)
-                  }}
-                  className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-xs font-semibold uppercase tracking-wider text-sidebar-text-muted transition-colors hover:bg-sidebar-hover-bg hover:text-sidebar-active-text"
-                  aria-expanded={appearanceOpen}
-                >
-                  <IconLayout size={12} className="shrink-0" />
-                  <span className="flex-1 text-left">{t('admin.nav.appearance')}</span>
-                  <IconChevronRight
-                    size={12}
-                    className={[
-                      'shrink-0 transition-transform duration-150',
-                      appearanceOpen ? 'rotate-90' : '',
-                    ].join(' ')}
-                  />
-                </button>
-                {appearanceOpen ? (
-                  <ul className="mt-0.5 space-y-0.5">
-                    <li>
-                      <NavItem
-                        to="/admin/navigation"
-                        icon={<IconLink size={16} />}
-                        label={t('admin.nav.navigation')}
-                        onClick={closeSidebar}
-                      />
-                    </li>
-                  </ul>
-                ) : null}
-              </div>
-            </>
-          ) : null}
-
-          {/* ── Advanced (collapsible, default closed) ── */}
-          {canManageSettings ? (
-            <>
-              <div className="my-4 border-t border-sidebar-border" />
-              <div>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setAdvancedOpen((o) => !o)
-                  }}
-                  className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-xs font-semibold uppercase tracking-wider text-sidebar-text-muted transition-colors hover:bg-sidebar-hover-bg hover:text-sidebar-active-text"
-                  aria-expanded={advancedOpen}
-                >
-                  <span className="flex-1 text-left">{t('admin.nav.advanced')}</span>
-                  <IconChevronRight
-                    size={12}
-                    className={[
-                      'shrink-0 transition-transform duration-150',
-                      advancedOpen ? 'rotate-90' : '',
-                    ].join(' ')}
-                  />
-                </button>
-                {advancedOpen ? (
-                  <ul className="mt-0.5 space-y-0.5">
-                    <li>
-                      <NavItem
-                        to="/admin/entity-types"
-                        icon={<IconLayers size={16} />}
-                        label={t('admin.nav.entityTypes')}
-                        onClick={closeSidebar}
-                      />
-                    </li>
-                    <li>
-                      <NavItem
-                        to="/admin/webhooks"
-                        icon={<IconWebhook size={16} />}
-                        label={t('admin.nav.webhooks')}
-                        onClick={closeSidebar}
-                      />
-                    </li>
-                  </ul>
-                ) : null}
-              </div>
-            </>
-          ) : null}
-
-          <div className="my-4 border-t border-sidebar-border" />
-
-          <ul className="space-y-0.5">
-            <li>
-              <NavItem
-                to="/"
-                icon={<IconGlobe size={16} />}
-                label={t('admin.nav.publicSite')}
-                onClick={closeSidebar}
-              />
-            </li>
-          </ul>
-        </nav>
-
-        {/* Bottom: user info + controls */}
-        <div className="shrink-0 space-y-2 border-t border-sidebar-border p-3">
-          {session && (
-            <div className="truncate px-1 text-xs text-sidebar-text-muted" title={session.email}>
-              {session.email}
-            </div>
-          )}
-
-          <div className="flex items-center gap-1">
-            {/* Language selector */}
-            <select
-              aria-label="Language"
-              value={locale}
-              onChange={(e) => {
-                setLocale(e.target.value as typeof locale)
-              }}
-              className="min-w-0 flex-1 rounded-md border border-sidebar-border bg-sidebar-active-bg px-2 py-1.5 text-xs text-sidebar-text focus:outline-none focus:ring-1 focus:ring-accent"
-            >
-              {SUPPORTED_LOCALE_IDS.map((id) => (
-                <option key={id} value={id}>
-                  {LOCALES[id].label}
-                </option>
-              ))}
-            </select>
-
-            {/* Theme toggle — both variants available のみ表示 */}
-            {canToggleVariant ? (
-              <button
-                type="button"
-                onClick={toggleVariant}
-                aria-label={
-                  themeVariant === 'dark'
-                    ? t('admin.theme.toggleLight')
-                    : t('admin.theme.toggleDark')
-                }
-                className="flex shrink-0 items-center justify-center rounded-md border border-sidebar-border bg-sidebar-active-bg p-1.5 text-sidebar-text transition-colors hover:bg-sidebar-hover-bg hover:text-sidebar-active-text"
-              >
-                {themeVariant === 'dark' ? <IconSun size={15} /> : <IconMoon size={15} />}
-              </button>
-            ) : null}
-
-            {/* Logout */}
+        {/* ── Sidebar ─────────────────────────────────────────────────────── */}
+        <aside
+          className={[
+            'fixed inset-y-0 left-0 z-30 flex w-64 flex-col border-r border-sidebar-border bg-sidebar-bg',
+            'transition-transform duration-200',
+            'lg:w-60 lg:translate-x-0',
+            sidebarOpen ? 'translate-x-0' : '-translate-x-full',
+          ].join(' ')}
+          aria-label="Sidebar"
+        >
+          {/* Brand */}
+          <div className="flex h-14 shrink-0 items-center gap-2 border-b border-sidebar-border px-4">
+            <span className="flex-1 text-sm font-semibold tracking-wide text-sidebar-active-text">
+              NeNe Records
+            </span>
+            <span className="rounded bg-accent px-1.5 py-0.5 text-caption font-semibold uppercase tracking-wider text-white">
+              Admin
+            </span>
+            {/* Close button — mobile only */}
             <button
               type="button"
-              onClick={handleLogout}
-              aria-label={t('admin.nav.logout')}
-              title={t('admin.nav.logout')}
-              className="flex shrink-0 items-center justify-center rounded-md border border-sidebar-border bg-sidebar-active-bg p-1.5 text-sidebar-text transition-colors hover:border-red-800 hover:bg-red-950/60 hover:text-red-300"
+              onClick={closeSidebar}
+              aria-label={t('admin.nav.closeMenu')}
+              className="ml-1 flex items-center justify-center rounded-md p-1 text-sidebar-text transition-colors hover:bg-sidebar-hover-bg hover:text-sidebar-active-text lg:hidden"
             >
-              <IconLogOut size={15} />
+              <IconX size={18} />
             </button>
           </div>
-        </div>
-      </aside>
 
-      {/* ── Main content ────────────────────────────────────────────────── */}
-      <main className="min-w-0 flex-1 pb-8 pt-14 lg:ml-60 lg:pt-0">
-        <div className="mx-auto max-w-5xl px-4 py-6 sm:px-6 sm:py-8">
-          <Outlet />
-        </div>
-      </main>
+          {/* Nav links */}
+          <nav className="flex-1 overflow-y-auto px-3 py-4" aria-label="Main">
+            {/* ── Primary nav ── */}
+            <ul className="space-y-0.5">
+              <li>
+                <NavItem
+                  to="/admin"
+                  end
+                  icon={<IconHome size={16} />}
+                  label={t('admin.nav.home')}
+                  onClick={closeSidebar}
+                />
+              </li>
+              {/* ── Pinned content types (dynamic) ── */}
+              {pinnedEntityTypes.map((entityType) => (
+                <li key={entityType.id}>
+                  <NavItem
+                    to={`/admin/${entityType.slug}`}
+                    icon={<IconFileText size={16} />}
+                    label={getLocalizedEntityTypeName(entityType, locale)}
+                    onClick={closeSidebar}
+                  />
+                </li>
+              ))}
+              {pinnedEntityTypes.length > 0 && (
+                <li aria-hidden="true" className="my-2 border-t border-sidebar-border opacity-50" />
+              )}
+              {canManageTags ? (
+                <li>
+                  <NavItem
+                    to="/admin/tags"
+                    icon={<IconTag size={16} />}
+                    label={t('admin.nav.tags')}
+                    onClick={closeSidebar}
+                  />
+                </li>
+              ) : null}
+              {canReadSettings ? (
+                <li>
+                  <NavItem
+                    to="/admin/settings"
+                    icon={<IconSettings size={16} />}
+                    label={t('admin.nav.settings')}
+                    onClick={closeSidebar}
+                  />
+                </li>
+              ) : null}
+            </ul>
 
-      {/* ── Footer (fixed bottom-right) ─────────────────────────────────── */}
-      <footer className="fixed bottom-0 right-0 pb-3 pl-4 pr-5 pt-2">
-        <p className="font-sans text-caption text-text-muted">Powered by NENE2 · © 2026 AYANE</p>
-      </footer>
-    </div>
+            {/* ── Appearance (collapsible, default open) ── */}
+            {canManageSettings ? (
+              <>
+                <div className="my-4 border-t border-sidebar-border" />
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setAppearanceOpen((o) => !o)
+                    }}
+                    className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-xs font-semibold uppercase tracking-wider text-sidebar-text-muted transition-colors hover:bg-sidebar-hover-bg hover:text-sidebar-active-text"
+                    aria-expanded={appearanceOpen}
+                  >
+                    <IconLayout size={12} className="shrink-0" />
+                    <span className="flex-1 text-left">{t('admin.nav.appearance')}</span>
+                    <IconChevronRight
+                      size={12}
+                      className={[
+                        'shrink-0 transition-transform duration-150',
+                        appearanceOpen ? 'rotate-90' : '',
+                      ].join(' ')}
+                    />
+                  </button>
+                  {appearanceOpen ? (
+                    <ul className="mt-0.5 space-y-0.5">
+                      <li>
+                        <NavItem
+                          to="/admin/navigation"
+                          icon={<IconLink size={16} />}
+                          label={t('admin.nav.navigation')}
+                          onClick={closeSidebar}
+                        />
+                      </li>
+                    </ul>
+                  ) : null}
+                </div>
+              </>
+            ) : null}
+
+            {/* ── Advanced (collapsible, default closed) ── */}
+            {canManageSettings ? (
+              <>
+                <div className="my-4 border-t border-sidebar-border" />
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setAdvancedOpen((o) => !o)
+                    }}
+                    className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-xs font-semibold uppercase tracking-wider text-sidebar-text-muted transition-colors hover:bg-sidebar-hover-bg hover:text-sidebar-active-text"
+                    aria-expanded={advancedOpen}
+                  >
+                    <span className="flex-1 text-left">{t('admin.nav.advanced')}</span>
+                    <IconChevronRight
+                      size={12}
+                      className={[
+                        'shrink-0 transition-transform duration-150',
+                        advancedOpen ? 'rotate-90' : '',
+                      ].join(' ')}
+                    />
+                  </button>
+                  {advancedOpen ? (
+                    <ul className="mt-0.5 space-y-0.5">
+                      <li>
+                        <NavItem
+                          to="/admin/entity-types"
+                          icon={<IconLayers size={16} />}
+                          label={t('admin.nav.entityTypes')}
+                          onClick={closeSidebar}
+                        />
+                      </li>
+                      <li>
+                        <NavItem
+                          to="/admin/webhooks"
+                          icon={<IconWebhook size={16} />}
+                          label={t('admin.nav.webhooks')}
+                          onClick={closeSidebar}
+                        />
+                      </li>
+                    </ul>
+                  ) : null}
+                </div>
+              </>
+            ) : null}
+
+            <div className="my-4 border-t border-sidebar-border" />
+
+            <ul className="space-y-0.5">
+              <li>
+                <NavItem
+                  to="/"
+                  icon={<IconGlobe size={16} />}
+                  label={t('admin.nav.publicSite')}
+                  onClick={closeSidebar}
+                />
+              </li>
+            </ul>
+          </nav>
+
+          {/* Bottom: user info + controls */}
+          <div className="shrink-0 space-y-2 border-t border-sidebar-border p-3">
+            {session && (
+              <div className="truncate px-1 text-xs text-sidebar-text-muted" title={session.email}>
+                {session.email}
+              </div>
+            )}
+
+            <div className="flex items-center gap-1">
+              {/* Language selector */}
+              <select
+                aria-label="Language"
+                value={locale}
+                onChange={(e) => {
+                  setLocale(e.target.value as typeof locale)
+                }}
+                className="min-w-0 flex-1 rounded-md border border-sidebar-border bg-sidebar-active-bg px-2 py-1.5 text-xs text-sidebar-text focus:outline-none focus:ring-1 focus:ring-accent"
+              >
+                {SUPPORTED_LOCALE_IDS.map((id) => (
+                  <option key={id} value={id}>
+                    {LOCALES[id].label}
+                  </option>
+                ))}
+              </select>
+
+              {/* Theme toggle — both variants available のみ表示 */}
+              {canToggleVariant ? (
+                <button
+                  type="button"
+                  onClick={toggleVariant}
+                  aria-label={
+                    themeVariant === 'dark'
+                      ? t('admin.theme.toggleLight')
+                      : t('admin.theme.toggleDark')
+                  }
+                  className="flex shrink-0 items-center justify-center rounded-md border border-sidebar-border bg-sidebar-active-bg p-1.5 text-sidebar-text transition-colors hover:bg-sidebar-hover-bg hover:text-sidebar-active-text"
+                >
+                  {themeVariant === 'dark' ? <IconSun size={15} /> : <IconMoon size={15} />}
+                </button>
+              ) : null}
+
+              {/* Logout */}
+              <button
+                type="button"
+                onClick={handleLogout}
+                aria-label={t('admin.nav.logout')}
+                title={t('admin.nav.logout')}
+                className="flex shrink-0 items-center justify-center rounded-md border border-sidebar-border bg-sidebar-active-bg p-1.5 text-sidebar-text transition-colors hover:border-red-800 hover:bg-red-950/60 hover:text-red-300"
+              >
+                <IconLogOut size={15} />
+              </button>
+            </div>
+          </div>
+        </aside>
+
+        {/* ── Main content ────────────────────────────────────────────────── */}
+        <main className="min-w-0 flex-1 pb-8 pt-14 lg:ml-60 lg:pt-0">
+          <div className="mx-auto max-w-5xl px-4 py-6 sm:px-6 sm:py-8">
+            <Outlet />
+          </div>
+        </main>
+
+        {/* ── Footer (fixed bottom-right) ─────────────────────────────────── */}
+        <footer className="fixed bottom-0 right-0 pb-3 pl-4 pr-5 pt-2">
+          <p className="font-sans text-caption text-text-muted">Powered by NENE2 · © 2026 AYANE</p>
+        </footer>
+      </div>
+    </ToastProvider>
   )
 }

--- a/frontend/src/shared/ui/index.ts
+++ b/frontend/src/shared/ui/index.ts
@@ -1,3 +1,5 @@
+export { ToastProvider, useToast } from './toast'
+export type { Toast, ToastContextValue, ToastType } from './toast'
 export { Button } from './primitives/Button'
 export type { ButtonProps, ButtonSize, ButtonVariant } from './primitives/Button'
 export { ConfirmDialog } from './components/ConfirmDialog'

--- a/frontend/src/shared/ui/toast/ToastProvider.tsx
+++ b/frontend/src/shared/ui/toast/ToastProvider.tsx
@@ -1,0 +1,147 @@
+import { useCallback, useRef, useState } from 'react'
+import { ToastContext } from './toast-context'
+import type { Toast, ToastType } from './toast-context'
+
+// ── Icons ────────────────────────────────────────────────────────────────────
+
+function IconCheck() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path
+        d="M3 8l3.5 3.5L13 4.5"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+function IconAlertCircle() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <circle cx="8" cy="8" r="6.5" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M8 5v4" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" />
+      <circle cx="8" cy="11" r="0.75" fill="currentColor" />
+    </svg>
+  )
+}
+
+function IconInfo() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <circle cx="8" cy="8" r="6.5" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M8 7v4" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" />
+      <circle cx="8" cy="5" r="0.75" fill="currentColor" />
+    </svg>
+  )
+}
+
+// ── Single toast item ─────────────────────────────────────────────────────────
+
+const TYPE_STYLES: Record<
+  ToastType,
+  { container: string; icon: string; iconNode: React.ReactNode }
+> = {
+  success: {
+    container: 'bg-surface-raised border border-border text-text-primary shadow-lg',
+    icon: 'text-green-500',
+    iconNode: <IconCheck />,
+  },
+  error: {
+    container: 'bg-surface-raised border border-red-500/40 text-text-primary shadow-lg',
+    icon: 'text-red-400',
+    iconNode: <IconAlertCircle />,
+  },
+  info: {
+    container: 'bg-surface-raised border border-border text-text-primary shadow-lg',
+    icon: 'text-accent',
+    iconNode: <IconInfo />,
+  },
+}
+
+function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: (id: number) => void }) {
+  const styles = TYPE_STYLES[toast.type]
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={[
+        'flex items-start gap-2.5 rounded-lg px-4 py-3 font-sans text-body transition-all duration-300',
+        styles.container,
+        toast.fading ? 'translate-x-2 opacity-0' : 'translate-x-0 opacity-100',
+      ].join(' ')}
+    >
+      <span className={['mt-0.5 shrink-0', styles.icon].join(' ')}>{styles.iconNode}</span>
+      <span className="flex-1 leading-snug">{toast.message}</span>
+      <button
+        type="button"
+        onClick={() => {
+          onDismiss(toast.id)
+        }}
+        aria-label="閉じる"
+        className="ml-1 shrink-0 text-text-muted transition-colors hover:text-text-primary"
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+          <path
+            d="M3 3l8 8M11 3L3 11"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        </svg>
+      </button>
+    </div>
+  )
+}
+
+// ── Provider ─────────────────────────────────────────────────────────────────
+
+const DISPLAY_MS = 3000
+const FADE_MS = 300
+
+let nextId = 1
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([])
+  const timersRef = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map())
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => prev.map((t) => (t.id === id ? { ...t, fading: true } : t)))
+    const removeTimer = setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id))
+    }, FADE_MS)
+    timersRef.current.set(id, removeTimer)
+  }, [])
+
+  const showToast = useCallback(
+    (message: string, type: ToastType = 'success') => {
+      const id = nextId++
+      setToasts((prev) => [...prev, { id, message, type, fading: false }])
+      const timer = setTimeout(() => {
+        dismiss(id)
+      }, DISPLAY_MS)
+      timersRef.current.set(id, timer)
+    },
+    [dismiss],
+  )
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      {/* ── Toast container (top-right) ── */}
+      <div
+        aria-label="通知"
+        className="pointer-events-none fixed right-4 top-4 z-50 flex flex-col gap-2"
+        style={{ minWidth: '18rem', maxWidth: '22rem' }}
+      >
+        {toasts.map((toast) => (
+          <div key={toast.id} className="pointer-events-auto">
+            <ToastItem toast={toast} onDismiss={dismiss} />
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  )
+}

--- a/frontend/src/shared/ui/toast/index.ts
+++ b/frontend/src/shared/ui/toast/index.ts
@@ -1,0 +1,3 @@
+export { ToastProvider } from './ToastProvider'
+export type { Toast, ToastContextValue, ToastType } from './toast-context'
+export { useToast } from './use-toast'

--- a/frontend/src/shared/ui/toast/toast-context.ts
+++ b/frontend/src/shared/ui/toast/toast-context.ts
@@ -1,0 +1,23 @@
+import { createContext } from 'react'
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type ToastType = 'success' | 'error' | 'info'
+
+export interface Toast {
+  id: number
+  message: string
+  type: ToastType
+  /** true = フェードアウト中 */
+  fading: boolean
+}
+
+export interface ToastContextValue {
+  showToast: (message: string, type?: ToastType) => void
+}
+
+// ── Context ──────────────────────────────────────────────────────────────────
+
+export const ToastContext = createContext<ToastContextValue>({
+  showToast: () => undefined,
+})

--- a/frontend/src/shared/ui/toast/use-toast.ts
+++ b/frontend/src/shared/ui/toast/use-toast.ts
@@ -1,0 +1,6 @@
+import { useContext } from 'react'
+import { ToastContext } from './toast-context'
+
+export function useToast() {
+  return useContext(ToastContext)
+}


### PR DESCRIPTION
## 概要
フォーム保存後のフィードバックを「インライン小テキスト」から**トースト通知**に改善します。

## 変更内容

### Toast システム（新規）
`frontend/src/shared/ui/toast/`

| ファイル | 役割 |
|---|---|
| `toast-context.ts` | `ToastContext` / `Toast` / `ToastType` 型（ESLint fast-refresh 対応で分離）|
| `ToastProvider.tsx` | Context Provider + トーストコンテナ（右上固定・z-50）|
| `use-toast.ts` | `useToast()` フック |

外部ライブラリなし・ネイティブ実装。

**仕様:**
- 位置: 右上 (top-4 right-4)、サイドバーの上に重ならない
- 自動消去: 3秒後フェードアウト（300ms transition）
- 複数スタック可能
- ×ボタンで手動クローズ
- success / error / info の3種類（アイコン付き）

### AppShell
- `ToastProvider` を全管理画面に適用

### 置き換え対象コンポーネント

| コンポーネント | 変更前 | 変更後 |
|---|---|---|
| `EditEntityTextFieldsView` | ボタン横「保存しました。」3秒表示 | success / error Toast |
| `EntityStatusPanel` | スラッグ横インライン表示 + errorMessage state | success / error Toast |
| `EntitySeoPanel` | ボタン横インライン表示 + saved/errorMessage state | success / error Toast |
| `EntityTextFieldsForm` | `isSaved` prop あり | prop 削除（不要化）|

## チェックリスト
- [x] `npm run check --prefix frontend` パス
- [x] ESLint 0 warnings / 0 errors
- [x] Prettier フォーマット済み

Closes #186

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)