### PR TITLE
feat(permalink): パーマリンクパターン設定を追加

### DIFF
--- a/database/migrations/20260610000000_add_permalink_pattern_to_entity_types.php
+++ b/database/migrations/20260610000000_add_permalink_pattern_to_entity_types.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddPermalinkPatternToEntityTypes extends AbstractMigration
+{
+    public function up(): void
+    {
+        $this->table('entity_types')
+            ->addColumn('permalink_pattern', 'string', [
+                'limit'   => 255,
+                'null'    => true,
+                'default' => null,
+                'after'   => 'labels',
+            ])
+            ->save();
+    }
+
+    public function down(): void
+    {
+        $this->table('entity_types')
+            ->removeColumn('permalink_pattern')
+            ->save();
+    }
+}

--- a/database/migrations/20260615000000_add_previous_permalink_pattern_to_entity_types.php
+++ b/database/migrations/20260615000000_add_previous_permalink_pattern_to_entity_types.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddPreviousPermalinkPatternToEntityTypes extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('entity_types')
+            ->addColumn('previous_permalink_pattern', 'string', [
+                'limit'   => 255,
+                'null'    => true,
+                'default' => null,
+                'after'   => 'permalink_pattern',
+            ])
+            ->save();
+    }
+}

--- a/database/schema/entity_types.sql
+++ b/database/schema/entity_types.sql
@@ -3,6 +3,7 @@ CREATE TABLE entity_types (
     name VARCHAR(255) NOT NULL,
     slug VARCHAR(255) NOT NULL,
     is_pinned BOOLEAN NOT NULL DEFAULT 0,
-    labels TEXT NULL DEFAULT NULL
+    labels TEXT NULL DEFAULT NULL,
+    permalink_pattern VARCHAR(255) NULL DEFAULT NULL
 );
 CREATE UNIQUE INDEX entity_types_slug ON entity_types (slug);

--- a/database/schema/entity_types.sql
+++ b/database/schema/entity_types.sql
@@ -4,6 +4,7 @@ CREATE TABLE entity_types (
     slug VARCHAR(255) NOT NULL,
     is_pinned BOOLEAN NOT NULL DEFAULT 0,
     labels TEXT NULL DEFAULT NULL,
-    permalink_pattern VARCHAR(255) NULL DEFAULT NULL
+    permalink_pattern VARCHAR(255) NULL DEFAULT NULL,
+    previous_permalink_pattern VARCHAR(255) NULL DEFAULT NULL
 );
 CREATE UNIQUE INDEX entity_types_slug ON entity_types (slug);

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2712,6 +2712,10 @@ components:
           nullable: true
           description: 'URL pattern for public records. Tokens: {type} {slug} {id} {year} {month} {day}. Null = default "/{type}/{id}".'
           example: '/{type}/{slug}'
+        previous_permalink_pattern:
+          type: string
+          nullable: true
+          description: 'Previous URL pattern, automatically saved when permalink_pattern changes. Used to redirect old URLs.'
     CreateEntityTypeRequest:
       type: object
       required:

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2707,6 +2707,11 @@ components:
           type: string
         is_pinned:
           type: boolean
+        permalink_pattern:
+          type: string
+          nullable: true
+          description: 'URL pattern for public records. Tokens: {type} {slug} {id} {year} {month} {day}. Null = default "/{type}/{id}".'
+          example: '/{type}/{slug}'
     CreateEntityTypeRequest:
       type: object
       required:
@@ -2723,7 +2728,28 @@ components:
           type: boolean
       additionalProperties: false
     UpdateEntityTypeRequest:
-      $ref: '#/components/schemas/CreateEntityTypeRequest'
+      type: object
+      required:
+        - name
+        - slug
+      properties:
+        name:
+          type: string
+          minLength: 1
+        slug:
+          type: string
+          pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
+        is_pinned:
+          type: boolean
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        permalink_pattern:
+          type: string
+          nullable: true
+          description: 'URL pattern. Must contain {slug} or {id}. Must start with /.'
+      additionalProperties: false
     EntityTypeListResponse:
       type: object
       required:

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -67,7 +67,9 @@ const router = createBrowserRouter([
     children: [
       { index: true, element: <PublicIndexPage /> },
       { path: ':entityTypeSlug', element: <PublicBrowsePage /> },
-      { path: ':entityTypeSlug/:entityId', element: <PublicRecordDetailPage /> },
+      // Wildcard captures any permalink pattern after the entity type slug
+      // e.g. /posts/42, /posts/my-article, /posts/2024/01/my-article
+      { path: ':entityTypeSlug/*', element: <PublicRecordDetailPage /> },
     ],
   },
   {

--- a/frontend/src/entities/entity-type/api-types.ts
+++ b/frontend/src/entities/entity-type/api-types.ts
@@ -11,6 +11,8 @@ export interface EntityTypeDto {
    * Null = default "/{type}/{id}".
    */
   permalink_pattern?: string | null
+  /** Previous URL pattern, saved automatically when permalink_pattern changes. */
+  previous_permalink_pattern?: string | null
 }
 
 export interface EntityTypeListDto {

--- a/frontend/src/entities/entity-type/api-types.ts
+++ b/frontend/src/entities/entity-type/api-types.ts
@@ -5,6 +5,12 @@ export interface EntityTypeDto {
   is_pinned: boolean
   /** Locale-keyed display names, e.g. {"ja":"投稿","fr":"Articles"}. Empty object = no overrides. */
   labels?: Record<string, string>
+  /**
+   * URL pattern for public records.
+   * Tokens: {type} {slug} {id} {year} {month} {day}
+   * Null = default "/{type}/{id}".
+   */
+  permalink_pattern?: string | null
 }
 
 export interface EntityTypeListDto {
@@ -24,4 +30,5 @@ export interface UpdateEntityTypeDto {
   slug: string
   is_pinned?: boolean
   labels?: Record<string, string>
+  permalink_pattern?: string | null
 }

--- a/frontend/src/entities/entity-type/mapper.test.ts
+++ b/frontend/src/entities/entity-type/mapper.test.ts
@@ -16,6 +16,7 @@ describe('entity-type mapper', () => {
       name: 'Article',
       slug: 'article',
       isPinned: true,
+      permalinkPattern: null,
     })
   })
 

--- a/frontend/src/entities/entity-type/mapper.test.ts
+++ b/frontend/src/entities/entity-type/mapper.test.ts
@@ -17,6 +17,7 @@ describe('entity-type mapper', () => {
       slug: 'article',
       isPinned: true,
       permalinkPattern: null,
+      previousPermalinkPattern: null,
     })
   })
 

--- a/frontend/src/entities/entity-type/mapper.ts
+++ b/frontend/src/entities/entity-type/mapper.ts
@@ -20,6 +20,7 @@ export function mapEntityTypeDtoToModel(dto: EntityTypeDto): EntityType {
     isPinned: dto.is_pinned,
     labels: dto.labels && Object.keys(dto.labels).length > 0 ? dto.labels : undefined,
     permalinkPattern: dto.permalink_pattern ?? null,
+    previousPermalinkPattern: dto.previous_permalink_pattern ?? null,
   }
 }
 

--- a/frontend/src/entities/entity-type/mapper.ts
+++ b/frontend/src/entities/entity-type/mapper.ts
@@ -19,6 +19,7 @@ export function mapEntityTypeDtoToModel(dto: EntityTypeDto): EntityType {
     slug: dto.slug,
     isPinned: dto.is_pinned,
     labels: dto.labels && Object.keys(dto.labels).length > 0 ? dto.labels : undefined,
+    permalinkPattern: dto.permalink_pattern ?? null,
   }
 }
 
@@ -44,5 +45,6 @@ export function mapUpdateInputToDto(input: UpdateEntityTypeInput): UpdateEntityT
     slug: input.slug,
     is_pinned: input.isPinned ?? false,
     labels: input.labels,
+    permalink_pattern: input.permalinkPattern,
   }
 }

--- a/frontend/src/entities/entity-type/model.ts
+++ b/frontend/src/entities/entity-type/model.ts
@@ -7,6 +7,12 @@ export interface EntityType {
   isPinned: boolean
   /** Locale-keyed display names. Empty object / undefined = no overrides. */
   labels?: Record<string, string>
+  /**
+   * URL pattern for public records.
+   * Tokens: {type} {slug} {id} {year} {month} {day}
+   * Undefined/null = use default "/{type}/{id}".
+   */
+  permalinkPattern?: string | null
 }
 
 export interface EntityTypeList {
@@ -26,4 +32,5 @@ export interface UpdateEntityTypeInput {
   slug: string
   isPinned?: boolean
   labels?: Record<string, string>
+  permalinkPattern?: string | null
 }

--- a/frontend/src/entities/entity-type/model.ts
+++ b/frontend/src/entities/entity-type/model.ts
@@ -13,6 +13,8 @@ export interface EntityType {
    * Undefined/null = use default "/{type}/{id}".
    */
   permalinkPattern?: string | null
+  /** Previous URL pattern — saved when permalink_pattern changes. Used to redirect old URLs. */
+  previousPermalinkPattern?: string | null
 }
 
 export interface EntityTypeList {

--- a/frontend/src/entities/entity/queries.ts
+++ b/frontend/src/entities/entity/queries.ts
@@ -54,9 +54,13 @@ export function useEntityList(
   })
 }
 
-export function useEntity(id: EntityId): UseQueryResult<Entity, AppError> {
+export function useEntity(
+  id: EntityId,
+  options?: { enabled?: boolean },
+): UseQueryResult<Entity, AppError> {
   return useQuery({
     queryKey: entityKeys.detail(id),
+    enabled: options?.enabled ?? true,
     queryFn: async ({ signal }) => {
       const dto = await apiClient.get<EntityDto>(`/api/v1/entities/${String(id)}`, signal)
       return mapEntityDtoToModel(dto)

--- a/frontend/src/features/manage-appearance/index.ts
+++ b/frontend/src/features/manage-appearance/index.ts
@@ -1,1 +1,2 @@
 export { AppearanceView } from './ui/AppearanceView'
+export { PermalinkSettingsView } from './ui/PermalinkSettingsView'

--- a/frontend/src/features/manage-appearance/ui/PermalinkSettingsView.tsx
+++ b/frontend/src/features/manage-appearance/ui/PermalinkSettingsView.tsx
@@ -1,0 +1,225 @@
+import { useState } from 'react'
+import { useEntityTypeList, useUpdateEntityType, type EntityType } from '@/entities/entity-type'
+import { useTranslation } from '@/shared/i18n'
+import {
+  DEFAULT_PERMALINK_PATTERN,
+  PERMALINK_PRESETS,
+  resolvePermalink,
+} from '@/shared/lib/resolve-permalink'
+import { Button, Stack, Text } from '@/shared/ui'
+
+// ── Warning for patterns without {type} ──────────────────────────────────────
+
+function NoTypeTokenWarning({ pattern }: { pattern: string }) {
+  const { t } = useTranslation()
+  if (!pattern || pattern.includes('{type}')) return null
+  return (
+    <p className="mt-1 text-xs text-warning">
+      ⚠ {t('admin.entityTypes.editForm.permalink.noTypeWarning')}
+    </p>
+  )
+}
+
+// ── Helper: match value to preset or null (= custom) ─────────────────────────
+
+function matchPreset(value: string | null | undefined): string | null {
+  if (!value) return DEFAULT_PERMALINK_PATTERN
+  return PERMALINK_PRESETS.find((p) => p.pattern === value)?.pattern ?? null
+}
+
+// ── Per-entity-type permalink row ─────────────────────────────────────────────
+
+function PermalinkRow({ entityType, onSaved }: { entityType: EntityType; onSaved: () => void }) {
+  const { t } = useTranslation()
+  const updateMutation = useUpdateEntityType()
+
+  const [pattern, setPattern] = useState<string>(
+    entityType.permalinkPattern ?? DEFAULT_PERMALINK_PATTERN,
+  )
+  const [isDirty, setIsDirty] = useState(false)
+
+  const exampleCtx = {
+    typeSlug: entityType.slug,
+    entitySlug: 'my-article',
+    entityId: 42,
+    publishedAt: '2024-03-15T00:00:00Z',
+  }
+
+  const matchedPreset = matchPreset(pattern)
+  const isCustom = matchedPreset === null
+  const effectivePattern = isCustom ? pattern : matchedPreset
+
+  function handleRadioChange(value: string) {
+    setPattern(value)
+    setIsDirty(true)
+  }
+
+  async function handleSave() {
+    const permalinkPattern = pattern === '' ? null : pattern
+    await updateMutation.mutateAsync({
+      id: entityType.id,
+      input: {
+        name: entityType.name,
+        slug: entityType.slug,
+        isPinned: entityType.isPinned,
+        labels: entityType.labels,
+        permalinkPattern,
+      },
+    })
+    setIsDirty(false)
+    onSaved()
+  }
+
+  return (
+    <div className="rounded-md border border-border bg-surface-raised p-inline-md">
+      <Stack gap="sm">
+        <div className="flex items-center justify-between">
+          <Text variant="heading-sm">{entityType.name}</Text>
+          <code className="font-mono text-xs text-text-muted">/{entityType.slug}</code>
+        </div>
+
+        <div className="space-y-1">
+          {PERMALINK_PRESETS.map((preset) => (
+            <label
+              key={preset.id}
+              htmlFor={`permalink-settings-${String(entityType.id)}-${preset.id}`}
+              aria-label={preset.label}
+              className="flex cursor-pointer items-start gap-3 rounded p-1.5 hover:bg-surface"
+            >
+              <input
+                id={`permalink-settings-${String(entityType.id)}-${preset.id}`}
+                type="radio"
+                name={`permalink-${String(entityType.id)}`}
+                checked={!isCustom && matchedPreset === preset.pattern}
+                disabled={updateMutation.isPending}
+                onChange={() => {
+                  handleRadioChange(preset.pattern)
+                }}
+                className="mt-0.5 h-4 w-4 shrink-0 accent-accent"
+              />
+              <span className="flex flex-col gap-0">
+                <span className="text-sm font-medium text-text-primary">{preset.label}</span>
+                <code className="font-mono text-xs text-text-muted">
+                  {resolvePermalink(preset.pattern, exampleCtx)}
+                </code>
+              </span>
+            </label>
+          ))}
+
+          {/* Custom option */}
+          <label
+            htmlFor={`permalink-settings-${String(entityType.id)}-custom`}
+            className="flex cursor-pointer items-start gap-3 rounded p-1.5 hover:bg-surface"
+          >
+            <input
+              id={`permalink-settings-${String(entityType.id)}-custom`}
+              type="radio"
+              name={`permalink-${String(entityType.id)}`}
+              checked={isCustom}
+              disabled={updateMutation.isPending}
+              onChange={() => {
+                handleRadioChange('')
+              }}
+              className="mt-0.5 h-4 w-4 shrink-0 accent-accent"
+            />
+            <span className="text-sm font-medium text-text-primary">
+              {t('admin.entityTypes.editForm.permalink.custom')}
+            </span>
+          </label>
+        </div>
+
+        {isCustom && (
+          <div className="ml-7">
+            <input
+              type="text"
+              value={pattern}
+              placeholder={t('admin.entityTypes.editForm.permalink.customPlaceholder')}
+              disabled={updateMutation.isPending}
+              onChange={(e) => {
+                setPattern(e.target.value)
+                setIsDirty(true)
+              }}
+              className="w-full rounded-md border border-border bg-surface-raised px-3 py-1.5 font-mono text-sm text-text-primary focus-visible:outline-none focus-visible:shadow-focus"
+            />
+            <p className="mt-1 text-xs text-text-muted">
+              {t('admin.entityTypes.editForm.permalink.customHelp')}
+            </p>
+          </div>
+        )}
+
+        {/* No {type} warning */}
+        {effectivePattern && <NoTypeTokenWarning pattern={effectivePattern} />}
+
+        {/* Live example */}
+        {effectivePattern && !isCustom && (
+          <p className="text-xs text-text-muted">
+            {t('admin.entityTypes.editForm.permalink.example', {
+              example: resolvePermalink(effectivePattern, exampleCtx),
+            })}
+          </p>
+        )}
+
+        {updateMutation.error !== null && <Text muted>{updateMutation.error.title}</Text>}
+
+        {isDirty && (
+          <div className="flex gap-inline-sm">
+            <Button
+              size="sm"
+              disabled={updateMutation.isPending}
+              onClick={() => {
+                void handleSave()
+              }}
+            >
+              {updateMutation.isPending ? t('common.actions.saving') : t('common.actions.save')}
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={updateMutation.isPending}
+              onClick={() => {
+                setPattern(entityType.permalinkPattern ?? DEFAULT_PERMALINK_PATTERN)
+                setIsDirty(false)
+                updateMutation.reset()
+              }}
+            >
+              {t('common.actions.cancel')}
+            </Button>
+          </div>
+        )}
+      </Stack>
+    </div>
+  )
+}
+
+// ── Main view ─────────────────────────────────────────────────────────────────
+
+export function PermalinkSettingsView() {
+  const { t } = useTranslation()
+  const listQuery = useEntityTypeList({ limit: 100, offset: 0 })
+  const items = listQuery.data?.items ?? []
+
+  return (
+    <Stack gap="sm">
+      <Stack gap="xs">
+        <Text variant="heading-sm">{t('admin.settings.permalink.title')}</Text>
+        <Text muted>{t('admin.settings.permalink.description')}</Text>
+      </Stack>
+
+      {listQuery.isLoading && <Text muted>{t('admin.entityTypes.existingList.loading')}</Text>}
+
+      {items.length === 0 && !listQuery.isLoading && (
+        <Text muted>{t('admin.entityTypes.existingList.empty.description')}</Text>
+      )}
+
+      {items.map((entityType) => (
+        <PermalinkRow
+          key={String(entityType.id)}
+          entityType={entityType}
+          onSaved={() => {
+            void listQuery.refetch()
+          }}
+        />
+      ))}
+    </Stack>
+  )
+}

--- a/frontend/src/features/manage-entity-types/hooks/use-create-entity-type-form.ts
+++ b/frontend/src/features/manage-entity-types/hooks/use-create-entity-type-form.ts
@@ -19,6 +19,8 @@ export const editEntityTypeFormSchema = createEntityTypeFormSchema.extend({
   labelZhHans: z.string().optional(),
   labelPtBr: z.string().optional(),
   labelDe: z.string().optional(),
+  /** null = use default pattern (/{type}/{id}); empty string treated as null */
+  permalinkPattern: z.string().nullable().optional(),
 })
 
 export type EditEntityTypeFormValues = z.infer<typeof editEntityTypeFormSchema>

--- a/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.ts
+++ b/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.ts
@@ -43,6 +43,11 @@ export function useManageEntityTypesPage() {
       }
 
       const labels = formValuesToLabels(values)
+
+      // Normalize: empty string → null (use backend default)
+      const rawPermalink = values.permalinkPattern
+      const permalinkPattern = rawPermalink === '' || rawPermalink == null ? null : rawPermalink
+
       await updateMutation.mutateAsync({
         id: editTarget.id,
         input: {
@@ -50,6 +55,7 @@ export function useManageEntityTypesPage() {
           slug: values.slug,
           isPinned: values.isPinned,
           labels: Object.keys(labels).length > 0 ? labels : undefined,
+          permalinkPattern,
         },
       })
       setEditTarget(null)

--- a/frontend/src/features/manage-entity-types/ui/EntityTypeEditForm.tsx
+++ b/frontend/src/features/manage-entity-types/ui/EntityTypeEditForm.tsx
@@ -1,6 +1,11 @@
 import { Controller } from 'react-hook-form'
 import type { EntityType } from '@/entities/entity-type'
 import { useTranslation } from '@/shared/i18n'
+import {
+  DEFAULT_PERMALINK_PATTERN,
+  PERMALINK_PRESETS,
+  resolvePermalink,
+} from '@/shared/lib/resolve-permalink'
 import { Button, Input, Stack, Text } from '@/shared/ui'
 import {
   EDIT_LABEL_FIELDS,
@@ -16,6 +21,135 @@ export interface EntityTypeEditFormProps {
   onCancel: () => void
 }
 
+/** Returns the preset pattern if the value matches one; otherwise undefined (= custom). */
+function matchPreset(value: string | null | undefined) {
+  if (!value) return DEFAULT_PERMALINK_PATTERN
+  return PERMALINK_PRESETS.find((p) => p.pattern === value)?.pattern ?? null
+}
+
+function PermalinkFieldset({
+  control,
+  isSubmitting,
+  entityTypeSlug,
+}: {
+  control: ReturnType<typeof useEditEntityTypeForm>['control']
+  isSubmitting: boolean
+  entityTypeSlug: string
+}) {
+  const { t } = useTranslation()
+
+  const exampleCtx = {
+    typeSlug: entityTypeSlug,
+    entitySlug: 'my-article',
+    entityId: 42,
+    publishedAt: '2024-03-15T00:00:00Z',
+  }
+
+  return (
+    <Controller
+      name="permalinkPattern"
+      control={control}
+      render={({ field }) => {
+        // "custom" when the current value doesn't match any preset
+        const matchedPreset = matchPreset(field.value)
+        const isCustom = matchedPreset === null
+
+        // Live example — matchedPreset is always a string here (non-custom branch)
+        const effectivePattern = isCustom ? (field.value ?? '') : matchedPreset
+        const liveExample = effectivePattern ? resolvePermalink(effectivePattern, exampleCtx) : null
+
+        return (
+          <fieldset className="space-y-3 rounded-md border border-border p-4">
+            <legend className="px-1 text-xs font-semibold uppercase tracking-wider text-text-muted">
+              {t('admin.entityTypes.editForm.permalink.title')}
+            </legend>
+            <p className="text-xs text-text-muted">
+              {t('admin.entityTypes.editForm.permalink.description')}
+            </p>
+
+            <div className="space-y-2">
+              {PERMALINK_PRESETS.map((preset) => (
+                <label
+                  key={preset.id}
+                  htmlFor={`permalink-preset-${preset.id}`}
+                  aria-label={preset.label}
+                  className="flex cursor-pointer items-start gap-3 rounded-md border border-transparent p-2 hover:bg-surface-raised"
+                >
+                  <input
+                    id={`permalink-preset-${preset.id}`}
+                    type="radio"
+                    name="permalinkPattern-radio"
+                    checked={!isCustom && matchedPreset === preset.pattern}
+                    disabled={isSubmitting}
+                    onChange={() => {
+                      field.onChange(preset.pattern)
+                    }}
+                    className="mt-0.5 h-4 w-4 shrink-0 accent-accent"
+                  />
+                  <span className="flex flex-col gap-0.5">
+                    <span className="text-sm font-medium text-text-primary">{preset.label}</span>
+                    <code className="font-mono text-xs text-text-muted">
+                      {resolvePermalink(preset.pattern, exampleCtx)}
+                    </code>
+                  </span>
+                </label>
+              ))}
+
+              {/* Custom option */}
+              <label
+                htmlFor="permalink-preset-custom"
+                className="flex cursor-pointer items-start gap-3 rounded-md border border-transparent p-2 hover:bg-surface-raised"
+              >
+                <input
+                  id="permalink-preset-custom"
+                  type="radio"
+                  name="permalinkPattern-radio"
+                  checked={isCustom}
+                  disabled={isSubmitting}
+                  onChange={() => {
+                    // When switching to custom, start with empty string so user can type
+                    field.onChange('')
+                  }}
+                  className="mt-0.5 h-4 w-4 shrink-0 accent-accent"
+                />
+                <span className="text-sm font-medium text-text-primary">
+                  {t('admin.entityTypes.editForm.permalink.custom')}
+                </span>
+              </label>
+            </div>
+
+            {isCustom && (
+              <div className="ml-7 space-y-1">
+                <Input
+                  id="entity-type-edit-permalink-custom"
+                  label={t('admin.entityTypes.editForm.permalink.custom')}
+                  placeholder={t('admin.entityTypes.editForm.permalink.customPlaceholder')}
+                  autoComplete="off"
+                  disabled={isSubmitting}
+                  value={field.value ?? ''}
+                  onChange={(e) => {
+                    field.onChange(e.target.value)
+                  }}
+                  onBlur={field.onBlur}
+                />
+                <p className="text-xs text-text-muted">
+                  {t('admin.entityTypes.editForm.permalink.customHelp')}
+                </p>
+              </div>
+            )}
+
+            {liveExample !== null && !isCustom && (
+              <p className="text-xs text-text-muted">
+                {t('admin.entityTypes.editForm.permalink.example', { example: liveExample })}
+              </p>
+            )}
+          </fieldset>
+        )
+      }}
+    />
+  )
+}
+
 export function EntityTypeEditForm({
   entityType,
   isSubmitting,
@@ -24,6 +158,7 @@ export function EntityTypeEditForm({
   onCancel,
 }: EntityTypeEditFormProps) {
   const { t } = useTranslation()
+
   const {
     control,
     handleSubmit,
@@ -37,6 +172,8 @@ export function EntityTypeEditForm({
     labelZhHans: entityType.labels?.['zh-Hans'] ?? '',
     labelPtBr: entityType.labels?.['pt-BR'] ?? '',
     labelDe: entityType.labels?.['de'] ?? '',
+    // null/undefined → store null; will default to DEFAULT_PERMALINK_PATTERN in the UI
+    permalinkPattern: entityType.permalinkPattern ?? null,
   })
 
   return (
@@ -112,6 +249,13 @@ export function EntityTypeEditForm({
               </span>
             </label>
           )}
+        />
+
+        {/* ── Permalink structure ── */}
+        <PermalinkFieldset
+          control={control}
+          isSubmitting={isSubmitting}
+          entityTypeSlug={entityType.slug}
         />
 
         {/* ── Display names by language ── */}

--- a/frontend/src/features/manage-entity-types/ui/EntityTypeEditForm.tsx
+++ b/frontend/src/features/manage-entity-types/ui/EntityTypeEditForm.tsx
@@ -143,6 +143,13 @@ function PermalinkFieldset({
                 {t('admin.entityTypes.editForm.permalink.example', { example: liveExample })}
               </p>
             )}
+
+            {/* ⚠ No {type} warning */}
+            {effectivePattern && !effectivePattern.includes('{type}') && (
+              <p className="text-xs text-warning">
+                ⚠ {t('admin.entityTypes.editForm.permalink.noTypeWarning')}
+              </p>
+            )}
           </fieldset>
         )
       }}

--- a/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.ts
+++ b/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.ts
@@ -4,11 +4,14 @@ import { useEntityTypeList } from '@/entities/entity-type'
 import { defaultTextFieldListParamsForEntityType, useTextFieldList } from '@/entities/text-field'
 import { findEntityTypeBySlug } from '@/shared/lib/find-entity-type-by-slug'
 import { getRecordDisplayLabel } from '@/shared/lib/get-record-display-label'
+import { resolvePermalink } from '@/shared/lib/resolve-permalink'
 import { PUBLIC_BROWSE_PAGE_SIZE } from '../lib/public-browse-pagination'
 
 export interface PublicRecordListItem {
   id: number
   label: string
+  /** Resolved public URL for this record based on the entity type's permalink pattern */
+  publicUrl: string
 }
 
 export function usePublicBrowseEntityRecordsPage(entityTypeSlug: string, offset: number) {
@@ -36,12 +39,27 @@ export function usePublicBrowseEntityRecordsPage(entityTypeSlug: string, offset:
   const items = useMemo((): PublicRecordListItem[] => {
     const entities = entityListQuery.data?.items ?? []
     const textFields = textFieldQuery.data?.items ?? []
+    const pattern = entityType?.permalinkPattern
 
-    return entities.map((entity) => ({
-      id: Number(entity.id),
-      label: getRecordDisplayLabel(Number(entity.id), textFields, `Record #${String(entity.id)}`),
-    }))
-  }, [entityListQuery.data?.items, textFieldQuery.data?.items])
+    return entities.map((entity) => {
+      const id = Number(entity.id)
+      return {
+        id,
+        label: getRecordDisplayLabel(id, textFields, `Record #${String(id)}`),
+        publicUrl: resolvePermalink(pattern, {
+          typeSlug: entityTypeSlug,
+          entitySlug: entity.slug ?? null,
+          entityId: id,
+          publishedAt: entity.publishedAt ?? null,
+        }),
+      }
+    })
+  }, [
+    entityListQuery.data?.items,
+    textFieldQuery.data?.items,
+    entityType?.permalinkPattern,
+    entityTypeSlug,
+  ])
 
   const isLoading =
     entityTypeQuery.isLoading ||

--- a/frontend/src/features/public-browse-entity-records/ui/PublicRecordListView.tsx
+++ b/frontend/src/features/public-browse-entity-records/ui/PublicRecordListView.tsx
@@ -86,7 +86,7 @@ export function PublicRecordListView({
             className="rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm shadow-sm"
           >
             <Link
-              to={`/${entityTypeSlug}/${String(item.id)}`}
+              to={item.publicUrl}
               className="font-sans text-heading-sm font-semibold text-text-primary hover:text-accent"
             >
               {item.label}

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.test.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.test.tsx
@@ -16,7 +16,7 @@ function renderDetailPage(entityTypeSlug = 'article', entityId = 1) {
   return renderWithProviders(
     <MemoryRouter initialEntries={[`/${entityTypeSlug}/${String(entityId)}`]}>
       <Routes>
-        <Route path="/:entityTypeSlug/:entityId" element={<PublicRecordDetailPage />} />
+        <Route path="/:entityTypeSlug/*" element={<PublicRecordDetailPage />} />
       </Routes>
     </MemoryRouter>,
   )

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
@@ -6,7 +6,9 @@ import {
   usePublicViewEntityRecordPage,
 } from '@/features/public-view-entity-record'
 import { findEntityTypeBySlug } from '@/shared/lib/find-entity-type-by-slug'
+import { extractEntityKeyFromSplat } from '@/shared/lib/resolve-permalink'
 import { Button, EmptyState, Stack, Text } from '@/shared/ui'
+import { useEntityIdBySlug } from './hooks/use-entity-id-by-slug'
 
 function PublicRecordDetailContent({
   entityTypeSlug,
@@ -51,9 +53,43 @@ function PublicRecordDetailContent({
   )
 }
 
+/** Resolved splat → entityId, then renders content */
+function PublicRecordDetailBySlug({
+  entityTypeSlug,
+  entityTypeName,
+  entityTypeId,
+  entitySlug,
+  entityTypeSlugById,
+}: {
+  entityTypeSlug: string
+  entityTypeName: string
+  entityTypeId: number
+  entitySlug: string
+  entityTypeSlugById: Record<number, string>
+}) {
+  const { entityId, isLoading, isError } = useEntityIdBySlug(entityTypeId, entitySlug)
+
+  if (isLoading) return <Text muted>Loading…</Text>
+  if (isError || entityId === null) {
+    return (
+      <EmptyState title="Record not found" description={`No record with slug "${entitySlug}".`} />
+    )
+  }
+
+  return (
+    <PublicRecordDetailContent
+      entityTypeSlug={entityTypeSlug}
+      entityTypeName={entityTypeName}
+      entityTypeId={entityTypeId}
+      entityId={entityId}
+      entityTypeSlugById={entityTypeSlugById}
+    />
+  )
+}
+
 export function PublicRecordDetailPage() {
-  const { entityTypeSlug = '', entityId: entityIdParam = '' } = useParams()
-  const entityId = Number(entityIdParam)
+  // React Router v6: splat param is '*'
+  const { entityTypeSlug = '', '*': splat = '' } = useParams()
 
   const entityTypeQuery = useEntityTypeList({ limit: 100, offset: 0 })
   const entityType = useMemo(
@@ -81,12 +117,27 @@ export function PublicRecordDetailPage() {
     )
   }
 
+  const entityTypeId = Number(entityType.id)
+  const key = extractEntityKeyFromSplat(entityType.permalinkPattern, splat)
+
+  if (key.kind === 'id') {
+    return (
+      <PublicRecordDetailContent
+        entityTypeSlug={entityTypeSlug}
+        entityTypeName={entityType.name}
+        entityTypeId={entityTypeId}
+        entityId={key.id}
+        entityTypeSlugById={entityTypeSlugById}
+      />
+    )
+  }
+
   return (
-    <PublicRecordDetailContent
+    <PublicRecordDetailBySlug
       entityTypeSlug={entityTypeSlug}
       entityTypeName={entityType.name}
-      entityTypeId={Number(entityType.id)}
-      entityId={entityId}
+      entityTypeId={entityTypeId}
+      entitySlug={key.slug}
       entityTypeSlugById={entityTypeSlugById}
     />
   )

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
@@ -1,14 +1,44 @@
 import { useMemo } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, Navigate, useLocation, useParams } from 'react-router-dom'
+import { toEntityId, useEntity } from '@/entities/entity'
 import { useEntityTypeList } from '@/entities/entity-type'
 import {
   PublicRecordDetailView,
   usePublicViewEntityRecordPage,
 } from '@/features/public-view-entity-record'
 import { findEntityTypeBySlug } from '@/shared/lib/find-entity-type-by-slug'
-import { extractEntityKeyFromSplat } from '@/shared/lib/resolve-permalink'
+import {
+  DEFAULT_PERMALINK_PATTERN,
+  extractEntityKeyFromSplat,
+  resolvePermalink,
+} from '@/shared/lib/resolve-permalink'
 import { Button, EmptyState, Stack, Text } from '@/shared/ui'
 import { useEntityIdBySlug } from './hooks/use-entity-id-by-slug'
+
+// ── Canonical redirect helper ─────────────────────────────────────────────────
+
+/**
+ * Compare the current URL to the entity's canonical URL.
+ * Returns the canonical URL if they differ (→ redirect needed), otherwise null.
+ */
+function useCanonicalRedirect(
+  pattern: string | null | undefined,
+  entityTypeSlug: string,
+  entityId: number,
+  entitySlug: string | null,
+  publishedAt: string | null,
+): string | null {
+  const { pathname } = useLocation()
+  const canonical = resolvePermalink(pattern ?? DEFAULT_PERMALINK_PATTERN, {
+    typeSlug: entityTypeSlug,
+    entitySlug,
+    entityId,
+    publishedAt,
+  })
+  return pathname !== canonical ? canonical : null
+}
+
+// ── Content renderer (entity already resolved to a numeric ID) ────────────────
 
 function PublicRecordDetailContent({
   entityTypeSlug,
@@ -16,15 +46,30 @@ function PublicRecordDetailContent({
   entityTypeId,
   entityId,
   entityTypeSlugById,
+  currentPattern,
 }: {
   entityTypeSlug: string
   entityTypeName: string
   entityTypeId: number
   entityId: number
   entityTypeSlugById: Record<number, string>
+  currentPattern: string | null | undefined
 }) {
   const { entity, fieldRows, isLoading, isError, errorTitle, refetch } =
     usePublicViewEntityRecordPage(entityTypeId, entityId)
+
+  // Redirect if the current URL doesn't match the canonical URL for this entity.
+  // This handles pattern changes (e.g. /{type}/{id} → /{type}/{slug}) transparently.
+  const redirect = useCanonicalRedirect(
+    currentPattern,
+    entityTypeSlug,
+    entityId,
+    entity?.slug ?? null,
+    entity?.publishedAt ?? null,
+  )
+  if (!isLoading && !isError && entity !== null && redirect !== null) {
+    return <Navigate to={redirect} replace />
+  }
 
   return (
     <Stack gap="md">
@@ -53,21 +98,91 @@ function PublicRecordDetailContent({
   )
 }
 
-/** Resolved splat → entityId, then renders content */
+// ── Slug → ID resolver with old-pattern fallback ──────────────────────────────
+
+/**
+ * Resolves a slug (from the current pattern) to an entity ID.
+ * If not found, tries the previous permalink pattern's key as a fallback.
+ * Returns null when neither lookup finds anything.
+ */
+function useEntityIdWithFallback(
+  entityTypeId: number,
+  currentSlug: string,
+  previousPattern: string | null | undefined,
+  splat: string,
+): { entityId: number | null; isLoading: boolean; isError: boolean } {
+  // Primary: look up by slug
+  const primary = useEntityIdBySlug(entityTypeId, currentSlug)
+
+  // Fallback key from previous pattern (only when primary fails)
+  const previousKey = useMemo(
+    () => (previousPattern != null ? extractEntityKeyFromSplat(previousPattern, splat) : null),
+    [previousPattern, splat],
+  )
+  const fallbackId = previousKey?.kind === 'id' ? previousKey.id : null
+  const fallbackSlug = previousKey?.kind === 'slug' ? previousKey.slug : ''
+
+  // Fetch the fallback entity by ID (only when primary slug not found and fallback is ID-based)
+  const fallbackEntityQuery = useEntity(toEntityId(fallbackId ?? 0), {
+    enabled: primary.entityId === null && !primary.isLoading && fallbackId !== null,
+  })
+
+  // Fallback slug lookup (only when primary slug not found and fallback is slug-based)
+  const fallbackSlugQuery = useEntityIdBySlug(entityTypeId, fallbackSlug)
+  // Only use fallback slug result when primary has finished and returned nothing
+  const useFallbackSlug =
+    primary.entityId === null && !primary.isLoading && previousKey?.kind === 'slug'
+
+  if (primary.isLoading) return { entityId: null, isLoading: true, isError: false }
+  if (primary.entityId !== null)
+    return { entityId: primary.entityId, isLoading: false, isError: false }
+
+  // Primary failed — check fallback
+  if (fallbackId !== null) {
+    if (fallbackEntityQuery.isLoading) return { entityId: null, isLoading: true, isError: false }
+    if (fallbackEntityQuery.data !== undefined) {
+      return { entityId: Number(fallbackEntityQuery.data.id), isLoading: false, isError: false }
+    }
+    return { entityId: null, isLoading: false, isError: false }
+  }
+
+  if (useFallbackSlug) {
+    if (fallbackSlugQuery.isLoading) return { entityId: null, isLoading: true, isError: false }
+    if (fallbackSlugQuery.entityId !== null) {
+      return { entityId: fallbackSlugQuery.entityId, isLoading: false, isError: false }
+    }
+  }
+
+  return { entityId: null, isLoading: false, isError: primary.isError }
+}
+
+// ── Slug-based entry (uses hook above) ───────────────────────────────────────
+
 function PublicRecordDetailBySlug({
   entityTypeSlug,
   entityTypeName,
   entityTypeId,
   entitySlug,
   entityTypeSlugById,
+  currentPattern,
+  previousPattern,
+  splat,
 }: {
   entityTypeSlug: string
   entityTypeName: string
   entityTypeId: number
   entitySlug: string
   entityTypeSlugById: Record<number, string>
+  currentPattern: string | null | undefined
+  previousPattern: string | null | undefined
+  splat: string
 }) {
-  const { entityId, isLoading, isError } = useEntityIdBySlug(entityTypeId, entitySlug)
+  const { entityId, isLoading, isError } = useEntityIdWithFallback(
+    entityTypeId,
+    entitySlug,
+    previousPattern,
+    splat,
+  )
 
   if (isLoading) return <Text muted>Loading…</Text>
   if (isError || entityId === null) {
@@ -83,9 +198,51 @@ function PublicRecordDetailBySlug({
       entityTypeId={entityTypeId}
       entityId={entityId}
       entityTypeSlugById={entityTypeSlugById}
+      currentPattern={currentPattern}
     />
   )
 }
+
+// ── ID-based entry with old-pattern fallback ──────────────────────────────────
+
+/**
+ * Fetch the entity by ID with a fallback to the previous slug-pattern key.
+ * Covers the case where the old URL used /{type}/{id} but the new pattern is slug-based.
+ */
+// Note: when the current pattern is ID-based but an old URL uses a slug
+// (e.g. /posts/my-article), extractEntityKeyFromSplat returns kind:'slug' so
+// it goes to PublicRecordDetailBySlug, not here. This component only handles
+// the case where the current key is already a numeric ID.
+// The canonical-URL redirect in PublicRecordDetailContent handles any pattern
+// changes that keep the same key type (id→id or slug→slug).
+function PublicRecordDetailById({
+  entityTypeSlug,
+  entityTypeName,
+  entityTypeId,
+  entityId,
+  entityTypeSlugById,
+  currentPattern,
+}: {
+  entityTypeSlug: string
+  entityTypeName: string
+  entityTypeId: number
+  entityId: number
+  entityTypeSlugById: Record<number, string>
+  currentPattern: string | null | undefined
+}) {
+  return (
+    <PublicRecordDetailContent
+      entityTypeSlug={entityTypeSlug}
+      entityTypeName={entityTypeName}
+      entityTypeId={entityTypeId}
+      entityId={entityId}
+      entityTypeSlugById={entityTypeSlugById}
+      currentPattern={currentPattern}
+    />
+  )
+}
+
+// ── Page root ─────────────────────────────────────────────────────────────────
 
 export function PublicRecordDetailPage() {
   // React Router v6: splat param is '*'
@@ -122,12 +279,13 @@ export function PublicRecordDetailPage() {
 
   if (key.kind === 'id') {
     return (
-      <PublicRecordDetailContent
+      <PublicRecordDetailById
         entityTypeSlug={entityTypeSlug}
         entityTypeName={entityType.name}
         entityTypeId={entityTypeId}
         entityId={key.id}
         entityTypeSlugById={entityTypeSlugById}
+        currentPattern={entityType.permalinkPattern}
       />
     )
   }
@@ -139,6 +297,9 @@ export function PublicRecordDetailPage() {
       entityTypeId={entityTypeId}
       entitySlug={key.slug}
       entityTypeSlugById={entityTypeSlugById}
+      currentPattern={entityType.permalinkPattern}
+      previousPattern={entityType.previousPermalinkPattern}
+      splat={splat}
     />
   )
 }

--- a/frontend/src/pages/consumer/hooks/use-entity-id-by-slug.ts
+++ b/frontend/src/pages/consumer/hooks/use-entity-id-by-slug.ts
@@ -1,0 +1,31 @@
+import { useMemo } from 'react'
+import { defaultEntityListParams, useEntityList } from '@/entities/entity'
+
+/**
+ * Resolve an entity slug to its numeric ID within a given entity type.
+ * Uses the list API with a text search (q=slug) and filters client-side
+ * for an exact slug match so date-based patterns like /posts/2024/01/my-article work.
+ */
+export function useEntityIdBySlug(entityTypeId: number, entitySlug: string) {
+  const params = useMemo(
+    () => ({
+      ...defaultEntityListParams(entityTypeId, [], {}, 0, entitySlug),
+      status: 'published' as const,
+      limit: 50,
+    }),
+    [entityTypeId, entitySlug],
+  )
+
+  const query = useEntityList(params, { enabled: entityTypeId > 0 && entitySlug !== '' })
+
+  const entityId = useMemo(() => {
+    const match = (query.data?.items ?? []).find((e) => e.slug === entitySlug)
+    return match !== undefined ? Number(match.id) : null
+  }, [query.data?.items, entitySlug])
+
+  return {
+    entityId,
+    isLoading: query.isLoading,
+    isError: query.isError,
+  }
+}

--- a/frontend/src/pages/settings/SiteSettingsPage.tsx
+++ b/frontend/src/pages/settings/SiteSettingsPage.tsx
@@ -1,5 +1,5 @@
 import { ManageSiteSettingsView } from '@/features/manage-settings'
-import { AppearanceView } from '@/features/manage-appearance'
+import { AppearanceView, PermalinkSettingsView } from '@/features/manage-appearance'
 import { currentUserHasCapability } from '@/entities/auth'
 import { useTranslation } from '@/shared/i18n'
 import { Stack, Text } from '@/shared/ui'
@@ -16,6 +16,7 @@ export function SiteSettingsPage() {
         <Text muted>{t('admin.settings.description')}</Text>
       </Stack>
       <AppearanceView />
+      <PermalinkSettingsView />
       <ManageSiteSettingsView canManageSettings={canManageSettings} />
     </Stack>
   )

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -131,6 +131,8 @@ export const en = {
   'admin.entityTypes.editForm.permalink.customHelp':
     'Available tokens: {type}, {slug}, {id}, {year}, {month}, {day}',
   'admin.entityTypes.editForm.permalink.example': 'Example: {{example}}',
+  'admin.entityTypes.editForm.permalink.noTypeWarning':
+    'Pattern does not include {type} — URLs from different content types may collide.',
   'admin.entityTypes.delete.title': 'Delete content type?',
   'admin.entityTypes.delete.description': '"{{name}}" will be removed. This cannot be undone.',
   'admin.entityTypes.actions.fields': 'Fields',
@@ -343,6 +345,9 @@ export const en = {
 
   // ── Settings ──────────────────────────────────────────────────────────────
   'admin.settings.appearance.title': 'Appearance',
+  'admin.settings.permalink.title': 'Permalinks',
+  'admin.settings.permalink.description':
+    'Choose the URL structure for each content type. Changes take effect immediately; old URLs redirect automatically.',
 
   'admin.settings.pageTitle': 'Site settings',
   'admin.settings.description':

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -123,6 +123,14 @@ export const en = {
   'admin.entityTypes.editForm.labels.title': 'Display names',
   'admin.entityTypes.editForm.labels.description':
     'Optionally override the display name for each language. Leave blank to use the base name.',
+  'admin.entityTypes.editForm.permalink.title': 'Permalink',
+  'admin.entityTypes.editForm.permalink.description':
+    'Choose the URL structure for public records of this content type.',
+  'admin.entityTypes.editForm.permalink.custom': 'Custom structure',
+  'admin.entityTypes.editForm.permalink.customPlaceholder': 'e.g. /{type}/{year}/{month}/{slug}',
+  'admin.entityTypes.editForm.permalink.customHelp':
+    'Available tokens: {type}, {slug}, {id}, {year}, {month}, {day}',
+  'admin.entityTypes.editForm.permalink.example': 'Example: {{example}}',
   'admin.entityTypes.delete.title': 'Delete content type?',
   'admin.entityTypes.delete.description': '"{{name}}" will be removed. This cannot be undone.',
   'admin.entityTypes.actions.fields': 'Fields',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -125,6 +125,8 @@ export const ja: Partial<MessageCatalog> = {
   'admin.entityTypes.editForm.permalink.customHelp':
     '使用できるトークン: {type}、{slug}、{id}、{year}、{month}、{day}',
   'admin.entityTypes.editForm.permalink.example': '例: {{example}}',
+  'admin.entityTypes.editForm.permalink.noTypeWarning':
+    'パターンに {type} が含まれていません — 複数のコンテンツタイプで URL が衝突する可能性があります。',
   'admin.entityTypes.delete.title': 'コンテンツタイプを削除しますか？',
   'admin.entityTypes.delete.description': '「{{name}}」が削除されます。この操作は元に戻せません。',
   'admin.entityTypes.actions.fields': 'フィールド',
@@ -344,6 +346,9 @@ export const ja: Partial<MessageCatalog> = {
 
   // ── Settings ──────────────────────────────────────────────────────────────
   'admin.settings.appearance.title': '外観',
+  'admin.settings.permalink.title': 'パーマリンク',
+  'admin.settings.permalink.description':
+    'コンテンツタイプごとに公開 URL の構造を選択します。変更はすぐ反映され、旧 URL は自動リダイレクトされます。',
 
   'admin.settings.pageTitle': 'サイト設定',
   'admin.settings.description':

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -117,6 +117,14 @@ export const ja: Partial<MessageCatalog> = {
   'admin.entityTypes.editForm.labels.title': '言語別の表示名',
   'admin.entityTypes.editForm.labels.description':
     '言語ごとに表示名を上書きできます。空白のままにすると、ベース名が使用されます。',
+  'admin.entityTypes.editForm.permalink.title': 'パーマリンク',
+  'admin.entityTypes.editForm.permalink.description':
+    'このコンテンツタイプの公開 URL の構造を選択してください。',
+  'admin.entityTypes.editForm.permalink.custom': 'カスタム構造',
+  'admin.entityTypes.editForm.permalink.customPlaceholder': '例: /{type}/{year}/{month}/{slug}',
+  'admin.entityTypes.editForm.permalink.customHelp':
+    '使用できるトークン: {type}、{slug}、{id}、{year}、{month}、{day}',
+  'admin.entityTypes.editForm.permalink.example': '例: {{example}}',
   'admin.entityTypes.delete.title': 'コンテンツタイプを削除しますか？',
   'admin.entityTypes.delete.description': '「{{name}}」が削除されます。この操作は元に戻せません。',
   'admin.entityTypes.actions.fields': 'フィールド',

--- a/frontend/src/shared/lib/resolve-permalink.ts
+++ b/frontend/src/shared/lib/resolve-permalink.ts
@@ -1,0 +1,113 @@
+/**
+ * Permalink pattern resolver for public entity URLs.
+ *
+ * Supported tokens:
+ *   {type}  – entity type slug (e.g. "posts")
+ *   {slug}  – entity slug      (e.g. "my-article")
+ *   {id}    – entity numeric ID
+ *   {year}  – 4-digit year from publishedAt (or createdAt, or "0000")
+ *   {month} – 2-digit month (01–12)
+ *   {day}   – 2-digit day   (01–31)
+ */
+
+export const DEFAULT_PERMALINK_PATTERN = '/{type}/{id}'
+
+export interface PermalinkContext {
+  typeSlug: string
+  entitySlug: string | null
+  entityId: number
+  publishedAt: string | null // ISO-8601
+}
+
+/** Built-in preset patterns, mirroring WordPress permalink settings. */
+export const PERMALINK_PRESETS = [
+  {
+    id: 'default',
+    label: 'Default',
+    labelJa: 'デフォルト',
+    pattern: '/{type}/{id}',
+    example: '/posts/42',
+  },
+  {
+    id: 'post-name',
+    label: 'Post name',
+    labelJa: '投稿名',
+    pattern: '/{type}/{slug}',
+    example: '/posts/my-article',
+  },
+  {
+    id: 'month-name',
+    label: 'Month and name',
+    labelJa: '月と投稿名',
+    pattern: '/{type}/{year}/{month}/{slug}',
+    example: '/posts/2024/01/my-article',
+  },
+  {
+    id: 'day-name',
+    label: 'Day and name',
+    labelJa: '日付と投稿名',
+    pattern: '/{type}/{year}/{month}/{day}/{slug}',
+    example: '/posts/2024/01/15/my-article',
+  },
+] as const
+
+export type PermalinkPresetId = (typeof PERMALINK_PRESETS)[number]['id']
+
+/**
+ * Resolve a permalink pattern with the given context.
+ * Returns a URL path string starting with "/".
+ */
+export function resolvePermalink(
+  pattern: string | null | undefined,
+  ctx: PermalinkContext,
+): string {
+  const pat = pattern ?? DEFAULT_PERMALINK_PATTERN
+
+  const date = ctx.publishedAt ? new Date(ctx.publishedAt) : null
+  const year = date ? String(date.getUTCFullYear()) : '0000'
+  const month = date ? String(date.getUTCMonth() + 1).padStart(2, '0') : '00'
+  const day = date ? String(date.getUTCDate()).padStart(2, '0') : '00'
+
+  return pat
+    .replace(/\{type\}/g, ctx.typeSlug)
+    .replace(/\{slug\}/g, ctx.entitySlug ?? String(ctx.entityId))
+    .replace(/\{id\}/g, String(ctx.entityId))
+    .replace(/\{year\}/g, year)
+    .replace(/\{month\}/g, month)
+    .replace(/\{day\}/g, day)
+}
+
+/**
+ * Given a permalink pattern and the "splat" path segment (everything after the
+ * entity type slug in a `/:typeSlug/*` route), extract what we need to look up
+ * the entity.
+ *
+ * Returns `{ kind: 'id', id: number }` or `{ kind: 'slug', slug: string }`.
+ */
+export type EntityLookupKey = { kind: 'id'; id: number } | { kind: 'slug'; slug: string }
+
+export function extractEntityKeyFromSplat(
+  pattern: string | null | undefined,
+  splat: string,
+): EntityLookupKey {
+  const pat = pattern ?? DEFAULT_PERMALINK_PATTERN
+
+  // Count the token segments in the pattern after {type}
+  // e.g. "/{type}/{year}/{month}/{slug}" → after {type} we have 3 more segments
+  // The last token in the pattern determines how we resolve
+  if (pat.includes('{id}') && !pat.includes('{slug}')) {
+    const id = Number(splat.split('/').at(-1))
+    if (!Number.isNaN(id)) return { kind: 'id', id }
+  }
+
+  // Default: use the last path segment as slug
+  const slug = splat.split('/').filter(Boolean).at(-1) ?? splat
+  return { kind: 'slug', slug }
+}
+
+/**
+ * Returns true when the pattern requires slug (not just numeric ID) in the URL.
+ */
+export function patternUsesSlug(pattern: string | null | undefined): boolean {
+  return (pattern ?? DEFAULT_PERMALINK_PATTERN).includes('{slug}')
+}

--- a/src/EntityType/EntityType.php
+++ b/src/EntityType/EntityType.php
@@ -19,6 +19,7 @@ final readonly class EntityType
         public ?int $id = null,
         public ?array $labels = null,
         public ?string $permalinkPattern = null,
+        public ?string $previousPermalinkPattern = null,
     ) {
     }
 }

--- a/src/EntityType/EntityType.php
+++ b/src/EntityType/EntityType.php
@@ -7,8 +7,10 @@ namespace NeNeRecords\EntityType;
 final readonly class EntityType
 {
     /**
-     * @param array<string, string>|null $labels Locale-keyed display names, e.g. {"ja":"投稿","fr":"Articles"}.
-     *                                            Null means no overrides; `$name` is used as fallback.
+     * @param array<string, string>|null $labels             Locale-keyed display names.
+     * @param string|null                $permalinkPattern   URL pattern for public records.
+     *                                                        Tokens: {type} {slug} {id} {year} {month} {day}
+     *                                                        Null = use default "/{type}/{id}".
      */
     public function __construct(
         public string $name,
@@ -16,6 +18,7 @@ final readonly class EntityType
         public bool $isPinned = false,
         public ?int $id = null,
         public ?array $labels = null,
+        public ?string $permalinkPattern = null,
     ) {
     }
 }

--- a/src/EntityType/GetEntityTypeByIdHandler.php
+++ b/src/EntityType/GetEntityTypeByIdHandler.php
@@ -29,11 +29,12 @@ final readonly class GetEntityTypeByIdHandler
         $output = $this->useCase->execute(new GetEntityTypeByIdInput($id));
 
         return $this->response->create([
-            'id' => $output->id,
-            'name' => $output->name,
-            'slug' => $output->slug,
-            'is_pinned' => $output->isPinned,
-            'labels' => $output->labels ?? new \stdClass(),
+            'id'                => $output->id,
+            'name'              => $output->name,
+            'slug'              => $output->slug,
+            'is_pinned'         => $output->isPinned,
+            'labels'            => $output->labels ?? new \stdClass(),
+            'permalink_pattern' => $output->permalinkPattern,
         ]);
     }
 }

--- a/src/EntityType/GetEntityTypeByIdHandler.php
+++ b/src/EntityType/GetEntityTypeByIdHandler.php
@@ -29,12 +29,13 @@ final readonly class GetEntityTypeByIdHandler
         $output = $this->useCase->execute(new GetEntityTypeByIdInput($id));
 
         return $this->response->create([
-            'id'                => $output->id,
-            'name'              => $output->name,
-            'slug'              => $output->slug,
-            'is_pinned'         => $output->isPinned,
-            'labels'            => $output->labels ?? new \stdClass(),
-            'permalink_pattern' => $output->permalinkPattern,
+            'id'                         => $output->id,
+            'name'                       => $output->name,
+            'slug'                       => $output->slug,
+            'is_pinned'                  => $output->isPinned,
+            'labels'                     => $output->labels ?? new \stdClass(),
+            'permalink_pattern'          => $output->permalinkPattern,
+            'previous_permalink_pattern' => $output->previousPermalinkPattern,
         ]);
     }
 }

--- a/src/EntityType/GetEntityTypeByIdOutput.php
+++ b/src/EntityType/GetEntityTypeByIdOutput.php
@@ -15,6 +15,7 @@ final readonly class GetEntityTypeByIdOutput
         public string $slug,
         public bool $isPinned,
         public ?array $labels = null,
+        public ?string $permalinkPattern = null,
     ) {
     }
 }

--- a/src/EntityType/GetEntityTypeByIdOutput.php
+++ b/src/EntityType/GetEntityTypeByIdOutput.php
@@ -16,6 +16,7 @@ final readonly class GetEntityTypeByIdOutput
         public bool $isPinned,
         public ?array $labels = null,
         public ?string $permalinkPattern = null,
+        public ?string $previousPermalinkPattern = null,
     ) {
     }
 }

--- a/src/EntityType/GetEntityTypeByIdUseCase.php
+++ b/src/EntityType/GetEntityTypeByIdUseCase.php
@@ -25,6 +25,7 @@ final readonly class GetEntityTypeByIdUseCase implements GetEntityTypeByIdUseCas
             slug: $entityType->slug,
             isPinned: $entityType->isPinned,
             labels: $entityType->labels,
+            permalinkPattern: $entityType->permalinkPattern,
         );
     }
 }

--- a/src/EntityType/GetEntityTypeByIdUseCase.php
+++ b/src/EntityType/GetEntityTypeByIdUseCase.php
@@ -26,6 +26,7 @@ final readonly class GetEntityTypeByIdUseCase implements GetEntityTypeByIdUseCas
             isPinned: $entityType->isPinned,
             labels: $entityType->labels,
             permalinkPattern: $entityType->permalinkPattern,
+            previousPermalinkPattern: $entityType->previousPermalinkPattern,
         );
     }
 }

--- a/src/EntityType/ListEntityTypeItem.php
+++ b/src/EntityType/ListEntityTypeItem.php
@@ -16,6 +16,7 @@ final readonly class ListEntityTypeItem
         public bool $isPinned,
         public ?array $labels = null,
         public ?string $permalinkPattern = null,
+        public ?string $previousPermalinkPattern = null,
     ) {
     }
 }

--- a/src/EntityType/ListEntityTypeItem.php
+++ b/src/EntityType/ListEntityTypeItem.php
@@ -15,6 +15,7 @@ final readonly class ListEntityTypeItem
         public string $slug,
         public bool $isPinned,
         public ?array $labels = null,
+        public ?string $permalinkPattern = null,
     ) {
     }
 }

--- a/src/EntityType/ListEntityTypesHandler.php
+++ b/src/EntityType/ListEntityTypesHandler.php
@@ -28,11 +28,12 @@ final readonly class ListEntityTypesHandler
             (new PaginationResponse(
                 items: array_map(
                     static fn (ListEntityTypeItem $item) => [
-                        'id' => $item->id,
-                        'name' => $item->name,
-                        'slug' => $item->slug,
-                        'is_pinned' => $item->isPinned,
-                        'labels' => $item->labels ?? new \stdClass(),
+                        'id'                => $item->id,
+                        'name'              => $item->name,
+                        'slug'              => $item->slug,
+                        'is_pinned'         => $item->isPinned,
+                        'labels'            => $item->labels ?? new \stdClass(),
+                        'permalink_pattern' => $item->permalinkPattern,
                     ],
                     $output->items,
                 ),

--- a/src/EntityType/ListEntityTypesHandler.php
+++ b/src/EntityType/ListEntityTypesHandler.php
@@ -28,12 +28,13 @@ final readonly class ListEntityTypesHandler
             (new PaginationResponse(
                 items: array_map(
                     static fn (ListEntityTypeItem $item) => [
-                        'id'                => $item->id,
-                        'name'              => $item->name,
-                        'slug'              => $item->slug,
-                        'is_pinned'         => $item->isPinned,
-                        'labels'            => $item->labels ?? new \stdClass(),
-                        'permalink_pattern' => $item->permalinkPattern,
+                        'id'                          => $item->id,
+                        'name'                        => $item->name,
+                        'slug'                        => $item->slug,
+                        'is_pinned'                   => $item->isPinned,
+                        'labels'                      => $item->labels ?? new \stdClass(),
+                        'permalink_pattern'           => $item->permalinkPattern,
+                        'previous_permalink_pattern'  => $item->previousPermalinkPattern,
                     ],
                     $output->items,
                 ),

--- a/src/EntityType/ListEntityTypesUseCase.php
+++ b/src/EntityType/ListEntityTypesUseCase.php
@@ -23,6 +23,7 @@ final readonly class ListEntityTypesUseCase implements ListEntityTypesUseCaseInt
                 isPinned: $entityType->isPinned,
                 labels: $entityType->labels,
                 permalinkPattern: $entityType->permalinkPattern,
+                previousPermalinkPattern: $entityType->previousPermalinkPattern,
             ),
             $rows,
         );

--- a/src/EntityType/ListEntityTypesUseCase.php
+++ b/src/EntityType/ListEntityTypesUseCase.php
@@ -22,6 +22,7 @@ final readonly class ListEntityTypesUseCase implements ListEntityTypesUseCaseInt
                 slug: $entityType->slug,
                 isPinned: $entityType->isPinned,
                 labels: $entityType->labels,
+                permalinkPattern: $entityType->permalinkPattern,
             ),
             $rows,
         );

--- a/src/EntityType/PdoEntityTypeRepository.php
+++ b/src/EntityType/PdoEntityTypeRepository.php
@@ -16,7 +16,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function findById(int $id): ?EntityType
     {
         $row = $this->query->fetchOne(
-            'SELECT id, name, slug, is_pinned, labels FROM entity_types WHERE id = ?',
+            'SELECT id, name, slug, is_pinned, labels, permalink_pattern FROM entity_types WHERE id = ?',
             [$id],
         );
 
@@ -30,7 +30,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function findBySlug(string $slug): ?EntityType
     {
         $row = $this->query->fetchOne(
-            'SELECT id, name, slug, is_pinned, labels FROM entity_types WHERE slug = ?',
+            'SELECT id, name, slug, is_pinned, labels, permalink_pattern FROM entity_types WHERE slug = ?',
             [$slug],
         );
 
@@ -45,7 +45,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function findAll(int $limit, int $offset): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT id, name, slug, is_pinned, labels FROM entity_types ORDER BY id ASC LIMIT ? OFFSET ?',
+            'SELECT id, name, slug, is_pinned, labels, permalink_pattern FROM entity_types ORDER BY id ASC LIMIT ? OFFSET ?',
             [$limit, $offset],
         );
 
@@ -55,12 +55,13 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function save(EntityType $entityType): int
     {
         $this->query->execute(
-            'INSERT INTO entity_types (name, slug, is_pinned, labels) VALUES (?, ?, ?, ?)',
+            'INSERT INTO entity_types (name, slug, is_pinned, labels, permalink_pattern) VALUES (?, ?, ?, ?, ?)',
             [
                 $entityType->name,
                 $entityType->slug,
                 $entityType->isPinned ? 1 : 0,
                 $entityType->labels !== null ? json_encode($entityType->labels, JSON_UNESCAPED_UNICODE) : null,
+                $entityType->permalinkPattern,
             ],
         );
 
@@ -70,12 +71,13 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function update(EntityType $entityType): void
     {
         $this->query->execute(
-            'UPDATE entity_types SET name = ?, slug = ?, is_pinned = ?, labels = ? WHERE id = ?',
+            'UPDATE entity_types SET name = ?, slug = ?, is_pinned = ?, labels = ?, permalink_pattern = ? WHERE id = ?',
             [
                 $entityType->name,
                 $entityType->slug,
                 $entityType->isPinned ? 1 : 0,
                 $entityType->labels !== null ? json_encode($entityType->labels, JSON_UNESCAPED_UNICODE) : null,
+                $entityType->permalinkPattern,
                 $entityType->id,
             ],
         );
@@ -99,12 +101,17 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
             }
         }
 
+        $permalinkPattern = isset($row['permalink_pattern']) && is_string($row['permalink_pattern']) && $row['permalink_pattern'] !== ''
+            ? $row['permalink_pattern']
+            : null;
+
         return new EntityType(
             name: (string) $row['name'],
             slug: (string) $row['slug'],
             isPinned: (bool) $row['is_pinned'],
             id: (int) $row['id'],
             labels: $labels,
+            permalinkPattern: $permalinkPattern,
         );
     }
 }

--- a/src/EntityType/PdoEntityTypeRepository.php
+++ b/src/EntityType/PdoEntityTypeRepository.php
@@ -16,7 +16,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function findById(int $id): ?EntityType
     {
         $row = $this->query->fetchOne(
-            'SELECT id, name, slug, is_pinned, labels, permalink_pattern FROM entity_types WHERE id = ?',
+            'SELECT id, name, slug, is_pinned, labels, permalink_pattern, previous_permalink_pattern FROM entity_types WHERE id = ?',
             [$id],
         );
 
@@ -30,7 +30,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function findBySlug(string $slug): ?EntityType
     {
         $row = $this->query->fetchOne(
-            'SELECT id, name, slug, is_pinned, labels, permalink_pattern FROM entity_types WHERE slug = ?',
+            'SELECT id, name, slug, is_pinned, labels, permalink_pattern, previous_permalink_pattern FROM entity_types WHERE slug = ?',
             [$slug],
         );
 
@@ -45,7 +45,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function findAll(int $limit, int $offset): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT id, name, slug, is_pinned, labels, permalink_pattern FROM entity_types ORDER BY id ASC LIMIT ? OFFSET ?',
+            'SELECT id, name, slug, is_pinned, labels, permalink_pattern, previous_permalink_pattern FROM entity_types ORDER BY id ASC LIMIT ? OFFSET ?',
             [$limit, $offset],
         );
 
@@ -71,13 +71,14 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function update(EntityType $entityType): void
     {
         $this->query->execute(
-            'UPDATE entity_types SET name = ?, slug = ?, is_pinned = ?, labels = ?, permalink_pattern = ? WHERE id = ?',
+            'UPDATE entity_types SET name = ?, slug = ?, is_pinned = ?, labels = ?, permalink_pattern = ?, previous_permalink_pattern = ? WHERE id = ?',
             [
                 $entityType->name,
                 $entityType->slug,
                 $entityType->isPinned ? 1 : 0,
                 $entityType->labels !== null ? json_encode($entityType->labels, JSON_UNESCAPED_UNICODE) : null,
                 $entityType->permalinkPattern,
+                $entityType->previousPermalinkPattern,
                 $entityType->id,
             ],
         );
@@ -105,6 +106,10 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
             ? $row['permalink_pattern']
             : null;
 
+        $previousPermalinkPattern = isset($row['previous_permalink_pattern']) && is_string($row['previous_permalink_pattern']) && $row['previous_permalink_pattern'] !== ''
+            ? $row['previous_permalink_pattern']
+            : null;
+
         return new EntityType(
             name: (string) $row['name'],
             slug: (string) $row['slug'],
@@ -112,6 +117,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
             id: (int) $row['id'],
             labels: $labels,
             permalinkPattern: $permalinkPattern,
+            previousPermalinkPattern: $previousPermalinkPattern,
         );
     }
 }

--- a/src/EntityType/UpdateEntityTypeHandler.php
+++ b/src/EntityType/UpdateEntityTypeHandler.php
@@ -105,12 +105,13 @@ final readonly class UpdateEntityTypeHandler
         ));
 
         return $this->response->create([
-            'id'                => $output->id,
-            'name'              => $output->name,
-            'slug'              => $output->slug,
-            'is_pinned'         => $output->isPinned,
-            'labels'            => $output->labels ?? new \stdClass(),
-            'permalink_pattern' => $output->permalinkPattern,
+            'id'                         => $output->id,
+            'name'                       => $output->name,
+            'slug'                       => $output->slug,
+            'is_pinned'                  => $output->isPinned,
+            'labels'                     => $output->labels ?? new \stdClass(),
+            'permalink_pattern'          => $output->permalinkPattern,
+            'previous_permalink_pattern' => $output->previousPermalinkPattern,
         ]);
     }
 }

--- a/src/EntityType/UpdateEntityTypeHandler.php
+++ b/src/EntityType/UpdateEntityTypeHandler.php
@@ -16,6 +16,12 @@ final readonly class UpdateEntityTypeHandler
 {
     private const SLUG_PATTERN = '/^[a-z0-9]+(?:-[a-z0-9]+)*$/';
 
+    /**
+     * Valid tokens in permalink_pattern.
+     * At minimum {slug} or {id} must appear so we can resolve an entity.
+     */
+    private const RESERVED_PATHS = ['/admin', '/login', '/forbidden', '/api'];
+
     public function __construct(
         private UpdateEntityTypeUseCaseInterface $useCase,
         private JsonResponseFactory $response,
@@ -50,6 +56,31 @@ final readonly class UpdateEntityTypeHandler
             $labels = $filtered !== [] ? array_map('strval', $filtered) : null;
         }
 
+        // permalink_pattern: optional, e.g. "/{type}/{slug}", "/{type}/{year}/{month}/{slug}"
+        $rawPattern = $body['permalink_pattern'] ?? null;
+        $permalinkPattern = null;
+        if (is_string($rawPattern) && trim($rawPattern) !== '') {
+            $permalinkPattern = trim($rawPattern);
+
+            // Must start with /
+            if (!str_starts_with($permalinkPattern, '/')) {
+                $errors[] = new ValidationError('permalink_pattern', 'Permalink pattern must start with /.', 'format');
+            }
+
+            // Must contain {slug} or {id} to be resolvable
+            if (!str_contains($permalinkPattern, '{slug}') && !str_contains($permalinkPattern, '{id}')) {
+                $errors[] = new ValidationError('permalink_pattern', 'Permalink pattern must contain {slug} or {id}.', 'format');
+            }
+
+            // Must not conflict with reserved application paths
+            foreach (self::RESERVED_PATHS as $reserved) {
+                if (str_starts_with($permalinkPattern, $reserved)) {
+                    $errors[] = new ValidationError('permalink_pattern', "Permalink pattern must not start with reserved path \"{$reserved}\".", 'conflict');
+                    break;
+                }
+            }
+        }
+
         if ($name === '') {
             $errors[] = new ValidationError('name', 'Name is required.', 'required');
         }
@@ -64,14 +95,22 @@ final readonly class UpdateEntityTypeHandler
             throw new ValidationException($errors);
         }
 
-        $output = $this->useCase->execute(new UpdateEntityTypeInput(id: $id, name: $name, slug: $slug, isPinned: $isPinned, labels: $labels));
+        $output = $this->useCase->execute(new UpdateEntityTypeInput(
+            id: $id,
+            name: $name,
+            slug: $slug,
+            isPinned: $isPinned,
+            labels: $labels,
+            permalinkPattern: $permalinkPattern,
+        ));
 
         return $this->response->create([
-            'id' => $output->id,
-            'name' => $output->name,
-            'slug' => $output->slug,
-            'is_pinned' => $output->isPinned,
-            'labels' => $output->labels ?? new \stdClass(),
+            'id'                => $output->id,
+            'name'              => $output->name,
+            'slug'              => $output->slug,
+            'is_pinned'         => $output->isPinned,
+            'labels'            => $output->labels ?? new \stdClass(),
+            'permalink_pattern' => $output->permalinkPattern,
         ]);
     }
 }

--- a/src/EntityType/UpdateEntityTypeInput.php
+++ b/src/EntityType/UpdateEntityTypeInput.php
@@ -16,6 +16,7 @@ final readonly class UpdateEntityTypeInput
         public bool $isPinned = false,
         public ?array $labels = null,
         public ?string $permalinkPattern = null,
+        public ?string $previousPermalinkPattern = null,
     ) {
     }
 }

--- a/src/EntityType/UpdateEntityTypeInput.php
+++ b/src/EntityType/UpdateEntityTypeInput.php
@@ -15,6 +15,7 @@ final readonly class UpdateEntityTypeInput
         public string $slug,
         public bool $isPinned = false,
         public ?array $labels = null,
+        public ?string $permalinkPattern = null,
     ) {
     }
 }

--- a/src/EntityType/UpdateEntityTypeOutput.php
+++ b/src/EntityType/UpdateEntityTypeOutput.php
@@ -16,6 +16,7 @@ final readonly class UpdateEntityTypeOutput
         public bool $isPinned,
         public ?array $labels = null,
         public ?string $permalinkPattern = null,
+        public ?string $previousPermalinkPattern = null,
     ) {
     }
 }

--- a/src/EntityType/UpdateEntityTypeOutput.php
+++ b/src/EntityType/UpdateEntityTypeOutput.php
@@ -15,6 +15,7 @@ final readonly class UpdateEntityTypeOutput
         public string $slug,
         public bool $isPinned,
         public ?array $labels = null,
+        public ?string $permalinkPattern = null,
     ) {
     }
 }

--- a/src/EntityType/UpdateEntityTypeUseCase.php
+++ b/src/EntityType/UpdateEntityTypeUseCase.php
@@ -27,9 +27,9 @@ final readonly class UpdateEntityTypeUseCase implements UpdateEntityTypeUseCaseI
             }
         }
 
-        $updated = new EntityType(name: $input->name, slug: $input->slug, isPinned: $input->isPinned, id: $input->id, labels: $input->labels);
+        $updated = new EntityType(name: $input->name, slug: $input->slug, isPinned: $input->isPinned, id: $input->id, labels: $input->labels, permalinkPattern: $input->permalinkPattern);
         $this->entityTypes->update($updated);
 
-        return new UpdateEntityTypeOutput(id: $input->id, name: $input->name, slug: $input->slug, isPinned: $input->isPinned, labels: $input->labels);
+        return new UpdateEntityTypeOutput(id: $input->id, name: $input->name, slug: $input->slug, isPinned: $input->isPinned, labels: $input->labels, permalinkPattern: $input->permalinkPattern);
     }
 }

--- a/src/EntityType/UpdateEntityTypeUseCase.php
+++ b/src/EntityType/UpdateEntityTypeUseCase.php
@@ -27,9 +27,31 @@ final readonly class UpdateEntityTypeUseCase implements UpdateEntityTypeUseCaseI
             }
         }
 
-        $updated = new EntityType(name: $input->name, slug: $input->slug, isPinned: $input->isPinned, id: $input->id, labels: $input->labels, permalinkPattern: $input->permalinkPattern);
+        // When the permalink pattern changes, preserve the old one for redirect purposes.
+        $previousPermalinkPattern = $entityType->previousPermalinkPattern;
+        if ($input->permalinkPattern !== $entityType->permalinkPattern) {
+            $previousPermalinkPattern = $entityType->permalinkPattern;
+        }
+
+        $updated = new EntityType(
+            name: $input->name,
+            slug: $input->slug,
+            isPinned: $input->isPinned,
+            id: $input->id,
+            labels: $input->labels,
+            permalinkPattern: $input->permalinkPattern,
+            previousPermalinkPattern: $previousPermalinkPattern,
+        );
         $this->entityTypes->update($updated);
 
-        return new UpdateEntityTypeOutput(id: $input->id, name: $input->name, slug: $input->slug, isPinned: $input->isPinned, labels: $input->labels, permalinkPattern: $input->permalinkPattern);
+        return new UpdateEntityTypeOutput(
+            id: $input->id,
+            name: $input->name,
+            slug: $input->slug,
+            isPinned: $input->isPinned,
+            labels: $input->labels,
+            permalinkPattern: $input->permalinkPattern,
+            previousPermalinkPattern: $previousPermalinkPattern,
+        );
     }
 }

--- a/tests/EntityType/InMemoryEntityTypeRepository.php
+++ b/tests/EntityType/InMemoryEntityTypeRepository.php
@@ -34,6 +34,7 @@ final class InMemoryEntityTypeRepository implements EntityTypeRepositoryInterfac
                     id: $id,
                     labels: $entityType->labels,
                     permalinkPattern: $entityType->permalinkPattern,
+                    previousPermalinkPattern: $entityType->previousPermalinkPattern,
                 );
                 $this->byId[$id] = $stored;
                 $this->slugToId[$stored->slug] = $id;
@@ -77,6 +78,7 @@ final class InMemoryEntityTypeRepository implements EntityTypeRepositoryInterfac
             id: $id,
             labels: $entityType->labels,
             permalinkPattern: $entityType->permalinkPattern,
+            previousPermalinkPattern: $entityType->previousPermalinkPattern,
         );
         $this->byId[$id] = $stored;
         $this->slugToId[$stored->slug] = $id;

--- a/tests/EntityType/InMemoryEntityTypeRepository.php
+++ b/tests/EntityType/InMemoryEntityTypeRepository.php
@@ -27,7 +27,14 @@ final class InMemoryEntityTypeRepository implements EntityTypeRepositoryInterfac
         foreach ($seed as $entityType) {
             if ($entityType->id !== null) {
                 $id = $entityType->id;
-                $stored = new EntityType(name: $entityType->name, slug: $entityType->slug, isPinned: $entityType->isPinned, id: $id);
+                $stored = new EntityType(
+                    name: $entityType->name,
+                    slug: $entityType->slug,
+                    isPinned: $entityType->isPinned,
+                    id: $id,
+                    labels: $entityType->labels,
+                    permalinkPattern: $entityType->permalinkPattern,
+                );
                 $this->byId[$id] = $stored;
                 $this->slugToId[$stored->slug] = $id;
                 $this->nextId = max($this->nextId, $id + 1);
@@ -63,7 +70,14 @@ final class InMemoryEntityTypeRepository implements EntityTypeRepositoryInterfac
     public function save(EntityType $entityType): int
     {
         $id = $this->nextId++;
-        $stored = new EntityType(name: $entityType->name, slug: $entityType->slug, isPinned: $entityType->isPinned, id: $id);
+        $stored = new EntityType(
+            name: $entityType->name,
+            slug: $entityType->slug,
+            isPinned: $entityType->isPinned,
+            id: $id,
+            labels: $entityType->labels,
+            permalinkPattern: $entityType->permalinkPattern,
+        );
         $this->byId[$id] = $stored;
         $this->slugToId[$stored->slug] = $id;
 


### PR DESCRIPTION
## 目的
Issue #169 — WordPress 風のパーマリンク設定機能を実装。

## 変更内容

### バックエンド
- `entity_types` テーブルに `permalink_pattern` カラムを追加（migration + SQLite スキーマ）
- `UpdateEntityTypeHandler` でパターン検証：先頭 `/` 必須、`{slug}` か `{id}` を含む必要あり、予約パス（/admin, /login 等）禁止
- `EntityType` モデル・リポジトリ・DTO すべてに `permalinkPattern` を伝搬
- OpenAPI スペックを更新

### フロントエンド
- **`EntityTypeEditForm`**: パーマリンク設定フィールドセット追加
  - 4 プリセット（Default / Post name / Month and name / Day and name）をラジオボタンで選択
  - 選択時にリアルタイムで URL 例を表示
  - 「カスタム構造」選択時はテキスト入力が展開される
- **公開ページ**: `resolvePermalink()` で動的 URL を生成
  - トークン: `{type}`, `{slug}`, `{id}`, `{year}`, `{month}`, `{day}`
  - `PublicRecordListView`: 一覧ページのリンクも permalink パターン対応
  - `PublicRecordDetailPage`: splat ルート対応、スラッグ/ID を自動判別
- **i18n**: 日本語・英語にパーマリンク設定の翻訳を追加

## 検証
- `composer check` — 264 tests passed ✓
- `npm run check` — type-check + lint + test + storybook ✓

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)