### PR TITLE
feat(users): ユーザー管理 API・招待・パスワードリセット (#190 #191)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "require": {
         "php": ">=8.4.1 <9.0",
         "hideyukimori/nene2": "@dev",
-        "league/commonmark": "^2.7"
+        "league/commonmark": "^2.7",
+        "symfony/mailer": "^8.0"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "27fe8387417b63fca40d0eb0795aa559",
+    "content-hash": "0a27cdef20a9e04798685cd820daa90b",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -82,6 +82,150 @@
             "time": "2024-07-08T12:26:09+00:00"
         },
         {
+            "name": "doctrine/lexer",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^10.5",
+                "psalm/plugin-phpunit": "^0.18.3",
+                "vimeo/psalm": "^5.21"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/lexer/issues",
+                "source": "https://github.com/doctrine/lexer/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-05T11:56:58+00:00"
+        },
+        {
+            "name": "egulias/email-validator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/egulias/EmailValidator.git",
+                "reference": "d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa",
+                "reference": "d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2.0 || ^3.0",
+                "php": ">=8.1",
+                "symfony/polyfill-intl-idn": "^1.26"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.2",
+                "vimeo/psalm": "^5.12"
+            },
+            "suggest": {
+                "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Egulias\\EmailValidator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eduardo Gulias Davis"
+                }
+            ],
+            "description": "A library for validating emails against several RFCs",
+            "homepage": "https://github.com/egulias/EmailValidator",
+            "keywords": [
+                "email",
+                "emailvalidation",
+                "emailvalidator",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/egulias/EmailValidator/issues",
+                "source": "https://github.com/egulias/EmailValidator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/egulias",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
             "name": "graham-campbell/result-type",
             "version": "v1.1.4",
             "source": {
@@ -145,11 +289,11 @@
         },
         {
             "name": "hideyukimori/nene2",
-            "version": "dev-main",
+            "version": "dev-docs/1042-ft248-content-approval-workflow",
             "dist": {
                 "type": "path",
                 "url": "../NENE2",
-                "reference": "03a6de8f1c589ff862d1aa9f199a466526a7e5f2"
+                "reference": "349def332e018d8ab515a71624ae8416753020a9"
             },
             "require": {
                 "monolog/monolog": "^3.0",
@@ -1358,6 +1502,337 @@
             "time": "2026-04-13T15:52:40+00:00"
         },
         {
+            "name": "symfony/event-dispatcher",
+            "version": "v8.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "0c3c1a17604c4dbbec4b93fe162c538482096e1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/0c3c1a17604c4dbbec4b93fe162c538482096e1f",
+                "reference": "0c3c1a17604c4dbbec4b93fe162c538482096e1f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/event-dispatcher-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/security-http": "<7.4",
+                "symfony/service-contracts": "<2.5"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/stopwatch": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.0.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-18T13:51:42+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/event-dispatcher": "^1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-05T13:30:16+00:00"
+        },
+        {
+            "name": "symfony/mailer",
+            "version": "v8.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mailer.git",
+                "reference": "5266d594e83593dff3492b5655ff6e8f38d67cfc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/5266d594e83593dff3492b5655ff6e8f38d67cfc",
+                "reference": "5266d594e83593dff3492b5655ff6e8f38d67cfc",
+                "shasum": ""
+            },
+            "require": {
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "php": ">=8.4",
+                "psr/event-dispatcher": "^1",
+                "psr/log": "^1|^2|^3",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/mime": "^7.4|^8.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/http-client-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/console": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/twig-bridge": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mailer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps sending emails",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/mailer/tree/v8.0.12"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-20T07:22:03+00:00"
+        },
+        {
+            "name": "symfony/mime",
+            "version": "v8.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "7d9a72bbf0a9cb169ed1cbbbbbf709a592207fc1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/7d9a72bbf0a9cb169ed1cbbbbbf709a592207fc1",
+                "reference": "7d9a72bbf0a9cb169ed1cbbbbbf709a592207fc1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "egulias/email-validator": "~3.0.0",
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3.1|^4",
+                "league/html-to-markdown": "^5.0",
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/property-info": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows manipulating MIME messages",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/mime/tree/v8.0.12"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-20T07:22:03+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.37.0",
             "source": {
@@ -1439,6 +1914,178 @@
                 }
             ],
             "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "symfony/polyfill-intl-normalizer": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T15:22:23+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1608,6 +2255,93 @@
                 }
             ],
             "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -5405,171 +6139,6 @@
             "time": "2026-05-13T12:07:53+00:00"
         },
         {
-            "name": "symfony/event-dispatcher",
-            "version": "v8.0.9",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "0c3c1a17604c4dbbec4b93fe162c538482096e1f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/0c3c1a17604c4dbbec4b93fe162c538482096e1f",
-                "reference": "0c3c1a17604c4dbbec4b93fe162c538482096e1f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.4",
-                "symfony/event-dispatcher-contracts": "^2.5|^3"
-            },
-            "conflict": {
-                "symfony/security-http": "<7.4",
-                "symfony/service-contracts": "<2.5"
-            },
-            "provide": {
-                "psr/event-dispatcher-implementation": "1.0",
-                "symfony/event-dispatcher-implementation": "2.0|3.0"
-            },
-            "require-dev": {
-                "psr/log": "^1|^2|^3",
-                "symfony/config": "^7.4|^8.0",
-                "symfony/dependency-injection": "^7.4|^8.0",
-                "symfony/error-handler": "^7.4|^8.0",
-                "symfony/expression-language": "^7.4|^8.0",
-                "symfony/framework-bundle": "^7.4|^8.0",
-                "symfony/http-foundation": "^7.4|^8.0",
-                "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^7.4|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\EventDispatcher\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v8.0.9"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-18T13:51:42+00:00"
-        },
-        {
-            "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
-                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "psr/event-dispatcher": "^1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\EventDispatcher\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to dispatching event",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-01-05T13:30:16+00:00"
-        },
-        {
             "name": "symfony/filesystem",
             "version": "v8.0.11",
             "source": {
@@ -5861,91 +6430,6 @@
             "time": "2026-04-26T13:13:48+00:00"
         },
         {
-            "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.37.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's Normalizer class and related functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "intl",
-                "normalizer",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-09T11:45:10+00:00"
-        },
-        {
             "name": "symfony/polyfill-php81",
             "version": "v1.37.0",
             "source": {
@@ -6169,93 +6653,6 @@
                 }
             ],
             "time": "2026-05-11T16:56:32+00:00"
-        },
-        {
-            "name": "symfony/service-contracts",
-            "version": "v3.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "psr/container": "^1.1|^2.0",
-                "symfony/deprecation-contracts": "^2.5|^3"
-            },
-            "conflict": {
-                "ext-psr": "<1.1|>=2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\Service\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Test/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to writing services",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "symfony/stopwatch",

--- a/database/migrations/20260620000000_add_user_management_columns.php
+++ b/database/migrations/20260620000000_add_user_management_columns.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddUserManagementColumns extends AbstractMigration
+{
+    public function up(): void
+    {
+        // Add status, invite token, and password reset token columns to users table
+        $this->execute("
+            ALTER TABLE users
+                ADD COLUMN status ENUM('active', 'invited') NOT NULL DEFAULT 'active' AFTER role,
+                ADD COLUMN invite_token_hash VARCHAR(64) NULL DEFAULT NULL AFTER status,
+                ADD COLUMN invite_expires_at DATETIME NULL DEFAULT NULL AFTER invite_token_hash,
+                ADD COLUMN password_reset_token_hash VARCHAR(64) NULL DEFAULT NULL AFTER invite_expires_at,
+                ADD COLUMN password_reset_expires_at DATETIME NULL DEFAULT NULL AFTER password_reset_token_hash
+        ");
+    }
+
+    public function down(): void
+    {
+        $this->execute('
+            ALTER TABLE users
+                DROP COLUMN password_reset_expires_at,
+                DROP COLUMN password_reset_token_hash,
+                DROP COLUMN invite_expires_at,
+                DROP COLUMN invite_token_hash,
+                DROP COLUMN status
+        ');
+    }
+}

--- a/database/schema/users.sql
+++ b/database/schema/users.sql
@@ -3,6 +3,11 @@ CREATE TABLE users (
     email VARCHAR(255) NOT NULL,
     password_hash VARCHAR(255) NOT NULL,
     role VARCHAR(32) NOT NULL DEFAULT 'admin',
+    status ENUM('active', 'invited') NOT NULL DEFAULT 'active',
+    invite_token_hash VARCHAR(64) NULL DEFAULT NULL,
+    invite_expires_at DATETIME NULL DEFAULT NULL,
+    password_reset_token_hash VARCHAR(64) NULL DEFAULT NULL,
+    password_reset_expires_at DATETIME NULL DEFAULT NULL,
     created_at DATETIME NOT NULL,
     updated_at DATETIME NOT NULL
 );

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2626,6 +2626,92 @@ paths:
                 $ref: '#/components/schemas/ProblemDetails'
         '422':
           $ref: '#/components/responses/ValidationFailed'
+  /api/v1/users/invite:
+    post:
+      tags:
+        - Users
+      summary: Invite user
+      description: Creates an invited user and sends an email with an activation link. Admin only.
+      operationId: inviteUser
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InviteUserRequest'
+      responses:
+        '201':
+          description: Invite sent.
+          headers:
+            Location:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+  /api/v1/auth/accept-invite:
+    post:
+      tags:
+        - Users
+      summary: Accept invite
+      description: Accepts an invitation token and sets the user's password, activating the account.
+      operationId: acceptInvite
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AcceptInviteRequest'
+      responses:
+        '204':
+          description: Account activated.
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+  /api/v1/auth/password-reset:
+    post:
+      tags:
+        - Auth
+      summary: Request password reset
+      description: >
+        Sends a password reset email. Always returns 204 regardless of whether
+        the email exists (prevents email enumeration).
+      operationId: requestPasswordReset
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordResetRequest'
+      responses:
+        '204':
+          description: Reset email sent (or silently ignored if email not found).
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+  /api/v1/auth/password-reset/confirm:
+    post:
+      tags:
+        - Auth
+      summary: Confirm password reset
+      description: Validates the reset token and sets a new password.
+      operationId: confirmPasswordReset
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordResetConfirmRequest'
+      responses:
+        '204':
+          description: Password updated.
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
 components:
   parameters:
     IdPath:
@@ -2954,6 +3040,60 @@ components:
         - new_password
       properties:
         current_password:
+          type: string
+        new_password:
+          type: string
+          minLength: 8
+      additionalProperties: false
+    InviteUserRequest:
+      type: object
+      required:
+        - email
+        - role
+      properties:
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+          enum:
+            - admin
+            - editor
+        app_base_url:
+          type: string
+          description: Optional base URL for the invite link (defaults to request origin).
+      additionalProperties: false
+    AcceptInviteRequest:
+      type: object
+      required:
+        - token
+        - password
+      properties:
+        token:
+          type: string
+        password:
+          type: string
+          minLength: 8
+      additionalProperties: false
+    PasswordResetRequest:
+      type: object
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          format: email
+        app_base_url:
+          type: string
+          description: Optional base URL for the reset link (defaults to request origin).
+      additionalProperties: false
+    PasswordResetConfirmRequest:
+      type: object
+      required:
+        - token
+        - new_password
+      properties:
+        token:
           type: string
         new_password:
           type: string

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -44,6 +44,8 @@ tags:
     description: Ordered navigation link management for the public site header.
   - name: Webhooks
     description: Webhook endpoints for entity create/update/delete event notifications.
+  - name: Users
+    description: User account management (admin only) and self-service password change.
 paths:
   /api/v1/auth/login:
     post:
@@ -2394,6 +2396,236 @@ paths:
           $ref: '#/components/responses/ValidationFailed'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/users:
+    get:
+      tags:
+        - Users
+      summary: List users
+      description: Returns all user accounts. Admin only.
+      operationId: listUsers
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: List of users.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserListResponse'
+        '401':
+          description: Unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+    post:
+      tags:
+        - Users
+      summary: Create user
+      description: Creates a new user account with a password set immediately. Admin only.
+      operationId: createUser
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateUserRequest'
+      responses:
+        '201':
+          description: User created.
+          headers:
+            Location:
+              schema:
+                type: string
+              description: URL of the new user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '401':
+          description: Unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+  /api/v1/users/{id}:
+    get:
+      tags:
+        - Users
+      summary: Get user
+      description: Returns a single user by ID. Admin only.
+      operationId: getUserById
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      responses:
+        '200':
+          description: User found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '401':
+          description: Unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      tags:
+        - Users
+      summary: Update user role
+      description: Changes the role of a user. Admin only.
+      operationId: updateUserRole
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserRoleRequest'
+      responses:
+        '200':
+          description: Role updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '401':
+          description: Unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+    delete:
+      tags:
+        - Users
+      summary: Delete user
+      description: Deletes a user account. Admin only. Cannot delete own account or the last admin.
+      operationId: deleteUser
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      responses:
+        '204':
+          description: User deleted.
+        '401':
+          description: Unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/users/{id}/password:
+    patch:
+      tags:
+        - Users
+      summary: Admin password reset
+      description: Sets a new password for any user. Admin only.
+      operationId: adminResetPassword
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminResetPasswordRequest'
+      responses:
+        '204':
+          description: Password updated.
+        '401':
+          description: Unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+  /api/v1/users/me/password:
+    put:
+      tags:
+        - Users
+      summary: Change own password
+      description: Changes the authenticated user's own password. Requires current password verification.
+      operationId: changeOwnPassword
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangeOwnPasswordRequest'
+      responses:
+        '204':
+          description: Password changed.
+        '401':
+          description: Unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
 components:
   parameters:
     IdPath:
@@ -2634,6 +2866,99 @@ components:
                 detail: An unexpected error occurred.
                 instance: /api/v1/entity-types
   schemas:
+    UserResponse:
+      type: object
+      required:
+        - id
+        - email
+        - role
+        - status
+      properties:
+        id:
+          type: integer
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+          enum:
+            - admin
+            - editor
+        status:
+          type: string
+          enum:
+            - active
+            - invited
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+      additionalProperties: false
+    UserListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserResponse'
+      additionalProperties: false
+    CreateUserRequest:
+      type: object
+      required:
+        - email
+        - password
+        - role
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          minLength: 8
+        role:
+          type: string
+          enum:
+            - admin
+            - editor
+      additionalProperties: false
+    UpdateUserRoleRequest:
+      type: object
+      required:
+        - role
+      properties:
+        role:
+          type: string
+          enum:
+            - admin
+            - editor
+      additionalProperties: false
+    AdminResetPasswordRequest:
+      type: object
+      required:
+        - new_password
+      properties:
+        new_password:
+          type: string
+          minLength: 8
+      additionalProperties: false
+    ChangeOwnPasswordRequest:
+      type: object
+      required:
+        - current_password
+        - new_password
+      properties:
+        current_password:
+          type: string
+        new_password:
+          type: string
+          minLength: 8
+      additionalProperties: false
     HealthResponse:
       type: object
       required:

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -67,6 +67,12 @@ use NeNeRecords\TextField\FieldKeyNotRegisteredExceptionHandler as TextFieldKeyN
 use NeNeRecords\TextField\FieldTypeMismatchExceptionHandler as TextFieldTypeMismatchExceptionHandler;
 use NeNeRecords\TextField\TextFieldNotFoundExceptionHandler;
 use NeNeRecords\TextField\TextFieldServiceProvider;
+use NeNeRecords\User\CannotDeleteSelfExceptionHandler;
+use NeNeRecords\User\InvalidCurrentPasswordExceptionHandler;
+use NeNeRecords\User\InvalidUserRoleExceptionHandler;
+use NeNeRecords\User\UserEmailConflictExceptionHandler;
+use NeNeRecords\User\UserNotFoundExceptionHandler;
+use NeNeRecords\User\UserServiceProvider;
 use NeNeRecords\Webhook\WebhookNotFoundExceptionHandler;
 use NeNeRecords\Webhook\WebhookServiceProvider;
 use Psr\Container\ContainerInterface;
@@ -99,7 +105,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new NavigationItemServiceProvider())
             ->addProvider(new WebhookServiceProvider())
             ->addProvider(new PreviewTokenServiceProvider())
-            ->addProvider(new DashboardServiceProvider());
+            ->addProvider(new DashboardServiceProvider())
+            ->addProvider(new UserServiceProvider());
 
         $builder
             ->set(
@@ -125,6 +132,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $webhook = $container->get('nene-records.route_registrar.webhook');
                     $previewToken = $container->get('nene-records.route_registrar.preview_token');
                     $dashboard = $container->get('nene-records.route_registrar.dashboard');
+                    $user = $container->get('nene-records.route_registrar.user');
                     $auth = $container->get('nene-records.route_registrar.auth');
 
                     if (
@@ -148,6 +156,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !is_callable($webhook)
                         || !is_callable($previewToken)
                         || !is_callable($dashboard)
+                        || !is_callable($user)
                         || !is_callable($auth)
                     ) {
                         throw new LogicException('Route registrar service is invalid.');
@@ -175,6 +184,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $webhook,
                         $previewToken,
                         $dashboard,
+                        $user,
                     ];
                 },
             )
@@ -222,6 +232,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $navigationItemNotFound = $container->get(NavigationItemNotFoundExceptionHandler::class);
                     $webhookNotFound = $container->get(WebhookNotFoundExceptionHandler::class);
                     $previewTokenNotFound = $container->get(PreviewTokenNotFoundExceptionHandler::class);
+                    $userNotFound = $container->get(UserNotFoundExceptionHandler::class);
+                    $userEmailConflict = $container->get(UserEmailConflictExceptionHandler::class);
+                    $cannotDeleteSelf = $container->get(CannotDeleteSelfExceptionHandler::class);
+                    $invalidUserRole = $container->get(InvalidUserRoleExceptionHandler::class);
+                    $invalidCurrentPassword = $container->get(InvalidCurrentPasswordExceptionHandler::class);
 
                     foreach ([
                         $entityTypeNotFound,
@@ -265,6 +280,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $navigationItemNotFound,
                         $webhookNotFound,
                         $previewTokenNotFound,
+                        $userNotFound,
+                        $userEmailConflict,
+                        $cannotDeleteSelf,
+                        $invalidUserRole,
+                        $invalidCurrentPassword,
                     ] as $handler) {
                         if (!$handler instanceof DomainExceptionHandlerInterface) {
                             throw new LogicException('Exception handler service is invalid.');
@@ -313,6 +333,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $navigationItemNotFound,
                         $webhookNotFound,
                         $previewTokenNotFound,
+                        $userNotFound,
+                        $userEmailConflict,
+                        $cannotDeleteSelf,
+                        $invalidUserRole,
+                        $invalidCurrentPassword,
                     ];
                 },
             );

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -73,6 +73,9 @@ use NeNeRecords\User\InvalidUserRoleExceptionHandler;
 use NeNeRecords\User\UserEmailConflictExceptionHandler;
 use NeNeRecords\User\UserNotFoundExceptionHandler;
 use NeNeRecords\User\UserServiceProvider;
+use NeNeRecords\UserInvite\InvalidInviteTokenExceptionHandler;
+use NeNeRecords\UserInvite\InvalidPasswordResetTokenExceptionHandler;
+use NeNeRecords\UserInvite\UserInviteServiceProvider;
 use NeNeRecords\Webhook\WebhookNotFoundExceptionHandler;
 use NeNeRecords\Webhook\WebhookServiceProvider;
 use Psr\Container\ContainerInterface;
@@ -106,7 +109,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new WebhookServiceProvider())
             ->addProvider(new PreviewTokenServiceProvider())
             ->addProvider(new DashboardServiceProvider())
-            ->addProvider(new UserServiceProvider());
+            ->addProvider(new UserServiceProvider())
+            ->addProvider(new UserInviteServiceProvider());
 
         $builder
             ->set(
@@ -133,6 +137,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $previewToken = $container->get('nene-records.route_registrar.preview_token');
                     $dashboard = $container->get('nene-records.route_registrar.dashboard');
                     $user = $container->get('nene-records.route_registrar.user');
+                    $userInvite = $container->get('nene-records.route_registrar.user_invite');
                     $auth = $container->get('nene-records.route_registrar.auth');
 
                     if (
@@ -157,6 +162,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !is_callable($previewToken)
                         || !is_callable($dashboard)
                         || !is_callable($user)
+                        || !is_callable($userInvite)
                         || !is_callable($auth)
                     ) {
                         throw new LogicException('Route registrar service is invalid.');
@@ -185,6 +191,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $previewToken,
                         $dashboard,
                         $user,
+                        $userInvite,
                     ];
                 },
             )
@@ -237,6 +244,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $cannotDeleteSelf = $container->get(CannotDeleteSelfExceptionHandler::class);
                     $invalidUserRole = $container->get(InvalidUserRoleExceptionHandler::class);
                     $invalidCurrentPassword = $container->get(InvalidCurrentPasswordExceptionHandler::class);
+                    $invalidInviteToken = $container->get(InvalidInviteTokenExceptionHandler::class);
+                    $invalidResetToken = $container->get(InvalidPasswordResetTokenExceptionHandler::class);
 
                     foreach ([
                         $entityTypeNotFound,
@@ -285,6 +294,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $cannotDeleteSelf,
                         $invalidUserRole,
                         $invalidCurrentPassword,
+                        $invalidInviteToken,
+                        $invalidResetToken,
                     ] as $handler) {
                         if (!$handler instanceof DomainExceptionHandlerInterface) {
                             throw new LogicException('Exception handler service is invalid.');
@@ -338,6 +349,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $cannotDeleteSelf,
                         $invalidUserRole,
                         $invalidCurrentPassword,
+                        $invalidInviteToken,
+                        $invalidResetToken,
                     ];
                 },
             );

--- a/src/Auth/AdminApiAuthMiddleware.php
+++ b/src/Auth/AdminApiAuthMiddleware.php
@@ -34,6 +34,7 @@ final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
     private const ADMIN_ONLY_PREFIXES = [
         '/api/v1/settings',
         '/api/v1/navigation-items',
+        '/api/v1/users',
     ];
 
     public function __construct(

--- a/src/Auth/CapabilityResolver.php
+++ b/src/Auth/CapabilityResolver.php
@@ -54,6 +54,16 @@ final class CapabilityResolver
             return Capability::ManageTags;
         }
 
+        // User management: all mutations require ManageSettings (admin-only)
+        // Exception: PUT /api/v1/users/me/password is accessible to any authenticated user (no capability check)
+        if (str_starts_with($path, '/api/v1/users') && $path !== '/api/v1/users/me/password' && self::isMutationMethod($method)) {
+            return Capability::ManageSettings;
+        }
+
+        if (str_starts_with($path, '/api/v1/users') && self::isAdminReadPath($path) && $method === 'GET') {
+            return Capability::ManageSettings;
+        }
+
         foreach (self::CONTENT_MUTATION_PREFIXES as $prefix) {
             if (str_starts_with($path, $prefix) && self::isMutationMethod($method)) {
                 return Capability::EditContent;
@@ -66,5 +76,15 @@ final class CapabilityResolver
     private static function isMutationMethod(string $method): bool
     {
         return !in_array($method, ['GET', 'HEAD', 'OPTIONS'], true);
+    }
+
+    /**
+     * Paths under /api/v1/users that expose sensitive user data — admin-only even for GET.
+     */
+    private static function isAdminReadPath(string $path): bool
+    {
+        // /api/v1/users (list) and /api/v1/users/{id} (get specific user)
+        // Exclude /api/v1/users/me/password which is self-service
+        return $path !== '/api/v1/users/me/password';
     }
 }

--- a/src/Auth/PdoUserRepository.php
+++ b/src/Auth/PdoUserRepository.php
@@ -16,7 +16,12 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
     public function findByEmail(string $email): ?User
     {
         $row = $this->query->fetchOne(
-            'SELECT id, email, password_hash, role FROM users WHERE email = ?',
+            'SELECT id, email, password_hash, role, status,
+                    invite_token_hash, invite_expires_at,
+                    password_reset_token_hash, password_reset_expires_at,
+                    UNIX_TIMESTAMP(created_at) AS created_at,
+                    UNIX_TIMESTAMP(updated_at) AS updated_at
+             FROM users WHERE email = ?',
             [$email],
         );
 
@@ -24,11 +29,186 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
             return null;
         }
 
+        return $this->mapRow($row);
+    }
+
+    public function findById(int $id): ?User
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, email, password_hash, role, status,
+                    invite_token_hash, invite_expires_at,
+                    password_reset_token_hash, password_reset_expires_at,
+                    UNIX_TIMESTAMP(created_at) AS created_at,
+                    UNIX_TIMESTAMP(updated_at) AS updated_at
+             FROM users WHERE id = ?',
+            [$id],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return $this->mapRow($row);
+    }
+
+    /** @return list<User> */
+    public function list(): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, email, password_hash, role, status,
+                    invite_token_hash, invite_expires_at,
+                    password_reset_token_hash, password_reset_expires_at,
+                    UNIX_TIMESTAMP(created_at) AS created_at,
+                    UNIX_TIMESTAMP(updated_at) AS updated_at
+             FROM users ORDER BY id ASC',
+            [],
+        );
+
+        return array_map($this->mapRow(...), $rows);
+    }
+
+    public function create(string $email, string $passwordHash, string $role): User
+    {
+        $now = date('Y-m-d H:i:s');
+        $this->query->execute(
+            'INSERT INTO users (email, password_hash, role, status, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?)',
+            [$email, $passwordHash, $role, 'active', $now, $now],
+        );
+
+        $user = $this->findByEmail($email);
+
+        assert($user !== null);
+
+        return $user;
+    }
+
+    public function updateRole(int $id, string $role): void
+    {
+        $this->query->execute(
+            'UPDATE users SET role = ?, updated_at = NOW() WHERE id = ?',
+            [$role, $id],
+        );
+    }
+
+    public function updatePassword(int $id, string $passwordHash): void
+    {
+        $this->query->execute(
+            'UPDATE users SET password_hash = ?, updated_at = NOW() WHERE id = ?',
+            [$passwordHash, $id],
+        );
+    }
+
+    public function updateStatus(int $id, string $status): void
+    {
+        $this->query->execute(
+            'UPDATE users SET status = ?, updated_at = NOW() WHERE id = ?',
+            [$status, $id],
+        );
+    }
+
+    public function storeInviteToken(int $id, string $tokenHash, int $expiresAt): void
+    {
+        $expiresAtStr = date('Y-m-d H:i:s', $expiresAt);
+        $this->query->execute(
+            'UPDATE users SET invite_token_hash = ?, invite_expires_at = ?, status = ?, updated_at = NOW() WHERE id = ?',
+            [$tokenHash, $expiresAtStr, 'invited', $id],
+        );
+    }
+
+    public function findByInviteToken(string $tokenHash): ?User
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, email, password_hash, role, status,
+                    invite_token_hash, invite_expires_at,
+                    password_reset_token_hash, password_reset_expires_at,
+                    UNIX_TIMESTAMP(created_at) AS created_at,
+                    UNIX_TIMESTAMP(updated_at) AS updated_at
+             FROM users WHERE invite_token_hash = ?',
+            [$tokenHash],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return $this->mapRow($row);
+    }
+
+    public function clearInviteToken(int $id): void
+    {
+        $this->query->execute(
+            'UPDATE users SET invite_token_hash = NULL, invite_expires_at = NULL, status = ?, updated_at = NOW() WHERE id = ?',
+            ['active', $id],
+        );
+    }
+
+    public function storePasswordResetToken(int $id, string $tokenHash, int $expiresAt): void
+    {
+        $expiresAtStr = date('Y-m-d H:i:s', $expiresAt);
+        $this->query->execute(
+            'UPDATE users SET password_reset_token_hash = ?, password_reset_expires_at = ?, updated_at = NOW() WHERE id = ?',
+            [$tokenHash, $expiresAtStr, $id],
+        );
+    }
+
+    public function findByPasswordResetToken(string $tokenHash): ?User
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, email, password_hash, role, status,
+                    invite_token_hash, invite_expires_at,
+                    password_reset_token_hash, password_reset_expires_at,
+                    UNIX_TIMESTAMP(created_at) AS created_at,
+                    UNIX_TIMESTAMP(updated_at) AS updated_at
+             FROM users WHERE password_reset_token_hash = ?',
+            [$tokenHash],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return $this->mapRow($row);
+    }
+
+    public function clearPasswordResetToken(int $id): void
+    {
+        $this->query->execute(
+            'UPDATE users SET password_reset_token_hash = NULL, password_reset_expires_at = NULL, updated_at = NOW() WHERE id = ?',
+            [$id],
+        );
+    }
+
+    public function delete(int $id): void
+    {
+        $this->query->execute('DELETE FROM users WHERE id = ?', [$id]);
+    }
+
+    public function countByRole(string $role): int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS cnt FROM users WHERE role = ?',
+            [$role],
+        );
+
+        return (int) ($row['cnt'] ?? 0);
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): User
+    {
         return new User(
             id: (int) $row['id'],
             email: (string) $row['email'],
             passwordHash: (string) $row['password_hash'],
             role: (string) $row['role'],
+            status: (string) ($row['status'] ?? 'active'),
+            inviteTokenHash: isset($row['invite_token_hash']) ? (string) $row['invite_token_hash'] : null,
+            inviteExpiresAt: isset($row['invite_expires_at']) ? (int) $row['invite_expires_at'] : null,
+            passwordResetTokenHash: isset($row['password_reset_token_hash']) ? (string) $row['password_reset_token_hash'] : null,
+            passwordResetExpiresAt: isset($row['password_reset_expires_at']) ? (int) $row['password_reset_expires_at'] : null,
+            createdAt: isset($row['created_at']) ? (int) $row['created_at'] : null,
+            updatedAt: isset($row['updated_at']) ? (int) $row['updated_at'] : null,
         );
     }
 }

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -11,6 +11,13 @@ final readonly class User
         public string $email,
         public string $passwordHash,
         public string $role,
+        public string $status = 'active',
+        public ?string $inviteTokenHash = null,
+        public ?int $inviteExpiresAt = null,
+        public ?string $passwordResetTokenHash = null,
+        public ?int $passwordResetExpiresAt = null,
+        public ?int $createdAt = null,
+        public ?int $updatedAt = null,
     ) {
     }
 }

--- a/src/Auth/UserRepositoryInterface.php
+++ b/src/Auth/UserRepositoryInterface.php
@@ -7,4 +7,33 @@ namespace NeNeRecords\Auth;
 interface UserRepositoryInterface
 {
     public function findByEmail(string $email): ?User;
+
+    public function findById(int $id): ?User;
+
+    /** @return list<User> */
+    public function list(): array;
+
+    public function create(string $email, string $passwordHash, string $role): User;
+
+    public function updateRole(int $id, string $role): void;
+
+    public function updatePassword(int $id, string $passwordHash): void;
+
+    public function updateStatus(int $id, string $status): void;
+
+    public function storeInviteToken(int $id, string $tokenHash, int $expiresAt): void;
+
+    public function findByInviteToken(string $tokenHash): ?User;
+
+    public function clearInviteToken(int $id): void;
+
+    public function storePasswordResetToken(int $id, string $tokenHash, int $expiresAt): void;
+
+    public function findByPasswordResetToken(string $tokenHash): ?User;
+
+    public function clearPasswordResetToken(int $id): void;
+
+    public function delete(int $id): void;
+
+    public function countByRole(string $role): int;
 }

--- a/src/Mail/MailMessage.php
+++ b/src/Mail/MailMessage.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Mail;
+
+final readonly class MailMessage
+{
+    public function __construct(
+        public string $to,
+        public string $subject,
+        public string $textBody,
+        public string $htmlBody,
+    ) {
+    }
+}

--- a/src/Mail/MailerInterface.php
+++ b/src/Mail/MailerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Mail;
+
+interface MailerInterface
+{
+    public function send(MailMessage $message): void;
+}

--- a/src/Mail/SymfonyMailer.php
+++ b/src/Mail/SymfonyMailer.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Mail;
+
+use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mailer\Transport;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+
+final readonly class SymfonyMailer implements MailerInterface
+{
+    private Mailer $mailer;
+
+    public function __construct(
+        private string $dsn,
+        private string $fromAddress,
+        private string $fromName,
+    ) {
+        $transport = Transport::fromDsn($this->dsn);
+        $this->mailer = new Mailer($transport);
+    }
+
+    public function send(MailMessage $message): void
+    {
+        $email = (new Email())
+            ->from(new Address($this->fromAddress, $this->fromName))
+            ->to($message->to)
+            ->subject($message->subject)
+            ->text($message->textBody)
+            ->html($message->htmlBody);
+
+        $this->mailer->send($email);
+    }
+}

--- a/src/User/AdminResetPasswordHandler.php
+++ b/src/User/AdminResetPasswordHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class AdminResetPasswordHandler
+{
+    public function __construct(
+        private AdminResetPasswordUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+        $newPassword = (string) ($body['new_password'] ?? '');
+
+        if ($newPassword === '') {
+            $errors[] = new ValidationError('new_password', 'New password is required.', 'required');
+        } elseif (strlen($newPassword) < 8) {
+            $errors[] = new ValidationError('new_password', 'Password must be at least 8 characters.', 'min_length');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $this->useCase->execute(new AdminResetPasswordInput(id: $id, newPassword: $newPassword));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/User/AdminResetPasswordInput.php
+++ b/src/User/AdminResetPasswordInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+final readonly class AdminResetPasswordInput
+{
+    public function __construct(
+        public int $id,
+        public string $newPassword,
+    ) {
+    }
+}

--- a/src/User/AdminResetPasswordUseCase.php
+++ b/src/User/AdminResetPasswordUseCase.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use NeNeRecords\Auth\UserRepositoryInterface;
+
+final readonly class AdminResetPasswordUseCase implements AdminResetPasswordUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(AdminResetPasswordInput $input): void
+    {
+        $user = $this->users->findById($input->id);
+
+        if ($user === null) {
+            throw new UserNotFoundException($input->id);
+        }
+
+        $newHash = password_hash($input->newPassword, PASSWORD_BCRYPT);
+        $this->users->updatePassword($input->id, $newHash);
+    }
+}

--- a/src/User/AdminResetPasswordUseCaseInterface.php
+++ b/src/User/AdminResetPasswordUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+interface AdminResetPasswordUseCaseInterface
+{
+    public function execute(AdminResetPasswordInput $input): void;
+}

--- a/src/User/CannotDeleteLastAdminException.php
+++ b/src/User/CannotDeleteLastAdminException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use DomainException;
+
+final class CannotDeleteLastAdminException extends DomainException
+{
+    public function __construct()
+    {
+        parent::__construct('Cannot delete the last admin user.');
+    }
+}

--- a/src/User/CannotDeleteSelfException.php
+++ b/src/User/CannotDeleteSelfException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use DomainException;
+
+final class CannotDeleteSelfException extends DomainException
+{
+    public function __construct()
+    {
+        parent::__construct('You cannot delete your own account.');
+    }
+}

--- a/src/User/CannotDeleteSelfExceptionHandler.php
+++ b/src/User/CannotDeleteSelfExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class CannotDeleteSelfExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof CannotDeleteSelfException || $exception instanceof CannotDeleteLastAdminException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'forbidden',
+            'Forbidden',
+            403,
+            $exception->getMessage(),
+        );
+    }
+}

--- a/src/User/ChangeOwnPasswordHandler.php
+++ b/src/User/ChangeOwnPasswordHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ChangeOwnPasswordHandler
+{
+    public function __construct(
+        private ChangeOwnPasswordUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $claims = $request->getAttribute('nene2.auth.claims');
+        $currentUserEmail = is_array($claims) ? (string) ($claims['sub'] ?? '') : '';
+
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+        $currentPassword = (string) ($body['current_password'] ?? '');
+        $newPassword = (string) ($body['new_password'] ?? '');
+
+        if ($currentPassword === '') {
+            $errors[] = new ValidationError('current_password', 'Current password is required.', 'required');
+        }
+
+        if ($newPassword === '') {
+            $errors[] = new ValidationError('new_password', 'New password is required.', 'required');
+        } elseif (strlen($newPassword) < 8) {
+            $errors[] = new ValidationError('new_password', 'Password must be at least 8 characters.', 'min_length');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $this->useCase->execute(new ChangeOwnPasswordInput(
+            currentUserEmail: $currentUserEmail,
+            currentPassword: $currentPassword,
+            newPassword: $newPassword,
+        ));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/User/ChangeOwnPasswordInput.php
+++ b/src/User/ChangeOwnPasswordInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+final readonly class ChangeOwnPasswordInput
+{
+    public function __construct(
+        public string $currentUserEmail,
+        public string $currentPassword,
+        public string $newPassword,
+    ) {
+    }
+}

--- a/src/User/ChangeOwnPasswordUseCase.php
+++ b/src/User/ChangeOwnPasswordUseCase.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use NeNeRecords\Auth\UserRepositoryInterface;
+
+final readonly class ChangeOwnPasswordUseCase implements ChangeOwnPasswordUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(ChangeOwnPasswordInput $input): void
+    {
+        $user = $this->users->findByEmail($input->currentUserEmail);
+
+        if ($user === null) {
+            throw new UserNotFoundException(0);
+        }
+
+        if (!password_verify($input->currentPassword, $user->passwordHash)) {
+            throw new InvalidCurrentPasswordException();
+        }
+
+        $newHash = password_hash($input->newPassword, PASSWORD_BCRYPT);
+        $this->users->updatePassword($user->id, $newHash);
+    }
+}

--- a/src/User/ChangeOwnPasswordUseCaseInterface.php
+++ b/src/User/ChangeOwnPasswordUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+interface ChangeOwnPasswordUseCaseInterface
+{
+    public function execute(ChangeOwnPasswordInput $input): void;
+}

--- a/src/User/CreateUserHandler.php
+++ b/src/User/CreateUserHandler.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateUserHandler
+{
+    public function __construct(
+        private CreateUserUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+
+        $email = trim((string) ($body['email'] ?? ''));
+        $password = (string) ($body['password'] ?? '');
+        $role = trim((string) ($body['role'] ?? ''));
+
+        if ($email === '') {
+            $errors[] = new ValidationError('email', 'Email is required.', 'required');
+        } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $errors[] = new ValidationError('email', 'Email format is invalid.', 'format');
+        }
+
+        if ($password === '') {
+            $errors[] = new ValidationError('password', 'Password is required.', 'required');
+        } elseif (strlen($password) < 8) {
+            $errors[] = new ValidationError('password', 'Password must be at least 8 characters.', 'min_length');
+        }
+
+        if ($role === '') {
+            $errors[] = new ValidationError('role', 'Role is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new CreateUserInput(
+            email: $email,
+            password: $password,
+            role: $role,
+        ));
+
+        return $this->response->create(
+            [
+                'id' => $output->id,
+                'email' => $output->email,
+                'role' => $output->role,
+                'status' => $output->status,
+                'created_at' => $output->createdAt !== null ? date('c', $output->createdAt) : null,
+            ],
+            201,
+            ['Location' => '/api/v1/users/' . $output->id],
+        );
+    }
+}

--- a/src/User/CreateUserInput.php
+++ b/src/User/CreateUserInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+final readonly class CreateUserInput
+{
+    public function __construct(
+        public string $email,
+        public string $password,
+        public string $role,
+    ) {
+    }
+}

--- a/src/User/CreateUserOutput.php
+++ b/src/User/CreateUserOutput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+final readonly class CreateUserOutput
+{
+    public function __construct(
+        public int $id,
+        public string $email,
+        public string $role,
+        public string $status,
+        public ?int $createdAt,
+    ) {
+    }
+}

--- a/src/User/CreateUserUseCase.php
+++ b/src/User/CreateUserUseCase.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use NeNeRecords\Auth\Role;
+use NeNeRecords\Auth\UserRepositoryInterface;
+
+final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(CreateUserInput $input): CreateUserOutput
+    {
+        if (Role::tryFrom($input->role) === null) {
+            throw new InvalidUserRoleException($input->role);
+        }
+
+        $existing = $this->users->findByEmail($input->email);
+
+        if ($existing !== null) {
+            throw new UserEmailConflictException($input->email);
+        }
+
+        $passwordHash = password_hash($input->password, PASSWORD_BCRYPT);
+        $user = $this->users->create($input->email, $passwordHash, $input->role);
+
+        return new CreateUserOutput(
+            id: $user->id,
+            email: $user->email,
+            role: $user->role,
+            status: $user->status,
+            createdAt: $user->createdAt,
+        );
+    }
+}

--- a/src/User/CreateUserUseCaseInterface.php
+++ b/src/User/CreateUserUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+interface CreateUserUseCaseInterface
+{
+    public function execute(CreateUserInput $input): CreateUserOutput;
+}

--- a/src/User/DeleteUserHandler.php
+++ b/src/User/DeleteUserHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteUserHandler
+{
+    public function __construct(
+        private DeleteUserUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+        $claims = $request->getAttribute('nene2.auth.claims');
+        $currentUserEmail = is_array($claims) ? (string) ($claims['sub'] ?? '') : '';
+
+        $this->useCase->execute(new DeleteUserInput(id: $id, currentUserEmail: $currentUserEmail));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/User/DeleteUserInput.php
+++ b/src/User/DeleteUserInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+final readonly class DeleteUserInput
+{
+    public function __construct(
+        public int $id,
+        public string $currentUserEmail,
+    ) {
+    }
+}

--- a/src/User/DeleteUserUseCase.php
+++ b/src/User/DeleteUserUseCase.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use NeNeRecords\Auth\UserRepositoryInterface;
+
+final readonly class DeleteUserUseCase implements DeleteUserUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(DeleteUserInput $input): void
+    {
+        $user = $this->users->findById($input->id);
+
+        if ($user === null) {
+            throw new UserNotFoundException($input->id);
+        }
+
+        if ($user->email === $input->currentUserEmail) {
+            throw new CannotDeleteSelfException();
+        }
+
+        if ($user->role === 'admin' && $this->users->countByRole('admin') <= 1) {
+            throw new CannotDeleteLastAdminException();
+        }
+
+        $this->users->delete($input->id);
+    }
+}

--- a/src/User/DeleteUserUseCaseInterface.php
+++ b/src/User/DeleteUserUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+interface DeleteUserUseCaseInterface
+{
+    public function execute(DeleteUserInput $input): void;
+}

--- a/src/User/GetUserByIdHandler.php
+++ b/src/User/GetUserByIdHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetUserByIdHandler
+{
+    public function __construct(
+        private GetUserByIdUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        $output = $this->useCase->execute(new GetUserByIdInput($id));
+
+        return $this->response->create([
+            'id' => $output->id,
+            'email' => $output->email,
+            'role' => $output->role,
+            'status' => $output->status,
+            'created_at' => $output->createdAt !== null ? date('c', $output->createdAt) : null,
+            'updated_at' => $output->updatedAt !== null ? date('c', $output->updatedAt) : null,
+        ]);
+    }
+}

--- a/src/User/GetUserByIdInput.php
+++ b/src/User/GetUserByIdInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+final readonly class GetUserByIdInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/User/GetUserByIdOutput.php
+++ b/src/User/GetUserByIdOutput.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+final readonly class GetUserByIdOutput
+{
+    public function __construct(
+        public int $id,
+        public string $email,
+        public string $role,
+        public string $status,
+        public ?int $createdAt,
+        public ?int $updatedAt,
+    ) {
+    }
+}

--- a/src/User/GetUserByIdUseCase.php
+++ b/src/User/GetUserByIdUseCase.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use NeNeRecords\Auth\UserRepositoryInterface;
+
+final readonly class GetUserByIdUseCase implements GetUserByIdUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(GetUserByIdInput $input): GetUserByIdOutput
+    {
+        $user = $this->users->findById($input->id);
+
+        if ($user === null) {
+            throw new UserNotFoundException($input->id);
+        }
+
+        return new GetUserByIdOutput(
+            id: $user->id,
+            email: $user->email,
+            role: $user->role,
+            status: $user->status,
+            createdAt: $user->createdAt,
+            updatedAt: $user->updatedAt,
+        );
+    }
+}

--- a/src/User/GetUserByIdUseCaseInterface.php
+++ b/src/User/GetUserByIdUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+interface GetUserByIdUseCaseInterface
+{
+    public function execute(GetUserByIdInput $input): GetUserByIdOutput;
+}

--- a/src/User/InvalidCurrentPasswordException.php
+++ b/src/User/InvalidCurrentPasswordException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use DomainException;
+
+final class InvalidCurrentPasswordException extends DomainException
+{
+    public function __construct()
+    {
+        parent::__construct('Current password is incorrect.');
+    }
+}

--- a/src/User/InvalidCurrentPasswordExceptionHandler.php
+++ b/src/User/InvalidCurrentPasswordExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class InvalidCurrentPasswordExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof InvalidCurrentPasswordException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'invalid-credentials',
+            'Unprocessable Entity',
+            422,
+            'Current password is incorrect.',
+        );
+    }
+}

--- a/src/User/InvalidUserRoleException.php
+++ b/src/User/InvalidUserRoleException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use DomainException;
+
+final class InvalidUserRoleException extends DomainException
+{
+    public function __construct(string $role)
+    {
+        parent::__construct(sprintf('Invalid role "%s". Valid roles are: admin, editor.', $role));
+    }
+}

--- a/src/User/InvalidUserRoleExceptionHandler.php
+++ b/src/User/InvalidUserRoleExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class InvalidUserRoleExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof InvalidUserRoleException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'unprocessable-entity',
+            'Unprocessable Entity',
+            422,
+            $exception->getMessage(),
+        );
+    }
+}

--- a/src/User/ListUserItem.php
+++ b/src/User/ListUserItem.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+final readonly class ListUserItem
+{
+    public function __construct(
+        public int $id,
+        public string $email,
+        public string $role,
+        public string $status,
+        public ?int $createdAt,
+        public ?int $updatedAt,
+    ) {
+    }
+}

--- a/src/User/ListUsersHandler.php
+++ b/src/User/ListUsersHandler.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListUsersHandler
+{
+    public function __construct(
+        private ListUsersUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $output = $this->useCase->execute(new ListUsersInput());
+
+        return $this->response->create([
+            'items' => array_map(
+                static fn (ListUserItem $item) => [
+                    'id' => $item->id,
+                    'email' => $item->email,
+                    'role' => $item->role,
+                    'status' => $item->status,
+                    'created_at' => $item->createdAt !== null ? date('c', $item->createdAt) : null,
+                    'updated_at' => $item->updatedAt !== null ? date('c', $item->updatedAt) : null,
+                ],
+                $output->items,
+            ),
+        ]);
+    }
+}

--- a/src/User/ListUsersInput.php
+++ b/src/User/ListUsersInput.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+final readonly class ListUsersInput
+{
+}

--- a/src/User/ListUsersOutput.php
+++ b/src/User/ListUsersOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+final readonly class ListUsersOutput
+{
+    /**
+     * @param list<ListUserItem> $items
+     */
+    public function __construct(
+        public array $items,
+    ) {
+    }
+}

--- a/src/User/ListUsersUseCase.php
+++ b/src/User/ListUsersUseCase.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use NeNeRecords\Auth\UserRepositoryInterface;
+
+final readonly class ListUsersUseCase implements ListUsersUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(ListUsersInput $input): ListUsersOutput
+    {
+        $users = $this->users->list();
+
+        $items = array_map(
+            static fn ($user) => new ListUserItem(
+                id: $user->id,
+                email: $user->email,
+                role: $user->role,
+                status: $user->status,
+                createdAt: $user->createdAt,
+                updatedAt: $user->updatedAt,
+            ),
+            $users,
+        );
+
+        return new ListUsersOutput(items: $items);
+    }
+}

--- a/src/User/ListUsersUseCaseInterface.php
+++ b/src/User/ListUsersUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+interface ListUsersUseCaseInterface
+{
+    public function execute(ListUsersInput $input): ListUsersOutput;
+}

--- a/src/User/UpdateUserRoleHandler.php
+++ b/src/User/UpdateUserRoleHandler.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateUserRoleHandler
+{
+    public function __construct(
+        private UpdateUserRoleUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+        $role = trim((string) ($body['role'] ?? ''));
+
+        if ($role === '') {
+            $errors[] = new ValidationError('role', 'Role is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new UpdateUserRoleInput(id: $id, role: $role));
+
+        return $this->response->create([
+            'id' => $output->id,
+            'email' => $output->email,
+            'role' => $output->role,
+            'status' => $output->status,
+        ]);
+    }
+}

--- a/src/User/UpdateUserRoleInput.php
+++ b/src/User/UpdateUserRoleInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+final readonly class UpdateUserRoleInput
+{
+    public function __construct(
+        public int $id,
+        public string $role,
+    ) {
+    }
+}

--- a/src/User/UpdateUserRoleOutput.php
+++ b/src/User/UpdateUserRoleOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+final readonly class UpdateUserRoleOutput
+{
+    public function __construct(
+        public int $id,
+        public string $email,
+        public string $role,
+        public string $status,
+    ) {
+    }
+}

--- a/src/User/UpdateUserRoleUseCase.php
+++ b/src/User/UpdateUserRoleUseCase.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use NeNeRecords\Auth\Role;
+use NeNeRecords\Auth\UserRepositoryInterface;
+
+final readonly class UpdateUserRoleUseCase implements UpdateUserRoleUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(UpdateUserRoleInput $input): UpdateUserRoleOutput
+    {
+        if (Role::tryFrom($input->role) === null) {
+            throw new InvalidUserRoleException($input->role);
+        }
+
+        $user = $this->users->findById($input->id);
+
+        if ($user === null) {
+            throw new UserNotFoundException($input->id);
+        }
+
+        $this->users->updateRole($input->id, $input->role);
+
+        return new UpdateUserRoleOutput(
+            id: $user->id,
+            email: $user->email,
+            role: $input->role,
+            status: $user->status,
+        );
+    }
+}

--- a/src/User/UpdateUserRoleUseCaseInterface.php
+++ b/src/User/UpdateUserRoleUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+interface UpdateUserRoleUseCaseInterface
+{
+    public function execute(UpdateUserRoleInput $input): UpdateUserRoleOutput;
+}

--- a/src/User/UserEmailConflictException.php
+++ b/src/User/UserEmailConflictException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use DomainException;
+
+final class UserEmailConflictException extends DomainException
+{
+    public function __construct(string $email)
+    {
+        parent::__construct(sprintf('A user with email "%s" already exists.', $email));
+    }
+}

--- a/src/User/UserEmailConflictExceptionHandler.php
+++ b/src/User/UserEmailConflictExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class UserEmailConflictExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof UserEmailConflictException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'conflict',
+            'Conflict',
+            409,
+            $exception->getMessage(),
+        );
+    }
+}

--- a/src/User/UserNotFoundException.php
+++ b/src/User/UserNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use DomainException;
+
+final class UserNotFoundException extends DomainException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct(sprintf('User with id %d not found.', $id));
+    }
+}

--- a/src/User/UserNotFoundExceptionHandler.php
+++ b/src/User/UserNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class UserNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof UserNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'not-found',
+            'Not Found',
+            404,
+            'The requested user was not found.',
+        );
+    }
+}

--- a/src/User/UserRouteRegistrar.php
+++ b/src/User/UserRouteRegistrar.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UserRouteRegistrar
+{
+    public function __construct(
+        private ListUsersHandler $listHandler,
+        private GetUserByIdHandler $getHandler,
+        private CreateUserHandler $createHandler,
+        private UpdateUserRoleHandler $updateRoleHandler,
+        private AdminResetPasswordHandler $resetPasswordHandler,
+        private DeleteUserHandler $deleteHandler,
+        private ChangeOwnPasswordHandler $changeOwnPasswordHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $list = $this->listHandler;
+        $get = $this->getHandler;
+        $create = $this->createHandler;
+        $updateRole = $this->updateRoleHandler;
+        $resetPassword = $this->resetPasswordHandler;
+        $delete = $this->deleteHandler;
+        $changeOwn = $this->changeOwnPasswordHandler;
+
+        $router->get('/api/v1/users', static fn (ServerRequestInterface $r) => $list->handle($r));
+        $router->get('/api/v1/users/{id}', static fn (ServerRequestInterface $r) => $get->handle($r));
+        $router->post('/api/v1/users', static fn (ServerRequestInterface $r) => $create->handle($r));
+        $router->patch('/api/v1/users/{id}', static fn (ServerRequestInterface $r) => $updateRole->handle($r));
+        $router->patch('/api/v1/users/{id}/password', static fn (ServerRequestInterface $r) => $resetPassword->handle($r));
+        $router->delete('/api/v1/users/{id}', static fn (ServerRequestInterface $r) => $delete->handle($r));
+        $router->put('/api/v1/users/me/password', static fn (ServerRequestInterface $r) => $changeOwn->handle($r));
+    }
+}

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Auth\UserRepositoryInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class UserServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                ListUsersUseCaseInterface::class,
+                static function (ContainerInterface $c): ListUsersUseCaseInterface {
+                    $users = $c->get(UserRepositoryInterface::class);
+
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('UserRepositoryInterface service is invalid.');
+                    }
+
+                    return new ListUsersUseCase($users);
+                },
+            )
+            ->set(
+                GetUserByIdUseCaseInterface::class,
+                static function (ContainerInterface $c): GetUserByIdUseCaseInterface {
+                    $users = $c->get(UserRepositoryInterface::class);
+
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('UserRepositoryInterface service is invalid.');
+                    }
+
+                    return new GetUserByIdUseCase($users);
+                },
+            )
+            ->set(
+                CreateUserUseCaseInterface::class,
+                static function (ContainerInterface $c): CreateUserUseCaseInterface {
+                    $users = $c->get(UserRepositoryInterface::class);
+
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('UserRepositoryInterface service is invalid.');
+                    }
+
+                    return new CreateUserUseCase($users);
+                },
+            )
+            ->set(
+                UpdateUserRoleUseCaseInterface::class,
+                static function (ContainerInterface $c): UpdateUserRoleUseCaseInterface {
+                    $users = $c->get(UserRepositoryInterface::class);
+
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('UserRepositoryInterface service is invalid.');
+                    }
+
+                    return new UpdateUserRoleUseCase($users);
+                },
+            )
+            ->set(
+                DeleteUserUseCaseInterface::class,
+                static function (ContainerInterface $c): DeleteUserUseCaseInterface {
+                    $users = $c->get(UserRepositoryInterface::class);
+
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('UserRepositoryInterface service is invalid.');
+                    }
+
+                    return new DeleteUserUseCase($users);
+                },
+            )
+            ->set(
+                ChangeOwnPasswordUseCaseInterface::class,
+                static function (ContainerInterface $c): ChangeOwnPasswordUseCaseInterface {
+                    $users = $c->get(UserRepositoryInterface::class);
+
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('UserRepositoryInterface service is invalid.');
+                    }
+
+                    return new ChangeOwnPasswordUseCase($users);
+                },
+            )
+            ->set(
+                AdminResetPasswordUseCaseInterface::class,
+                static function (ContainerInterface $c): AdminResetPasswordUseCaseInterface {
+                    $users = $c->get(UserRepositoryInterface::class);
+
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('UserRepositoryInterface service is invalid.');
+                    }
+
+                    return new AdminResetPasswordUseCase($users);
+                },
+            )
+            ->set(
+                ListUsersHandler::class,
+                static function (ContainerInterface $c): ListUsersHandler {
+                    $useCase = $c->get(ListUsersUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListUsersUseCaseInterface) {
+                        throw new LogicException('ListUsersUseCase service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory service is invalid.');
+                    }
+
+                    return new ListUsersHandler($useCase, $response);
+                },
+            )
+            ->set(
+                GetUserByIdHandler::class,
+                static function (ContainerInterface $c): GetUserByIdHandler {
+                    $useCase = $c->get(GetUserByIdUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof GetUserByIdUseCaseInterface) {
+                        throw new LogicException('GetUserByIdUseCase service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory service is invalid.');
+                    }
+
+                    return new GetUserByIdHandler($useCase, $response);
+                },
+            )
+            ->set(
+                CreateUserHandler::class,
+                static function (ContainerInterface $c): CreateUserHandler {
+                    $useCase = $c->get(CreateUserUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof CreateUserUseCaseInterface) {
+                        throw new LogicException('CreateUserUseCase service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory service is invalid.');
+                    }
+
+                    return new CreateUserHandler($useCase, $response);
+                },
+            )
+            ->set(
+                UpdateUserRoleHandler::class,
+                static function (ContainerInterface $c): UpdateUserRoleHandler {
+                    $useCase = $c->get(UpdateUserRoleUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof UpdateUserRoleUseCaseInterface) {
+                        throw new LogicException('UpdateUserRoleUseCase service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory service is invalid.');
+                    }
+
+                    return new UpdateUserRoleHandler($useCase, $response);
+                },
+            )
+            ->set(
+                AdminResetPasswordHandler::class,
+                static function (ContainerInterface $c): AdminResetPasswordHandler {
+                    $useCase = $c->get(AdminResetPasswordUseCaseInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof AdminResetPasswordUseCaseInterface) {
+                        throw new LogicException('AdminResetPasswordUseCase service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('ResponseFactoryInterface service is invalid.');
+                    }
+
+                    return new AdminResetPasswordHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
+                DeleteUserHandler::class,
+                static function (ContainerInterface $c): DeleteUserHandler {
+                    $useCase = $c->get(DeleteUserUseCaseInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof DeleteUserUseCaseInterface) {
+                        throw new LogicException('DeleteUserUseCase service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('ResponseFactoryInterface service is invalid.');
+                    }
+
+                    return new DeleteUserHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
+                ChangeOwnPasswordHandler::class,
+                static function (ContainerInterface $c): ChangeOwnPasswordHandler {
+                    $useCase = $c->get(ChangeOwnPasswordUseCaseInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof ChangeOwnPasswordUseCaseInterface) {
+                        throw new LogicException('ChangeOwnPasswordUseCase service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('ResponseFactoryInterface service is invalid.');
+                    }
+
+                    return new ChangeOwnPasswordHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
+                UserNotFoundExceptionHandler::class,
+                static function (ContainerInterface $c): UserNotFoundExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new UserNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                UserEmailConflictExceptionHandler::class,
+                static function (ContainerInterface $c): UserEmailConflictExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new UserEmailConflictExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                CannotDeleteSelfExceptionHandler::class,
+                static function (ContainerInterface $c): CannotDeleteSelfExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new CannotDeleteSelfExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                InvalidUserRoleExceptionHandler::class,
+                static function (ContainerInterface $c): InvalidUserRoleExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new InvalidUserRoleExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                InvalidCurrentPasswordExceptionHandler::class,
+                static function (ContainerInterface $c): InvalidCurrentPasswordExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new InvalidCurrentPasswordExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.user',
+                static function (ContainerInterface $c): UserRouteRegistrar {
+                    $list = $c->get(ListUsersHandler::class);
+                    $get = $c->get(GetUserByIdHandler::class);
+                    $create = $c->get(CreateUserHandler::class);
+                    $updateRole = $c->get(UpdateUserRoleHandler::class);
+                    $resetPassword = $c->get(AdminResetPasswordHandler::class);
+                    $delete = $c->get(DeleteUserHandler::class);
+                    $changeOwn = $c->get(ChangeOwnPasswordHandler::class);
+
+                    if (!$list instanceof ListUsersHandler) {
+                        throw new LogicException('ListUsersHandler service is invalid.');
+                    }
+
+                    if (!$get instanceof GetUserByIdHandler) {
+                        throw new LogicException('GetUserByIdHandler service is invalid.');
+                    }
+
+                    if (!$create instanceof CreateUserHandler) {
+                        throw new LogicException('CreateUserHandler service is invalid.');
+                    }
+
+                    if (!$updateRole instanceof UpdateUserRoleHandler) {
+                        throw new LogicException('UpdateUserRoleHandler service is invalid.');
+                    }
+
+                    if (!$resetPassword instanceof AdminResetPasswordHandler) {
+                        throw new LogicException('AdminResetPasswordHandler service is invalid.');
+                    }
+
+                    if (!$delete instanceof DeleteUserHandler) {
+                        throw new LogicException('DeleteUserHandler service is invalid.');
+                    }
+
+                    if (!$changeOwn instanceof ChangeOwnPasswordHandler) {
+                        throw new LogicException('ChangeOwnPasswordHandler service is invalid.');
+                    }
+
+                    return new UserRouteRegistrar($list, $get, $create, $updateRole, $resetPassword, $delete, $changeOwn);
+                },
+            );
+    }
+}

--- a/src/UserInvite/AcceptInviteHandler.php
+++ b/src/UserInvite/AcceptInviteHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class AcceptInviteHandler
+{
+    public function __construct(
+        private AcceptInviteUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+        $token = trim((string) ($body['token'] ?? ''));
+        $password = (string) ($body['password'] ?? '');
+
+        if ($token === '') {
+            $errors[] = new ValidationError('token', 'Token is required.', 'required');
+        }
+
+        if ($password === '') {
+            $errors[] = new ValidationError('password', 'Password is required.', 'required');
+        } elseif (strlen($password) < 8) {
+            $errors[] = new ValidationError('password', 'Password must be at least 8 characters.', 'min_length');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $this->useCase->execute(new AcceptInviteInput(token: $token, password: $password));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/UserInvite/AcceptInviteInput.php
+++ b/src/UserInvite/AcceptInviteInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+final readonly class AcceptInviteInput
+{
+    public function __construct(
+        public string $token,
+        public string $password,
+    ) {
+    }
+}

--- a/src/UserInvite/AcceptInviteUseCase.php
+++ b/src/UserInvite/AcceptInviteUseCase.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+use Nene2\Http\SecureTokenHelper;
+use NeNeRecords\Auth\UserRepositoryInterface;
+
+final readonly class AcceptInviteUseCase implements AcceptInviteUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(AcceptInviteInput $input): void
+    {
+        $tokenHash = SecureTokenHelper::hash($input->token);
+        $user = $this->users->findByInviteToken($tokenHash);
+
+        if ($user === null || $user->inviteExpiresAt === null || $user->inviteExpiresAt < time()) {
+            throw new InvalidInviteTokenException();
+        }
+
+        $newHash = password_hash($input->password, PASSWORD_BCRYPT);
+        $this->users->updatePassword($user->id, $newHash);
+        $this->users->clearInviteToken($user->id);
+    }
+}

--- a/src/UserInvite/AcceptInviteUseCaseInterface.php
+++ b/src/UserInvite/AcceptInviteUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+interface AcceptInviteUseCaseInterface
+{
+    public function execute(AcceptInviteInput $input): void;
+}

--- a/src/UserInvite/ConfirmPasswordResetHandler.php
+++ b/src/UserInvite/ConfirmPasswordResetHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ConfirmPasswordResetHandler
+{
+    public function __construct(
+        private ConfirmPasswordResetUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+        $token = trim((string) ($body['token'] ?? ''));
+        $newPassword = (string) ($body['new_password'] ?? '');
+
+        if ($token === '') {
+            $errors[] = new ValidationError('token', 'Token is required.', 'required');
+        }
+
+        if ($newPassword === '') {
+            $errors[] = new ValidationError('new_password', 'New password is required.', 'required');
+        } elseif (strlen($newPassword) < 8) {
+            $errors[] = new ValidationError('new_password', 'Password must be at least 8 characters.', 'min_length');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $this->useCase->execute(new ConfirmPasswordResetInput(token: $token, newPassword: $newPassword));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/UserInvite/ConfirmPasswordResetInput.php
+++ b/src/UserInvite/ConfirmPasswordResetInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+final readonly class ConfirmPasswordResetInput
+{
+    public function __construct(
+        public string $token,
+        public string $newPassword,
+    ) {
+    }
+}

--- a/src/UserInvite/ConfirmPasswordResetUseCase.php
+++ b/src/UserInvite/ConfirmPasswordResetUseCase.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+use Nene2\Http\SecureTokenHelper;
+use NeNeRecords\Auth\UserRepositoryInterface;
+
+final readonly class ConfirmPasswordResetUseCase implements ConfirmPasswordResetUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(ConfirmPasswordResetInput $input): void
+    {
+        $tokenHash = SecureTokenHelper::hash($input->token);
+        $user = $this->users->findByPasswordResetToken($tokenHash);
+
+        if ($user === null || $user->passwordResetExpiresAt === null || $user->passwordResetExpiresAt < time()) {
+            throw new InvalidPasswordResetTokenException();
+        }
+
+        $newHash = password_hash($input->newPassword, PASSWORD_BCRYPT);
+        $this->users->updatePassword($user->id, $newHash);
+        $this->users->clearPasswordResetToken($user->id);
+    }
+}

--- a/src/UserInvite/ConfirmPasswordResetUseCaseInterface.php
+++ b/src/UserInvite/ConfirmPasswordResetUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+interface ConfirmPasswordResetUseCaseInterface
+{
+    public function execute(ConfirmPasswordResetInput $input): void;
+}

--- a/src/UserInvite/InvalidInviteTokenException.php
+++ b/src/UserInvite/InvalidInviteTokenException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+use DomainException;
+
+final class InvalidInviteTokenException extends DomainException
+{
+    public function __construct()
+    {
+        parent::__construct('Invite token is invalid or has expired.');
+    }
+}

--- a/src/UserInvite/InvalidInviteTokenExceptionHandler.php
+++ b/src/UserInvite/InvalidInviteTokenExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class InvalidInviteTokenExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof InvalidInviteTokenException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'invalid-token',
+            'Unprocessable Entity',
+            422,
+            'Invite token is invalid or has expired.',
+        );
+    }
+}

--- a/src/UserInvite/InvalidPasswordResetTokenException.php
+++ b/src/UserInvite/InvalidPasswordResetTokenException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+use DomainException;
+
+final class InvalidPasswordResetTokenException extends DomainException
+{
+    public function __construct()
+    {
+        parent::__construct('Password reset token is invalid or has expired.');
+    }
+}

--- a/src/UserInvite/InvalidPasswordResetTokenExceptionHandler.php
+++ b/src/UserInvite/InvalidPasswordResetTokenExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class InvalidPasswordResetTokenExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof InvalidPasswordResetTokenException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'invalid-token',
+            'Unprocessable Entity',
+            422,
+            'Password reset token is invalid or has expired.',
+        );
+    }
+}

--- a/src/UserInvite/InviteUserHandler.php
+++ b/src/UserInvite/InviteUserHandler.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class InviteUserHandler
+{
+    public function __construct(
+        private InviteUserUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+
+        $email = trim((string) ($body['email'] ?? ''));
+        $role = trim((string) ($body['role'] ?? ''));
+
+        if ($email === '') {
+            $errors[] = new ValidationError('email', 'Email is required.', 'required');
+        } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $errors[] = new ValidationError('email', 'Email format is invalid.', 'format');
+        }
+
+        if ($role === '') {
+            $errors[] = new ValidationError('role', 'Role is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $appBaseUrl = (string) ($body['app_base_url'] ?? '');
+
+        if ($appBaseUrl === '') {
+            $scheme = $request->getUri()->getScheme();
+            $host = $request->getUri()->getHost();
+            $port = $request->getUri()->getPort();
+            $appBaseUrl = $scheme . '://' . $host . ($port !== null ? ':' . $port : '');
+        }
+
+        $output = $this->useCase->execute(new InviteUserInput(
+            email: $email,
+            role: $role,
+            appBaseUrl: $appBaseUrl,
+        ));
+
+        return $this->response->create(
+            [
+                'id' => $output->id,
+                'email' => $output->email,
+                'role' => $output->role,
+                'status' => $output->status,
+            ],
+            201,
+            ['Location' => '/api/v1/users/' . $output->id],
+        );
+    }
+}

--- a/src/UserInvite/InviteUserInput.php
+++ b/src/UserInvite/InviteUserInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+final readonly class InviteUserInput
+{
+    public function __construct(
+        public string $email,
+        public string $role,
+        public string $appBaseUrl,
+    ) {
+    }
+}

--- a/src/UserInvite/InviteUserOutput.php
+++ b/src/UserInvite/InviteUserOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+final readonly class InviteUserOutput
+{
+    public function __construct(
+        public int $id,
+        public string $email,
+        public string $role,
+        public string $status,
+    ) {
+    }
+}

--- a/src/UserInvite/InviteUserUseCase.php
+++ b/src/UserInvite/InviteUserUseCase.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+use Nene2\Http\SecureTokenHelper;
+use NeNeRecords\Auth\Role;
+use NeNeRecords\Auth\UserRepositoryInterface;
+use NeNeRecords\Mail\MailerInterface;
+use NeNeRecords\Mail\MailMessage;
+use NeNeRecords\User\InvalidUserRoleException;
+use NeNeRecords\User\UserEmailConflictException;
+
+final readonly class InviteUserUseCase implements InviteUserUseCaseInterface
+{
+    private const INVITE_TTL_SECONDS = 72 * 3600; // 72 hours
+
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private MailerInterface $mailer,
+    ) {
+    }
+
+    public function execute(InviteUserInput $input): InviteUserOutput
+    {
+        if (Role::tryFrom($input->role) === null) {
+            throw new InvalidUserRoleException($input->role);
+        }
+
+        $existing = $this->users->findByEmail($input->email);
+
+        if ($existing !== null) {
+            throw new UserEmailConflictException($input->email);
+        }
+
+        // Create as invited user with a temporary random password (never usable without the invite)
+        $tempHash = password_hash(bin2hex(random_bytes(32)), PASSWORD_BCRYPT);
+        $user = $this->users->create($input->email, $tempHash, $input->role);
+
+        [$rawToken, $tokenHash] = SecureTokenHelper::generateWithHash();
+        $expiresAt = time() + self::INVITE_TTL_SECONDS;
+        $this->users->storeInviteToken($user->id, $tokenHash, $expiresAt);
+
+        $acceptUrl = rtrim($input->appBaseUrl, '/') . '/admin/accept-invite?token=' . $rawToken;
+
+        $this->mailer->send(new MailMessage(
+            to: $input->email,
+            subject: 'NeNe Records へのご招待',
+            textBody: <<<TEXT
+                NeNe Records 管理画面にご招待されました。
+
+                以下のリンクをクリックしてパスワードを設定し、アカウントを有効化してください。
+                （有効期限: 72時間）
+
+                {$acceptUrl}
+
+                このメールに心当たりのない場合は、無視してください。
+                TEXT,
+            htmlBody: <<<HTML
+                <p>NeNe Records 管理画面にご招待されました。</p>
+                <p>以下のリンクをクリックしてパスワードを設定し、アカウントを有効化してください。<br>
+                （有効期限: 72時間）</p>
+                <p><a href="{$acceptUrl}">{$acceptUrl}</a></p>
+                <p>このメールに心当たりのない場合は、無視してください。</p>
+                HTML,
+        ));
+
+        return new InviteUserOutput(
+            id: $user->id,
+            email: $user->email,
+            role: $user->role,
+            status: 'invited',
+        );
+    }
+}

--- a/src/UserInvite/InviteUserUseCaseInterface.php
+++ b/src/UserInvite/InviteUserUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+interface InviteUserUseCaseInterface
+{
+    public function execute(InviteUserInput $input): InviteUserOutput;
+}

--- a/src/UserInvite/RequestPasswordResetHandler.php
+++ b/src/UserInvite/RequestPasswordResetHandler.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class RequestPasswordResetHandler
+{
+    public function __construct(
+        private RequestPasswordResetUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+        $email = trim((string) ($body['email'] ?? ''));
+
+        if ($email === '') {
+            $errors[] = new ValidationError('email', 'Email is required.', 'required');
+        } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $errors[] = new ValidationError('email', 'Email format is invalid.', 'format');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $appBaseUrl = (string) ($body['app_base_url'] ?? '');
+
+        if ($appBaseUrl === '') {
+            $scheme = $request->getUri()->getScheme();
+            $host = $request->getUri()->getHost();
+            $port = $request->getUri()->getPort();
+            $appBaseUrl = $scheme . '://' . $host . ($port !== null ? ':' . $port : '');
+        }
+
+        $this->useCase->execute(new RequestPasswordResetInput(email: $email, appBaseUrl: $appBaseUrl));
+
+        // Always return 204 regardless of whether email exists (prevents enumeration)
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/UserInvite/RequestPasswordResetInput.php
+++ b/src/UserInvite/RequestPasswordResetInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+final readonly class RequestPasswordResetInput
+{
+    public function __construct(
+        public string $email,
+        public string $appBaseUrl,
+    ) {
+    }
+}

--- a/src/UserInvite/RequestPasswordResetUseCase.php
+++ b/src/UserInvite/RequestPasswordResetUseCase.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+use Nene2\Http\SecureTokenHelper;
+use NeNeRecords\Auth\UserRepositoryInterface;
+use NeNeRecords\Mail\MailerInterface;
+use NeNeRecords\Mail\MailMessage;
+
+final readonly class RequestPasswordResetUseCase implements RequestPasswordResetUseCaseInterface
+{
+    private const RESET_TTL_SECONDS = 3600; // 1 hour
+
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private MailerInterface $mailer,
+    ) {
+    }
+
+    public function execute(RequestPasswordResetInput $input): void
+    {
+        $user = $this->users->findByEmail($input->email);
+
+        // Always succeed silently to prevent email enumeration
+        if ($user === null) {
+            return;
+        }
+
+        [$rawToken, $tokenHash] = SecureTokenHelper::generateWithHash();
+        $expiresAt = time() + self::RESET_TTL_SECONDS;
+        $this->users->storePasswordResetToken($user->id, $tokenHash, $expiresAt);
+
+        $resetUrl = rtrim($input->appBaseUrl, '/') . '/admin/reset-password?token=' . $rawToken;
+
+        $this->mailer->send(new MailMessage(
+            to: $input->email,
+            subject: 'NeNe Records パスワードリセット',
+            textBody: <<<TEXT
+                パスワードリセットのリクエストを受け付けました。
+
+                以下のリンクをクリックして新しいパスワードを設定してください。
+                （有効期限: 1時間）
+
+                {$resetUrl}
+
+                このメールに心当たりのない場合は、無視してください。
+                TEXT,
+            htmlBody: <<<HTML
+                <p>パスワードリセットのリクエストを受け付けました。</p>
+                <p>以下のリンクをクリックして新しいパスワードを設定してください。<br>
+                （有効期限: 1時間）</p>
+                <p><a href="{$resetUrl}">{$resetUrl}</a></p>
+                <p>このメールに心当たりのない場合は、無視してください。</p>
+                HTML,
+        ));
+    }
+}

--- a/src/UserInvite/RequestPasswordResetUseCaseInterface.php
+++ b/src/UserInvite/RequestPasswordResetUseCaseInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+interface RequestPasswordResetUseCaseInterface
+{
+    /**
+     * Initiates a password reset for the given email.
+     * Always returns silently even if the email is not found (prevents email enumeration).
+     */
+    public function execute(RequestPasswordResetInput $input): void;
+}

--- a/src/UserInvite/UserInviteRouteRegistrar.php
+++ b/src/UserInvite/UserInviteRouteRegistrar.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UserInviteRouteRegistrar
+{
+    public function __construct(
+        private InviteUserHandler $inviteHandler,
+        private AcceptInviteHandler $acceptHandler,
+        private RequestPasswordResetHandler $requestResetHandler,
+        private ConfirmPasswordResetHandler $confirmResetHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $invite = $this->inviteHandler;
+        $accept = $this->acceptHandler;
+        $requestReset = $this->requestResetHandler;
+        $confirmReset = $this->confirmResetHandler;
+
+        $router->post('/api/v1/users/invite', static fn (ServerRequestInterface $r) => $invite->handle($r));
+        $router->post('/api/v1/auth/accept-invite', static fn (ServerRequestInterface $r) => $accept->handle($r));
+        $router->post('/api/v1/auth/password-reset', static fn (ServerRequestInterface $r) => $requestReset->handle($r));
+        $router->post('/api/v1/auth/password-reset/confirm', static fn (ServerRequestInterface $r) => $confirmReset->handle($r));
+    }
+}

--- a/src/UserInvite/UserInviteServiceProvider.php
+++ b/src/UserInvite/UserInviteServiceProvider.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UserInvite;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Auth\UserRepositoryInterface;
+use NeNeRecords\Mail\MailerInterface;
+use NeNeRecords\Mail\SymfonyMailer;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class UserInviteServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                MailerInterface::class,
+                static function (ContainerInterface $c): MailerInterface {
+                    /** @var array<string, string> $env */
+                    $env = $_ENV;
+                    $dsn = $env['MAIL_DSN'] ?? 'smtp://mailpit:1025';
+                    $fromAddress = $env['MAIL_FROM_ADDRESS'] ?? 'noreply@nene-records.local';
+                    $fromName = $env['MAIL_FROM_NAME'] ?? 'NeNe Records';
+
+                    return new SymfonyMailer($dsn, $fromAddress, $fromName);
+                },
+            )
+            ->set(
+                InviteUserUseCaseInterface::class,
+                static function (ContainerInterface $c): InviteUserUseCaseInterface {
+                    $users = $c->get(UserRepositoryInterface::class);
+                    $mailer = $c->get(MailerInterface::class);
+
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('UserRepositoryInterface service is invalid.');
+                    }
+
+                    if (!$mailer instanceof MailerInterface) {
+                        throw new LogicException('MailerInterface service is invalid.');
+                    }
+
+                    return new InviteUserUseCase($users, $mailer);
+                },
+            )
+            ->set(
+                AcceptInviteUseCaseInterface::class,
+                static function (ContainerInterface $c): AcceptInviteUseCaseInterface {
+                    $users = $c->get(UserRepositoryInterface::class);
+
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('UserRepositoryInterface service is invalid.');
+                    }
+
+                    return new AcceptInviteUseCase($users);
+                },
+            )
+            ->set(
+                RequestPasswordResetUseCaseInterface::class,
+                static function (ContainerInterface $c): RequestPasswordResetUseCaseInterface {
+                    $users = $c->get(UserRepositoryInterface::class);
+                    $mailer = $c->get(MailerInterface::class);
+
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('UserRepositoryInterface service is invalid.');
+                    }
+
+                    if (!$mailer instanceof MailerInterface) {
+                        throw new LogicException('MailerInterface service is invalid.');
+                    }
+
+                    return new RequestPasswordResetUseCase($users, $mailer);
+                },
+            )
+            ->set(
+                ConfirmPasswordResetUseCaseInterface::class,
+                static function (ContainerInterface $c): ConfirmPasswordResetUseCaseInterface {
+                    $users = $c->get(UserRepositoryInterface::class);
+
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('UserRepositoryInterface service is invalid.');
+                    }
+
+                    return new ConfirmPasswordResetUseCase($users);
+                },
+            )
+            ->set(
+                InviteUserHandler::class,
+                static function (ContainerInterface $c): InviteUserHandler {
+                    $useCase = $c->get(InviteUserUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof InviteUserUseCaseInterface) {
+                        throw new LogicException('InviteUserUseCase service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory service is invalid.');
+                    }
+
+                    return new InviteUserHandler($useCase, $response);
+                },
+            )
+            ->set(
+                AcceptInviteHandler::class,
+                static function (ContainerInterface $c): AcceptInviteHandler {
+                    $useCase = $c->get(AcceptInviteUseCaseInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof AcceptInviteUseCaseInterface) {
+                        throw new LogicException('AcceptInviteUseCase service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('ResponseFactoryInterface service is invalid.');
+                    }
+
+                    return new AcceptInviteHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
+                RequestPasswordResetHandler::class,
+                static function (ContainerInterface $c): RequestPasswordResetHandler {
+                    $useCase = $c->get(RequestPasswordResetUseCaseInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof RequestPasswordResetUseCaseInterface) {
+                        throw new LogicException('RequestPasswordResetUseCase service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('ResponseFactoryInterface service is invalid.');
+                    }
+
+                    return new RequestPasswordResetHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
+                ConfirmPasswordResetHandler::class,
+                static function (ContainerInterface $c): ConfirmPasswordResetHandler {
+                    $useCase = $c->get(ConfirmPasswordResetUseCaseInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof ConfirmPasswordResetUseCaseInterface) {
+                        throw new LogicException('ConfirmPasswordResetUseCase service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('ResponseFactoryInterface service is invalid.');
+                    }
+
+                    return new ConfirmPasswordResetHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
+                InvalidInviteTokenExceptionHandler::class,
+                static function (ContainerInterface $c): InvalidInviteTokenExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new InvalidInviteTokenExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                InvalidPasswordResetTokenExceptionHandler::class,
+                static function (ContainerInterface $c): InvalidPasswordResetTokenExceptionHandler {
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new InvalidPasswordResetTokenExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.user_invite',
+                static function (ContainerInterface $c): UserInviteRouteRegistrar {
+                    $invite = $c->get(InviteUserHandler::class);
+                    $accept = $c->get(AcceptInviteHandler::class);
+                    $requestReset = $c->get(RequestPasswordResetHandler::class);
+                    $confirmReset = $c->get(ConfirmPasswordResetHandler::class);
+
+                    if (!$invite instanceof InviteUserHandler) {
+                        throw new LogicException('InviteUserHandler service is invalid.');
+                    }
+
+                    if (!$accept instanceof AcceptInviteHandler) {
+                        throw new LogicException('AcceptInviteHandler service is invalid.');
+                    }
+
+                    if (!$requestReset instanceof RequestPasswordResetHandler) {
+                        throw new LogicException('RequestPasswordResetHandler service is invalid.');
+                    }
+
+                    if (!$confirmReset instanceof ConfirmPasswordResetHandler) {
+                        throw new LogicException('ConfirmPasswordResetHandler service is invalid.');
+                    }
+
+                    return new UserInviteRouteRegistrar($invite, $accept, $requestReset, $confirmReset);
+                },
+            );
+    }
+}

--- a/tests/User/InMemoryUserRepository.php
+++ b/tests/User/InMemoryUserRepository.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\User;
+
+use NeNeRecords\Auth\User;
+use NeNeRecords\Auth\UserRepositoryInterface;
+
+final class InMemoryUserRepository implements UserRepositoryInterface
+{
+    /** @var array<int, User> */
+    private array $byId = [];
+
+    /** @var array<string, int> */
+    private array $emailToId = [];
+
+    /** @var array<string, int> */
+    private array $inviteTokenToId = [];
+
+    /** @var array<string, int> */
+    private array $resetTokenToId = [];
+
+    private int $nextId = 1;
+
+    /** @param list<User> $seed */
+    public function __construct(array $seed = [])
+    {
+        foreach ($seed as $user) {
+            $id = $user->id;
+            $this->byId[$id] = $user;
+            $this->emailToId[$user->email] = $id;
+            $this->nextId = max($this->nextId, $id + 1);
+        }
+    }
+
+    public function findByEmail(string $email): ?User
+    {
+        $id = $this->emailToId[$email] ?? null;
+
+        return $id !== null ? ($this->byId[$id] ?? null) : null;
+    }
+
+    public function findById(int $id): ?User
+    {
+        return $this->byId[$id] ?? null;
+    }
+
+    /** @return list<User> */
+    public function list(): array
+    {
+        $users = array_values($this->byId);
+        usort($users, static fn (User $a, User $b): int => $a->id <=> $b->id);
+
+        return $users;
+    }
+
+    public function create(string $email, string $passwordHash, string $role): User
+    {
+        $id = $this->nextId++;
+        $user = new User(id: $id, email: $email, passwordHash: $passwordHash, role: $role, status: 'active', createdAt: time(), updatedAt: time());
+        $this->byId[$id] = $user;
+        $this->emailToId[$email] = $id;
+
+        return $user;
+    }
+
+    public function updateRole(int $id, string $role): void
+    {
+        $user = $this->byId[$id] ?? null;
+
+        if ($user === null) {
+            return;
+        }
+
+        $this->byId[$id] = new User(
+            id: $user->id,
+            email: $user->email,
+            passwordHash: $user->passwordHash,
+            role: $role,
+            status: $user->status,
+            inviteTokenHash: $user->inviteTokenHash,
+            inviteExpiresAt: $user->inviteExpiresAt,
+            passwordResetTokenHash: $user->passwordResetTokenHash,
+            passwordResetExpiresAt: $user->passwordResetExpiresAt,
+            createdAt: $user->createdAt,
+            updatedAt: time(),
+        );
+    }
+
+    public function updatePassword(int $id, string $passwordHash): void
+    {
+        $user = $this->byId[$id] ?? null;
+
+        if ($user === null) {
+            return;
+        }
+
+        $this->byId[$id] = new User(
+            id: $user->id,
+            email: $user->email,
+            passwordHash: $passwordHash,
+            role: $user->role,
+            status: $user->status,
+            inviteTokenHash: $user->inviteTokenHash,
+            inviteExpiresAt: $user->inviteExpiresAt,
+            passwordResetTokenHash: $user->passwordResetTokenHash,
+            passwordResetExpiresAt: $user->passwordResetExpiresAt,
+            createdAt: $user->createdAt,
+            updatedAt: time(),
+        );
+    }
+
+    public function updateStatus(int $id, string $status): void
+    {
+        $user = $this->byId[$id] ?? null;
+
+        if ($user === null) {
+            return;
+        }
+
+        $this->byId[$id] = new User(
+            id: $user->id,
+            email: $user->email,
+            passwordHash: $user->passwordHash,
+            role: $user->role,
+            status: $status,
+            inviteTokenHash: $user->inviteTokenHash,
+            inviteExpiresAt: $user->inviteExpiresAt,
+            passwordResetTokenHash: $user->passwordResetTokenHash,
+            passwordResetExpiresAt: $user->passwordResetExpiresAt,
+            createdAt: $user->createdAt,
+            updatedAt: time(),
+        );
+    }
+
+    public function storeInviteToken(int $id, string $tokenHash, int $expiresAt): void
+    {
+        $user = $this->byId[$id] ?? null;
+
+        if ($user === null) {
+            return;
+        }
+
+        $this->inviteTokenToId[$tokenHash] = $id;
+        $this->byId[$id] = new User(
+            id: $user->id,
+            email: $user->email,
+            passwordHash: $user->passwordHash,
+            role: $user->role,
+            status: 'invited',
+            inviteTokenHash: $tokenHash,
+            inviteExpiresAt: $expiresAt,
+            passwordResetTokenHash: $user->passwordResetTokenHash,
+            passwordResetExpiresAt: $user->passwordResetExpiresAt,
+            createdAt: $user->createdAt,
+            updatedAt: time(),
+        );
+    }
+
+    public function findByInviteToken(string $tokenHash): ?User
+    {
+        $id = $this->inviteTokenToId[$tokenHash] ?? null;
+
+        return $id !== null ? ($this->byId[$id] ?? null) : null;
+    }
+
+    public function clearInviteToken(int $id): void
+    {
+        $user = $this->byId[$id] ?? null;
+
+        if ($user === null) {
+            return;
+        }
+
+        if ($user->inviteTokenHash !== null) {
+            unset($this->inviteTokenToId[$user->inviteTokenHash]);
+        }
+
+        $this->byId[$id] = new User(
+            id: $user->id,
+            email: $user->email,
+            passwordHash: $user->passwordHash,
+            role: $user->role,
+            status: 'active',
+            inviteTokenHash: null,
+            inviteExpiresAt: null,
+            passwordResetTokenHash: $user->passwordResetTokenHash,
+            passwordResetExpiresAt: $user->passwordResetExpiresAt,
+            createdAt: $user->createdAt,
+            updatedAt: time(),
+        );
+    }
+
+    public function storePasswordResetToken(int $id, string $tokenHash, int $expiresAt): void
+    {
+        $user = $this->byId[$id] ?? null;
+
+        if ($user === null) {
+            return;
+        }
+
+        $this->resetTokenToId[$tokenHash] = $id;
+        $this->byId[$id] = new User(
+            id: $user->id,
+            email: $user->email,
+            passwordHash: $user->passwordHash,
+            role: $user->role,
+            status: $user->status,
+            inviteTokenHash: $user->inviteTokenHash,
+            inviteExpiresAt: $user->inviteExpiresAt,
+            passwordResetTokenHash: $tokenHash,
+            passwordResetExpiresAt: $expiresAt,
+            createdAt: $user->createdAt,
+            updatedAt: time(),
+        );
+    }
+
+    public function findByPasswordResetToken(string $tokenHash): ?User
+    {
+        $id = $this->resetTokenToId[$tokenHash] ?? null;
+
+        return $id !== null ? ($this->byId[$id] ?? null) : null;
+    }
+
+    public function clearPasswordResetToken(int $id): void
+    {
+        $user = $this->byId[$id] ?? null;
+
+        if ($user === null) {
+            return;
+        }
+
+        if ($user->passwordResetTokenHash !== null) {
+            unset($this->resetTokenToId[$user->passwordResetTokenHash]);
+        }
+
+        $this->byId[$id] = new User(
+            id: $user->id,
+            email: $user->email,
+            passwordHash: $user->passwordHash,
+            role: $user->role,
+            status: $user->status,
+            inviteTokenHash: $user->inviteTokenHash,
+            inviteExpiresAt: $user->inviteExpiresAt,
+            passwordResetTokenHash: null,
+            passwordResetExpiresAt: null,
+            createdAt: $user->createdAt,
+            updatedAt: time(),
+        );
+    }
+
+    public function delete(int $id): void
+    {
+        $user = $this->byId[$id] ?? null;
+
+        if ($user === null) {
+            return;
+        }
+
+        unset($this->emailToId[$user->email]);
+        unset($this->byId[$id]);
+    }
+
+    public function countByRole(string $role): int
+    {
+        return count(array_filter(
+            $this->byId,
+            static fn (User $u): bool => $u->role === $role,
+        ));
+    }
+}

--- a/tests/User/UserHttpTest.php
+++ b/tests/User/UserHttpTest.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\User;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Auth\User;
+use NeNeRecords\User\AdminResetPasswordHandler;
+use NeNeRecords\User\AdminResetPasswordUseCase;
+use NeNeRecords\User\CannotDeleteSelfExceptionHandler;
+use NeNeRecords\User\ChangeOwnPasswordHandler;
+use NeNeRecords\User\ChangeOwnPasswordUseCase;
+use NeNeRecords\User\CreateUserHandler;
+use NeNeRecords\User\CreateUserUseCase;
+use NeNeRecords\User\DeleteUserHandler;
+use NeNeRecords\User\DeleteUserUseCase;
+use NeNeRecords\User\GetUserByIdHandler;
+use NeNeRecords\User\GetUserByIdUseCase;
+use NeNeRecords\User\InvalidCurrentPasswordExceptionHandler;
+use NeNeRecords\User\InvalidUserRoleExceptionHandler;
+use NeNeRecords\User\ListUsersHandler;
+use NeNeRecords\User\ListUsersUseCase;
+use NeNeRecords\User\UpdateUserRoleHandler;
+use NeNeRecords\User\UpdateUserRoleUseCase;
+use NeNeRecords\User\UserEmailConflictExceptionHandler;
+use NeNeRecords\User\UserNotFoundExceptionHandler;
+use NeNeRecords\User\UserRouteRegistrar;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class UserHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryUserRepository $repository;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+
+        // Seed with an admin user
+        $this->repository = new InMemoryUserRepository([
+            new User(
+                id: 1,
+                email: 'admin@example.test',
+                passwordHash: password_hash('secret123', PASSWORD_BCRYPT),
+                role: 'admin',
+                status: 'active',
+                createdAt: 1700000000,
+                updatedAt: 1700000000,
+            ),
+        ]);
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+
+        $registrar = new UserRouteRegistrar(
+            new ListUsersHandler(new ListUsersUseCase($this->repository), $jsonResponse),
+            new GetUserByIdHandler(new GetUserByIdUseCase($this->repository), $jsonResponse),
+            new CreateUserHandler(new CreateUserUseCase($this->repository), $jsonResponse),
+            new UpdateUserRoleHandler(new UpdateUserRoleUseCase($this->repository), $jsonResponse),
+            new AdminResetPasswordHandler(new AdminResetPasswordUseCase($this->repository), $this->factory),
+            new DeleteUserHandler(new DeleteUserUseCase($this->repository), $this->factory),
+            new ChangeOwnPasswordHandler(new ChangeOwnPasswordUseCase($this->repository), $this->factory),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [
+                new UserNotFoundExceptionHandler($problemDetails),
+                new UserEmailConflictExceptionHandler($problemDetails),
+                new CannotDeleteSelfExceptionHandler($problemDetails),
+                new InvalidUserRoleExceptionHandler($problemDetails),
+                new InvalidCurrentPasswordExceptionHandler($problemDetails),
+            ],
+            routeRegistrars: [$registrar],
+        ))->create();
+    }
+
+    // ── List ────────────────────────────────────────────────────────────────────
+
+    public function testGetUsersReturnsListWithSeededUser(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/users'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertIsArray($payload['items']);
+        self::assertCount(1, $payload['items']);
+        self::assertSame('admin@example.test', $payload['items'][0]['email']);
+        self::assertSame('admin', $payload['items'][0]['role']);
+        self::assertSame('active', $payload['items'][0]['status']);
+    }
+
+    // ── Create ──────────────────────────────────────────────────────────────────
+
+    public function testPostUserCreatesUserAndReturns201(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'email' => 'editor@example.test',
+            'password' => 'password123',
+            'role' => 'editor',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/users')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertStringStartsWith('/api/v1/users/', $response->getHeaderLine('Location'));
+        self::assertSame('editor@example.test', $payload['email']);
+        self::assertSame('editor', $payload['role']);
+        self::assertSame('active', $payload['status']);
+    }
+
+    public function testPostDuplicateEmailReturns409(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'email' => 'admin@example.test',
+            'password' => 'password123',
+            'role' => 'admin',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/users')->withBody($body),
+        );
+
+        self::assertSame(409, $response->getStatusCode());
+    }
+
+    public function testPostInvalidRoleReturns422(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'email' => 'new@example.test',
+            'password' => 'password123',
+            'role' => 'superadmin',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/users')->withBody($body),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    // ── Get by ID ──────────────────────────────────────────────────────────────
+
+    public function testGetUserByIdReturns200(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/users/1'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(1, $payload['id']);
+        self::assertSame('admin@example.test', $payload['email']);
+    }
+
+    public function testGetNonExistentUserReturns404(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/users/999'),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    // ── Update role ─────────────────────────────────────────────────────────────
+
+    public function testPatchUserRoleUpdatesRole(): void
+    {
+        $body = $this->factory->createStream(json_encode(['role' => 'editor'], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('PATCH', 'https://example.test/api/v1/users/1')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('editor', $payload['role']);
+    }
+
+    // ── Admin password reset ────────────────────────────────────────────────────
+
+    public function testPatchUserPasswordReturns204(): void
+    {
+        $body = $this->factory->createStream(json_encode(['new_password' => 'newpassword123'], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('PATCH', 'https://example.test/api/v1/users/1/password')->withBody($body),
+        );
+
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    // ── Delete ──────────────────────────────────────────────────────────────────
+
+    public function testDeleteUserReturns204(): void
+    {
+        // First create a second user so admin is not the last one
+        $createBody = $this->factory->createStream(json_encode([
+            'email' => 'admin2@example.test',
+            'password' => 'password123',
+            'role' => 'admin',
+        ], JSON_THROW_ON_ERROR));
+
+        $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/users')->withBody($createBody),
+        );
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', 'https://example.test/api/v1/users/1')
+                ->withAttribute('nene2.auth.claims', ['sub' => 'other@example.test']),
+        );
+
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testDeleteSelfReturns403(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', 'https://example.test/api/v1/users/1')
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function testDeleteLastAdminReturns403(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', 'https://example.test/api/v1/users/1')
+                ->withAttribute('nene2.auth.claims', ['sub' => 'other@example.test']),
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    // ── Change own password ─────────────────────────────────────────────────────
+
+    public function testPutMePasswordReturns204(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'current_password' => 'secret123',
+            'new_password' => 'newsecret456',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('PUT', 'https://example.test/api/v1/users/me/password')
+                ->withBody($body)
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
+        );
+
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testPutMePasswordWithWrongCurrentPasswordReturns422(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'current_password' => 'wrongpassword',
+            'new_password' => 'newsecret456',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('PUT', 'https://example.test/api/v1/users/me/password')
+                ->withBody($body)
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    /** @return array<string, mixed> */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $body = (string) $response->getBody();
+        $data = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($data)) {
+            return [];
+        }
+
+        return $data;
+    }
+}

--- a/tests/UserInvite/NullMailer.php
+++ b/tests/UserInvite/NullMailer.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\UserInvite;
+
+use NeNeRecords\Mail\MailerInterface;
+use NeNeRecords\Mail\MailMessage;
+
+/**
+ * Test double that records sent messages without actually sending them.
+ */
+final class NullMailer implements MailerInterface
+{
+    /** @var list<MailMessage> */
+    public array $sent = [];
+
+    public function send(MailMessage $message): void
+    {
+        $this->sent[] = $message;
+    }
+}

--- a/tests/UserInvite/UserInviteHttpTest.php
+++ b/tests/UserInvite/UserInviteHttpTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\UserInvite;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Auth\User;
+use NeNeRecords\Tests\User\InMemoryUserRepository;
+use NeNeRecords\User\InvalidUserRoleExceptionHandler;
+use NeNeRecords\User\UserEmailConflictExceptionHandler;
+use NeNeRecords\UserInvite\AcceptInviteHandler;
+use NeNeRecords\UserInvite\AcceptInviteUseCase;
+use NeNeRecords\UserInvite\ConfirmPasswordResetHandler;
+use NeNeRecords\UserInvite\ConfirmPasswordResetUseCase;
+use NeNeRecords\UserInvite\InvalidInviteTokenExceptionHandler;
+use NeNeRecords\UserInvite\InvalidPasswordResetTokenExceptionHandler;
+use NeNeRecords\UserInvite\InviteUserHandler;
+use NeNeRecords\UserInvite\InviteUserUseCase;
+use NeNeRecords\UserInvite\RequestPasswordResetHandler;
+use NeNeRecords\UserInvite\RequestPasswordResetUseCase;
+use NeNeRecords\UserInvite\UserInviteRouteRegistrar;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class UserInviteHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryUserRepository $repository;
+    private NullMailer $mailer;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->repository = new InMemoryUserRepository([
+            new User(
+                id: 1,
+                email: 'admin@example.test',
+                passwordHash: password_hash('secret123', PASSWORD_BCRYPT),
+                role: 'admin',
+                status: 'active',
+                createdAt: time(),
+                updatedAt: time(),
+            ),
+        ]);
+        $this->mailer = new NullMailer();
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+
+        $registrar = new UserInviteRouteRegistrar(
+            new InviteUserHandler(new InviteUserUseCase($this->repository, $this->mailer), $jsonResponse),
+            new AcceptInviteHandler(new AcceptInviteUseCase($this->repository), $this->factory),
+            new RequestPasswordResetHandler(new RequestPasswordResetUseCase($this->repository, $this->mailer), $this->factory),
+            new ConfirmPasswordResetHandler(new ConfirmPasswordResetUseCase($this->repository), $this->factory),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [
+                new UserEmailConflictExceptionHandler($problemDetails),
+                new InvalidUserRoleExceptionHandler($problemDetails),
+                new InvalidInviteTokenExceptionHandler($problemDetails),
+                new InvalidPasswordResetTokenExceptionHandler($problemDetails),
+            ],
+            routeRegistrars: [$registrar],
+        ))->create();
+    }
+
+    // ── Invite ──────────────────────────────────────────────────────────────────
+
+    public function testPostInviteCreatesInvitedUserAndSendsEmail(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'email' => 'neweditor@example.test',
+            'role' => 'editor',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/users/invite')->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame('neweditor@example.test', $payload['email']);
+        self::assertSame('invited', $payload['status']);
+        self::assertCount(1, $this->mailer->sent);
+        self::assertSame('neweditor@example.test', $this->mailer->sent[0]->to);
+    }
+
+    public function testPostInviteDuplicateEmailReturns409(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'email' => 'admin@example.test',
+            'role' => 'editor',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/users/invite')->withBody($body),
+        );
+
+        self::assertSame(409, $response->getStatusCode());
+    }
+
+    // ── Accept invite ───────────────────────────────────────────────────────────
+
+    public function testPostAcceptInviteActivatesUser(): void
+    {
+        // First create an invite
+        $inviteBody = $this->factory->createStream(json_encode([
+            'email' => 'invited@example.test',
+            'role' => 'editor',
+        ], JSON_THROW_ON_ERROR));
+
+        $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/users/invite')->withBody($inviteBody),
+        );
+
+        // Extract raw token from the email body
+        $emailBody = $this->mailer->sent[0]->textBody;
+        $rawToken = $this->extractToken($emailBody);
+
+        // Accept the invite
+        $acceptBody = $this->factory->createStream(json_encode([
+            'token' => $rawToken,
+            'password' => 'newpassword123',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/auth/accept-invite')->withBody($acceptBody),
+        );
+
+        self::assertSame(204, $response->getStatusCode());
+
+        // User should now be active
+        $user = $this->repository->findByEmail('invited@example.test');
+        self::assertNotNull($user);
+        self::assertSame('active', $user->status);
+        self::assertNull($user->inviteTokenHash);
+    }
+
+    public function testPostAcceptInviteWithInvalidTokenReturns422(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'token' => str_repeat('a', 64),
+            'password' => 'newpassword123',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/auth/accept-invite')->withBody($body),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    // ── Password reset ──────────────────────────────────────────────────────────
+
+    public function testPostPasswordResetAlwaysReturns204(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'email' => 'admin@example.test',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/auth/password-reset')->withBody($body),
+        );
+
+        self::assertSame(204, $response->getStatusCode());
+        self::assertCount(1, $this->mailer->sent);
+    }
+
+    public function testPostPasswordResetForUnknownEmailAlsoReturns204(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'email' => 'unknown@example.test',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/auth/password-reset')->withBody($body),
+        );
+
+        // Must NOT reveal whether email exists
+        self::assertSame(204, $response->getStatusCode());
+        self::assertCount(0, $this->mailer->sent);
+    }
+
+    public function testPostConfirmPasswordResetChangesPassword(): void
+    {
+        // Request a reset
+        $requestBody = $this->factory->createStream(json_encode([
+            'email' => 'admin@example.test',
+        ], JSON_THROW_ON_ERROR));
+
+        $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/auth/password-reset')->withBody($requestBody),
+        );
+
+        // Extract raw token from email
+        $emailBody = $this->mailer->sent[0]->textBody;
+        $rawToken = $this->extractToken($emailBody);
+
+        // Confirm reset
+        $confirmBody = $this->factory->createStream(json_encode([
+            'token' => $rawToken,
+            'new_password' => 'newpassword456',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/auth/password-reset/confirm')->withBody($confirmBody),
+        );
+
+        self::assertSame(204, $response->getStatusCode());
+
+        // Verify new password works
+        $user = $this->repository->findByEmail('admin@example.test');
+        self::assertNotNull($user);
+        self::assertTrue(password_verify('newpassword456', $user->passwordHash));
+        self::assertNull($user->passwordResetTokenHash);
+    }
+
+    public function testPostConfirmPasswordResetWithInvalidTokenReturns422(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'token' => str_repeat('b', 64),
+            'new_password' => 'newpassword456',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/auth/password-reset/confirm')->withBody($body),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    private function extractToken(string $body): string
+    {
+        if (preg_match('/token=([a-f0-9]+)/', $body, $matches) !== 1) {
+            self::fail('Token not found in email body.');
+        }
+
+        return (string) $matches[1];
+    }
+
+    /** @return array<string, mixed> */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $body = (string) $response->getBody();
+        $data = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($data)) {
+            return [];
+        }
+
+        return $data;
+    }
+}


### PR DESCRIPTION
## 概要

Issue #190（ユーザー管理 API）と Issue #191（メール招待・パスワードリセット）を実装します。

## 変更内容

### Issue #190 — ユーザー管理 API

**新規ドメイン `src/User/`**
- ユースケース: `ListUsers` / `GetUserById` / `CreateUser` / `UpdateUserRole` / `DeleteUser` / `AdminResetPassword` / `ChangeOwnPassword`
- HTTP ハンドラー・`UserRouteRegistrar` ・`UserServiceProvider`
- 例外: `UserNotFoundException` / `UserEmailConflictException` / `CannotDeleteSelfException` / `CannotDeleteLastAdminException` / `InvalidUserRoleException` / `InvalidCurrentPasswordException`

**`src/Auth/` 拡張**
- `User` エンティティに `status` / トークンハッシュ / 有効期限フィールドを追加
- `UserRepositoryInterface` にトークン管理・カウント・削除メソッドを追加
- `PdoUserRepository` を全メソッド実装に書き換え
- `CapabilityResolver`: `/api/v1/users` 系を `ManageSettings` 必須に（`/api/v1/users/me/password` は全認証ユーザー可）
- `AdminApiAuthMiddleware`: `/api/v1/users` を認証必須プレフィックスに追加

**DB**
- マイグレーション: `users` テーブルに `status` / `invite_token_hash` / `invite_expires_at` / `password_reset_token_hash` / `password_reset_expires_at` 追加
- `database/schema/users.sql` 更新

**テスト**
- `tests/User/InMemoryUserRepository` — 全インターフェースメソッドのインメモリ実装
- `tests/User/UserHttpTest` — CRUD・権限・ビジネスルール（最終管理者削除不可など）を網羅

### Issue #191 — メール招待・パスワードリセット

**新規名前空間 `src/Mail/`**
- `MailerInterface` / `MailMessage`
- `SymfonyMailer`（`MAIL_DSN` 環境変数で設定、開発環境は Mailpit）

**新規名前空間 `src/UserInvite/`**
- `InviteUserUseCase`: 招待ユーザー作成→72h トークン→招待メール送信
- `AcceptInviteUseCase`: トークン検証→パスワード設定→アカウント有効化
- `RequestPasswordResetUseCase`: 1h トークン→リセットメール送信（メール不在時も 204、列挙攻撃防止）
- `ConfirmPasswordResetUseCase`: トークン検証→パスワード更新
- `UserInviteRouteRegistrar` / `UserInviteServiceProvider`

**テスト**
- `tests/UserInvite/NullMailer` — 送信記録テストダブル
- `tests/UserInvite/UserInviteHttpTest` — 招待フロー・パスワードリセットフローの E2E テスト

### OpenAPI 更新
- `Users` タグ追加
- 全エンドポイント・スキーマを追加

## 検証

```
composer check  → 285 tests, PHPStan OK, CS-Fixer OK, OpenAPI valid, MCP valid
```

## チェックリスト

- [x] 全テスト通過（285 件）
- [x] PHPStan エラーなし
- [x] CS-Fixer 通過
- [x] OpenAPI スペック有効
- [x] トークンは SHA-256 ハッシュのみ DB 保存、生トークンはメールのみ
- [x] パスワードリセットはメール不在でも 204（列挙攻撃対策）
- [x] 最終管理者の削除を禁止
- [x] 自分自身の削除を禁止

Closes #190
Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)