### PR TITLE
docs: M5 完了を CHANGELOG・todo に記録（ユーザー管理・メディアライブラリ）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ NeNe Records does not yet follow Semantic Versioning — entries are grouped by 
 
 ---
 
+## [M5 — ユーザー管理・メディアライブラリ] — 2026-05-27
+
+### Added
+- User management API — `GET/POST /api/v1/users`, `GET/PATCH/DELETE /api/v1/users/{id}`, `POST /api/v1/users/{id}/admin-reset-password`, `PUT /api/v1/users/me/password`; admin/editor role enforcement (#190 #191, PR #194)
+- User invite flow — `POST /api/v1/user-invites` sends invite email with one-time token; `POST /api/v1/user-invites/accept` activates account (#190 #191, PR #194)
+- Password reset flow — `POST /api/v1/user-invites/request-password-reset` (anti-enumeration 204); `POST /api/v1/user-invites/confirm-password-reset` exchanges token for new password (#190 #191, PR #194)
+- `MailerInterface` + `SymfonyMailer` using Mailpit in development (#191, PR #194)
+- User management Admin UI — user list, invite form, role change, admin password reset, self-service password change, delete with confirmation (#192, PR #195)
+- Accept-invite public page `/admin/accept-invite?token=…` and reset-password public page `/admin/reset-password?token=…` (#192, PR #195)
+- Media library list API — `GET /api/v1/media` returns all uploads ordered by `created_at DESC`; `created_at` added to upload response (#196, PR #198)
+- Media delete API — `DELETE /api/v1/media/{id}` removes DB record and best-effort unlinks physical file (#196, PR #198)
+- Media library Admin UI — drag-and-drop upload, thumbnail grid, copy-URL, delete with confirmation; `/admin/media` route (#197, PR #198)
+
+---
+
 ## [M4 — 機能拡充・使い勝手改善] — 2026-05-26
 
 ### Added

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -12,7 +12,29 @@ Last updated: 2026-05-27
 
 **M4 — 機能拡充＋使い勝手改善: 完了（2026-05-27）**
 
-264 tests / PHPStan Max / CS-Fixer / OpenAPI / MCP バリデーション — 全グリーン。
+**M5 — ユーザー管理・メディアライブラリ: 完了（2026-05-27）**
+
+tests / PHPStan Max / CS-Fixer / OpenAPI / MCP バリデーション — 全グリーン。
+
+---
+
+## M5 完了（マージ済み）
+
+| Issue | PR | Summary |
+| --- | --- | --- |
+| #190, #191 | #194 | feat: ユーザー管理 API・招待・パスワードリセット |
+| #192 | #195 | feat: ユーザー管理フロントエンド（一覧・招待・パスワード変更） |
+| #196, #197 | #198 | feat: メディアライブラリ（一覧・削除 API ＋管理画面） |
+
+---
+
+## 次フェーズ候補
+
+| 項目 | 概要 | 難易度 |
+| --- | --- | --- |
+| AI Consumer Chat | NeNe Records を外部 API として使うチャットシステム（**別リポジトリ**） | 大 |
+| コメント機能 | エンティティへのコメント投稿・管理 | 中 |
+| 関連エンティティの公開表示 | Relation フィールドを公開ページでリンク表示 | 小 |
 
 ---
 
@@ -44,17 +66,6 @@ Last updated: 2026-05-27
 
 ---
 
-## 次フェーズ候補
-
-| 項目 | 概要 | 難易度 |
-| --- | --- | --- |
-| AI Consumer Chat | NeNe Records を外部 API として使うチャットシステム（**別リポジトリ**） | 大 |
-| コメント機能 | エンティティへのコメント投稿・管理 | 中 |
-| メディアライブラリ | アップロード済みメディアの一覧・再利用 | 中 |
-| 関連エンティティの公開表示 | Relation フィールドを公開ページでリンク表示 | 小 |
-
----
-
 ## M3 完了（マージ済み）
 
 | 優先 | 項目 | Issue | PR |
@@ -73,7 +84,7 @@ Last updated: 2026-05-27
 ## Verification
 
 ```bash
-composer check                    # 264 tests + PHPStan + CS-Fixer + OpenAPI + MCP
+composer check                    # tests + PHPStan + CS-Fixer + OpenAPI + MCP
 npm run check --prefix frontend   # type-check + lint + test + storybook
 docker compose exec app vendor/bin/phinx migrate
 docker compose exec app php tools/seed-blog-demo.php http://localhost


### PR DESCRIPTION
## 概要

M5（ユーザー管理・メディアライブラリ）の完了を記録。

## 変更内容

- `CHANGELOG.md`: M5 セクション追加（PR #194, #195, #198 の内容）
- `docs/todo/current.md`: M5 完了テーブル・次フェーズ候補を更新

## 対象 PR

- #194 ユーザー管理 API・招待・パスワードリセット
- #195 ユーザー管理フロントエンド
- #198 メディアライブラリ（一覧・削除 API ＋管理画面）

Closes なし（ドキュメント更新のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)