### PR TITLE
feat(public): 関連エンティティリンクをパーマリンクパターンで解決 (#200)

### DIFF
--- a/frontend/src/features/public-view-entity-record/hooks/use-public-relation-field-display.ts
+++ b/frontend/src/features/public-view-entity-record/hooks/use-public-relation-field-display.ts
@@ -1,8 +1,10 @@
 import { useMemo } from 'react'
+import { defaultEntityListParams, useEntityList } from '@/entities/entity'
 import { useEntityRelationList } from '@/entities/entity-relation'
 import type { RelationFieldDef } from '@/entities/field-def'
 import { defaultTextFieldListParamsForEntityType, useTextFieldList } from '@/entities/text-field'
 import { getRecordDisplayLabel } from '@/shared/lib/get-record-display-label'
+import { resolvePermalink } from '@/shared/lib/resolve-permalink'
 
 export interface PublicRelationTargetLink {
   targetEntityId: number
@@ -14,37 +16,68 @@ export function usePublicRelationFieldDisplay(
   entityId: number,
   fieldDef: RelationFieldDef,
   entityTypeSlugById: Record<number, string>,
+  entityTypePatternById: Record<number, string | null | undefined>,
 ) {
   const relationQuery = useEntityRelationList(entityId, fieldDef.fieldKey)
+
+  // Load text fields for label generation
   const textFieldQuery = useTextFieldList(
     defaultTextFieldListParamsForEntityType(fieldDef.targetEntityTypeId),
   )
 
+  // Load entity list for the target type to get slug/publishedAt for permalink resolution.
+  // limit:200 mirrors the text-field ceiling; relations are typically small in practice.
+  const targetEntityListParams = useMemo(
+    () => ({
+      ...defaultEntityListParams(fieldDef.targetEntityTypeId),
+      limit: 200,
+    }),
+    [fieldDef.targetEntityTypeId],
+  )
+  const targetEntityListQuery = useEntityList(targetEntityListParams)
+
   const targets = useMemo((): PublicRelationTargetLink[] => {
     const relations = relationQuery.data?.items ?? []
     const textFields = textFieldQuery.data?.items ?? []
+    const targetEntities = targetEntityListQuery.data?.items ?? []
     const targetSlug =
       entityTypeSlugById[fieldDef.targetEntityTypeId] ?? String(fieldDef.targetEntityTypeId)
+    const targetPattern = entityTypePatternById[fieldDef.targetEntityTypeId]
 
-    return relations.map((relation) => ({
-      targetEntityId: relation.targetEntityId,
-      label: getRecordDisplayLabel(
-        relation.targetEntityId,
-        textFields,
-        `Record #${String(relation.targetEntityId)}`,
-      ),
-      href: `/${targetSlug}/${String(relation.targetEntityId)}`,
-    }))
+    return relations.map((relation) => {
+      const targetEntity = targetEntities.find((e) => Number(e.id) === relation.targetEntityId)
+      return {
+        targetEntityId: relation.targetEntityId,
+        label: getRecordDisplayLabel(
+          relation.targetEntityId,
+          textFields,
+          `Record #${String(relation.targetEntityId)}`,
+        ),
+        href: resolvePermalink(targetPattern, {
+          typeSlug: targetSlug,
+          entitySlug: targetEntity?.slug ?? null,
+          entityId: relation.targetEntityId,
+          publishedAt: targetEntity?.publishedAt ?? null,
+        }),
+      }
+    })
   }, [
+    entityTypePatternById,
     entityTypeSlugById,
     fieldDef.targetEntityTypeId,
     relationQuery.data?.items,
+    targetEntityListQuery.data?.items,
     textFieldQuery.data?.items,
   ])
 
-  const isLoading = relationQuery.isLoading || textFieldQuery.isLoading
-  const isError = relationQuery.isError || textFieldQuery.isError
-  const errorTitle = relationQuery.error?.title ?? textFieldQuery.error?.title ?? null
+  const isLoading =
+    relationQuery.isLoading || textFieldQuery.isLoading || targetEntityListQuery.isLoading
+  const isError = relationQuery.isError || textFieldQuery.isError || targetEntityListQuery.isError
+  const errorTitle =
+    relationQuery.error?.title ??
+    textFieldQuery.error?.title ??
+    targetEntityListQuery.error?.title ??
+    null
 
   return {
     targets,
@@ -52,7 +85,11 @@ export function usePublicRelationFieldDisplay(
     isError,
     errorTitle,
     refetch: async () => {
-      await Promise.all([relationQuery.refetch(), textFieldQuery.refetch()])
+      await Promise.all([
+        relationQuery.refetch(),
+        textFieldQuery.refetch(),
+        targetEntityListQuery.refetch(),
+      ])
     },
   }
 }

--- a/frontend/src/features/public-view-entity-record/ui/PublicRecordDetailView.tsx
+++ b/frontend/src/features/public-view-entity-record/ui/PublicRecordDetailView.tsx
@@ -9,6 +9,7 @@ export interface PublicRecordDetailViewProps {
   entity: Entity | null
   fieldRows: PublicFieldRow[]
   entityTypeSlugById: Record<number, string>
+  entityTypePatternById: Record<number, string | null | undefined>
   isLoading: boolean
   isError: boolean
   errorTitle: string | null
@@ -19,6 +20,7 @@ export function PublicRecordDetailView({
   entity,
   fieldRows,
   entityTypeSlugById,
+  entityTypePatternById,
   isLoading,
   isError,
   errorTitle,
@@ -58,6 +60,7 @@ export function PublicRecordDetailView({
               entityId={Number(entity.id)}
               fieldDef={row.fieldDef}
               entityTypeSlugById={entityTypeSlugById}
+              entityTypePatternById={entityTypePatternById}
             />
           )
         }

--- a/frontend/src/features/public-view-entity-record/ui/PublicRelationFieldDisplay.tsx
+++ b/frontend/src/features/public-view-entity-record/ui/PublicRelationFieldDisplay.tsx
@@ -7,17 +7,20 @@ export interface PublicRelationFieldDisplayProps {
   entityId: number
   fieldDef: RelationFieldDef
   entityTypeSlugById: Record<number, string>
+  entityTypePatternById: Record<number, string | null | undefined>
 }
 
 export function PublicRelationFieldDisplay({
   entityId,
   fieldDef,
   entityTypeSlugById,
+  entityTypePatternById,
 }: PublicRelationFieldDisplayProps) {
   const { targets, isLoading, isError, errorTitle, refetch } = usePublicRelationFieldDisplay(
     entityId,
     fieldDef,
     entityTypeSlugById,
+    entityTypePatternById,
   )
 
   if (isLoading) {

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
@@ -47,6 +47,7 @@ function PublicRecordDetailContent({
   entityTypeId,
   entityId,
   entityTypeSlugById,
+  entityTypePatternById,
   currentPattern,
 }: {
   entityTypeSlug: string
@@ -54,6 +55,7 @@ function PublicRecordDetailContent({
   entityTypeId: number
   entityId: number
   entityTypeSlugById: Record<number, string>
+  entityTypePatternById: Record<number, string | null | undefined>
   currentPattern: string | null | undefined
 }) {
   const { entity, fieldRows, isLoading, isError, errorTitle, refetch } =
@@ -88,6 +90,7 @@ function PublicRecordDetailContent({
         entity={entity}
         fieldRows={fieldRows}
         entityTypeSlugById={entityTypeSlugById}
+        entityTypePatternById={entityTypePatternById}
         isLoading={isLoading}
         isError={isError}
         errorTitle={errorTitle}
@@ -165,6 +168,7 @@ function PublicRecordDetailBySlug({
   entityTypeId,
   entitySlug,
   entityTypeSlugById,
+  entityTypePatternById,
   currentPattern,
   previousPattern,
   splat,
@@ -174,6 +178,7 @@ function PublicRecordDetailBySlug({
   entityTypeId: number
   entitySlug: string
   entityTypeSlugById: Record<number, string>
+  entityTypePatternById: Record<number, string | null | undefined>
   currentPattern: string | null | undefined
   previousPattern: string | null | undefined
   splat: string
@@ -203,6 +208,7 @@ function PublicRecordDetailBySlug({
       entityTypeId={entityTypeId}
       entityId={entityId}
       entityTypeSlugById={entityTypeSlugById}
+      entityTypePatternById={entityTypePatternById}
       currentPattern={currentPattern}
     />
   )
@@ -226,6 +232,7 @@ function PublicRecordDetailById({
   entityTypeId,
   entityId,
   entityTypeSlugById,
+  entityTypePatternById,
   currentPattern,
 }: {
   entityTypeSlug: string
@@ -233,6 +240,7 @@ function PublicRecordDetailById({
   entityTypeId: number
   entityId: number
   entityTypeSlugById: Record<number, string>
+  entityTypePatternById: Record<number, string | null | undefined>
   currentPattern: string | null | undefined
 }) {
   return (
@@ -242,6 +250,7 @@ function PublicRecordDetailById({
       entityTypeId={entityTypeId}
       entityId={entityId}
       entityTypeSlugById={entityTypeSlugById}
+      entityTypePatternById={entityTypePatternById}
       currentPattern={currentPattern}
     />
   )
@@ -263,6 +272,14 @@ export function PublicRecordDetailPage() {
     (): Record<number, string> =>
       Object.fromEntries(
         (entityTypeQuery.data?.items ?? []).map((item) => [Number(item.id), item.slug]),
+      ),
+    [entityTypeQuery.data?.items],
+  )
+
+  const entityTypePatternById = useMemo(
+    (): Record<number, string | null | undefined> =>
+      Object.fromEntries(
+        (entityTypeQuery.data?.items ?? []).map((item) => [Number(item.id), item.permalinkPattern]),
       ),
     [entityTypeQuery.data?.items],
   )
@@ -291,6 +308,7 @@ export function PublicRecordDetailPage() {
         entityTypeId={entityTypeId}
         entityId={key.id}
         entityTypeSlugById={entityTypeSlugById}
+        entityTypePatternById={entityTypePatternById}
         currentPattern={entityType.permalinkPattern}
       />
     )
@@ -303,6 +321,7 @@ export function PublicRecordDetailPage() {
       entityTypeId={entityTypeId}
       entitySlug={key.slug}
       entityTypeSlugById={entityTypeSlugById}
+      entityTypePatternById={entityTypePatternById}
       currentPattern={entityType.permalinkPattern}
       previousPattern={entityType.previousPermalinkPattern}
       splat={splat}


### PR DESCRIPTION
## 概要

公開ページの Relation フィールドリンクが常に `/{type}/{id}` (ID固定) になっていた問題を修正。ターゲットエンティティタイプのパーマリンクパターンに従った正しい URL を生成するようになった。

## 変更内容

### フロントエンド

- `use-public-relation-field-display.ts`: `useEntityList` でターゲットエンティティの `slug` / `publishedAt` を取得し `resolvePermalink()` で href を解決
- `PublicRelationFieldDisplay.tsx`: `entityTypePatternById` prop 追加
- `PublicRecordDetailView.tsx`: `entityTypePatternById` prop 追加
- `PublicRecordDetailPage.tsx`: `entityTypePatternById` を構築して渡す

## 修正した問題

Before:
```
href: `/${targetSlug}/${entityId}`  // 常に /{type}/{id}
```

After:
```
href: resolvePermalink(targetPattern, { typeSlug, entitySlug, entityId, publishedAt })
// /{type}/{slug} パターン → /posts/my-article
// /{type}/{id}  パターン → /posts/42 (変化なし)
// /{type}/{year}/{month}/{slug} パターン → /posts/2024/01/my-article
```

## 確認方法

- `npm run check` — 21 test files, 84 tests, 全グリーン
- 既存テスト `renders relation fields as links to target records` が `/author/2` を返すことを確認（デフォルトパターン変化なし）

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)