### PR TITLE
feat(comment): コメント機能（バックエンドAPI・フロントエンド管理・公開フォーム）

### DIFF
--- a/database/migrations/20260625000000_create_comments_table.php
+++ b/database/migrations/20260625000000_create_comments_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateCommentsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $table = $this->table('comments', ['engine' => 'InnoDB', 'charset' => 'utf8mb4', 'collation' => 'utf8mb4_unicode_ci']);
+        $table
+            ->addColumn('entity_id', 'integer', ['signed' => false, 'null' => false])
+            ->addColumn('author_name', 'string', ['limit' => 100, 'null' => false])
+            ->addColumn('author_email', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('body', 'text', ['null' => false])
+            ->addColumn('is_approved', 'boolean', ['default' => false, 'null' => false])
+            ->addColumn('created_at', 'datetime', ['default' => 'CURRENT_TIMESTAMP', 'null' => false])
+            ->addForeignKey('entity_id', 'entities', 'id', ['delete' => 'CASCADE', 'update' => 'RESTRICT'])
+            ->addIndex(['entity_id', 'is_approved'])
+            ->create();
+    }
+}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2079,6 +2079,159 @@ paths:
           description: Webhook deleted.
         '404':
           $ref: '#/components/responses/NotFound'
+  /api/v1/entities/{id}/comments:
+    get:
+      tags:
+        - Comments
+      summary: List approved comments for an entity
+      description: Returns approved comments for the specified entity, ordered by created_at ascending.
+      operationId: listComments
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Comment list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommentListResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Comments
+      summary: Post a comment
+      description: Submits a new comment. The comment is stored with is_approved=false and awaits moderation.
+      operationId: postComment
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PostCommentRequest'
+      responses:
+        '201':
+          description: Comment submitted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommentResponse'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/admin/comments:
+    get:
+      tags:
+        - Comments
+      summary: List all comments (admin)
+      description: Returns all comments (approved and pending), ordered by created_at descending. Requires ManageSettings capability.
+      operationId: listAllComments
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Comment list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminCommentListResponse'
+        '401':
+          description: Unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/admin/comments/{id}/approve:
+    patch:
+      tags:
+        - Comments
+      summary: Approve a comment
+      description: Sets is_approved=true for the specified comment.
+      operationId: approveComment
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Comment approved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminCommentResponse'
+        '401':
+          description: Unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/admin/comments/{id}:
+    delete:
+      tags:
+        - Comments
+      summary: Delete a comment
+      description: Permanently removes the specified comment.
+      operationId: deleteComment
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Comment deleted.
+        '401':
+          description: Unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /api/v1/media:
     get:
       tags:
@@ -4594,6 +4747,94 @@ components:
         draft_count:
           type: integer
           minimum: 0
+      additionalProperties: false
+    PostCommentRequest:
+      type: object
+      required:
+        - author_name
+        - author_email
+        - body
+      properties:
+        author_name:
+          type: string
+          maxLength: 100
+        author_email:
+          type: string
+          format: email
+          maxLength: 255
+        body:
+          type: string
+      additionalProperties: false
+    CommentResponse:
+      type: object
+      required:
+        - id
+        - entity_id
+        - author_name
+        - body
+        - is_approved
+        - created_at
+      properties:
+        id:
+          type: integer
+        entity_id:
+          type: integer
+        author_name:
+          type: string
+        body:
+          type: string
+        is_approved:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+      additionalProperties: false
+    CommentListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/CommentResponse'
+      additionalProperties: false
+    AdminCommentResponse:
+      type: object
+      required:
+        - id
+        - entity_id
+        - author_name
+        - author_email
+        - body
+        - is_approved
+        - created_at
+      properties:
+        id:
+          type: integer
+        entity_id:
+          type: integer
+        author_name:
+          type: string
+        author_email:
+          type: string
+        body:
+          type: string
+        is_approved:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+      additionalProperties: false
+    AdminCommentListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminCommentResponse'
       additionalProperties: false
     GeneratePreviewTokenResponse:
       type: object

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -17,6 +17,7 @@ import { NavigationPage } from '@/pages/navigation/NavigationPage'
 import { NotFoundPage } from '@/pages/not-found/NotFoundPage'
 import { ResetPasswordPage } from '@/pages/reset-password/ResetPasswordPage'
 import { SiteSettingsPage } from '@/pages/settings/SiteSettingsPage'
+import { CommentsPage } from '@/pages/comments/CommentsPage'
 import { UsersPage } from '@/pages/users/UsersPage'
 import { WebhooksPage } from '@/pages/webhooks/WebhooksPage'
 import { TagsPage } from '@/pages/tags/TagsPage'
@@ -59,6 +60,7 @@ const router = createBrowserRouter([
       { index: true, element: <HomePage /> },
       { path: 'entity-types', element: <EntityTypesPage /> },
       { path: 'tags', element: <TagsPage /> },
+      { path: 'comments', element: <CommentsPage /> },
       { path: 'navigation', element: <NavigationPage /> },
       { path: 'media', element: <MediaPage /> },
       { path: 'webhooks', element: <WebhooksPage /> },

--- a/frontend/src/entities/comment/api-types.ts
+++ b/frontend/src/entities/comment/api-types.ts
@@ -1,0 +1,32 @@
+export interface CommentDto {
+  id: number
+  entity_id: number
+  author_name: string
+  body: string
+  is_approved: boolean
+  created_at: string
+}
+
+export interface AdminCommentDto {
+  id: number
+  entity_id: number
+  author_name: string
+  author_email: string
+  body: string
+  is_approved: boolean
+  created_at: string
+}
+
+export interface CommentListDto {
+  items: CommentDto[]
+}
+
+export interface AdminCommentListDto {
+  items: AdminCommentDto[]
+}
+
+export interface PostCommentRequestDto {
+  author_name: string
+  author_email: string
+  body: string
+}

--- a/frontend/src/entities/comment/index.ts
+++ b/frontend/src/entities/comment/index.ts
@@ -1,0 +1,9 @@
+export type {
+  AdminComment,
+  AdminCommentList,
+  Comment,
+  CommentList,
+  PostCommentInput,
+} from './model'
+export { useApproveComment, useDeleteComment, usePostComment } from './mutations'
+export { useAdminCommentList, useCommentList } from './queries'

--- a/frontend/src/entities/comment/mapper.ts
+++ b/frontend/src/entities/comment/mapper.ts
@@ -1,0 +1,37 @@
+import type { AdminCommentDto, AdminCommentListDto, CommentDto, CommentListDto } from './api-types'
+import type { AdminComment, AdminCommentList, Comment, CommentList } from './model'
+
+export function mapCommentDtoToModel(dto: CommentDto): Comment {
+  return {
+    id: dto.id,
+    entityId: dto.entity_id,
+    authorName: dto.author_name,
+    body: dto.body,
+    isApproved: dto.is_approved,
+    createdAt: dto.created_at,
+  }
+}
+
+export function mapCommentListDtoToModel(dto: CommentListDto): CommentList {
+  return {
+    items: dto.items.map(mapCommentDtoToModel),
+  }
+}
+
+export function mapAdminCommentDtoToModel(dto: AdminCommentDto): AdminComment {
+  return {
+    id: dto.id,
+    entityId: dto.entity_id,
+    authorName: dto.author_name,
+    authorEmail: dto.author_email,
+    body: dto.body,
+    isApproved: dto.is_approved,
+    createdAt: dto.created_at,
+  }
+}
+
+export function mapAdminCommentListDtoToModel(dto: AdminCommentListDto): AdminCommentList {
+  return {
+    items: dto.items.map(mapAdminCommentDtoToModel),
+  }
+}

--- a/frontend/src/entities/comment/model.ts
+++ b/frontend/src/entities/comment/model.ts
@@ -1,0 +1,33 @@
+export interface Comment {
+  id: number
+  entityId: number
+  authorName: string
+  body: string
+  isApproved: boolean
+  createdAt: string
+}
+
+export interface AdminComment {
+  id: number
+  entityId: number
+  authorName: string
+  authorEmail: string
+  body: string
+  isApproved: boolean
+  createdAt: string
+}
+
+export interface CommentList {
+  items: Comment[]
+}
+
+export interface AdminCommentList {
+  items: AdminComment[]
+}
+
+export interface PostCommentInput {
+  entityId: number
+  authorName: string
+  authorEmail: string
+  body: string
+}

--- a/frontend/src/entities/comment/mutations.ts
+++ b/frontend/src/entities/comment/mutations.ts
@@ -1,0 +1,57 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { AdminCommentDto, CommentDto } from './api-types'
+import { mapAdminCommentDtoToModel, mapCommentDtoToModel } from './mapper'
+import type { AdminComment, Comment, PostCommentInput } from './model'
+import { commentKeys } from './query-keys'
+
+export function usePostComment(): UseMutationResult<Comment, AppError, PostCommentInput> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input) => {
+      const dto = await apiClient.post<CommentDto>(
+        `/api/v1/entities/${String(input.entityId)}/comments`,
+        {
+          author_name: input.authorName,
+          author_email: input.authorEmail,
+          body: input.body,
+        },
+      )
+      return mapCommentDtoToModel(dto)
+    },
+    onSuccess: async (_data, input) => {
+      await queryClient.invalidateQueries({ queryKey: commentKeys.byEntity(input.entityId) })
+    },
+  })
+}
+
+export function useApproveComment(): UseMutationResult<AdminComment, AppError, number> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (id) => {
+      const dto = await apiClient.patch<AdminCommentDto>(
+        `/api/v1/admin/comments/${String(id)}/approve`,
+        {},
+      )
+      return mapAdminCommentDtoToModel(dto)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: commentKeys.adminList() })
+    },
+  })
+}
+
+export function useDeleteComment(): UseMutationResult<void, AppError, number> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (id) => {
+      await apiClient.delete(`/api/v1/admin/comments/${String(id)}`)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: commentKeys.adminList() })
+    },
+  })
+}

--- a/frontend/src/entities/comment/queries.ts
+++ b/frontend/src/entities/comment/queries.ts
@@ -1,0 +1,29 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { AdminCommentListDto, CommentListDto } from './api-types'
+import { mapAdminCommentListDtoToModel, mapCommentListDtoToModel } from './mapper'
+import type { AdminCommentList, CommentList } from './model'
+import { commentKeys } from './query-keys'
+
+export function useCommentList(entityId: number): UseQueryResult<CommentList, AppError> {
+  return useQuery({
+    queryKey: commentKeys.byEntity(entityId),
+    queryFn: async ({ signal }) => {
+      const dto = await apiClient.get<CommentListDto>(
+        `/api/v1/entities/${String(entityId)}/comments`,
+        signal,
+      )
+      return mapCommentListDtoToModel(dto)
+    },
+  })
+}
+
+export function useAdminCommentList(): UseQueryResult<AdminCommentList, AppError> {
+  return useQuery({
+    queryKey: commentKeys.adminList(),
+    queryFn: async ({ signal }) => {
+      const dto = await apiClient.get<AdminCommentListDto>('/api/v1/admin/comments', signal)
+      return mapAdminCommentListDtoToModel(dto)
+    },
+  })
+}

--- a/frontend/src/entities/comment/query-keys.ts
+++ b/frontend/src/entities/comment/query-keys.ts
@@ -1,0 +1,5 @@
+export const commentKeys = {
+  all: ['comments'] as const,
+  byEntity: (entityId: number) => [...commentKeys.all, 'entity', entityId] as const,
+  adminList: () => [...commentKeys.all, 'admin-list'] as const,
+}

--- a/frontend/src/features/comment-section/index.ts
+++ b/frontend/src/features/comment-section/index.ts
@@ -1,0 +1,1 @@
+export { CommentSection } from './ui/CommentSection'

--- a/frontend/src/features/comment-section/ui/CommentSection.tsx
+++ b/frontend/src/features/comment-section/ui/CommentSection.tsx
@@ -1,0 +1,142 @@
+import { useCommentList, usePostComment } from '@/entities/comment'
+import { useTranslation } from '@/shared/i18n'
+import { Button, Input, Stack, Text } from '@/shared/ui'
+import { useState } from 'react'
+
+interface Props {
+  entityId: number
+}
+
+export function CommentSection({ entityId }: Props) {
+  const { t } = useTranslation()
+  const commentsQuery = useCommentList(entityId)
+  const postComment = usePostComment()
+
+  const [authorName, setAuthorName] = useState('')
+  const [authorEmail, setAuthorEmail] = useState('')
+  const [body, setBody] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+
+  function handleSubmit(e: React.SyntheticEvent) {
+    e.preventDefault()
+    setSubmitted(false)
+    postComment.mutate(
+      {
+        entityId,
+        authorName: authorName.trim(),
+        authorEmail: authorEmail.trim(),
+        body: body.trim(),
+      },
+      {
+        onSuccess: () => {
+          setAuthorName('')
+          setAuthorEmail('')
+          setBody('')
+          setSubmitted(true)
+        },
+      },
+    )
+  }
+
+  const comments = commentsQuery.data?.items ?? []
+
+  return (
+    <Stack gap="lg">
+      <Text as="h2" variant="heading-sm">
+        {t('public.comments.title')}
+      </Text>
+
+      {/* Comment list */}
+      {commentsQuery.isLoading ? (
+        <Text muted>{t('public.comments.loading')}</Text>
+      ) : commentsQuery.isError ? (
+        <Text muted>{t('public.comments.loadError')}</Text>
+      ) : comments.length === 0 ? (
+        <Text muted>{t('public.comments.empty')}</Text>
+      ) : (
+        <Stack gap="md">
+          {comments.map((comment) => (
+            <div
+              key={comment.id}
+              className="rounded-lg border border-border bg-surface-raised px-inline-md py-stack-sm"
+            >
+              <Stack gap="xs">
+                <div className="flex items-baseline gap-2">
+                  <Text variant="heading-sm">{comment.authorName}</Text>
+                  <Text muted>
+                    <time dateTime={comment.createdAt}>
+                      {new Date(comment.createdAt).toLocaleDateString()}
+                    </time>
+                  </Text>
+                </div>
+                <Text>{comment.body}</Text>
+              </Stack>
+            </div>
+          ))}
+        </Stack>
+      )}
+
+      {/* Post comment form */}
+      <Stack gap="md">
+        <Text as="h3" variant="heading-sm">
+          {t('public.comments.form.title')}
+        </Text>
+        {submitted ? (
+          <p className="rounded-md bg-success/10 px-inline-md py-stack-sm font-sans text-body text-success">
+            {t('public.comments.form.success')}
+          </p>
+        ) : null}
+        <form onSubmit={handleSubmit}>
+          <Stack gap="md">
+            <Input
+              id="comment-author-name"
+              label={t('public.comments.form.authorName')}
+              type="text"
+              value={authorName}
+              onChange={(e) => {
+                setAuthorName(e.target.value)
+              }}
+              disabled={postComment.isPending}
+            />
+            <Input
+              id="comment-author-email"
+              label={t('public.comments.form.authorEmail')}
+              type="email"
+              value={authorEmail}
+              onChange={(e) => {
+                setAuthorEmail(e.target.value)
+              }}
+              disabled={postComment.isPending}
+            />
+            <div className="flex flex-col gap-stack-xs">
+              <label
+                htmlFor="comment-body"
+                className="font-sans text-body font-medium text-text-primary"
+              >
+                {t('public.comments.form.body')}
+              </label>
+              <textarea
+                id="comment-body"
+                value={body}
+                onChange={(e) => {
+                  setBody(e.target.value)
+                }}
+                disabled={postComment.isPending}
+                rows={4}
+                className="rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm font-sans text-body text-text-primary shadow-sm focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-50"
+              />
+            </div>
+            {postComment.isError ? <Text muted>{t('public.comments.form.error')}</Text> : null}
+            <div>
+              <Button type="submit" disabled={postComment.isPending}>
+                {postComment.isPending
+                  ? t('public.comments.form.submitting')
+                  : t('public.comments.form.submit')}
+              </Button>
+            </div>
+          </Stack>
+        </form>
+      </Stack>
+    </Stack>
+  )
+}

--- a/frontend/src/features/manage-comments/index.ts
+++ b/frontend/src/features/manage-comments/index.ts
@@ -1,0 +1,1 @@
+export { ManageCommentsView } from './ui/ManageCommentsView'

--- a/frontend/src/features/manage-comments/ui/ManageCommentsView.tsx
+++ b/frontend/src/features/manage-comments/ui/ManageCommentsView.tsx
@@ -1,0 +1,150 @@
+import type { AdminComment } from '@/entities/comment'
+import { useAdminCommentList, useApproveComment, useDeleteComment } from '@/entities/comment'
+import { useTranslation } from '@/shared/i18n'
+import { Button, ConfirmDialog, EmptyState, Stack, Text } from '@/shared/ui'
+import { useToast } from '@/shared/ui'
+import { useState } from 'react'
+
+export function ManageCommentsView() {
+  const { t } = useTranslation()
+  const { showToast } = useToast()
+  const commentsQuery = useAdminCommentList()
+  const approveComment = useApproveComment()
+  const deleteComment = useDeleteComment()
+
+  const [deleteTarget, setDeleteTarget] = useState<AdminComment | null>(null)
+
+  function handleApprove(comment: AdminComment) {
+    approveComment.mutate(comment.id, {
+      onSuccess: () => {
+        showToast(t('admin.comments.approveSuccess'), 'success')
+      },
+    })
+  }
+
+  function handleDeleteConfirm() {
+    if (deleteTarget === null) return
+    const id = deleteTarget.id
+    setDeleteTarget(null)
+    deleteComment.mutate(id, {
+      onSuccess: () => {
+        showToast(t('admin.comments.deleteSuccess'), 'success')
+      },
+    })
+  }
+
+  if (commentsQuery.isLoading) {
+    return <Text muted>{t('admin.comments.loading')}</Text>
+  }
+
+  if (commentsQuery.isError) {
+    return (
+      <Stack gap="sm">
+        <Text muted>{t('admin.comments.loadError')}</Text>
+        <Button
+          variant="secondary"
+          onClick={() => {
+            void commentsQuery.refetch()
+          }}
+        >
+          {t('common.actions.retry')}
+        </Button>
+      </Stack>
+    )
+  }
+
+  const items = commentsQuery.data?.items ?? []
+
+  return (
+    <>
+      {items.length === 0 ? (
+        <EmptyState
+          title={t('admin.comments.empty')}
+          description={t('admin.comments.empty.description')}
+        />
+      ) : (
+        <Stack gap="md">
+          {items.map((comment) => (
+            <div
+              key={comment.id}
+              className="rounded-lg border border-border bg-surface-raised px-inline-md py-stack-sm"
+            >
+              <Stack gap="sm">
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <Stack gap="xs">
+                    <div className="flex items-baseline gap-2">
+                      <Text variant="heading-sm">{comment.authorName}</Text>
+                      <span className="font-sans text-caption text-text-muted">
+                        {comment.authorEmail}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="font-sans text-caption text-text-muted">
+                        {t('admin.comments.entityId', { id: String(comment.entityId) })}
+                      </span>
+                      <span className="font-sans text-caption text-text-muted">·</span>
+                      <time
+                        dateTime={comment.createdAt}
+                        className="font-sans text-caption text-text-muted"
+                      >
+                        {new Date(comment.createdAt).toLocaleString()}
+                      </time>
+                      {comment.isApproved ? (
+                        <span className="rounded-full bg-success/15 px-2 py-0.5 font-sans text-caption font-medium text-success">
+                          {t('admin.comments.approved')}
+                        </span>
+                      ) : (
+                        <span className="rounded-full bg-warning/15 px-2 py-0.5 font-sans text-caption font-medium text-warning">
+                          {t('admin.comments.pending')}
+                        </span>
+                      )}
+                    </div>
+                  </Stack>
+                  <div className="flex gap-2">
+                    {!comment.isApproved ? (
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        disabled={approveComment.isPending}
+                        onClick={() => {
+                          handleApprove(comment)
+                        }}
+                      >
+                        {t('admin.comments.approve')}
+                      </Button>
+                    ) : null}
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      disabled={deleteComment.isPending}
+                      onClick={() => {
+                        setDeleteTarget(comment)
+                      }}
+                    >
+                      {t('admin.comments.delete')}
+                    </Button>
+                  </div>
+                </div>
+                <Text>{comment.body}</Text>
+              </Stack>
+            </div>
+          ))}
+        </Stack>
+      )}
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={t('admin.comments.deleteConfirmTitle')}
+        description={t('admin.comments.deleteConfirmDescription', {
+          name: deleteTarget?.authorName ?? '',
+        })}
+        confirmLabel={t('admin.comments.delete')}
+        isPending={deleteComment.isPending}
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => {
+          setDeleteTarget(null)
+        }}
+      />
+    </>
+  )
+}

--- a/frontend/src/pages/comments/CommentsPage.tsx
+++ b/frontend/src/pages/comments/CommentsPage.tsx
@@ -1,0 +1,24 @@
+import { Navigate } from 'react-router-dom'
+import { currentUserHasCapability } from '@/entities/auth'
+import { ManageCommentsView } from '@/features/manage-comments'
+import { useTranslation } from '@/shared/i18n'
+import { Stack, Text } from '@/shared/ui'
+
+export function CommentsPage() {
+  const { t } = useTranslation()
+  const canManageSettings = currentUserHasCapability('manage_settings')
+
+  if (!canManageSettings) {
+    return <Navigate to="/forbidden" replace />
+  }
+
+  return (
+    <Stack gap="md">
+      <Text as="h1" variant="heading-md">
+        {t('admin.comments.pageTitle')}
+      </Text>
+      <Text muted>{t('admin.comments.description')}</Text>
+      <ManageCommentsView />
+    </Stack>
+  )
+}

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { Link, Navigate, useLocation, useParams } from 'react-router-dom'
 import { toEntityId, useEntity } from '@/entities/entity'
 import { useEntityTypeList } from '@/entities/entity-type'
+import { CommentSection } from '@/features/comment-section'
 import {
   PublicRecordDetailView,
   usePublicViewEntityRecordPage,
@@ -98,6 +99,7 @@ function PublicRecordDetailContent({
           void refetch()
         }}
       />
+      {entity !== null && !isLoading && !isError ? <CommentSection entityId={entityId} /> : null}
     </Stack>
   )
 }

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -16,6 +16,7 @@ import {
   IconLink,
   IconLogOut,
   IconMenu,
+  IconMessageCircle,
   IconMoon,
   IconSettings,
   IconSun,
@@ -250,6 +251,14 @@ export function AppShell() {
                           to="/admin/media"
                           icon={<IconImage size={16} />}
                           label={t('admin.nav.media')}
+                          onClick={closeSidebar}
+                        />
+                      </li>
+                      <li>
+                        <NavItem
+                          to="/admin/comments"
+                          icon={<IconMessageCircle size={16} />}
+                          label={t('admin.nav.comments')}
                           onClick={closeSidebar}
                         />
                       </li>

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -488,11 +488,43 @@ export const en = {
   'admin.resetPassword.success': 'Your password has been reset. You can now sign in.',
   'admin.resetPassword.invalidToken': 'This reset link is invalid or has expired.',
 
+  // ── Comments (admin) ────────────────────────────────────────────────────
+  'admin.nav.comments': 'Comments',
+  'admin.comments.pageTitle': 'Comments',
+  'admin.comments.description': 'Review and moderate reader comments.',
+  'admin.comments.loading': 'Loading comments…',
+  'admin.comments.loadError': 'Could not load comments.',
+  'admin.comments.empty': 'No comments yet',
+  'admin.comments.empty.description': 'Comments submitted by readers will appear here.',
+  'admin.comments.entityId': 'Entity #{{id}}',
+  'admin.comments.approved': 'Approved',
+  'admin.comments.pending': 'Pending',
+  'admin.comments.approve': 'Approve',
+  'admin.comments.delete': 'Delete',
+  'admin.comments.approveSuccess': 'Comment approved.',
+  'admin.comments.deleteSuccess': 'Comment deleted.',
+  'admin.comments.deleteConfirmTitle': 'Delete comment?',
+  'admin.comments.deleteConfirmDescription': 'Delete comment by {{name}}? This cannot be undone.',
+
   // ── Public consumer pages ────────────────────────────────────────────────
   'public.record.notFound.title': 'Record not found',
   'public.record.notFound.description': 'No record with slug "{{slug}}".',
   'public.entityType.notFound.title': 'Not found',
   'public.entityType.notFound.description': 'No public content for "{{slug}}".',
+
+  // ── Public comments ──────────────────────────────────────────────────────
+  'public.comments.title': 'Comments',
+  'public.comments.loading': 'Loading comments…',
+  'public.comments.loadError': 'Could not load comments.',
+  'public.comments.empty': 'No comments yet. Be the first!',
+  'public.comments.form.title': 'Leave a comment',
+  'public.comments.form.authorName': 'Name',
+  'public.comments.form.authorEmail': 'Email address',
+  'public.comments.form.body': 'Comment',
+  'public.comments.form.submit': 'Submit',
+  'public.comments.form.submitting': 'Submitting…',
+  'public.comments.form.success': 'Your comment has been submitted and is awaiting moderation.',
+  'public.comments.form.error': 'Could not submit comment. Please try again.',
 } as const
 
 /** Complete message catalog type — derived from the English source of truth. */

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -491,9 +491,42 @@ export const ja: Partial<MessageCatalog> = {
   'admin.resetPassword.success': 'パスワードがリセットされました。サインインできます。',
   'admin.resetPassword.invalidToken': 'このリセットリンクは無効または期限切れです。',
 
+  // ── Comments (admin) ────────────────────────────────────────────────────
+  'admin.nav.comments': 'コメント',
+  'admin.comments.pageTitle': 'コメント',
+  'admin.comments.description': '読者のコメントを確認・モデレートします。',
+  'admin.comments.loading': 'コメントを読み込み中…',
+  'admin.comments.loadError': 'コメントを読み込めませんでした。',
+  'admin.comments.empty': 'コメントはまだありません',
+  'admin.comments.empty.description': '読者から送信されたコメントがここに表示されます。',
+  'admin.comments.entityId': 'エンティティ #{{id}}',
+  'admin.comments.approved': '承認済み',
+  'admin.comments.pending': '承認待ち',
+  'admin.comments.approve': '承認',
+  'admin.comments.delete': '削除',
+  'admin.comments.approveSuccess': 'コメントを承認しました。',
+  'admin.comments.deleteSuccess': 'コメントを削除しました。',
+  'admin.comments.deleteConfirmTitle': 'コメントを削除しますか？',
+  'admin.comments.deleteConfirmDescription':
+    '{{name}} のコメントを削除しますか？この操作は元に戻せません。',
+
   // ── Public consumer pages ────────────────────────────────────────────────
   'public.record.notFound.title': 'レコードが見つかりません',
   'public.record.notFound.description': 'スラッグ "{{slug}}" のレコードが見つかりません。',
   'public.entityType.notFound.title': '見つかりません',
   'public.entityType.notFound.description': '"{{slug}}" の公開コンテンツが見つかりません。',
+
+  // ── Public comments ──────────────────────────────────────────────────────
+  'public.comments.title': 'コメント',
+  'public.comments.loading': 'コメントを読み込み中…',
+  'public.comments.loadError': 'コメントを読み込めませんでした。',
+  'public.comments.empty': 'まだコメントがありません。最初のコメントを投稿してください！',
+  'public.comments.form.title': 'コメントを書く',
+  'public.comments.form.authorName': 'お名前',
+  'public.comments.form.authorEmail': 'メールアドレス',
+  'public.comments.form.body': 'コメント',
+  'public.comments.form.submit': '送信',
+  'public.comments.form.submitting': '送信中…',
+  'public.comments.form.success': 'コメントを送信しました。承認後に表示されます。',
+  'public.comments.form.error': 'コメントを送信できませんでした。もう一度お試しください。',
 }

--- a/frontend/src/shared/ui/icons/Icons.tsx
+++ b/frontend/src/shared/ui/icons/Icons.tsx
@@ -235,3 +235,11 @@ export function IconShield({ size = 16, className }: IconProps) {
     </svg>
   )
 }
+
+export function IconMessageCircle({ size = 16, className }: IconProps) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+    </svg>
+  )
+}

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -14,6 +14,9 @@ use NeNeRecords\BoolField\BoolFieldNotFoundExceptionHandler;
 use NeNeRecords\BoolField\BoolFieldServiceProvider;
 use NeNeRecords\BoolField\FieldKeyNotRegisteredExceptionHandler as BoolFieldKeyNotRegisteredExceptionHandler;
 use NeNeRecords\BoolField\FieldTypeMismatchExceptionHandler as BoolFieldTypeMismatchExceptionHandler;
+use NeNeRecords\Comment\CommentNotFoundExceptionHandler;
+use NeNeRecords\Comment\CommentRouteRegistrar;
+use NeNeRecords\Comment\CommentServiceProvider;
 use NeNeRecords\Dashboard\DashboardServiceProvider;
 use NeNeRecords\DateTimeField\DateTimeFieldNotFoundExceptionHandler;
 use NeNeRecords\DateTimeField\DateTimeFieldServiceProvider;
@@ -111,7 +114,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new PreviewTokenServiceProvider())
             ->addProvider(new DashboardServiceProvider())
             ->addProvider(new UserServiceProvider())
-            ->addProvider(new UserInviteServiceProvider());
+            ->addProvider(new UserInviteServiceProvider())
+            ->addProvider(new CommentServiceProvider());
 
         $builder
             ->set(
@@ -140,6 +144,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $user = $container->get('nene-records.route_registrar.user');
                     $userInvite = $container->get('nene-records.route_registrar.user_invite');
                     $auth = $container->get('nene-records.route_registrar.auth');
+                    $comment = $container->get(CommentRouteRegistrar::class);
 
                     if (
                         !is_callable($entityType)
@@ -165,6 +170,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !is_callable($user)
                         || !is_callable($userInvite)
                         || !is_callable($auth)
+                        || !is_callable($comment)
                     ) {
                         throw new LogicException('Route registrar service is invalid.');
                     }
@@ -193,6 +199,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $dashboard,
                         $user,
                         $userInvite,
+                        $comment,
                     ];
                 },
             )
@@ -248,6 +255,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $invalidCurrentPassword = $container->get(InvalidCurrentPasswordExceptionHandler::class);
                     $invalidInviteToken = $container->get(InvalidInviteTokenExceptionHandler::class);
                     $invalidResetToken = $container->get(InvalidPasswordResetTokenExceptionHandler::class);
+                    $commentNotFound = $container->get(CommentNotFoundExceptionHandler::class);
 
                     foreach ([
                         $entityTypeNotFound,
@@ -299,6 +307,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $invalidCurrentPassword,
                         $invalidInviteToken,
                         $invalidResetToken,
+                        $commentNotFound,
                     ] as $handler) {
                         if (!$handler instanceof DomainExceptionHandlerInterface) {
                             throw new LogicException('Exception handler service is invalid.');
@@ -355,6 +364,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $invalidCurrentPassword,
                         $invalidInviteToken,
                         $invalidResetToken,
+                        $commentNotFound,
                     ];
                 },
             );

--- a/src/Auth/AdminApiAuthMiddleware.php
+++ b/src/Auth/AdminApiAuthMiddleware.php
@@ -36,6 +36,7 @@ final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
         '/api/v1/navigation-items',
         '/api/v1/media',
         '/api/v1/users',
+        '/api/v1/admin/comments',
     ];
 
     public function __construct(

--- a/src/Auth/CapabilityResolver.php
+++ b/src/Auth/CapabilityResolver.php
@@ -72,6 +72,11 @@ final class CapabilityResolver
             return Capability::ManageSettings;
         }
 
+        // Admin comment management endpoints require ManageSettings
+        if (str_starts_with($path, '/api/v1/admin/comments')) {
+            return Capability::ManageSettings;
+        }
+
         foreach (self::CONTENT_MUTATION_PREFIXES as $prefix) {
             if (str_starts_with($path, $prefix) && self::isMutationMethod($method)) {
                 return Capability::EditContent;

--- a/src/Comment/ApproveCommentHandler.php
+++ b/src/Comment/ApproveCommentHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ApproveCommentHandler
+{
+    public function __construct(
+        private ApproveCommentUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+
+        $comment = $this->useCase->execute(new ApproveCommentInput($id));
+
+        return $this->response->create([
+            'id'          => $comment->id,
+            'entity_id'   => $comment->entityId,
+            'author_name' => $comment->authorName,
+            'body'        => $comment->body,
+            'is_approved' => $comment->isApproved,
+            'created_at'  => $comment->createdAt,
+        ]);
+    }
+}

--- a/src/Comment/ApproveCommentInput.php
+++ b/src/Comment/ApproveCommentInput.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+final readonly class ApproveCommentInput
+{
+    public function __construct(public int $id)
+    {
+    }
+}

--- a/src/Comment/ApproveCommentUseCase.php
+++ b/src/Comment/ApproveCommentUseCase.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+final readonly class ApproveCommentUseCase implements ApproveCommentUseCaseInterface
+{
+    public function __construct(private CommentRepositoryInterface $comments)
+    {
+    }
+
+    public function execute(ApproveCommentInput $input): Comment
+    {
+        return $this->comments->approve($input->id);
+    }
+}

--- a/src/Comment/ApproveCommentUseCaseInterface.php
+++ b/src/Comment/ApproveCommentUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+interface ApproveCommentUseCaseInterface
+{
+    public function execute(ApproveCommentInput $input): Comment;
+}

--- a/src/Comment/Comment.php
+++ b/src/Comment/Comment.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+final readonly class Comment
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $authorName,
+        public string $authorEmail,
+        public string $body,
+        public bool $isApproved,
+        public string $createdAt,
+    ) {
+    }
+}

--- a/src/Comment/CommentNotFoundException.php
+++ b/src/Comment/CommentNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+use DomainException;
+
+final class CommentNotFoundException extends DomainException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct('Comment not found: ' . $id);
+    }
+}

--- a/src/Comment/CommentNotFoundExceptionHandler.php
+++ b/src/Comment/CommentNotFoundExceptionHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CommentNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(private ProblemDetailsResponseFactory $problemDetails)
+    {
+    }
+
+    public function supports(\Throwable $e): bool
+    {
+        return $e instanceof CommentNotFoundException;
+    }
+
+    public function handle(\Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'not-found', 'Not Found', 404, $exception->getMessage());
+    }
+}

--- a/src/Comment/CommentRepositoryInterface.php
+++ b/src/Comment/CommentRepositoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+interface CommentRepositoryInterface
+{
+    /** @return Comment[] */
+    public function listByEntity(int $entityId, bool $approvedOnly): array;
+
+    /** @return Comment[] */
+    public function listAll(): array;
+
+    public function findById(int $id): Comment;
+
+    public function create(int $entityId, string $authorName, string $authorEmail, string $body): Comment;
+
+    public function approve(int $id): Comment;
+
+    public function delete(int $id): void;
+}

--- a/src/Comment/CommentRouteRegistrar.php
+++ b/src/Comment/CommentRouteRegistrar.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CommentRouteRegistrar
+{
+    public function __construct(
+        private PostCommentHandler $postHandler,
+        private ListCommentsHandler $listHandler,
+        private ListAllCommentsHandler $listAllHandler,
+        private ApproveCommentHandler $approveHandler,
+        private DeleteCommentHandler $deleteHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $postHandler = $this->postHandler;
+        $listHandler = $this->listHandler;
+        $listAllHandler = $this->listAllHandler;
+        $approveHandler = $this->approveHandler;
+        $deleteHandler = $this->deleteHandler;
+
+        // Public endpoints
+        $router->post('/api/v1/entities/{id}/comments', static fn (ServerRequestInterface $r) => $postHandler->handle($r));
+        $router->get('/api/v1/entities/{id}/comments', static fn (ServerRequestInterface $r) => $listHandler->handle($r));
+
+        // Admin endpoints
+        $router->get('/api/v1/admin/comments', static fn (ServerRequestInterface $r) => $listAllHandler->handle($r));
+        $router->patch('/api/v1/admin/comments/{id}/approve', static fn (ServerRequestInterface $r) => $approveHandler->handle($r));
+        $router->delete('/api/v1/admin/comments/{id}', static fn (ServerRequestInterface $r) => $deleteHandler->handle($r));
+    }
+}

--- a/src/Comment/CommentServiceProvider.php
+++ b/src/Comment/CommentServiceProvider.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class CommentServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                CommentRepositoryInterface::class,
+                static function (ContainerInterface $c): CommentRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoCommentRepository($query);
+                },
+            )
+            ->set(
+                PostCommentUseCaseInterface::class,
+                static function (ContainerInterface $c): PostCommentUseCaseInterface {
+                    $repo = $c->get(CommentRepositoryInterface::class);
+                    if (!$repo instanceof CommentRepositoryInterface) {
+                        throw new LogicException('Comment repository service is invalid.');
+                    }
+
+                    return new PostCommentUseCase($repo);
+                },
+            )
+            ->set(
+                ListCommentsUseCaseInterface::class,
+                static function (ContainerInterface $c): ListCommentsUseCaseInterface {
+                    $repo = $c->get(CommentRepositoryInterface::class);
+                    if (!$repo instanceof CommentRepositoryInterface) {
+                        throw new LogicException('Comment repository service is invalid.');
+                    }
+
+                    return new ListCommentsUseCase($repo);
+                },
+            )
+            ->set(
+                ListAllCommentsUseCaseInterface::class,
+                static function (ContainerInterface $c): ListAllCommentsUseCaseInterface {
+                    $repo = $c->get(CommentRepositoryInterface::class);
+                    if (!$repo instanceof CommentRepositoryInterface) {
+                        throw new LogicException('Comment repository service is invalid.');
+                    }
+
+                    return new ListAllCommentsUseCase($repo);
+                },
+            )
+            ->set(
+                ApproveCommentUseCaseInterface::class,
+                static function (ContainerInterface $c): ApproveCommentUseCaseInterface {
+                    $repo = $c->get(CommentRepositoryInterface::class);
+                    if (!$repo instanceof CommentRepositoryInterface) {
+                        throw new LogicException('Comment repository service is invalid.');
+                    }
+
+                    return new ApproveCommentUseCase($repo);
+                },
+            )
+            ->set(
+                DeleteCommentUseCaseInterface::class,
+                static function (ContainerInterface $c): DeleteCommentUseCaseInterface {
+                    $repo = $c->get(CommentRepositoryInterface::class);
+                    if (!$repo instanceof CommentRepositoryInterface) {
+                        throw new LogicException('Comment repository service is invalid.');
+                    }
+
+                    return new DeleteCommentUseCase($repo);
+                },
+            )
+            ->set(
+                PostCommentHandler::class,
+                static function (ContainerInterface $c): PostCommentHandler {
+                    $useCase = $c->get(PostCommentUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+                    if (!$useCase instanceof PostCommentUseCaseInterface) {
+                        throw new LogicException('PostComment use case service is invalid.');
+                    }
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory service is invalid.');
+                    }
+
+                    return new PostCommentHandler($useCase, $response);
+                },
+            )
+            ->set(
+                ListCommentsHandler::class,
+                static function (ContainerInterface $c): ListCommentsHandler {
+                    $useCase = $c->get(ListCommentsUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+                    if (!$useCase instanceof ListCommentsUseCaseInterface) {
+                        throw new LogicException('ListComments use case service is invalid.');
+                    }
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory service is invalid.');
+                    }
+
+                    return new ListCommentsHandler($useCase, $response);
+                },
+            )
+            ->set(
+                ListAllCommentsHandler::class,
+                static function (ContainerInterface $c): ListAllCommentsHandler {
+                    $useCase = $c->get(ListAllCommentsUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+                    if (!$useCase instanceof ListAllCommentsUseCaseInterface) {
+                        throw new LogicException('ListAllComments use case service is invalid.');
+                    }
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory service is invalid.');
+                    }
+
+                    return new ListAllCommentsHandler($useCase, $response);
+                },
+            )
+            ->set(
+                ApproveCommentHandler::class,
+                static function (ContainerInterface $c): ApproveCommentHandler {
+                    $useCase = $c->get(ApproveCommentUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+                    if (!$useCase instanceof ApproveCommentUseCaseInterface) {
+                        throw new LogicException('ApproveComment use case service is invalid.');
+                    }
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory service is invalid.');
+                    }
+
+                    return new ApproveCommentHandler($useCase, $response);
+                },
+            )
+            ->set(
+                DeleteCommentHandler::class,
+                static function (ContainerInterface $c): DeleteCommentHandler {
+                    $useCase = $c->get(DeleteCommentUseCaseInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+                    if (!$useCase instanceof DeleteCommentUseCaseInterface) {
+                        throw new LogicException('DeleteComment use case service is invalid.');
+                    }
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('ResponseFactory service is invalid.');
+                    }
+
+                    return new DeleteCommentHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
+                CommentRouteRegistrar::class,
+                static function (ContainerInterface $c): CommentRouteRegistrar {
+                    return new CommentRouteRegistrar(
+                        $c->get(PostCommentHandler::class),
+                        $c->get(ListCommentsHandler::class),
+                        $c->get(ListAllCommentsHandler::class),
+                        $c->get(ApproveCommentHandler::class),
+                        $c->get(DeleteCommentHandler::class),
+                    );
+                },
+            )
+            ->set(
+                CommentNotFoundExceptionHandler::class,
+                static function (ContainerInterface $c): CommentNotFoundExceptionHandler {
+                    $factory = $c->get(ProblemDetailsResponseFactory::class);
+                    if (!$factory instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new CommentNotFoundExceptionHandler($factory);
+                },
+            );
+    }
+}

--- a/src/Comment/DeleteCommentHandler.php
+++ b/src/Comment/DeleteCommentHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteCommentHandler
+{
+    public function __construct(
+        private DeleteCommentUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+
+        $this->useCase->execute(new DeleteCommentInput($id));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/Comment/DeleteCommentInput.php
+++ b/src/Comment/DeleteCommentInput.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+final readonly class DeleteCommentInput
+{
+    public function __construct(public int $id)
+    {
+    }
+}

--- a/src/Comment/DeleteCommentUseCase.php
+++ b/src/Comment/DeleteCommentUseCase.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+final readonly class DeleteCommentUseCase implements DeleteCommentUseCaseInterface
+{
+    public function __construct(private CommentRepositoryInterface $comments)
+    {
+    }
+
+    public function execute(DeleteCommentInput $input): void
+    {
+        $this->comments->delete($input->id);
+    }
+}

--- a/src/Comment/DeleteCommentUseCaseInterface.php
+++ b/src/Comment/DeleteCommentUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+interface DeleteCommentUseCaseInterface
+{
+    public function execute(DeleteCommentInput $input): void;
+}

--- a/src/Comment/ListAllCommentsHandler.php
+++ b/src/Comment/ListAllCommentsHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListAllCommentsHandler
+{
+    public function __construct(
+        private ListAllCommentsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $output = $this->useCase->execute();
+
+        $items = array_map(
+            static fn (ListCommentsItem $item): array => [
+                'id'           => $item->id,
+                'entity_id'    => $item->entityId,
+                'author_name'  => $item->authorName,
+                'author_email' => $item->authorEmail,
+                'body'         => $item->body,
+                'is_approved'  => $item->isApproved,
+                'created_at'   => $item->createdAt,
+            ],
+            $output->items,
+        );
+
+        return $this->response->create(['items' => $items]);
+    }
+}

--- a/src/Comment/ListAllCommentsUseCase.php
+++ b/src/Comment/ListAllCommentsUseCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+final readonly class ListAllCommentsUseCase implements ListAllCommentsUseCaseInterface
+{
+    public function __construct(private CommentRepositoryInterface $comments)
+    {
+    }
+
+    public function execute(): ListCommentsOutput
+    {
+        $comments = $this->comments->listAll();
+
+        return new ListCommentsOutput(
+            items: array_map(ListCommentsItem::fromComment(...), $comments),
+        );
+    }
+}

--- a/src/Comment/ListAllCommentsUseCaseInterface.php
+++ b/src/Comment/ListAllCommentsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+interface ListAllCommentsUseCaseInterface
+{
+    public function execute(): ListCommentsOutput;
+}

--- a/src/Comment/ListCommentsHandler.php
+++ b/src/Comment/ListCommentsHandler.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListCommentsHandler
+{
+    public function __construct(
+        private ListCommentsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $entityId = (int) ($params['id'] ?? 0);
+
+        // Public endpoint: only return approved comments
+        $output = $this->useCase->execute(new ListCommentsInput(
+            entityId: $entityId,
+            approvedOnly: true,
+        ));
+
+        $items = array_map(
+            static fn (ListCommentsItem $item): array => [
+                'id'          => $item->id,
+                'entity_id'   => $item->entityId,
+                'author_name' => $item->authorName,
+                'body'        => $item->body,
+                'is_approved' => $item->isApproved,
+                'created_at'  => $item->createdAt,
+            ],
+            $output->items,
+        );
+
+        return $this->response->create(['items' => $items]);
+    }
+}

--- a/src/Comment/ListCommentsInput.php
+++ b/src/Comment/ListCommentsInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+final readonly class ListCommentsInput
+{
+    public function __construct(
+        public int $entityId,
+        public bool $approvedOnly,
+    ) {
+    }
+}

--- a/src/Comment/ListCommentsItem.php
+++ b/src/Comment/ListCommentsItem.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+final readonly class ListCommentsItem
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $authorName,
+        public string $authorEmail,
+        public string $body,
+        public bool $isApproved,
+        public string $createdAt,
+    ) {
+    }
+
+    public static function fromComment(Comment $comment): self
+    {
+        return new self(
+            id: $comment->id,
+            entityId: $comment->entityId,
+            authorName: $comment->authorName,
+            authorEmail: $comment->authorEmail,
+            body: $comment->body,
+            isApproved: $comment->isApproved,
+            createdAt: $comment->createdAt,
+        );
+    }
+}

--- a/src/Comment/ListCommentsOutput.php
+++ b/src/Comment/ListCommentsOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+final readonly class ListCommentsOutput
+{
+    /** @param ListCommentsItem[] $items */
+    public function __construct(public array $items)
+    {
+    }
+}

--- a/src/Comment/ListCommentsUseCase.php
+++ b/src/Comment/ListCommentsUseCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+final readonly class ListCommentsUseCase implements ListCommentsUseCaseInterface
+{
+    public function __construct(private CommentRepositoryInterface $comments)
+    {
+    }
+
+    public function execute(ListCommentsInput $input): ListCommentsOutput
+    {
+        $comments = $this->comments->listByEntity($input->entityId, $input->approvedOnly);
+
+        return new ListCommentsOutput(
+            items: array_map(ListCommentsItem::fromComment(...), $comments),
+        );
+    }
+}

--- a/src/Comment/ListCommentsUseCaseInterface.php
+++ b/src/Comment/ListCommentsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+interface ListCommentsUseCaseInterface
+{
+    public function execute(ListCommentsInput $input): ListCommentsOutput;
+}

--- a/src/Comment/PdoCommentRepository.php
+++ b/src/Comment/PdoCommentRepository.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoCommentRepository implements CommentRepositoryInterface
+{
+    public function __construct(private DatabaseQueryExecutorInterface $query)
+    {
+    }
+
+    public function listByEntity(int $entityId, bool $approvedOnly): array
+    {
+        $sql = 'SELECT * FROM comments WHERE entity_id = :entity_id';
+        if ($approvedOnly) {
+            $sql .= ' AND is_approved = 1';
+        }
+        $sql .= ' ORDER BY created_at ASC';
+
+        $rows = $this->query->fetchAll($sql, [':entity_id' => $entityId]);
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function listAll(): array
+    {
+        $rows = $this->query->fetchAll('SELECT * FROM comments ORDER BY created_at DESC');
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function findById(int $id): Comment
+    {
+        $row = $this->query->fetchOne('SELECT * FROM comments WHERE id = :id', [':id' => $id]);
+
+        if ($row === null) {
+            throw new CommentNotFoundException($id);
+        }
+
+        return $this->hydrate($row);
+    }
+
+    public function create(int $entityId, string $authorName, string $authorEmail, string $body): Comment
+    {
+        $id = $this->query->insert(
+            'INSERT INTO comments (entity_id, author_name, author_email, body, is_approved, created_at)
+             VALUES (:entity_id, :author_name, :author_email, :body, 0, NOW())',
+            [
+                ':entity_id'    => $entityId,
+                ':author_name'  => $authorName,
+                ':author_email' => $authorEmail,
+                ':body'         => $body,
+            ],
+        );
+
+        return $this->findById($id);
+    }
+
+    public function approve(int $id): Comment
+    {
+        $this->findById($id); // throws if not found
+
+        $this->query->execute(
+            'UPDATE comments SET is_approved = 1 WHERE id = :id',
+            [':id' => $id],
+        );
+
+        return $this->findById($id);
+    }
+
+    public function delete(int $id): void
+    {
+        $this->findById($id); // throws if not found
+
+        $this->query->execute('DELETE FROM comments WHERE id = :id', [':id' => $id]);
+    }
+
+    /** @param array<string, mixed> $row */
+    private function hydrate(array $row): Comment
+    {
+        return new Comment(
+            id: (int) $row['id'],
+            entityId: (int) $row['entity_id'],
+            authorName: (string) $row['author_name'],
+            authorEmail: (string) $row['author_email'],
+            body: (string) $row['body'],
+            isApproved: (bool) $row['is_approved'],
+            createdAt: (string) $row['created_at'],
+        );
+    }
+}

--- a/src/Comment/PostCommentHandler.php
+++ b/src/Comment/PostCommentHandler.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class PostCommentHandler
+{
+    public function __construct(
+        private PostCommentUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $entityId = (int) ($params['id'] ?? 0);
+
+        $body = JsonRequestBodyParser::parse($request);
+        $errors = [];
+
+        $authorName = trim((string) ($body['author_name'] ?? ''));
+        $authorEmail = trim((string) ($body['author_email'] ?? ''));
+        $commentBody = trim((string) ($body['body'] ?? ''));
+
+        if ($authorName === '') {
+            $errors[] = new ValidationError('author_name', 'Author name is required.', 'required');
+        }
+
+        if ($authorEmail === '') {
+            $errors[] = new ValidationError('author_email', 'Author email is required.', 'required');
+        } elseif (!filter_var($authorEmail, FILTER_VALIDATE_EMAIL)) {
+            $errors[] = new ValidationError('author_email', 'Author email must be a valid email address.', 'email');
+        }
+
+        if ($commentBody === '') {
+            $errors[] = new ValidationError('body', 'Body is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $comment = $this->useCase->execute(new PostCommentInput(
+            entityId: $entityId,
+            authorName: $authorName,
+            authorEmail: $authorEmail,
+            body: $commentBody,
+        ));
+
+        return $this->response->create($this->serialize($comment), 201);
+    }
+
+    /** @return array<string, mixed> */
+    private function serialize(Comment $comment): array
+    {
+        return [
+            'id'          => $comment->id,
+            'entity_id'   => $comment->entityId,
+            'author_name' => $comment->authorName,
+            'body'        => $comment->body,
+            'is_approved' => $comment->isApproved,
+            'created_at'  => $comment->createdAt,
+        ];
+    }
+}

--- a/src/Comment/PostCommentInput.php
+++ b/src/Comment/PostCommentInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+final readonly class PostCommentInput
+{
+    public function __construct(
+        public int $entityId,
+        public string $authorName,
+        public string $authorEmail,
+        public string $body,
+    ) {
+    }
+}

--- a/src/Comment/PostCommentUseCase.php
+++ b/src/Comment/PostCommentUseCase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+final readonly class PostCommentUseCase implements PostCommentUseCaseInterface
+{
+    public function __construct(private CommentRepositoryInterface $comments)
+    {
+    }
+
+    public function execute(PostCommentInput $input): Comment
+    {
+        return $this->comments->create(
+            $input->entityId,
+            $input->authorName,
+            $input->authorEmail,
+            $input->body,
+        );
+    }
+}

--- a/src/Comment/PostCommentUseCaseInterface.php
+++ b/src/Comment/PostCommentUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+interface PostCommentUseCaseInterface
+{
+    public function execute(PostCommentInput $input): Comment;
+}

--- a/tests/Comment/CommentHttpTest.php
+++ b/tests/Comment/CommentHttpTest.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Comment;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Comment\ApproveCommentHandler;
+use NeNeRecords\Comment\ApproveCommentUseCase;
+use NeNeRecords\Comment\CommentNotFoundExceptionHandler;
+use NeNeRecords\Comment\CommentRouteRegistrar;
+use NeNeRecords\Comment\DeleteCommentHandler;
+use NeNeRecords\Comment\DeleteCommentUseCase;
+use NeNeRecords\Comment\ListAllCommentsHandler;
+use NeNeRecords\Comment\ListAllCommentsUseCase;
+use NeNeRecords\Comment\ListCommentsHandler;
+use NeNeRecords\Comment\ListCommentsUseCase;
+use NeNeRecords\Comment\PostCommentHandler;
+use NeNeRecords\Comment\PostCommentUseCase;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class CommentHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryCommentRepository $repository;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->repository = new InMemoryCommentRepository();
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+
+        $registrar = new CommentRouteRegistrar(
+            new PostCommentHandler(new PostCommentUseCase($this->repository), $jsonResponse),
+            new ListCommentsHandler(new ListCommentsUseCase($this->repository), $jsonResponse),
+            new ListAllCommentsHandler(new ListAllCommentsUseCase($this->repository), $jsonResponse),
+            new ApproveCommentHandler(new ApproveCommentUseCase($this->repository), $jsonResponse),
+            new DeleteCommentHandler(new DeleteCommentUseCase($this->repository), $this->factory),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [
+                new CommentNotFoundExceptionHandler($problemDetails),
+            ],
+            routeRegistrars: [$registrar],
+        ))->create();
+    }
+
+    public function testListCommentsReturnsEmptyInitially(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/entities/1/comments'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame([], $payload['items']);
+    }
+
+    public function testPostCommentReturns201(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'author_name'  => 'Alice',
+            'author_email' => 'alice@example.com',
+            'body'         => 'Great post!',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities/1/comments')
+                ->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame('Alice', $payload['author_name']);
+        self::assertSame('Great post!', $payload['body']);
+        self::assertFalse($payload['is_approved']);
+        self::assertIsInt($payload['id']);
+    }
+
+    public function testPostCommentWithoutAuthorNameReturns422(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'author_email' => 'alice@example.com',
+            'body'         => 'Hello',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities/1/comments')
+                ->withBody($body),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function testPostCommentWithInvalidEmailReturns422(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'author_name'  => 'Alice',
+            'author_email' => 'not-an-email',
+            'body'         => 'Hello',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities/1/comments')
+                ->withBody($body),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function testPostCommentWithoutBodyReturns422(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'author_name'  => 'Alice',
+            'author_email' => 'alice@example.com',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities/1/comments')
+                ->withBody($body),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function testListCommentsOnlyShowsApproved(): void
+    {
+        // Post two comments
+        foreach (['Alice', 'Bob'] as $name) {
+            $body = $this->factory->createStream(json_encode([
+                'author_name'  => $name,
+                'author_email' => strtolower($name) . '@example.com',
+                'body'         => 'Comment from ' . $name,
+            ], JSON_THROW_ON_ERROR));
+            $this->application->handle(
+                $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities/1/comments')
+                    ->withBody($body),
+            );
+        }
+
+        // Approve only Alice's (id=1)
+        $this->application->handle(
+            $this->factory->createServerRequest('PATCH', 'https://example.test/api/v1/admin/comments/1/approve'),
+        );
+
+        // Public list should only show Alice's comment
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/entities/1/comments'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertCount(1, $payload['items']);
+        self::assertSame('Alice', $payload['items'][0]['author_name']);
+        self::assertArrayNotHasKey('author_email', $payload['items'][0]);
+    }
+
+    public function testListAllCommentsIncludesPendingAndEmail(): void
+    {
+        // Post a comment
+        $body = $this->factory->createStream(json_encode([
+            'author_name'  => 'Alice',
+            'author_email' => 'alice@example.com',
+            'body'         => 'Hello',
+        ], JSON_THROW_ON_ERROR));
+        $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities/1/comments')
+                ->withBody($body),
+        );
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/admin/comments'),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertCount(1, $payload['items']);
+        self::assertArrayHasKey('author_email', $payload['items'][0]);
+        self::assertSame('alice@example.com', $payload['items'][0]['author_email']);
+        self::assertFalse($payload['items'][0]['is_approved']);
+    }
+
+    public function testApproveCommentReturns200(): void
+    {
+        // Post a comment
+        $body = $this->factory->createStream(json_encode([
+            'author_name'  => 'Bob',
+            'author_email' => 'bob@example.com',
+            'body'         => 'Nice!',
+        ], JSON_THROW_ON_ERROR));
+        $createResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities/5/comments')
+                ->withBody($body),
+        );
+        $created = $this->decodeJson($createResponse);
+        $id = $created['id'];
+
+        // Approve
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('PATCH', "https://example.test/api/v1/admin/comments/{$id}/approve"),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertTrue($payload['is_approved']);
+    }
+
+    public function testApproveNonExistentCommentReturns404(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('PATCH', 'https://example.test/api/v1/admin/comments/9999/approve'),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testDeleteCommentReturns204(): void
+    {
+        // Post
+        $body = $this->factory->createStream(json_encode([
+            'author_name'  => 'Charlie',
+            'author_email' => 'charlie@example.com',
+            'body'         => 'To be deleted',
+        ], JSON_THROW_ON_ERROR));
+        $createResponse = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities/2/comments')
+                ->withBody($body),
+        );
+        $created = $this->decodeJson($createResponse);
+        $id = $created['id'];
+
+        // Delete
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', "https://example.test/api/v1/admin/comments/{$id}"),
+        );
+        self::assertSame(204, $response->getStatusCode());
+
+        // Admin list should be empty now
+        $listResponse = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/admin/comments'),
+        );
+        $listPayload = $this->decodeJson($listResponse);
+        self::assertCount(0, $listPayload['items']);
+    }
+
+    public function testDeleteNonExistentCommentReturns404(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', 'https://example.test/api/v1/admin/comments/9999'),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    /** @return array<string, mixed> */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/tests/Comment/InMemoryCommentRepository.php
+++ b/tests/Comment/InMemoryCommentRepository.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Comment;
+
+use NeNeRecords\Comment\Comment;
+use NeNeRecords\Comment\CommentNotFoundException;
+use NeNeRecords\Comment\CommentRepositoryInterface;
+
+final class InMemoryCommentRepository implements CommentRepositoryInterface
+{
+    /** @var array<int, Comment> */
+    private array $comments = [];
+
+    private int $nextId = 1;
+
+    /** @return Comment[] */
+    public function listByEntity(int $entityId, bool $approvedOnly): array
+    {
+        $items = array_filter(
+            $this->comments,
+            static fn (Comment $c): bool =>
+                $c->entityId === $entityId && (!$approvedOnly || $c->isApproved),
+        );
+
+        $items = array_values($items);
+        usort($items, static fn (Comment $a, Comment $b): int => $a->createdAt <=> $b->createdAt);
+
+        return $items;
+    }
+
+    /** @return Comment[] */
+    public function listAll(): array
+    {
+        $items = array_values($this->comments);
+        usort($items, static fn (Comment $a, Comment $b): int => $b->createdAt <=> $a->createdAt);
+
+        return $items;
+    }
+
+    public function findById(int $id): Comment
+    {
+        if (!isset($this->comments[$id])) {
+            throw new CommentNotFoundException($id);
+        }
+
+        return $this->comments[$id];
+    }
+
+    public function create(int $entityId, string $authorName, string $authorEmail, string $body): Comment
+    {
+        $id = $this->nextId++;
+        $comment = new Comment(
+            id: $id,
+            entityId: $entityId,
+            authorName: $authorName,
+            authorEmail: $authorEmail,
+            body: $body,
+            isApproved: false,
+            createdAt: date('Y-m-d H:i:s'),
+        );
+        $this->comments[$id] = $comment;
+
+        return $comment;
+    }
+
+    public function approve(int $id): Comment
+    {
+        if (!isset($this->comments[$id])) {
+            throw new CommentNotFoundException($id);
+        }
+
+        $old = $this->comments[$id];
+        $approved = new Comment(
+            id: $old->id,
+            entityId: $old->entityId,
+            authorName: $old->authorName,
+            authorEmail: $old->authorEmail,
+            body: $old->body,
+            isApproved: true,
+            createdAt: $old->createdAt,
+        );
+        $this->comments[$id] = $approved;
+
+        return $approved;
+    }
+
+    public function delete(int $id): void
+    {
+        if (!isset($this->comments[$id])) {
+            throw new CommentNotFoundException($id);
+        }
+
+        unset($this->comments[$id]);
+    }
+}


### PR DESCRIPTION
## 目的

Issues #202 (バックエンドAPI) と #203 (フロントエンド) を実装します。
読者がエンティティレコードにコメントを投稿し、管理者がモデレートできる機能を追加します。

## 変更内容

### バックエンド (Issue #202)
- **DB**: `comments` テーブルマイグレーション（`entity_id` FK, `is_approved` デフォルト `false`）
- **ドメイン**: `Comment`, `CommentRepositoryInterface`, `PdoCommentRepository`
- **ユースケース**: PostComment / ListComments / ListAllComments / ApproveComment / DeleteComment
- **ルート** (5エンドポイント):
  - `POST /api/v1/entities/{id}/comments` — コメント投稿（認証不要）
  - `GET /api/v1/entities/{id}/comments` — 承認済みコメント一覧（公開）
  - `GET /api/v1/admin/comments` — 全コメント一覧（管理者）
  - `PATCH /api/v1/admin/comments/{id}/approve` — コメント承認
  - `DELETE /api/v1/admin/comments/{id}` — コメント削除
- **認証**: admin エンドポイントは `ManageSettings` capability が必要
- **OpenAPI**: 5エンドポイント・5スキーマ追加
- **テスト**: `InMemoryCommentRepository` + `CommentHttpTest`（11テスト追加、合計304テスト）

### フロントエンド (Issue #203)
- **エンティティ層**: `entities/comment`（DTO型・モデル・マッパー・クエリキー・クエリ・ミューテーション）
- **公開機能**: `features/comment-section` — 承認済みコメント一覧 + 投稿フォーム（名前・メール・本文）
- **管理機能**: `features/manage-comments` — 全コメント一覧・承認・削除（確認ダイアログ付き）
- **ページ**: `pages/comments/CommentsPage`、`/admin/comments` ルート追加
- **AppShell**: Appearance セクションに「Comments」ナビリンク（`IconMessageCircle`）追加
- **i18n**: `en.ts` / `ja.ts` に管理・公開コメントキー追加

## 確認

- `composer check`: 304テスト合格 ✅、PHPStan クリーン ✅、CS-Fixer クリーン ✅、OpenAPI 有効 ✅
- `npm run check --prefix frontend`: 型チェック ✅、lint ✅、フォーマット ✅、テスト ✅、Storybook ✅

## チェックリスト

- [x] composer check 通過
- [x] npm run check 通過
- [x] HTTP テスト追加（CommentHttpTest 11件）
- [x] OpenAPI 仕様更新
- [x] i18n: en.ts / ja.ts 更新

Closes #202
Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)