### PR TITLE
feat(superadmin): テナント解決モード設定 UI (#211 #212)

### DIFF
--- a/database/migrations/20260629000000_create_system_config_table.php
+++ b/database/migrations/20260629000000_create_system_config_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateSystemConfigTable extends AbstractMigration
+{
+    public function up(): void
+    {
+        $this->execute(<<<SQL
+            CREATE TABLE IF NOT EXISTS system_config (
+                `key`        VARCHAR(191)  NOT NULL,
+                `value`      VARCHAR(1024) NOT NULL DEFAULT '',
+                `updated_at` DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (`key`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        SQL);
+
+        // デフォルト値を挿入（single = org_slug 固定モード）
+        $this->execute(<<<SQL
+            INSERT IGNORE INTO system_config (`key`, `value`) VALUES
+                ('tenant_resolution_mode', 'single'),
+                ('tenant_org_slug',        ''),
+                ('tenant_base_domain',     'localhost')
+        SQL);
+    }
+
+    public function down(): void
+    {
+        $this->execute('DROP TABLE IF EXISTS system_config');
+    }
+}

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -24,6 +24,7 @@ import { TagsPage } from '@/pages/tags/TagsPage'
 import { SuperadminShell } from '@/pages/superadmin/SuperadminShell'
 import { OrganizationsPage } from '@/pages/superadmin/OrganizationsPage'
 import { OrganizationDetailPage } from '@/pages/superadmin/OrganizationDetailPage'
+import { SettingsPage } from '@/pages/superadmin/SettingsPage'
 import { RequireAuth } from '@/shared/auth/RequireAuth'
 
 function AdminShell() {
@@ -95,6 +96,7 @@ const router = createBrowserRouter([
       { index: true, element: <OrganizationsPage /> },
       { path: 'organizations', element: <OrganizationsPage /> },
       { path: 'organizations/:id', element: <OrganizationDetailPage /> },
+      { path: 'settings', element: <SettingsPage /> },
     ],
   },
   {

--- a/frontend/src/entities/system-config/api-types.ts
+++ b/frontend/src/entities/system-config/api-types.ts
@@ -1,0 +1,5 @@
+export interface SystemConfigDto {
+  tenant_resolution_mode: 'single' | 'subdomain' | 'path'
+  tenant_org_slug: string
+  tenant_base_domain: string
+}

--- a/frontend/src/entities/system-config/index.ts
+++ b/frontend/src/entities/system-config/index.ts
@@ -1,0 +1,2 @@
+export type { SystemConfigDto } from './api-types'
+export { useSystemConfig, useUpdateSystemConfig } from './queries'

--- a/frontend/src/entities/system-config/queries.ts
+++ b/frontend/src/entities/system-config/queries.ts
@@ -1,0 +1,23 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiClient } from '@/shared/api/client'
+import type { SystemConfigDto } from './api-types'
+
+const QUERY_KEY = ['system-config'] as const
+
+export function useSystemConfig() {
+  return useQuery<SystemConfigDto>({
+    queryKey: QUERY_KEY,
+    queryFn: () => apiClient.get<SystemConfigDto>('/api/v1/superadmin/system-config'),
+  })
+}
+
+export function useUpdateSystemConfig() {
+  const queryClient = useQueryClient()
+  return useMutation<SystemConfigDto, Error, Partial<SystemConfigDto>>({
+    mutationFn: (input) =>
+      apiClient.patch<SystemConfigDto>('/api/v1/superadmin/system-config', input),
+    onSuccess: (data) => {
+      queryClient.setQueryData(QUERY_KEY, data)
+    },
+  })
+}

--- a/frontend/src/pages/superadmin/SettingsPage.tsx
+++ b/frontend/src/pages/superadmin/SettingsPage.tsx
@@ -1,0 +1,211 @@
+import { useState } from 'react'
+import { useSystemConfig, useUpdateSystemConfig } from '@/entities/system-config'
+import type { SystemConfigDto } from '@/entities/system-config'
+import { Button, Input, Stack, Text } from '@/shared/ui'
+import { useToast } from '@/shared/ui'
+
+type ResolutionMode = SystemConfigDto['tenant_resolution_mode']
+
+const MODES: { value: ResolutionMode; label: string; description: string }[] = [
+  {
+    value: 'single',
+    label: 'シングルテナント（固定 org）',
+    description: 'すべてのリクエストを特定の組織に固定する。単一組織の運用に最適。',
+  },
+  {
+    value: 'subdomain',
+    label: 'サブドメイン方式',
+    description: 'acme.example.com のようにサブドメインで組織を判定する。本番 SaaS 向け。',
+  },
+  {
+    value: 'path',
+    label: 'パスプレフィックス方式',
+    description: '/org/acme/... のように URL パスで組織を判定する。DNS 設定不要でシンプル。',
+  },
+]
+
+export function SettingsPage() {
+  const { showToast } = useToast()
+  const { data, isLoading } = useSystemConfig()
+  const update = useUpdateSystemConfig()
+
+  // undefined = 未編集 → loaded data にフォールバック（useEffect 不要）
+  const [mode, setMode] = useState<ResolutionMode | undefined>(undefined)
+  const [orgSlug, setOrgSlug] = useState<string | undefined>(undefined)
+  const [baseDomain, setBaseDomain] = useState<string | undefined>(undefined)
+
+  const currentMode = mode ?? data?.tenant_resolution_mode ?? 'single'
+  const currentOrgSlug = orgSlug ?? data?.tenant_org_slug ?? ''
+  const currentBaseDomain = baseDomain ?? data?.tenant_base_domain ?? 'localhost'
+
+  function handleSubmit(e: React.SyntheticEvent) {
+    e.preventDefault()
+    update.mutate(
+      {
+        tenant_resolution_mode: currentMode,
+        tenant_org_slug: currentOrgSlug.trim(),
+        tenant_base_domain: currentBaseDomain.trim(),
+      },
+      {
+        onSuccess: () => {
+          showToast('設定を保存しました。', 'success')
+        },
+        onError: () => {
+          showToast('保存に失敗しました。', 'error')
+        },
+      },
+    )
+  }
+
+  if (isLoading) {
+    return <Text muted>Loading…</Text>
+  }
+
+  return (
+    <Stack gap="lg">
+      <div>
+        <Text as="h1" variant="heading-md">
+          システム設定
+        </Text>
+        <Text muted>テナント解決方式など、システム全体の設定を管理します。</Text>
+      </div>
+
+      <form onSubmit={handleSubmit}>
+        <div className="rounded-lg border border-border bg-surface-raised p-6">
+          <Text as="h2" variant="heading-sm">
+            テナント解決方式
+          </Text>
+          <Text muted className="mt-1 text-sm">
+            リクエストがどの組織に属するかを判定する方法を選択します。
+          </Text>
+
+          <Stack gap="sm" className="mt-5">
+            {MODES.map((m) => (
+              <div
+                key={m.value}
+                className={[
+                  'flex cursor-pointer items-start gap-3 rounded-lg border p-4 transition-colors',
+                  currentMode === m.value
+                    ? 'border-accent bg-accent/5'
+                    : 'border-border bg-surface hover:bg-surface-raised/50',
+                ].join(' ')}
+              >
+                <input
+                  id={`mode-${m.value}`}
+                  type="radio"
+                  name="resolution_mode"
+                  value={m.value}
+                  checked={currentMode === m.value}
+                  onChange={() => {
+                    setMode(m.value)
+                  }}
+                  className="mt-0.5 accent-accent"
+                />
+                <div>
+                  <label
+                    htmlFor={`mode-${m.value}`}
+                    className="cursor-pointer text-sm font-medium text-text-primary"
+                  >
+                    {m.label}
+                  </label>
+                  <p className="mt-0.5 text-xs text-text-muted">{m.description}</p>
+                </div>
+              </div>
+            ))}
+          </Stack>
+
+          {/* モード別の補助入力 */}
+          {currentMode === 'single' && (
+            <div className="mt-5">
+              <label
+                htmlFor="tenant-org-slug"
+                className="mb-1 block text-sm font-medium text-text-primary"
+              >
+                組織スラッグ
+              </label>
+              <Input
+                id="tenant-org-slug"
+                value={currentOrgSlug}
+                onChange={(e) => {
+                  setOrgSlug(e.target.value)
+                }}
+                placeholder="my-org"
+                className="max-w-xs"
+              />
+              <p className="mt-1 text-xs text-text-muted">
+                すべてのリクエストをこのスラッグの組織に紐付けます。
+              </p>
+            </div>
+          )}
+
+          {currentMode === 'subdomain' && (
+            <div className="mt-5">
+              <label
+                htmlFor="tenant-base-domain"
+                className="mb-1 block text-sm font-medium text-text-primary"
+              >
+                ベースドメイン
+              </label>
+              <Input
+                id="tenant-base-domain"
+                value={currentBaseDomain}
+                onChange={(e) => {
+                  setBaseDomain(e.target.value)
+                }}
+                placeholder="example.com"
+                className="max-w-xs"
+              />
+              <p className="mt-1 text-xs text-text-muted">
+                例: <code className="font-mono">example.com</code> → リクエストの{' '}
+                <code className="font-mono">acme.example.com</code> から{' '}
+                <code className="font-mono">acme</code> を抽出します。
+              </p>
+            </div>
+          )}
+
+          {currentMode === 'path' && (
+            <div className="mt-5 rounded-md bg-surface p-3 text-xs text-text-muted">
+              URL の先頭パスセグメントを組織スラッグとして使用します。
+              <br />
+              例: <code className="font-mono">/acme/api/v1/entities</code> →{' '}
+              <code className="font-mono">acme</code>
+            </div>
+          )}
+
+          <div className="mt-6">
+            <Button type="submit" variant="primary" disabled={update.isPending}>
+              {update.isPending ? '保存中…' : '設定を保存'}
+            </Button>
+          </div>
+        </div>
+      </form>
+
+      {/* 現在の DB 保存済み設定 */}
+      {data !== undefined && (
+        <div className="rounded-lg border border-border bg-surface-raised p-6">
+          <Text as="h2" variant="heading-sm">
+            現在の設定（DB 保存値）
+          </Text>
+          <dl className="mt-3 space-y-2 text-sm">
+            <div className="flex gap-3">
+              <dt className="w-44 shrink-0 text-text-muted">解決方式</dt>
+              <dd className="font-mono text-text-primary">{data.tenant_resolution_mode}</dd>
+            </div>
+            {data.tenant_org_slug !== '' && (
+              <div className="flex gap-3">
+                <dt className="w-44 shrink-0 text-text-muted">組織スラッグ</dt>
+                <dd className="font-mono text-text-primary">{data.tenant_org_slug}</dd>
+              </div>
+            )}
+            {data.tenant_resolution_mode === 'subdomain' && (
+              <div className="flex gap-3">
+                <dt className="w-44 shrink-0 text-text-muted">ベースドメイン</dt>
+                <dd className="font-mono text-text-primary">{data.tenant_base_domain}</dd>
+              </div>
+            )}
+          </dl>
+        </div>
+      )}
+    </Stack>
+  )
+}

--- a/frontend/src/pages/superadmin/SuperadminShell.tsx
+++ b/frontend/src/pages/superadmin/SuperadminShell.tsx
@@ -1,6 +1,6 @@
 import { Link, NavLink, Outlet, Navigate } from 'react-router-dom'
 import { currentUserIsSuperadmin } from '@/entities/auth'
-import { IconBuilding, IconHome } from '@/shared/ui/icons/Icons'
+import { IconBuilding, IconHome, IconSettings } from '@/shared/ui/icons/Icons'
 
 function SuperadminNavItem({
   to,
@@ -46,6 +46,11 @@ export function SuperadminShell() {
             to="/superadmin/organizations"
             icon={<IconBuilding size={16} />}
             label="Organizations"
+          />
+          <SuperadminNavItem
+            to="/superadmin/settings"
+            icon={<IconSettings size={16} />}
+            label="Settings"
           />
         </nav>
         <div className="absolute bottom-0 left-0 w-56 border-t border-border p-3">

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -69,6 +69,8 @@ use NeNeRecords\PublicRecord\PublicRecordServiceProvider;
 use NeNeRecords\Setting\SettingKeyNotFoundExceptionHandler;
 use NeNeRecords\Setting\SettingServiceProvider;
 use NeNeRecords\Setting\SettingValueInvalidExceptionHandler;
+use NeNeRecords\SystemConfig\SystemConfigRouteRegistrar;
+use NeNeRecords\SystemConfig\SystemConfigServiceProvider;
 use NeNeRecords\Tag\TagNotFoundExceptionHandler;
 use NeNeRecords\Tag\TagServiceProvider;
 use NeNeRecords\Tag\TagSlugConflictExceptionHandler;
@@ -133,7 +135,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new UserServiceProvider())
             ->addProvider(new UserInviteServiceProvider())
             ->addProvider(new CommentServiceProvider())
-            ->addProvider(new OrganizationServiceProvider());
+            ->addProvider(new OrganizationServiceProvider())
+            ->addProvider(new SystemConfigServiceProvider());
 
         $builder
             ->set(
@@ -164,6 +167,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $auth = $container->get('nene-records.route_registrar.auth');
                     $comment = $container->get(CommentRouteRegistrar::class);
                     $organization = $container->get(OrganizationRouteRegistrar::class);
+                    $systemConfig = $container->get(SystemConfigRouteRegistrar::class);
 
                     if (
                         !is_callable($entityType)
@@ -191,6 +195,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !is_callable($auth)
                         || !is_callable($comment)
                         || !$organization instanceof OrganizationRouteRegistrar
+                        || !$systemConfig instanceof SystemConfigRouteRegistrar
                     ) {
                         throw new LogicException('Route registrar service is invalid.');
                     }
@@ -221,6 +226,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $userInvite,
                         $comment,
                         $organization,
+                        $systemConfig,
                     ];
                 },
             )

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -35,8 +35,10 @@ use NeNeRecords\Auth\CapabilityMiddleware;
 use NeNeRecords\Organization\OrganizationRepositoryInterface;
 use NeNeRecords\Organization\Resolution\EnvResolutionStrategy;
 use NeNeRecords\Organization\Resolution\OrgResolverMiddleware;
+use NeNeRecords\Organization\Resolution\PathPrefixResolutionStrategy;
 use NeNeRecords\Organization\Resolution\SubdomainResolutionStrategy;
 use NeNeRecords\RateLimit\RateLimitServiceProvider;
+use NeNeRecords\SystemConfig\SystemConfigRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -305,14 +307,21 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     }
                     /** @var RequestScopedHolder<int> $orgIdHolder */
 
-                    $tenantResolution = (string) (getenv('TENANT_RESOLUTION') ?: 'env');
-                    $strategy = match ($tenantResolution) {
-                        'subdomain' => new SubdomainResolutionStrategy(
-                            (string) (getenv('BASE_DOMAIN') ?: 'localhost'),
-                        ),
-                        default => new EnvResolutionStrategy(
-                            (string) (getenv('ORG_SLUG') ?: ''),
-                        ),
+                    // DB の system_config から解決モードを読む（env フォールバック付き）
+                    $sysConfig      = $container->get(SystemConfigRepository::class);
+                    $resolvedMode   = 'single';
+                    $resolvedSlug   = (string) (getenv('ORG_SLUG') ?: '');
+                    $resolvedDomain = (string) (getenv('BASE_DOMAIN') ?: 'localhost');
+                    if ($sysConfig instanceof SystemConfigRepository) {
+                        $resolvedMode   = $sysConfig->get('tenant_resolution_mode') ?? (string) (getenv('TENANT_RESOLUTION') ?: 'single');
+                        $resolvedSlug   = $sysConfig->get('tenant_org_slug') ?? $resolvedSlug;
+                        $resolvedDomain = $sysConfig->get('tenant_base_domain') ?? $resolvedDomain;
+                    }
+
+                    $strategy = match ($resolvedMode) {
+                        'subdomain' => new SubdomainResolutionStrategy($resolvedDomain),
+                        'path'      => new PathPrefixResolutionStrategy(),
+                        default     => new EnvResolutionStrategy($resolvedSlug),
                     };
 
                     $authMiddleware[] = new OrgResolverMiddleware($orgIdHolder, $orgRepo, $problemDetails, $strategy);

--- a/src/Organization/Resolution/OrgResolverMiddleware.php
+++ b/src/Organization/Resolution/OrgResolverMiddleware.php
@@ -37,6 +37,7 @@ final readonly class OrgResolverMiddleware implements MiddlewareInterface
     private const BYPASS_PREFIXES = [
         '/health',
         '/api/v1/organizations',
+        '/api/v1/superadmin/',
         '/api/v1/auth/',
     ];
 

--- a/src/SystemConfig/GetSystemConfigHandler.php
+++ b/src/SystemConfig/GetSystemConfigHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\SystemConfig;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final readonly class GetSystemConfigHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private SystemConfigRepository $config,
+        private JsonResponseFactory $json,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $all = $this->config->all();
+
+        return $this->json->create([
+            'tenant_resolution_mode' => $all['tenant_resolution_mode'] ?? 'single',
+            'tenant_org_slug'        => $all['tenant_org_slug'] ?? '',
+            'tenant_base_domain'     => $all['tenant_base_domain'] ?? 'localhost',
+        ]);
+    }
+}

--- a/src/SystemConfig/SystemConfigRepository.php
+++ b/src/SystemConfig/SystemConfigRepository.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\SystemConfig;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+/**
+ * Lightweight key-value store backed by the system_config table.
+ */
+final readonly class SystemConfigRepository
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function get(string $key): ?string
+    {
+        $row = $this->query->fetchOne('SELECT `value` FROM system_config WHERE `key` = ?', [$key]);
+        if ($row === null) {
+            return null;
+        }
+
+        return (string) $row['value'];
+    }
+
+    public function set(string $key, string $value): void
+    {
+        $this->query->execute(
+            'INSERT INTO system_config (`key`, `value`) VALUES (?, ?)
+             ON DUPLICATE KEY UPDATE `value` = VALUES(`value`), `updated_at` = NOW()',
+            [$key, $value],
+        );
+    }
+
+    /** @return array<string, string> */
+    public function all(): array
+    {
+        $rows = $this->query->fetchAll('SELECT `key`, `value` FROM system_config ORDER BY `key`', []);
+        $result = [];
+        foreach ($rows as $row) {
+            $result[(string) $row['key']] = (string) $row['value'];
+        }
+
+        return $result;
+    }
+}

--- a/src/SystemConfig/SystemConfigRouteRegistrar.php
+++ b/src/SystemConfig/SystemConfigRouteRegistrar.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\SystemConfig;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class SystemConfigRouteRegistrar
+{
+    public function __construct(
+        private GetSystemConfigHandler $getHandler,
+        private UpdateSystemConfigHandler $updateHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $get    = $this->getHandler;
+        $update = $this->updateHandler;
+
+        $router->get(
+            '/api/v1/superadmin/system-config',
+            static fn (ServerRequestInterface $r) => $get->handle($r),
+        );
+        $router->patch(
+            '/api/v1/superadmin/system-config',
+            static fn (ServerRequestInterface $r) => $update->handle($r),
+        );
+    }
+}

--- a/src/SystemConfig/SystemConfigServiceProvider.php
+++ b/src/SystemConfig/SystemConfigServiceProvider.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\SystemConfig;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Container\ContainerInterface;
+
+final readonly class SystemConfigServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                SystemConfigRepository::class,
+                static function (ContainerInterface $c): SystemConfigRepository {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('DatabaseQueryExecutorInterface is invalid.');
+                    }
+
+                    return new SystemConfigRepository($query);
+                },
+            )
+            ->set(
+                GetSystemConfigHandler::class,
+                static function (ContainerInterface $c): GetSystemConfigHandler {
+                    $config = $c->get(SystemConfigRepository::class);
+                    $json   = $c->get(JsonResponseFactory::class);
+                    if (!$config instanceof SystemConfigRepository) {
+                        throw new LogicException('SystemConfigRepository is invalid.');
+                    }
+
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory is invalid.');
+                    }
+
+                    return new GetSystemConfigHandler($config, $json);
+                },
+            )
+            ->set(
+                SystemConfigRouteRegistrar::class,
+                static function (ContainerInterface $c): SystemConfigRouteRegistrar {
+                    $get    = $c->get(GetSystemConfigHandler::class);
+                    $update = $c->get(UpdateSystemConfigHandler::class);
+                    if (!$get instanceof GetSystemConfigHandler) {
+                        throw new LogicException('GetSystemConfigHandler is invalid.');
+                    }
+
+                    if (!$update instanceof UpdateSystemConfigHandler) {
+                        throw new LogicException('UpdateSystemConfigHandler is invalid.');
+                    }
+
+                    return new SystemConfigRouteRegistrar($get, $update);
+                },
+            )
+            ->set(
+                UpdateSystemConfigHandler::class,
+                static function (ContainerInterface $c): UpdateSystemConfigHandler {
+                    $config  = $c->get(SystemConfigRepository::class);
+                    $json    = $c->get(JsonResponseFactory::class);
+                    $problem = $c->get(ProblemDetailsResponseFactory::class);
+                    if (!$config instanceof SystemConfigRepository) {
+                        throw new LogicException('SystemConfigRepository is invalid.');
+                    }
+
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory is invalid.');
+                    }
+
+                    if (!$problem instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory is invalid.');
+                    }
+
+                    return new UpdateSystemConfigHandler($config, $json, $problem);
+                },
+            );
+    }
+}

--- a/src/SystemConfig/UpdateSystemConfigHandler.php
+++ b/src/SystemConfig/UpdateSystemConfigHandler.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\SystemConfig;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final readonly class UpdateSystemConfigHandler implements RequestHandlerInterface
+{
+    private const VALID_MODES = ['single', 'subdomain', 'path'];
+
+    public function __construct(
+        private SystemConfigRepository $config,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $mode = isset($body['tenant_resolution_mode'])
+            ? (string) $body['tenant_resolution_mode']
+            : null;
+
+        if ($mode === null || !in_array($mode, self::VALID_MODES, true)) {
+            return $this->problemDetails->create(
+                $request,
+                'validation-failed',
+                'Validation Failed',
+                422,
+                'tenant_resolution_mode must be one of: ' . implode(', ', self::VALID_MODES),
+            );
+        }
+
+        $this->config->set('tenant_resolution_mode', $mode);
+
+        if (isset($body['tenant_org_slug'])) {
+            $this->config->set('tenant_org_slug', (string) $body['tenant_org_slug']);
+        }
+
+        if (isset($body['tenant_base_domain'])) {
+            $this->config->set('tenant_base_domain', (string) $body['tenant_base_domain']);
+        }
+
+        $all = $this->config->all();
+
+        return $this->json->create([
+            'tenant_resolution_mode' => $all['tenant_resolution_mode'] ?? 'single',
+            'tenant_org_slug'        => $all['tenant_org_slug'] ?? '',
+            'tenant_base_domain'     => $all['tenant_base_domain'] ?? 'localhost',
+        ]);
+    }
+}


### PR DESCRIPTION
## 目的
Superadmin からテナント解決方式を GUI で切り替えられるようにする。

## 変更内容

### バックエンド (#211)
- `system_config` テーブル — key-value ストア（`tenant_resolution_mode` / `tenant_org_slug` / `tenant_base_domain`）
- `SystemConfigRepository` — `fetchOne` / `fetchAll` / UPSERT
- `GET /api/v1/superadmin/system-config` / `PATCH /api/v1/superadmin/system-config`
- `OrgResolverMiddleware` が起動時に DB を参照してモードを選択（env フォールバック付き）
- `/api/v1/superadmin/` を bypass に追加（org 解決不要）

### フロントエンド (#212)
- `entities/system-config` — API 型・React Query フック
- `/superadmin/settings` — ラジオボタンで 3 モードを選択
  - **single**: 固定 org スラッグ（単一テナント）
  - **subdomain**: サブドメインで org を判定（SaaS 向け）
  - **path**: URL パスプレフィックスで判定
- モードに応じた補助入力（org slug / base domain）
- SuperadminShell に Settings ナビリンク追加

## 検証
```bash
composer check   # 318 tests / PHPStan / CS-Fixer / OpenAPI / MCP — all pass
npm run check --prefix frontend  # type-check / lint / test / storybook — all pass
```

Closes #211
Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)