### PR TITLE
feat(superadmin): 既存データ組織割当 UI・JSON エクスポート／インポート

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -25,6 +25,7 @@ import { SuperadminShell } from '@/pages/superadmin/SuperadminShell'
 import { OrganizationsPage } from '@/pages/superadmin/OrganizationsPage'
 import { OrganizationDetailPage } from '@/pages/superadmin/OrganizationDetailPage'
 import { SettingsPage } from '@/pages/superadmin/SettingsPage'
+import { DataMigrationPage } from '@/pages/superadmin/DataMigrationPage'
 import { RequireAuth } from '@/shared/auth/RequireAuth'
 
 function AdminShell() {
@@ -96,6 +97,7 @@ const router = createBrowserRouter([
       { index: true, element: <OrganizationsPage /> },
       { path: 'organizations', element: <OrganizationsPage /> },
       { path: 'organizations/:id', element: <OrganizationDetailPage /> },
+      { path: 'data-migration', element: <DataMigrationPage /> },
       { path: 'settings', element: <SettingsPage /> },
     ],
   },

--- a/frontend/src/entities/data-migration/api-types.ts
+++ b/frontend/src/entities/data-migration/api-types.ts
@@ -1,0 +1,11 @@
+export interface DataMigrationStatusDto {
+  total: number
+  tables: Record<string, number>
+}
+
+export interface AssignOrgResultDto {
+  organization_id: number
+  organization_name: string
+  total: number
+  tables: Record<string, number>
+}

--- a/frontend/src/entities/data-migration/index.ts
+++ b/frontend/src/entities/data-migration/index.ts
@@ -1,0 +1,3 @@
+export type { DataMigrationStatusDto, AssignOrgResultDto } from './api-types'
+export { useDataMigrationStatus, dataMigrationKeys } from './queries'
+export { useAssignOrg } from './mutations'

--- a/frontend/src/entities/data-migration/mutations.ts
+++ b/frontend/src/entities/data-migration/mutations.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { AssignOrgResultDto } from './api-types'
+import { dataMigrationKeys } from './queries'
+
+export function useAssignOrg(): UseMutationResult<
+  AssignOrgResultDto,
+  AppError,
+  { targetOrgId: number }
+> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ targetOrgId }) => {
+      return apiClient.post<AssignOrgResultDto>('/api/v1/superadmin/data-migration/assign-org', {
+        target_org_id: targetOrgId,
+      })
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: dataMigrationKeys.status() })
+    },
+  })
+}

--- a/frontend/src/entities/data-migration/queries.ts
+++ b/frontend/src/entities/data-migration/queries.ts
@@ -1,0 +1,19 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { DataMigrationStatusDto } from './api-types'
+
+export const dataMigrationKeys = {
+  status: () => ['data-migration', 'status'] as const,
+}
+
+export function useDataMigrationStatus(): UseQueryResult<DataMigrationStatusDto, AppError> {
+  return useQuery({
+    queryKey: dataMigrationKeys.status(),
+    queryFn: async ({ signal }) => {
+      return apiClient.get<DataMigrationStatusDto>(
+        '/api/v1/superadmin/data-migration/status',
+        signal,
+      )
+    },
+  })
+}

--- a/frontend/src/entities/org-export/api-types.ts
+++ b/frontend/src/entities/org-export/api-types.ts
@@ -1,0 +1,6 @@
+export interface OrgImportResultDto {
+  organization_id: number
+  organization_name: string
+  total: number
+  imported: Record<string, number>
+}

--- a/frontend/src/entities/org-export/index.ts
+++ b/frontend/src/entities/org-export/index.ts
@@ -1,0 +1,3 @@
+export type { OrgImportResultDto } from './api-types'
+export { fetchOrgExport } from './queries'
+export { useImportOrg } from './mutations'

--- a/frontend/src/entities/org-export/mutations.ts
+++ b/frontend/src/entities/org-export/mutations.ts
@@ -1,0 +1,16 @@
+import { useMutation, type UseMutationResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { OrgImportResultDto } from './api-types'
+
+export function useImportOrg(
+  orgId: number,
+): UseMutationResult<OrgImportResultDto, AppError, Record<string, unknown>> {
+  return useMutation({
+    mutationFn: async (payload) => {
+      return apiClient.post<OrgImportResultDto>(
+        `/api/v1/superadmin/organizations/${String(orgId)}/import`,
+        payload,
+      )
+    },
+  })
+}

--- a/frontend/src/entities/org-export/queries.ts
+++ b/frontend/src/entities/org-export/queries.ts
@@ -1,0 +1,11 @@
+import { apiClient } from '@/shared/api/client'
+
+/**
+ * Fetches the full JSON export for an organization.
+ * Returns the raw payload so callers can serialize and download it.
+ */
+export async function fetchOrgExport(orgId: number): Promise<Record<string, unknown>> {
+  return apiClient.get<Record<string, unknown>>(
+    `/api/v1/superadmin/organizations/${String(orgId)}/export`,
+  )
+}

--- a/frontend/src/pages/superadmin/DataMigrationPage.tsx
+++ b/frontend/src/pages/superadmin/DataMigrationPage.tsx
@@ -1,0 +1,167 @@
+import { useState } from 'react'
+import { useDataMigrationStatus, useAssignOrg } from '@/entities/data-migration'
+import { useOrganizationList } from '@/entities/organization'
+import { Button, Stack, Text } from '@/shared/ui'
+import { useToast } from '@/shared/ui'
+
+export function DataMigrationPage() {
+  const { showToast } = useToast()
+  const { data: status, isLoading: statusLoading, isError: statusError } = useDataMigrationStatus()
+  const { data: orgs } = useOrganizationList()
+  const assignOrg = useAssignOrg()
+
+  const [targetOrgId, setTargetOrgId] = useState<number>(0)
+
+  const hasUnassigned = (status?.total ?? 0) > 0
+
+  function handleAssign() {
+    if (targetOrgId <= 0) {
+      showToast('Please select a target organization.', 'error')
+      return
+    }
+
+    assignOrg.mutate(
+      { targetOrgId },
+      {
+        onSuccess: (result) => {
+          showToast(
+            `Migrated ${String(result.total)} records to "${result.organization_name}".`,
+            'success',
+          )
+        },
+        onError: (err) => {
+          showToast(err.title, 'error')
+        },
+      },
+    )
+  }
+
+  return (
+    <Stack gap="lg">
+      <div>
+        <Text as="h1" variant="heading-md">
+          Data Migration
+        </Text>
+        <Text muted>
+          Assign legacy records (organization_id&nbsp;= 0) to a specific organization. Use this when
+          migrating from single-tenant to multi-tenant mode.
+        </Text>
+      </div>
+
+      {/* Status panel */}
+      <div className="rounded-lg border border-border bg-surface-raised p-6">
+        <Text as="h2" variant="heading-sm">
+          Unassigned Records
+        </Text>
+
+        {statusLoading && (
+          <Text muted className="mt-3">
+            Loading…
+          </Text>
+        )}
+        {statusError && (
+          <Text muted className="mt-3 text-red-500">
+            Failed to load migration status.
+          </Text>
+        )}
+
+        {status !== undefined && (
+          <>
+            <div className="mt-3 mb-4">
+              {hasUnassigned ? (
+                <div className="rounded-md bg-amber-50 border border-amber-200 px-4 py-3 dark:bg-amber-950/20 dark:border-amber-900/40">
+                  <Text className="font-semibold text-amber-800 dark:text-amber-300">
+                    {status.total.toLocaleString()} unassigned record
+                    {status.total !== 1 ? 's' : ''} found
+                  </Text>
+                </div>
+              ) : (
+                <div className="rounded-md bg-green-50 border border-green-200 px-4 py-3 dark:bg-green-950/20 dark:border-green-900/40">
+                  <Text className="font-semibold text-green-800 dark:text-green-300">
+                    All records are assigned to an organization. ✓
+                  </Text>
+                </div>
+              )}
+            </div>
+
+            {hasUnassigned && (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border">
+                      <th className="pb-2 text-left font-medium text-text-secondary">Table</th>
+                      <th className="pb-2 text-right font-medium text-text-secondary">
+                        Unassigned rows
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {Object.entries(status.tables)
+                      .filter(([, count]) => count > 0)
+                      .map(([table, count]) => (
+                        <tr key={table} className="border-b border-border last:border-0">
+                          <td className="py-2 font-mono text-text-primary">{table}</td>
+                          <td className="py-2 text-right tabular-nums text-text-primary">
+                            {count.toLocaleString()}
+                          </td>
+                        </tr>
+                      ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Assign panel */}
+      {hasUnassigned && (
+        <div className="rounded-lg border border-border bg-surface-raised p-6">
+          <Text as="h2" variant="heading-sm">
+            Assign to Organization
+          </Text>
+          <Text muted className="mt-1">
+            All unassigned records will be moved to the selected organization. This cannot be
+            undone.
+          </Text>
+
+          <Stack gap="md" className="mt-4">
+            <div>
+              <label
+                htmlFor="target-org"
+                className="mb-1 block text-sm font-medium text-text-primary"
+              >
+                Target organization *
+              </label>
+              <select
+                id="target-org"
+                value={targetOrgId}
+                onChange={(e) => {
+                  setTargetOrgId(Number(e.target.value))
+                }}
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
+              >
+                <option value={0}>— Select organization —</option>
+                {orgs?.items.map((org) => (
+                  <option key={org.id} value={org.id}>
+                    {org.name} ({org.slug})
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <Button
+                variant="primary"
+                disabled={targetOrgId <= 0 || assignOrg.isPending}
+                onClick={handleAssign}
+              >
+                {assignOrg.isPending ? 'Migrating…' : 'Assign Records'}
+              </Button>
+            </div>
+          </Stack>
+        </div>
+      )}
+    </Stack>
+  )
+}

--- a/frontend/src/pages/superadmin/OrganizationDetailPage.tsx
+++ b/frontend/src/pages/superadmin/OrganizationDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import {
   useOrganization,
@@ -7,9 +7,10 @@ import {
   PLANS,
 } from '@/entities/organization'
 import type { UpdateOrganizationInput } from '@/entities/organization'
+import { fetchOrgExport, useImportOrg } from '@/entities/org-export'
 import { Button, ConfirmDialog, Input, Stack, Text } from '@/shared/ui'
 import { useToast } from '@/shared/ui'
-import { IconChevronLeft } from '@/shared/ui/icons/Icons'
+import { IconChevronLeft, IconDownload, IconUpload } from '@/shared/ui/icons/Icons'
 
 export function OrganizationDetailPage() {
   const { id } = useParams<{ id: string }>()
@@ -27,6 +28,9 @@ export function OrganizationDetailPage() {
   const [isActive, setIsActive] = useState<boolean | undefined>(undefined)
   const [customDomain, setCustomDomain] = useState<string | undefined>(undefined)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [isExporting, setIsExporting] = useState(false)
+  const importFileRef = useRef<HTMLInputElement>(null)
+  const importOrg = useImportOrg(orgId)
 
   // Controlled values fall back to loaded org data before user edits
   const currentName = name ?? org?.name ?? ''
@@ -57,6 +61,56 @@ export function OrganizationDetailPage() {
         },
       },
     )
+  }
+
+  async function handleExport() {
+    setIsExporting(true)
+    try {
+      const payload = await fetchOrgExport(orgId)
+      const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `org-${String(orgId)}-export.json`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch {
+      showToast('Export failed.', 'error')
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  function handleImportFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (file === undefined) return
+
+    const reader = new FileReader()
+    reader.onload = (event) => {
+      try {
+        const raw = event.target?.result
+        if (typeof raw !== 'string') return
+        const payload = JSON.parse(raw) as Record<string, unknown>
+        importOrg.mutate(payload, {
+          onSuccess: (result) => {
+            showToast(
+              `Imported ${String(result.total)} records into "${result.organization_name}".`,
+              'success',
+            )
+          },
+          onError: (err) => {
+            showToast(err.title, 'error')
+          },
+        })
+      } catch {
+        showToast('Invalid JSON file.', 'error')
+      }
+      // Reset file input so the same file can be selected again
+      if (importFileRef.current !== null) {
+        importFileRef.current.value = ''
+      }
+    }
+    reader.readAsText(file)
   }
 
   function handleDelete() {
@@ -217,6 +271,50 @@ export function OrganizationDetailPage() {
           </Stack>
         </div>
       </form>
+
+      {/* Export / Import */}
+      <div className="rounded-lg border border-border bg-surface-raised p-6">
+        <Text as="h2" variant="heading-sm">
+          Export &amp; Import
+        </Text>
+        <Text muted className="mt-1">
+          Export all data for this organization as a JSON file, or import a previously exported
+          file.
+        </Text>
+
+        <div className="mt-4 flex flex-wrap gap-3">
+          {/* Export */}
+          <Button
+            variant="secondary"
+            onClick={() => {
+              void handleExport()
+            }}
+            disabled={isExporting}
+          >
+            <IconDownload size={14} className="mr-1.5" />
+            {isExporting ? 'Exporting…' : 'Export JSON'}
+          </Button>
+
+          {/* Import */}
+          <Button
+            variant="secondary"
+            onClick={() => {
+              importFileRef.current?.click()
+            }}
+            disabled={importOrg.isPending}
+          >
+            <IconUpload size={14} className="mr-1.5" />
+            {importOrg.isPending ? 'Importing…' : 'Import JSON'}
+          </Button>
+          <input
+            ref={importFileRef}
+            type="file"
+            accept="application/json,.json"
+            className="hidden"
+            onChange={handleImportFileChange}
+          />
+        </div>
+      </div>
 
       {/* Danger zone */}
       <div className="rounded-lg border border-red-200 bg-red-50 p-6 dark:border-red-900/40 dark:bg-red-950/20">

--- a/frontend/src/pages/superadmin/SuperadminShell.tsx
+++ b/frontend/src/pages/superadmin/SuperadminShell.tsx
@@ -1,6 +1,6 @@
 import { Link, NavLink, Outlet, Navigate } from 'react-router-dom'
 import { currentUserIsSuperadmin } from '@/entities/auth'
-import { IconBuilding, IconHome, IconSettings } from '@/shared/ui/icons/Icons'
+import { IconBuilding, IconDatabase, IconHome, IconSettings } from '@/shared/ui/icons/Icons'
 
 function SuperadminNavItem({
   to,
@@ -46,6 +46,11 @@ export function SuperadminShell() {
             to="/superadmin/organizations"
             icon={<IconBuilding size={16} />}
             label="Organizations"
+          />
+          <SuperadminNavItem
+            to="/superadmin/data-migration"
+            icon={<IconDatabase size={16} />}
+            label="Data Migration"
           />
           <SuperadminNavItem
             to="/superadmin/settings"

--- a/frontend/src/shared/ui/icons/Icons.tsx
+++ b/frontend/src/shared/ui/icons/Icons.tsx
@@ -253,3 +253,23 @@ export function IconBuilding({ size = 16, className }: IconProps) {
     </svg>
   )
 }
+
+export function IconDatabase({ size = 16, className }: IconProps) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <ellipse cx="12" cy="5" rx="9" ry="3" />
+      <path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3" />
+      <path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5" />
+    </svg>
+  )
+}
+
+export function IconDownload({ size = 16, className }: IconProps) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" y1="15" x2="12" y2="3" />
+    </svg>
+  )
+}

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -19,6 +19,8 @@ use NeNeRecords\Comment\CommentNotFoundExceptionHandler;
 use NeNeRecords\Comment\CommentRouteRegistrar;
 use NeNeRecords\Comment\CommentServiceProvider;
 use NeNeRecords\Dashboard\DashboardServiceProvider;
+use NeNeRecords\DataMigration\DataMigrationRouteRegistrar;
+use NeNeRecords\DataMigration\DataMigrationServiceProvider;
 use NeNeRecords\DateTimeField\DateTimeFieldNotFoundExceptionHandler;
 use NeNeRecords\DateTimeField\DateTimeFieldServiceProvider;
 use NeNeRecords\DateTimeField\FieldKeyNotRegisteredExceptionHandler as DateTimeFieldKeyNotRegisteredExceptionHandler;
@@ -61,6 +63,8 @@ use NeNeRecords\Organization\OrganizationNotFoundExceptionHandler;
 use NeNeRecords\Organization\OrganizationRouteRegistrar;
 use NeNeRecords\Organization\OrganizationServiceProvider;
 use NeNeRecords\Organization\OrganizationSlugConflictExceptionHandler;
+use NeNeRecords\OrgExport\OrgExportRouteRegistrar;
+use NeNeRecords\OrgExport\OrgExportServiceProvider;
 use NeNeRecords\PreviewToken\PreviewTokenNotFoundExceptionHandler;
 use NeNeRecords\PreviewToken\PreviewTokenServiceProvider;
 use NeNeRecords\PublicRecord\PublicEntityTypeNotFoundExceptionHandler;
@@ -136,7 +140,9 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new UserInviteServiceProvider())
             ->addProvider(new CommentServiceProvider())
             ->addProvider(new OrganizationServiceProvider())
-            ->addProvider(new SystemConfigServiceProvider());
+            ->addProvider(new SystemConfigServiceProvider())
+            ->addProvider(new DataMigrationServiceProvider())
+            ->addProvider(new OrgExportServiceProvider());
 
         $builder
             ->set(
@@ -168,6 +174,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $comment = $container->get(CommentRouteRegistrar::class);
                     $organization = $container->get(OrganizationRouteRegistrar::class);
                     $systemConfig = $container->get(SystemConfigRouteRegistrar::class);
+                    $dataMigration = $container->get(DataMigrationRouteRegistrar::class);
+                    $orgExport     = $container->get(OrgExportRouteRegistrar::class);
 
                     if (
                         !is_callable($entityType)
@@ -196,6 +204,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !is_callable($comment)
                         || !$organization instanceof OrganizationRouteRegistrar
                         || !$systemConfig instanceof SystemConfigRouteRegistrar
+                        || !$dataMigration instanceof DataMigrationRouteRegistrar
+                        || !$orgExport instanceof OrgExportRouteRegistrar
                     ) {
                         throw new LogicException('Route registrar service is invalid.');
                     }
@@ -227,6 +237,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $comment,
                         $organization,
                         $systemConfig,
+                        $dataMigration,
+                        $orgExport,
                     ];
                 },
             )

--- a/src/DataMigration/AssignOrgHandler.php
+++ b/src/DataMigration/AssignOrgHandler.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DataMigration;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Organization\OrganizationRepositoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Reassigns all records with organization_id = 0 to the specified organization.
+ * This is the "single → multi" data migration operation.
+ */
+final readonly class AssignOrgHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private DataMigrationRepository $repository,
+        private OrganizationRepositoryInterface $orgs,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body  = JsonRequestBodyParser::parse($request);
+        $orgId = isset($body['target_org_id']) ? (int) $body['target_org_id'] : 0;
+
+        if ($orgId <= 0) {
+            return $this->problemDetails->create(
+                $request,
+                'validation-failed',
+                'Validation Failed',
+                422,
+                'target_org_id must be a positive integer.',
+            );
+        }
+
+        $org = $this->orgs->findById($orgId);
+        if ($org === null) {
+            return $this->problemDetails->create(
+                $request,
+                'org-not-found',
+                'Organization Not Found',
+                404,
+                "No organization found with id {$orgId}.",
+            );
+        }
+
+        $migrated = $this->repository->assignAll($orgId);
+        $total    = array_sum($migrated);
+
+        return $this->json->create([
+            'organization_id'   => $orgId,
+            'organization_name' => $org->name,
+            'total'             => $total,
+            'tables'            => $migrated,
+        ]);
+    }
+}

--- a/src/DataMigration/DataMigrationRepository.php
+++ b/src/DataMigration/DataMigrationRepository.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DataMigration;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+/**
+ * Low-level operations for migrating organization_id across all tenant-scoped tables.
+ */
+final readonly class DataMigrationRepository
+{
+    /** Tables that carry organization_id and should be included in migration. */
+    private const TABLES = [
+        'entity_types',
+        'entities',
+        'field_defs',
+        'text_fields',
+        'int_fields',
+        'enum_fields',
+        'bool_fields',
+        'datetime_fields',
+        'tags',
+        'media',
+        'navigation_items',
+        'webhooks',
+        'setting_defs',
+        'setting_values',
+        'setting_revisions',
+        'comments',
+        'access_logs',
+        'entity_revisions',
+        'entity_preview_tokens',
+    ];
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    /**
+     * Returns the count of records with organization_id = 0 per table.
+     *
+     * @return array<string, int>
+     */
+    public function countUnassigned(): array
+    {
+        $counts = [];
+        foreach (self::TABLES as $table) {
+            $row = $this->query->fetchOne(
+                "SELECT COUNT(*) AS cnt FROM `{$table}` WHERE organization_id = 0",
+                [],
+            );
+            $counts[$table] = (int) ($row['cnt'] ?? 0);
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Reassigns all records with organization_id = 0 to the given org.
+     * Returns the number of updated rows per table.
+     *
+     * @return array<string, int>
+     */
+    public function assignAll(int $targetOrgId): array
+    {
+        $updated = [];
+        foreach (self::TABLES as $table) {
+            $affected = $this->query->execute(
+                "UPDATE `{$table}` SET organization_id = ? WHERE organization_id = 0",
+                [$targetOrgId],
+            );
+            $updated[$table] = $affected;
+        }
+
+        return $updated;
+    }
+}

--- a/src/DataMigration/DataMigrationRouteRegistrar.php
+++ b/src/DataMigration/DataMigrationRouteRegistrar.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DataMigration;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DataMigrationRouteRegistrar
+{
+    public function __construct(
+        private DataMigrationStatusHandler $statusHandler,
+        private AssignOrgHandler $assignHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $status = $this->statusHandler;
+        $assign = $this->assignHandler;
+
+        $router->get(
+            '/api/v1/superadmin/data-migration/status',
+            static fn (ServerRequestInterface $r) => $status->handle($r),
+        );
+        $router->post(
+            '/api/v1/superadmin/data-migration/assign-org',
+            static fn (ServerRequestInterface $r) => $assign->handle($r),
+        );
+    }
+}

--- a/src/DataMigration/DataMigrationServiceProvider.php
+++ b/src/DataMigration/DataMigrationServiceProvider.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DataMigration;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Organization\OrganizationRepositoryInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class DataMigrationServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                DataMigrationRepository::class,
+                static function (ContainerInterface $c): DataMigrationRepository {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('DatabaseQueryExecutorInterface is invalid.');
+                    }
+
+                    return new DataMigrationRepository($query);
+                },
+            )
+            ->set(
+                DataMigrationStatusHandler::class,
+                static function (ContainerInterface $c): DataMigrationStatusHandler {
+                    $repo = $c->get(DataMigrationRepository::class);
+                    $json = $c->get(JsonResponseFactory::class);
+                    if (!$repo instanceof DataMigrationRepository || !$json instanceof JsonResponseFactory) {
+                        throw new LogicException('DataMigrationStatusHandler dependencies are invalid.');
+                    }
+
+                    return new DataMigrationStatusHandler($repo, $json);
+                },
+            )
+            ->set(
+                AssignOrgHandler::class,
+                static function (ContainerInterface $c): AssignOrgHandler {
+                    $repo    = $c->get(DataMigrationRepository::class);
+                    $orgs    = $c->get(OrganizationRepositoryInterface::class);
+                    $json    = $c->get(JsonResponseFactory::class);
+                    $problem = $c->get(ProblemDetailsResponseFactory::class);
+                    if (
+                        !$repo instanceof DataMigrationRepository
+                        || !$orgs instanceof OrganizationRepositoryInterface
+                        || !$json instanceof JsonResponseFactory
+                        || !$problem instanceof ProblemDetailsResponseFactory
+                    ) {
+                        throw new LogicException('AssignOrgHandler dependencies are invalid.');
+                    }
+
+                    return new AssignOrgHandler($repo, $orgs, $json, $problem);
+                },
+            )
+            ->set(
+                DataMigrationRouteRegistrar::class,
+                static function (ContainerInterface $c): DataMigrationRouteRegistrar {
+                    $status = $c->get(DataMigrationStatusHandler::class);
+                    $assign = $c->get(AssignOrgHandler::class);
+                    if (!$status instanceof DataMigrationStatusHandler || !$assign instanceof AssignOrgHandler) {
+                        throw new LogicException('DataMigrationRouteRegistrar dependencies are invalid.');
+                    }
+
+                    return new DataMigrationRouteRegistrar($status, $assign);
+                },
+            );
+    }
+}

--- a/src/DataMigration/DataMigrationStatusHandler.php
+++ b/src/DataMigration/DataMigrationStatusHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DataMigration;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Returns the count of records with organization_id = 0 per table.
+ * Used to show the user how many records would be affected by an org assignment.
+ */
+final readonly class DataMigrationStatusHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private DataMigrationRepository $repository,
+        private JsonResponseFactory $json,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $counts = $this->repository->countUnassigned();
+        $total  = array_sum($counts);
+
+        return $this->json->create([
+            'total'  => $total,
+            'tables' => $counts,
+        ]);
+    }
+}

--- a/src/OrgExport/OrgExportHandler.php
+++ b/src/OrgExport/OrgExportHandler.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgExport;
+
+use DateTimeImmutable;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Organization\OrganizationRepositoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Exports all tenant-scoped data for a given organization as a JSON payload.
+ *
+ * GET /api/v1/superadmin/organizations/{id}/export
+ */
+final readonly class OrgExportHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private OrgExportRepository $repository,
+        private OrganizationRepositoryInterface $orgs,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $id    = (int) ($request->getAttribute('id') ?? 0);
+        $org   = $this->orgs->findById($id);
+
+        if ($org === null) {
+            return $this->problemDetails->create(
+                $request,
+                'org-not-found',
+                'Organization Not Found',
+                404,
+                "No organization found with id {$id}.",
+            );
+        }
+
+        $now = (new DateTimeImmutable('now'))->format('c');
+
+        $payload = [
+            'meta'              => [
+                'exported_at'     => $now,
+                'organization_id' => $id,
+            ],
+            'entity_types'      => $this->repository->fetchEntityTypes($id),
+            'entities'          => $this->repository->fetchEntities($id),
+            'field_defs'        => $this->repository->fetchFieldDefs($id),
+            'text_fields'       => $this->repository->fetchTextFields($id),
+            'int_fields'        => $this->repository->fetchIntFields($id),
+            'enum_fields'       => $this->repository->fetchEnumFields($id),
+            'bool_fields'       => $this->repository->fetchBoolFields($id),
+            'datetime_fields'   => $this->repository->fetchDatetimeFields($id),
+            'tags'              => $this->repository->fetchTags($id),
+            'entity_tags'       => $this->repository->fetchEntityTags($id),
+            'navigation_items'  => $this->repository->fetchNavigationItems($id),
+            'setting_defs'      => $this->repository->fetchSettingDefs($id),
+            'setting_values'    => $this->repository->fetchSettingValues($id),
+            'media'             => $this->repository->fetchMedia($id),
+        ];
+
+        return $this->json->create($payload);
+    }
+}

--- a/src/OrgExport/OrgExportRepository.php
+++ b/src/OrgExport/OrgExportRepository.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgExport;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+/**
+ * Reads all tenant-scoped data for a given organization.
+ */
+final readonly class OrgExportRepository
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function fetchEntityTypes(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT * FROM entity_types WHERE organization_id = ? ORDER BY id',
+            [$orgId],
+        );
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function fetchEntities(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT * FROM entities WHERE organization_id = ? ORDER BY id',
+            [$orgId],
+        );
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function fetchFieldDefs(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT * FROM field_defs WHERE organization_id = ? ORDER BY id',
+            [$orgId],
+        );
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function fetchTextFields(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT * FROM text_fields WHERE organization_id = ? ORDER BY id',
+            [$orgId],
+        );
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function fetchIntFields(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT * FROM int_fields WHERE organization_id = ? ORDER BY id',
+            [$orgId],
+        );
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function fetchEnumFields(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT * FROM enum_fields WHERE organization_id = ? ORDER BY id',
+            [$orgId],
+        );
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function fetchBoolFields(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT * FROM bool_fields WHERE organization_id = ? ORDER BY id',
+            [$orgId],
+        );
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function fetchDatetimeFields(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT * FROM datetime_fields WHERE organization_id = ? ORDER BY id',
+            [$orgId],
+        );
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function fetchTags(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT * FROM tags WHERE organization_id = ? ORDER BY id',
+            [$orgId],
+        );
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function fetchEntityTags(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT et.* FROM entity_tags et
+             JOIN entities e ON e.id = et.entity_id
+             WHERE e.organization_id = ?
+             ORDER BY et.entity_id, et.tag_id',
+            [$orgId],
+        );
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function fetchNavigationItems(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT * FROM navigation_items WHERE organization_id = ? ORDER BY display_order',
+            [$orgId],
+        );
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function fetchSettingDefs(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT * FROM setting_defs WHERE organization_id = ? ORDER BY setting_key',
+            [$orgId],
+        );
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function fetchSettingValues(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT * FROM setting_values WHERE organization_id = ? ORDER BY setting_key',
+            [$orgId],
+        );
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function fetchMedia(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT * FROM media WHERE organization_id = ? ORDER BY id',
+            [$orgId],
+        );
+    }
+}

--- a/src/OrgExport/OrgExportRouteRegistrar.php
+++ b/src/OrgExport/OrgExportRouteRegistrar.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgExport;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class OrgExportRouteRegistrar
+{
+    public function __construct(
+        private OrgExportHandler $exportHandler,
+        private OrgImportHandler $importHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $export = $this->exportHandler;
+        $import = $this->importHandler;
+
+        $router->get(
+            '/api/v1/superadmin/organizations/{id}/export',
+            static fn (ServerRequestInterface $r) => $export->handle($r),
+        );
+        $router->post(
+            '/api/v1/superadmin/organizations/{id}/import',
+            static fn (ServerRequestInterface $r) => $import->handle($r),
+        );
+    }
+}

--- a/src/OrgExport/OrgExportServiceProvider.php
+++ b/src/OrgExport/OrgExportServiceProvider.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgExport;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Organization\OrganizationRepositoryInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class OrgExportServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                OrgExportRepository::class,
+                static function (ContainerInterface $c): OrgExportRepository {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('DatabaseQueryExecutorInterface is invalid.');
+                    }
+
+                    return new OrgExportRepository($query);
+                },
+            )
+            ->set(
+                OrgImportRepository::class,
+                static function (ContainerInterface $c): OrgImportRepository {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('DatabaseQueryExecutorInterface is invalid.');
+                    }
+
+                    return new OrgImportRepository($query);
+                },
+            )
+            ->set(
+                OrgExportHandler::class,
+                static function (ContainerInterface $c): OrgExportHandler {
+                    $repo    = $c->get(OrgExportRepository::class);
+                    $orgs    = $c->get(OrganizationRepositoryInterface::class);
+                    $json    = $c->get(JsonResponseFactory::class);
+                    $problem = $c->get(ProblemDetailsResponseFactory::class);
+                    if (
+                        !$repo instanceof OrgExportRepository
+                        || !$orgs instanceof OrganizationRepositoryInterface
+                        || !$json instanceof JsonResponseFactory
+                        || !$problem instanceof ProblemDetailsResponseFactory
+                    ) {
+                        throw new LogicException('OrgExportHandler dependencies are invalid.');
+                    }
+
+                    return new OrgExportHandler($repo, $orgs, $json, $problem);
+                },
+            )
+            ->set(
+                OrgImportHandler::class,
+                static function (ContainerInterface $c): OrgImportHandler {
+                    $repo    = $c->get(OrgImportRepository::class);
+                    $orgs    = $c->get(OrganizationRepositoryInterface::class);
+                    $json    = $c->get(JsonResponseFactory::class);
+                    $problem = $c->get(ProblemDetailsResponseFactory::class);
+                    if (
+                        !$repo instanceof OrgImportRepository
+                        || !$orgs instanceof OrganizationRepositoryInterface
+                        || !$json instanceof JsonResponseFactory
+                        || !$problem instanceof ProblemDetailsResponseFactory
+                    ) {
+                        throw new LogicException('OrgImportHandler dependencies are invalid.');
+                    }
+
+                    return new OrgImportHandler($repo, $orgs, $json, $problem);
+                },
+            )
+            ->set(
+                OrgExportRouteRegistrar::class,
+                static function (ContainerInterface $c): OrgExportRouteRegistrar {
+                    $export = $c->get(OrgExportHandler::class);
+                    $import = $c->get(OrgImportHandler::class);
+                    if (
+                        !$export instanceof OrgExportHandler
+                        || !$import instanceof OrgImportHandler
+                    ) {
+                        throw new LogicException('OrgExportRouteRegistrar dependencies are invalid.');
+                    }
+
+                    return new OrgExportRouteRegistrar($export, $import);
+                },
+            );
+    }
+}

--- a/src/OrgExport/OrgImportHandler.php
+++ b/src/OrgExport/OrgImportHandler.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgExport;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Organization\OrganizationRepositoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Imports an org-export payload into the target organization.
+ *
+ * POST /api/v1/superadmin/organizations/{id}/import
+ *
+ * The request body must be a JSON export payload produced by OrgExportHandler.
+ * All IDs are remapped to new auto-increment values; existing data in the
+ * target organization is not removed before import.
+ */
+final readonly class OrgImportHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private OrgImportRepository $repository,
+        private OrganizationRepositoryInterface $orgs,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $id  = (int) ($request->getAttribute('id') ?? 0);
+        $org = $this->orgs->findById($id);
+
+        if ($org === null) {
+            return $this->problemDetails->create(
+                $request,
+                'org-not-found',
+                'Organization Not Found',
+                404,
+                "No organization found with id {$id}.",
+            );
+        }
+
+        $payload = JsonRequestBodyParser::parse($request);
+
+        if (!isset($payload['meta'])) {
+            return $this->problemDetails->create(
+                $request,
+                'invalid-payload',
+                'Invalid Import Payload',
+                422,
+                'Request body must be a valid org-export JSON payload (must contain "meta" key).',
+            );
+        }
+
+        $counts = $this->repository->import($id, $payload);
+        $total  = array_sum($counts);
+
+        return $this->json->create([
+            'organization_id'   => $id,
+            'organization_name' => $org->name,
+            'total'             => $total,
+            'imported'          => $counts,
+        ], 201);
+    }
+}

--- a/src/OrgExport/OrgImportRepository.php
+++ b/src/OrgExport/OrgImportRepository.php
@@ -1,0 +1,340 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgExport;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+/**
+ * Inserts an exported org payload into the target organization.
+ *
+ * All primary-key IDs are remapped to new auto-increment values so the import
+ * can safely coexist with existing data. Cross-table references are updated
+ * accordingly before insertion.
+ */
+final readonly class OrgImportRepository
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    /**
+     * Imports exported data into the given organization.
+     *
+     * @param  array<string, mixed> $payload  The decoded JSON export payload.
+     * @return array<string, int>             Row counts per table.
+     */
+    public function import(int $targetOrgId, array $payload): array
+    {
+        $counts = [];
+
+        // ── entity_types ───────────────────────────────────────────────────
+        /** @var array<int, int> $entityTypeMap  old_id → new_id */
+        $entityTypeMap = [];
+        foreach ((array) ($payload['entity_types'] ?? []) as $row) {
+            $oldId = (int) $row['id'];
+            $newId = $this->query->insert(
+                'INSERT INTO entity_types
+                    (organization_id, name, slug, is_pinned, labels, permalink_pattern, previous_permalink_pattern)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)',
+                [
+                    $targetOrgId,
+                    (string) $row['name'],
+                    (string) $row['slug'],
+                    (int) $row['is_pinned'],
+                    isset($row['labels']) ? (string) $row['labels'] : null,
+                    isset($row['permalink_pattern']) ? (string) $row['permalink_pattern'] : null,
+                    isset($row['previous_permalink_pattern']) ? (string) $row['previous_permalink_pattern'] : null,
+                ],
+            );
+            $entityTypeMap[$oldId] = $newId;
+        }
+        $counts['entity_types'] = count($entityTypeMap);
+
+        // ── field_defs ─────────────────────────────────────────────────────
+        /** @var array<int, int> $fieldDefMap  old_id → new_id */
+        $fieldDefMap = [];
+        foreach ((array) ($payload['field_defs'] ?? []) as $row) {
+            $oldId           = (int) $row['id'];
+            $newEntityTypeId = $entityTypeMap[(int) $row['entity_type_id']] ?? null;
+            if ($newEntityTypeId === null) {
+                continue;
+            }
+            $newTargetEntityTypeId = isset($row['target_entity_type_id'])
+                ? ($entityTypeMap[(int) $row['target_entity_type_id']] ?? null)
+                : null;
+            $newId = $this->query->insert(
+                'INSERT INTO field_defs
+                    (organization_id, entity_type_id, field_key, data_type, target_entity_type_id, cardinality, is_deleted, deleted_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+                [
+                    $targetOrgId,
+                    $newEntityTypeId,
+                    (string) $row['field_key'],
+                    (string) $row['data_type'],
+                    $newTargetEntityTypeId,
+                    isset($row['cardinality']) ? (string) $row['cardinality'] : null,
+                    (int) $row['is_deleted'],
+                    isset($row['deleted_at']) ? (string) $row['deleted_at'] : null,
+                ],
+            );
+            $fieldDefMap[$oldId] = $newId;
+        }
+        $counts['field_defs'] = count($fieldDefMap);
+
+        // ── entities ───────────────────────────────────────────────────────
+        /** @var array<int, int> $entityMap  old_id → new_id */
+        $entityMap = [];
+        foreach ((array) ($payload['entities'] ?? []) as $row) {
+            $oldId           = (int) $row['id'];
+            $newEntityTypeId = $entityTypeMap[(int) $row['entity_type_id']] ?? null;
+            if ($newEntityTypeId === null) {
+                continue;
+            }
+            $newId = $this->query->insert(
+                'INSERT INTO entities
+                    (organization_id, entity_type_id, slug, status, published_at, scheduled_at,
+                     meta_title, meta_description, is_deleted, created_at, updated_at, deleted_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                [
+                    $targetOrgId,
+                    $newEntityTypeId,
+                    isset($row['slug']) ? (string) $row['slug'] : null,
+                    (string) ($row['status'] ?? 'draft'),
+                    isset($row['published_at']) ? (string) $row['published_at'] : null,
+                    isset($row['scheduled_at']) ? (string) $row['scheduled_at'] : null,
+                    isset($row['meta_title']) ? (string) $row['meta_title'] : null,
+                    isset($row['meta_description']) ? (string) $row['meta_description'] : null,
+                    (int) $row['is_deleted'],
+                    isset($row['created_at']) ? (string) $row['created_at'] : null,
+                    isset($row['updated_at']) ? (string) $row['updated_at'] : null,
+                    isset($row['deleted_at']) ? (string) $row['deleted_at'] : null,
+                ],
+            );
+            $entityMap[$oldId] = $newId;
+        }
+        $counts['entities'] = count($entityMap);
+
+        // ── text_fields ────────────────────────────────────────────────────
+        $counts['text_fields'] = $this->importFieldValues(
+            'text_fields',
+            (array) ($payload['text_fields'] ?? []),
+            $targetOrgId,
+            $entityMap,
+            'value',
+        );
+
+        // ── int_fields ─────────────────────────────────────────────────────
+        $counts['int_fields'] = $this->importFieldValues(
+            'int_fields',
+            (array) ($payload['int_fields'] ?? []),
+            $targetOrgId,
+            $entityMap,
+            'value',
+        );
+
+        // ── enum_fields ────────────────────────────────────────────────────
+        $counts['enum_fields'] = $this->importFieldValues(
+            'enum_fields',
+            (array) ($payload['enum_fields'] ?? []),
+            $targetOrgId,
+            $entityMap,
+            'value',
+        );
+
+        // ── bool_fields ────────────────────────────────────────────────────
+        $counts['bool_fields'] = $this->importFieldValues(
+            'bool_fields',
+            (array) ($payload['bool_fields'] ?? []),
+            $targetOrgId,
+            $entityMap,
+            'value',
+        );
+
+        // ── datetime_fields ────────────────────────────────────────────────
+        $counts['datetime_fields'] = $this->importFieldValues(
+            'datetime_fields',
+            (array) ($payload['datetime_fields'] ?? []),
+            $targetOrgId,
+            $entityMap,
+            'value',
+        );
+
+        // ── tags ───────────────────────────────────────────────────────────
+        /** @var array<int, int> $tagMap  old_id → new_id */
+        $tagMap = [];
+        foreach ((array) ($payload['tags'] ?? []) as $row) {
+            $oldId = (int) $row['id'];
+            // tags.slug is globally unique; reuse existing tag if slug already exists.
+            $existing = $this->query->fetchOne(
+                'SELECT id FROM tags WHERE slug = ?',
+                [(string) $row['slug']],
+            );
+            if ($existing !== null) {
+                $tagMap[$oldId] = (int) $existing['id'];
+            } else {
+                $newId = $this->query->insert(
+                    'INSERT INTO tags (organization_id, slug, name) VALUES (?, ?, ?)',
+                    [$targetOrgId, (string) $row['slug'], (string) $row['name']],
+                );
+                $tagMap[$oldId] = $newId;
+            }
+        }
+        $counts['tags'] = count($tagMap);
+
+        // ── entity_tags ────────────────────────────────────────────────────
+        $entityTagCount = 0;
+        foreach ((array) ($payload['entity_tags'] ?? []) as $row) {
+            $newEntityId = $entityMap[(int) $row['entity_id']] ?? null;
+            $newTagId    = $tagMap[(int) $row['tag_id']] ?? null;
+            if ($newEntityId === null || $newTagId === null) {
+                continue;
+            }
+            $this->query->execute(
+                'INSERT IGNORE INTO entity_tags (entity_id, tag_id) VALUES (?, ?)',
+                [$newEntityId, $newTagId],
+            );
+            $entityTagCount++;
+        }
+        $counts['entity_tags'] = $entityTagCount;
+
+        // ── navigation_items ───────────────────────────────────────────────
+        $navCount = 0;
+        foreach ((array) ($payload['navigation_items'] ?? []) as $row) {
+            $this->query->insert(
+                'INSERT INTO navigation_items (organization_id, label, url, display_order, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?)',
+                [
+                    $targetOrgId,
+                    (string) $row['label'],
+                    (string) $row['url'],
+                    (int) $row['display_order'],
+                    (string) ($row['created_at'] ?? date('Y-m-d H:i:s')),
+                    (string) ($row['updated_at'] ?? date('Y-m-d H:i:s')),
+                ],
+            );
+            $navCount++;
+        }
+        $counts['navigation_items'] = $navCount;
+
+        // ── setting_defs ───────────────────────────────────────────────────
+        $settingDefCount = 0;
+        foreach ((array) ($payload['setting_defs'] ?? []) as $row) {
+            $this->query->insert(
+                'INSERT INTO setting_defs (organization_id, setting_key, data_type, default_value, is_public, label, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+                [
+                    $targetOrgId,
+                    (string) $row['setting_key'],
+                    (string) $row['data_type'],
+                    isset($row['default_value']) ? (string) $row['default_value'] : null,
+                    (int) $row['is_public'],
+                    (string) $row['label'],
+                    (string) ($row['created_at'] ?? date('Y-m-d H:i:s')),
+                    (string) ($row['updated_at'] ?? date('Y-m-d H:i:s')),
+                ],
+            );
+            $settingDefCount++;
+        }
+        $counts['setting_defs'] = $settingDefCount;
+
+        // ── setting_values ─────────────────────────────────────────────────
+        $settingValueCount = 0;
+        foreach ((array) ($payload['setting_values'] ?? []) as $row) {
+            $this->query->insert(
+                'INSERT INTO setting_values (organization_id, setting_key, value, is_deleted, deleted_at, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)',
+                [
+                    $targetOrgId,
+                    (string) $row['setting_key'],
+                    isset($row['value']) ? (string) $row['value'] : null,
+                    (int) $row['is_deleted'],
+                    isset($row['deleted_at']) ? (string) $row['deleted_at'] : null,
+                    (string) ($row['created_at'] ?? date('Y-m-d H:i:s')),
+                    (string) ($row['updated_at'] ?? date('Y-m-d H:i:s')),
+                ],
+            );
+            $settingValueCount++;
+        }
+        $counts['setting_values'] = $settingValueCount;
+
+        // ── media ──────────────────────────────────────────────────────────
+        $mediaCount = 0;
+        foreach ((array) ($payload['media'] ?? []) as $row) {
+            $this->query->insert(
+                'INSERT INTO media (organization_id, original_name, stored_name, mime_type, size, url, created_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)',
+                [
+                    $targetOrgId,
+                    (string) $row['original_name'],
+                    (string) $row['stored_name'],
+                    (string) $row['mime_type'],
+                    (int) $row['size'],
+                    (string) $row['url'],
+                    (string) ($row['created_at'] ?? date('Y-m-d H:i:s')),
+                ],
+            );
+            $mediaCount++;
+        }
+        $counts['media'] = $mediaCount;
+
+        return $counts;
+    }
+
+    /**
+     * Inserts field value rows (text/int/enum/bool/datetime) for the given table.
+     *
+     * @param array<int, array<string, mixed>> $rows
+     * @param array<int, int>                  $entityMap  old entity_id → new entity_id
+     */
+    private function importFieldValues(
+        string $table,
+        array $rows,
+        int $targetOrgId,
+        array $entityMap,
+        string $valueColumn,
+    ): int {
+        $count = 0;
+        foreach ($rows as $row) {
+            $newEntityId = $entityMap[(int) $row['entity_id']] ?? null;
+            if ($newEntityId === null) {
+                continue;
+            }
+            $locale = isset($row['locale']) ? (string) $row['locale'] : null;
+            if ($locale !== null) {
+                // text_fields has locale column
+                $this->query->insert(
+                    "INSERT INTO `{$table}` (organization_id, entity_id, field_key, locale, `{$valueColumn}`, is_deleted, deleted_at)
+                     VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    [
+                        $targetOrgId,
+                        $newEntityId,
+                        (string) $row['field_key'],
+                        $locale,
+                        $row[$valueColumn],
+                        (int) $row['is_deleted'],
+                        isset($row['deleted_at']) ? (string) $row['deleted_at'] : null,
+                    ],
+                );
+            } else {
+                $this->query->insert(
+                    "INSERT INTO `{$table}` (organization_id, entity_id, field_key, `{$valueColumn}`, is_deleted, deleted_at)
+                     VALUES (?, ?, ?, ?, ?, ?)",
+                    [
+                        $targetOrgId,
+                        $newEntityId,
+                        (string) $row['field_key'],
+                        $row[$valueColumn],
+                        (int) $row['is_deleted'],
+                        isset($row['deleted_at']) ? (string) $row['deleted_at'] : null,
+                    ],
+                );
+            }
+            $count++;
+        }
+
+        return $count;
+    }
+}


### PR DESCRIPTION
## 概要

#214・#215 を実装。シングルテナント→マルチテナント移行および組織データのバックアップ・復元機能を追加。

## 変更内容

### #214 — 既存データ組織割当 UI
- **GET** `/api/v1/superadmin/data-migration/status` — `organization_id=0` のレコード件数をテーブル別に返す
- **POST** `/api/v1/superadmin/data-migration/assign-org` — 指定組織へ一括再割当
- フロントエンド: `/superadmin/data-migration` ページ（件数一覧 → 組織セレクト → 実行）

### #215 — JSON 完全エクスポート／インポート
- **GET** `/api/v1/superadmin/organizations/{id}/export` — 全テナントデータを JSON ペイロードとして返す
- **POST** `/api/v1/superadmin/organizations/{id}/import` — JSON ペイロードをターゲット組織にインポート
  - 全テーブルの PK を新規採番し、相互参照 ID を正確にマッピング
  - tags はグローバル slug ユニーク制約に対応（重複時は既存タグを再利用）
- フロントエンド: 組織詳細ページに **Export JSON** / **Import JSON** ボタン

### その他
- Superadmin サイドバーに「Data Migration」ナビリンク追加（`IconDatabase` アイコン）
- `IconDownload` アイコン追加

## 検証

```
composer check   # 318 tests pass, PHPStan OK, CS-Fixer OK, OpenAPI OK
npm run check --prefix frontend   # type-check + lint + format + test + storybook すべてパス
```

Closes #214
Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)