### PR TITLE
refactor(system-config): UseCase 層の追加・VALID_MODES バリデーションをハンドラから除去 (#221)

### DIFF
--- a/src/SystemConfig/GetSystemConfigHandler.php
+++ b/src/SystemConfig/GetSystemConfigHandler.php
@@ -12,19 +12,19 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class GetSystemConfigHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private SystemConfigRepositoryInterface $config,
+        private GetSystemConfigUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $all = $this->config->all();
+        $output = $this->useCase->execute();
 
         return $this->json->create([
-            'tenant_resolution_mode' => $all['tenant_resolution_mode'] ?? 'single',
-            'tenant_org_slug'        => $all['tenant_org_slug'] ?? '',
-            'tenant_base_domain'     => $all['tenant_base_domain'] ?? 'localhost',
+            'tenant_resolution_mode' => $output->tenantResolutionMode,
+            'tenant_org_slug'        => $output->tenantOrgSlug,
+            'tenant_base_domain'     => $output->tenantBaseDomain,
         ]);
     }
 }

--- a/src/SystemConfig/GetSystemConfigOutput.php
+++ b/src/SystemConfig/GetSystemConfigOutput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\SystemConfig;
+
+final readonly class GetSystemConfigOutput
+{
+    public function __construct(
+        public string $tenantResolutionMode,
+        public string $tenantOrgSlug,
+        public string $tenantBaseDomain,
+    ) {
+    }
+}

--- a/src/SystemConfig/GetSystemConfigUseCase.php
+++ b/src/SystemConfig/GetSystemConfigUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\SystemConfig;
+
+final readonly class GetSystemConfigUseCase implements GetSystemConfigUseCaseInterface
+{
+    public function __construct(
+        private SystemConfigRepositoryInterface $config,
+    ) {
+    }
+
+    public function execute(): GetSystemConfigOutput
+    {
+        $all = $this->config->all();
+
+        return new GetSystemConfigOutput(
+            tenantResolutionMode: $all['tenant_resolution_mode'] ?? 'single',
+            tenantOrgSlug: $all['tenant_org_slug'] ?? '',
+            tenantBaseDomain: $all['tenant_base_domain'] ?? 'localhost',
+        );
+    }
+}

--- a/src/SystemConfig/GetSystemConfigUseCaseInterface.php
+++ b/src/SystemConfig/GetSystemConfigUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\SystemConfig;
+
+interface GetSystemConfigUseCaseInterface
+{
+    public function execute(): GetSystemConfigOutput;
+}

--- a/src/SystemConfig/SystemConfigServiceProvider.php
+++ b/src/SystemConfig/SystemConfigServiceProvider.php
@@ -8,7 +8,6 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Psr\Container\ContainerInterface;
 
@@ -29,40 +28,57 @@ final readonly class SystemConfigServiceProvider implements ServiceProviderInter
                 },
             )
             ->set(
-                GetSystemConfigHandler::class,
-                static function (ContainerInterface $c): GetSystemConfigHandler {
+                GetSystemConfigUseCaseInterface::class,
+                static function (ContainerInterface $c): GetSystemConfigUseCaseInterface {
                     $config = $c->get(SystemConfigRepositoryInterface::class);
-                    $json   = $c->get(JsonResponseFactory::class);
                     if (!$config instanceof SystemConfigRepositoryInterface) {
                         throw new LogicException('SystemConfigRepositoryInterface is invalid.');
+                    }
+
+                    return new GetSystemConfigUseCase($config);
+                },
+            )
+            ->set(
+                UpdateSystemConfigUseCaseInterface::class,
+                static function (ContainerInterface $c): UpdateSystemConfigUseCaseInterface {
+                    $config = $c->get(SystemConfigRepositoryInterface::class);
+                    if (!$config instanceof SystemConfigRepositoryInterface) {
+                        throw new LogicException('SystemConfigRepositoryInterface is invalid.');
+                    }
+
+                    return new UpdateSystemConfigUseCase($config);
+                },
+            )
+            ->set(
+                GetSystemConfigHandler::class,
+                static function (ContainerInterface $c): GetSystemConfigHandler {
+                    $useCase = $c->get(GetSystemConfigUseCaseInterface::class);
+                    $json    = $c->get(JsonResponseFactory::class);
+                    if (!$useCase instanceof GetSystemConfigUseCaseInterface) {
+                        throw new LogicException('GetSystemConfigUseCaseInterface is invalid.');
                     }
 
                     if (!$json instanceof JsonResponseFactory) {
                         throw new LogicException('JsonResponseFactory is invalid.');
                     }
 
-                    return new GetSystemConfigHandler($config, $json);
+                    return new GetSystemConfigHandler($useCase, $json);
                 },
             )
             ->set(
                 UpdateSystemConfigHandler::class,
                 static function (ContainerInterface $c): UpdateSystemConfigHandler {
-                    $config  = $c->get(SystemConfigRepositoryInterface::class);
+                    $useCase = $c->get(UpdateSystemConfigUseCaseInterface::class);
                     $json    = $c->get(JsonResponseFactory::class);
-                    $problem = $c->get(ProblemDetailsResponseFactory::class);
-                    if (!$config instanceof SystemConfigRepositoryInterface) {
-                        throw new LogicException('SystemConfigRepositoryInterface is invalid.');
+                    if (!$useCase instanceof UpdateSystemConfigUseCaseInterface) {
+                        throw new LogicException('UpdateSystemConfigUseCaseInterface is invalid.');
                     }
 
                     if (!$json instanceof JsonResponseFactory) {
                         throw new LogicException('JsonResponseFactory is invalid.');
                     }
 
-                    if (!$problem instanceof ProblemDetailsResponseFactory) {
-                        throw new LogicException('ProblemDetailsResponseFactory is invalid.');
-                    }
-
-                    return new UpdateSystemConfigHandler($config, $json, $problem);
+                    return new UpdateSystemConfigHandler($useCase, $json);
                 },
             )
             ->set(

--- a/src/SystemConfig/UpdateSystemConfigHandler.php
+++ b/src/SystemConfig/UpdateSystemConfigHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace NeNeRecords\SystemConfig;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Psr\Http\Message\ResponseInterface;
@@ -13,12 +12,9 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 final readonly class UpdateSystemConfigHandler implements RequestHandlerInterface
 {
-    private const VALID_MODES = ['single', 'subdomain', 'path'];
-
     public function __construct(
-        private SystemConfigRepositoryInterface $config,
+        private UpdateSystemConfigUseCaseInterface $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
@@ -26,36 +22,24 @@ final readonly class UpdateSystemConfigHandler implements RequestHandlerInterfac
     {
         $body = JsonRequestBodyParser::parse($request);
 
-        $mode = isset($body['tenant_resolution_mode'])
-            ? (string) $body['tenant_resolution_mode']
-            : null;
+        $input = new UpdateSystemConfigInput(
+            tenantResolutionMode: isset($body['tenant_resolution_mode'])
+                ? (string) $body['tenant_resolution_mode']
+                : '',
+            tenantOrgSlug: isset($body['tenant_org_slug'])
+                ? (string) $body['tenant_org_slug']
+                : null,
+            tenantBaseDomain: isset($body['tenant_base_domain'])
+                ? (string) $body['tenant_base_domain']
+                : null,
+        );
 
-        if ($mode === null || !in_array($mode, self::VALID_MODES, true)) {
-            return $this->problemDetails->create(
-                $request,
-                'validation-failed',
-                'Validation Failed',
-                422,
-                'tenant_resolution_mode must be one of: ' . implode(', ', self::VALID_MODES),
-            );
-        }
-
-        $this->config->set('tenant_resolution_mode', $mode);
-
-        if (isset($body['tenant_org_slug'])) {
-            $this->config->set('tenant_org_slug', (string) $body['tenant_org_slug']);
-        }
-
-        if (isset($body['tenant_base_domain'])) {
-            $this->config->set('tenant_base_domain', (string) $body['tenant_base_domain']);
-        }
-
-        $all = $this->config->all();
+        $output = $this->useCase->execute($input);
 
         return $this->json->create([
-            'tenant_resolution_mode' => $all['tenant_resolution_mode'] ?? 'single',
-            'tenant_org_slug'        => $all['tenant_org_slug'] ?? '',
-            'tenant_base_domain'     => $all['tenant_base_domain'] ?? 'localhost',
+            'tenant_resolution_mode' => $output->tenantResolutionMode,
+            'tenant_org_slug'        => $output->tenantOrgSlug,
+            'tenant_base_domain'     => $output->tenantBaseDomain,
         ]);
     }
 }

--- a/src/SystemConfig/UpdateSystemConfigInput.php
+++ b/src/SystemConfig/UpdateSystemConfigInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\SystemConfig;
+
+final readonly class UpdateSystemConfigInput
+{
+    public function __construct(
+        public string $tenantResolutionMode,
+        public ?string $tenantOrgSlug,
+        public ?string $tenantBaseDomain,
+    ) {
+    }
+}

--- a/src/SystemConfig/UpdateSystemConfigOutput.php
+++ b/src/SystemConfig/UpdateSystemConfigOutput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\SystemConfig;
+
+final readonly class UpdateSystemConfigOutput
+{
+    public function __construct(
+        public string $tenantResolutionMode,
+        public string $tenantOrgSlug,
+        public string $tenantBaseDomain,
+    ) {
+    }
+}

--- a/src/SystemConfig/UpdateSystemConfigUseCase.php
+++ b/src/SystemConfig/UpdateSystemConfigUseCase.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\SystemConfig;
+
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+
+final readonly class UpdateSystemConfigUseCase implements UpdateSystemConfigUseCaseInterface
+{
+    private const VALID_MODES = ['single', 'subdomain', 'path'];
+
+    public function __construct(
+        private SystemConfigRepositoryInterface $config,
+    ) {
+    }
+
+    public function execute(UpdateSystemConfigInput $input): UpdateSystemConfigOutput
+    {
+        if (!in_array($input->tenantResolutionMode, self::VALID_MODES, true)) {
+            throw new ValidationException([
+                new ValidationError(
+                    'tenant_resolution_mode',
+                    'tenant_resolution_mode must be one of: ' . implode(', ', self::VALID_MODES) . '.',
+                    'invalid',
+                ),
+            ]);
+        }
+
+        $this->config->set('tenant_resolution_mode', $input->tenantResolutionMode);
+
+        if ($input->tenantOrgSlug !== null) {
+            $this->config->set('tenant_org_slug', $input->tenantOrgSlug);
+        }
+
+        if ($input->tenantBaseDomain !== null) {
+            $this->config->set('tenant_base_domain', $input->tenantBaseDomain);
+        }
+
+        $all = $this->config->all();
+
+        return new UpdateSystemConfigOutput(
+            tenantResolutionMode: $all['tenant_resolution_mode'] ?? 'single',
+            tenantOrgSlug: $all['tenant_org_slug'] ?? '',
+            tenantBaseDomain: $all['tenant_base_domain'] ?? 'localhost',
+        );
+    }
+}

--- a/src/SystemConfig/UpdateSystemConfigUseCaseInterface.php
+++ b/src/SystemConfig/UpdateSystemConfigUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\SystemConfig;
+
+interface UpdateSystemConfigUseCaseInterface
+{
+    public function execute(UpdateSystemConfigInput $input): UpdateSystemConfigOutput;
+}


### PR DESCRIPTION
## 目的

SystemConfig ドメインの2ハンドラに UseCase 層を追加し、アーキテクチャ規約（Handler → UseCase → Repository）を適用する。

## 変更内容

### 新規ファイル

| ファイル | 役割 |
|---------|------|
| `GetSystemConfigOutput.php` | GET レスポンス DTO |
| `GetSystemConfigUseCaseInterface.php` | インターフェース |
| `GetSystemConfigUseCase.php` | config->all() → Output DTO |
| `UpdateSystemConfigInput.php` | UPDATE リクエスト DTO |
| `UpdateSystemConfigOutput.php` | UPDATE レスポンス DTO |
| `UpdateSystemConfigUseCaseInterface.php` | インターフェース |
| `UpdateSystemConfigUseCase.php` | VALID_MODES 検証 + 永続化 |

### バリデーション変更

**Before:** ハンドラ内で `ProblemDetailsResponseFactory` を直接呼び出して 422 を返していた  
**After:** UseCase が `ValidationException` をスロー → フレームワークのエラーハンドラが 422 に変換

### ハンドラの責務整理

**Before:** VALID_MODES チェック・Repository 直呼び・レスポンスマッピングがハンドラ内  
**After:** 「パース → DTO → UseCase 呼び出し → JSON レスポンス」のみ

## 確認

```
✅ PHPUnit   318 tests, 1237 assertions
✅ PHPStan   No errors
✅ CS-Fixer  0 files to fix
✅ OpenAPI   valid
✅ MCP       valid
```

Closes #221
Part of #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)