### PR TITLE
refactor(data-migration): UseCase 層の追加・OrganizationRepository のハンドラ直インジェクト除去 (#222)

### DIFF
--- a/src/DataMigration/AssignOrganizationHandler.php
+++ b/src/DataMigration/AssignOrganizationHandler.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace NeNeRecords\DataMigration;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
-use NeNeRecords\Organization\OrganizationRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -19,10 +17,8 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class AssignOrganizationHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private DataMigrationRepositoryInterface $repository,
-        private OrganizationRepositoryInterface $orgs,
+        private AssignOrganizationUseCaseInterface $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
@@ -31,35 +27,14 @@ final readonly class AssignOrganizationHandler implements RequestHandlerInterfac
         $body  = JsonRequestBodyParser::parse($request);
         $orgId = isset($body['target_org_id']) ? (int) $body['target_org_id'] : 0;
 
-        if ($orgId <= 0) {
-            return $this->problemDetails->create(
-                $request,
-                'validation-failed',
-                'Validation Failed',
-                422,
-                'target_org_id must be a positive integer.',
-            );
-        }
-
-        $org = $this->orgs->findById($orgId);
-        if ($org === null) {
-            return $this->problemDetails->create(
-                $request,
-                'org-not-found',
-                'Organization Not Found',
-                404,
-                "No organization found with id {$orgId}.",
-            );
-        }
-
-        $migrated = $this->repository->assignAll($orgId);
-        $total    = array_sum($migrated);
+        $input  = new AssignOrganizationInput(targetOrgId: $orgId);
+        $output = $this->useCase->execute($input);
 
         return $this->json->create([
-            'organization_id'   => $orgId,
-            'organization_name' => $org->name,
-            'total'             => $total,
-            'tables'            => $migrated,
+            'organization_id'   => $output->organizationId,
+            'organization_name' => $output->organizationName,
+            'total'             => $output->total,
+            'tables'            => $output->tables,
         ]);
     }
 }

--- a/src/DataMigration/AssignOrganizationInput.php
+++ b/src/DataMigration/AssignOrganizationInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DataMigration;
+
+final readonly class AssignOrganizationInput
+{
+    public function __construct(
+        public int $targetOrgId,
+    ) {
+    }
+}

--- a/src/DataMigration/AssignOrganizationOutput.php
+++ b/src/DataMigration/AssignOrganizationOutput.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DataMigration;
+
+final readonly class AssignOrganizationOutput
+{
+    /**
+     * @param array<string, int> $tables
+     */
+    public function __construct(
+        public int $organizationId,
+        public string $organizationName,
+        public int $total,
+        public array $tables,
+    ) {
+    }
+}

--- a/src/DataMigration/AssignOrganizationUseCase.php
+++ b/src/DataMigration/AssignOrganizationUseCase.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DataMigration;
+
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeNeRecords\Organization\OrganizationNotFoundException;
+use NeNeRecords\Organization\OrganizationRepositoryInterface;
+
+final readonly class AssignOrganizationUseCase implements AssignOrganizationUseCaseInterface
+{
+    public function __construct(
+        private DataMigrationRepositoryInterface $repository,
+        private OrganizationRepositoryInterface $organizations,
+    ) {
+    }
+
+    public function execute(AssignOrganizationInput $input): AssignOrganizationOutput
+    {
+        if ($input->targetOrgId <= 0) {
+            throw new ValidationException([
+                new ValidationError(
+                    'target_org_id',
+                    'target_org_id must be a positive integer.',
+                    'invalid',
+                ),
+            ]);
+        }
+
+        $org = $this->organizations->findById($input->targetOrgId);
+        if ($org === null) {
+            throw new OrganizationNotFoundException($input->targetOrgId);
+        }
+
+        $migrated = $this->repository->assignAll($input->targetOrgId);
+        $total    = array_sum($migrated);
+
+        return new AssignOrganizationOutput(
+            organizationId: $input->targetOrgId,
+            organizationName: $org->name,
+            total: $total,
+            tables: $migrated,
+        );
+    }
+}

--- a/src/DataMigration/AssignOrganizationUseCaseInterface.php
+++ b/src/DataMigration/AssignOrganizationUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DataMigration;
+
+interface AssignOrganizationUseCaseInterface
+{
+    public function execute(AssignOrganizationInput $input): AssignOrganizationOutput;
+}

--- a/src/DataMigration/DataMigrationServiceProvider.php
+++ b/src/DataMigration/DataMigrationServiceProvider.php
@@ -8,7 +8,6 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use NeNeRecords\Organization\OrganizationRepositoryInterface;
 use Psr\Container\ContainerInterface;
@@ -30,34 +29,62 @@ final readonly class DataMigrationServiceProvider implements ServiceProviderInte
                 },
             )
             ->set(
-                GetDataMigrationStatusHandler::class,
-                static function (ContainerInterface $c): GetDataMigrationStatusHandler {
+                GetDataMigrationStatusUseCaseInterface::class,
+                static function (ContainerInterface $c): GetDataMigrationStatusUseCaseInterface {
                     $repo = $c->get(DataMigrationRepositoryInterface::class);
-                    $json = $c->get(JsonResponseFactory::class);
-                    if (!$repo instanceof DataMigrationRepositoryInterface || !$json instanceof JsonResponseFactory) {
-                        throw new LogicException('GetDataMigrationStatusHandler dependencies are invalid.');
+                    if (!$repo instanceof DataMigrationRepositoryInterface) {
+                        throw new LogicException('DataMigrationRepositoryInterface is invalid.');
                     }
 
-                    return new GetDataMigrationStatusHandler($repo, $json);
+                    return new GetDataMigrationStatusUseCase($repo);
+                },
+            )
+            ->set(
+                AssignOrganizationUseCaseInterface::class,
+                static function (ContainerInterface $c): AssignOrganizationUseCaseInterface {
+                    $repo  = $c->get(DataMigrationRepositoryInterface::class);
+                    $orgs  = $c->get(OrganizationRepositoryInterface::class);
+                    if (!$repo instanceof DataMigrationRepositoryInterface) {
+                        throw new LogicException('DataMigrationRepositoryInterface is invalid.');
+                    }
+
+                    if (!$orgs instanceof OrganizationRepositoryInterface) {
+                        throw new LogicException('OrganizationRepositoryInterface is invalid.');
+                    }
+
+                    return new AssignOrganizationUseCase($repo, $orgs);
+                },
+            )
+            ->set(
+                GetDataMigrationStatusHandler::class,
+                static function (ContainerInterface $c): GetDataMigrationStatusHandler {
+                    $useCase = $c->get(GetDataMigrationStatusUseCaseInterface::class);
+                    $json    = $c->get(JsonResponseFactory::class);
+                    if (!$useCase instanceof GetDataMigrationStatusUseCaseInterface) {
+                        throw new LogicException('GetDataMigrationStatusUseCaseInterface is invalid.');
+                    }
+
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory is invalid.');
+                    }
+
+                    return new GetDataMigrationStatusHandler($useCase, $json);
                 },
             )
             ->set(
                 AssignOrganizationHandler::class,
                 static function (ContainerInterface $c): AssignOrganizationHandler {
-                    $repo    = $c->get(DataMigrationRepositoryInterface::class);
-                    $orgs    = $c->get(OrganizationRepositoryInterface::class);
+                    $useCase = $c->get(AssignOrganizationUseCaseInterface::class);
                     $json    = $c->get(JsonResponseFactory::class);
-                    $problem = $c->get(ProblemDetailsResponseFactory::class);
-                    if (
-                        !$repo instanceof DataMigrationRepositoryInterface
-                        || !$orgs instanceof OrganizationRepositoryInterface
-                        || !$json instanceof JsonResponseFactory
-                        || !$problem instanceof ProblemDetailsResponseFactory
-                    ) {
-                        throw new LogicException('AssignOrganizationHandler dependencies are invalid.');
+                    if (!$useCase instanceof AssignOrganizationUseCaseInterface) {
+                        throw new LogicException('AssignOrganizationUseCaseInterface is invalid.');
                     }
 
-                    return new AssignOrganizationHandler($repo, $orgs, $json, $problem);
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory is invalid.');
+                    }
+
+                    return new AssignOrganizationHandler($useCase, $json);
                 },
             )
             ->set(
@@ -65,8 +92,12 @@ final readonly class DataMigrationServiceProvider implements ServiceProviderInte
                 static function (ContainerInterface $c): DataMigrationRouteRegistrar {
                     $status = $c->get(GetDataMigrationStatusHandler::class);
                     $assign = $c->get(AssignOrganizationHandler::class);
-                    if (!$status instanceof GetDataMigrationStatusHandler || !$assign instanceof AssignOrganizationHandler) {
-                        throw new LogicException('DataMigrationRouteRegistrar dependencies are invalid.');
+                    if (!$status instanceof GetDataMigrationStatusHandler) {
+                        throw new LogicException('GetDataMigrationStatusHandler is invalid.');
+                    }
+
+                    if (!$assign instanceof AssignOrganizationHandler) {
+                        throw new LogicException('AssignOrganizationHandler is invalid.');
                     }
 
                     return new DataMigrationRouteRegistrar($status, $assign);

--- a/src/DataMigration/GetDataMigrationStatusHandler.php
+++ b/src/DataMigration/GetDataMigrationStatusHandler.php
@@ -16,19 +16,18 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class GetDataMigrationStatusHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private DataMigrationRepositoryInterface $repository,
+        private GetDataMigrationStatusUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $counts = $this->repository->countUnassigned();
-        $total  = array_sum($counts);
+        $output = $this->useCase->execute();
 
         return $this->json->create([
-            'total'  => $total,
-            'tables' => $counts,
+            'total'  => $output->total,
+            'tables' => $output->tables,
         ]);
     }
 }

--- a/src/DataMigration/GetDataMigrationStatusOutput.php
+++ b/src/DataMigration/GetDataMigrationStatusOutput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DataMigration;
+
+final readonly class GetDataMigrationStatusOutput
+{
+    /**
+     * @param array<string, int> $tables
+     */
+    public function __construct(
+        public int $total,
+        public array $tables,
+    ) {
+    }
+}

--- a/src/DataMigration/GetDataMigrationStatusUseCase.php
+++ b/src/DataMigration/GetDataMigrationStatusUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DataMigration;
+
+final readonly class GetDataMigrationStatusUseCase implements GetDataMigrationStatusUseCaseInterface
+{
+    public function __construct(
+        private DataMigrationRepositoryInterface $repository,
+    ) {
+    }
+
+    public function execute(): GetDataMigrationStatusOutput
+    {
+        $counts = $this->repository->countUnassigned();
+        $total  = array_sum($counts);
+
+        return new GetDataMigrationStatusOutput(
+            total: $total,
+            tables: $counts,
+        );
+    }
+}

--- a/src/DataMigration/GetDataMigrationStatusUseCaseInterface.php
+++ b/src/DataMigration/GetDataMigrationStatusUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\DataMigration;
+
+interface GetDataMigrationStatusUseCaseInterface
+{
+    public function execute(): GetDataMigrationStatusOutput;
+}


### PR DESCRIPTION
## 目的

DataMigration ドメインの2ハンドラに UseCase 層を追加し、クロスドメイン違反（ハンドラが `OrganizationRepositoryInterface` を直接インジェクト）を解消する。

## 変更内容

### 新規ファイル

| ファイル | 役割 |
|---------|------|
| `GetDataMigrationStatusOutput.php` | GET レスポンス DTO |
| `GetDataMigrationStatusUseCaseInterface.php` | インターフェース |
| `GetDataMigrationStatusUseCase.php` | countUnassigned → Output DTO |
| `AssignOrganizationInput.php` | POST リクエスト DTO |
| `AssignOrganizationOutput.php` | POST レスポンス DTO |
| `AssignOrganizationUseCaseInterface.php` | インターフェース |
| `AssignOrganizationUseCase.php` | バリデーション + org 確認 + マイグレーション実行 |

### クロスドメイン違反の修正

**Before:** `AssignOrganizationHandler` が `OrganizationRepositoryInterface` と `ProblemDetailsResponseFactory` を直接インジェクト  
**After:** `AssignOrganizationUseCase` が `OrganizationRepositoryInterface` を保持（Handler → UseCase の境界に収める）

### バリデーション変更

| ケース | Before | After |
|--------|--------|-------|
| `target_org_id <= 0` | `ProblemDetailsResponseFactory` で直接 422 | `ValidationException` をスロー |
| org 未発見 | `ProblemDetailsResponseFactory` で直接 404 | `OrganizationNotFoundException` をスロー（既存ハンドラが変換） |

## 確認

```
✅ PHPUnit   318 tests, 1237 assertions
✅ PHPStan   No errors
✅ CS-Fixer  0 files to fix
✅ OpenAPI   valid
✅ MCP       valid
```

Closes #222
Part of #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)