### PR TITLE
refactor(entity-archive): UseCase 層の追加・CSV 生成ロジックをハンドラから分離 (#224)

### DIFF
--- a/src/EntityArchive/EntityArchiveServiceProvider.php
+++ b/src/EntityArchive/EntityArchiveServiceProvider.php
@@ -35,20 +35,32 @@ final readonly class EntityArchiveServiceProvider implements ServiceProviderInte
                 },
             )
             ->set(
-                GetEntityArchiveCsvHandler::class,
-                static function (ContainerInterface $c): GetEntityArchiveCsvHandler {
+                GetEntityArchiveCsvUseCaseInterface::class,
+                static function (ContainerInterface $c): GetEntityArchiveCsvUseCaseInterface {
                     $archive = $c->get(EntityArchiveRepositoryInterface::class);
-                    $responseFactory = $c->get(ResponseFactoryInterface::class);
 
                     if (!$archive instanceof EntityArchiveRepositoryInterface) {
                         throw new LogicException('Entity archive repository service is invalid.');
+                    }
+
+                    return new GetEntityArchiveCsvUseCase($archive);
+                },
+            )
+            ->set(
+                GetEntityArchiveCsvHandler::class,
+                static function (ContainerInterface $c): GetEntityArchiveCsvHandler {
+                    $useCase         = $c->get(GetEntityArchiveCsvUseCaseInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof GetEntityArchiveCsvUseCaseInterface) {
+                        throw new LogicException('GetEntityArchiveCsvUseCaseInterface service is invalid.');
                     }
 
                     if (!$responseFactory instanceof ResponseFactoryInterface) {
                         throw new LogicException('Response factory service is invalid.');
                     }
 
-                    return new GetEntityArchiveCsvHandler($archive, $responseFactory);
+                    return new GetEntityArchiveCsvHandler($useCase, $responseFactory);
                 },
             )
             ->set(
@@ -57,7 +69,7 @@ final readonly class EntityArchiveServiceProvider implements ServiceProviderInte
                     $csv = $c->get(GetEntityArchiveCsvHandler::class);
 
                     if (!$csv instanceof GetEntityArchiveCsvHandler) {
-                        throw new \LogicException('GetEntityArchiveCsv handler service is invalid.');
+                        throw new LogicException('GetEntityArchiveCsv handler service is invalid.');
                     }
 
                     return new EntityArchiveRouteRegistrar($csv);

--- a/src/EntityArchive/GetEntityArchiveCsvHandler.php
+++ b/src/EntityArchive/GetEntityArchiveCsvHandler.php
@@ -8,13 +8,13 @@ use Nene2\Routing\Router;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use RuntimeException;
 
 final readonly class GetEntityArchiveCsvHandler
 {
-    private const int PAGE_SIZE = 500;
-
     public function __construct(
-        private EntityArchiveRepositoryInterface $archive,
+        private GetEntityArchiveCsvUseCaseInterface $useCase,
         private ResponseFactoryInterface $responseFactory,
     ) {
     }
@@ -24,10 +24,27 @@ final readonly class GetEntityArchiveCsvHandler
         $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $entityTypeId = (int) ($parameters['entity_type_id'] ?? 0);
 
+        $input  = new GetEntityArchiveCsvInput(entityTypeId: $entityTypeId);
+        $output = $this->useCase->execute($input);
+
+        $csv      = $this->buildCsv($output->rows);
+        $filename = "entity_archive_{$output->entityTypeId}_" . date('Ymd_His') . '.csv';
+
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'text/csv; charset=UTF-8')
+            ->withHeader('Content-Disposition', "attachment; filename=\"{$filename}\"")
+            ->withBody($this->streamFromString($csv));
+    }
+
+    /**
+     * @param list<ArchivedEntity> $rows
+     */
+    private function buildCsv(array $rows): string
+    {
         $output = fopen('php://temp', 'r+');
 
         if ($output === false) {
-            throw new \RuntimeException('Failed to open temp stream.');
+            throw new RuntimeException('Failed to open temp stream.');
         }
 
         fputcsv($output, [
@@ -42,47 +59,33 @@ final readonly class GetEntityArchiveCsvHandler
             'snapshot',
         ], escape: '\\');
 
-        $offset = 0;
-
-        do {
-            $entries = $this->archive->findByEntityTypeId($entityTypeId, self::PAGE_SIZE, $offset);
-
-            foreach ($entries as $entry) {
-                fputcsv($output, escape: '\\', fields: [
-                    $entry->originalEntityId,
-                    $entry->entityTypeSlug,
-                    $entry->entityTypeName,
-                    $entry->entitySlug ?? '',
-                    $entry->entityStatus,
-                    $entry->deletedAt?->format('Y-m-d H:i:s') ?? '',
-                    $entry->archivedAt->format('Y-m-d H:i:s'),
-                    $entry->archivedReason,
-                    json_encode($entry->snapshot, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR),
-                ]);
-            }
-
-
-            $offset += self::PAGE_SIZE;
-        } while (count($entries) === self::PAGE_SIZE);
+        foreach ($rows as $entry) {
+            fputcsv($output, escape: '\\', fields: [
+                $entry->originalEntityId,
+                $entry->entityTypeSlug,
+                $entry->entityTypeName,
+                $entry->entitySlug ?? '',
+                $entry->entityStatus,
+                $entry->deletedAt?->format('Y-m-d H:i:s') ?? '',
+                $entry->archivedAt->format('Y-m-d H:i:s'),
+                $entry->archivedReason,
+                json_encode($entry->snapshot, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR),
+            ]);
+        }
 
         rewind($output);
         $csv = stream_get_contents($output);
         fclose($output);
 
-        $filename = "entity_archive_{$entityTypeId}_" . date('Ymd_His') . '.csv';
-
-        return $this->responseFactory->createResponse(200)
-            ->withHeader('Content-Type', 'text/csv; charset=UTF-8')
-            ->withHeader('Content-Disposition', "attachment; filename=\"{$filename}\"")
-            ->withBody($this->streamFromString($csv !== false ? $csv : ''));
+        return $csv !== false ? $csv : '';
     }
 
-    private function streamFromString(string $content): \Psr\Http\Message\StreamInterface
+    private function streamFromString(string $content): StreamInterface
     {
         $stream = fopen('php://temp', 'r+');
 
         if ($stream === false) {
-            throw new \RuntimeException('Failed to create stream.');
+            throw new RuntimeException('Failed to create stream.');
         }
 
         fwrite($stream, $content);

--- a/src/EntityArchive/GetEntityArchiveCsvInput.php
+++ b/src/EntityArchive/GetEntityArchiveCsvInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityArchive;
+
+final readonly class GetEntityArchiveCsvInput
+{
+    public function __construct(
+        public int $entityTypeId,
+    ) {
+    }
+}

--- a/src/EntityArchive/GetEntityArchiveCsvOutput.php
+++ b/src/EntityArchive/GetEntityArchiveCsvOutput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityArchive;
+
+final readonly class GetEntityArchiveCsvOutput
+{
+    /**
+     * @param list<ArchivedEntity> $rows
+     */
+    public function __construct(
+        public int $entityTypeId,
+        public array $rows,
+    ) {
+    }
+}

--- a/src/EntityArchive/GetEntityArchiveCsvUseCase.php
+++ b/src/EntityArchive/GetEntityArchiveCsvUseCase.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityArchive;
+
+final readonly class GetEntityArchiveCsvUseCase implements GetEntityArchiveCsvUseCaseInterface
+{
+    private const int PAGE_SIZE = 500;
+
+    public function __construct(
+        private EntityArchiveRepositoryInterface $archive,
+    ) {
+    }
+
+    public function execute(GetEntityArchiveCsvInput $input): GetEntityArchiveCsvOutput
+    {
+        $rows = [];
+        $offset = 0;
+
+        do {
+            $entries = $this->archive->findByEntityTypeId($input->entityTypeId, self::PAGE_SIZE, $offset);
+
+            foreach ($entries as $entry) {
+                $rows[] = $entry;
+            }
+
+            $offset += self::PAGE_SIZE;
+        } while (count($entries) === self::PAGE_SIZE);
+
+        return new GetEntityArchiveCsvOutput(
+            entityTypeId: $input->entityTypeId,
+            rows: $rows,
+        );
+    }
+}

--- a/src/EntityArchive/GetEntityArchiveCsvUseCaseInterface.php
+++ b/src/EntityArchive/GetEntityArchiveCsvUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityArchive;
+
+interface GetEntityArchiveCsvUseCaseInterface
+{
+    public function execute(GetEntityArchiveCsvInput $input): GetEntityArchiveCsvOutput;
+}


### PR DESCRIPTION
## 目的

`GetEntityArchiveCsvHandler` に UseCase 層を追加し、ページネーションループによるデータ取得をハンドラから分離する。

## 変更内容

| ファイル | 役割 |
|---------|------|
| `GetEntityArchiveCsvInput.php` | リクエスト DTO（entityTypeId） |
| `GetEntityArchiveCsvOutput.php` | レスポンス DTO（entityTypeId + rows） |
| `GetEntityArchiveCsvUseCaseInterface.php` | インターフェース |
| `GetEntityArchiveCsvUseCase.php` | 500件単位のページネーションループ |

**Before:** ハンドラがページネーションループ + `fputcsv` + HTTP レスポンスをすべて担当  
**After:**
- UseCase: ページネーションループで全 `ArchivedEntity` を収集して Output DTO で返す
- ハンドラ: Input DTO 組み立て → UseCase 呼び出し → CSV 文字列生成 → HTTP レスポンス

## 確認

```
✅ PHPUnit   318 tests, 1237 assertions
✅ PHPStan   No errors
✅ CS-Fixer  0 files to fix
✅ OpenAPI   valid
✅ MCP       valid
```

Closes #224
Part of #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)