### PR TITLE
refactor(frontend): data-migration / system-config / org-export entity に model.ts・mapper.ts・query-keys.ts を追加 (#225 #226 #227)

### DIFF
--- a/frontend/src/entities/data-migration/index.ts
+++ b/frontend/src/entities/data-migration/index.ts
@@ -1,3 +1,6 @@
 export type { DataMigrationStatusDto, AssignOrgResultDto } from './api-types'
-export { useDataMigrationStatus, dataMigrationKeys } from './queries'
+export type { DataMigrationStatus, AssignOrgResult } from './model'
+export { mapDataMigrationStatusDtoToModel, mapAssignOrgResultDtoToModel } from './mapper'
+export { dataMigrationKeys } from './query-keys'
+export { useDataMigrationStatus } from './queries'
 export { useAssignOrg } from './mutations'

--- a/frontend/src/entities/data-migration/mapper.ts
+++ b/frontend/src/entities/data-migration/mapper.ts
@@ -1,0 +1,18 @@
+import type { DataMigrationStatusDto, AssignOrgResultDto } from './api-types'
+import type { DataMigrationStatus, AssignOrgResult } from './model'
+
+export function mapDataMigrationStatusDtoToModel(dto: DataMigrationStatusDto): DataMigrationStatus {
+  return {
+    total: dto.total,
+    tables: dto.tables,
+  }
+}
+
+export function mapAssignOrgResultDtoToModel(dto: AssignOrgResultDto): AssignOrgResult {
+  return {
+    organizationId: dto.organization_id,
+    organizationName: dto.organization_name,
+    total: dto.total,
+    tables: dto.tables,
+  }
+}

--- a/frontend/src/entities/data-migration/model.ts
+++ b/frontend/src/entities/data-migration/model.ts
@@ -1,0 +1,11 @@
+export interface DataMigrationStatus {
+  total: number
+  tables: Record<string, number>
+}
+
+export interface AssignOrgResult {
+  organizationId: number
+  organizationName: string
+  total: number
+  tables: Record<string, number>
+}

--- a/frontend/src/entities/data-migration/mutations.ts
+++ b/frontend/src/entities/data-migration/mutations.ts
@@ -1,10 +1,12 @@
 import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
 import { apiClient, AppError } from '@/shared/api/client'
 import type { AssignOrgResultDto } from './api-types'
-import { dataMigrationKeys } from './queries'
+import { mapAssignOrgResultDtoToModel } from './mapper'
+import type { AssignOrgResult } from './model'
+import { dataMigrationKeys } from './query-keys'
 
 export function useAssignOrg(): UseMutationResult<
-  AssignOrgResultDto,
+  AssignOrgResult,
   AppError,
   { targetOrgId: number }
 > {
@@ -12,9 +14,11 @@ export function useAssignOrg(): UseMutationResult<
 
   return useMutation({
     mutationFn: async ({ targetOrgId }) => {
-      return apiClient.post<AssignOrgResultDto>('/api/v1/superadmin/data-migration/assign-org', {
-        target_org_id: targetOrgId,
-      })
+      const dto = await apiClient.post<AssignOrgResultDto>(
+        '/api/v1/superadmin/data-migration/assign-org',
+        { target_org_id: targetOrgId },
+      )
+      return mapAssignOrgResultDtoToModel(dto)
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: dataMigrationKeys.status() })

--- a/frontend/src/entities/data-migration/queries.ts
+++ b/frontend/src/entities/data-migration/queries.ts
@@ -1,19 +1,19 @@
 import { useQuery, type UseQueryResult } from '@tanstack/react-query'
 import { apiClient, AppError } from '@/shared/api/client'
 import type { DataMigrationStatusDto } from './api-types'
+import { mapDataMigrationStatusDtoToModel } from './mapper'
+import type { DataMigrationStatus } from './model'
+import { dataMigrationKeys } from './query-keys'
 
-export const dataMigrationKeys = {
-  status: () => ['data-migration', 'status'] as const,
-}
-
-export function useDataMigrationStatus(): UseQueryResult<DataMigrationStatusDto, AppError> {
+export function useDataMigrationStatus(): UseQueryResult<DataMigrationStatus, AppError> {
   return useQuery({
     queryKey: dataMigrationKeys.status(),
     queryFn: async ({ signal }) => {
-      return apiClient.get<DataMigrationStatusDto>(
+      const dto = await apiClient.get<DataMigrationStatusDto>(
         '/api/v1/superadmin/data-migration/status',
         signal,
       )
+      return mapDataMigrationStatusDtoToModel(dto)
     },
   })
 }

--- a/frontend/src/entities/data-migration/query-keys.ts
+++ b/frontend/src/entities/data-migration/query-keys.ts
@@ -1,0 +1,4 @@
+export const dataMigrationKeys = {
+  all: ['data-migration'] as const,
+  status: () => [...dataMigrationKeys.all, 'status'] as const,
+}

--- a/frontend/src/entities/org-export/index.ts
+++ b/frontend/src/entities/org-export/index.ts
@@ -1,3 +1,6 @@
 export type { OrgImportResultDto } from './api-types'
+export type { OrgImportResult } from './model'
+export { mapOrgImportResultDtoToModel } from './mapper'
+export { orgExportKeys } from './query-keys'
 export { fetchOrgExport } from './queries'
 export { useImportOrg } from './mutations'

--- a/frontend/src/entities/org-export/mapper.ts
+++ b/frontend/src/entities/org-export/mapper.ts
@@ -1,0 +1,11 @@
+import type { OrgImportResultDto } from './api-types'
+import type { OrgImportResult } from './model'
+
+export function mapOrgImportResultDtoToModel(dto: OrgImportResultDto): OrgImportResult {
+  return {
+    organizationId: dto.organization_id,
+    organizationName: dto.organization_name,
+    total: dto.total,
+    imported: dto.imported,
+  }
+}

--- a/frontend/src/entities/org-export/model.ts
+++ b/frontend/src/entities/org-export/model.ts
@@ -1,0 +1,6 @@
+export interface OrgImportResult {
+  organizationId: number
+  organizationName: string
+  total: number
+  imported: Record<string, number>
+}

--- a/frontend/src/entities/org-export/mutations.ts
+++ b/frontend/src/entities/org-export/mutations.ts
@@ -1,16 +1,19 @@
 import { useMutation, type UseMutationResult } from '@tanstack/react-query'
 import { apiClient, AppError } from '@/shared/api/client'
 import type { OrgImportResultDto } from './api-types'
+import { mapOrgImportResultDtoToModel } from './mapper'
+import type { OrgImportResult } from './model'
 
 export function useImportOrg(
   orgId: number,
-): UseMutationResult<OrgImportResultDto, AppError, Record<string, unknown>> {
+): UseMutationResult<OrgImportResult, AppError, Record<string, unknown>> {
   return useMutation({
     mutationFn: async (payload) => {
-      return apiClient.post<OrgImportResultDto>(
+      const dto = await apiClient.post<OrgImportResultDto>(
         `/api/v1/superadmin/organizations/${String(orgId)}/import`,
         payload,
       )
+      return mapOrgImportResultDtoToModel(dto)
     },
   })
 }

--- a/frontend/src/entities/org-export/query-keys.ts
+++ b/frontend/src/entities/org-export/query-keys.ts
@@ -1,0 +1,4 @@
+export const orgExportKeys = {
+  all: ['org-export'] as const,
+  export: (orgId: number) => [...orgExportKeys.all, 'export', orgId] as const,
+}

--- a/frontend/src/entities/system-config/index.ts
+++ b/frontend/src/entities/system-config/index.ts
@@ -1,2 +1,6 @@
 export type { SystemConfigDto } from './api-types'
-export { useSystemConfig, useUpdateSystemConfig } from './queries'
+export type { SystemConfig, UpdateSystemConfigInput, TenantResolutionMode } from './model'
+export { mapSystemConfigDtoToModel, mapUpdateInputToDto } from './mapper'
+export { systemConfigKeys } from './query-keys'
+export { useSystemConfig } from './queries'
+export { useUpdateSystemConfig } from './mutations'

--- a/frontend/src/entities/system-config/mapper.ts
+++ b/frontend/src/entities/system-config/mapper.ts
@@ -1,0 +1,20 @@
+import type { SystemConfigDto } from './api-types'
+import type { SystemConfig, UpdateSystemConfigInput } from './model'
+
+export function mapSystemConfigDtoToModel(dto: SystemConfigDto): SystemConfig {
+  return {
+    tenantResolutionMode: dto.tenant_resolution_mode,
+    tenantOrgSlug: dto.tenant_org_slug,
+    tenantBaseDomain: dto.tenant_base_domain,
+  }
+}
+
+export function mapUpdateInputToDto(input: UpdateSystemConfigInput): Partial<SystemConfigDto> {
+  return {
+    ...(input.tenantResolutionMode !== undefined && {
+      tenant_resolution_mode: input.tenantResolutionMode,
+    }),
+    ...(input.tenantOrgSlug !== undefined && { tenant_org_slug: input.tenantOrgSlug }),
+    ...(input.tenantBaseDomain !== undefined && { tenant_base_domain: input.tenantBaseDomain }),
+  }
+}

--- a/frontend/src/entities/system-config/model.ts
+++ b/frontend/src/entities/system-config/model.ts
@@ -1,0 +1,13 @@
+export type TenantResolutionMode = 'single' | 'subdomain' | 'path'
+
+export interface SystemConfig {
+  tenantResolutionMode: TenantResolutionMode
+  tenantOrgSlug: string
+  tenantBaseDomain: string
+}
+
+export interface UpdateSystemConfigInput {
+  tenantResolutionMode?: TenantResolutionMode
+  tenantOrgSlug?: string
+  tenantBaseDomain?: string
+}

--- a/frontend/src/entities/system-config/mutations.ts
+++ b/frontend/src/entities/system-config/mutations.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
+import { apiClient } from '@/shared/api/client'
+import type { SystemConfigDto } from './api-types'
+import { mapSystemConfigDtoToModel, mapUpdateInputToDto } from './mapper'
+import type { SystemConfig, UpdateSystemConfigInput } from './model'
+import { systemConfigKeys } from './query-keys'
+
+export function useUpdateSystemConfig(): UseMutationResult<
+  SystemConfig,
+  Error,
+  UpdateSystemConfigInput
+> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input) => {
+      const dto = await apiClient.patch<SystemConfigDto>(
+        '/api/v1/superadmin/system-config',
+        mapUpdateInputToDto(input),
+      )
+      return mapSystemConfigDtoToModel(dto)
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(systemConfigKeys.detail(), data)
+    },
+  })
+}

--- a/frontend/src/entities/system-config/queries.ts
+++ b/frontend/src/entities/system-config/queries.ts
@@ -1,23 +1,16 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
 import { apiClient } from '@/shared/api/client'
 import type { SystemConfigDto } from './api-types'
+import { mapSystemConfigDtoToModel } from './mapper'
+import type { SystemConfig } from './model'
+import { systemConfigKeys } from './query-keys'
 
-const QUERY_KEY = ['system-config'] as const
-
-export function useSystemConfig() {
-  return useQuery<SystemConfigDto>({
-    queryKey: QUERY_KEY,
-    queryFn: () => apiClient.get<SystemConfigDto>('/api/v1/superadmin/system-config'),
-  })
-}
-
-export function useUpdateSystemConfig() {
-  const queryClient = useQueryClient()
-  return useMutation<SystemConfigDto, Error, Partial<SystemConfigDto>>({
-    mutationFn: (input) =>
-      apiClient.patch<SystemConfigDto>('/api/v1/superadmin/system-config', input),
-    onSuccess: (data) => {
-      queryClient.setQueryData(QUERY_KEY, data)
+export function useSystemConfig(): UseQueryResult<SystemConfig> {
+  return useQuery({
+    queryKey: systemConfigKeys.detail(),
+    queryFn: async () => {
+      const dto = await apiClient.get<SystemConfigDto>('/api/v1/superadmin/system-config')
+      return mapSystemConfigDtoToModel(dto)
     },
   })
 }

--- a/frontend/src/entities/system-config/query-keys.ts
+++ b/frontend/src/entities/system-config/query-keys.ts
@@ -1,0 +1,4 @@
+export const systemConfigKeys = {
+  all: ['system-config'] as const,
+  detail: () => [...systemConfigKeys.all, 'detail'] as const,
+}

--- a/frontend/src/pages/superadmin/DataMigrationPage.tsx
+++ b/frontend/src/pages/superadmin/DataMigrationPage.tsx
@@ -25,7 +25,7 @@ export function DataMigrationPage() {
       {
         onSuccess: (result) => {
           showToast(
-            `Migrated ${String(result.total)} records to "${result.organization_name}".`,
+            `Migrated ${String(result.total)} records to "${result.organizationName}".`,
             'success',
           )
         },

--- a/frontend/src/pages/superadmin/OrganizationDetailPage.tsx
+++ b/frontend/src/pages/superadmin/OrganizationDetailPage.tsx
@@ -94,7 +94,7 @@ export function OrganizationDetailPage() {
         importOrg.mutate(payload, {
           onSuccess: (result) => {
             showToast(
-              `Imported ${String(result.total)} records into "${result.organization_name}".`,
+              `Imported ${String(result.total)} records into "${result.organizationName}".`,
               'success',
             )
           },

--- a/frontend/src/pages/superadmin/SettingsPage.tsx
+++ b/frontend/src/pages/superadmin/SettingsPage.tsx
@@ -1,12 +1,10 @@
 import { useState } from 'react'
 import { useSystemConfig, useUpdateSystemConfig } from '@/entities/system-config'
-import type { SystemConfigDto } from '@/entities/system-config'
+import type { TenantResolutionMode } from '@/entities/system-config'
 import { Button, Input, Stack, Text } from '@/shared/ui'
 import { useToast } from '@/shared/ui'
 
-type ResolutionMode = SystemConfigDto['tenant_resolution_mode']
-
-const MODES: { value: ResolutionMode; label: string; description: string }[] = [
+const MODES: { value: TenantResolutionMode; label: string; description: string }[] = [
   {
     value: 'single',
     label: 'シングルテナント（固定 org）',
@@ -30,21 +28,21 @@ export function SettingsPage() {
   const update = useUpdateSystemConfig()
 
   // undefined = 未編集 → loaded data にフォールバック（useEffect 不要）
-  const [mode, setMode] = useState<ResolutionMode | undefined>(undefined)
+  const [mode, setMode] = useState<TenantResolutionMode | undefined>(undefined)
   const [orgSlug, setOrgSlug] = useState<string | undefined>(undefined)
   const [baseDomain, setBaseDomain] = useState<string | undefined>(undefined)
 
-  const currentMode = mode ?? data?.tenant_resolution_mode ?? 'single'
-  const currentOrgSlug = orgSlug ?? data?.tenant_org_slug ?? ''
-  const currentBaseDomain = baseDomain ?? data?.tenant_base_domain ?? 'localhost'
+  const currentMode = mode ?? data?.tenantResolutionMode ?? 'single'
+  const currentOrgSlug = orgSlug ?? data?.tenantOrgSlug ?? ''
+  const currentBaseDomain = baseDomain ?? data?.tenantBaseDomain ?? 'localhost'
 
   function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault()
     update.mutate(
       {
-        tenant_resolution_mode: currentMode,
-        tenant_org_slug: currentOrgSlug.trim(),
-        tenant_base_domain: currentBaseDomain.trim(),
+        tenantResolutionMode: currentMode,
+        tenantOrgSlug: currentOrgSlug.trim(),
+        tenantBaseDomain: currentBaseDomain.trim(),
       },
       {
         onSuccess: () => {
@@ -189,18 +187,18 @@ export function SettingsPage() {
           <dl className="mt-3 space-y-2 text-sm">
             <div className="flex gap-3">
               <dt className="w-44 shrink-0 text-text-muted">解決方式</dt>
-              <dd className="font-mono text-text-primary">{data.tenant_resolution_mode}</dd>
+              <dd className="font-mono text-text-primary">{data.tenantResolutionMode}</dd>
             </div>
-            {data.tenant_org_slug !== '' && (
+            {data.tenantOrgSlug !== '' && (
               <div className="flex gap-3">
                 <dt className="w-44 shrink-0 text-text-muted">組織スラッグ</dt>
-                <dd className="font-mono text-text-primary">{data.tenant_org_slug}</dd>
+                <dd className="font-mono text-text-primary">{data.tenantOrgSlug}</dd>
               </div>
             )}
-            {data.tenant_resolution_mode === 'subdomain' && (
+            {data.tenantResolutionMode === 'subdomain' && (
               <div className="flex gap-3">
                 <dt className="w-44 shrink-0 text-text-muted">ベースドメイン</dt>
-                <dd className="font-mono text-text-primary">{data.tenant_base_domain}</dd>
+                <dd className="font-mono text-text-primary">{data.tenantBaseDomain}</dd>
               </div>
             )}
           </dl>


### PR DESCRIPTION
## 目的

frontend-standards の entity 配置規約（model.ts / mapper.ts / query-keys.ts 必須）に準拠する。

## 変更内容

### data-migration (#225)

| ファイル | 変更 |
|---------|------|
| `model.ts` | `DataMigrationStatus` / `AssignOrgResult`（camelCase） |
| `mapper.ts` | DTO → model 純粋関数 |
| `query-keys.ts` | `dataMigrationKeys` ファクトリ |
| `queries.ts` | mapper 経由に更新 |
| `mutations.ts` | mapper 経由・camelCase 型を返す |
| `DataMigrationPage.tsx` | `result.organizationName` に修正 |

### system-config (#226)

| ファイル | 変更 |
|---------|------|
| `model.ts` | `SystemConfig` / `UpdateSystemConfigInput` / `TenantResolutionMode` |
| `mapper.ts` | DTO ↔ model 変換 |
| `query-keys.ts` | `systemConfigKeys` ファクトリ |
| `queries.ts` | mapper 経由・GET のみ |
| `mutations.ts` | 新規（queries.ts から分離）|
| `SettingsPage.tsx` | camelCase プロパティに全面更新 |

### org-export (#227)

| ファイル | 変更 |
|---------|------|
| `model.ts` | `OrgImportResult`（camelCase） |
| `mapper.ts` | DTO → model 純粋関数 |
| `query-keys.ts` | `orgExportKeys` ファクトリ |
| `mutations.ts` | mapper 経由に更新 |
| `OrganizationDetailPage.tsx` | `result.organizationName` に修正 |

## 確認

```
✅ type-check   no errors
✅ lint         0 warnings
✅ format       ok
✅ test         84 passed
✅ storybook    build ok
```

Closes #225
Closes #226
Closes #227
Part of #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)