### PR TITLE
refactor(frontend): comment-section・manage-entity-status の Hook+View パターン修正

### DIFF
--- a/frontend/src/features/comment-section/hooks/useCommentSection.ts
+++ b/frontend/src/features/comment-section/hooks/useCommentSection.ts
@@ -1,0 +1,66 @@
+import { useState } from 'react'
+import type { Comment } from '@/entities/comment'
+import { useCommentList, usePostComment } from '@/entities/comment'
+
+export interface CommentSectionState {
+  comments: Comment[]
+  isLoading: boolean
+  isError: boolean
+  authorName: string
+  authorEmail: string
+  body: string
+  submitted: boolean
+  isPending: boolean
+  isPostError: boolean
+  onAuthorNameChange: (value: string) => void
+  onAuthorEmailChange: (value: string) => void
+  onBodyChange: (value: string) => void
+  onSubmit: (e: React.SyntheticEvent) => void
+}
+
+export function useCommentSection(entityId: number): CommentSectionState {
+  const commentsQuery = useCommentList(entityId)
+  const postComment = usePostComment()
+
+  const [authorName, setAuthorName] = useState('')
+  const [authorEmail, setAuthorEmail] = useState('')
+  const [body, setBody] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+
+  function onSubmit(e: React.SyntheticEvent) {
+    e.preventDefault()
+    setSubmitted(false)
+    postComment.mutate(
+      {
+        entityId,
+        authorName: authorName.trim(),
+        authorEmail: authorEmail.trim(),
+        body: body.trim(),
+      },
+      {
+        onSuccess: () => {
+          setAuthorName('')
+          setAuthorEmail('')
+          setBody('')
+          setSubmitted(true)
+        },
+      },
+    )
+  }
+
+  return {
+    comments: commentsQuery.data?.items ?? [],
+    isLoading: commentsQuery.isLoading,
+    isError: commentsQuery.isError,
+    authorName,
+    authorEmail,
+    body,
+    submitted,
+    isPending: postComment.isPending,
+    isPostError: postComment.isError,
+    onAuthorNameChange: setAuthorName,
+    onAuthorEmailChange: setAuthorEmail,
+    onBodyChange: setBody,
+    onSubmit,
+  }
+}

--- a/frontend/src/features/comment-section/index.ts
+++ b/frontend/src/features/comment-section/index.ts
@@ -1,1 +1,3 @@
 export { CommentSection } from './ui/CommentSection'
+export { useCommentSection } from './hooks/useCommentSection'
+export type { CommentSectionState } from './hooks/useCommentSection'

--- a/frontend/src/features/comment-section/ui/CommentSection.tsx
+++ b/frontend/src/features/comment-section/ui/CommentSection.tsx
@@ -1,44 +1,39 @@
-import { useCommentList, usePostComment } from '@/entities/comment'
+import type { Comment } from '@/entities/comment'
 import { useTranslation } from '@/shared/i18n'
 import { Button, Input, Stack, Text } from '@/shared/ui'
-import { useState } from 'react'
 
 interface Props {
-  entityId: number
+  comments: Comment[]
+  isLoading: boolean
+  isError: boolean
+  authorName: string
+  authorEmail: string
+  body: string
+  submitted: boolean
+  isPending: boolean
+  isPostError: boolean
+  onAuthorNameChange: (value: string) => void
+  onAuthorEmailChange: (value: string) => void
+  onBodyChange: (value: string) => void
+  onSubmit: (e: React.SyntheticEvent) => void
 }
 
-export function CommentSection({ entityId }: Props) {
+export function CommentSection({
+  comments,
+  isLoading,
+  isError,
+  authorName,
+  authorEmail,
+  body,
+  submitted,
+  isPending,
+  isPostError,
+  onAuthorNameChange,
+  onAuthorEmailChange,
+  onBodyChange,
+  onSubmit,
+}: Props) {
   const { t } = useTranslation()
-  const commentsQuery = useCommentList(entityId)
-  const postComment = usePostComment()
-
-  const [authorName, setAuthorName] = useState('')
-  const [authorEmail, setAuthorEmail] = useState('')
-  const [body, setBody] = useState('')
-  const [submitted, setSubmitted] = useState(false)
-
-  function handleSubmit(e: React.SyntheticEvent) {
-    e.preventDefault()
-    setSubmitted(false)
-    postComment.mutate(
-      {
-        entityId,
-        authorName: authorName.trim(),
-        authorEmail: authorEmail.trim(),
-        body: body.trim(),
-      },
-      {
-        onSuccess: () => {
-          setAuthorName('')
-          setAuthorEmail('')
-          setBody('')
-          setSubmitted(true)
-        },
-      },
-    )
-  }
-
-  const comments = commentsQuery.data?.items ?? []
 
   return (
     <Stack gap="lg">
@@ -47,9 +42,9 @@ export function CommentSection({ entityId }: Props) {
       </Text>
 
       {/* Comment list */}
-      {commentsQuery.isLoading ? (
+      {isLoading ? (
         <Text muted>{t('public.comments.loading')}</Text>
-      ) : commentsQuery.isError ? (
+      ) : isError ? (
         <Text muted>{t('public.comments.loadError')}</Text>
       ) : comments.length === 0 ? (
         <Text muted>{t('public.comments.empty')}</Text>
@@ -86,7 +81,7 @@ export function CommentSection({ entityId }: Props) {
             {t('public.comments.form.success')}
           </p>
         ) : null}
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={onSubmit}>
           <Stack gap="md">
             <Input
               id="comment-author-name"
@@ -94,9 +89,9 @@ export function CommentSection({ entityId }: Props) {
               type="text"
               value={authorName}
               onChange={(e) => {
-                setAuthorName(e.target.value)
+                onAuthorNameChange(e.target.value)
               }}
-              disabled={postComment.isPending}
+              disabled={isPending}
             />
             <Input
               id="comment-author-email"
@@ -104,9 +99,9 @@ export function CommentSection({ entityId }: Props) {
               type="email"
               value={authorEmail}
               onChange={(e) => {
-                setAuthorEmail(e.target.value)
+                onAuthorEmailChange(e.target.value)
               }}
-              disabled={postComment.isPending}
+              disabled={isPending}
             />
             <div className="flex flex-col gap-stack-xs">
               <label
@@ -119,17 +114,17 @@ export function CommentSection({ entityId }: Props) {
                 id="comment-body"
                 value={body}
                 onChange={(e) => {
-                  setBody(e.target.value)
+                  onBodyChange(e.target.value)
                 }}
-                disabled={postComment.isPending}
+                disabled={isPending}
                 rows={4}
                 className="rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm font-sans text-body text-text-primary shadow-sm focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-50"
               />
             </div>
-            {postComment.isError ? <Text muted>{t('public.comments.form.error')}</Text> : null}
+            {isPostError ? <Text muted>{t('public.comments.form.error')}</Text> : null}
             <div>
-              <Button type="submit" disabled={postComment.isPending}>
-                {postComment.isPending
+              <Button type="submit" disabled={isPending}>
+                {isPending
                   ? t('public.comments.form.submitting')
                   : t('public.comments.form.submit')}
               </Button>

--- a/frontend/src/features/manage-entity-status/hooks/useEntityRevisionsPanel.ts
+++ b/frontend/src/features/manage-entity-status/hooks/useEntityRevisionsPanel.ts
@@ -1,0 +1,28 @@
+import { useState } from 'react'
+import type { EntityRevision } from '@/entities/entity'
+import { toEntityId, useEntityRevisions } from '@/entities/entity'
+
+export interface EntityRevisionsPanelState {
+  revisions: EntityRevision[]
+  isLoading: boolean
+  isError: boolean
+  isExpanded: boolean
+  onToggle: () => void
+}
+
+export function useEntityRevisionsPanel(entityId: number): EntityRevisionsPanelState {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const revisionsQuery = useEntityRevisions(toEntityId(entityId))
+
+  function onToggle() {
+    setIsExpanded((prev) => !prev)
+  }
+
+  return {
+    revisions: revisionsQuery.data?.items ?? [],
+    isLoading: revisionsQuery.isLoading,
+    isError: revisionsQuery.isError,
+    isExpanded,
+    onToggle,
+  }
+}

--- a/frontend/src/features/manage-entity-status/hooks/useEntitySeoPanel.ts
+++ b/frontend/src/features/manage-entity-status/hooks/useEntitySeoPanel.ts
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+import type { Entity } from '@/entities/entity'
+import { useUpdateEntity } from '@/entities/entity'
+import { useTranslation } from '@/shared/i18n'
+import { useToast } from '@/shared/ui'
+
+export interface EntitySeoPanelState {
+  metaTitle: string
+  metaDescription: string
+  isPending: boolean
+  onMetaTitleChange: (value: string) => void
+  onMetaDescriptionChange: (value: string) => void
+  onSave: () => void
+}
+
+/**
+ * Orchestration hook for EntitySeoPanel.
+ * Accepts a non-null entity — call site should guard with `entity !== null`.
+ */
+export function useEntitySeoPanel(entity: Entity): EntitySeoPanelState {
+  const { t } = useTranslation()
+  const { showToast } = useToast()
+  const updateMutation = useUpdateEntity()
+
+  const [metaTitle, setMetaTitle] = useState(entity.metaTitle ?? '')
+  const [metaDescription, setMetaDescription] = useState(entity.metaDescription ?? '')
+
+  function onSave() {
+    void updateMutation
+      .mutateAsync({
+        id: Number(entity.id),
+        entityTypeId: entity.entityTypeId,
+        slug: entity.slug,
+        status: entity.status,
+        metaTitle: metaTitle !== '' ? metaTitle : null,
+        metaDescription: metaDescription !== '' ? metaDescription : null,
+      })
+      .then(() => {
+        showToast(t('admin.entitySeo.saveSuccess'), 'success')
+      })
+      .catch(() => {
+        showToast(t('common.error.serverError'), 'error')
+      })
+  }
+
+  return {
+    metaTitle,
+    metaDescription,
+    isPending: updateMutation.isPending,
+    onMetaTitleChange: setMetaTitle,
+    onMetaDescriptionChange: setMetaDescription,
+    onSave,
+  }
+}

--- a/frontend/src/features/manage-entity-status/index.ts
+++ b/frontend/src/features/manage-entity-status/index.ts
@@ -1,3 +1,7 @@
 export { EntityRevisionsPanel } from './ui/EntityRevisionsPanel'
 export { EntitySeoPanel } from './ui/EntitySeoPanel'
 export { EntityStatusPanel } from './ui/EntityStatusPanel'
+export { useEntitySeoPanel } from './hooks/useEntitySeoPanel'
+export { useEntityRevisionsPanel } from './hooks/useEntityRevisionsPanel'
+export type { EntitySeoPanelState } from './hooks/useEntitySeoPanel'
+export type { EntityRevisionsPanelState } from './hooks/useEntityRevisionsPanel'

--- a/frontend/src/features/manage-entity-status/ui/EntityRevisionsPanel.tsx
+++ b/frontend/src/features/manage-entity-status/ui/EntityRevisionsPanel.tsx
@@ -1,44 +1,23 @@
-import { useState } from 'react'
-import { toEntityId, useEntityRevisions } from '@/entities/entity'
+import type { EntityRevision } from '@/entities/entity'
 import { useTranslation } from '@/shared/i18n'
 import { Button, Stack, Text } from '@/shared/ui'
 
-function RevisionsList({ entityId }: { entityId: number }) {
-  const { t } = useTranslation()
-  const revisionsQuery = useEntityRevisions(toEntityId(entityId))
-
-  if (revisionsQuery.isLoading) {
-    return <Text muted>{t('admin.entityRevisions.loading')}</Text>
-  }
-
-  if (revisionsQuery.isError) {
-    return <Text muted>{t('admin.entityRevisions.error')}</Text>
-  }
-
-  const items = revisionsQuery.data?.items ?? []
-
-  if (items.length === 0) {
-    return <Text muted>{t('admin.entityRevisions.empty')}</Text>
-  }
-
-  return (
-    <Stack gap="xs">
-      {items.map((revision) => (
-        <Text key={revision.id} muted variant="caption">
-          {revision.createdAt} · {revision.action} · {revision.status}
-          {revision.previousStatus !== null && revision.previousStatus !== revision.status
-            ? ` ← ${revision.previousStatus}`
-            : ''}
-          {revision.slug !== null ? ` · /${revision.slug}` : ''}
-        </Text>
-      ))}
-    </Stack>
-  )
+interface EntityRevisionsPanelProps {
+  revisions: EntityRevision[]
+  isLoading: boolean
+  isError: boolean
+  isExpanded: boolean
+  onToggle: () => void
 }
 
-export function EntityRevisionsPanel({ entityId }: { entityId: number }) {
+export function EntityRevisionsPanel({
+  revisions,
+  isLoading,
+  isError,
+  isExpanded,
+  onToggle,
+}: EntityRevisionsPanelProps) {
   const { t } = useTranslation()
-  const [isExpanded, setIsExpanded] = useState(false)
 
   return (
     <section className="rounded-md border border-border bg-surface-raised p-inline-md shadow-sm">
@@ -47,17 +26,32 @@ export function EntityRevisionsPanel({ entityId }: { entityId: number }) {
           <Text as="h2" variant="heading-sm">
             {t('admin.entityRevisions.title')}
           </Text>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => {
-              setIsExpanded((prev) => !prev)
-            }}
-          >
+          <Button variant="secondary" size="sm" onClick={onToggle}>
             {isExpanded ? t('admin.entityRevisions.hide') : t('admin.entityRevisions.show')}
           </Button>
         </div>
-        {isExpanded ? <RevisionsList entityId={entityId} /> : null}
+
+        {isExpanded ? (
+          isLoading ? (
+            <Text muted>{t('admin.entityRevisions.loading')}</Text>
+          ) : isError ? (
+            <Text muted>{t('admin.entityRevisions.error')}</Text>
+          ) : revisions.length === 0 ? (
+            <Text muted>{t('admin.entityRevisions.empty')}</Text>
+          ) : (
+            <Stack gap="xs">
+              {revisions.map((revision) => (
+                <Text key={revision.id} muted variant="caption">
+                  {revision.createdAt} · {revision.action} · {revision.status}
+                  {revision.previousStatus !== null && revision.previousStatus !== revision.status
+                    ? ` ← ${revision.previousStatus}`
+                    : ''}
+                  {revision.slug !== null ? ` · /${revision.slug}` : ''}
+                </Text>
+              ))}
+            </Stack>
+          )
+        ) : null}
       </Stack>
     </section>
   )

--- a/frontend/src/features/manage-entity-status/ui/EntitySeoPanel.tsx
+++ b/frontend/src/features/manage-entity-status/ui/EntitySeoPanel.tsx
@@ -1,36 +1,24 @@
-import { useState } from 'react'
-import type { Entity } from '@/entities/entity'
-import { useUpdateEntity } from '@/entities/entity'
 import { useTranslation } from '@/shared/i18n'
-import { Button, Stack, Text, useToast } from '@/shared/ui'
+import { Button, Stack, Text } from '@/shared/ui'
 
 interface EntitySeoPanelProps {
-  entity: Entity
+  metaTitle: string
+  metaDescription: string
+  isPending: boolean
+  onMetaTitleChange: (value: string) => void
+  onMetaDescriptionChange: (value: string) => void
+  onSave: () => void
 }
 
-export function EntitySeoPanel({ entity }: EntitySeoPanelProps) {
+export function EntitySeoPanel({
+  metaTitle,
+  metaDescription,
+  isPending,
+  onMetaTitleChange,
+  onMetaDescriptionChange,
+  onSave,
+}: EntitySeoPanelProps) {
   const { t } = useTranslation()
-  const { showToast } = useToast()
-  const updateMutation = useUpdateEntity()
-
-  const [metaTitle, setMetaTitle] = useState(entity.metaTitle ?? '')
-  const [metaDescription, setMetaDescription] = useState(entity.metaDescription ?? '')
-
-  const save = async () => {
-    try {
-      await updateMutation.mutateAsync({
-        id: Number(entity.id),
-        entityTypeId: entity.entityTypeId,
-        slug: entity.slug,
-        status: entity.status,
-        metaTitle: metaTitle !== '' ? metaTitle : null,
-        metaDescription: metaDescription !== '' ? metaDescription : null,
-      })
-      showToast(t('admin.entitySeo.saveSuccess'), 'success')
-    } catch {
-      showToast(t('common.error.serverError'), 'error')
-    }
-  }
 
   return (
     <section className="rounded-xl border border-border bg-surface p-4">
@@ -48,7 +36,7 @@ export function EntitySeoPanel({ entity }: EntitySeoPanelProps) {
             type="text"
             value={metaTitle}
             onChange={(e) => {
-              setMetaTitle(e.target.value)
+              onMetaTitleChange(e.target.value)
             }}
             placeholder={t('admin.entitySeo.metaTitle.placeholder')}
             maxLength={255}
@@ -67,7 +55,7 @@ export function EntitySeoPanel({ entity }: EntitySeoPanelProps) {
             id="entity-meta-description"
             value={metaDescription}
             onChange={(e) => {
-              setMetaDescription(e.target.value)
+              onMetaDescriptionChange(e.target.value)
             }}
             placeholder={t('admin.entitySeo.metaDescription.placeholder')}
             rows={3}
@@ -76,13 +64,8 @@ export function EntitySeoPanel({ entity }: EntitySeoPanelProps) {
         </Stack>
 
         <div className="flex items-center gap-inline-sm">
-          <Button
-            variant="secondary"
-            size="sm"
-            disabled={updateMutation.isPending}
-            onClick={() => void save()}
-          >
-            {updateMutation.isPending ? t('admin.entitySeo.saving') : t('admin.entitySeo.save')}
+          <Button variant="secondary" size="sm" disabled={isPending} onClick={onSave}>
+            {isPending ? t('admin.entitySeo.saving') : t('admin.entitySeo.save')}
           </Button>
         </div>
       </Stack>

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { Link, Navigate, useLocation, useParams } from 'react-router-dom'
 import { toEntityId, useEntity } from '@/entities/entity'
 import { useEntityTypeList } from '@/entities/entity-type'
-import { CommentSection } from '@/features/comment-section'
+import { CommentSection, useCommentSection } from '@/features/comment-section'
 import {
   PublicRecordDetailView,
   usePublicViewEntityRecordPage,
@@ -61,6 +61,7 @@ function PublicRecordDetailContent({
 }) {
   const { entity, fieldRows, isLoading, isError, errorTitle, refetch } =
     usePublicViewEntityRecordPage(entityTypeId, entityId)
+  const commentSection = useCommentSection(entityId)
 
   // Redirect if the current URL doesn't match the canonical URL for this entity.
   // This handles pattern changes (e.g. /{type}/{id} → /{type}/{slug}) transparently.
@@ -99,7 +100,7 @@ function PublicRecordDetailContent({
           void refetch()
         }}
       />
-      {entity !== null && !isLoading && !isError ? <CommentSection entityId={entityId} /> : null}
+      {entity !== null && !isLoading && !isError ? <CommentSection {...commentSection} /> : null}
     </Stack>
   )
 }

--- a/frontend/src/pages/entity-record/EntityRecordPage.tsx
+++ b/frontend/src/pages/entity-record/EntityRecordPage.tsx
@@ -1,4 +1,5 @@
 import { Link, useParams } from 'react-router-dom'
+import type { Entity } from '@/entities/entity'
 import {
   getLocalizedEntityTypeName,
   useEntityTypeBySlug,
@@ -12,6 +13,8 @@ import {
   EntityRevisionsPanel,
   EntitySeoPanel,
   EntityStatusPanel,
+  useEntityRevisionsPanel,
+  useEntitySeoPanel,
 } from '@/features/manage-entity-status'
 import { ManageEntityTagsView, useManageEntityTagsPage } from '@/features/manage-entity-tags'
 import { ManageEntityRelationsView } from '@/features/manage-entity-relations'
@@ -35,6 +38,15 @@ export function EntityRecordPage() {
 
   return <EntityRecordContent entityType={entityTypeQuery.data} entityId={entityId} />
 }
+
+// ── Thin wrapper so useEntitySeoPanel runs only after entity loads ────────────
+
+function EntitySeoPanelSection({ entity }: { entity: Entity }) {
+  const seoPanel = useEntitySeoPanel(entity)
+  return <EntitySeoPanel {...seoPanel} />
+}
+
+// ── Main content ─────────────────────────────────────────────────────────────
 
 function EntityRecordContent({
   entityType,
@@ -61,6 +73,8 @@ function EntityRecordContent({
     isSaving,
     saveErrorTitle,
   } = useEditEntityTextFieldsPage(entityTypeId, entityId)
+
+  const revisionsPanel = useEntityRevisionsPanel(entityId)
 
   const {
     attachedTags,
@@ -127,8 +141,8 @@ function EntityRecordContent({
       />
       <ManageEntityRelationsView entityId={entityId} entityTypeId={entityTypeId} />
       <InverseEntityRelationsView entityId={entityId} entityTypeId={entityTypeId} />
-      {entity !== null && <EntitySeoPanel entity={entity} />}
-      <EntityRevisionsPanel entityId={entityId} />
+      {entity !== null && <EntitySeoPanelSection entity={entity} />}
+      <EntityRevisionsPanel {...revisionsPanel} />
     </Stack>
   )
 }


### PR DESCRIPTION
## 目的
Issue #228 — フィーチャー UI コンポーネントへのエンティティフック直呼び出しを解消し、Hook+View パターンを適用する。

## 変更内容

### comment-section
- **新規**: `hooks/useCommentSection.ts`
  - `useCommentList`・`usePostComment`・フォーム state（authorName / authorEmail / body / submitted）をオーケストレーションフックへ移動
  - 戻り値: `CommentSectionState`（データ + コールバック）
- **変更**: `ui/CommentSection.tsx` — すべての hooks 呼び出しを削除。props + callbacks のみ受け取るピュア UI に変更
- **変更**: `index.ts` — `useCommentSection` / `CommentSectionState` をエクスポート追加
- **変更**: `PublicRecordDetailPage.tsx` — `useCommentSection(entityId)` を呼び出し、結果を `<CommentSection {...} />` に渡す

### manage-entity-status
- **新規**: `hooks/useEntitySeoPanel.ts`
  - `useUpdateEntity`・`showToast`・metaTitle / metaDescription state を抽出
  - `Entity`（非 null）を受け取り、`EntitySeoPanelState` を返す
- **新規**: `hooks/useEntityRevisionsPanel.ts`
  - `useEntityRevisions`・isExpanded state・onToggle を抽出
- **変更**: `ui/EntitySeoPanel.tsx` — props + callbacks のみに変更
- **変更**: `ui/EntityRevisionsPanel.tsx` — props + callbacks のみに変更。内部コンポーネント `RevisionsList` を解消し本体へ統合
- **変更**: `index.ts` — 新フック・型をエクスポート追加
- **変更**: `EntityRecordPage.tsx`
  - `EntitySeoPanelSection` ラッパーコンポーネントを追加し、`entity !== null` 保証後に `useEntitySeoPanel` を呼び出す（hooks-in-effect の lint エラーを回避）
  - `useEntityRevisionsPanel(entityId)` を呼び出し結果を `<EntityRevisionsPanel />` に渡す

## 検証
```
npm run check --prefix frontend  ✅ type-check / lint / format / test / storybook すべて通過
```

## チェックリスト
- [x] `comment-section` に `hooks/` ディレクトリ追加
- [x] `manage-entity-status` に `hooks/` ディレクトリ追加
- [x] エンティティフック呼び出しをオーケストレーションフックに移動
- [x] UI コンポーネントはプロパティ駆動に変更（props + callbacks のみ）
- [x] `npm run check` 全パス

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)