### PR TITLE
refactor(frontend): 残存 Hook+View 違反を一括解消（5フィーチャー）

### DIFF
--- a/frontend/src/features/manage-appearance/hooks/usePermalinkSettingsPage.ts
+++ b/frontend/src/features/manage-appearance/hooks/usePermalinkSettingsPage.ts
@@ -1,0 +1,19 @@
+import { useEntityTypeList, type EntityType } from '@/entities/entity-type'
+
+export interface PermalinkSettingsPageState {
+  entityTypes: EntityType[]
+  isLoading: boolean
+  onRefresh: () => void
+}
+
+export function usePermalinkSettingsPage(): PermalinkSettingsPageState {
+  const listQuery = useEntityTypeList({ limit: 100, offset: 0 })
+
+  return {
+    entityTypes: listQuery.data?.items ?? [],
+    isLoading: listQuery.isLoading,
+    onRefresh: () => {
+      void listQuery.refetch()
+    },
+  }
+}

--- a/frontend/src/features/manage-appearance/index.ts
+++ b/frontend/src/features/manage-appearance/index.ts
@@ -1,2 +1,4 @@
 export { AppearanceView } from './ui/AppearanceView'
 export { PermalinkSettingsView } from './ui/PermalinkSettingsView'
+export { usePermalinkSettingsPage } from './hooks/usePermalinkSettingsPage'
+export type { PermalinkSettingsPageState } from './hooks/usePermalinkSettingsPage'

--- a/frontend/src/features/manage-appearance/ui/PermalinkSettingsView.tsx
+++ b/frontend/src/features/manage-appearance/ui/PermalinkSettingsView.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useEntityTypeList, useUpdateEntityType, type EntityType } from '@/entities/entity-type'
+import { useUpdateEntityType, type EntityType } from '@/entities/entity-type'
 import { useTranslation } from '@/shared/i18n'
 import {
   DEFAULT_PERMALINK_PATTERN,
@@ -27,7 +27,7 @@ function matchPreset(value: string | null | undefined): string | null {
   return PERMALINK_PRESETS.find((p) => p.pattern === value)?.pattern ?? null
 }
 
-// ── Per-entity-type permalink row ─────────────────────────────────────────────
+// ── Per-entity-type permalink row (per-row mutation kept internal) ─────────────
 
 function PermalinkRow({ entityType, onSaved }: { entityType: EntityType; onSaved: () => void }) {
   const { t } = useTranslation()
@@ -147,10 +147,8 @@ function PermalinkRow({ entityType, onSaved }: { entityType: EntityType; onSaved
           </div>
         )}
 
-        {/* No {type} warning */}
         {effectivePattern && <NoTypeTokenWarning pattern={effectivePattern} />}
 
-        {/* Live example */}
         {effectivePattern && !isCustom && (
           <p className="text-xs text-text-muted">
             {t('admin.entityTypes.editForm.permalink.example', {
@@ -191,12 +189,20 @@ function PermalinkRow({ entityType, onSaved }: { entityType: EntityType; onSaved
   )
 }
 
-// ── Main view ─────────────────────────────────────────────────────────────────
+// ── Main view (props-driven) ──────────────────────────────────────────────────
 
-export function PermalinkSettingsView() {
+interface PermalinkSettingsViewProps {
+  entityTypes: EntityType[]
+  isLoading: boolean
+  onRefresh: () => void
+}
+
+export function PermalinkSettingsView({
+  entityTypes,
+  isLoading,
+  onRefresh,
+}: PermalinkSettingsViewProps) {
   const { t } = useTranslation()
-  const listQuery = useEntityTypeList({ limit: 100, offset: 0 })
-  const items = listQuery.data?.items ?? []
 
   return (
     <Stack gap="sm">
@@ -205,20 +211,14 @@ export function PermalinkSettingsView() {
         <Text muted>{t('admin.settings.permalink.description')}</Text>
       </Stack>
 
-      {listQuery.isLoading && <Text muted>{t('admin.entityTypes.existingList.loading')}</Text>}
+      {isLoading && <Text muted>{t('admin.entityTypes.existingList.loading')}</Text>}
 
-      {items.length === 0 && !listQuery.isLoading && (
+      {entityTypes.length === 0 && !isLoading && (
         <Text muted>{t('admin.entityTypes.existingList.empty.description')}</Text>
       )}
 
-      {items.map((entityType) => (
-        <PermalinkRow
-          key={String(entityType.id)}
-          entityType={entityType}
-          onSaved={() => {
-            void listQuery.refetch()
-          }}
-        />
+      {entityTypes.map((entityType) => (
+        <PermalinkRow key={String(entityType.id)} entityType={entityType} onSaved={onRefresh} />
       ))}
     </Stack>
   )

--- a/frontend/src/features/manage-comments/hooks/useManageCommentsPage.ts
+++ b/frontend/src/features/manage-comments/hooks/useManageCommentsPage.ts
@@ -1,0 +1,66 @@
+import { useState } from 'react'
+import type { AdminComment } from '@/entities/comment'
+import { useAdminCommentList, useApproveComment, useDeleteComment } from '@/entities/comment'
+import { useTranslation } from '@/shared/i18n'
+import { useToast } from '@/shared/ui'
+
+export interface ManageCommentsPageState {
+  comments: AdminComment[]
+  isLoading: boolean
+  isError: boolean
+  isApproving: boolean
+  isDeleting: boolean
+  deleteTarget: AdminComment | null
+  onRetry: () => void
+  onApprove: (comment: AdminComment) => void
+  onDeleteRequest: (comment: AdminComment) => void
+  onDeleteConfirm: () => void
+  onDeleteCancel: () => void
+}
+
+export function useManageCommentsPage(): ManageCommentsPageState {
+  const { t } = useTranslation()
+  const { showToast } = useToast()
+  const commentsQuery = useAdminCommentList()
+  const approveComment = useApproveComment()
+  const deleteComment = useDeleteComment()
+
+  const [deleteTarget, setDeleteTarget] = useState<AdminComment | null>(null)
+
+  function onApprove(comment: AdminComment) {
+    approveComment.mutate(comment.id, {
+      onSuccess: () => {
+        showToast(t('admin.comments.approveSuccess'), 'success')
+      },
+    })
+  }
+
+  function onDeleteConfirm() {
+    if (deleteTarget === null) return
+    const id = deleteTarget.id
+    setDeleteTarget(null)
+    deleteComment.mutate(id, {
+      onSuccess: () => {
+        showToast(t('admin.comments.deleteSuccess'), 'success')
+      },
+    })
+  }
+
+  return {
+    comments: commentsQuery.data?.items ?? [],
+    isLoading: commentsQuery.isLoading,
+    isError: commentsQuery.isError,
+    isApproving: approveComment.isPending,
+    isDeleting: deleteComment.isPending,
+    deleteTarget,
+    onRetry: () => {
+      void commentsQuery.refetch()
+    },
+    onApprove,
+    onDeleteRequest: setDeleteTarget,
+    onDeleteConfirm,
+    onDeleteCancel: () => {
+      setDeleteTarget(null)
+    },
+  }
+}

--- a/frontend/src/features/manage-comments/index.ts
+++ b/frontend/src/features/manage-comments/index.ts
@@ -1,1 +1,3 @@
 export { ManageCommentsView } from './ui/ManageCommentsView'
+export { useManageCommentsPage } from './hooks/useManageCommentsPage'
+export type { ManageCommentsPageState } from './hooks/useManageCommentsPage'

--- a/frontend/src/features/manage-comments/ui/ManageCommentsView.tsx
+++ b/frontend/src/features/manage-comments/ui/ManageCommentsView.tsx
@@ -1,70 +1,61 @@
 import type { AdminComment } from '@/entities/comment'
-import { useAdminCommentList, useApproveComment, useDeleteComment } from '@/entities/comment'
 import { useTranslation } from '@/shared/i18n'
 import { Button, ConfirmDialog, EmptyState, Stack, Text } from '@/shared/ui'
-import { useToast } from '@/shared/ui'
-import { useState } from 'react'
 
-export function ManageCommentsView() {
+interface ManageCommentsViewProps {
+  comments: AdminComment[]
+  isLoading: boolean
+  isError: boolean
+  isApproving: boolean
+  isDeleting: boolean
+  deleteTarget: AdminComment | null
+  onRetry: () => void
+  onApprove: (comment: AdminComment) => void
+  onDeleteRequest: (comment: AdminComment) => void
+  onDeleteConfirm: () => void
+  onDeleteCancel: () => void
+}
+
+export function ManageCommentsView({
+  comments,
+  isLoading,
+  isError,
+  isApproving,
+  isDeleting,
+  deleteTarget,
+  onRetry,
+  onApprove,
+  onDeleteRequest,
+  onDeleteConfirm,
+  onDeleteCancel,
+}: ManageCommentsViewProps) {
   const { t } = useTranslation()
-  const { showToast } = useToast()
-  const commentsQuery = useAdminCommentList()
-  const approveComment = useApproveComment()
-  const deleteComment = useDeleteComment()
 
-  const [deleteTarget, setDeleteTarget] = useState<AdminComment | null>(null)
-
-  function handleApprove(comment: AdminComment) {
-    approveComment.mutate(comment.id, {
-      onSuccess: () => {
-        showToast(t('admin.comments.approveSuccess'), 'success')
-      },
-    })
-  }
-
-  function handleDeleteConfirm() {
-    if (deleteTarget === null) return
-    const id = deleteTarget.id
-    setDeleteTarget(null)
-    deleteComment.mutate(id, {
-      onSuccess: () => {
-        showToast(t('admin.comments.deleteSuccess'), 'success')
-      },
-    })
-  }
-
-  if (commentsQuery.isLoading) {
+  if (isLoading) {
     return <Text muted>{t('admin.comments.loading')}</Text>
   }
 
-  if (commentsQuery.isError) {
+  if (isError) {
     return (
       <Stack gap="sm">
         <Text muted>{t('admin.comments.loadError')}</Text>
-        <Button
-          variant="secondary"
-          onClick={() => {
-            void commentsQuery.refetch()
-          }}
-        >
+        <Button variant="secondary" onClick={onRetry}>
           {t('common.actions.retry')}
         </Button>
       </Stack>
     )
   }
 
-  const items = commentsQuery.data?.items ?? []
-
   return (
     <>
-      {items.length === 0 ? (
+      {comments.length === 0 ? (
         <EmptyState
           title={t('admin.comments.empty')}
           description={t('admin.comments.empty.description')}
         />
       ) : (
         <Stack gap="md">
-          {items.map((comment) => (
+          {comments.map((comment) => (
             <div
               key={comment.id}
               className="rounded-lg border border-border bg-surface-raised px-inline-md py-stack-sm"
@@ -105,9 +96,9 @@ export function ManageCommentsView() {
                       <Button
                         variant="secondary"
                         size="sm"
-                        disabled={approveComment.isPending}
+                        disabled={isApproving}
                         onClick={() => {
-                          handleApprove(comment)
+                          onApprove(comment)
                         }}
                       >
                         {t('admin.comments.approve')}
@@ -116,9 +107,9 @@ export function ManageCommentsView() {
                     <Button
                       variant="danger"
                       size="sm"
-                      disabled={deleteComment.isPending}
+                      disabled={isDeleting}
                       onClick={() => {
-                        setDeleteTarget(comment)
+                        onDeleteRequest(comment)
                       }}
                     >
                       {t('admin.comments.delete')}
@@ -139,11 +130,9 @@ export function ManageCommentsView() {
           name: deleteTarget?.authorName ?? '',
         })}
         confirmLabel={t('admin.comments.delete')}
-        isPending={deleteComment.isPending}
-        onConfirm={handleDeleteConfirm}
-        onCancel={() => {
-          setDeleteTarget(null)
-        }}
+        isPending={isDeleting}
+        onConfirm={onDeleteConfirm}
+        onCancel={onDeleteCancel}
       />
     </>
   )

--- a/frontend/src/features/manage-entity-relations/hooks/use-manage-entity-relations-view.ts
+++ b/frontend/src/features/manage-entity-relations/hooks/use-manage-entity-relations-view.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react'
+import {
+  defaultFieldDefListParams,
+  isRelationFieldDef,
+  useFieldDefList,
+  type RelationFieldDef,
+} from '@/entities/field-def'
+
+export interface ManageEntityRelationsViewState {
+  relationFieldDefs: RelationFieldDef[]
+  isLoading: boolean
+  isError: boolean
+  errorTitle: string | null
+}
+
+export function useManageEntityRelationsView(entityTypeId: number): ManageEntityRelationsViewState {
+  const fieldDefQuery = useFieldDefList(defaultFieldDefListParams(entityTypeId))
+
+  const relationFieldDefs = useMemo(
+    () => (fieldDefQuery.data?.items ?? []).filter(isRelationFieldDef),
+    [fieldDefQuery.data?.items],
+  )
+
+  return {
+    relationFieldDefs,
+    isLoading: fieldDefQuery.isLoading,
+    isError: fieldDefQuery.isError,
+    errorTitle: fieldDefQuery.error?.title ?? null,
+  }
+}

--- a/frontend/src/features/manage-entity-relations/index.ts
+++ b/frontend/src/features/manage-entity-relations/index.ts
@@ -1,4 +1,6 @@
 export { useRelationFieldPanel } from './hooks/use-relation-field-panel'
+export { useManageEntityRelationsView } from './hooks/use-manage-entity-relations-view'
+export type { ManageEntityRelationsViewState } from './hooks/use-manage-entity-relations-view'
 export { ManageEntityRelationsView } from './ui/ManageEntityRelationsView'
 export { RelationFieldPanel } from './ui/RelationFieldPanel'
 export type { ManageEntityRelationsViewProps } from './ui/ManageEntityRelationsView'

--- a/frontend/src/features/manage-entity-relations/ui/ManageEntityRelationsView.tsx
+++ b/frontend/src/features/manage-entity-relations/ui/ManageEntityRelationsView.tsx
@@ -1,39 +1,34 @@
-import { useMemo } from 'react'
-import {
-  defaultFieldDefListParams,
-  isRelationFieldDef,
-  useFieldDefList,
-} from '@/entities/field-def'
+import type { RelationFieldDef } from '@/entities/field-def'
 import { useTranslation } from '@/shared/i18n'
 import { Stack, Text } from '@/shared/ui'
 import { RelationFieldPanel } from './RelationFieldPanel'
 
 export interface ManageEntityRelationsViewProps {
   entityId: number
-  entityTypeId: number
+  relationFieldDefs: RelationFieldDef[]
+  isLoading: boolean
+  isError: boolean
+  errorTitle: string | null
 }
 
 export function ManageEntityRelationsView({
   entityId,
-  entityTypeId,
+  relationFieldDefs,
+  isLoading,
+  isError,
+  errorTitle,
 }: ManageEntityRelationsViewProps) {
   const { t } = useTranslation()
-  const fieldDefQuery = useFieldDefList(defaultFieldDefListParams(entityTypeId))
 
-  const relationFieldDefs = useMemo(
-    () => (fieldDefQuery.data?.items ?? []).filter(isRelationFieldDef),
-    [fieldDefQuery.data?.items],
-  )
-
-  if (fieldDefQuery.isLoading) {
+  if (isLoading) {
     return <Text muted>{t('admin.relations.loadingField', { fieldKey: '…' })}</Text>
   }
 
-  if (fieldDefQuery.isError) {
+  if (isError) {
     return (
       <Stack gap="sm">
         <Text variant="heading-sm">{t('admin.relations.title')}</Text>
-        <Text muted>{fieldDefQuery.error.title}</Text>
+        <Text muted>{errorTitle}</Text>
       </Stack>
     )
   }

--- a/frontend/src/features/manage-settings/hooks/useManageSiteSettingsPage.ts
+++ b/frontend/src/features/manage-settings/hooks/useManageSiteSettingsPage.ts
@@ -1,0 +1,53 @@
+import { useCallback, useMemo, useState } from 'react'
+import type { SettingItem, SettingRevision } from '@/entities/setting'
+import { useSettingList, useSettingRevisions, useUpdateSetting } from '@/entities/setting'
+
+export interface ManageSiteSettingsPageState {
+  items: SettingItem[]
+  isLoading: boolean
+  isError: boolean
+  isSaving: boolean
+  expandedKey: string | null
+  revisions: SettingRevision[]
+  revisionsLoading: boolean
+  revisionsError: boolean
+  onRetry: () => void
+  onSave: (settingKey: string, value: string) => Promise<void>
+  onToggleExpanded: (settingKey: string) => void
+}
+
+export function useManageSiteSettingsPage(): ManageSiteSettingsPageState {
+  const listQuery = useSettingList()
+  const updateMutation = useUpdateSetting()
+  const [expandedKey, setExpandedKey] = useState<string | null>(null)
+
+  // Fetch revisions only for the currently expanded setting
+  const revisionsQuery = useSettingRevisions(expandedKey ?? '')
+
+  const onSave = useCallback(
+    async (settingKey: string, value: string) => {
+      await updateMutation.mutateAsync({ settingKey, input: { value } })
+    },
+    [updateMutation],
+  )
+
+  const items = useMemo(() => listQuery.data?.items ?? [], [listQuery.data?.items])
+
+  return {
+    items,
+    isLoading: listQuery.isLoading,
+    isError: listQuery.isError,
+    isSaving: updateMutation.isPending,
+    expandedKey,
+    revisions: revisionsQuery.data?.items ?? [],
+    revisionsLoading: revisionsQuery.isLoading,
+    revisionsError: revisionsQuery.isError,
+    onRetry: () => {
+      void listQuery.refetch()
+    },
+    onSave,
+    onToggleExpanded: (settingKey: string) => {
+      setExpandedKey((cur) => (cur === settingKey ? null : settingKey))
+    },
+  }
+}

--- a/frontend/src/features/manage-settings/index.ts
+++ b/frontend/src/features/manage-settings/index.ts
@@ -1,1 +1,3 @@
 export { ManageSiteSettingsView } from './ui/ManageSiteSettingsView'
+export { useManageSiteSettingsPage } from './hooks/useManageSiteSettingsPage'
+export type { ManageSiteSettingsPageState } from './hooks/useManageSiteSettingsPage'

--- a/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.tsx
+++ b/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.tsx
@@ -1,34 +1,34 @@
-import { useCallback, useMemo, useState } from 'react'
-import {
-  useSettingList,
-  useSettingRevisions,
-  useUpdateSetting,
-  type SettingItem,
-} from '@/entities/setting'
+import { useState } from 'react'
+import type { SettingItem, SettingRevision } from '@/entities/setting'
 import { useTranslation } from '@/shared/i18n'
 import { Button, Stack, Text } from '@/shared/ui'
 
-function SettingRevisionsPanel({ settingKey }: { settingKey: string }) {
-  const { t } = useTranslation()
-  const revisionsQuery = useSettingRevisions(settingKey)
+// ── Revisions panel (props-driven) ───────────────────────────────────────────
 
-  if (revisionsQuery.isLoading) {
+interface SettingRevisionsPanelProps {
+  revisions: SettingRevision[]
+  isLoading: boolean
+  isError: boolean
+}
+
+function SettingRevisionsPanel({ revisions, isLoading, isError }: SettingRevisionsPanelProps) {
+  const { t } = useTranslation()
+
+  if (isLoading) {
     return <Text muted>{t('admin.settings.history.loading')}</Text>
   }
 
-  if (revisionsQuery.isError) {
+  if (isError) {
     return <Text muted>{t('admin.settings.history.error')}</Text>
   }
 
-  const items = revisionsQuery.data?.items ?? []
-
-  if (items.length === 0) {
+  if (revisions.length === 0) {
     return <Text muted>{t('admin.settings.history.empty')}</Text>
   }
 
   return (
     <Stack gap="xs">
-      {items.map((revision) => (
+      {revisions.map((revision) => (
         <Text key={revision.id} muted variant="caption">
           {revision.createdAt} · {revision.action}
           {revision.previousValue !== null ? ` · from "${revision.previousValue}"` : ''}
@@ -38,6 +38,20 @@ function SettingRevisionsPanel({ settingKey }: { settingKey: string }) {
   )
 }
 
+// ── Setting card (local form state only) ─────────────────────────────────────
+
+interface SettingCardProps {
+  item: SettingItem
+  isSaving: boolean
+  canManageSettings: boolean
+  onSave: (settingKey: string, value: string) => Promise<void>
+  isExpanded: boolean
+  onToggle: () => void
+  revisions: SettingRevision[]
+  revisionsLoading: boolean
+  revisionsError: boolean
+}
+
 function SettingCard({
   item,
   isSaving,
@@ -45,14 +59,10 @@ function SettingCard({
   onSave,
   isExpanded,
   onToggle,
-}: {
-  item: SettingItem
-  isSaving: boolean
-  canManageSettings: boolean
-  onSave: (settingKey: string, value: string) => Promise<void>
-  isExpanded: boolean
-  onToggle: () => void
-}) {
+  revisions,
+  revisionsLoading,
+  revisionsError,
+}: SettingCardProps) {
   const { t } = useTranslation()
   const [value, setValue] = useState(item.value)
   const inputId = `setting-${item.settingKey}`
@@ -79,7 +89,6 @@ function SettingCard({
 
       {/* ── Field ── */}
       {item.dataType === 'markdown' ? (
-        /* Markdown: textarea stacked, save right-aligned below */
         <div className="flex flex-col gap-stack-sm">
           <Text muted variant="caption">
             Markdown ·{' '}
@@ -113,7 +122,6 @@ function SettingCard({
           ) : null}
         </div>
       ) : (
-        /* Text: input + save button inline */
         <div className="flex items-center gap-stack-sm">
           <input
             id={inputId}
@@ -143,37 +151,59 @@ function SettingCard({
       {/* ── History panel ── */}
       {isExpanded ? (
         <div className="mt-stack-md border-t border-border pt-stack-sm">
-          <SettingRevisionsPanel settingKey={item.settingKey} />
+          <SettingRevisionsPanel
+            revisions={revisions}
+            isLoading={revisionsLoading}
+            isError={revisionsError}
+          />
         </div>
       ) : null}
     </section>
   )
 }
 
-export function ManageSiteSettingsView({ canManageSettings }: { canManageSettings: boolean }) {
+// ── Main view ─────────────────────────────────────────────────────────────────
+
+interface ManageSiteSettingsViewProps {
+  items: SettingItem[]
+  isLoading: boolean
+  isError: boolean
+  isSaving: boolean
+  expandedKey: string | null
+  revisions: SettingRevision[]
+  revisionsLoading: boolean
+  revisionsError: boolean
+  canManageSettings: boolean
+  onRetry: () => void
+  onSave: (settingKey: string, value: string) => Promise<void>
+  onToggleExpanded: (settingKey: string) => void
+}
+
+export function ManageSiteSettingsView({
+  items,
+  isLoading,
+  isError,
+  isSaving,
+  expandedKey,
+  revisions,
+  revisionsLoading,
+  revisionsError,
+  canManageSettings,
+  onRetry,
+  onSave,
+  onToggleExpanded,
+}: ManageSiteSettingsViewProps) {
   const { t } = useTranslation()
-  const listQuery = useSettingList()
-  const updateMutation = useUpdateSetting()
-  const [expandedKey, setExpandedKey] = useState<string | null>(null)
 
-  const saveSetting = useCallback(
-    async (settingKey: string, value: string) => {
-      await updateMutation.mutateAsync({ settingKey, input: { value } })
-    },
-    [updateMutation],
-  )
-
-  const items = useMemo(() => listQuery.data?.items ?? [], [listQuery.data?.items])
-
-  if (listQuery.isLoading) {
+  if (isLoading) {
     return <Text muted>{t('admin.settings.loading')}</Text>
   }
 
-  if (listQuery.isError) {
+  if (isError) {
     return (
       <Stack gap="sm">
         <Text muted>{t('admin.settings.error')}</Text>
-        <Button variant="secondary" size="sm" onClick={() => void listQuery.refetch()}>
+        <Button variant="secondary" size="sm" onClick={onRetry}>
           {t('common.actions.retry')}
         </Button>
       </Stack>
@@ -186,13 +216,16 @@ export function ManageSiteSettingsView({ canManageSettings }: { canManageSetting
         <SettingCard
           key={`${item.settingKey}:${item.updatedAt ?? 'default'}`}
           item={item}
-          isSaving={updateMutation.isPending}
+          isSaving={isSaving}
           canManageSettings={canManageSettings}
-          onSave={saveSetting}
+          onSave={onSave}
           isExpanded={expandedKey === item.settingKey}
           onToggle={() => {
-            setExpandedKey((cur) => (cur === item.settingKey ? null : item.settingKey))
+            onToggleExpanded(item.settingKey)
           }}
+          revisions={expandedKey === item.settingKey ? revisions : []}
+          revisionsLoading={expandedKey === item.settingKey && revisionsLoading}
+          revisionsError={expandedKey === item.settingKey && revisionsError}
         />
       ))}
     </Stack>

--- a/frontend/src/features/manage-webhooks/hooks/useManageWebhooksPage.ts
+++ b/frontend/src/features/manage-webhooks/hooks/useManageWebhooksPage.ts
@@ -1,0 +1,110 @@
+import { useState } from 'react'
+import type { CreateWebhookInput, Webhook, WebhookList } from '@/entities/webhook'
+import {
+  useCreateWebhook,
+  useDeleteWebhook,
+  useUpdateWebhook,
+  useWebhookList,
+} from '@/entities/webhook'
+import { useTranslation } from '@/shared/i18n'
+
+export interface ManageWebhooksPageState {
+  webhooks: WebhookList | undefined
+  isLoading: boolean
+  isError: boolean
+  showCreateForm: boolean
+  editingId: number | null
+  deleteTarget: Webhook | null
+  isCreating: boolean
+  isUpdating: boolean
+  isDeleting: boolean
+  createError: string | null
+  updateError: string | null
+  onCreate: (input: CreateWebhookInput) => Promise<void>
+  onUpdate: (id: number, input: CreateWebhookInput) => Promise<void>
+  onDeleteConfirm: () => Promise<void>
+  onShowCreateForm: () => void
+  onHideCreateForm: () => void
+  onStartEdit: (id: number) => void
+  onCancelEdit: () => void
+  onDeleteRequest: (webhook: Webhook) => void
+  onDeleteCancel: () => void
+}
+
+export function useManageWebhooksPage(): ManageWebhooksPageState {
+  const { t } = useTranslation()
+  const { data, isLoading, isError } = useWebhookList()
+  const createMutation = useCreateWebhook()
+  const updateMutation = useUpdateWebhook()
+  const deleteMutation = useDeleteWebhook()
+
+  const [showCreateForm, setShowCreateForm] = useState(false)
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<Webhook | null>(null)
+  const [createError, setCreateError] = useState<string | null>(null)
+  const [updateError, setUpdateError] = useState<string | null>(null)
+
+  async function onCreate(input: CreateWebhookInput) {
+    setCreateError(null)
+    try {
+      await createMutation.mutateAsync(input)
+      setShowCreateForm(false)
+    } catch {
+      setCreateError(t('admin.webhooks.createError'))
+    }
+  }
+
+  async function onUpdate(id: number, input: CreateWebhookInput) {
+    setUpdateError(null)
+    try {
+      await updateMutation.mutateAsync({ id, input })
+      setEditingId(null)
+    } catch {
+      setUpdateError(t('admin.webhooks.updateError'))
+    }
+  }
+
+  async function onDeleteConfirm() {
+    if (deleteTarget === null) return
+    try {
+      await deleteMutation.mutateAsync(deleteTarget.id)
+    } finally {
+      setDeleteTarget(null)
+    }
+  }
+
+  return {
+    webhooks: data,
+    isLoading,
+    isError,
+    showCreateForm,
+    editingId,
+    deleteTarget,
+    isCreating: createMutation.isPending,
+    isUpdating: updateMutation.isPending,
+    isDeleting: deleteMutation.isPending,
+    createError,
+    updateError,
+    onCreate,
+    onUpdate,
+    onDeleteConfirm,
+    onShowCreateForm: () => {
+      setShowCreateForm(true)
+    },
+    onHideCreateForm: () => {
+      setShowCreateForm(false)
+      setCreateError(null)
+    },
+    onStartEdit: (id: number) => {
+      setEditingId(id)
+    },
+    onCancelEdit: () => {
+      setEditingId(null)
+      setUpdateError(null)
+    },
+    onDeleteRequest: setDeleteTarget,
+    onDeleteCancel: () => {
+      setDeleteTarget(null)
+    },
+  }
+}

--- a/frontend/src/features/manage-webhooks/index.ts
+++ b/frontend/src/features/manage-webhooks/index.ts
@@ -1,1 +1,3 @@
 export { ManageWebhooksView } from './ui/ManageWebhooksView'
+export { useManageWebhooksPage } from './hooks/useManageWebhooksPage'
+export type { ManageWebhooksPageState } from './hooks/useManageWebhooksPage'

--- a/frontend/src/features/manage-webhooks/ui/ManageWebhooksView.tsx
+++ b/frontend/src/features/manage-webhooks/ui/ManageWebhooksView.tsx
@@ -1,62 +1,60 @@
-import { useState } from 'react'
-import type { CreateWebhookInput, Webhook } from '@/entities/webhook'
-import {
-  useCreateWebhook,
-  useDeleteWebhook,
-  useUpdateWebhook,
-  useWebhookList,
-} from '@/entities/webhook'
+import type { CreateWebhookInput, Webhook, WebhookList } from '@/entities/webhook'
 import { useTranslation } from '@/shared/i18n'
 import { Button, ConfirmDialog, EmptyState, Stack, Text } from '@/shared/ui'
 import { WebhookForm } from './WebhookForm'
 
-export function ManageWebhooksView() {
+interface ManageWebhooksViewProps {
+  webhooks: WebhookList | undefined
+  isLoading: boolean
+  isError: boolean
+  showCreateForm: boolean
+  editingId: number | null
+  deleteTarget: Webhook | null
+  isCreating: boolean
+  isUpdating: boolean
+  isDeleting: boolean
+  createError: string | null
+  updateError: string | null
+  onCreate: (input: CreateWebhookInput) => Promise<void>
+  onUpdate: (id: number, input: CreateWebhookInput) => Promise<void>
+  onDeleteConfirm: () => Promise<void>
+  onShowCreateForm: () => void
+  onHideCreateForm: () => void
+  onStartEdit: (id: number) => void
+  onCancelEdit: () => void
+  onDeleteRequest: (webhook: Webhook) => void
+  onDeleteCancel: () => void
+}
+
+export function ManageWebhooksView({
+  webhooks,
+  isLoading,
+  isError,
+  showCreateForm,
+  editingId,
+  deleteTarget,
+  isCreating,
+  isUpdating,
+  isDeleting,
+  createError,
+  updateError,
+  onCreate,
+  onUpdate,
+  onDeleteConfirm,
+  onShowCreateForm,
+  onHideCreateForm,
+  onStartEdit,
+  onCancelEdit,
+  onDeleteRequest,
+  onDeleteCancel,
+}: ManageWebhooksViewProps) {
   const { t } = useTranslation()
-  const { data, isLoading, isError } = useWebhookList()
-  const createMutation = useCreateWebhook()
-  const updateMutation = useUpdateWebhook()
-  const deleteMutation = useDeleteWebhook()
-
-  const [showCreateForm, setShowCreateForm] = useState(false)
-  const [editingId, setEditingId] = useState<number | null>(null)
-  const [deleteTarget, setDeleteTarget] = useState<Webhook | null>(null)
-  const [createError, setCreateError] = useState<string | null>(null)
-  const [updateError, setUpdateError] = useState<string | null>(null)
-
-  const handleCreate = async (input: CreateWebhookInput) => {
-    setCreateError(null)
-    try {
-      await createMutation.mutateAsync(input)
-      setShowCreateForm(false)
-    } catch {
-      setCreateError(t('admin.webhooks.createError'))
-    }
-  }
-
-  const handleUpdate = async (id: number, input: CreateWebhookInput) => {
-    setUpdateError(null)
-    try {
-      await updateMutation.mutateAsync({ id, input })
-      setEditingId(null)
-    } catch {
-      setUpdateError(t('admin.webhooks.updateError'))
-    }
-  }
-
-  const handleDelete = async () => {
-    if (deleteTarget === null) return
-    try {
-      await deleteMutation.mutateAsync(deleteTarget.id)
-    } finally {
-      setDeleteTarget(null)
-    }
-  }
 
   if (isLoading) {
     return <Text muted>{t('admin.webhooks.loading')}</Text>
   }
 
-  if (isError || data === undefined) {
+  if (isError || webhooks === undefined) {
     return <Text muted>{t('common.error.serverError')}</Text>
   }
 
@@ -67,13 +65,7 @@ export function ManageWebhooksView() {
           {t('admin.webhooks.title')}
         </Text>
         {!showCreateForm && (
-          <Button
-            type="button"
-            size="sm"
-            onClick={() => {
-              setShowCreateForm(true)
-            }}
-          >
+          <Button type="button" size="sm" onClick={onShowCreateForm}>
             {t('admin.webhooks.addButton')}
           </Button>
         )}
@@ -83,25 +75,22 @@ export function ManageWebhooksView() {
 
       {showCreateForm && (
         <WebhookForm
-          isSubmitting={createMutation.isPending}
+          isSubmitting={isCreating}
           serverErrorTitle={createError}
           submitLabel={t('common.actions.create')}
-          onSubmit={handleCreate}
-          onCancel={() => {
-            setShowCreateForm(false)
-            setCreateError(null)
-          }}
+          onSubmit={onCreate}
+          onCancel={onHideCreateForm}
         />
       )}
 
-      {data.items.length === 0 && !showCreateForm ? (
+      {webhooks.items.length === 0 && !showCreateForm ? (
         <EmptyState
           title={t('admin.webhooks.empty.title')}
           description={t('admin.webhooks.empty.description')}
         />
       ) : (
         <Stack gap="sm">
-          {data.items.map((webhook) =>
+          {webhooks.items.map((webhook) =>
             editingId === webhook.id ? (
               <WebhookForm
                 key={webhook.id}
@@ -112,14 +101,11 @@ export function ManageWebhooksView() {
                   secret: webhook.secret ?? '',
                   isActive: webhook.isActive,
                 }}
-                isSubmitting={updateMutation.isPending}
+                isSubmitting={isUpdating}
                 serverErrorTitle={updateError}
                 submitLabel={t('common.actions.save')}
-                onSubmit={async (input) => handleUpdate(webhook.id, input)}
-                onCancel={() => {
-                  setEditingId(null)
-                  setUpdateError(null)
-                }}
+                onSubmit={async (input) => onUpdate(webhook.id, input)}
+                onCancel={onCancelEdit}
               />
             ) : (
               <div
@@ -170,7 +156,7 @@ export function ManageWebhooksView() {
                     variant="secondary"
                     size="sm"
                     onClick={() => {
-                      setEditingId(webhook.id)
+                      onStartEdit(webhook.id)
                     }}
                   >
                     {t('common.actions.edit')}
@@ -180,7 +166,7 @@ export function ManageWebhooksView() {
                     variant="secondary"
                     size="sm"
                     onClick={() => {
-                      setDeleteTarget(webhook)
+                      onDeleteRequest(webhook)
                     }}
                   >
                     {t('common.actions.delete')}
@@ -200,16 +186,12 @@ export function ManageWebhooksView() {
             ? t('admin.webhooks.delete.description', { url: deleteTarget.url })
             : undefined
         }
-        confirmLabel={
-          deleteMutation.isPending ? t('common.actions.deleting') : t('common.actions.delete')
-        }
+        confirmLabel={isDeleting ? t('common.actions.deleting') : t('common.actions.delete')}
         cancelLabel={t('common.actions.cancel')}
-        isPending={deleteMutation.isPending}
-        onCancel={() => {
-          setDeleteTarget(null)
-        }}
+        isPending={isDeleting}
+        onCancel={onDeleteCancel}
         onConfirm={() => {
-          void handleDelete()
+          void onDeleteConfirm()
         }}
       />
     </Stack>

--- a/frontend/src/pages/comments/CommentsPage.tsx
+++ b/frontend/src/pages/comments/CommentsPage.tsx
@@ -1,12 +1,13 @@
 import { Navigate } from 'react-router-dom'
 import { currentUserHasCapability } from '@/entities/auth'
-import { ManageCommentsView } from '@/features/manage-comments'
+import { ManageCommentsView, useManageCommentsPage } from '@/features/manage-comments'
 import { useTranslation } from '@/shared/i18n'
 import { Stack, Text } from '@/shared/ui'
 
 export function CommentsPage() {
   const { t } = useTranslation()
   const canManageSettings = currentUserHasCapability('manage_settings')
+  const commentsPage = useManageCommentsPage()
 
   if (!canManageSettings) {
     return <Navigate to="/forbidden" replace />
@@ -18,7 +19,7 @@ export function CommentsPage() {
         {t('admin.comments.pageTitle')}
       </Text>
       <Text muted>{t('admin.comments.description')}</Text>
-      <ManageCommentsView />
+      <ManageCommentsView {...commentsPage} />
     </Stack>
   )
 }

--- a/frontend/src/pages/entity-record/EntityRecordPage.tsx
+++ b/frontend/src/pages/entity-record/EntityRecordPage.tsx
@@ -17,7 +17,10 @@ import {
   useEntitySeoPanel,
 } from '@/features/manage-entity-status'
 import { ManageEntityTagsView, useManageEntityTagsPage } from '@/features/manage-entity-tags'
-import { ManageEntityRelationsView } from '@/features/manage-entity-relations'
+import {
+  ManageEntityRelationsView,
+  useManageEntityRelationsView,
+} from '@/features/manage-entity-relations'
 import { InverseEntityRelationsView } from '@/features/inverse-entity-relations'
 import { useTranslation } from '@/shared/i18n'
 import { Button, Stack, Text } from '@/shared/ui'
@@ -75,6 +78,7 @@ function EntityRecordContent({
   } = useEditEntityTextFieldsPage(entityTypeId, entityId)
 
   const revisionsPanel = useEntityRevisionsPanel(entityId)
+  const entityRelations = useManageEntityRelationsView(entityTypeId)
 
   const {
     attachedTags,
@@ -139,7 +143,7 @@ function EntityRecordContent({
         onAttach={attachTag}
         onDetach={detachTag}
       />
-      <ManageEntityRelationsView entityId={entityId} entityTypeId={entityTypeId} />
+      <ManageEntityRelationsView entityId={entityId} {...entityRelations} />
       <InverseEntityRelationsView entityId={entityId} entityTypeId={entityTypeId} />
       {entity !== null && <EntitySeoPanelSection entity={entity} />}
       <EntityRevisionsPanel {...revisionsPanel} />

--- a/frontend/src/pages/settings/SiteSettingsPage.tsx
+++ b/frontend/src/pages/settings/SiteSettingsPage.tsx
@@ -1,12 +1,19 @@
-import { ManageSiteSettingsView } from '@/features/manage-settings'
-import { AppearanceView, PermalinkSettingsView } from '@/features/manage-appearance'
 import { currentUserHasCapability } from '@/entities/auth'
+import {
+  AppearanceView,
+  PermalinkSettingsView,
+  usePermalinkSettingsPage,
+} from '@/features/manage-appearance'
+import { ManageSiteSettingsView, useManageSiteSettingsPage } from '@/features/manage-settings'
 import { useTranslation } from '@/shared/i18n'
 import { Stack, Text } from '@/shared/ui'
 
 export function SiteSettingsPage() {
   const { t } = useTranslation()
   const canManageSettings = currentUserHasCapability('manage_settings')
+  const settingsPage = useManageSiteSettingsPage()
+  const permalinkPage = usePermalinkSettingsPage()
+
   return (
     <Stack gap="lg">
       <Stack gap="xs">
@@ -16,8 +23,8 @@ export function SiteSettingsPage() {
         <Text muted>{t('admin.settings.description')}</Text>
       </Stack>
       <AppearanceView />
-      <ManageSiteSettingsView canManageSettings={canManageSettings} />
-      <PermalinkSettingsView />
+      <ManageSiteSettingsView {...settingsPage} canManageSettings={canManageSettings} />
+      <PermalinkSettingsView {...permalinkPage} />
     </Stack>
   )
 }

--- a/frontend/src/pages/webhooks/WebhooksPage.tsx
+++ b/frontend/src/pages/webhooks/WebhooksPage.tsx
@@ -1,5 +1,6 @@
-import { ManageWebhooksView } from '@/features/manage-webhooks/ui/ManageWebhooksView'
+import { ManageWebhooksView, useManageWebhooksPage } from '@/features/manage-webhooks'
 
 export function WebhooksPage() {
-  return <ManageWebhooksView />
+  const webhooksPage = useManageWebhooksPage()
+  return <ManageWebhooksView {...webhooksPage} />
 }


### PR DESCRIPTION
## 目的
コード品質監査（Issue #219）の追加対応。#228 で修正しきれなかった5フィーチャーの Hook+View パターン違反をすべて解消する。

## 変更内容

### manage-comments
- **新規**: `hooks/useManageCommentsPage.ts`
  - `useAdminCommentList`・`useApproveComment`・`useDeleteComment`・`showToast`・deleteTarget state を抽出
- **変更**: `ManageCommentsView` → props+callbacks 駆動に変更
- **変更**: `CommentsPage` → `useManageCommentsPage()` を呼び出してpropsを渡す

### manage-settings
- **新規**: `hooks/useManageSiteSettingsPage.ts`
  - `useSettingList`・`useUpdateSetting`・`useSettingRevisions`（展開中キーのみフェッチ）・state を抽出
- **変更**: `ManageSiteSettingsView` → props 駆動に変更
- **変更**: `SettingRevisionsPanel` → revisions/isLoading/isError を props で受け取るように変更
- **変更**: `SiteSettingsPage` → `useManageSiteSettingsPage()` を呼び出し

### manage-webhooks
- **新規**: `hooks/useManageWebhooksPage.ts`
  - `useWebhookList`・`useCreateWebhook`・`useUpdateWebhook`・`useDeleteWebhook`・全 state を抽出
- **変更**: `ManageWebhooksView` → props+callbacks 駆動に変更
- **変更**: `WebhooksPage` → `useManageWebhooksPage()` を呼び出し

### manage-appearance
- **新規**: `hooks/usePermalinkSettingsPage.ts`
  - `useEntityTypeList` を `PermalinkSettingsView` から抽出
- **変更**: `PermalinkSettingsView` → entityTypes/isLoading/onRefresh を props で受け取る
  - ※ `PermalinkRow`（非公開内部コンポーネント）の per-row `useUpdateEntityType` はそのまま保持
- **変更**: `SiteSettingsPage` → `usePermalinkSettingsPage()` を呼び出し

### manage-entity-relations
- **新規**: `hooks/use-manage-entity-relations-view.ts`
  - `useFieldDefList` + `isRelationFieldDef` フィルタリングを抽出
- **変更**: `ManageEntityRelationsView` → relationFieldDefs/isLoading/isError/errorTitle を props で受け取る（entityTypeId props を削除）
- **変更**: `EntityRecordPage` → `useManageEntityRelationsView(entityTypeId)` を呼び出し

## 検証
```
npm run check --prefix frontend  ✅ type-check / lint / format / test / storybook すべて通過
```

## チェックリスト
- [x] 5フィーチャーすべてに `hooks/` ディレクトリを追加
- [x] エンティティフック呼び出しをオーケストレーションフックに移動
- [x] UI コンポーネントは props + callbacks のみ
- [x] `npm run check` 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)