### PR TITLE
refactor(usecase): UseCase の Input/Output DTO 未整備を一括解消（Webhook/NavigationItem/Comment）

### DIFF
--- a/src/Comment/ApproveCommentHandler.php
+++ b/src/Comment/ApproveCommentHandler.php
@@ -22,15 +22,15 @@ final readonly class ApproveCommentHandler
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = (int) ($params['id'] ?? 0);
 
-        $comment = $this->useCase->execute(new ApproveCommentInput($id));
+        $output = $this->useCase->execute(new ApproveCommentInput($id));
 
         return $this->response->create([
-            'id'          => $comment->id,
-            'entity_id'   => $comment->entityId,
-            'author_name' => $comment->authorName,
-            'body'        => $comment->body,
-            'is_approved' => $comment->isApproved,
-            'created_at'  => $comment->createdAt,
+            'id'          => $output->id,
+            'entity_id'   => $output->entityId,
+            'author_name' => $output->authorName,
+            'body'        => $output->body,
+            'is_approved' => $output->isApproved,
+            'created_at'  => $output->createdAt,
         ]);
     }
 }

--- a/src/Comment/ApproveCommentOutput.php
+++ b/src/Comment/ApproveCommentOutput.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+final readonly class ApproveCommentOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $authorName,
+        public string $body,
+        public bool $isApproved,
+        public string $createdAt,
+    ) {
+    }
+}

--- a/src/Comment/ApproveCommentUseCase.php
+++ b/src/Comment/ApproveCommentUseCase.php
@@ -10,8 +10,17 @@ final readonly class ApproveCommentUseCase implements ApproveCommentUseCaseInter
     {
     }
 
-    public function execute(ApproveCommentInput $input): Comment
+    public function execute(ApproveCommentInput $input): ApproveCommentOutput
     {
-        return $this->comments->approve($input->id);
+        $comment = $this->comments->approve($input->id);
+
+        return new ApproveCommentOutput(
+            id: $comment->id,
+            entityId: $comment->entityId,
+            authorName: $comment->authorName,
+            body: $comment->body,
+            isApproved: $comment->isApproved,
+            createdAt: $comment->createdAt,
+        );
     }
 }

--- a/src/Comment/ApproveCommentUseCaseInterface.php
+++ b/src/Comment/ApproveCommentUseCaseInterface.php
@@ -6,5 +6,5 @@ namespace NeNeRecords\Comment;
 
 interface ApproveCommentUseCaseInterface
 {
-    public function execute(ApproveCommentInput $input): Comment;
+    public function execute(ApproveCommentInput $input): ApproveCommentOutput;
 }

--- a/src/Comment/PostCommentHandler.php
+++ b/src/Comment/PostCommentHandler.php
@@ -50,26 +50,20 @@ final readonly class PostCommentHandler
             throw new ValidationException($errors);
         }
 
-        $comment = $this->useCase->execute(new PostCommentInput(
+        $output = $this->useCase->execute(new PostCommentInput(
             entityId: $entityId,
             authorName: $authorName,
             authorEmail: $authorEmail,
             body: $commentBody,
         ));
 
-        return $this->response->create($this->serialize($comment), 201);
-    }
-
-    /** @return array<string, mixed> */
-    private function serialize(Comment $comment): array
-    {
-        return [
-            'id'          => $comment->id,
-            'entity_id'   => $comment->entityId,
-            'author_name' => $comment->authorName,
-            'body'        => $comment->body,
-            'is_approved' => $comment->isApproved,
-            'created_at'  => $comment->createdAt,
-        ];
+        return $this->response->create([
+            'id'          => $output->id,
+            'entity_id'   => $output->entityId,
+            'author_name' => $output->authorName,
+            'body'        => $output->body,
+            'is_approved' => $output->isApproved,
+            'created_at'  => $output->createdAt,
+        ], 201);
     }
 }

--- a/src/Comment/PostCommentOutput.php
+++ b/src/Comment/PostCommentOutput.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Comment;
+
+final readonly class PostCommentOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $authorName,
+        public string $body,
+        public bool $isApproved,
+        public string $createdAt,
+    ) {
+    }
+}

--- a/src/Comment/PostCommentUseCase.php
+++ b/src/Comment/PostCommentUseCase.php
@@ -10,13 +10,22 @@ final readonly class PostCommentUseCase implements PostCommentUseCaseInterface
     {
     }
 
-    public function execute(PostCommentInput $input): Comment
+    public function execute(PostCommentInput $input): PostCommentOutput
     {
-        return $this->comments->create(
+        $comment = $this->comments->create(
             $input->entityId,
             $input->authorName,
             $input->authorEmail,
             $input->body,
+        );
+
+        return new PostCommentOutput(
+            id: $comment->id,
+            entityId: $comment->entityId,
+            authorName: $comment->authorName,
+            body: $comment->body,
+            isApproved: $comment->isApproved,
+            createdAt: $comment->createdAt,
         );
     }
 }

--- a/src/Comment/PostCommentUseCaseInterface.php
+++ b/src/Comment/PostCommentUseCaseInterface.php
@@ -6,5 +6,5 @@ namespace NeNeRecords\Comment;
 
 interface PostCommentUseCaseInterface
 {
-    public function execute(PostCommentInput $input): Comment;
+    public function execute(PostCommentInput $input): PostCommentOutput;
 }

--- a/src/NavigationItem/DeleteNavigationItemHandler.php
+++ b/src/NavigationItem/DeleteNavigationItemHandler.php
@@ -22,7 +22,7 @@ final readonly class DeleteNavigationItemHandler
         $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = (int) ($parameters['id'] ?? 0);
 
-        $this->useCase->execute($id);
+        $this->useCase->execute(new DeleteNavigationItemInput($id));
 
         return $this->response->createEmpty(204);
     }

--- a/src/NavigationItem/DeleteNavigationItemInput.php
+++ b/src/NavigationItem/DeleteNavigationItemInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\NavigationItem;
+
+final readonly class DeleteNavigationItemInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/NavigationItem/DeleteNavigationItemUseCase.php
+++ b/src/NavigationItem/DeleteNavigationItemUseCase.php
@@ -11,12 +11,12 @@ final readonly class DeleteNavigationItemUseCase implements DeleteNavigationItem
     ) {
     }
 
-    public function execute(int $id): void
+    public function execute(DeleteNavigationItemInput $input): void
     {
-        if ($this->repository->findById($id) === null) {
-            throw new NavigationItemNotFoundException($id);
+        if ($this->repository->findById($input->id) === null) {
+            throw new NavigationItemNotFoundException($input->id);
         }
 
-        $this->repository->delete($id);
+        $this->repository->delete($input->id);
     }
 }

--- a/src/NavigationItem/DeleteNavigationItemUseCaseInterface.php
+++ b/src/NavigationItem/DeleteNavigationItemUseCaseInterface.php
@@ -6,5 +6,5 @@ namespace NeNeRecords\NavigationItem;
 
 interface DeleteNavigationItemUseCaseInterface
 {
-    public function execute(int $id): void;
+    public function execute(DeleteNavigationItemInput $input): void;
 }

--- a/src/Webhook/DeleteWebhookHandler.php
+++ b/src/Webhook/DeleteWebhookHandler.php
@@ -22,7 +22,7 @@ final readonly class DeleteWebhookHandler
         $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = (int) ($parameters['id'] ?? 0);
 
-        $this->useCase->execute($id);
+        $this->useCase->execute(new DeleteWebhookInput($id));
 
         return $this->response->createEmpty(204);
     }

--- a/src/Webhook/DeleteWebhookInput.php
+++ b/src/Webhook/DeleteWebhookInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Webhook;
+
+final readonly class DeleteWebhookInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/Webhook/DeleteWebhookUseCase.php
+++ b/src/Webhook/DeleteWebhookUseCase.php
@@ -11,12 +11,12 @@ final readonly class DeleteWebhookUseCase implements DeleteWebhookUseCaseInterfa
     ) {
     }
 
-    public function execute(int $id): void
+    public function execute(DeleteWebhookInput $input): void
     {
-        if ($this->webhooks->findById($id) === null) {
-            throw new WebhookNotFoundException($id);
+        if ($this->webhooks->findById($input->id) === null) {
+            throw new WebhookNotFoundException($input->id);
         }
 
-        $this->webhooks->delete($id);
+        $this->webhooks->delete($input->id);
     }
 }

--- a/src/Webhook/DeleteWebhookUseCaseInterface.php
+++ b/src/Webhook/DeleteWebhookUseCaseInterface.php
@@ -6,5 +6,5 @@ namespace NeNeRecords\Webhook;
 
 interface DeleteWebhookUseCaseInterface
 {
-    public function execute(int $id): void;
+    public function execute(DeleteWebhookInput $input): void;
 }

--- a/src/Webhook/GetWebhookByIdHandler.php
+++ b/src/Webhook/GetWebhookByIdHandler.php
@@ -21,8 +21,9 @@ final readonly class GetWebhookByIdHandler
     {
         $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = (int) ($parameters['id'] ?? 0);
-        $webhook = $this->useCase->execute($id);
 
-        return $this->response->create(WebhookHttpMapper::toArray($webhook));
+        $output = $this->useCase->execute(new GetWebhookByIdInput($id));
+
+        return $this->response->create(WebhookHttpMapper::toArray($output->webhook));
     }
 }

--- a/src/Webhook/GetWebhookByIdInput.php
+++ b/src/Webhook/GetWebhookByIdInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Webhook;
+
+final readonly class GetWebhookByIdInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/Webhook/GetWebhookByIdOutput.php
+++ b/src/Webhook/GetWebhookByIdOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Webhook;
+
+final readonly class GetWebhookByIdOutput
+{
+    public function __construct(
+        public Webhook $webhook,
+    ) {
+    }
+}

--- a/src/Webhook/GetWebhookByIdUseCase.php
+++ b/src/Webhook/GetWebhookByIdUseCase.php
@@ -11,14 +11,14 @@ final readonly class GetWebhookByIdUseCase implements GetWebhookByIdUseCaseInter
     ) {
     }
 
-    public function execute(int $id): Webhook
+    public function execute(GetWebhookByIdInput $input): GetWebhookByIdOutput
     {
-        $webhook = $this->webhooks->findById($id);
+        $webhook = $this->webhooks->findById($input->id);
 
         if ($webhook === null) {
-            throw new WebhookNotFoundException($id);
+            throw new WebhookNotFoundException($input->id);
         }
 
-        return $webhook;
+        return new GetWebhookByIdOutput(webhook: $webhook);
     }
 }

--- a/src/Webhook/GetWebhookByIdUseCaseInterface.php
+++ b/src/Webhook/GetWebhookByIdUseCaseInterface.php
@@ -6,5 +6,5 @@ namespace NeNeRecords\Webhook;
 
 interface GetWebhookByIdUseCaseInterface
 {
-    public function execute(int $id): Webhook;
+    public function execute(GetWebhookByIdInput $input): GetWebhookByIdOutput;
 }

--- a/src/Webhook/ListWebhooksHandler.php
+++ b/src/Webhook/ListWebhooksHandler.php
@@ -18,12 +18,12 @@ final readonly class ListWebhooksHandler
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $items = $this->useCase->execute();
+        $output = $this->useCase->execute();
 
         return $this->response->create([
             'items' => array_map(
                 static fn (Webhook $webhook) => WebhookHttpMapper::toArray($webhook),
-                $items,
+                $output->items,
             ),
         ]);
     }

--- a/src/Webhook/ListWebhooksOutput.php
+++ b/src/Webhook/ListWebhooksOutput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Webhook;
+
+final readonly class ListWebhooksOutput
+{
+    public function __construct(
+        /** @var list<Webhook> */
+        public array $items,
+    ) {
+    }
+}

--- a/src/Webhook/ListWebhooksUseCase.php
+++ b/src/Webhook/ListWebhooksUseCase.php
@@ -11,9 +11,10 @@ final readonly class ListWebhooksUseCase implements ListWebhooksUseCaseInterface
     ) {
     }
 
-    /** @return list<Webhook> */
-    public function execute(): array
+    public function execute(): ListWebhooksOutput
     {
-        return $this->webhooks->findAll();
+        return new ListWebhooksOutput(
+            items: $this->webhooks->findAll(),
+        );
     }
 }

--- a/src/Webhook/ListWebhooksUseCaseInterface.php
+++ b/src/Webhook/ListWebhooksUseCaseInterface.php
@@ -6,6 +6,5 @@ namespace NeNeRecords\Webhook;
 
 interface ListWebhooksUseCaseInterface
 {
-    /** @return list<Webhook> */
-    public function execute(): array;
+    public function execute(): ListWebhooksOutput;
 }


### PR DESCRIPTION
## 目的
コード品質監査の追加対応。UseCase の `execute()` シグネチャで raw プリミティブ型（`int $id`）や ドメインモデル直返し（`Webhook`・`Comment`）が残っていた 6 件を Input/Output DTO に統一する。

## 変更内容

### Webhook ドメイン（4 件）
| UseCase | 修正前 | 修正後 |
|---|---|---|
| ListWebhooks | `execute(): array` | `execute(): ListWebhooksOutput` |
| GetWebhookById | `execute(int $id): Webhook` | `execute(GetWebhookByIdInput): GetWebhookByIdOutput` |
| DeleteWebhook | `execute(int $id): void` | `execute(DeleteWebhookInput): void` |

**新規 DTO**: `ListWebhooksOutput` / `GetWebhookByIdInput` / `GetWebhookByIdOutput` / `DeleteWebhookInput`

### NavigationItem ドメイン（1 件）
| UseCase | 修正前 | 修正後 |
|---|---|---|
| DeleteNavigationItem | `execute(int $id): void` | `execute(DeleteNavigationItemInput): void` |

**新規 DTO**: `DeleteNavigationItemInput`

### Comment ドメイン（2 件）
| UseCase | 修正前 | 修正後 |
|---|---|---|
| PostComment | `execute(PostCommentInput): Comment` | `execute(PostCommentInput): PostCommentOutput` |
| ApproveComment | `execute(ApproveCommentInput): Comment` | `execute(ApproveCommentInput): ApproveCommentOutput` |

**新規 DTO**: `PostCommentOutput` / `ApproveCommentOutput`
**Handler 改善**: `PostCommentHandler` の private `serialize()` メソッドを廃止し、Output DTO 経由の一貫したシリアライズに統一

## 検証
```
composer check  ✅ 318 tests / PHPStan / CS-Fixer / OpenAPI / MCP すべて通過
```

## チェックリスト
- [x] 全 UseCase の `execute()` が Input/Output DTO を使用
- [x] Interface・Handler・UseCase 実装の 3 点セット更新
- [x] テスト（HTTP 統合テスト）変更不要（UseCase 内部の変更のため）
- [x] `composer check` 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)