### PR TITLE
refactor(entity): UnscheduleEntityUseCase に Input DTO を追加

### DIFF
--- a/src/Entity/UnscheduleEntityHandler.php
+++ b/src/Entity/UnscheduleEntityHandler.php
@@ -26,7 +26,7 @@ final readonly class UnscheduleEntityHandler
             throw new EntityNotFoundException($id);
         }
 
-        $this->useCase->execute($id);
+        $this->useCase->execute(new UnscheduleEntityInput($id));
 
         return $this->responseFactory->createResponse(204);
     }

--- a/src/Entity/UnscheduleEntityInput.php
+++ b/src/Entity/UnscheduleEntityInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+final readonly class UnscheduleEntityInput
+{
+    public function __construct(
+        public int $entityId,
+    ) {
+    }
+}

--- a/src/Entity/UnscheduleEntityUseCase.php
+++ b/src/Entity/UnscheduleEntityUseCase.php
@@ -13,12 +13,12 @@ final readonly class UnscheduleEntityUseCase implements UnscheduleEntityUseCaseI
     ) {
     }
 
-    public function execute(int $entityId): void
+    public function execute(UnscheduleEntityInput $input): void
     {
-        $existing = $this->entities->findById($entityId);
+        $existing = $this->entities->findById($input->entityId);
 
         if ($existing === null) {
-            throw new EntityNotFoundException($entityId);
+            throw new EntityNotFoundException($input->entityId);
         }
 
         $id = $existing->id;

--- a/src/Entity/UnscheduleEntityUseCaseInterface.php
+++ b/src/Entity/UnscheduleEntityUseCaseInterface.php
@@ -6,5 +6,5 @@ namespace NeNeRecords\Entity;
 
 interface UnscheduleEntityUseCaseInterface
 {
-    public function execute(int $entityId): void;
+    public function execute(UnscheduleEntityInput $input): void;
 }


### PR DESCRIPTION
## 目的

`UnscheduleEntityUseCase::execute(int $entityId)` が raw primitive 引数を取っており、他の UseCase との一貫性が欠如していた。

## 変更内容

- `UnscheduleEntityInput` readonly class 新規作成
- `execute(int $entityId)` → `execute(UnscheduleEntityInput $input)` に変更
- `UnscheduleEntityUseCaseInterface`・`UnscheduleEntityHandler` を合わせて修正

## 検証

```
composer check  # 318 tests + PHPStan + CS-Fixer + OpenAPI + MCP: all passed
```

## チェックリスト

- [x] テスト通過
- [x] PHPStan エラーなし
- [x] CS-Fixer 通過
- [x] 既存の API 動作変更なし

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)