### PR TITLE
test(setting): SettingValueValidator の単体テスト追加

### DIFF
--- a/tests/Setting/SettingValueValidatorTest.php
+++ b/tests/Setting/SettingValueValidatorTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Setting;
+
+use NeNeRecords\Setting\SettingValueInvalidException;
+use NeNeRecords\Setting\SettingValueValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class SettingValueValidatorTest extends TestCase
+{
+    // ── normalize ────────────────────────────────────────────────────────────
+
+    #[DataProvider('provideBoolNormalize')]
+    public function testNormalizeBool(string $input, string $expected): void
+    {
+        self::assertSame($expected, SettingValueValidator::normalize('bool', $input));
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function provideBoolNormalize(): iterable
+    {
+        yield '1 → true'           => ['1', 'true'];
+        yield 'true → true'        => ['true', 'true'];
+        yield 'TRUE → true'        => ['TRUE', 'true'];
+        yield '  True  → true'     => ['  True  ', 'true'];
+        yield '0 → false'          => ['0', 'false'];
+        yield 'false → false'      => ['false', 'false'];
+        yield 'FALSE → false'      => ['FALSE', 'false'];
+        yield '  False  → false'   => ['  False  ', 'false'];
+    }
+
+    public function testNormalizeBoolWithInvalidValueThrows(): void
+    {
+        $this->expectException(SettingValueInvalidException::class);
+        SettingValueValidator::normalize('bool', 'yes');
+    }
+
+    public function testNormalizeTextPassesThrough(): void
+    {
+        self::assertSame('hello', SettingValueValidator::normalize('text', 'hello'));
+    }
+
+    public function testNormalizeMarkdownPassesThrough(): void
+    {
+        self::assertSame('# Heading', SettingValueValidator::normalize('markdown', '# Heading'));
+    }
+
+    public function testNormalizeUrlPassesThrough(): void
+    {
+        self::assertSame('https://example.com', SettingValueValidator::normalize('url', 'https://example.com'));
+    }
+
+    public function testNormalizeUnsupportedTypeThrows(): void
+    {
+        $this->expectException(SettingValueInvalidException::class);
+        SettingValueValidator::normalize('json', 'value');
+    }
+
+    // ── validate ─────────────────────────────────────────────────────────────
+
+    public function testValidateBoolWithTrueDoesNotThrow(): void
+    {
+        $this->expectNotToPerformAssertions();
+        SettingValueValidator::validate('bool', 'true');
+    }
+
+    public function testValidateBoolWithFalseDoesNotThrow(): void
+    {
+        $this->expectNotToPerformAssertions();
+        SettingValueValidator::validate('bool', 'false');
+    }
+
+    public function testValidateBoolWithInvalidValueThrows(): void
+    {
+        $this->expectException(SettingValueInvalidException::class);
+        SettingValueValidator::validate('bool', 'maybe');
+    }
+
+    public function testValidateUrlWithValidUrlDoesNotThrow(): void
+    {
+        $this->expectNotToPerformAssertions();
+        SettingValueValidator::validate('url', 'https://example.com/path?q=1');
+    }
+
+    public function testValidateUrlWithEmptyStringDoesNotThrow(): void
+    {
+        $this->expectNotToPerformAssertions();
+        SettingValueValidator::validate('url', '');
+    }
+
+    public function testValidateUrlWithInvalidUrlThrows(): void
+    {
+        $this->expectException(SettingValueInvalidException::class);
+        SettingValueValidator::validate('url', 'not-a-url');
+    }
+
+    public function testValidateTextDoesNotThrow(): void
+    {
+        $this->expectNotToPerformAssertions();
+        SettingValueValidator::validate('text', 'anything goes');
+    }
+
+    public function testValidateMarkdownDoesNotThrow(): void
+    {
+        $this->expectNotToPerformAssertions();
+        SettingValueValidator::validate('markdown', '# Header\n\nContent');
+    }
+
+    public function testValidateUnsupportedTypeThrows(): void
+    {
+        $this->expectException(SettingValueInvalidException::class);
+        SettingValueValidator::validate('xml', 'value');
+    }
+}


### PR DESCRIPTION
## 目的

`SettingValueValidator` のバリデーション・正規化ロジックに単体テストが存在しなかった。

## 変更内容

`tests/Setting/SettingValueValidatorTest.php` を新規作成:

- **normalize()**
  - bool: '1', 'true', 'TRUE', 前後空白付き → 'true' へ正規化
  - bool: '0', 'false', 'FALSE' → 'false' へ正規化
  - bool: 不正値 → `SettingValueInvalidException`
  - text/markdown/url: そのまま通過
  - 未対応型: `SettingValueInvalidException`
- **validate()**
  - bool: 'true'/'false' → 正常
  - bool: 不正値 → `SettingValueInvalidException`
  - url: 有効 URL → 正常
  - url: 空文字列 → 正常（任意フィールド）
  - url: 不正 URL → `SettingValueInvalidException`
  - text/markdown: 何でも通過
  - 未対応型: `SettingValueInvalidException`

## 検証

```
composer check  # 340 tests (+ 22 new assertions) + PHPStan + CS-Fixer + OpenAPI + MCP: all passed
```

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)