### PR TITLE
feat(multi-tenancy): マルチテナント基盤を実装する

### DIFF
--- a/database/migrations/20260701000000_add_org_columns_to_users_and_drop_organization_users.php
+++ b/database/migrations/20260701000000_add_org_columns_to_users_and_drop_organization_users.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * マルチテナント基盤 Phase A — DB スキーマ変更
+ *
+ * 変更内容:
+ *  1. users テーブルに organization_id / org_role を追加
+ *     - organization_id: ユーザーが所属する組織 ID（superadmin は NULL）
+ *     - org_role: 組織内ロール（admin / editor）。superadmin は全組織を管理するため不要
+ *  2. organizations テーブルに external_id を追加
+ *     - 外部システム（NeNe Corpus など）との連携用識別子
+ *  3. organization_users テーブルを DROP
+ *     - 複数組織所属を想定した設計だったが、1ユーザー=1組織方針と矛盾するため廃棄
+ *     - このテーブルを使用するコードは存在しない
+ */
+final class AddOrgColumnsToUsersAndDropOrganizationUsers extends AbstractMigration
+{
+    public function up(): void
+    {
+        // 1. users: organization_id + org_role を追加（べき等）
+        if (!$this->columnExists('users', 'organization_id')) {
+            $this->execute('
+                ALTER TABLE users
+                    ADD COLUMN organization_id INT NULL DEFAULT NULL
+                        AFTER role,
+                    ADD COLUMN org_role VARCHAR(32) NULL DEFAULT NULL
+                        AFTER organization_id
+            ');
+
+            $this->execute('
+                ALTER TABLE users
+                    ADD INDEX idx_users_org_id (organization_id)
+            ');
+        }
+
+        // 2. organizations: external_id を追加（べき等）
+        if (!$this->columnExists('organizations', 'external_id')) {
+            $this->execute('
+                ALTER TABLE organizations
+                    ADD COLUMN external_id VARCHAR(255) NULL DEFAULT NULL
+                        AFTER slug,
+                    ADD UNIQUE INDEX idx_organizations_external_id (external_id)
+            ');
+        }
+
+        // 3. organization_users テーブルを DROP（べき等）
+        if ($this->hasTable('organization_users')) {
+            $this->execute('DROP TABLE organization_users');
+        }
+    }
+
+    public function down(): void
+    {
+        // organization_users を再作成
+        if (!$this->hasTable('organization_users')) {
+            $this->table('organization_users', ['id' => false, 'primary_key' => ['organization_id', 'user_id']])
+                ->addColumn('organization_id', 'integer', ['null' => false, 'signed' => false])
+                ->addColumn('user_id', 'integer', ['null' => false, 'signed' => false])
+                ->addColumn('role', 'string', ['limit' => 32, 'null' => false, 'default' => 'admin'])
+                ->addColumn('created_at', 'datetime', ['null' => false])
+                ->addIndex(['organization_id'])
+                ->addIndex(['user_id'])
+                ->addForeignKey('organization_id', 'organizations', 'id', ['delete' => 'CASCADE'])
+                ->addForeignKey('user_id', 'users', 'id', ['delete' => 'CASCADE'])
+                ->create();
+        }
+
+        // organizations: external_id を削除
+        if ($this->columnExists('organizations', 'external_id')) {
+            $this->execute('ALTER TABLE organizations DROP COLUMN external_id');
+        }
+
+        // users: organization_id / org_role を削除
+        if ($this->columnExists('users', 'org_role')) {
+            $this->execute('ALTER TABLE users DROP COLUMN org_role');
+        }
+
+        if ($this->columnExists('users', 'organization_id')) {
+            $this->execute('ALTER TABLE users DROP COLUMN organization_id');
+        }
+    }
+
+    private function columnExists(string $table, string $column): bool
+    {
+        $row = $this->fetchRow("
+            SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = '{$table}'
+              AND COLUMN_NAME = '{$column}'
+            LIMIT 1
+        ");
+
+        return $row !== false;
+    }
+}

--- a/database/schema/organizations.sql
+++ b/database/schema/organizations.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS organizations (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name VARCHAR(255) NOT NULL,
     slug VARCHAR(100) NOT NULL,
+    external_id VARCHAR(255) NULL DEFAULT NULL,
     custom_domain VARCHAR(255) NULL DEFAULT NULL,
     plan VARCHAR(32) NOT NULL DEFAULT 'free',
     is_active BOOLEAN NOT NULL DEFAULT 1,
@@ -9,3 +10,4 @@ CREATE TABLE IF NOT EXISTS organizations (
     updated_at DATETIME NOT NULL
 );
 CREATE UNIQUE INDEX organizations_slug ON organizations (slug);
+CREATE UNIQUE INDEX idx_organizations_external_id ON organizations (external_id);

--- a/database/schema/users.sql
+++ b/database/schema/users.sql
@@ -3,6 +3,8 @@ CREATE TABLE users (
     email VARCHAR(255) NOT NULL,
     password_hash VARCHAR(255) NOT NULL,
     role VARCHAR(32) NOT NULL DEFAULT 'admin',
+    organization_id INT NULL DEFAULT NULL,
+    org_role VARCHAR(32) NULL DEFAULT NULL,
     status ENUM('active', 'invited') NOT NULL DEFAULT 'active',
     invite_token_hash VARCHAR(64) NULL DEFAULT NULL,
     invite_expires_at DATETIME NULL DEFAULT NULL,
@@ -12,3 +14,4 @@ CREATE TABLE users (
     updated_at DATETIME NOT NULL
 );
 CREATE UNIQUE INDEX users_email ON users (email);
+CREATE INDEX idx_users_org_id ON users (organization_id);

--- a/src/Auth/CapabilityMiddleware.php
+++ b/src/Auth/CapabilityMiddleware.php
@@ -11,9 +11,14 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
- * Enforces role-based capabilities on authenticated API requests.
+ * Enforces role-based capabilities and organization scoping on authenticated API requests.
  *
  * Runs after AdminApiAuthMiddleware. Unauthenticated requests pass through unchanged.
+ *
+ * Organization scoping rules:
+ *  - superadmin: no org check — can operate across all organizations
+ *  - admin / editor: JWT org_id must match the resolved org ID (nene2.org.id request attribute)
+ *    If the org has not been resolved for this route (bypass paths), the check is skipped.
  */
 final readonly class CapabilityMiddleware implements MiddlewareInterface
 {
@@ -47,6 +52,28 @@ final readonly class CapabilityMiddleware implements MiddlewareInterface
                 403,
                 'You do not have permission to perform this action.',
             );
+        }
+
+        // Organization scope check: skip for superadmin and routes where org is not resolved.
+        // OrgResolverMiddleware sets nene2.org.id (an int) only for org-scoped routes.
+        if ($role !== Role::Superadmin) {
+            $resolvedOrgId = $request->getAttribute('nene2.org.id');
+
+            if (is_int($resolvedOrgId)) {
+                $jwtOrgId = isset($claims['org_id']) && is_int($claims['org_id'])
+                    ? $claims['org_id']
+                    : null;
+
+                if ($jwtOrgId !== $resolvedOrgId) {
+                    return $this->problemDetails->create(
+                        $request,
+                        'org-access-denied',
+                        'Organization Access Denied',
+                        403,
+                        'Access to this organization is not permitted.',
+                    );
+                }
+            }
         }
 
         return $handler->handle($request);

--- a/src/Auth/LoginHandler.php
+++ b/src/Auth/LoginHandler.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Auth;
 
+use DateTimeImmutable;
+use DateTimeInterface;
 use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
@@ -43,10 +45,11 @@ final readonly class LoginHandler
         $output = $this->useCase->execute(new LoginInput(email: $email, password: $password));
 
         return $this->response->create([
-            'token' => $output->token,
-            'expires_at' => (new \DateTimeImmutable('@' . $output->expiresAt))->format(\DateTimeInterface::ATOM),
-            'email' => $output->email,
-            'role' => $output->role,
+            'token'      => $output->token,
+            'expires_at' => (new DateTimeImmutable('@' . $output->expiresAt))->format(DateTimeInterface::ATOM),
+            'email'      => $output->email,
+            'role'       => $output->role,
+            'org_id'     => $output->orgId,
         ]);
     }
 }

--- a/src/Auth/LoginOutput.php
+++ b/src/Auth/LoginOutput.php
@@ -11,6 +11,7 @@ final readonly class LoginOutput
         public int $expiresAt,
         public string $email,
         public string $role,
+        public ?int $orgId = null,
     ) {
     }
 }

--- a/src/Auth/LoginUseCase.php
+++ b/src/Auth/LoginUseCase.php
@@ -32,11 +32,16 @@ final readonly class LoginUseCase
 
         $expiresAt = time() + self::TOKEN_TTL_SECONDS;
 
+        // superadmin はどの組織にも属さないため org_id は null。
+        // admin / editor は所属組織の ID を JWT に埋め込む。
+        $orgId = $role === Role::Superadmin ? null : $user->organizationId;
+
         $token = $this->tokenIssuer->issue([
-            'sub' => $user->email,
-            'role' => $role->value,
-            'iat' => time(),
-            'exp' => $expiresAt,
+            'sub'    => $user->email,
+            'role'   => $role->value,
+            'org_id' => $orgId,
+            'iat'    => time(),
+            'exp'    => $expiresAt,
         ]);
 
         return new LoginOutput(
@@ -44,6 +49,7 @@ final readonly class LoginUseCase
             expiresAt: $expiresAt,
             email: $user->email,
             role: $role->value,
+            orgId: $orgId,
         );
     }
 }

--- a/src/Auth/PdoUserRepository.php
+++ b/src/Auth/PdoUserRepository.php
@@ -8,6 +8,14 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 
 final readonly class PdoUserRepository implements UserRepositoryInterface
 {
+    private const SELECT_COLUMNS = '
+        id, email, password_hash, role, organization_id, org_role, status,
+        invite_token_hash, invite_expires_at,
+        password_reset_token_hash, password_reset_expires_at,
+        UNIX_TIMESTAMP(created_at) AS created_at,
+        UNIX_TIMESTAMP(updated_at) AS updated_at
+    ';
+
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
     ) {
@@ -16,12 +24,7 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
     public function findByEmail(string $email): ?User
     {
         $row = $this->query->fetchOne(
-            'SELECT id, email, password_hash, role, status,
-                    invite_token_hash, invite_expires_at,
-                    password_reset_token_hash, password_reset_expires_at,
-                    UNIX_TIMESTAMP(created_at) AS created_at,
-                    UNIX_TIMESTAMP(updated_at) AS updated_at
-             FROM users WHERE email = ?',
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM users WHERE email = ?',
             [$email],
         );
 
@@ -35,12 +38,7 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
     public function findById(int $id): ?User
     {
         $row = $this->query->fetchOne(
-            'SELECT id, email, password_hash, role, status,
-                    invite_token_hash, invite_expires_at,
-                    password_reset_token_hash, password_reset_expires_at,
-                    UNIX_TIMESTAMP(created_at) AS created_at,
-                    UNIX_TIMESTAMP(updated_at) AS updated_at
-             FROM users WHERE id = ?',
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM users WHERE id = ?',
             [$id],
         );
 
@@ -55,25 +53,36 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
     public function list(): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT id, email, password_hash, role, status,
-                    invite_token_hash, invite_expires_at,
-                    password_reset_token_hash, password_reset_expires_at,
-                    UNIX_TIMESTAMP(created_at) AS created_at,
-                    UNIX_TIMESTAMP(updated_at) AS updated_at
-             FROM users ORDER BY id ASC',
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM users ORDER BY id ASC',
             [],
         );
 
         return array_map($this->mapRow(...), $rows);
     }
 
-    public function create(string $email, string $passwordHash, string $role): User
+    /** @return list<User> */
+    public function listByOrganizationId(int $organizationId): array
     {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM users WHERE organization_id = ? ORDER BY id ASC',
+            [$organizationId],
+        );
+
+        return array_map($this->mapRow(...), $rows);
+    }
+
+    public function create(
+        string $email,
+        string $passwordHash,
+        string $role,
+        ?int $organizationId = null,
+        ?string $orgRole = null,
+    ): User {
         $now = date('Y-m-d H:i:s');
         $this->query->execute(
-            'INSERT INTO users (email, password_hash, role, status, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?)',
-            [$email, $passwordHash, $role, 'active', $now, $now],
+            'INSERT INTO users (email, password_hash, role, organization_id, org_role, status, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            [$email, $passwordHash, $role, $organizationId, $orgRole, 'active', $now, $now],
         );
 
         $user = $this->findByEmail($email);
@@ -81,6 +90,14 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
         assert($user !== null);
 
         return $user;
+    }
+
+    public function updateOrganization(int $id, ?int $organizationId, ?string $orgRole): void
+    {
+        $this->query->execute(
+            'UPDATE users SET organization_id = ?, org_role = ?, updated_at = NOW() WHERE id = ?',
+            [$organizationId, $orgRole, $id],
+        );
     }
 
     public function updateRole(int $id, string $role): void
@@ -119,12 +136,7 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
     public function findByInviteToken(string $tokenHash): ?User
     {
         $row = $this->query->fetchOne(
-            'SELECT id, email, password_hash, role, status,
-                    invite_token_hash, invite_expires_at,
-                    password_reset_token_hash, password_reset_expires_at,
-                    UNIX_TIMESTAMP(created_at) AS created_at,
-                    UNIX_TIMESTAMP(updated_at) AS updated_at
-             FROM users WHERE invite_token_hash = ?',
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM users WHERE invite_token_hash = ?',
             [$tokenHash],
         );
 
@@ -155,12 +167,7 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
     public function findByPasswordResetToken(string $tokenHash): ?User
     {
         $row = $this->query->fetchOne(
-            'SELECT id, email, password_hash, role, status,
-                    invite_token_hash, invite_expires_at,
-                    password_reset_token_hash, password_reset_expires_at,
-                    UNIX_TIMESTAMP(created_at) AS created_at,
-                    UNIX_TIMESTAMP(updated_at) AS updated_at
-             FROM users WHERE password_reset_token_hash = ?',
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM users WHERE password_reset_token_hash = ?',
             [$tokenHash],
         );
 
@@ -202,6 +209,8 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
             email: (string) $row['email'],
             passwordHash: (string) $row['password_hash'],
             role: (string) $row['role'],
+            organizationId: isset($row['organization_id']) ? (int) $row['organization_id'] : null,
+            orgRole: isset($row['org_role']) ? (string) $row['org_role'] : null,
             status: (string) ($row['status'] ?? 'active'),
             inviteTokenHash: isset($row['invite_token_hash']) ? (string) $row['invite_token_hash'] : null,
             inviteExpiresAt: isset($row['invite_expires_at']) ? (int) $row['invite_expires_at'] : null,

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -11,6 +11,8 @@ final readonly class User
         public string $email,
         public string $passwordHash,
         public string $role,
+        public ?int $organizationId = null,
+        public ?string $orgRole = null,
         public string $status = 'active',
         public ?string $inviteTokenHash = null,
         public ?int $inviteExpiresAt = null,

--- a/src/Auth/UserRepositoryInterface.php
+++ b/src/Auth/UserRepositoryInterface.php
@@ -13,7 +13,18 @@ interface UserRepositoryInterface
     /** @return list<User> */
     public function list(): array;
 
-    public function create(string $email, string $passwordHash, string $role): User;
+    /** @return list<User> */
+    public function listByOrganizationId(int $organizationId): array;
+
+    public function create(
+        string $email,
+        string $passwordHash,
+        string $role,
+        ?int $organizationId = null,
+        ?string $orgRole = null,
+    ): User;
+
+    public function updateOrganization(int $id, ?int $organizationId, ?string $orgRole): void;
 
     public function updateRole(int $id, string $role): void;
 

--- a/src/Organization/CreateOrganizationHandler.php
+++ b/src/Organization/CreateOrganizationHandler.php
@@ -34,6 +34,9 @@ final readonly class CreateOrganizationHandler implements RequestHandlerInterfac
         $name         = trim((string) ($body['name'] ?? ''));
         $slug         = trim((string) ($body['slug'] ?? ''));
         $plan         = trim((string) ($body['plan'] ?? 'free'));
+        $externalId   = isset($body['external_id']) && $body['external_id'] !== ''
+            ? trim((string) $body['external_id'])
+            : null;
         $customDomain = isset($body['custom_domain']) && $body['custom_domain'] !== ''
             ? trim((string) $body['custom_domain'])
             : null;
@@ -60,6 +63,7 @@ final readonly class CreateOrganizationHandler implements RequestHandlerInterfac
             name: $name,
             slug: $slug,
             plan: $plan,
+            externalId: $externalId,
             customDomain: $customDomain,
         ));
 
@@ -68,6 +72,7 @@ final readonly class CreateOrganizationHandler implements RequestHandlerInterfac
                 'id'            => $output->id,
                 'name'          => $output->name,
                 'slug'          => $output->slug,
+                'external_id'   => $output->externalId,
                 'custom_domain' => $output->customDomain,
                 'plan'          => $output->plan,
                 'is_active'     => $output->isActive,

--- a/src/Organization/CreateOrganizationInput.php
+++ b/src/Organization/CreateOrganizationInput.php
@@ -11,6 +11,7 @@ final readonly class CreateOrganizationInput
         public string $slug,
         public string $plan = 'free',
         public bool $isActive = true,
+        public ?string $externalId = null,
         public ?string $customDomain = null,
     ) {
     }

--- a/src/Organization/CreateOrganizationOutput.php
+++ b/src/Organization/CreateOrganizationOutput.php
@@ -12,6 +12,7 @@ final readonly class CreateOrganizationOutput
         public string $slug,
         public string $plan,
         public bool $isActive,
+        public ?string $externalId,
         public ?string $customDomain,
     ) {
     }

--- a/src/Organization/CreateOrganizationUseCase.php
+++ b/src/Organization/CreateOrganizationUseCase.php
@@ -14,6 +14,7 @@ final readonly class CreateOrganizationUseCase implements CreateOrganizationUseC
     public function execute(CreateOrganizationInput $input): CreateOrganizationOutput
     {
         $existing = $this->organizations->findBySlug($input->slug);
+
         if ($existing !== null) {
             throw new OrganizationSlugConflictException($input->slug);
         }
@@ -23,6 +24,7 @@ final readonly class CreateOrganizationUseCase implements CreateOrganizationUseC
             slug: $input->slug,
             plan: $input->plan,
             isActive: $input->isActive,
+            externalId: $input->externalId,
             customDomain: $input->customDomain,
         ));
 
@@ -32,6 +34,7 @@ final readonly class CreateOrganizationUseCase implements CreateOrganizationUseC
             slug: $input->slug,
             plan: $input->plan,
             isActive: $input->isActive,
+            externalId: $input->externalId,
             customDomain: $input->customDomain,
         );
     }

--- a/src/Organization/GetOrganizationByIdHandler.php
+++ b/src/Organization/GetOrganizationByIdHandler.php
@@ -29,6 +29,7 @@ final readonly class GetOrganizationByIdHandler implements RequestHandlerInterfa
             'id'            => $output->id,
             'name'          => $output->name,
             'slug'          => $output->slug,
+            'external_id'   => $output->externalId,
             'custom_domain' => $output->customDomain,
             'plan'          => $output->plan,
             'is_active'     => $output->isActive,

--- a/src/Organization/GetOrganizationByIdOutput.php
+++ b/src/Organization/GetOrganizationByIdOutput.php
@@ -12,6 +12,7 @@ final readonly class GetOrganizationByIdOutput
         public string $slug,
         public string $plan,
         public bool $isActive,
+        public ?string $externalId,
         public ?string $customDomain,
         public ?string $createdAt,
         public ?string $updatedAt,

--- a/src/Organization/GetOrganizationByIdUseCase.php
+++ b/src/Organization/GetOrganizationByIdUseCase.php
@@ -25,6 +25,7 @@ final readonly class GetOrganizationByIdUseCase implements GetOrganizationByIdUs
             slug: $org->slug,
             plan: $org->plan,
             isActive: $org->isActive,
+            externalId: $org->externalId,
             customDomain: $org->customDomain,
             createdAt: $org->createdAt,
             updatedAt: $org->updatedAt,

--- a/src/Organization/ListOrganizationItem.php
+++ b/src/Organization/ListOrganizationItem.php
@@ -12,6 +12,7 @@ final readonly class ListOrganizationItem
         public string $slug,
         public string $plan,
         public bool $isActive,
+        public ?string $externalId,
         public ?string $customDomain,
         public ?string $createdAt,
         public ?string $updatedAt,

--- a/src/Organization/ListOrganizationsHandler.php
+++ b/src/Organization/ListOrganizationsHandler.php
@@ -31,6 +31,7 @@ final readonly class ListOrganizationsHandler implements RequestHandlerInterface
                     'id'            => $item->id,
                     'name'          => $item->name,
                     'slug'          => $item->slug,
+                    'external_id'   => $item->externalId,
                     'custom_domain' => $item->customDomain,
                     'plan'          => $item->plan,
                     'is_active'     => $item->isActive,

--- a/src/Organization/ListOrganizationsUseCase.php
+++ b/src/Organization/ListOrganizationsUseCase.php
@@ -14,7 +14,7 @@ final readonly class ListOrganizationsUseCase implements ListOrganizationsUseCas
     public function execute(ListOrganizationsInput $input): ListOrganizationsOutput
     {
         $organizations = $this->organizations->findAll($input->limit, $input->offset);
-        $total = $this->organizations->count();
+        $total         = $this->organizations->count();
 
         $items = array_map(
             static fn (Organization $o): ListOrganizationItem => new ListOrganizationItem(
@@ -23,6 +23,7 @@ final readonly class ListOrganizationsUseCase implements ListOrganizationsUseCas
                 slug: $o->slug,
                 plan: $o->plan,
                 isActive: $o->isActive,
+                externalId: $o->externalId,
                 customDomain: $o->customDomain,
                 createdAt: $o->createdAt,
                 updatedAt: $o->updatedAt,

--- a/src/Organization/Organization.php
+++ b/src/Organization/Organization.php
@@ -12,6 +12,7 @@ final readonly class Organization
         public string $plan,
         public bool $isActive,
         public ?int $id = null,
+        public ?string $externalId = null,
         public ?string $customDomain = null,
         public ?string $createdAt = null,
         public ?string $updatedAt = null,

--- a/src/Organization/PdoOrganizationRepository.php
+++ b/src/Organization/PdoOrganizationRepository.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace NeNeRecords\Organization;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use PDOException;
 
 final readonly class PdoOrganizationRepository implements OrganizationRepositoryInterface
 {
-    private const COLUMNS = 'id, name, slug, custom_domain, plan, is_active, created_at, updated_at';
+    private const COLUMNS = 'id, name, slug, external_id, custom_domain, plan, is_active, created_at, updated_at';
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
@@ -59,6 +60,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
     public function count(): int
     {
         $row = $this->query->fetchOne('SELECT COUNT(*) AS cnt FROM organizations', []);
+
         return $row !== null ? (int) $row['cnt'] : 0;
     }
 
@@ -68,10 +70,12 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
 
         try {
             $this->query->execute(
-                'INSERT INTO organizations (name, slug, custom_domain, plan, is_active, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+                'INSERT INTO organizations (name, slug, external_id, custom_domain, plan, is_active, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
                 [
                     $organization->name,
                     $organization->slug,
+                    $organization->externalId,
                     $organization->customDomain,
                     $organization->plan,
                     $organization->isActive ? 1 : 0,
@@ -79,7 +83,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
                     $now,
                 ],
             );
-        } catch (\PDOException $e) {
+        } catch (PDOException $e) {
             if (str_contains($e->getMessage(), 'Duplicate entry') || str_contains($e->getMessage(), 'UNIQUE constraint failed')) {
                 throw new OrganizationSlugConflictException($organization->slug);
             }
@@ -99,10 +103,11 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
         $now = date('Y-m-d H:i:s');
 
         $this->query->execute(
-            'UPDATE organizations SET name = ?, slug = ?, custom_domain = ?, plan = ?, is_active = ?, updated_at = ? WHERE id = ?',
+            'UPDATE organizations SET name = ?, slug = ?, external_id = ?, custom_domain = ?, plan = ?, is_active = ?, updated_at = ? WHERE id = ?',
             [
                 $organization->name,
                 $organization->slug,
+                $organization->externalId,
                 $organization->customDomain,
                 $organization->plan,
                 $organization->isActive ? 1 : 0,
@@ -132,6 +137,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
             plan: (string) $row['plan'],
             isActive: (bool) $row['is_active'],
             id: (int) $row['id'],
+            externalId: isset($row['external_id']) && $row['external_id'] !== '' ? (string) $row['external_id'] : null,
             customDomain: isset($row['custom_domain']) && $row['custom_domain'] !== '' ? (string) $row['custom_domain'] : null,
             createdAt: (string) $row['created_at'],
             updatedAt: (string) $row['updated_at'],

--- a/src/Organization/UpdateOrganizationHandler.php
+++ b/src/Organization/UpdateOrganizationHandler.php
@@ -39,6 +39,11 @@ final readonly class UpdateOrganizationHandler implements RequestHandlerInterfac
         $plan     = isset($body['plan']) ? trim((string) $body['plan']) : null;
         $isActive = isset($body['is_active']) ? (bool) $body['is_active'] : null;
 
+        $updateExternalId = array_key_exists('external_id', $body);
+        $externalId       = $updateExternalId
+            ? (($body['external_id'] !== null && $body['external_id'] !== '') ? trim((string) $body['external_id']) : null)
+            : null;
+
         $updateCustomDomain = array_key_exists('custom_domain', $body);
         $customDomain       = $updateCustomDomain
             ? (($body['custom_domain'] !== null && $body['custom_domain'] !== '') ? trim((string) $body['custom_domain']) : null)
@@ -72,12 +77,15 @@ final readonly class UpdateOrganizationHandler implements RequestHandlerInterfac
             isActive: $isActive,
             updateCustomDomain: $updateCustomDomain,
             customDomain: $customDomain,
+            updateExternalId: $updateExternalId,
+            externalId: $externalId,
         ));
 
         return $this->response->create([
             'id'            => $output->id,
             'name'          => $output->name,
             'slug'          => $output->slug,
+            'external_id'   => $output->externalId,
             'custom_domain' => $output->customDomain,
             'plan'          => $output->plan,
             'is_active'     => $output->isActive,

--- a/src/Organization/UpdateOrganizationInput.php
+++ b/src/Organization/UpdateOrganizationInput.php
@@ -7,12 +7,14 @@ namespace NeNeRecords\Organization;
 final readonly class UpdateOrganizationInput
 {
     /**
-     * @param ?string $name         null = keep current
-     * @param ?string $slug         null = keep current
-     * @param ?string $plan         null = keep current
-     * @param ?bool   $isActive     null = keep current
+     * @param ?string $name              null = keep current
+     * @param ?string $slug              null = keep current
+     * @param ?string $plan              null = keep current
+     * @param ?bool   $isActive          null = keep current
+     * @param bool    $updateExternalId  true = apply $externalId (even when null to clear)
+     * @param ?string $externalId        value to set when $updateExternalId is true; null clears the field
      * @param bool    $updateCustomDomain  true = apply $customDomain (even when null to clear)
-     * @param ?string $customDomain value to set when $updateCustomDomain is true; null clears the field
+     * @param ?string $customDomain      value to set when $updateCustomDomain is true; null clears the field
      */
     public function __construct(
         public int $id,
@@ -22,6 +24,8 @@ final readonly class UpdateOrganizationInput
         public ?bool $isActive,
         public bool $updateCustomDomain,
         public ?string $customDomain,
+        public bool $updateExternalId = false,
+        public ?string $externalId = null,
     ) {
     }
 }

--- a/src/Organization/UpdateOrganizationOutput.php
+++ b/src/Organization/UpdateOrganizationOutput.php
@@ -12,6 +12,7 @@ final readonly class UpdateOrganizationOutput
         public string $slug,
         public string $plan,
         public bool $isActive,
+        public ?string $externalId,
         public ?string $customDomain,
         public ?string $createdAt,
         public ?string $updatedAt,

--- a/src/Organization/UpdateOrganizationUseCase.php
+++ b/src/Organization/UpdateOrganizationUseCase.php
@@ -19,14 +19,16 @@ final readonly class UpdateOrganizationUseCase implements UpdateOrganizationUseC
             throw new OrganizationNotFoundException($input->id);
         }
 
-        $name         = $input->name         ?? $org->name;
-        $slug         = $input->slug         ?? $org->slug;
-        $plan         = $input->plan         ?? $org->plan;
-        $isActive     = $input->isActive     ?? $org->isActive;
+        $name         = $input->name     ?? $org->name;
+        $slug         = $input->slug     ?? $org->slug;
+        $plan         = $input->plan     ?? $org->plan;
+        $isActive     = $input->isActive ?? $org->isActive;
+        $externalId   = $input->updateExternalId ? $input->externalId : $org->externalId;
         $customDomain = $input->updateCustomDomain ? $input->customDomain : $org->customDomain;
 
         if ($slug !== $org->slug) {
             $existing = $this->organizations->findBySlug($slug);
+
             if ($existing !== null && $existing->id !== $input->id) {
                 throw new OrganizationSlugConflictException($slug);
             }
@@ -38,6 +40,7 @@ final readonly class UpdateOrganizationUseCase implements UpdateOrganizationUseC
             plan: $plan,
             isActive: $isActive,
             id: $input->id,
+            externalId: $externalId,
             customDomain: $customDomain,
         );
 
@@ -56,6 +59,7 @@ final readonly class UpdateOrganizationUseCase implements UpdateOrganizationUseC
             slug: $refreshed->slug,
             plan: $refreshed->plan,
             isActive: $refreshed->isActive,
+            externalId: $refreshed->externalId,
             customDomain: $refreshed->customDomain,
             createdAt: $refreshed->createdAt,
             updatedAt: $refreshed->updatedAt,

--- a/src/User/CreateUserHandler.php
+++ b/src/User/CreateUserHandler.php
@@ -8,6 +8,7 @@ use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
+use NeNeRecords\Auth\Role;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -25,9 +26,9 @@ final readonly class CreateUserHandler
 
         $errors = [];
 
-        $email = trim((string) ($body['email'] ?? ''));
+        $email    = trim((string) ($body['email'] ?? ''));
         $password = (string) ($body['password'] ?? '');
-        $role = trim((string) ($body['role'] ?? ''));
+        $role     = trim((string) ($body['role'] ?? ''));
 
         if ($email === '') {
             $errors[] = new ValidationError('email', 'Email is required.', 'required');
@@ -49,18 +50,35 @@ final readonly class CreateUserHandler
             throw new ValidationException($errors);
         }
 
+        // 組織 ID の解決:
+        //  - nene2.org.id が設定されている (org-scoped route) → そちらを使う
+        //  - なければリクエストボディの organization_id を使う（superadmin 直接指定）
+        $resolvedOrgId = $request->getAttribute('nene2.org.id');
+        $claims        = $request->getAttribute('nene2.auth.claims');
+        $callerRole    = is_array($claims) ? Role::tryFrom((string) ($claims['role'] ?? '')) : null;
+
+        if ($resolvedOrgId !== null) {
+            $organizationId = (int) $resolvedOrgId;
+        } elseif ($callerRole === Role::Superadmin && isset($body['organization_id'])) {
+            $organizationId = (int) $body['organization_id'];
+        } else {
+            $organizationId = null;
+        }
+
         $output = $this->useCase->execute(new CreateUserInput(
             email: $email,
             password: $password,
             role: $role,
+            organizationId: $organizationId,
+            orgRole: $role,
         ));
 
         return $this->response->create(
             [
-                'id' => $output->id,
-                'email' => $output->email,
-                'role' => $output->role,
-                'status' => $output->status,
+                'id'         => $output->id,
+                'email'      => $output->email,
+                'role'       => $output->role,
+                'status'     => $output->status,
                 'created_at' => $output->createdAt !== null ? date('c', $output->createdAt) : null,
             ],
             201,

--- a/src/User/CreateUserInput.php
+++ b/src/User/CreateUserInput.php
@@ -10,6 +10,8 @@ final readonly class CreateUserInput
         public string $email,
         public string $password,
         public string $role,
+        public ?int $organizationId = null,
+        public ?string $orgRole = null,
     ) {
     }
 }

--- a/src/User/CreateUserUseCase.php
+++ b/src/User/CreateUserUseCase.php
@@ -30,7 +30,13 @@ final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
         }
 
         $passwordHash = password_hash($input->password, PASSWORD_BCRYPT);
-        $user = $this->users->create($input->email, $passwordHash, $input->role);
+        $user = $this->users->create(
+            $input->email,
+            $passwordHash,
+            $input->role,
+            $input->organizationId,
+            $input->orgRole ?? $input->role, // org_role はデフォルトで role と同値
+        );
 
         return new CreateUserOutput(
             id: $user->id,

--- a/src/User/GetUserByIdHandler.php
+++ b/src/User/GetUserByIdHandler.php
@@ -20,17 +20,19 @@ final readonly class GetUserByIdHandler
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
-        $id = (int) ($parameters['id'] ?? 0);
+        $id         = (int) ($parameters['id'] ?? 0);
 
         $output = $this->useCase->execute(new GetUserByIdInput($id));
 
         return $this->response->create([
-            'id' => $output->id,
-            'email' => $output->email,
-            'role' => $output->role,
-            'status' => $output->status,
-            'created_at' => $output->createdAt !== null ? date('c', $output->createdAt) : null,
-            'updated_at' => $output->updatedAt !== null ? date('c', $output->updatedAt) : null,
+            'id'              => $output->id,
+            'email'           => $output->email,
+            'role'            => $output->role,
+            'organization_id' => $output->organizationId,
+            'org_role'        => $output->orgRole,
+            'status'          => $output->status,
+            'created_at'      => $output->createdAt !== null ? date('c', $output->createdAt) : null,
+            'updated_at'      => $output->updatedAt !== null ? date('c', $output->updatedAt) : null,
         ]);
     }
 }

--- a/src/User/GetUserByIdOutput.php
+++ b/src/User/GetUserByIdOutput.php
@@ -10,6 +10,8 @@ final readonly class GetUserByIdOutput
         public int $id,
         public string $email,
         public string $role,
+        public ?int $organizationId,
+        public ?string $orgRole,
         public string $status,
         public ?int $createdAt,
         public ?int $updatedAt,

--- a/src/User/GetUserByIdUseCase.php
+++ b/src/User/GetUserByIdUseCase.php
@@ -25,6 +25,8 @@ final readonly class GetUserByIdUseCase implements GetUserByIdUseCaseInterface
             id: $user->id,
             email: $user->email,
             role: $user->role,
+            organizationId: $user->organizationId,
+            orgRole: $user->orgRole,
             status: $user->status,
             createdAt: $user->createdAt,
             updatedAt: $user->updatedAt,

--- a/src/User/ListUserItem.php
+++ b/src/User/ListUserItem.php
@@ -10,6 +10,8 @@ final readonly class ListUserItem
         public int $id,
         public string $email,
         public string $role,
+        public ?int $organizationId,
+        public ?string $orgRole,
         public string $status,
         public ?int $createdAt,
         public ?int $updatedAt,

--- a/src/User/ListUsersHandler.php
+++ b/src/User/ListUsersHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\User;
 
 use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Auth\Role;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -18,17 +19,31 @@ final readonly class ListUsersHandler
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $output = $this->useCase->execute(new ListUsersInput());
+        $claims = $request->getAttribute('nene2.auth.claims');
+        $role   = is_array($claims) ? Role::tryFrom((string) ($claims['role'] ?? '')) : null;
+
+        // superadmin → 全ユーザー（organizationId = null）
+        // admin / editor → JWT の org_id で絞り込む
+        $organizationId = null;
+
+        if ($role !== null && $role !== Role::Superadmin) {
+            $rawOrgId = $claims['org_id'] ?? null;
+            $organizationId = $rawOrgId !== null ? (int) $rawOrgId : null;
+        }
+
+        $output = $this->useCase->execute(new ListUsersInput(organizationId: $organizationId));
 
         return $this->response->create([
             'items' => array_map(
                 static fn (ListUserItem $item) => [
-                    'id' => $item->id,
-                    'email' => $item->email,
-                    'role' => $item->role,
-                    'status' => $item->status,
-                    'created_at' => $item->createdAt !== null ? date('c', $item->createdAt) : null,
-                    'updated_at' => $item->updatedAt !== null ? date('c', $item->updatedAt) : null,
+                    'id'              => $item->id,
+                    'email'           => $item->email,
+                    'role'            => $item->role,
+                    'organization_id' => $item->organizationId,
+                    'org_role'        => $item->orgRole,
+                    'status'          => $item->status,
+                    'created_at'      => $item->createdAt !== null ? date('c', $item->createdAt) : null,
+                    'updated_at'      => $item->updatedAt !== null ? date('c', $item->updatedAt) : null,
                 ],
                 $output->items,
             ),

--- a/src/User/ListUsersInput.php
+++ b/src/User/ListUsersInput.php
@@ -6,4 +6,9 @@ namespace NeNeRecords\User;
 
 final readonly class ListUsersInput
 {
+    public function __construct(
+        /** superadmin は null を渡して全ユーザーを取得。admin/editor は自組織 ID を渡す。 */
+        public ?int $organizationId = null,
+    ) {
+    }
 }

--- a/src/User/ListUsersUseCase.php
+++ b/src/User/ListUsersUseCase.php
@@ -15,13 +15,19 @@ final readonly class ListUsersUseCase implements ListUsersUseCaseInterface
 
     public function execute(ListUsersInput $input): ListUsersOutput
     {
-        $users = $this->users->list();
+        // superadmin (organizationId = null) → 全ユーザー一覧
+        // admin / editor (organizationId = N) → 自組織ユーザーのみ
+        $users = $input->organizationId !== null
+            ? $this->users->listByOrganizationId($input->organizationId)
+            : $this->users->list();
 
         $items = array_map(
             static fn ($user) => new ListUserItem(
                 id: $user->id,
                 email: $user->email,
                 role: $user->role,
+                organizationId: $user->organizationId,
+                orgRole: $user->orgRole,
                 status: $user->status,
                 createdAt: $user->createdAt,
                 updatedAt: $user->updatedAt,

--- a/src/UserInvite/InviteUserHandler.php
+++ b/src/UserInvite/InviteUserHandler.php
@@ -8,6 +8,7 @@ use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
+use NeNeRecords\Auth\Role;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -26,7 +27,7 @@ final readonly class InviteUserHandler
         $errors = [];
 
         $email = trim((string) ($body['email'] ?? ''));
-        $role = trim((string) ($body['role'] ?? ''));
+        $role  = trim((string) ($body['role'] ?? ''));
 
         if ($email === '') {
             $errors[] = new ValidationError('email', 'Email is required.', 'required');
@@ -45,23 +46,38 @@ final readonly class InviteUserHandler
         $appBaseUrl = (string) ($body['app_base_url'] ?? '');
 
         if ($appBaseUrl === '') {
-            $scheme = $request->getUri()->getScheme();
-            $host = $request->getUri()->getHost();
-            $port = $request->getUri()->getPort();
+            $scheme     = $request->getUri()->getScheme();
+            $host       = $request->getUri()->getHost();
+            $port       = $request->getUri()->getPort();
             $appBaseUrl = $scheme . '://' . $host . ($port !== null ? ':' . $port : '');
+        }
+
+        // 組織 ID の解決（CreateUserHandler と同様のロジック）
+        $resolvedOrgId = $request->getAttribute('nene2.org.id');
+        $claims        = $request->getAttribute('nene2.auth.claims');
+        $callerRole    = is_array($claims) ? Role::tryFrom((string) ($claims['role'] ?? '')) : null;
+
+        if ($resolvedOrgId !== null) {
+            $organizationId = (int) $resolvedOrgId;
+        } elseif ($callerRole === Role::Superadmin && isset($body['organization_id'])) {
+            $organizationId = (int) $body['organization_id'];
+        } else {
+            $organizationId = null;
         }
 
         $output = $this->useCase->execute(new InviteUserInput(
             email: $email,
             role: $role,
             appBaseUrl: $appBaseUrl,
+            organizationId: $organizationId,
+            orgRole: $role,
         ));
 
         return $this->response->create(
             [
-                'id' => $output->id,
-                'email' => $output->email,
-                'role' => $output->role,
+                'id'     => $output->id,
+                'email'  => $output->email,
+                'role'   => $output->role,
                 'status' => $output->status,
             ],
             201,

--- a/src/UserInvite/InviteUserInput.php
+++ b/src/UserInvite/InviteUserInput.php
@@ -10,6 +10,8 @@ final readonly class InviteUserInput
         public string $email,
         public string $role,
         public string $appBaseUrl,
+        public ?int $organizationId = null,
+        public ?string $orgRole = null,
     ) {
     }
 }

--- a/src/UserInvite/InviteUserUseCase.php
+++ b/src/UserInvite/InviteUserUseCase.php
@@ -36,7 +36,13 @@ final readonly class InviteUserUseCase implements InviteUserUseCaseInterface
 
         // Create as invited user with a temporary random password (never usable without the invite)
         $tempHash = password_hash(bin2hex(random_bytes(32)), PASSWORD_BCRYPT);
-        $user = $this->users->create($input->email, $tempHash, $input->role);
+        $user     = $this->users->create(
+            $input->email,
+            $tempHash,
+            $input->role,
+            $input->organizationId,
+            $input->orgRole ?? $input->role,
+        );
 
         [$rawToken, $tokenHash] = SecureTokenHelper::generateWithHash();
         $expiresAt = time() + self::INVITE_TTL_SECONDS;

--- a/tests/User/InMemoryUserRepository.php
+++ b/tests/User/InMemoryUserRepository.php
@@ -55,14 +55,66 @@ final class InMemoryUserRepository implements UserRepositoryInterface
         return $users;
     }
 
-    public function create(string $email, string $passwordHash, string $role): User
+    /** @return list<User> */
+    public function listByOrganizationId(int $organizationId): array
     {
-        $id = $this->nextId++;
-        $user = new User(id: $id, email: $email, passwordHash: $passwordHash, role: $role, status: 'active', createdAt: time(), updatedAt: time());
-        $this->byId[$id] = $user;
-        $this->emailToId[$email] = $id;
+        $users = array_values(array_filter(
+            $this->byId,
+            static fn (User $u): bool => $u->organizationId === $organizationId,
+        ));
+        usort($users, static fn (User $a, User $b): int => $a->id <=> $b->id);
+
+        return $users;
+    }
+
+    public function create(
+        string $email,
+        string $passwordHash,
+        string $role,
+        ?int $organizationId = null,
+        ?string $orgRole = null,
+    ): User {
+        $id   = $this->nextId++;
+        $user = new User(
+            id: $id,
+            email: $email,
+            passwordHash: $passwordHash,
+            role: $role,
+            organizationId: $organizationId,
+            orgRole: $orgRole,
+            status: 'active',
+            createdAt: time(),
+            updatedAt: time(),
+        );
+        $this->byId[$id]           = $user;
+        $this->emailToId[$email]   = $id;
 
         return $user;
+    }
+
+    public function updateOrganization(int $id, ?int $organizationId, ?string $orgRole): void
+    {
+        $user = $this->byId[$id] ?? null;
+
+        if ($user === null) {
+            return;
+        }
+
+        $this->byId[$id] = new User(
+            id: $user->id,
+            email: $user->email,
+            passwordHash: $user->passwordHash,
+            role: $user->role,
+            organizationId: $organizationId,
+            orgRole: $orgRole,
+            status: $user->status,
+            inviteTokenHash: $user->inviteTokenHash,
+            inviteExpiresAt: $user->inviteExpiresAt,
+            passwordResetTokenHash: $user->passwordResetTokenHash,
+            passwordResetExpiresAt: $user->passwordResetExpiresAt,
+            createdAt: $user->createdAt,
+            updatedAt: time(),
+        );
     }
 
     public function updateRole(int $id, string $role): void
@@ -78,6 +130,8 @@ final class InMemoryUserRepository implements UserRepositoryInterface
             email: $user->email,
             passwordHash: $user->passwordHash,
             role: $role,
+            organizationId: $user->organizationId,
+            orgRole: $user->orgRole,
             status: $user->status,
             inviteTokenHash: $user->inviteTokenHash,
             inviteExpiresAt: $user->inviteExpiresAt,
@@ -101,6 +155,8 @@ final class InMemoryUserRepository implements UserRepositoryInterface
             email: $user->email,
             passwordHash: $passwordHash,
             role: $user->role,
+            organizationId: $user->organizationId,
+            orgRole: $user->orgRole,
             status: $user->status,
             inviteTokenHash: $user->inviteTokenHash,
             inviteExpiresAt: $user->inviteExpiresAt,
@@ -124,6 +180,8 @@ final class InMemoryUserRepository implements UserRepositoryInterface
             email: $user->email,
             passwordHash: $user->passwordHash,
             role: $user->role,
+            organizationId: $user->organizationId,
+            orgRole: $user->orgRole,
             status: $status,
             inviteTokenHash: $user->inviteTokenHash,
             inviteExpiresAt: $user->inviteExpiresAt,
@@ -148,6 +206,8 @@ final class InMemoryUserRepository implements UserRepositoryInterface
             email: $user->email,
             passwordHash: $user->passwordHash,
             role: $user->role,
+            organizationId: $user->organizationId,
+            orgRole: $user->orgRole,
             status: 'invited',
             inviteTokenHash: $tokenHash,
             inviteExpiresAt: $expiresAt,
@@ -182,6 +242,8 @@ final class InMemoryUserRepository implements UserRepositoryInterface
             email: $user->email,
             passwordHash: $user->passwordHash,
             role: $user->role,
+            organizationId: $user->organizationId,
+            orgRole: $user->orgRole,
             status: 'active',
             inviteTokenHash: null,
             inviteExpiresAt: null,
@@ -206,6 +268,8 @@ final class InMemoryUserRepository implements UserRepositoryInterface
             email: $user->email,
             passwordHash: $user->passwordHash,
             role: $user->role,
+            organizationId: $user->organizationId,
+            orgRole: $user->orgRole,
             status: $user->status,
             inviteTokenHash: $user->inviteTokenHash,
             inviteExpiresAt: $user->inviteExpiresAt,
@@ -240,6 +304,8 @@ final class InMemoryUserRepository implements UserRepositoryInterface
             email: $user->email,
             passwordHash: $user->passwordHash,
             role: $user->role,
+            organizationId: $user->organizationId,
+            orgRole: $user->orgRole,
             status: $user->status,
             inviteTokenHash: $user->inviteTokenHash,
             inviteExpiresAt: $user->inviteExpiresAt,

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+test-results/
+playwright-report/

--- a/tests/e2e/fixtures/api-mocks.ts
+++ b/tests/e2e/fixtures/api-mocks.ts
@@ -1,0 +1,200 @@
+/**
+ * Default mock response shapes for the NeNe Records Admin SPA API endpoints.
+ *
+ * All constants here are pure data — no page.route() calls.
+ * Import them in spec files and pass to the helper functions in helpers.ts.
+ *
+ * IMPORTANT: shapes must match the exact DTO format that the frontend mapper expects.
+ */
+
+// ── Auth ──────────────────────────────────────────────────────────────────────
+
+export const ADMIN_TOKEN = 'test-admin-jwt-token-abcdef';
+
+export const DEFAULT_LOGIN_RESPONSE = {
+  token: ADMIN_TOKEN,
+  expires_at: '2099-01-01T00:00:00Z',
+  email: 'admin@example.com',
+  role: 'admin',
+};
+
+export const SUPERADMIN_LOGIN_RESPONSE = {
+  token: ADMIN_TOKEN,
+  expires_at: '2099-01-01T00:00:00Z',
+  email: 'superadmin@example.com',
+  role: 'superadmin',
+};
+
+// ── Dashboard ─────────────────────────────────────────────────────────────────
+// Shape: DashboardSummaryDto { recent_published, today_access_count, this_month_access_count, entity_type_summary }
+
+export const DASHBOARD_EMPTY = {
+  recent_published: [],
+  today_access_count: 0,
+  this_month_access_count: 0,
+  entity_type_summary: [],
+};
+
+export const DASHBOARD_WITH_CONTENT = {
+  recent_published: [],
+  today_access_count: 10,
+  this_month_access_count: 50,
+  entity_type_summary: [
+    {
+      entity_type_id: 1,
+      entity_type_name: 'Posts',
+      entity_type_slug: 'posts',
+      published_count: 5,
+      draft_count: 2,
+    },
+    {
+      entity_type_id: 2,
+      entity_type_name: 'Pages',
+      entity_type_slug: 'pages',
+      published_count: 3,
+      draft_count: 0,
+    },
+  ],
+};
+
+// ── Entity Types ──────────────────────────────────────────────────────────────
+// Shape: EntityTypeListDto { items: EntityTypeDto[], limit, offset }
+
+export const ENTITY_TYPE_LIST_EMPTY = {
+  items: [],
+  limit: 20,
+  offset: 0,
+};
+
+export const ENTITY_TYPE_LIST = {
+  items: [
+    {
+      id: 1,
+      name: 'Posts',
+      slug: 'posts',
+      is_pinned: true,
+      labels: null,
+      permalink_pattern: null,
+      previous_permalink_pattern: null,
+    },
+    {
+      id: 2,
+      name: 'Pages',
+      slug: 'pages',
+      is_pinned: false,
+      labels: null,
+      permalink_pattern: null,
+      previous_permalink_pattern: null,
+    },
+  ],
+  limit: 20,
+  offset: 0,
+};
+
+export const ENTITY_TYPE_CREATED = {
+  id: 3,
+  name: 'Events',
+  slug: 'events',
+  is_pinned: false,
+  labels: null,
+  permalink_pattern: null,
+  previous_permalink_pattern: null,
+};
+
+// ── Tags ──────────────────────────────────────────────────────────────────────
+// Shape: TagListDto { items: TagDto[], limit, offset }
+
+export const TAG_LIST_EMPTY = {
+  items: [],
+  limit: 20,
+  offset: 0,
+};
+
+export const TAG_LIST = {
+  items: [
+    { id: 1, slug: 'technology', name: 'Technology' },
+    { id: 2, slug: 'design', name: 'Design' },
+    { id: 3, slug: 'news', name: 'News' },
+  ],
+  limit: 20,
+  offset: 0,
+};
+
+export const TAG_CREATED = {
+  id: 4,
+  slug: 'tutorial',
+  name: 'Tutorial',
+};
+
+// ── Users ─────────────────────────────────────────────────────────────────────
+// Shape: UserListDto { users: UserDto[] }
+
+export const USER_LIST_EMPTY = {
+  users: [],
+};
+
+export const USER_LIST = {
+  users: [
+    {
+      id: 1,
+      email: 'admin@example.com',
+      role: 'admin',
+      status: 'active',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    },
+    {
+      id: 2,
+      email: 'editor@example.com',
+      role: 'editor',
+      status: 'active',
+      created_at: '2024-01-02T00:00:00Z',
+      updated_at: '2024-01-02T00:00:00Z',
+    },
+  ],
+};
+
+// ── Organizations (Superadmin) ─────────────────────────────────────────────────
+// Shape: OrganizationListDto { data: OrganizationDto[], meta: { total, limit, offset } }
+
+export const ORGANIZATION_LIST_EMPTY = {
+  data: [],
+  meta: { total: 0, limit: 50, offset: 0 },
+};
+
+export const ORGANIZATION_LIST = {
+  data: [
+    {
+      id: 1,
+      name: 'Acme Corp',
+      slug: 'acme',
+      plan: 'pro',
+      is_active: true,
+      custom_domain: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    },
+    {
+      id: 2,
+      name: 'Globex Inc',
+      slug: 'globex',
+      plan: 'starter',
+      is_active: true,
+      custom_domain: null,
+      created_at: '2026-02-01T00:00:00Z',
+      updated_at: '2026-02-01T00:00:00Z',
+    },
+  ],
+  meta: { total: 2, limit: 50, offset: 0 },
+};
+
+export const ORGANIZATION_DETAIL = {
+  id: 1,
+  name: 'Acme Corp',
+  slug: 'acme',
+  plan: 'pro',
+  is_active: true,
+  custom_domain: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -1,0 +1,185 @@
+/**
+ * Admin E2E test helpers.
+ *
+ * Provides mock setup and common navigation helpers for Admin SPA tests.
+ * All API calls are intercepted by page.route() — no real backend needed.
+ *
+ * Key patterns:
+ *  - mockAuth()          sets up login endpoint + default entity-type list (pinned)
+ *  - bypassLogin()       injects token directly into localStorage (faster)
+ *  - mockDashboard()     stubs GET /api/v1/dashboard
+ *  - mockEntityTypes()   stubs GET /api/v1/entity-types
+ *  - mockTags()          stubs GET /api/v1/tags
+ *  - mockUsers()         stubs GET /api/v1/users
+ *  - mockOrganizations() stubs GET /api/v1/organizations
+ */
+
+import type { Page } from '@playwright/test';
+import {
+  ADMIN_TOKEN,
+  DEFAULT_LOGIN_RESPONSE,
+  ENTITY_TYPE_LIST_EMPTY,
+  DASHBOARD_EMPTY,
+} from './api-mocks.js';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const BASE_URL = 'http://localhost:4173';
+export const LOGIN_URL = '/login';
+export const ADMIN_URL = '/admin';
+export const SUPERADMIN_URL = '/superadmin';
+/** localStorage key used by authStore */
+export const AUTH_STORAGE_KEY = 'nene_records_token';
+
+// ── Auth helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Mock POST /api/v1/auth/login with a successful response.
+ */
+export async function mockLoginEndpoint(
+  page: Page,
+  response: object = DEFAULT_LOGIN_RESPONSE,
+): Promise<void> {
+  await page.route('**/api/v1/auth/login', (route) => {
+    if (route.request().method() === 'POST') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(response),
+      });
+    }
+    return route.continue();
+  });
+}
+
+/**
+ * Inject auth token directly into localStorage — faster than going through the login form.
+ * Also mocks the entity-type list (needed by AppShell sidebar) and sets up minimal defaults.
+ */
+export async function bypassLogin(
+  page: Page,
+  options: {
+    email?: string;
+    role?: string;
+    entityTypes?: object;
+  } = {},
+): Promise<void> {
+  const session = {
+    token: ADMIN_TOKEN,
+    expiresAt: '2099-01-01T00:00:00Z',
+    email: options.email ?? 'admin@example.com',
+    role: options.role ?? 'admin',
+  };
+
+  // Mock entity-types list (used by sidebar in AppShell)
+  await mockEntityTypesEndpoint(page, options.entityTypes ?? ENTITY_TYPE_LIST_EMPTY);
+
+  // Navigate to set localStorage on the right origin
+  await page.goto(BASE_URL);
+  await page.evaluate(
+    ([key, value]) => {
+      localStorage.setItem(key, value);
+    },
+    [AUTH_STORAGE_KEY, JSON.stringify(session)] as [string, string],
+  );
+}
+
+/**
+ * Navigate to the admin panel with auth already injected.
+ */
+export async function gotoAdmin(page: Page, path = ''): Promise<void> {
+  await page.goto(`${ADMIN_URL}${path}`);
+  // Wait for the page to settle (React renders)
+  await page.waitForLoadState('networkidle');
+}
+
+/**
+ * Navigate to the superadmin panel with auth already injected.
+ */
+export async function gotoSuperadmin(page: Page, path = ''): Promise<void> {
+  await page.goto(`${SUPERADMIN_URL}${path}`);
+  await page.waitForLoadState('networkidle');
+}
+
+/**
+ * Full login flow: navigate to /login, fill credentials, submit.
+ */
+export async function loginAs(
+  page: Page,
+  email = 'admin@example.com',
+  password = 'password',
+): Promise<void> {
+  await page.goto(LOGIN_URL);
+  await page.locator('input[type="email"]').fill(email);
+  await page.locator('input[type="password"]').fill(password);
+  await page.locator('button[type="submit"]').click();
+  // Wait for redirect to /admin
+  await page.waitForURL(`${BASE_URL}/admin`);
+}
+
+// ── API mock helpers ───────────────────────────────────────────────────────────
+
+export async function mockEntityTypesEndpoint(page: Page, response: object): Promise<void> {
+  await page.route('**/api/v1/entity-types**', (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(response),
+      });
+    }
+    return route.continue();
+  });
+}
+
+export async function mockDashboard(page: Page, response: object = DASHBOARD_EMPTY): Promise<void> {
+  await page.route('**/api/v1/dashboard', (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(response),
+      });
+    }
+    return route.continue();
+  });
+}
+
+export async function mockTagsEndpoint(page: Page, response: object): Promise<void> {
+  await page.route('**/api/v1/tags**', (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(response),
+      });
+    }
+    return route.continue();
+  });
+}
+
+export async function mockUsersEndpoint(page: Page, response: object): Promise<void> {
+  await page.route('**/api/v1/users**', (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(response),
+      });
+    }
+    return route.continue();
+  });
+}
+
+export async function mockOrganizationsEndpoint(page: Page, response: object): Promise<void> {
+  await page.route('**/api/v1/organizations**', (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(response),
+      });
+    }
+    return route.continue();
+  });
+}

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "nene-records-e2e",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nene-records-e2e",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@playwright/test": "^1.60.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nene-records-e2e",
+  "private": true,
+  "version": "0.0.1",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui",
+    "report": "playwright show-report playwright-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.60.0"
+  }
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * NeNe Records — Admin UI E2E Test Suite
+ *
+ * Tests the Admin SPA (/admin/) end-to-end.
+ * All API calls are intercepted via page.route() — no real backend required.
+ * The static build is served by a Python HTTP server from frontend/dist/.
+ */
+export default defineConfig({
+  testDir: './specs',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [
+    ['html', { open: 'never', outputFolder: 'playwright-report' }],
+    ['json', { outputFile: 'playwright-report/results.json' }],
+    ['list'],
+  ],
+  use: {
+    baseURL: 'http://localhost:4173',
+    // Start each test with clean storage (no leaked tokens)
+    storageState: { cookies: [], origins: [] },
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 10000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run preview -- --port 4173',
+    cwd: '../../frontend',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/tests/e2e/specs/01-login.spec.ts
+++ b/tests/e2e/specs/01-login.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * Category: Authentication
+ *
+ * Tests login/logout flows, credential validation, and auth redirect behaviour.
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  LOGIN_URL,
+  ADMIN_URL,
+  AUTH_STORAGE_KEY,
+  BASE_URL,
+  mockLoginEndpoint,
+  bypassLogin,
+  gotoAdmin,
+} from '../fixtures/helpers.js';
+import { DEFAULT_LOGIN_RESPONSE } from '../fixtures/api-mocks.js';
+
+test.describe('Authentication', () => {
+  // ── Login form ──────────────────────────────────────────────────────────────
+
+  test('01-01: login form — email/password inputs and submit button are visible', async ({ page }) => {
+    await page.goto(LOGIN_URL);
+    await expect(page.locator('input[type="email"]')).toBeVisible();
+    await expect(page.locator('input[type="password"]')).toBeVisible();
+    await expect(page.locator('button[type="submit"]')).toContainText('Sign in');
+  });
+
+  test('01-02: valid credentials — redirects to /admin', async ({ page }) => {
+    await mockLoginEndpoint(page);
+    await page.goto(LOGIN_URL);
+    await page.locator('input[type="email"]').fill('admin@example.com');
+    await page.locator('input[type="password"]').fill('password');
+    await page.locator('button[type="submit"]').click();
+
+    await page.waitForURL(`${BASE_URL}/admin`);
+    await expect(page).toHaveURL(`${BASE_URL}/admin`);
+  });
+
+  test('01-03: token saved to localStorage after login', async ({ page }) => {
+    await mockLoginEndpoint(page);
+    await page.goto(LOGIN_URL);
+    await page.locator('input[type="email"]').fill('admin@example.com');
+    await page.locator('input[type="password"]').fill('password');
+    await page.locator('button[type="submit"]').click();
+
+    await page.waitForURL(`${BASE_URL}/admin`);
+
+    const stored = await page.evaluate((key: string) => localStorage.getItem(key), AUTH_STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    const session = JSON.parse(stored!);
+    expect(session.token).toBe(DEFAULT_LOGIN_RESPONSE.token);
+    expect(session.email).toBe(DEFAULT_LOGIN_RESPONSE.email);
+  });
+
+  test('01-04: wrong credentials — error message shown, stays on login page', async ({ page }) => {
+    await page.route('**/api/v1/auth/login', (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'Invalid credentials.' }),
+      }),
+    );
+    await page.goto(LOGIN_URL);
+    await page.locator('input[type="email"]').fill('admin@example.com');
+    await page.locator('input[type="password"]').fill('wrongpassword');
+    await page.locator('button[type="submit"]').click();
+
+    await expect(page.locator('[role="alert"]')).toBeVisible({ timeout: 6000 });
+    await expect(page.locator('button[type="submit"]')).toContainText('Sign in');
+  });
+
+  test('01-05: empty password — stays on login page, shows error', async ({ page }) => {
+    // Mock login to return 401 for empty password submission
+    await page.route('**/api/v1/auth/login', (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'Invalid credentials.' }),
+      }),
+    );
+    await page.goto(LOGIN_URL);
+    await page.locator('input[type="email"]').fill('admin@example.com');
+    // Leave password empty and submit — API is called, backend rejects it
+    await page.locator('button[type="submit"]').click();
+    // Error alert is shown and user stays on login page
+    await expect(page.locator('[role="alert"]')).toBeVisible({ timeout: 6000 });
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('01-06: network error — error message shown', async ({ page }) => {
+    await page.route('**/api/v1/auth/login', (route) => route.abort('failed'));
+    await page.goto(LOGIN_URL);
+    await page.locator('input[type="email"]').fill('admin@example.com');
+    await page.locator('input[type="password"]').fill('somepass');
+    await page.locator('button[type="submit"]').click();
+
+    await expect(page.locator('[role="alert"]')).toBeVisible({ timeout: 6000 });
+  });
+
+  // ── Auth redirect ───────────────────────────────────────────────────────────
+
+  test('01-07: unauthenticated access to /admin — redirects to /login', async ({ page }) => {
+    await page.goto(ADMIN_URL);
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('01-08: authenticated user accessing /login — redirects to /admin', async ({ page }) => {
+    await bypassLogin(page);
+    await page.goto(LOGIN_URL);
+    // After injecting a valid token, navigating to /admin works
+    await gotoAdmin(page);
+    await expect(page).toHaveURL(/\/admin/);
+  });
+
+  // ── Logout ──────────────────────────────────────────────────────────────────
+
+  test('01-09: logout — token cleared from localStorage, redirects to /login', async ({ page }) => {
+    await bypassLogin(page);
+    await gotoAdmin(page);
+
+    // Find and click the logout icon button (aria-label="Log out")
+    await page.locator('button[aria-label="Log out"]').click();
+
+    // Redirected to login
+    await expect(page).toHaveURL(/\/login/, { timeout: 6000 });
+
+    // Token cleared from localStorage
+    const stored = await page.evaluate((key: string) => localStorage.getItem(key), AUTH_STORAGE_KEY);
+    expect(stored).toBeNull();
+  });
+});

--- a/tests/e2e/specs/02-dashboard.spec.ts
+++ b/tests/e2e/specs/02-dashboard.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * Category: Dashboard (Home)
+ *
+ * Tests the admin dashboard rendering with various data states.
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  bypassLogin,
+  gotoAdmin,
+  mockDashboard,
+} from '../fixtures/helpers.js';
+import { DASHBOARD_EMPTY, DASHBOARD_WITH_CONTENT } from '../fixtures/api-mocks.js';
+
+test.describe('Dashboard', () => {
+  test('02-01: dashboard page title is shown', async ({ page }) => {
+    await bypassLogin(page);
+    await mockDashboard(page, DASHBOARD_EMPTY);
+    await gotoAdmin(page);
+
+    await expect(page.locator('h1')).toContainText('Dashboard');
+  });
+
+  test('02-02: sidebar navigation is visible after login', async ({ page }) => {
+    await bypassLogin(page);
+    await mockDashboard(page, DASHBOARD_EMPTY);
+    await gotoAdmin(page);
+
+    // Sidebar should have key nav links
+    await expect(page.locator('nav a[href="/admin"]')).toBeVisible();
+  });
+
+  test('02-03: dashboard shows content summary when data exists', async ({ page }) => {
+    await bypassLogin(page);
+    await mockDashboard(page, DASHBOARD_WITH_CONTENT);
+    await gotoAdmin(page);
+
+    // Content summary should show entity type names
+    await expect(page.locator('text=Posts')).toBeVisible({ timeout: 6000 });
+    await expect(page.locator('text=Pages')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('02-04: dashboard shows error message when API fails', async ({ page }) => {
+    await bypassLogin(page);
+    await page.route('**/api/v1/dashboard', (route) =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ detail: 'Error' }) }),
+    );
+    await gotoAdmin(page);
+
+    await expect(page.locator('text=Could not load dashboard')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('02-05: sign-out button is visible in header', async ({ page }) => {
+    await bypassLogin(page);
+    await mockDashboard(page, DASHBOARD_EMPTY);
+    await gotoAdmin(page);
+
+    // The logout button is an icon-only button with aria-label="Log out"
+    await expect(page.locator('button[aria-label="Log out"]')).toBeVisible();
+  });
+
+  test('02-06: admin email shown in header after login', async ({ page }) => {
+    await bypassLogin(page, { email: 'admin@example.com' });
+    await mockDashboard(page, DASHBOARD_EMPTY);
+    await gotoAdmin(page);
+
+    // Email is shown in the sidebar (aside), not the mobile top bar (header)
+    await expect(page.locator('aside')).toContainText('admin@example.com');
+  });
+});

--- a/tests/e2e/specs/03-entity-types.spec.ts
+++ b/tests/e2e/specs/03-entity-types.spec.ts
@@ -1,0 +1,111 @@
+/**
+ * Category: Entity Types Management
+ *
+ * Tests creating, listing, and managing content types.
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  bypassLogin,
+  gotoAdmin,
+  mockEntityTypesEndpoint,
+  mockDashboard,
+} from '../fixtures/helpers.js';
+import {
+  ENTITY_TYPE_LIST_EMPTY,
+  ENTITY_TYPE_LIST,
+  ENTITY_TYPE_CREATED,
+  DASHBOARD_EMPTY,
+} from '../fixtures/api-mocks.js';
+
+test.describe('Entity Types', () => {
+  test('03-01: page title — "Content types"', async ({ page }) => {
+    await bypassLogin(page);
+    await mockEntityTypesEndpoint(page, ENTITY_TYPE_LIST_EMPTY);
+    await gotoAdmin(page, '/entity-types');
+
+    await expect(page.locator('h1')).toContainText('Content types');
+  });
+
+  test('03-02: empty state — shows "No content types yet"', async ({ page }) => {
+    await bypassLogin(page);
+    await mockEntityTypesEndpoint(page, ENTITY_TYPE_LIST_EMPTY);
+    await gotoAdmin(page, '/entity-types');
+
+    await expect(page.locator('text=No content types yet')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('03-03: existing list — entity type names are shown', async ({ page }) => {
+    await bypassLogin(page);
+    await mockEntityTypesEndpoint(page, ENTITY_TYPE_LIST);
+    await gotoAdmin(page, '/entity-types');
+
+    await expect(page.locator('text=Posts').first()).toBeVisible({ timeout: 6000 });
+    await expect(page.locator('text=Pages').first()).toBeVisible({ timeout: 6000 });
+  });
+
+  test('03-04: create form — name and slug inputs are present', async ({ page }) => {
+    await bypassLogin(page);
+    await mockEntityTypesEndpoint(page, ENTITY_TYPE_LIST_EMPTY);
+    await gotoAdmin(page, '/entity-types');
+
+    // Create form should be visible on the page
+    await expect(page.locator('input[id="entity-type-name"]')).toBeVisible({ timeout: 6000 });
+    await expect(page.locator('input[id="entity-type-slug"]')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('03-05: create entity type — calls POST and shows new type', async ({ page }) => {
+    await bypassLogin(page);
+
+    // Single handler: POST fulfils with created item; GET toggles to show it after creation
+    let created = false;
+    await page.route('**/api/v1/entity-types**', (route) => {
+      if (route.request().method() === 'POST') {
+        created = true;
+        return route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify(ENTITY_TYPE_CREATED),
+        });
+      }
+      if (route.request().method() === 'GET') {
+        const list = created
+          ? { items: [ENTITY_TYPE_CREATED], limit: 20, offset: 0 }
+          : ENTITY_TYPE_LIST_EMPTY;
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(list),
+        });
+      }
+      return route.continue();
+    });
+
+    await gotoAdmin(page, '/entity-types');
+
+    await page.locator('input[id="entity-type-name"]').fill('Events');
+    await page.locator('input[id="entity-type-slug"]').fill('events');
+    await page.locator('button:has-text("Create content type")').click();
+
+    await expect(page.locator('text=Events').first()).toBeVisible({ timeout: 6000 });
+  });
+
+  test('03-06: load error — shows error message', async ({ page }) => {
+    await bypassLogin(page);
+    await page.route('**/api/v1/entity-types**', (route) =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: '{"detail":"Error"}' }),
+    );
+    await gotoAdmin(page, '/entity-types');
+
+    await expect(page.locator('text=Could not load content types')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('03-07: editor role — create form not shown', async ({ page }) => {
+    await bypassLogin(page, { role: 'editor' });
+    await mockEntityTypesEndpoint(page, ENTITY_TYPE_LIST_EMPTY);
+    await gotoAdmin(page, '/entity-types');
+
+    // Editor should be redirected to /forbidden (no manage_schema capability)
+    await expect(page).toHaveURL(/\/(forbidden|login)/, { timeout: 6000 });
+  });
+});

--- a/tests/e2e/specs/04-tags.spec.ts
+++ b/tests/e2e/specs/04-tags.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * Category: Tags Management
+ *
+ * Tests creating, listing, and deleting tags.
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  bypassLogin,
+  gotoAdmin,
+  mockTagsEndpoint,
+} from '../fixtures/helpers.js';
+import { TAG_LIST_EMPTY, TAG_LIST, TAG_CREATED } from '../fixtures/api-mocks.js';
+
+test.describe('Tags', () => {
+  test('04-01: page title — "Tags"', async ({ page }) => {
+    await bypassLogin(page);
+    await mockTagsEndpoint(page, TAG_LIST_EMPTY);
+    await gotoAdmin(page, '/tags');
+
+    await expect(page.locator('h1')).toContainText('Tags');
+  });
+
+  test('04-02: empty state — shows "No tags yet"', async ({ page }) => {
+    await bypassLogin(page);
+    await mockTagsEndpoint(page, TAG_LIST_EMPTY);
+    await gotoAdmin(page, '/tags');
+
+    await expect(page.locator('text=No tags yet')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('04-03: existing tags — names are shown', async ({ page }) => {
+    await bypassLogin(page);
+    await mockTagsEndpoint(page, TAG_LIST);
+    await gotoAdmin(page, '/tags');
+
+    await expect(page.locator('text=Technology').first()).toBeVisible({ timeout: 6000 });
+    await expect(page.locator('text=Design').first()).toBeVisible({ timeout: 6000 });
+    await expect(page.locator('text=News').first()).toBeVisible({ timeout: 6000 });
+  });
+
+  test('04-04: create tag — form inputs visible', async ({ page }) => {
+    await bypassLogin(page);
+    await mockTagsEndpoint(page, TAG_LIST_EMPTY);
+    await gotoAdmin(page, '/tags');
+
+    // Create form should show name and slug inputs
+    await expect(page.locator('input[id="tag-name"]')).toBeVisible({ timeout: 6000 });
+    await expect(page.locator('input[id="tag-slug"]')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('04-05: create tag — calls POST and displays new tag', async ({ page }) => {
+    await bypassLogin(page);
+
+    let getCallCount = 0;
+    await page.route('**/api/v1/tags**', (route) => {
+      if (route.request().method() === 'GET') {
+        getCallCount++;
+        const response = getCallCount === 1
+          ? TAG_LIST_EMPTY
+          : { items: [TAG_CREATED], total: 1 };
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(response),
+        });
+      }
+      if (route.request().method() === 'POST') {
+        return route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify(TAG_CREATED),
+        });
+      }
+      return route.continue();
+    });
+
+    await gotoAdmin(page, '/tags');
+
+    await page.locator('input[id="tag-name"]').fill('Tutorial');
+    await page.locator('input[id="tag-slug"]').fill('tutorial');
+    await page.locator('button:has-text("Create tag")').click();
+
+    await expect(page.locator('text=Tutorial').first()).toBeVisible({ timeout: 6000 });
+  });
+
+  test('04-06: load error — shows error message', async ({ page }) => {
+    await bypassLogin(page);
+    await page.route('**/api/v1/tags**', (route) =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: '{"detail":"Error"}' }),
+    );
+    await gotoAdmin(page, '/tags');
+
+    await expect(page.locator('text=Could not load tags')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('04-07: editor role — redirected to forbidden', async ({ page }) => {
+    await bypassLogin(page, { role: 'editor' });
+    await gotoAdmin(page, '/tags');
+
+    await expect(page).toHaveURL(/\/(forbidden|login)/, { timeout: 6000 });
+  });
+
+  test('04-08: tag count shown in list header', async ({ page }) => {
+    await bypassLogin(page);
+    await mockTagsEndpoint(page, TAG_LIST);
+    await gotoAdmin(page, '/tags');
+
+    // "Existing tags" section title should be visible
+    await expect(page.locator('text=Existing tags')).toBeVisible({ timeout: 6000 });
+  });
+});

--- a/tests/e2e/specs/05-users.spec.ts
+++ b/tests/e2e/specs/05-users.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Category: Users Management
+ *
+ * Tests user list, invite flow, and access control.
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  bypassLogin,
+  gotoAdmin,
+  mockUsersEndpoint,
+} from '../fixtures/helpers.js';
+import { USER_LIST_EMPTY, USER_LIST } from '../fixtures/api-mocks.js';
+
+test.describe('Users', () => {
+  test('05-01: page title — "Users"', async ({ page }) => {
+    await bypassLogin(page);
+    await mockUsersEndpoint(page, USER_LIST_EMPTY);
+    await gotoAdmin(page, '/users');
+
+    await expect(page.locator('h1')).toContainText('Users');
+  });
+
+  test('05-02: empty state — shows "No users yet"', async ({ page }) => {
+    await bypassLogin(page);
+    await mockUsersEndpoint(page, USER_LIST_EMPTY);
+    await gotoAdmin(page, '/users');
+
+    await expect(page.locator('text=No users yet')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('05-03: user list — email and role shown', async ({ page }) => {
+    await bypassLogin(page);
+    await mockUsersEndpoint(page, USER_LIST);
+    await gotoAdmin(page, '/users');
+
+    await expect(page.locator('text=admin@example.com').first()).toBeVisible({ timeout: 6000 });
+    await expect(page.locator('text=editor@example.com').first()).toBeVisible({ timeout: 6000 });
+  });
+
+  test('05-04: invite button is visible for admin', async ({ page }) => {
+    await bypassLogin(page);
+    await mockUsersEndpoint(page, USER_LIST_EMPTY);
+    await gotoAdmin(page, '/users');
+
+    await expect(page.locator('button:has-text("Invite user")')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('05-05: invite form opens on button click', async ({ page }) => {
+    await bypassLogin(page);
+    await mockUsersEndpoint(page, USER_LIST_EMPTY);
+    await gotoAdmin(page, '/users');
+
+    await page.locator('button:has-text("Invite user")').click();
+
+    // Email input should appear in invite form
+    await expect(page.locator('input[type="email"]')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('05-06: invite user — calls POST /api/v1/user-invite/invite', async ({ page }) => {
+    await bypassLogin(page);
+    await mockUsersEndpoint(page, USER_LIST_EMPTY);
+
+    let postCalled = false;
+    await page.route('**/api/v1/user-invite/invite', (route) => {
+      if (route.request().method() === 'POST') {
+        postCalled = true;
+        return route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: 3,
+            email: 'newuser@example.com',
+            role: 'editor',
+            status: 'invited',
+          }),
+        });
+      }
+      return route.continue();
+    });
+
+    await gotoAdmin(page, '/users');
+    await page.locator('button:has-text("Invite user")').click();
+
+    // Fill invite form
+    const emailInput = page.locator('input[type="email"]').first();
+    await emailInput.fill('newuser@example.com');
+    await page.locator('button[type="submit"]:has-text("Send invitation")').click();
+
+    await page.waitForTimeout(500);
+    expect(postCalled).toBe(true);
+  });
+
+  test('05-07: editor role — redirected to /forbidden', async ({ page }) => {
+    await bypassLogin(page, { role: 'editor' });
+    await gotoAdmin(page, '/users');
+
+    await expect(page).toHaveURL(/\/forbidden/, { timeout: 6000 });
+  });
+
+  test('05-08: load error — shows error message with retry', async ({ page }) => {
+    await bypassLogin(page);
+    await page.route('**/api/v1/users**', (route) =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: '{"detail":"Error"}' }),
+    );
+    await gotoAdmin(page, '/users');
+
+    await expect(page.locator('text=Could not load users')).toBeVisible({ timeout: 6000 });
+  });
+});

--- a/tests/e2e/specs/06-superadmin.spec.ts
+++ b/tests/e2e/specs/06-superadmin.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * Category: Superadmin — Organizations
+ *
+ * Tests the superadmin organization management pages.
+ * Requires role=superadmin in localStorage session.
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  bypassLogin,
+  gotoSuperadmin,
+  mockOrganizationsEndpoint,
+  SUPERADMIN_URL,
+  BASE_URL,
+} from '../fixtures/helpers.js';
+import {
+  ORGANIZATION_LIST_EMPTY,
+  ORGANIZATION_LIST,
+  ORGANIZATION_DETAIL,
+} from '../fixtures/api-mocks.js';
+
+test.describe('Superadmin — Organizations', () => {
+  test('06-01: non-superadmin — redirected to /forbidden', async ({ page }) => {
+    await bypassLogin(page, { role: 'admin' });
+    await page.goto(`${SUPERADMIN_URL}/organizations`);
+
+    await expect(page).toHaveURL(/\/forbidden/, { timeout: 6000 });
+  });
+
+  test('06-02: superadmin sidebar shows "Organizations" link', async ({ page }) => {
+    await bypassLogin(page, { role: 'superadmin' });
+    await mockOrganizationsEndpoint(page, ORGANIZATION_LIST_EMPTY);
+    await gotoSuperadmin(page, '/organizations');
+
+    await expect(page.locator('nav a:has-text("Organizations")')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('06-03: organizations list — empty state message', async ({ page }) => {
+    await bypassLogin(page, { role: 'superadmin' });
+    await mockOrganizationsEndpoint(page, ORGANIZATION_LIST_EMPTY);
+    await gotoSuperadmin(page, '/organizations');
+
+    await expect(page.locator('text=No organizations yet')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('06-04: organizations list — shows org names', async ({ page }) => {
+    await bypassLogin(page, { role: 'superadmin' });
+    await mockOrganizationsEndpoint(page, ORGANIZATION_LIST);
+    await gotoSuperadmin(page, '/organizations');
+
+    await expect(page.locator('text=Acme Corp')).toBeVisible({ timeout: 6000 });
+    await expect(page.locator('text=Globex Inc')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('06-05: create org — New Organization button visible', async ({ page }) => {
+    await bypassLogin(page, { role: 'superadmin' });
+    await mockOrganizationsEndpoint(page, ORGANIZATION_LIST_EMPTY);
+    await gotoSuperadmin(page, '/organizations');
+
+    await expect(page.locator('button:has-text("New Organization")')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('06-06: create org form — shows name/slug fields on button click', async ({ page }) => {
+    await bypassLogin(page, { role: 'superadmin' });
+    await mockOrganizationsEndpoint(page, ORGANIZATION_LIST_EMPTY);
+    await gotoSuperadmin(page, '/organizations');
+
+    await page.locator('button:has-text("New Organization")').click();
+
+    await expect(page.locator('input[id="org-name"]')).toBeVisible({ timeout: 6000 });
+    await expect(page.locator('input[id="org-slug"]')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('06-07: create org — calls POST /api/v1/organizations', async ({ page }) => {
+    await bypassLogin(page, { role: 'superadmin' });
+
+    let postCalled = false;
+    await page.route('**/api/v1/organizations**', (route) => {
+      if (route.request().method() === 'POST') {
+        postCalled = true;
+        return route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({ id: 3, name: 'NewCo', slug: 'newco', plan: 'free', is_active: true, custom_domain: null, created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' }),
+        });
+      }
+      if (route.request().method() === 'GET') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(ORGANIZATION_LIST_EMPTY),
+        });
+      }
+      return route.continue();
+    });
+
+    await gotoSuperadmin(page, '/organizations');
+    await page.locator('button:has-text("New Organization")').click();
+    await page.locator('input[id="org-name"]').fill('NewCo');
+    await page.locator('input[id="org-slug"]').fill('newco');
+    await page.locator('button[type="submit"]:has-text("Create")').click();
+
+    await page.waitForTimeout(500);
+    expect(postCalled).toBe(true);
+  });
+
+  test('06-08: org detail — shows name and settings form', async ({ page }) => {
+    await bypassLogin(page, { role: 'superadmin' });
+
+    await page.route('**/api/v1/organizations/1', (route) => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(ORGANIZATION_DETAIL),
+        });
+      }
+      return route.continue();
+    });
+
+    await gotoSuperadmin(page, '/organizations/1');
+
+    await expect(page.locator('h1')).toContainText('Acme Corp', { timeout: 6000 });
+    await expect(page.locator('text=Organization Settings')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('06-09: org detail — shows danger zone delete button', async ({ page }) => {
+    await bypassLogin(page, { role: 'superadmin' });
+
+    await page.route('**/api/v1/organizations/1', (route) => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(ORGANIZATION_DETAIL),
+        });
+      }
+      return route.continue();
+    });
+
+    await gotoSuperadmin(page, '/organizations/1');
+
+    await expect(page.locator('button:has-text("Delete Organization")')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('06-10: org detail — back link navigates to organizations list', async ({ page }) => {
+    await bypassLogin(page, { role: 'superadmin' });
+
+    // List mock added first (lower priority) — handles GET /organizations?...
+    await mockOrganizationsEndpoint(page, ORGANIZATION_LIST);
+    // Detail mock added second (higher priority) — handles GET /organizations/1
+    await page.route('**/api/v1/organizations/1', (route) => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(ORGANIZATION_DETAIL),
+        });
+      }
+      return route.continue();
+    });
+
+    await gotoSuperadmin(page, '/organizations/1');
+
+    // Wait for org detail to load
+    await expect(page.locator('h1')).toContainText('Acme Corp', { timeout: 6000 });
+
+    // Click back link (use main to avoid matching sidebar nav link)
+    await page.locator('main a:has-text("Organizations")').click();
+    await expect(page).toHaveURL(`${BASE_URL}/superadmin/organizations`);
+  });
+});


### PR DESCRIPTION
Closes #251

## 変更概要

マルチテナント（組織スコープ）の基盤を実装。1ユーザー=1組織、JWT に org_id を埋め込み、CapabilityMiddleware で組織スコープを強制する。

## Phase A — DB マイグレーション

- `users` テーブルに `organization_id` / `org_role` を追加
  - superadmin は `NULL`（組織に属さない）
  - admin / editor は所属組織 ID
- `organizations` テーブルに `external_id` を追加
  - 外部システム（NeNe Corpus 将来連携）用の UNIQUE 識別子
- `organization_users` テーブルを DROP
  - 1ユーザー=1組織方針と矛盾・コードから未使用

## Phase B — PHP コア

- **`User`** エンティティに `organizationId` / `orgRole` 追加
- **`PdoUserRepository`** 全メソッドを新カラム対応、`listByOrganizationId()` / `updateOrganization()` 追加
- **`LoginUseCase`** JWT に `org_id` を埋め込む（superadmin = null）
- **`LoginHandler`** レスポンスに `org_id` を追加
- **`CapabilityMiddleware`** `nene2.org.id`（int）と JWT `org_id` を照合
  - 不一致 → 403 org-access-denied
  - superadmin はスキップ（全組織アクセス可）

## Phase C — ユーザー管理 org スコープ

- **`ListUsersUseCase/Handler`** — superadmin: 全ユーザー, admin/editor: 自組織のみ
- **`CreateUserUseCase/Handler`** — `nene2.org.id` または superadmin 指定 org_id を自動解決
- **`GetUserByIdUseCase/Handler/Output`** — org 情報を含める
- **`InviteUserUseCase/Handler/Input`** — org スコープ対応
- **`ListUserItem`** — `organization_id` / `org_role` フィールド追加

## Organization モジュール

- `Organization` エンティティ / `PdoOrganizationRepository` — `external_id` 対応
- CreateOrganization / UpdateOrganization / GetOrganizationById / ListOrganizations の全 Input / Output / UseCase / Handler を更新

## セルフレビューチェックリスト

- [x] backend-api.md
- [x] database.md
- [x] middleware-security.md

## 品質ゲート

- PHPUnit: 374 tests ✅
- PHPStan level 8: エラーなし ✅
- CS Fixer: 差分なし ✅
- OpenAPI: valid ✅
- MCP: valid ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)