### PR TITLE
fix(e2e): Playwright E2E テストを全 48 件グリーンにする (#250)

### DIFF
--- a/frontend/src/shared/ui/primitives/Input.tsx
+++ b/frontend/src/shared/ui/primitives/Input.tsx
@@ -1,8 +1,11 @@
+import { forwardRef } from 'react'
+
 export interface InputProps {
   id: string
   label: string
   type?: 'text' | 'email' | 'password' | 'number' | 'datetime-local'
-  value: string
+  name?: string
+  value?: string
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void
   disabled?: boolean
@@ -10,17 +13,21 @@ export interface InputProps {
   autoComplete?: string
 }
 
-export function Input({
-  id,
-  label,
-  type = 'text',
-  value,
-  onChange,
-  onBlur,
-  disabled = false,
-  error,
-  autoComplete,
-}: InputProps) {
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  {
+    id,
+    label,
+    type = 'text',
+    name,
+    value,
+    onChange,
+    onBlur,
+    disabled = false,
+    error,
+    autoComplete,
+  },
+  ref,
+) {
   const errorId = error !== undefined ? `${id}-error` : undefined
 
   return (
@@ -29,8 +36,10 @@ export function Input({
         {label}
       </label>
       <input
+        ref={ref}
         id={id}
         type={type}
+        name={name}
         value={value}
         onChange={onChange}
         onBlur={onBlur}
@@ -53,4 +62,4 @@ export function Input({
       ) : null}
     </div>
   )
-}
+})

--- a/tests/e2e/specs/03-entity-types.spec.ts
+++ b/tests/e2e/specs/03-entity-types.spec.ts
@@ -9,13 +9,11 @@ import {
   bypassLogin,
   gotoAdmin,
   mockEntityTypesEndpoint,
-  mockDashboard,
 } from '../fixtures/helpers.js';
 import {
   ENTITY_TYPE_LIST_EMPTY,
   ENTITY_TYPE_LIST,
   ENTITY_TYPE_CREATED,
-  DASHBOARD_EMPTY,
 } from '../fixtures/api-mocks.js';
 
 test.describe('Entity Types', () => {
@@ -105,7 +103,7 @@ test.describe('Entity Types', () => {
     await mockEntityTypesEndpoint(page, ENTITY_TYPE_LIST_EMPTY);
     await gotoAdmin(page, '/entity-types');
 
-    // Editor should be redirected to /forbidden (no manage_schema capability)
-    await expect(page).toHaveURL(/\/(forbidden|login)/, { timeout: 6000 });
+    // Editor lacks manage_schema capability — stays on the page but create form is hidden
+    await expect(page.locator('input[id="entity-type-name"]')).not.toBeVisible({ timeout: 6000 });
   });
 });

--- a/tests/e2e/specs/05-users.spec.ts
+++ b/tests/e2e/specs/05-users.spec.ts
@@ -57,12 +57,12 @@ test.describe('Users', () => {
     await expect(page.locator('input[type="email"]')).toBeVisible({ timeout: 6000 });
   });
 
-  test('05-06: invite user — calls POST /api/v1/user-invite/invite', async ({ page }) => {
+  test('05-06: invite user — calls POST /api/v1/users/invite', async ({ page }) => {
     await bypassLogin(page);
     await mockUsersEndpoint(page, USER_LIST_EMPTY);
 
     let postCalled = false;
-    await page.route('**/api/v1/user-invite/invite', (route) => {
+    await page.route('**/api/v1/users/invite', (route) => {
       if (route.request().method() === 'POST') {
         postCalled = true;
         return route.fulfill({
@@ -82,9 +82,10 @@ test.describe('Users', () => {
     await gotoAdmin(page, '/users');
     await page.locator('button:has-text("Invite user")').click();
 
-    // Fill invite form
+    // Fill invite form — use pressSequentially to properly trigger react-hook-form onChange
     const emailInput = page.locator('input[type="email"]').first();
-    await emailInput.fill('newuser@example.com');
+    await emailInput.click();
+    await emailInput.pressSequentially('newuser@example.com');
     await page.locator('button[type="submit"]:has-text("Send invitation")').click();
 
     await page.waitForTimeout(500);


### PR DESCRIPTION
## 目的

Issue #250 で導入した Playwright E2E テストスイートを全 48 件グリーンにする。

## 変更内容

### 1. `Input` コンポーネントの `forwardRef` 対応（プロダクション修正）

`frontend/src/shared/ui/primitives/Input.tsx`

- `React.forwardRef` でラップし、`ref` を native `<input>` に転送
- `name?: string` プロパティを追加して native `<input>` に転送
- `value` を `string` (必須) → `string | undefined` (省略可) に変更

**根本原因**: `{...register('email', ...)}` の spread で渡される `ref` と `name` が Input コンポーネントを通り抜けなかったため、react-hook-form の `getFieldValue()` が `field._f.ref.value` を読もうとしたとき、ref が DOM 要素でなく RefCallback 関数のままで `undefined` を返し、required バリデーションが誤って発火していた。

### 2. テスト修正

**`03-entity-types.spec.ts` — test 03-07**
- `EntityTypesPage` はエディターを `/forbidden` にリダイレクトしない（フォームを非表示にするだけ）
- URL チェック → `input[id="entity-type-name"]` の not.toBeVisible チェックに変更
- 未使用の `mockDashboard` / `DASHBOARD_EMPTY` インポートを削除

**`05-users.spec.ts` — test 05-06**
- ルートモック URL を `/api/v1/user-invite/invite` → `/api/v1/users/invite` に修正（実際のエンドポイント）
- `fill()` → `click() + pressSequentially()` に変更（forwardRef 修正との組み合わせで react-hook-form onChange を確実にトリガー）

## 検証

```
cd tests/e2e && npx playwright test
# 48 passed (42.8s)
```

全 48 テストがグリーン。

## チェックリスト

- [x] Input コンポーネントの後方互換性確認（forwardRef / optional value は既存利用箇所に影響なし）
- [x] 全 48 E2E テスト グリーン
- [x] TypeScript エラーなし（`npm run build` 成功）

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)