### PR TITLE
docs: 次フェーズ候補に Issue 番号を追記する

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -113,15 +113,13 @@ PHPUnit 545 tests / PHPStan level 8 / CS-Fixer / OpenAPI / MCP + Playwright 157 
 
 ## 次フェーズ候補
 
-> Issue を作成してから実装着手。未 Issue 化のため現時点では未着手。
-
-| 項目 | 概要 | 難易度 | 優先度 |
-| --- | --- | --- | --- |
-| コメント通知 | 新規コメント時にメール通知（MailerInterface 活用） | 小 | P1 |
-| コメントスパム対策 | honeypot / CAPTCHA / レート制限 | 小〜中 | P1 |
-| AI Consumer Chat | NeNe Records を外部 API として使うチャットシステム（**別リポジトリ**） | 大 | P2 |
-| スケジュール公開改善 | `scheduled_at` ジョブ状態 UI・失敗ハンドリング | 小〜中 | P2 |
-| コンテンツ検索 UI | Admin SPA に全文検索フォーム追加 | 小 | P2 |
+| Issue | 項目 | 概要 | 難易度 | 優先度 |
+| --- | --- | --- | --- | --- |
+| #263 | コメント通知 | 新規コメント時にメール通知（MailerInterface 活用） | 小 | P1 |
+| #264 | コメントスパム対策 | honeypot / レート制限 | 小〜中 | P1 |
+| #265 | コンテンツ検索 UI | Admin SPA に全文検索フォーム追加 | 小 | P2 |
+| — | AI Consumer Chat | NeNe Records を外部 API として使うチャットシステム（**別リポジトリ**） | 大 | P2 |
+| — | スケジュール公開改善 | `scheduled_at` ジョブ状態 UI・失敗ハンドリング | 小〜中 | P2 |
 
 ---
 


### PR DESCRIPTION
## 概要

次フェーズ候補の 3 項目について GitHub Issues を作成し、`docs/todo/current.md` に Issue 番号を反映する。

Closes #261

## 作成した Issue

- #263 — コメント通知（新規コメント時にメール通知）
- #264 — コメントスパム対策（honeypot + レート制限）
- #265 — コンテンツ検索 UI（Admin SPA に全文検索フォーム）

## 変更内容

`docs/todo/current.md` の次フェーズ候補テーブルに Issue 列を追加し、作成した Issue 番号を反映。

🤖 Generated with [Claude Code](https://claude.com/claude-code)