### PR TITLE
feat(notification): 通知チャンネルモジュールを追加する — email/slack/discord/chatwork/webhook (#263)

### DIFF
--- a/database/migrations/20260702000000_create_notification_channels_table.php
+++ b/database/migrations/20260702000000_create_notification_channels_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateNotificationChannelsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $table = $this->table('notification_channels', ['engine' => 'InnoDB', 'charset' => 'utf8mb4', 'collation' => 'utf8mb4_unicode_ci']);
+        $table
+            ->addColumn('organization_id', 'integer', ['signed' => false, 'null' => false, 'default' => 0])
+            ->addColumn('channel_type', 'enum', ['values' => ['email', 'slack', 'discord', 'chatwork', 'webhook'], 'null' => false])
+            ->addColumn('label', 'string', ['limit' => 100, 'null' => false])
+            ->addColumn('is_enabled', 'boolean', ['default' => true, 'null' => false])
+            ->addColumn('config_json', 'text', ['null' => false])
+            ->addColumn('created_at', 'datetime', ['default' => 'CURRENT_TIMESTAMP', 'null' => false])
+            ->addColumn('updated_at', 'datetime', ['default' => 'CURRENT_TIMESTAMP', 'null' => false])
+            ->addIndex(['organization_id', 'is_enabled'])
+            ->addIndex(['organization_id', 'channel_type'])
+            ->create();
+    }
+}

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -51,6 +51,9 @@ use NeNeRecords\Media\MediaServiceProvider;
 use NeNeRecords\Media\MediaTooLargeExceptionHandler;
 use NeNeRecords\NavigationItem\NavigationItemNotFoundExceptionHandler;
 use NeNeRecords\NavigationItem\NavigationItemServiceProvider;
+use NeNeRecords\Notification\NotificationChannelNotFoundExceptionHandler;
+use NeNeRecords\Notification\NotificationRouteRegistrar;
+use NeNeRecords\Notification\NotificationServiceProvider;
 use NeNeRecords\Organization\OrganizationNotFoundExceptionHandler;
 use NeNeRecords\Organization\OrganizationRouteRegistrar;
 use NeNeRecords\Organization\OrganizationServiceProvider;
@@ -128,6 +131,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new DashboardServiceProvider())
             ->addProvider(new UserServiceProvider())
             ->addProvider(new UserInviteServiceProvider())
+            ->addProvider(new NotificationServiceProvider())
             ->addProvider(new CommentServiceProvider())
             ->addProvider(new OrganizationServiceProvider())
             ->addProvider(new SystemConfigServiceProvider())
@@ -161,6 +165,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $user = $container->get('nene-records.route_registrar.user');
                     $userInvite = $container->get('nene-records.route_registrar.user_invite');
                     $auth = $container->get('nene-records.route_registrar.auth');
+                    $notification = $container->get(NotificationRouteRegistrar::class);
                     $comment = $container->get(CommentRouteRegistrar::class);
                     $organization = $container->get(OrganizationRouteRegistrar::class);
                     $systemConfig = $container->get(SystemConfigRouteRegistrar::class);
@@ -191,6 +196,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !is_callable($user)
                         || !is_callable($userInvite)
                         || !is_callable($auth)
+                        || !$notification instanceof NotificationRouteRegistrar
                         || !is_callable($comment)
                         || !$organization instanceof OrganizationRouteRegistrar
                         || !$systemConfig instanceof SystemConfigRouteRegistrar
@@ -224,6 +230,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $dashboard,
                         $user,
                         $userInvite,
+                        $notification,
                         $comment,
                         $organization,
                         $systemConfig,
@@ -277,6 +284,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $commentNotFound = $container->get(CommentNotFoundExceptionHandler::class);
                     $organizationNotFound = $container->get(OrganizationNotFoundExceptionHandler::class);
                     $organizationSlugConflict = $container->get(OrganizationSlugConflictExceptionHandler::class);
+                    $notificationChannelNotFound = $container->get(NotificationChannelNotFoundExceptionHandler::class);
 
                     foreach ([
                         $entityTypeNotFound,
@@ -321,6 +329,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $commentNotFound,
                         $organizationNotFound,
                         $organizationSlugConflict,
+                        $notificationChannelNotFound,
                     ] as $handler) {
                         if (!$handler instanceof DomainExceptionHandlerInterface) {
                             throw new LogicException('Exception handler service is invalid.');
@@ -370,6 +379,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $commentNotFound,
                         $organizationNotFound,
                         $organizationSlugConflict,
+                        $notificationChannelNotFound,
                     ];
                 },
             );

--- a/src/Comment/CommentServiceProvider.php
+++ b/src/Comment/CommentServiceProvider.php
@@ -11,6 +11,7 @@ use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Notification\NotifierInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 
@@ -43,7 +44,12 @@ final readonly class CommentServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Comment repository service is invalid.');
                     }
 
-                    return new PostCommentUseCase($repo);
+                    $notifier = $c->get(NotifierInterface::class);
+                    if (!$notifier instanceof NotifierInterface) {
+                        throw new LogicException('Notifier service is invalid.');
+                    }
+
+                    return new PostCommentUseCase($repo, $notifier);
                 },
             )
             ->set(

--- a/src/Comment/PostCommentUseCase.php
+++ b/src/Comment/PostCommentUseCase.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Comment;
 
+use NeNeRecords\Notification\NotificationMessage;
+use NeNeRecords\Notification\NotifierInterface;
+
 final readonly class PostCommentUseCase implements PostCommentUseCaseInterface
 {
-    public function __construct(private CommentRepositoryInterface $comments)
-    {
+    public function __construct(
+        private CommentRepositoryInterface $comments,
+        private NotifierInterface $notifier,
+    ) {
     }
 
     public function execute(PostCommentInput $input): PostCommentOutput
@@ -18,6 +23,12 @@ final readonly class PostCommentUseCase implements PostCommentUseCaseInterface
             $input->authorEmail,
             $input->body,
         );
+
+        $this->notifier->notify(new NotificationMessage(
+            event: 'comment.submitted',
+            title: '新規コメントが届きました',
+            body: "{$comment->authorName} さんからコメントが届きました:\n{$comment->body}",
+        ));
 
         return new PostCommentOutput(
             id: $comment->id,

--- a/src/Notification/Channel/ChatWorkChannel.php
+++ b/src/Notification/Channel/ChatWorkChannel.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification\Channel;
+
+use NeNeRecords\Notification\NotificationChannelInterface;
+use NeNeRecords\Notification\NotificationMessage;
+use Throwable;
+
+/**
+ * ChatWork API v2 channel.
+ *
+ * config_json keys:
+ *   api_token (string, required) — ChatWork API token
+ *   room_id   (string, required) — ChatWork room ID (numeric)
+ */
+final readonly class ChatWorkChannel implements NotificationChannelInterface
+{
+    private const API_BASE = 'https://api.chatwork.com/v2';
+    private const TIMEOUT_SECONDS = 5;
+
+    public function send(NotificationMessage $message, array $config): void
+    {
+        try {
+            $apiToken = isset($config['api_token']) && is_string($config['api_token'])
+                ? $config['api_token']
+                : '';
+            $roomId = isset($config['room_id']) && (is_string($config['room_id']) || is_int($config['room_id']))
+                ? (string) $config['room_id']
+                : '';
+
+            if ($apiToken === '' || $roomId === '') {
+                return;
+            }
+
+            $body = "[info][title]{$message->title}[/title]{$message->body}";
+            if ($message->url !== null) {
+                $body .= "\n{$message->url}";
+            }
+            $body .= '[/info]';
+
+            $this->postMessage($apiToken, $roomId, $body);
+        } catch (Throwable) {
+            // fire-and-forget
+        }
+    }
+
+    private function postMessage(string $apiToken, string $roomId, string $body): void
+    {
+        $url = self::API_BASE . '/rooms/' . $roomId . '/messages';
+
+        $ch = curl_init($url);
+        if ($ch === false) {
+            return;
+        }
+
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => http_build_query(['body' => $body]),
+            CURLOPT_HTTPHEADER => [
+                'X-ChatWorkToken: ' . $apiToken,
+                'Content-Type: application/x-www-form-urlencoded',
+            ],
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => self::TIMEOUT_SECONDS,
+            CURLOPT_CONNECTTIMEOUT => self::TIMEOUT_SECONDS,
+            CURLOPT_FOLLOWLOCATION => false,
+        ]);
+
+        curl_exec($ch);
+        curl_close($ch);
+    }
+}

--- a/src/Notification/Channel/DiscordChannel.php
+++ b/src/Notification/Channel/DiscordChannel.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification\Channel;
+
+use NeNeRecords\Notification\NotificationChannelInterface;
+use NeNeRecords\Notification\NotificationMessage;
+use Throwable;
+
+/**
+ * Discord Webhook channel.
+ *
+ * config_json keys:
+ *   webhook_url (string, required) — Discord webhook URL
+ */
+final readonly class DiscordChannel implements NotificationChannelInterface
+{
+    private const TIMEOUT_SECONDS = 5;
+
+    public function send(NotificationMessage $message, array $config): void
+    {
+        try {
+            $webhookUrl = isset($config['webhook_url']) && is_string($config['webhook_url'])
+                ? $config['webhook_url']
+                : '';
+
+            if ($webhookUrl === '') {
+                return;
+            }
+
+            $content = "**{$message->title}**\n{$message->body}";
+            if ($message->url !== null) {
+                $content .= "\n{$message->url}";
+            }
+
+            // Discord limits content to 2000 chars
+            if (mb_strlen($content) > 2000) {
+                $content = mb_substr($content, 0, 1997) . '...';
+            }
+
+            $payload = json_encode(['content' => $content], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+
+            $this->post($webhookUrl, $payload);
+        } catch (Throwable) {
+            // fire-and-forget
+        }
+    }
+
+    private function post(string $url, string $payload): void
+    {
+        $ch = curl_init($url);
+        if ($ch === false) {
+            return;
+        }
+
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $payload,
+            CURLOPT_HTTPHEADER => ['Content-Type: application/json'],
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => self::TIMEOUT_SECONDS,
+            CURLOPT_CONNECTTIMEOUT => self::TIMEOUT_SECONDS,
+            CURLOPT_FOLLOWLOCATION => false,
+        ]);
+
+        curl_exec($ch);
+        curl_close($ch);
+    }
+}

--- a/src/Notification/Channel/EmailChannel.php
+++ b/src/Notification/Channel/EmailChannel.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification\Channel;
+
+use NeNeRecords\Mail\MailerInterface;
+use NeNeRecords\Mail\MailMessage;
+use NeNeRecords\Notification\NotificationChannelInterface;
+use NeNeRecords\Notification\NotificationMessage;
+use Throwable;
+
+/**
+ * Email notification channel.
+ *
+ * config_json keys:
+ *   to_address (string, required) — recipient email address
+ */
+final readonly class EmailChannel implements NotificationChannelInterface
+{
+    public function __construct(private MailerInterface $mailer)
+    {
+    }
+
+    public function send(NotificationMessage $message, array $config): void
+    {
+        try {
+            $to = isset($config['to_address']) && is_string($config['to_address'])
+                ? $config['to_address']
+                : '';
+
+            if ($to === '') {
+                return;
+            }
+
+            $urlLine = $message->url !== null ? "\n\nURL: {$message->url}" : '';
+            $urlHtml = $message->url !== null
+                ? '<p><a href="' . htmlspecialchars($message->url, ENT_QUOTES | ENT_HTML5, 'UTF-8') . '">View →</a></p>'
+                : '';
+
+            $this->mailer->send(new MailMessage(
+                to: $to,
+                subject: "[NeNe Records] {$message->title}",
+                textBody: "{$message->title}\n\n{$message->body}{$urlLine}",
+                htmlBody: '<p><strong>' . htmlspecialchars($message->title, ENT_QUOTES | ENT_HTML5, 'UTF-8') . '</strong></p>'
+                    . '<p>' . nl2br(htmlspecialchars($message->body, ENT_QUOTES | ENT_HTML5, 'UTF-8')) . '</p>'
+                    . $urlHtml,
+            ));
+        } catch (Throwable) {
+            // fire-and-forget
+        }
+    }
+}

--- a/src/Notification/Channel/SlackChannel.php
+++ b/src/Notification/Channel/SlackChannel.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification\Channel;
+
+use NeNeRecords\Notification\NotificationChannelInterface;
+use NeNeRecords\Notification\NotificationMessage;
+use Throwable;
+
+/**
+ * Slack Incoming Webhook channel.
+ *
+ * config_json keys:
+ *   webhook_url (string, required) — Slack Incoming Webhook URL
+ */
+final readonly class SlackChannel implements NotificationChannelInterface
+{
+    private const TIMEOUT_SECONDS = 5;
+
+    public function send(NotificationMessage $message, array $config): void
+    {
+        try {
+            $webhookUrl = isset($config['webhook_url']) && is_string($config['webhook_url'])
+                ? $config['webhook_url']
+                : '';
+
+            if ($webhookUrl === '') {
+                return;
+            }
+
+            $text = "*{$message->title}*\n{$message->body}";
+            if ($message->url !== null) {
+                $text .= "\n<{$message->url}|View →>";
+            }
+
+            $payload = json_encode(['text' => $text], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+
+            $this->post($webhookUrl, $payload);
+        } catch (Throwable) {
+            // fire-and-forget
+        }
+    }
+
+    private function post(string $url, string $payload): void
+    {
+        $ch = curl_init($url);
+        if ($ch === false) {
+            return;
+        }
+
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $payload,
+            CURLOPT_HTTPHEADER => ['Content-Type: application/json'],
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => self::TIMEOUT_SECONDS,
+            CURLOPT_CONNECTTIMEOUT => self::TIMEOUT_SECONDS,
+            CURLOPT_FOLLOWLOCATION => false,
+        ]);
+
+        curl_exec($ch);
+        curl_close($ch);
+    }
+}

--- a/src/Notification/Channel/WebhookChannel.php
+++ b/src/Notification/Channel/WebhookChannel.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification\Channel;
+
+use NeNeRecords\Notification\NotificationChannelInterface;
+use NeNeRecords\Notification\NotificationMessage;
+use Throwable;
+
+/**
+ * Generic HTTP webhook channel (POST JSON).
+ *
+ * config_json keys:
+ *   url          (string, required)              — endpoint URL
+ *   headers_json (string|null, optional)         — JSON object of extra headers
+ */
+final readonly class WebhookChannel implements NotificationChannelInterface
+{
+    private const TIMEOUT_SECONDS = 5;
+
+    public function send(NotificationMessage $message, array $config): void
+    {
+        try {
+            $url = isset($config['url']) && is_string($config['url']) ? $config['url'] : '';
+
+            if ($url === '') {
+                return;
+            }
+
+            $payload = json_encode([
+                'event' => $message->event,
+                'title' => $message->title,
+                'body' => $message->body,
+                'url' => $message->url,
+                'occurred_at' => date('c'),
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+
+            $extraHeaders = $this->parseHeaders($config);
+
+            $this->post($url, $payload, $extraHeaders);
+        } catch (Throwable) {
+            // fire-and-forget
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $config
+     * @return string[]
+     */
+    private function parseHeaders(array $config): array
+    {
+        if (!isset($config['headers_json']) || !is_string($config['headers_json']) || $config['headers_json'] === '') {
+            return [];
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = json_decode($config['headers_json'], true, 8, JSON_THROW_ON_ERROR);
+
+            if (!is_array($decoded)) {
+                return [];
+            }
+
+            $result = [];
+            foreach ($decoded as $name => $value) {
+                if (is_string($name) && (is_string($value) || is_int($value))) {
+                    $result[] = $name . ': ' . $value;
+                }
+            }
+
+            return $result;
+        } catch (Throwable) {
+            return [];
+        }
+    }
+
+    /** @param string[] $extraHeaders */
+    private function post(string $url, string $payload, array $extraHeaders): void
+    {
+        $ch = curl_init($url);
+        if ($ch === false) {
+            return;
+        }
+
+        $headers = array_merge(
+            [
+                'Content-Type: application/json',
+                'User-Agent: NeNeRecords-Notification/1.0',
+            ],
+            $extraHeaders,
+        );
+
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $payload,
+            CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => self::TIMEOUT_SECONDS,
+            CURLOPT_CONNECTTIMEOUT => self::TIMEOUT_SECONDS,
+            CURLOPT_FOLLOWLOCATION => false,
+        ]);
+
+        curl_exec($ch);
+        curl_close($ch);
+    }
+}

--- a/src/Notification/CompositeNotifier.php
+++ b/src/Notification/CompositeNotifier.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+use NeNeRecords\Notification\Channel\ChatWorkChannel;
+use NeNeRecords\Notification\Channel\DiscordChannel;
+use NeNeRecords\Notification\Channel\EmailChannel;
+use NeNeRecords\Notification\Channel\SlackChannel;
+use NeNeRecords\Notification\Channel\WebhookChannel;
+use Throwable;
+
+/**
+ * Loads all enabled channels from the repository and fan-outs the message.
+ * Every delivery is fire-and-forget; failures never surface to the caller.
+ */
+final readonly class CompositeNotifier implements NotifierInterface
+{
+    public function __construct(
+        private NotificationChannelRepositoryInterface $channels,
+        private EmailChannel $emailChannel,
+        private SlackChannel $slackChannel,
+        private DiscordChannel $discordChannel,
+        private ChatWorkChannel $chatWorkChannel,
+        private WebhookChannel $webhookChannel,
+    ) {
+    }
+
+    public function notify(NotificationMessage $message): void
+    {
+        try {
+            $channels = $this->channels->findAllEnabled();
+        } catch (Throwable) {
+            return;
+        }
+
+        foreach ($channels as $channel) {
+            $this->deliver($channel, $message);
+        }
+    }
+
+    private function deliver(NotificationChannel $channel, NotificationMessage $message): void
+    {
+        try {
+            $impl = match ($channel->channelType) {
+                'email' => $this->emailChannel,
+                'slack' => $this->slackChannel,
+                'discord' => $this->discordChannel,
+                'chatwork' => $this->chatWorkChannel,
+                'webhook' => $this->webhookChannel,
+                default => null,
+            };
+
+            $impl?->send($message, $channel->config);
+        } catch (Throwable) {
+            // never propagate
+        }
+    }
+}

--- a/src/Notification/CreateNotificationChannelHandler.php
+++ b/src/Notification/CreateNotificationChannelHandler.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateNotificationChannelHandler
+{
+    private const VALID_TYPES = ['email', 'slack', 'discord', 'chatwork', 'webhook'];
+
+    public function __construct(
+        private CreateNotificationChannelUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+        $errors = [];
+
+        $channelType = trim((string) ($body['channel_type'] ?? ''));
+        $label = trim((string) ($body['label'] ?? ''));
+        $isEnabled = isset($body['is_enabled']) ? (bool) $body['is_enabled'] : true;
+        $config = isset($body['config']) && is_array($body['config']) ? $body['config'] : [];
+
+        if ($channelType === '') {
+            $errors[] = new ValidationError('channel_type', 'channel_type is required.', 'required');
+        } elseif (!in_array($channelType, self::VALID_TYPES, true)) {
+            $errors[] = new ValidationError('channel_type', 'Invalid channel_type. Allowed: ' . implode(', ', self::VALID_TYPES) . '.', 'enum');
+        }
+
+        if ($label === '') {
+            $errors[] = new ValidationError('label', 'label is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $channel = $this->useCase->execute(new CreateNotificationChannelInput(
+            channelType: $channelType,
+            label: $label,
+            isEnabled: $isEnabled,
+            config: $config,
+        ));
+
+        return $this->response->create($this->serialize($channel), 201);
+    }
+
+    /** @return array<string,mixed> */
+    private function serialize(NotificationChannel $ch): array
+    {
+        return [
+            'id'           => $ch->id,
+            'channel_type' => $ch->channelType,
+            'label'        => $ch->label,
+            'is_enabled'   => $ch->isEnabled,
+            'config'       => $ch->config,
+            'created_at'   => $ch->createdAt,
+            'updated_at'   => $ch->updatedAt,
+        ];
+    }
+}

--- a/src/Notification/CreateNotificationChannelInput.php
+++ b/src/Notification/CreateNotificationChannelInput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+final readonly class CreateNotificationChannelInput
+{
+    /** @param array<string,mixed> $config */
+    public function __construct(
+        public string $channelType,
+        public string $label,
+        public bool $isEnabled,
+        public array $config,
+    ) {
+    }
+}

--- a/src/Notification/CreateNotificationChannelUseCase.php
+++ b/src/Notification/CreateNotificationChannelUseCase.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+final readonly class CreateNotificationChannelUseCase implements CreateNotificationChannelUseCaseInterface
+{
+    private const VALID_TYPES = ['email', 'slack', 'discord', 'chatwork', 'webhook'];
+
+    public function __construct(private NotificationChannelRepositoryInterface $channels)
+    {
+    }
+
+    public function execute(CreateNotificationChannelInput $input): NotificationChannel
+    {
+        if (!in_array($input->channelType, self::VALID_TYPES, true)) {
+            throw new InvalidNotificationChannelTypeException($input->channelType);
+        }
+
+        return $this->channels->create(
+            $input->channelType,
+            $input->label,
+            $input->isEnabled,
+            $input->config,
+        );
+    }
+}

--- a/src/Notification/CreateNotificationChannelUseCaseInterface.php
+++ b/src/Notification/CreateNotificationChannelUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+interface CreateNotificationChannelUseCaseInterface
+{
+    public function execute(CreateNotificationChannelInput $input): NotificationChannel;
+}

--- a/src/Notification/DeleteNotificationChannelHandler.php
+++ b/src/Notification/DeleteNotificationChannelHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteNotificationChannelHandler
+{
+    public function __construct(
+        private DeleteNotificationChannelUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+
+        $this->useCase->execute(new DeleteNotificationChannelInput($id));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/Notification/DeleteNotificationChannelInput.php
+++ b/src/Notification/DeleteNotificationChannelInput.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+final readonly class DeleteNotificationChannelInput
+{
+    public function __construct(public int $id)
+    {
+    }
+}

--- a/src/Notification/DeleteNotificationChannelUseCase.php
+++ b/src/Notification/DeleteNotificationChannelUseCase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+final readonly class DeleteNotificationChannelUseCase implements DeleteNotificationChannelUseCaseInterface
+{
+    public function __construct(private NotificationChannelRepositoryInterface $channels)
+    {
+    }
+
+    public function execute(DeleteNotificationChannelInput $input): void
+    {
+        $channel = $this->channels->findById($input->id);
+        if ($channel === null) {
+            throw new NotificationChannelNotFoundException($input->id);
+        }
+
+        $this->channels->delete($input->id);
+    }
+}

--- a/src/Notification/DeleteNotificationChannelUseCaseInterface.php
+++ b/src/Notification/DeleteNotificationChannelUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+interface DeleteNotificationChannelUseCaseInterface
+{
+    public function execute(DeleteNotificationChannelInput $input): void;
+}

--- a/src/Notification/InvalidNotificationChannelTypeException.php
+++ b/src/Notification/InvalidNotificationChannelTypeException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+use DomainException;
+
+final class InvalidNotificationChannelTypeException extends DomainException
+{
+    public function __construct(string $type)
+    {
+        parent::__construct("Invalid notification channel type: '{$type}'. Allowed: email, slack, discord, chatwork, webhook.");
+    }
+}

--- a/src/Notification/ListNotificationChannelsHandler.php
+++ b/src/Notification/ListNotificationChannelsHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListNotificationChannelsHandler
+{
+    public function __construct(
+        private ListNotificationChannelsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $output = $this->useCase->execute();
+
+        $items = array_map(
+            static fn (NotificationChannel $ch): array => [
+                'id'           => $ch->id,
+                'channel_type' => $ch->channelType,
+                'label'        => $ch->label,
+                'is_enabled'   => $ch->isEnabled,
+                'config'       => $ch->config,
+                'created_at'   => $ch->createdAt,
+                'updated_at'   => $ch->updatedAt,
+            ],
+            $output->items,
+        );
+
+        return $this->response->create(['items' => $items]);
+    }
+}

--- a/src/Notification/ListNotificationChannelsOutput.php
+++ b/src/Notification/ListNotificationChannelsOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+final readonly class ListNotificationChannelsOutput
+{
+    /** @param NotificationChannel[] $items */
+    public function __construct(public array $items)
+    {
+    }
+}

--- a/src/Notification/ListNotificationChannelsUseCase.php
+++ b/src/Notification/ListNotificationChannelsUseCase.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+final readonly class ListNotificationChannelsUseCase implements ListNotificationChannelsUseCaseInterface
+{
+    public function __construct(private NotificationChannelRepositoryInterface $channels)
+    {
+    }
+
+    public function execute(): ListNotificationChannelsOutput
+    {
+        return new ListNotificationChannelsOutput($this->channels->findAll());
+    }
+}

--- a/src/Notification/ListNotificationChannelsUseCaseInterface.php
+++ b/src/Notification/ListNotificationChannelsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+interface ListNotificationChannelsUseCaseInterface
+{
+    public function execute(): ListNotificationChannelsOutput;
+}

--- a/src/Notification/NotificationChannel.php
+++ b/src/Notification/NotificationChannel.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+/**
+ * Persisted notification channel configuration.
+ *
+ * @phpstan-type ChannelType 'email'|'slack'|'discord'|'chatwork'|'webhook'
+ */
+final readonly class NotificationChannel
+{
+    /**
+     * @param array<string,mixed> $config Decoded channel-specific settings
+     */
+    public function __construct(
+        public int $id,
+        public int $organizationId,
+        public string $channelType,
+        public string $label,
+        public bool $isEnabled,
+        public array $config,
+        public string $createdAt,
+        public string $updatedAt,
+    ) {
+    }
+}

--- a/src/Notification/NotificationChannelInterface.php
+++ b/src/Notification/NotificationChannelInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+/**
+ * A single notification delivery channel (e.g. Email, Slack, Discord).
+ *
+ * Implementations MUST NOT let exceptions propagate — failures are silent.
+ */
+interface NotificationChannelInterface
+{
+    /**
+     * Send a notification. Must not throw; log or silently swallow failures.
+     *
+     * @param array<string,mixed> $config Channel-specific configuration
+     */
+    public function send(NotificationMessage $message, array $config): void;
+}

--- a/src/Notification/NotificationChannelNotFoundException.php
+++ b/src/Notification/NotificationChannelNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+use DomainException;
+
+final class NotificationChannelNotFoundException extends DomainException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("Notification channel #{$id} not found.");
+    }
+}

--- a/src/Notification/NotificationChannelNotFoundExceptionHandler.php
+++ b/src/Notification/NotificationChannelNotFoundExceptionHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class NotificationChannelNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(private ProblemDetailsResponseFactory $problemDetails)
+    {
+    }
+
+    public function supports(Throwable $e): bool
+    {
+        return $e instanceof NotificationChannelNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'not-found', 'Not Found', 404, $exception->getMessage());
+    }
+}

--- a/src/Notification/NotificationChannelRepositoryInterface.php
+++ b/src/Notification/NotificationChannelRepositoryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+interface NotificationChannelRepositoryInterface
+{
+    /** @return NotificationChannel[] */
+    public function findAll(): array;
+
+    /** @return NotificationChannel[] */
+    public function findAllEnabled(): array;
+
+    public function findById(int $id): NotificationChannel|null;
+
+    /**
+     * @param array<string,mixed> $config
+     */
+    public function create(string $channelType, string $label, bool $isEnabled, array $config): NotificationChannel;
+
+    /**
+     * @param array<string,mixed> $config
+     */
+    public function update(int $id, string $label, bool $isEnabled, array $config): void;
+
+    public function delete(int $id): void;
+}

--- a/src/Notification/NotificationMessage.php
+++ b/src/Notification/NotificationMessage.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+/**
+ * Channel-agnostic notification payload.
+ * Channels format this into their specific wire format (JSON/text/HTML).
+ */
+final readonly class NotificationMessage
+{
+    /**
+     * @param string      $event   Machine-readable event key (e.g. "comment.submitted")
+     * @param string      $title   Short human-readable summary
+     * @param string      $body    Full message text (plain text)
+     * @param string|null $url     Optional deep-link URL to the related resource
+     */
+    public function __construct(
+        public string $event,
+        public string $title,
+        public string $body,
+        public string|null $url = null,
+    ) {
+    }
+}

--- a/src/Notification/NotificationRouteRegistrar.php
+++ b/src/Notification/NotificationRouteRegistrar.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class NotificationRouteRegistrar
+{
+    public function __construct(
+        private ListNotificationChannelsHandler $listHandler,
+        private CreateNotificationChannelHandler $createHandler,
+        private UpdateNotificationChannelHandler $updateHandler,
+        private DeleteNotificationChannelHandler $deleteHandler,
+        private TestNotificationChannelHandler $testHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $list = $this->listHandler;
+        $create = $this->createHandler;
+        $update = $this->updateHandler;
+        $delete = $this->deleteHandler;
+        $test = $this->testHandler;
+
+        $router->get('/api/v1/notification-channels', static fn (ServerRequestInterface $r) => $list->handle($r));
+        $router->post('/api/v1/notification-channels', static fn (ServerRequestInterface $r) => $create->handle($r));
+        $router->patch('/api/v1/notification-channels/{id}', static fn (ServerRequestInterface $r) => $update->handle($r));
+        $router->delete('/api/v1/notification-channels/{id}', static fn (ServerRequestInterface $r) => $delete->handle($r));
+        $router->post('/api/v1/notification-channels/{id}/test', static fn (ServerRequestInterface $r) => $test->handle($r));
+    }
+}

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Mail\MailerInterface;
+use NeNeRecords\Notification\Channel\ChatWorkChannel;
+use NeNeRecords\Notification\Channel\DiscordChannel;
+use NeNeRecords\Notification\Channel\EmailChannel;
+use NeNeRecords\Notification\Channel\SlackChannel;
+use NeNeRecords\Notification\Channel\WebhookChannel;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class NotificationServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        // ── Repository ────────────────────────────────────────────────────────
+
+        $builder->set(
+            NotificationChannelRepositoryInterface::class,
+            static function (ContainerInterface $c): NotificationChannelRepositoryInterface {
+                $query = $c->get(DatabaseQueryExecutorInterface::class);
+                if (!$query instanceof DatabaseQueryExecutorInterface) {
+                    throw new LogicException('Database query executor service is invalid.');
+                }
+
+                $orgId = $c->get('nene-records.org_id_holder');
+                if (!$orgId instanceof RequestScopedHolder) {
+                    throw new LogicException('Org ID holder service is invalid.');
+                }
+
+                return new PdoNotificationChannelRepository($query, $orgId);
+            },
+        );
+
+        // ── Channels ──────────────────────────────────────────────────────────
+
+        $builder->set(
+            EmailChannel::class,
+            static function (ContainerInterface $c): EmailChannel {
+                $mailer = $c->get(MailerInterface::class);
+                if (!$mailer instanceof MailerInterface) {
+                    throw new LogicException('MailerInterface service is invalid.');
+                }
+
+                return new EmailChannel($mailer);
+            },
+        );
+
+        $builder->set(SlackChannel::class, static fn (): SlackChannel => new SlackChannel());
+        $builder->set(DiscordChannel::class, static fn (): DiscordChannel => new DiscordChannel());
+        $builder->set(ChatWorkChannel::class, static fn (): ChatWorkChannel => new ChatWorkChannel());
+        $builder->set(WebhookChannel::class, static fn (): WebhookChannel => new WebhookChannel());
+
+        // ── Notifier ──────────────────────────────────────────────────────────
+
+        $builder->set(
+            NotifierInterface::class,
+            static function (ContainerInterface $c): NotifierInterface {
+                $repo = $c->get(NotificationChannelRepositoryInterface::class);
+                if (!$repo instanceof NotificationChannelRepositoryInterface) {
+                    throw new LogicException('NotificationChannelRepository service is invalid.');
+                }
+
+                $email = $c->get(EmailChannel::class);
+                $slack = $c->get(SlackChannel::class);
+                $discord = $c->get(DiscordChannel::class);
+                $chatWork = $c->get(ChatWorkChannel::class);
+                $webhook = $c->get(WebhookChannel::class);
+
+                if (!$email instanceof EmailChannel) {
+                    throw new LogicException('EmailChannel service is invalid.');
+                }
+                if (!$slack instanceof SlackChannel) {
+                    throw new LogicException('SlackChannel service is invalid.');
+                }
+                if (!$discord instanceof DiscordChannel) {
+                    throw new LogicException('DiscordChannel service is invalid.');
+                }
+                if (!$chatWork instanceof ChatWorkChannel) {
+                    throw new LogicException('ChatWorkChannel service is invalid.');
+                }
+                if (!$webhook instanceof WebhookChannel) {
+                    throw new LogicException('WebhookChannel service is invalid.');
+                }
+
+                return new CompositeNotifier($repo, $email, $slack, $discord, $chatWork, $webhook);
+            },
+        );
+
+        // ── Use Cases ─────────────────────────────────────────────────────────
+
+        $builder->set(
+            ListNotificationChannelsUseCaseInterface::class,
+            static function (ContainerInterface $c): ListNotificationChannelsUseCaseInterface {
+                $repo = $c->get(NotificationChannelRepositoryInterface::class);
+                if (!$repo instanceof NotificationChannelRepositoryInterface) {
+                    throw new LogicException('NotificationChannelRepository service is invalid.');
+                }
+
+                return new ListNotificationChannelsUseCase($repo);
+            },
+        );
+
+        $builder->set(
+            CreateNotificationChannelUseCaseInterface::class,
+            static function (ContainerInterface $c): CreateNotificationChannelUseCaseInterface {
+                $repo = $c->get(NotificationChannelRepositoryInterface::class);
+                if (!$repo instanceof NotificationChannelRepositoryInterface) {
+                    throw new LogicException('NotificationChannelRepository service is invalid.');
+                }
+
+                return new CreateNotificationChannelUseCase($repo);
+            },
+        );
+
+        $builder->set(
+            UpdateNotificationChannelUseCaseInterface::class,
+            static function (ContainerInterface $c): UpdateNotificationChannelUseCaseInterface {
+                $repo = $c->get(NotificationChannelRepositoryInterface::class);
+                if (!$repo instanceof NotificationChannelRepositoryInterface) {
+                    throw new LogicException('NotificationChannelRepository service is invalid.');
+                }
+
+                return new UpdateNotificationChannelUseCase($repo);
+            },
+        );
+
+        $builder->set(
+            DeleteNotificationChannelUseCaseInterface::class,
+            static function (ContainerInterface $c): DeleteNotificationChannelUseCaseInterface {
+                $repo = $c->get(NotificationChannelRepositoryInterface::class);
+                if (!$repo instanceof NotificationChannelRepositoryInterface) {
+                    throw new LogicException('NotificationChannelRepository service is invalid.');
+                }
+
+                return new DeleteNotificationChannelUseCase($repo);
+            },
+        );
+
+        $builder->set(
+            TestNotificationChannelUseCaseInterface::class,
+            static function (ContainerInterface $c): TestNotificationChannelUseCaseInterface {
+                $repo = $c->get(NotificationChannelRepositoryInterface::class);
+                $email = $c->get(EmailChannel::class);
+                $slack = $c->get(SlackChannel::class);
+                $discord = $c->get(DiscordChannel::class);
+                $chatWork = $c->get(ChatWorkChannel::class);
+                $webhook = $c->get(WebhookChannel::class);
+
+                if (!$repo instanceof NotificationChannelRepositoryInterface
+                    || !$email instanceof EmailChannel
+                    || !$slack instanceof SlackChannel
+                    || !$discord instanceof DiscordChannel
+                    || !$chatWork instanceof ChatWorkChannel
+                    || !$webhook instanceof WebhookChannel
+                ) {
+                    throw new LogicException('Notification channel services are invalid.');
+                }
+
+                return new TestNotificationChannelUseCase($repo, $email, $slack, $discord, $chatWork, $webhook);
+            },
+        );
+
+        // ── Handlers ──────────────────────────────────────────────────────────
+
+        $builder->set(
+            ListNotificationChannelsHandler::class,
+            static function (ContainerInterface $c): ListNotificationChannelsHandler {
+                $useCase = $c->get(ListNotificationChannelsUseCaseInterface::class);
+                $response = $c->get(JsonResponseFactory::class);
+                if (!$useCase instanceof ListNotificationChannelsUseCaseInterface) {
+                    throw new LogicException('ListNotificationChannels use case service is invalid.');
+                }
+                if (!$response instanceof JsonResponseFactory) {
+                    throw new LogicException('JsonResponseFactory service is invalid.');
+                }
+
+                return new ListNotificationChannelsHandler($useCase, $response);
+            },
+        );
+
+        $builder->set(
+            CreateNotificationChannelHandler::class,
+            static function (ContainerInterface $c): CreateNotificationChannelHandler {
+                $useCase = $c->get(CreateNotificationChannelUseCaseInterface::class);
+                $response = $c->get(JsonResponseFactory::class);
+                if (!$useCase instanceof CreateNotificationChannelUseCaseInterface) {
+                    throw new LogicException('CreateNotificationChannel use case service is invalid.');
+                }
+                if (!$response instanceof JsonResponseFactory) {
+                    throw new LogicException('JsonResponseFactory service is invalid.');
+                }
+
+                return new CreateNotificationChannelHandler($useCase, $response);
+            },
+        );
+
+        $builder->set(
+            UpdateNotificationChannelHandler::class,
+            static function (ContainerInterface $c): UpdateNotificationChannelHandler {
+                $useCase = $c->get(UpdateNotificationChannelUseCaseInterface::class);
+                $response = $c->get(JsonResponseFactory::class);
+                if (!$useCase instanceof UpdateNotificationChannelUseCaseInterface) {
+                    throw new LogicException('UpdateNotificationChannel use case service is invalid.');
+                }
+                if (!$response instanceof JsonResponseFactory) {
+                    throw new LogicException('JsonResponseFactory service is invalid.');
+                }
+
+                return new UpdateNotificationChannelHandler($useCase, $response);
+            },
+        );
+
+        $builder->set(
+            DeleteNotificationChannelHandler::class,
+            static function (ContainerInterface $c): DeleteNotificationChannelHandler {
+                $useCase = $c->get(DeleteNotificationChannelUseCaseInterface::class);
+                $responseFactory = $c->get(ResponseFactoryInterface::class);
+                if (!$useCase instanceof DeleteNotificationChannelUseCaseInterface) {
+                    throw new LogicException('DeleteNotificationChannel use case service is invalid.');
+                }
+                if (!$responseFactory instanceof ResponseFactoryInterface) {
+                    throw new LogicException('ResponseFactory service is invalid.');
+                }
+
+                return new DeleteNotificationChannelHandler($useCase, $responseFactory);
+            },
+        );
+
+        $builder->set(
+            TestNotificationChannelHandler::class,
+            static function (ContainerInterface $c): TestNotificationChannelHandler {
+                $useCase = $c->get(TestNotificationChannelUseCaseInterface::class);
+                $response = $c->get(JsonResponseFactory::class);
+                if (!$useCase instanceof TestNotificationChannelUseCaseInterface) {
+                    throw new LogicException('TestNotificationChannel use case service is invalid.');
+                }
+                if (!$response instanceof JsonResponseFactory) {
+                    throw new LogicException('JsonResponseFactory service is invalid.');
+                }
+
+                return new TestNotificationChannelHandler($useCase, $response);
+            },
+        );
+
+        // ── Route Registrar ───────────────────────────────────────────────────
+
+        $builder->set(
+            NotificationRouteRegistrar::class,
+            static function (ContainerInterface $c): NotificationRouteRegistrar {
+                return new NotificationRouteRegistrar(
+                    $c->get(ListNotificationChannelsHandler::class),
+                    $c->get(CreateNotificationChannelHandler::class),
+                    $c->get(UpdateNotificationChannelHandler::class),
+                    $c->get(DeleteNotificationChannelHandler::class),
+                    $c->get(TestNotificationChannelHandler::class),
+                );
+            },
+        );
+
+        // ── Exception Handler ─────────────────────────────────────────────────
+
+        $builder->set(
+            NotificationChannelNotFoundExceptionHandler::class,
+            static function (ContainerInterface $c): NotificationChannelNotFoundExceptionHandler {
+                $factory = $c->get(ProblemDetailsResponseFactory::class);
+                if (!$factory instanceof ProblemDetailsResponseFactory) {
+                    throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                }
+
+                return new NotificationChannelNotFoundExceptionHandler($factory);
+            },
+        );
+    }
+}

--- a/src/Notification/NotifierInterface.php
+++ b/src/Notification/NotifierInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+/**
+ * Fan-out notifier: delivers a message to all active configured channels.
+ * Callers MUST treat this as fire-and-forget — failures are swallowed.
+ */
+interface NotifierInterface
+{
+    public function notify(NotificationMessage $message): void;
+}

--- a/src/Notification/NullNotifier.php
+++ b/src/Notification/NullNotifier.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+/**
+ * No-op notifier — used in unit tests and when no channels are configured.
+ */
+final readonly class NullNotifier implements NotifierInterface
+{
+    public function notify(NotificationMessage $message): void
+    {
+        // intentionally empty
+    }
+}

--- a/src/Notification/PdoNotificationChannelRepository.php
+++ b/src/Notification/PdoNotificationChannelRepository.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
+
+final readonly class PdoNotificationChannelRepository implements NotificationChannelRepositoryInterface
+{
+    /**
+     * @param RequestScopedHolder<int> $orgId
+     */
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    public function findAll(): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT * FROM notification_channels WHERE organization_id = ? ORDER BY id ASC',
+            [$this->resolveOrgId()],
+        );
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function findAllEnabled(): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT * FROM notification_channels WHERE organization_id = ? AND is_enabled = 1 ORDER BY id ASC',
+            [$this->resolveOrgId()],
+        );
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function findById(int $id): NotificationChannel|null
+    {
+        $row = $this->query->fetchOne(
+            'SELECT * FROM notification_channels WHERE id = ? AND organization_id = ?',
+            [$id, $this->resolveOrgId()],
+        );
+
+        return $row !== null ? $this->hydrate($row) : null;
+    }
+
+    public function create(string $channelType, string $label, bool $isEnabled, array $config): NotificationChannel
+    {
+        $configJson = json_encode($config, JSON_THROW_ON_ERROR);
+        $now = date('Y-m-d H:i:s');
+
+        $this->query->execute(
+            'INSERT INTO notification_channels (organization_id, channel_type, label, is_enabled, config_json, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?)',
+            [$this->resolveOrgId(), $channelType, $label, $isEnabled ? 1 : 0, $configJson, $now, $now],
+        );
+
+        $id = (int) $this->query->lastInsertId();
+
+        return new NotificationChannel(
+            id: $id,
+            organizationId: $this->resolveOrgId(),
+            channelType: $channelType,
+            label: $label,
+            isEnabled: $isEnabled,
+            config: $config,
+            createdAt: $now,
+            updatedAt: $now,
+        );
+    }
+
+    public function update(int $id, string $label, bool $isEnabled, array $config): void
+    {
+        $configJson = json_encode($config, JSON_THROW_ON_ERROR);
+        $now = date('Y-m-d H:i:s');
+
+        $this->query->execute(
+            'UPDATE notification_channels SET label = ?, is_enabled = ?, config_json = ?, updated_at = ? WHERE id = ? AND organization_id = ?',
+            [$label, $isEnabled ? 1 : 0, $configJson, $now, $id, $this->resolveOrgId()],
+        );
+    }
+
+    public function delete(int $id): void
+    {
+        $this->query->execute(
+            'DELETE FROM notification_channels WHERE id = ? AND organization_id = ?',
+            [$id, $this->resolveOrgId()],
+        );
+    }
+
+    /** @param array<string,mixed> $row */
+    private function hydrate(array $row): NotificationChannel
+    {
+        /** @var array<string,mixed> $config */
+        $config = json_decode((string) $row['config_json'], true, 512, JSON_THROW_ON_ERROR);
+
+        return new NotificationChannel(
+            id: (int) $row['id'],
+            organizationId: (int) $row['organization_id'],
+            channelType: (string) $row['channel_type'],
+            label: (string) $row['label'],
+            isEnabled: (bool) $row['is_enabled'],
+            config: $config,
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+
+    private function resolveOrgId(): int
+    {
+        return $this->orgId->get();
+    }
+}

--- a/src/Notification/TestNotificationChannelHandler.php
+++ b/src/Notification/TestNotificationChannelHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class TestNotificationChannelHandler
+{
+    public function __construct(
+        private TestNotificationChannelUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+
+        $this->useCase->execute(new TestNotificationChannelInput($id));
+
+        return $this->response->create(['sent' => true]);
+    }
+}

--- a/src/Notification/TestNotificationChannelInput.php
+++ b/src/Notification/TestNotificationChannelInput.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+final readonly class TestNotificationChannelInput
+{
+    public function __construct(public int $id)
+    {
+    }
+}

--- a/src/Notification/TestNotificationChannelUseCase.php
+++ b/src/Notification/TestNotificationChannelUseCase.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+use NeNeRecords\Notification\Channel\ChatWorkChannel;
+use NeNeRecords\Notification\Channel\DiscordChannel;
+use NeNeRecords\Notification\Channel\EmailChannel;
+use NeNeRecords\Notification\Channel\SlackChannel;
+use NeNeRecords\Notification\Channel\WebhookChannel;
+
+final readonly class TestNotificationChannelUseCase implements TestNotificationChannelUseCaseInterface
+{
+    public function __construct(
+        private NotificationChannelRepositoryInterface $channels,
+        private EmailChannel $emailChannel,
+        private SlackChannel $slackChannel,
+        private DiscordChannel $discordChannel,
+        private ChatWorkChannel $chatWorkChannel,
+        private WebhookChannel $webhookChannel,
+    ) {
+    }
+
+    public function execute(TestNotificationChannelInput $input): void
+    {
+        $channel = $this->channels->findById($input->id);
+        if ($channel === null) {
+            throw new NotificationChannelNotFoundException($input->id);
+        }
+
+        $testMessage = new NotificationMessage(
+            event: 'test',
+            title: 'NeNe Records — テスト通知',
+            body: "このメッセージは通知チャンネル「{$channel->label}」のテスト送信です。",
+            url: null,
+        );
+
+        $impl = match ($channel->channelType) {
+            'email' => $this->emailChannel,
+            'slack' => $this->slackChannel,
+            'discord' => $this->discordChannel,
+            'chatwork' => $this->chatWorkChannel,
+            'webhook' => $this->webhookChannel,
+            default => null,
+        };
+
+        $impl?->send($testMessage, $channel->config);
+    }
+}

--- a/src/Notification/TestNotificationChannelUseCaseInterface.php
+++ b/src/Notification/TestNotificationChannelUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+interface TestNotificationChannelUseCaseInterface
+{
+    public function execute(TestNotificationChannelInput $input): void;
+}

--- a/src/Notification/UpdateNotificationChannelHandler.php
+++ b/src/Notification/UpdateNotificationChannelHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateNotificationChannelHandler
+{
+    public function __construct(
+        private UpdateNotificationChannelUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+
+        $body = JsonRequestBodyParser::parse($request);
+        $errors = [];
+
+        $label = trim((string) ($body['label'] ?? ''));
+        $isEnabled = isset($body['is_enabled']) ? (bool) $body['is_enabled'] : true;
+        $config = isset($body['config']) && is_array($body['config']) ? $body['config'] : [];
+
+        if ($label === '') {
+            $errors[] = new ValidationError('label', 'label is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $this->useCase->execute(new UpdateNotificationChannelInput(
+            id: $id,
+            label: $label,
+            isEnabled: $isEnabled,
+            config: $config,
+        ));
+
+        return $this->response->create(['success' => true]);
+    }
+}

--- a/src/Notification/UpdateNotificationChannelInput.php
+++ b/src/Notification/UpdateNotificationChannelInput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+final readonly class UpdateNotificationChannelInput
+{
+    /** @param array<string,mixed> $config */
+    public function __construct(
+        public int $id,
+        public string $label,
+        public bool $isEnabled,
+        public array $config,
+    ) {
+    }
+}

--- a/src/Notification/UpdateNotificationChannelUseCase.php
+++ b/src/Notification/UpdateNotificationChannelUseCase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+final readonly class UpdateNotificationChannelUseCase implements UpdateNotificationChannelUseCaseInterface
+{
+    public function __construct(private NotificationChannelRepositoryInterface $channels)
+    {
+    }
+
+    public function execute(UpdateNotificationChannelInput $input): void
+    {
+        $channel = $this->channels->findById($input->id);
+        if ($channel === null) {
+            throw new NotificationChannelNotFoundException($input->id);
+        }
+
+        $this->channels->update($input->id, $input->label, $input->isEnabled, $input->config);
+    }
+}

--- a/src/Notification/UpdateNotificationChannelUseCaseInterface.php
+++ b/src/Notification/UpdateNotificationChannelUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+interface UpdateNotificationChannelUseCaseInterface
+{
+    public function execute(UpdateNotificationChannelInput $input): void;
+}

--- a/tests/Comment/CommentHttpTest.php
+++ b/tests/Comment/CommentHttpTest.php
@@ -19,6 +19,7 @@ use NeNeRecords\Comment\ListCommentsHandler;
 use NeNeRecords\Comment\ListCommentsUseCase;
 use NeNeRecords\Comment\PostCommentHandler;
 use NeNeRecords\Comment\PostCommentUseCase;
+use NeNeRecords\Notification\NullNotifier;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -41,7 +42,7 @@ final class CommentHttpTest extends TestCase
         $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
 
         $registrar = new CommentRouteRegistrar(
-            new PostCommentHandler(new PostCommentUseCase($this->repository), $jsonResponse),
+            new PostCommentHandler(new PostCommentUseCase($this->repository, new NullNotifier()), $jsonResponse),
             new ListCommentsHandler(new ListCommentsUseCase($this->repository), $jsonResponse),
             new ListAllCommentsHandler(new ListAllCommentsUseCase($this->repository), $jsonResponse),
             new ApproveCommentHandler(new ApproveCommentUseCase($this->repository), $jsonResponse),

--- a/tests/Comment/CommentUseCaseTest.php
+++ b/tests/Comment/CommentUseCaseTest.php
@@ -10,6 +10,7 @@ use NeNeRecords\Comment\DeleteCommentInput;
 use NeNeRecords\Comment\DeleteCommentUseCase;
 use NeNeRecords\Comment\PostCommentInput;
 use NeNeRecords\Comment\PostCommentUseCase;
+use NeNeRecords\Notification\NullNotifier;
 use PHPUnit\Framework\TestCase;
 
 final class CommentUseCaseTest extends TestCase
@@ -19,7 +20,7 @@ final class CommentUseCaseTest extends TestCase
     public function testPostCommentCreatesCommentWithIsApprovedFalse(): void
     {
         $comments = new InMemoryCommentRepository();
-        $useCase = new PostCommentUseCase($comments);
+        $useCase = new PostCommentUseCase($comments, new NullNotifier());
 
         $output = $useCase->execute(new PostCommentInput(
             entityId: 1,
@@ -34,7 +35,7 @@ final class CommentUseCaseTest extends TestCase
     public function testPostCommentReturnsCorrectOutput(): void
     {
         $comments = new InMemoryCommentRepository();
-        $useCase = new PostCommentUseCase($comments);
+        $useCase = new PostCommentUseCase($comments, new NullNotifier());
 
         $output = $useCase->execute(new PostCommentInput(
             entityId: 42,
@@ -53,7 +54,7 @@ final class CommentUseCaseTest extends TestCase
     public function testPostCommentAssignsSequentialIds(): void
     {
         $comments = new InMemoryCommentRepository();
-        $useCase = new PostCommentUseCase($comments);
+        $useCase = new PostCommentUseCase($comments, new NullNotifier());
 
         $first = $useCase->execute(new PostCommentInput(
             entityId: 1,
@@ -77,7 +78,7 @@ final class CommentUseCaseTest extends TestCase
     public function testApproveCommentSetsIsApprovedTrue(): void
     {
         $comments = new InMemoryCommentRepository();
-        $posted = (new PostCommentUseCase($comments))->execute(new PostCommentInput(
+        $posted = (new PostCommentUseCase($comments, new NullNotifier()))->execute(new PostCommentInput(
             entityId: 1,
             authorName: 'Alice',
             authorEmail: 'alice@example.com',
@@ -96,7 +97,7 @@ final class CommentUseCaseTest extends TestCase
     public function testApproveCommentReturnsCorrectOutput(): void
     {
         $comments = new InMemoryCommentRepository();
-        $posted = (new PostCommentUseCase($comments))->execute(new PostCommentInput(
+        $posted = (new PostCommentUseCase($comments, new NullNotifier()))->execute(new PostCommentInput(
             entityId: 7,
             authorName: 'Carol',
             authorEmail: 'carol@example.com',
@@ -119,7 +120,7 @@ final class CommentUseCaseTest extends TestCase
     public function testDeleteCommentSuccessfully(): void
     {
         $comments = new InMemoryCommentRepository();
-        $posted = (new PostCommentUseCase($comments))->execute(new PostCommentInput(
+        $posted = (new PostCommentUseCase($comments, new NullNotifier()))->execute(new PostCommentInput(
             entityId: 1,
             authorName: 'Dave',
             authorEmail: 'dave@example.com',
@@ -137,7 +138,7 @@ final class CommentUseCaseTest extends TestCase
     public function testDeleteCommentDeletesOnlySpecifiedComment(): void
     {
         $comments = new InMemoryCommentRepository();
-        $postUseCase = new PostCommentUseCase($comments);
+        $postUseCase = new PostCommentUseCase($comments, new NullNotifier());
 
         $first = $postUseCase->execute(new PostCommentInput(
             entityId: 1,

--- a/tests/Notification/InMemoryNotificationChannelRepository.php
+++ b/tests/Notification/InMemoryNotificationChannelRepository.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Notification;
+
+use NeNeRecords\Notification\NotificationChannel;
+use NeNeRecords\Notification\NotificationChannelRepositoryInterface;
+
+class InMemoryNotificationChannelRepository implements NotificationChannelRepositoryInterface
+{
+    /** @var array<int, NotificationChannel> */
+    private array $channels = [];
+
+    private int $nextId = 1;
+
+    /** @return NotificationChannel[] */
+    public function findAll(): array
+    {
+        return array_values($this->channels);
+    }
+
+    /** @return NotificationChannel[] */
+    public function findAllEnabled(): array
+    {
+        return array_values(
+            array_filter($this->channels, static fn (NotificationChannel $ch): bool => $ch->isEnabled),
+        );
+    }
+
+    public function findById(int $id): NotificationChannel|null
+    {
+        return $this->channels[$id] ?? null;
+    }
+
+    /**
+     * @param array<string,mixed> $config
+     */
+    public function create(string $channelType, string $label, bool $isEnabled, array $config): NotificationChannel
+    {
+        $id = $this->nextId++;
+        $channel = new NotificationChannel(
+            id: $id,
+            organizationId: 1,
+            channelType: $channelType,
+            label: $label,
+            isEnabled: $isEnabled,
+            config: $config,
+            createdAt: '2026-07-01 00:00:00',
+            updatedAt: '2026-07-01 00:00:00',
+        );
+        $this->channels[$id] = $channel;
+
+        return $channel;
+    }
+
+    /**
+     * @param array<string,mixed> $config
+     */
+    public function update(int $id, string $label, bool $isEnabled, array $config): void
+    {
+        $old = $this->channels[$id];
+        $this->channels[$id] = new NotificationChannel(
+            id: $old->id,
+            organizationId: $old->organizationId,
+            channelType: $old->channelType,
+            label: $label,
+            isEnabled: $isEnabled,
+            config: $config,
+            createdAt: $old->createdAt,
+            updatedAt: '2026-07-01 00:01:00',
+        );
+    }
+
+    public function delete(int $id): void
+    {
+        unset($this->channels[$id]);
+    }
+}

--- a/tests/Notification/NotificationChannelHttpTest.php
+++ b/tests/Notification/NotificationChannelHttpTest.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Notification;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Mail\MailerInterface;
+use NeNeRecords\Notification\Channel\ChatWorkChannel;
+use NeNeRecords\Notification\Channel\DiscordChannel;
+use NeNeRecords\Notification\Channel\EmailChannel;
+use NeNeRecords\Notification\Channel\SlackChannel;
+use NeNeRecords\Notification\Channel\WebhookChannel;
+use NeNeRecords\Notification\CreateNotificationChannelHandler;
+use NeNeRecords\Notification\CreateNotificationChannelUseCase;
+use NeNeRecords\Notification\DeleteNotificationChannelHandler;
+use NeNeRecords\Notification\DeleteNotificationChannelUseCase;
+use NeNeRecords\Notification\ListNotificationChannelsHandler;
+use NeNeRecords\Notification\ListNotificationChannelsUseCase;
+use NeNeRecords\Notification\NotificationChannelNotFoundExceptionHandler;
+use NeNeRecords\Notification\NotificationRouteRegistrar;
+use NeNeRecords\Notification\TestNotificationChannelHandler;
+use NeNeRecords\Notification\TestNotificationChannelUseCase;
+use NeNeRecords\Notification\UpdateNotificationChannelHandler;
+use NeNeRecords\Notification\UpdateNotificationChannelUseCase;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class NotificationChannelHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryNotificationChannelRepository $repository;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->repository = new InMemoryNotificationChannelRepository();
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+
+        $slackChannel = new SlackChannel();
+        $discordChannel = new DiscordChannel();
+        $chatWorkChannel = new ChatWorkChannel();
+        $webhookChannel = new WebhookChannel();
+        $emailStub = new EmailChannel($this->createStub(MailerInterface::class));
+
+        $registrar = new NotificationRouteRegistrar(
+            listHandler: new ListNotificationChannelsHandler(
+                new ListNotificationChannelsUseCase($this->repository),
+                $jsonResponse,
+            ),
+            createHandler: new CreateNotificationChannelHandler(
+                new CreateNotificationChannelUseCase($this->repository),
+                $jsonResponse,
+            ),
+            updateHandler: new UpdateNotificationChannelHandler(
+                new UpdateNotificationChannelUseCase($this->repository),
+                $jsonResponse,
+            ),
+            deleteHandler: new DeleteNotificationChannelHandler(
+                new DeleteNotificationChannelUseCase($this->repository),
+                $this->factory,
+            ),
+            testHandler: new TestNotificationChannelHandler(
+                new TestNotificationChannelUseCase(
+                    channels: $this->repository,
+                    emailChannel: $emailStub,
+                    slackChannel: $slackChannel,
+                    discordChannel: $discordChannel,
+                    chatWorkChannel: $chatWorkChannel,
+                    webhookChannel: $webhookChannel,
+                ),
+                $jsonResponse,
+            ),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [
+                new NotificationChannelNotFoundExceptionHandler($problemDetails),
+            ],
+            routeRegistrars: [$registrar],
+        ))->create();
+    }
+
+    // ── GET /api/v1/notification-channels ────────────────────────────────────
+
+    public function testListReturnsEmptyItemsInitially(): void
+    {
+        $response = $this->request('GET', '/api/v1/notification-channels');
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->json($response);
+        self::assertSame([], $body['items']);
+    }
+
+    public function testListReturnsCreatedChannels(): void
+    {
+        $this->repository->create('email', 'Email Alert', true, ['to_address' => 'admin@example.com']);
+        $this->repository->create('slack', 'Slack Dev', false, []);
+
+        $response = $this->request('GET', '/api/v1/notification-channels');
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->json($response);
+        self::assertCount(2, $body['items']);
+        self::assertSame('email', $body['items'][0]['channel_type']);
+        self::assertSame('Email Alert', $body['items'][0]['label']);
+        self::assertTrue($body['items'][0]['is_enabled']);
+    }
+
+    // ── POST /api/v1/notification-channels ───────────────────────────────────
+
+    public function testCreateReturns201WithChannel(): void
+    {
+        $response = $this->request('POST', '/api/v1/notification-channels', [
+            'channel_type' => 'slack',
+            'label'        => 'Slack Alerts',
+            'is_enabled'   => true,
+            'config'       => ['webhook_url' => 'https://hooks.slack.com/xxx'],
+        ]);
+
+        self::assertSame(201, $response->getStatusCode());
+        $body = $this->json($response);
+        self::assertSame(1, $body['id']);
+        self::assertSame('slack', $body['channel_type']);
+        self::assertSame('Slack Alerts', $body['label']);
+        self::assertTrue($body['is_enabled']);
+    }
+
+    public function testCreateWithoutChannelTypeReturns422(): void
+    {
+        $response = $this->request('POST', '/api/v1/notification-channels', [
+            'label' => 'No type',
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function testCreateWithoutLabelReturns422(): void
+    {
+        $response = $this->request('POST', '/api/v1/notification-channels', [
+            'channel_type' => 'slack',
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function testCreateWithInvalidChannelTypeReturns422(): void
+    {
+        $response = $this->request('POST', '/api/v1/notification-channels', [
+            'channel_type' => 'telegram',
+            'label'        => 'Telegram',
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function testCreateAllValidChannelTypes(): void
+    {
+        foreach (['email', 'slack', 'discord', 'chatwork', 'webhook'] as $type) {
+            $response = $this->request('POST', '/api/v1/notification-channels', [
+                'channel_type' => $type,
+                'label'        => "Test {$type}",
+            ]);
+            self::assertSame(201, $response->getStatusCode(), "Failed for type: {$type}");
+        }
+    }
+
+    // ── PATCH /api/v1/notification-channels/{id} ──────────────────────────────
+
+    public function testUpdateReturnsSuccessTrue(): void
+    {
+        $created = $this->repository->create('email', 'Old', true, ['to_address' => 'old@example.com']);
+
+        $response = $this->request('PATCH', "/api/v1/notification-channels/{$created->id}", [
+            'label'      => 'New',
+            'is_enabled' => false,
+            'config'     => ['to_address' => 'new@example.com'],
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->json($response);
+        self::assertTrue($body['success']);
+
+        $updated = $this->repository->findById($created->id);
+        self::assertNotNull($updated);
+        self::assertSame('New', $updated->label);
+        self::assertFalse($updated->isEnabled);
+    }
+
+    public function testUpdateWithoutLabelReturns422(): void
+    {
+        $created = $this->repository->create('slack', 'Old', true, []);
+
+        $response = $this->request('PATCH', "/api/v1/notification-channels/{$created->id}", [
+            'is_enabled' => false,
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function testUpdateNonExistentChannelReturns404(): void
+    {
+        $response = $this->request('PATCH', '/api/v1/notification-channels/999', [
+            'label'      => 'Ghost',
+            'is_enabled' => true,
+        ]);
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    // ── DELETE /api/v1/notification-channels/{id} ─────────────────────────────
+
+    public function testDeleteReturns204(): void
+    {
+        $created = $this->repository->create('webhook', 'Webhook', true, ['url' => 'https://example.com']);
+
+        $response = $this->request('DELETE', "/api/v1/notification-channels/{$created->id}");
+
+        self::assertSame(204, $response->getStatusCode());
+        self::assertNull($this->repository->findById($created->id));
+    }
+
+    public function testDeleteNonExistentChannelReturns404(): void
+    {
+        $response = $this->request('DELETE', '/api/v1/notification-channels/999');
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    // ── POST /api/v1/notification-channels/{id}/test ──────────────────────────
+
+    public function testTestChannelReturns200WithSentTrue(): void
+    {
+        $created = $this->repository->create('slack', 'Slack', true, ['webhook_url' => 'https://hooks.slack.com/xxx']);
+
+        $response = $this->request('POST', "/api/v1/notification-channels/{$created->id}/test");
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->json($response);
+        self::assertTrue($body['sent']);
+    }
+
+    public function testTestNonExistentChannelReturns404(): void
+    {
+        $response = $this->request('POST', '/api/v1/notification-channels/999/test');
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * @param array<string,mixed>|null $body
+     */
+    private function request(string $method, string $path, array|null $body = null): ResponseInterface
+    {
+        $request = $this->factory->createServerRequest($method, $path);
+
+        if ($body !== null) {
+            $stream = $this->factory->createStream(json_encode($body, JSON_THROW_ON_ERROR));
+            $request = $request
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($stream);
+        }
+
+        return $this->application->handle($request);
+    }
+
+    /** @return array<string,mixed> */
+    private function json(ResponseInterface $response): array
+    {
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+
+        return $data;
+    }
+}

--- a/tests/Notification/NotificationChannelUseCaseTest.php
+++ b/tests/Notification/NotificationChannelUseCaseTest.php
@@ -1,0 +1,349 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Notification;
+
+use NeNeRecords\Mail\MailerInterface;
+use NeNeRecords\Notification\Channel\ChatWorkChannel;
+use NeNeRecords\Notification\Channel\DiscordChannel;
+use NeNeRecords\Notification\Channel\EmailChannel;
+use NeNeRecords\Notification\Channel\SlackChannel;
+use NeNeRecords\Notification\Channel\WebhookChannel;
+use NeNeRecords\Notification\CompositeNotifier;
+use NeNeRecords\Notification\CreateNotificationChannelInput;
+use NeNeRecords\Notification\CreateNotificationChannelUseCase;
+use NeNeRecords\Notification\DeleteNotificationChannelInput;
+use NeNeRecords\Notification\DeleteNotificationChannelUseCase;
+use NeNeRecords\Notification\InvalidNotificationChannelTypeException;
+use NeNeRecords\Notification\ListNotificationChannelsUseCase;
+use NeNeRecords\Notification\NotificationChannel;
+use NeNeRecords\Notification\NotificationChannelNotFoundException;
+use NeNeRecords\Notification\NotificationChannelRepositoryInterface;
+use NeNeRecords\Notification\NotificationMessage;
+use NeNeRecords\Notification\NullNotifier;
+use NeNeRecords\Notification\TestNotificationChannelInput;
+use NeNeRecords\Notification\TestNotificationChannelUseCase;
+use NeNeRecords\Notification\UpdateNotificationChannelInput;
+use NeNeRecords\Notification\UpdateNotificationChannelUseCase;
+use PHPUnit\Framework\TestCase;
+
+final class NotificationChannelUseCaseTest extends TestCase
+{
+    // ── ListNotificationChannelsUseCase ───────────────────────────────────────
+
+    public function testListReturnsEmptyInitially(): void
+    {
+        $repo = new InMemoryNotificationChannelRepository();
+        $output = (new ListNotificationChannelsUseCase($repo))->execute();
+
+        self::assertSame([], $output->items);
+    }
+
+    public function testListReturnsCreatedChannels(): void
+    {
+        $repo = new InMemoryNotificationChannelRepository();
+        $repo->create('email', 'Email Alert', true, ['to_address' => 'admin@example.com']);
+        $repo->create('slack', 'Slack Dev', true, ['webhook_url' => 'https://hooks.slack.com/xxx']);
+
+        $output = (new ListNotificationChannelsUseCase($repo))->execute();
+
+        self::assertCount(2, $output->items);
+    }
+
+    // ── CreateNotificationChannelUseCase ─────────────────────────────────────
+
+    public function testCreateEmailChannelReturnsChannel(): void
+    {
+        $repo = new InMemoryNotificationChannelRepository();
+        $useCase = new CreateNotificationChannelUseCase($repo);
+
+        $channel = $useCase->execute(new CreateNotificationChannelInput(
+            channelType: 'email',
+            label: 'Email Alert',
+            isEnabled: true,
+            config: ['to_address' => 'admin@example.com'],
+        ));
+
+        self::assertSame(1, $channel->id);
+        self::assertSame('email', $channel->channelType);
+        self::assertSame('Email Alert', $channel->label);
+        self::assertTrue($channel->isEnabled);
+        self::assertSame('admin@example.com', $channel->config['to_address']);
+    }
+
+    public function testCreateAllChannelTypesSucceeds(): void
+    {
+        $repo = new InMemoryNotificationChannelRepository();
+        $useCase = new CreateNotificationChannelUseCase($repo);
+
+        foreach (['email', 'slack', 'discord', 'chatwork', 'webhook'] as $type) {
+            $channel = $useCase->execute(new CreateNotificationChannelInput(
+                channelType: $type,
+                label: "Test {$type}",
+                isEnabled: true,
+                config: [],
+            ));
+            self::assertSame($type, $channel->channelType);
+        }
+    }
+
+    public function testCreateInvalidChannelTypeThrows(): void
+    {
+        $repo = new InMemoryNotificationChannelRepository();
+        $useCase = new CreateNotificationChannelUseCase($repo);
+
+        $this->expectException(InvalidNotificationChannelTypeException::class);
+
+        $useCase->execute(new CreateNotificationChannelInput(
+            channelType: 'telegram',
+            label: 'Telegram',
+            isEnabled: true,
+            config: [],
+        ));
+    }
+
+    public function testCreateDisabledChannelIsNotEnabled(): void
+    {
+        $repo = new InMemoryNotificationChannelRepository();
+        $useCase = new CreateNotificationChannelUseCase($repo);
+
+        $channel = $useCase->execute(new CreateNotificationChannelInput(
+            channelType: 'slack',
+            label: 'Slack (disabled)',
+            isEnabled: false,
+            config: ['webhook_url' => 'https://hooks.slack.com/xxx'],
+        ));
+
+        self::assertFalse($channel->isEnabled);
+    }
+
+    // ── UpdateNotificationChannelUseCase ─────────────────────────────────────
+
+    public function testUpdateChangesLabelAndConfig(): void
+    {
+        $repo = new InMemoryNotificationChannelRepository();
+        $created = $repo->create('email', 'Old Label', true, ['to_address' => 'old@example.com']);
+
+        (new UpdateNotificationChannelUseCase($repo))->execute(new UpdateNotificationChannelInput(
+            id: $created->id,
+            label: 'New Label',
+            isEnabled: false,
+            config: ['to_address' => 'new@example.com'],
+        ));
+
+        $updated = $repo->findById($created->id);
+        self::assertNotNull($updated);
+        self::assertSame('New Label', $updated->label);
+        self::assertFalse($updated->isEnabled);
+        self::assertSame('new@example.com', $updated->config['to_address']);
+    }
+
+    public function testUpdateNonExistentChannelThrows(): void
+    {
+        $repo = new InMemoryNotificationChannelRepository();
+
+        $this->expectException(NotificationChannelNotFoundException::class);
+
+        (new UpdateNotificationChannelUseCase($repo))->execute(new UpdateNotificationChannelInput(
+            id: 999,
+            label: 'Ghost',
+            isEnabled: true,
+            config: [],
+        ));
+    }
+
+    // ── DeleteNotificationChannelUseCase ─────────────────────────────────────
+
+    public function testDeleteRemovesChannel(): void
+    {
+        $repo = new InMemoryNotificationChannelRepository();
+        $created = $repo->create('webhook', 'My Webhook', true, ['url' => 'https://example.com']);
+
+        (new DeleteNotificationChannelUseCase($repo))->execute(new DeleteNotificationChannelInput($created->id));
+
+        self::assertNull($repo->findById($created->id));
+        self::assertSame([], $repo->findAll());
+    }
+
+    public function testDeleteNonExistentChannelThrows(): void
+    {
+        $repo = new InMemoryNotificationChannelRepository();
+
+        $this->expectException(NotificationChannelNotFoundException::class);
+
+        (new DeleteNotificationChannelUseCase($repo))->execute(new DeleteNotificationChannelInput(42));
+    }
+
+    // ── TestNotificationChannelUseCase ───────────────────────────────────────
+
+    public function testTestUseCaseNonExistentChannelThrows(): void
+    {
+        $repo = new InMemoryNotificationChannelRepository();
+        $emailStub = new EmailChannel($this->createStub(MailerInterface::class));
+
+        $useCase = new TestNotificationChannelUseCase(
+            channels: $repo,
+            emailChannel: $emailStub,
+            slackChannel: new SlackChannel(),
+            discordChannel: new DiscordChannel(),
+            chatWorkChannel: new ChatWorkChannel(),
+            webhookChannel: new WebhookChannel(),
+        );
+
+        $this->expectException(NotificationChannelNotFoundException::class);
+
+        $useCase->execute(new TestNotificationChannelInput(999));
+    }
+
+    public function testTestUseCaseCompletesForExistingChannel(): void
+    {
+        $repo = new InMemoryNotificationChannelRepository();
+        // webhook channel with no URL: send() returns immediately without I/O
+        $created = $repo->create('webhook', 'Test Webhook', true, []);
+        $emailStub = new EmailChannel($this->createStub(MailerInterface::class));
+
+        $useCase = new TestNotificationChannelUseCase(
+            channels: $repo,
+            emailChannel: $emailStub,
+            slackChannel: new SlackChannel(),
+            discordChannel: new DiscordChannel(),
+            chatWorkChannel: new ChatWorkChannel(),
+            webhookChannel: new WebhookChannel(),
+        );
+
+        // No exception should be thrown
+        $useCase->execute(new TestNotificationChannelInput($created->id));
+
+        $this->addToAssertionCount(1);
+    }
+
+    // ── CompositeNotifier ────────────────────────────────────────────────────
+
+    public function testCompositeNotifierUsesEnabledChannelsOnly(): void
+    {
+        // The tracking repo records whether findAllEnabled() was called vs findAll()
+        $trackingRepo = new TrackingNotificationChannelRepository();
+        $trackingRepo->create('email', 'Enabled Email', true, []);
+        $trackingRepo->create('slack', 'Disabled Slack', false, []);
+
+        $emailStub = new EmailChannel($this->createStub(MailerInterface::class));
+        $notifier = new CompositeNotifier(
+            channels: $trackingRepo,
+            emailChannel: $emailStub,
+            slackChannel: new SlackChannel(),
+            discordChannel: new DiscordChannel(),
+            chatWorkChannel: new ChatWorkChannel(),
+            webhookChannel: new WebhookChannel(),
+        );
+
+        $notifier->notify(new NotificationMessage(
+            event: 'comment.submitted',
+            title: 'New comment',
+            body: 'Hello world',
+        ));
+
+        self::assertTrue($trackingRepo->findAllEnabledCalled, 'findAllEnabled() should have been called');
+        self::assertFalse($trackingRepo->findAllCalled, 'findAll() should NOT have been called');
+    }
+
+    public function testCompositeNotifierWithNoChannelsIsNoOp(): void
+    {
+        $repo = new InMemoryNotificationChannelRepository();
+        $emailStub = new EmailChannel($this->createStub(MailerInterface::class));
+
+        $notifier = new CompositeNotifier(
+            channels: $repo,
+            emailChannel: $emailStub,
+            slackChannel: new SlackChannel(),
+            discordChannel: new DiscordChannel(),
+            chatWorkChannel: new ChatWorkChannel(),
+            webhookChannel: new WebhookChannel(),
+        );
+
+        // Should not throw
+        $notifier->notify(new NotificationMessage(
+            event: 'comment.submitted',
+            title: 'New comment',
+            body: 'Hello world',
+        ));
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testCompositeNotifierSwallowsRepositoryException(): void
+    {
+        // A repo whose findAllEnabled() always throws
+        $throwingRepo = new class () implements NotificationChannelRepositoryInterface {
+            /** @return NotificationChannel[] */
+            public function findAll(): array
+            {
+                return [];
+            }
+
+            /** @return NotificationChannel[] */
+            public function findAllEnabled(): array
+            {
+                throw new \RuntimeException('DB error');
+            }
+
+            public function findById(int $id): NotificationChannel|null
+            {
+                return null;
+            }
+
+            /** @param array<string,mixed> $config */
+            public function create(string $channelType, string $label, bool $isEnabled, array $config): NotificationChannel
+            {
+                throw new \RuntimeException('DB error');
+            }
+
+            /** @param array<string,mixed> $config */
+            public function update(int $id, string $label, bool $isEnabled, array $config): void
+            {
+                throw new \RuntimeException('DB error');
+            }
+
+            public function delete(int $id): void
+            {
+                throw new \RuntimeException('DB error');
+            }
+        };
+
+        $emailStub = new EmailChannel($this->createStub(MailerInterface::class));
+
+        $notifier = new CompositeNotifier(
+            channels: $throwingRepo,
+            emailChannel: $emailStub,
+            slackChannel: new SlackChannel(),
+            discordChannel: new DiscordChannel(),
+            chatWorkChannel: new ChatWorkChannel(),
+            webhookChannel: new WebhookChannel(),
+        );
+
+        // Should NOT propagate the repository exception (fire-and-forget contract)
+        $notifier->notify(new NotificationMessage(
+            event: 'comment.submitted',
+            title: 'New comment',
+            body: 'Hello world',
+        ));
+
+        $this->addToAssertionCount(1);
+    }
+
+    // ── NullNotifier ─────────────────────────────────────────────────────────
+
+    public function testNullNotifierDoesNothing(): void
+    {
+        $notifier = new NullNotifier();
+
+        // Should not throw
+        $notifier->notify(new NotificationMessage(
+            event: 'comment.submitted',
+            title: 'No-op',
+            body: 'This should be silently dropped',
+        ));
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Notification/SpyNotificationChannel.php
+++ b/tests/Notification/SpyNotificationChannel.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Notification;
+
+use NeNeRecords\Notification\NotificationChannelInterface;
+use NeNeRecords\Notification\NotificationMessage;
+
+/**
+ * Test double that records send() calls without performing any I/O.
+ */
+final class SpyNotificationChannel implements NotificationChannelInterface
+{
+    /** @var array<int, array{message: NotificationMessage, config: array<string,mixed>}> */
+    private array $calls = [];
+
+    /**
+     * @param array<string,mixed> $config
+     */
+    public function send(NotificationMessage $message, array $config): void
+    {
+        $this->calls[] = ['message' => $message, 'config' => $config];
+    }
+
+    public function callCount(): int
+    {
+        return count($this->calls);
+    }
+
+    public function lastMessage(): NotificationMessage|null
+    {
+        $last = end($this->calls);
+
+        return $last !== false ? $last['message'] : null;
+    }
+}

--- a/tests/Notification/TrackingNotificationChannelRepository.php
+++ b/tests/Notification/TrackingNotificationChannelRepository.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Notification;
+
+use NeNeRecords\Notification\NotificationChannel;
+
+/**
+ * Extends InMemoryNotificationChannelRepository and records which
+ * methods are called, so tests can verify the correct method is used.
+ */
+final class TrackingNotificationChannelRepository extends InMemoryNotificationChannelRepository
+{
+    public bool $findAllEnabledCalled = false;
+    public bool $findAllCalled = false;
+
+    /** @return NotificationChannel[] */
+    public function findAllEnabled(): array
+    {
+        $this->findAllEnabledCalled = true;
+
+        return parent::findAllEnabled();
+    }
+
+    /** @return NotificationChannel[] */
+    public function findAll(): array
+    {
+        $this->findAllCalled = true;
+
+        return parent::findAll();
+    }
+}


### PR DESCRIPTION
Closes #263

## 概要

外部通知チャンネルシステムを新規実装。コメント投稿イベント等を email / Slack / Discord / ChatWork / generic webhook の各チャンネルに fan-out 送信する。

## 実装内容

### DB
- `notification_channels` テーブルマイグレーション（channel_type ENUM, config_json, is_enabled, org スコープ）

### バックエンド `src/Notification/`
- **NotificationChannelInterface** — チャンネル抽象（fire-and-forget契約）
- **NotifierInterface / NullNotifier** — ユースケース注入用抽象・テスト用 no-op 実装
- **CompositeNotifier** — findAllEnabled() で有効チャンネルを取得し fan-out
- **Channel 実装 5 本**:
  -  — MailerInterface 委譲
  -  — Slack Incoming Webhook (POST JSON)
  -  — Discord webhook (2000字制限対応)
  -  — ChatWork API v2 
  -  — 汎用 HTTP POST JSON（追加ヘッダー対応）
- **CRUD + テスト送信ユースケース** 5本
- **HTTP ハンドラー** 5本 + ルート登録
- **PdoNotificationChannelRepository** — org スコープ付き PDO 実装
- **NotificationServiceProvider** — 完全 DI 配線
- **ApplicationServiceProvider** への登録

### コメント連携
-  に  を注入
- コメント投稿成功後に  を呼び出し（fire-and-forget）

## エンドポイント

| Method | Path | 概要 |
|--------|------|------|
| GET |  | チャンネル一覧 |
| POST |  | チャンネル作成 |
| PATCH |  | チャンネル更新 |
| DELETE |  | チャンネル削除 |
| POST |  | テスト送信 |

## テスト

- PHPUnit 30 件追加（ユースケース単体 + HTTP 統合）
- 合計 575 件 → 全 pass

## セルフレビューチェックリスト

- [x]  — Handler・UseCase・ルート変更
- [x]  — マイグレーション・リポジトリ

🤖 Generated with [Claude Code](https://claude.com/claude-code)