### PR TITLE
fix(frontend): ユーザー一覧 DTO のキーを users → items に修正する (#271)

### DIFF
--- a/frontend/src/entities/user/api-types.ts
+++ b/frontend/src/entities/user/api-types.ts
@@ -8,7 +8,7 @@ export interface UserDto {
 }
 
 export interface UserListDto {
-  users: UserDto[]
+  items: UserDto[]
 }
 
 export interface CreateUserRequestDto {

--- a/frontend/src/entities/user/mapper.ts
+++ b/frontend/src/entities/user/mapper.ts
@@ -14,6 +14,6 @@ export function mapUserDtoToModel(dto: UserDto): User {
 
 export function mapUserListDtoToModel(dto: UserListDto): UserList {
   return {
-    users: dto.users.map(mapUserDtoToModel),
+    users: dto.items.map(mapUserDtoToModel),
   }
 }


### PR DESCRIPTION
## 概要

Closes #271

## 問題

`/admin/users` を開くと「ユーザーを読み込めませんでした。」が表示される。

## 原因

`UserListDto.users` でレスポンスを参照していたが、バックエンド（`ListUsersHandler`）と OpenAPI 仕様（`UserListResponse`）はどちらも `items` キーを返す。
マッパーも `dto.users.map()` のまま参照しており、undefined へのアクセスで空になっていた。

## 変更内容

| ファイル | 変更 |
|---|---|
| `frontend/src/entities/user/api-types.ts` | `UserListDto.users` → `UserListDto.items` |
| `frontend/src/entities/user/mapper.ts` | `dto.users.map()` → `dto.items.map()` |

## チェックリスト

- [x] TypeScript エラー 0 件
- [x] `npm run check --prefix frontend` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)