### PR TITLE
feat(user): メールアドレス変更機能を追加する (#274)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2753,6 +2753,44 @@ paths:
                 $ref: '#/components/schemas/ProblemDetails'
         '404':
           $ref: '#/components/responses/NotFound'
+  /api/v1/users/{id}/email:
+    patch:
+      tags:
+        - Users
+      summary: Change user email
+      description: Changes the email address for a user. Admin only.
+      operationId: changeUserEmail
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangeUserEmailRequest'
+      responses:
+        '204':
+          description: Email address updated.
+        '401':
+          description: Unauthorized.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
   /api/v1/users/{id}/password:
     patch:
       tags:
@@ -3212,6 +3250,15 @@ components:
           enum:
             - admin
             - editor
+      additionalProperties: false
+    ChangeUserEmailRequest:
+      type: object
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          format: email
       additionalProperties: false
     AdminResetPasswordRequest:
       type: object

--- a/frontend/src/entities/user/api-types.ts
+++ b/frontend/src/entities/user/api-types.ts
@@ -8,7 +8,11 @@ export interface UserDto {
 }
 
 export interface UserListDto {
-  users: UserDto[]
+  items: UserDto[]
+}
+
+export interface ChangeUserEmailRequestDto {
+  email: string
 }
 
 export interface CreateUserRequestDto {

--- a/frontend/src/entities/user/index.ts
+++ b/frontend/src/entities/user/index.ts
@@ -1,4 +1,5 @@
 export type {
+  ChangeEmailInput,
   CreateUserInput,
   AdminResetPasswordInput,
   ChangeOwnPasswordInput,
@@ -12,6 +13,7 @@ export type {
 export {
   useAcceptInvite,
   useAdminResetPassword,
+  useChangeEmail,
   useChangeOwnPassword,
   useConfirmPasswordReset,
   useCreateUser,

--- a/frontend/src/entities/user/mapper.ts
+++ b/frontend/src/entities/user/mapper.ts
@@ -14,6 +14,6 @@ export function mapUserDtoToModel(dto: UserDto): User {
 
 export function mapUserListDtoToModel(dto: UserListDto): UserList {
   return {
-    users: dto.users.map(mapUserDtoToModel),
+    users: dto.items.map(mapUserDtoToModel),
   }
 }

--- a/frontend/src/entities/user/model.ts
+++ b/frontend/src/entities/user/model.ts
@@ -14,6 +14,11 @@ export interface UserList {
   users: User[]
 }
 
+export interface ChangeEmailInput {
+  userId: number
+  email: string
+}
+
 export interface CreateUserInput {
   email: string
   password: string

--- a/frontend/src/entities/user/mutations.ts
+++ b/frontend/src/entities/user/mutations.ts
@@ -4,6 +4,7 @@ import type { InviteUserResponseDto, UserDto } from './api-types'
 import { mapUserDtoToModel } from './mapper'
 import type {
   AdminResetPasswordInput,
+  ChangeEmailInput,
   ChangeOwnPasswordInput,
   CreateUserInput,
   InviteUserInput,
@@ -71,6 +72,21 @@ export function useChangeOwnPassword(): UseMutationResult<void, AppError, Change
         current_password: input.currentPassword,
         new_password: input.newPassword,
       })
+    },
+  })
+}
+
+export function useChangeEmail(): UseMutationResult<void, AppError, ChangeEmailInput> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input) => {
+      await apiClient.patch(`/api/v1/users/${String(input.userId)}/email`, {
+        email: input.email,
+      })
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: userKeys.list() })
     },
   })
 }

--- a/frontend/src/features/manage-users/hooks/use-manage-users-page.ts
+++ b/frontend/src/features/manage-users/hooks/use-manage-users-page.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react'
 import {
   useAdminResetPassword,
+  useChangeEmail,
   useChangeOwnPassword,
   useDeleteUser,
   useInviteUser,
@@ -24,16 +25,22 @@ export interface AdminResetPasswordFormValues {
   newPassword: string
 }
 
+export interface ChangeEmailFormValues {
+  email: string
+}
+
 export function useManageUsersPage() {
   const listQuery = useUserList()
   const inviteMutation = useInviteUser()
   const updateRoleMutation = useUpdateUserRole()
   const adminResetPasswordMutation = useAdminResetPassword()
   const changeOwnPasswordMutation = useChangeOwnPassword()
+  const changeEmailMutation = useChangeEmail()
   const deleteMutation = useDeleteUser()
 
   const [deleteTarget, setDeleteTarget] = useState<User | null>(null)
   const [resetPasswordTarget, setResetPasswordTarget] = useState<User | null>(null)
+  const [changeEmailTarget, setChangeEmailTarget] = useState<User | null>(null)
   const [showInviteForm, setShowInviteForm] = useState(false)
   const [showChangeOwnPassword, setShowChangeOwnPassword] = useState(false)
 
@@ -73,6 +80,18 @@ export function useManageUsersPage() {
       setShowChangeOwnPassword(false)
     },
     [changeOwnPasswordMutation],
+  )
+
+  const changeEmail = useCallback(
+    async (values: ChangeEmailFormValues) => {
+      if (changeEmailTarget === null) return
+      await changeEmailMutation.mutateAsync({
+        userId: changeEmailTarget.id,
+        email: values.email,
+      })
+      setChangeEmailTarget(null)
+    },
+    [changeEmailMutation, changeEmailTarget],
   )
 
   const requestDelete = useCallback((user: User) => {
@@ -135,6 +154,17 @@ export function useManageUsersPage() {
     changeOwnPassword,
     isChangingOwnPassword: changeOwnPasswordMutation.isPending,
     changeOwnPasswordErrorTitle: changeOwnPasswordMutation.error?.title ?? null,
+
+    changeEmailTarget,
+    requestChangeEmail: (user: User) => {
+      setChangeEmailTarget(user)
+    },
+    cancelChangeEmail: () => {
+      setChangeEmailTarget(null)
+    },
+    changeEmail,
+    isChangingEmail: changeEmailMutation.isPending,
+    changeEmailErrorTitle: changeEmailMutation.error?.title ?? null,
 
     deleteTarget,
     requestDelete,

--- a/frontend/src/features/manage-users/ui/ChangeEmailForm.tsx
+++ b/frontend/src/features/manage-users/ui/ChangeEmailForm.tsx
@@ -1,0 +1,82 @@
+import { useCallback } from 'react'
+import { useForm } from 'react-hook-form'
+import type { User } from '@/entities/user'
+import { useTranslation } from '@/shared/i18n'
+import { Button, Input, Stack, Text } from '@/shared/ui'
+import type { ChangeEmailFormValues } from '../hooks/use-manage-users-page'
+
+export interface ChangeEmailFormProps {
+  user: User
+  isSubmitting: boolean
+  serverErrorTitle: string | null
+  onSubmit: (values: ChangeEmailFormValues) => Promise<void>
+  onCancel: () => void
+}
+
+export function ChangeEmailForm({
+  user,
+  isSubmitting,
+  serverErrorTitle,
+  onSubmit,
+  onCancel,
+}: ChangeEmailFormProps) {
+  const { t } = useTranslation()
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<ChangeEmailFormValues>({
+    defaultValues: { email: user.email },
+  })
+
+  const submit = useCallback(
+    async (values: ChangeEmailFormValues) => {
+      await onSubmit(values)
+      reset()
+    },
+    [onSubmit, reset],
+  )
+
+  return (
+    <form
+      className="rounded-md border border-border bg-surface-raised p-inline-md shadow-sm"
+      onSubmit={(event) => {
+        void handleSubmit(submit)(event)
+      }}
+    >
+      <Stack gap="md">
+        <Text as="h2" variant="heading-sm">
+          {t('admin.users.changeEmail.title')}
+        </Text>
+        <Text muted>{t('admin.users.changeEmail.description', { email: user.email })}</Text>
+        <Input
+          id="change-email-address"
+          label={t('admin.users.changeEmail.emailLabel')}
+          type="email"
+          error={errors.email?.message}
+          autoComplete="email"
+          disabled={isSubmitting}
+          {...register('email', {
+            required: t('admin.users.validation.emailRequired'),
+            pattern: {
+              value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+              message: t('admin.users.validation.emailInvalid'),
+            },
+          })}
+        />
+        {serverErrorTitle !== null ? <Text muted>{serverErrorTitle}</Text> : null}
+        <div className="flex gap-2">
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting
+              ? t('admin.users.changeEmail.saving')
+              : t('admin.users.changeEmail.submit')}
+          </Button>
+          <Button type="button" variant="secondary" disabled={isSubmitting} onClick={onCancel}>
+            {t('admin.users.cancel')}
+          </Button>
+        </div>
+      </Stack>
+    </form>
+  )
+}

--- a/frontend/src/features/manage-users/ui/ManageUsersView.tsx
+++ b/frontend/src/features/manage-users/ui/ManageUsersView.tsx
@@ -3,10 +3,12 @@ import { useTranslation } from '@/shared/i18n'
 import { Button, ConfirmDialog, Stack, Text } from '@/shared/ui'
 import type {
   AdminResetPasswordFormValues,
+  ChangeEmailFormValues,
   ChangeOwnPasswordFormValues,
   InviteFormValues,
 } from '../hooks/use-manage-users-page'
 import { AdminResetPasswordForm } from './AdminResetPasswordForm'
+import { ChangeEmailForm } from './ChangeEmailForm'
 import { ChangeOwnPasswordForm } from './ChangeOwnPasswordForm'
 import { UserInviteForm } from './UserInviteForm'
 import { UserListPanel } from './UserListPanel'
@@ -41,6 +43,13 @@ export interface ManageUsersViewProps {
   onOpenChangeOwnPassword: () => void
   onCloseChangeOwnPassword: () => void
   onChangeOwnPassword: (values: ChangeOwnPasswordFormValues) => Promise<void>
+
+  changeEmailTarget: User | null
+  isChangingEmail: boolean
+  changeEmailErrorTitle: string | null
+  onRequestChangeEmail: (user: User) => void
+  onCancelChangeEmail: () => void
+  onChangeEmail: (values: ChangeEmailFormValues) => Promise<void>
 
   deleteTarget: User | null
   isDeleting: boolean
@@ -81,6 +90,13 @@ export function ManageUsersView({
   onOpenChangeOwnPassword,
   onCloseChangeOwnPassword,
   onChangeOwnPassword,
+
+  changeEmailTarget,
+  isChangingEmail,
+  changeEmailErrorTitle,
+  onRequestChangeEmail,
+  onCancelChangeEmail,
+  onChangeEmail,
 
   deleteTarget,
   isDeleting,
@@ -140,6 +156,17 @@ export function ManageUsersView({
           />
         ) : null}
 
+        {/* Change email form */}
+        {changeEmailTarget !== null ? (
+          <ChangeEmailForm
+            user={changeEmailTarget}
+            isSubmitting={isChangingEmail}
+            serverErrorTitle={changeEmailErrorTitle}
+            onSubmit={onChangeEmail}
+            onCancel={onCancelChangeEmail}
+          />
+        ) : null}
+
         {/* User list */}
         <Stack gap="sm">
           <Text as="h2" variant="heading-sm">
@@ -153,6 +180,7 @@ export function ManageUsersView({
             currentUserEmail={currentUserEmail}
             onRetry={onRetry}
             onChangeRole={onChangeRole}
+            onChangeEmail={onRequestChangeEmail}
             onResetPassword={onRequestResetPassword}
             onDelete={onRequestDelete}
           />

--- a/frontend/src/features/manage-users/ui/UserListPanel.tsx
+++ b/frontend/src/features/manage-users/ui/UserListPanel.tsx
@@ -1,7 +1,7 @@
 import type { User, UserRole } from '@/entities/user'
 import { useTranslation } from '@/shared/i18n'
 import { Button, EmptyState, Stack, Text } from '@/shared/ui'
-import { IconKey, IconUsers } from '@/shared/ui/icons/Icons'
+import { IconKey, IconMail, IconUsers } from '@/shared/ui/icons/Icons'
 
 export interface UserListPanelProps {
   users: User[]
@@ -11,6 +11,7 @@ export interface UserListPanelProps {
   currentUserEmail: string | null
   onRetry: () => void
   onChangeRole: (user: User, role: UserRole) => Promise<void>
+  onChangeEmail: (user: User) => void
   onResetPassword: (user: User) => void
   onDelete: (user: User) => void
 }
@@ -25,6 +26,7 @@ export function UserListPanel({
   currentUserEmail,
   onRetry,
   onChangeRole,
+  onChangeEmail,
   onResetPassword,
   onDelete,
 }: UserListPanelProps) {
@@ -106,6 +108,16 @@ export function UserListPanel({
 
           {/* Action buttons */}
           <div className="flex shrink-0 gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              title={t('admin.users.changeEmail.button')}
+              onClick={() => {
+                onChangeEmail(user)
+              }}
+            >
+              <IconMail size={14} />
+            </Button>
             <Button
               variant="ghost"
               size="sm"

--- a/frontend/src/pages/users/UsersPage.tsx
+++ b/frontend/src/pages/users/UsersPage.tsx
@@ -46,6 +46,12 @@ export function UsersPage() {
         onOpenChangeOwnPassword={page.openChangeOwnPassword}
         onCloseChangeOwnPassword={page.closeChangeOwnPassword}
         onChangeOwnPassword={page.changeOwnPassword}
+        changeEmailTarget={page.changeEmailTarget}
+        isChangingEmail={page.isChangingEmail}
+        changeEmailErrorTitle={page.changeEmailErrorTitle}
+        onRequestChangeEmail={page.requestChangeEmail}
+        onCancelChangeEmail={page.cancelChangeEmail}
+        onChangeEmail={page.changeEmail}
         deleteTarget={page.deleteTarget}
         isDeleting={page.isDeleting}
         onRequestDelete={page.requestDelete}

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -468,7 +468,15 @@ export const en = {
   'admin.users.delete.confirmTitle': 'Delete user?',
   'admin.users.delete.confirmDescription': 'Delete {{email}}? This cannot be undone.',
   'admin.users.delete.deleting': 'Deleting…',
+  'admin.users.changeEmail.button': 'Change email',
+  'admin.users.changeEmail.title': 'Change email address',
+  'admin.users.changeEmail.description': 'Set a new email address for {{email}}.',
+  'admin.users.changeEmail.emailLabel': 'New email address',
+  'admin.users.changeEmail.submit': 'Save email',
+  'admin.users.changeEmail.saving': 'Saving…',
+
   'admin.users.validation.emailRequired': 'Email address is required.',
+  'admin.users.validation.emailInvalid': 'Email address is invalid.',
   'admin.users.validation.passwordRequired': 'Password is required.',
   'admin.users.validation.passwordMinLength': 'Password must be at least 8 characters.',
 

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -470,7 +470,15 @@ export const ja: Partial<MessageCatalog> = {
   'admin.users.delete.confirmTitle': 'ユーザーを削除しますか？',
   'admin.users.delete.confirmDescription': '{{email}} を削除しますか？この操作は元に戻せません。',
   'admin.users.delete.deleting': '削除中…',
+  'admin.users.changeEmail.button': 'メールアドレスを変更',
+  'admin.users.changeEmail.title': 'メールアドレスを変更',
+  'admin.users.changeEmail.description': '{{email}} の新しいメールアドレスを設定します。',
+  'admin.users.changeEmail.emailLabel': '新しいメールアドレス',
+  'admin.users.changeEmail.submit': 'メールアドレスを保存',
+  'admin.users.changeEmail.saving': '保存中…',
+
   'admin.users.validation.emailRequired': 'メールアドレスを入力してください。',
+  'admin.users.validation.emailInvalid': '有効なメールアドレスを入力してください。',
   'admin.users.validation.passwordRequired': 'パスワードを入力してください。',
   'admin.users.validation.passwordMinLength': 'パスワードは8文字以上にしてください。',
 

--- a/src/Auth/PdoUserRepository.php
+++ b/src/Auth/PdoUserRepository.php
@@ -108,6 +108,14 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
         );
     }
 
+    public function updateEmail(int $id, string $email): void
+    {
+        $this->query->execute(
+            'UPDATE users SET email = ?, updated_at = NOW() WHERE id = ?',
+            [$email, $id],
+        );
+    }
+
     public function updatePassword(int $id, string $passwordHash): void
     {
         $this->query->execute(

--- a/src/Auth/UserRepositoryInterface.php
+++ b/src/Auth/UserRepositoryInterface.php
@@ -28,6 +28,8 @@ interface UserRepositoryInterface
 
     public function updateRole(int $id, string $role): void;
 
+    public function updateEmail(int $id, string $email): void;
+
     public function updatePassword(int $id, string $passwordHash): void;
 
     public function updateStatus(int $id, string $status): void;

--- a/src/User/ChangeEmailHandler.php
+++ b/src/User/ChangeEmailHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ChangeEmailHandler
+{
+    public function __construct(
+        private ChangeEmailUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id         = (int) ($parameters['id'] ?? 0);
+
+        $body  = JsonRequestBodyParser::parse($request);
+        $email = trim((string) ($body['email'] ?? ''));
+
+        $errors = [];
+
+        if ($email === '') {
+            $errors[] = new ValidationError('email', 'Email address is required.', 'required');
+        } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $errors[] = new ValidationError('email', 'Email address is invalid.', 'invalid_format');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $this->useCase->execute(new ChangeEmailInput(userId: $id, email: $email));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/User/ChangeEmailInput.php
+++ b/src/User/ChangeEmailInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+final readonly class ChangeEmailInput
+{
+    public function __construct(
+        public int $userId,
+        public string $email,
+    ) {
+    }
+}

--- a/src/User/ChangeEmailUseCase.php
+++ b/src/User/ChangeEmailUseCase.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+use NeNeRecords\Auth\UserRepositoryInterface;
+
+final readonly class ChangeEmailUseCase implements ChangeEmailUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(ChangeEmailInput $input): void
+    {
+        $user = $this->users->findById($input->userId);
+
+        if ($user === null) {
+            throw new UserNotFoundException($input->userId);
+        }
+
+        // No-op if email is unchanged
+        if ($user->email === $input->email) {
+            return;
+        }
+
+        $existing = $this->users->findByEmail($input->email);
+
+        if ($existing !== null) {
+            throw new UserEmailConflictException($input->email);
+        }
+
+        $this->users->updateEmail($input->userId, $input->email);
+    }
+}

--- a/src/User/ChangeEmailUseCaseInterface.php
+++ b/src/User/ChangeEmailUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\User;
+
+interface ChangeEmailUseCaseInterface
+{
+    public function execute(ChangeEmailInput $input): void;
+}

--- a/src/User/UserRouteRegistrar.php
+++ b/src/User/UserRouteRegistrar.php
@@ -17,6 +17,7 @@ final readonly class UserRouteRegistrar
         private ResetUserPasswordHandler $resetPasswordHandler,
         private DeleteUserHandler $deleteHandler,
         private ChangePasswordHandler $changePasswordHandler,
+        private ChangeEmailHandler $changeEmailHandler,
     ) {
     }
 
@@ -29,11 +30,13 @@ final readonly class UserRouteRegistrar
         $resetPassword = $this->resetPasswordHandler;
         $delete = $this->deleteHandler;
         $changePassword = $this->changePasswordHandler;
+        $changeEmail = $this->changeEmailHandler;
 
         $router->get('/api/v1/users', static fn (ServerRequestInterface $r) => $list->handle($r));
         $router->get('/api/v1/users/{id}', static fn (ServerRequestInterface $r) => $get->handle($r));
         $router->post('/api/v1/users', static fn (ServerRequestInterface $r) => $create->handle($r));
         $router->patch('/api/v1/users/{id}', static fn (ServerRequestInterface $r) => $updateRole->handle($r));
+        $router->patch('/api/v1/users/{id}/email', static fn (ServerRequestInterface $r) => $changeEmail->handle($r));
         $router->patch('/api/v1/users/{id}/password', static fn (ServerRequestInterface $r) => $resetPassword->handle($r));
         $router->delete('/api/v1/users/{id}', static fn (ServerRequestInterface $r) => $delete->handle($r));
         $router->put('/api/v1/users/me/password', static fn (ServerRequestInterface $r) => $changePassword->handle($r));

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -91,6 +91,18 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                ChangeEmailUseCaseInterface::class,
+                static function (ContainerInterface $c): ChangeEmailUseCaseInterface {
+                    $users = $c->get(UserRepositoryInterface::class);
+
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('UserRepositoryInterface service is invalid.');
+                    }
+
+                    return new ChangeEmailUseCase($users);
+                },
+            )
+            ->set(
                 ResetUserPasswordUseCaseInterface::class,
                 static function (ContainerInterface $c): ResetUserPasswordUseCaseInterface {
                     $users = $c->get(UserRepositoryInterface::class);
@@ -270,6 +282,23 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                ChangeEmailHandler::class,
+                static function (ContainerInterface $c): ChangeEmailHandler {
+                    $useCase = $c->get(ChangeEmailUseCaseInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof ChangeEmailUseCaseInterface) {
+                        throw new LogicException('ChangeEmailUseCase service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('ResponseFactoryInterface service is invalid.');
+                    }
+
+                    return new ChangeEmailHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
                 InvalidCurrentPasswordExceptionHandler::class,
                 static function (ContainerInterface $c): InvalidCurrentPasswordExceptionHandler {
                     $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
@@ -291,6 +320,7 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
                     $resetPassword = $c->get(ResetUserPasswordHandler::class);
                     $delete = $c->get(DeleteUserHandler::class);
                     $changePassword = $c->get(ChangePasswordHandler::class);
+                    $changeEmail = $c->get(ChangeEmailHandler::class);
 
                     if (!$list instanceof ListUsersHandler) {
                         throw new LogicException('ListUsersHandler service is invalid.');
@@ -320,7 +350,11 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
                         throw new LogicException('ChangePasswordHandler service is invalid.');
                     }
 
-                    return new UserRouteRegistrar($list, $get, $create, $updateRole, $resetPassword, $delete, $changePassword);
+                    if (!$changeEmail instanceof ChangeEmailHandler) {
+                        throw new LogicException('ChangeEmailHandler service is invalid.');
+                    }
+
+                    return new UserRouteRegistrar($list, $get, $create, $updateRole, $resetPassword, $delete, $changePassword, $changeEmail);
                 },
             );
     }

--- a/tests/User/InMemoryUserRepository.php
+++ b/tests/User/InMemoryUserRepository.php
@@ -142,6 +142,34 @@ final class InMemoryUserRepository implements UserRepositoryInterface
         );
     }
 
+    public function updateEmail(int $id, string $email): void
+    {
+        $user = $this->byId[$id] ?? null;
+
+        if ($user === null) {
+            return;
+        }
+
+        unset($this->emailToId[$user->email]);
+        $this->emailToId[$email] = $id;
+
+        $this->byId[$id] = new User(
+            id: $user->id,
+            email: $email,
+            passwordHash: $user->passwordHash,
+            role: $user->role,
+            organizationId: $user->organizationId,
+            orgRole: $user->orgRole,
+            status: $user->status,
+            inviteTokenHash: $user->inviteTokenHash,
+            inviteExpiresAt: $user->inviteExpiresAt,
+            passwordResetTokenHash: $user->passwordResetTokenHash,
+            passwordResetExpiresAt: $user->passwordResetExpiresAt,
+            createdAt: $user->createdAt,
+            updatedAt: time(),
+        );
+    }
+
     public function updatePassword(int $id, string $passwordHash): void
     {
         $user = $this->byId[$id] ?? null;

--- a/tests/User/UserHttpTest.php
+++ b/tests/User/UserHttpTest.php
@@ -9,6 +9,8 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
 use NeNeRecords\Auth\User;
 use NeNeRecords\User\CannotDeleteSelfExceptionHandler;
+use NeNeRecords\User\ChangeEmailHandler;
+use NeNeRecords\User\ChangeEmailUseCase;
 use NeNeRecords\User\ChangePasswordHandler;
 use NeNeRecords\User\ChangePasswordUseCase;
 use NeNeRecords\User\CreateUserHandler;
@@ -69,6 +71,7 @@ final class UserHttpTest extends TestCase
             new ResetUserPasswordHandler(new ResetUserPasswordUseCase($this->repository), $this->factory),
             new DeleteUserHandler(new DeleteUserUseCase($this->repository), $this->factory),
             new ChangePasswordHandler(new ChangePasswordUseCase($this->repository), $this->factory),
+            new ChangeEmailHandler(new ChangeEmailUseCase($this->repository), $this->factory),
         );
 
         $this->application = (new RuntimeApplicationFactory(
@@ -280,6 +283,75 @@ final class UserHttpTest extends TestCase
         );
 
         self::assertSame(422, $response->getStatusCode());
+    }
+
+    // ── Change email ────────────────────────────────────────────────────────────
+
+    public function testPatchUserEmailReturns204(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'email' => 'newemail@example.test',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('PATCH', 'https://example.test/api/v1/users/1/email')
+                ->withBody($body)
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
+        );
+
+        self::assertSame(204, $response->getStatusCode());
+
+        $updated = $this->repository->findById(1);
+        self::assertNotNull($updated);
+        self::assertSame('newemail@example.test', $updated->email);
+    }
+
+    public function testPatchUserEmailWithDuplicateReturns409(): void
+    {
+        // Create a second user
+        $this->repository->create('other@example.test', 'hash', 'editor');
+
+        $body = $this->factory->createStream(json_encode([
+            'email' => 'other@example.test',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('PATCH', 'https://example.test/api/v1/users/1/email')
+                ->withBody($body)
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
+        );
+
+        self::assertSame(409, $response->getStatusCode());
+    }
+
+    public function testPatchUserEmailWithInvalidEmailReturns422(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'email' => 'not-an-email',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('PATCH', 'https://example.test/api/v1/users/1/email')
+                ->withBody($body)
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function testPatchNonExistentUserEmailReturns404(): void
+    {
+        $body = $this->factory->createStream(json_encode([
+            'email' => 'newemail@example.test',
+        ], JSON_THROW_ON_ERROR));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('PATCH', 'https://example.test/api/v1/users/999/email')
+                ->withBody($body)
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
     }
 
     /** @return array<string, mixed> */


### PR DESCRIPTION
Closes #274

## 概要

管理者がユーザーのメールアドレスを変更できる機能を追加します。

## 変更内容

### バックエンド
- `PATCH /api/v1/users/{id}/email` エンドポイントを追加（Admin 専用）
- `ChangeEmailHandler` / `ChangeEmailUseCase` / `ChangeEmailInput` を追加
- `UserRepositoryInterface` に `updateEmail()` を追加
- `PdoUserRepository` に `updateEmail()` を実装

### OpenAPI
- `PATCH /api/v1/users/{id}/email` パス定義を追加
- `ChangeUserEmailRequest` スキーマを追加

### フロントエンド
- `useChangeEmail` ミューテーションを追加
- `ChangeEmailForm` コンポーネントを新規作成
- ユーザー行に ✉ ボタンを追加してメールアドレス変更フォームを開く
- `admin.users.changeEmail.*` i18n キーを en/ja に追加

### バグ修正
- `UserListDto` のキーを `users` → `items` に修正（バックエンドの `items` フィールドに合わせる、#271 の修正も含む）

### テスト
- `UserHttpTest` に 4 テストを追加（204 / 409 / 422 / 404）
- `InMemoryUserRepository` に `updateEmail()` 実装

## セルフレビューチェックリスト

- [x] `docs/review/backend-api.md` — Handler / UseCase / Route
- [x] `docs/review/openapi-contract.md` — OpenAPI スキーマ
- [x] `docs/review/middleware-security.md` — 認証・バリデーション

🤖 Generated with [Claude Code](https://claude.com/claude-code)