### PR TITLE
improvement(auth): localStorage セッション JSON parse 失敗時に開発環境で警告ログを出力する (#277)

### DIFF
--- a/frontend/src/entities/auth/model.ts
+++ b/frontend/src/entities/auth/model.ts
@@ -13,7 +13,12 @@ export const authStore = {
     if (!raw) return null
     try {
       return JSON.parse(raw) as AuthSession
-    } catch {
+    } catch (e) {
+      // Corrupted session JSON is intentionally treated as "no session" (never
+      // honored as valid). In dev, surface it so unexpected logouts are debuggable.
+      if (import.meta.env.DEV) {
+        console.warn('[authStore] Failed to parse session from localStorage:', e)
+      }
       return null
     }
   },


### PR DESCRIPTION
## 概要

Closes #277

`authStore.getSession()` が localStorage の壊れた JSON を try-catch でサイレントに握りつぶしていたため、開発時に予期しないログアウトの原因が追いにくかった問題を改善する。

## 変更内容

- `frontend/src/entities/auth/model.ts` の catch ブロックで `import.meta.env.DEV` 時のみ `console.warn` を出力
- 本番環境では従来どおり無出力で `null` を返す（壊れたセッションを有効扱いしないセキュリティ挙動は維持）

## 検証

- `npx tsc --noEmit` — グリーン
- `eslint` / `prettier --check` — グリーン
- CI（`npm run check`）

## チェックリスト

- [x] Issue 紐付け（Closes #277）
- [x] 型チェック・lint・format 通過
- [x] 本番挙動に影響なし（DEV ガード）