### PR TITLE
docs(entity-type): useEntityTypeBySlug の 100 件上限制約を明記する (#278)

### DIFF
--- a/frontend/src/entities/entity-type/queries.ts
+++ b/frontend/src/entities/entity-type/queries.ts
@@ -63,6 +63,13 @@ const SLUG_LOOKUP_PARAMS = { limit: 100, offset: 0 } as const
 /**
  * Looks up an entity type by its slug.
  * Uses the same list endpoint as usePinnedEntityTypes (cache-friendly).
+ *
+ * NOTE: Slug resolution is done client-side over the first {@link SLUG_LOOKUP_PARAMS}.limit
+ * (100) entity types. If an organization ever holds more than 100 entity types, slugs on the
+ * 101st+ type will not be found here and surface as a misleading 404 ("No entity type with
+ * slug ..."). This is intentional for now (cache-friendly, well under realistic scale). When
+ * that ceiling becomes a concern, switch to a server-side slug filter
+ * (`GET /api/v1/entity-types?slug=xxx`) instead of raising the client-side limit. See #278.
  */
 export function useEntityTypeBySlug(slug: string): UseQueryResult<EntityType, AppError> {
   return useQuery({


### PR DESCRIPTION
## 概要

Closes #278

`useEntityTypeBySlug` はクライアントサイドで `limit=100` のリスト取得からスラグ検索を行う設計（cache-friendly）。1 組織が 100 件超のエンティティタイプを持つと 101 件目以降のスラグが誤った 404 になる制約を、コードコメントで明記する（Issue のオプション A）。

## 変更内容

- `frontend/src/entities/entity-type/queries.ts` の `SLUG_LOOKUP_PARAMS` / `useEntityTypeBySlug` JSDoc に制約と将来の移行方針（サーバーサイド `?slug=` フィルター）を追記

## 検証

- `eslint` / `prettier --check` — グリーン
- 挙動変更なし（コメントのみ）

## チェックリスト

- [x] Issue 紐付け（Closes #278）
- [x] lint / format 通過