### PR TITLE
refactor(client): 401/403 エラーハンドリングを handleErrorResponse に集約する (#276)

### DIFF
--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -10,6 +10,20 @@ interface RequestOptions {
   signal?: AbortSignal
 }
 
+/**
+ * Reacts to auth-related error responses with a side-effecting redirect.
+ * Shared by request() and upload() so the 401/403 handling stays in one place.
+ */
+function handleErrorResponse(response: Response, path: string): void {
+  if (response.status === 401 && !path.includes('/auth/login')) {
+    authStore.clearSession()
+    window.location.href = '/login'
+  }
+  if (response.status === 403) {
+    window.location.href = '/forbidden'
+  }
+}
+
 async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
   const base = env.apiBaseUrl.replace(/\/$/, '')
   const url = `${base}${path}`
@@ -31,13 +45,7 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
   })
 
   if (!response.ok) {
-    if (response.status === 401 && !path.includes('/auth/login')) {
-      authStore.clearSession()
-      window.location.href = '/login'
-    }
-    if (response.status === 403) {
-      window.location.href = '/forbidden'
-    }
+    handleErrorResponse(response, path)
     throw await parseProblemDetails(response)
   }
 
@@ -81,13 +89,7 @@ export const apiClient = {
     })
 
     if (!response.ok) {
-      if (response.status === 401 && !path.includes('/auth/login')) {
-        authStore.clearSession()
-        window.location.href = '/login'
-      }
-      if (response.status === 403) {
-        window.location.href = '/forbidden'
-      }
+      handleErrorResponse(response, path)
       throw await parseProblemDetails(response)
     }
 


### PR DESCRIPTION
## 概要

Closes #276

`frontend/src/shared/api/client.ts` の `request()` と `upload()` に重複していた 401/403 レスポンス処理を内部ヘルパー関数に切り出す。

## 変更内容

- `handleErrorResponse(response, path)` を追加（401 → `authStore.clearSession()` + `/login`、403 → `/forbidden`）
- `request()` / `upload()` の重複ブロックを同ヘルパー呼び出しに置換

挙動は変更なし（純粋なリファクタ）。

## 検証

- `npx tsc --noEmit` — グリーン
- `eslint` / `prettier --check` — グリーン

## チェックリスト

- [x] Issue 紐付け（Closes #276）
- [x] 型チェック・lint・format 通過
- [x] 挙動変更なし