### PR TITLE
feat(entities): エンティティ一覧の検索クエリを URL (?q=) に反映する (#265)

### DIFF
--- a/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
+++ b/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import {
   defaultEntityListParams,
   useCreateEntity,
@@ -26,9 +27,11 @@ const PAGE_LIMIT = 20
 
 export function useManageEntitiesPage(entityTypeId: number) {
   const { t } = useTranslation()
+  // The search query lives in the URL (?q=) so searches are bookmarkable / shareable.
+  const [searchParams, setSearchParams] = useSearchParams()
+  const searchQuery = searchParams.get('q') ?? ''
   const [selectedTagSlugs, setSelectedTagSlugs] = useState<string[]>([])
   const [selectedRelationFilters, setSelectedRelationFilters] = useState<EntityRelationFilters>({})
-  const [searchQuery, setSearchQuery] = useState('')
   const [selectedStatus, setSelectedStatus] = useState<EntityStatus | undefined>(undefined)
   const [sortKey, setSortKey] = useState<EntitySortKey>('id')
   const [sortOrder, setSortOrder] = useState<EntitySortOrder>('desc')
@@ -132,10 +135,24 @@ export function useManageEntitiesPage(entityTypeId: number) {
     setPage(0)
   }, [])
 
-  const setSearch = useCallback((q: string) => {
-    setSearchQuery(q)
-    setPage(0)
-  }, [])
+  const setSearch = useCallback(
+    (q: string) => {
+      setPage(0)
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev)
+          if (q === '') {
+            next.delete('q')
+          } else {
+            next.set('q', q)
+          }
+          return next
+        },
+        { replace: true },
+      )
+    },
+    [setSearchParams],
+  )
 
   const setSort = useCallback((key: EntitySortKey, order: EntitySortOrder) => {
     setSortKey(key)

--- a/frontend/src/pages/entity-records/EntityRecordsPage.test.tsx
+++ b/frontend/src/pages/entity-records/EntityRecordsPage.test.tsx
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { cleanup, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
 import { EntityRecordsPage } from '@/pages/entity-records/EntityRecordsPage'
 import { EntityTypesPage } from '@/pages/entity-types/EntityTypesPage'
 import { resetEntityStore, seedEntities } from '@tests/msw/handlers/entity'
@@ -16,8 +16,18 @@ import { renderWithProviders } from '@tests/render/render-with-providers'
 import { clearAuthSession, seedAdminSession } from '@tests/helpers/auth-session'
 
 function renderRecordsPage(entityTypeSlug = 'article') {
+  return renderRecordsPageAt(`/admin/${entityTypeSlug}`)
+}
+
+function LocationProbe() {
+  const location = useLocation()
+  return <div data-testid="location-search">{location.search}</div>
+}
+
+function renderRecordsPageAt(initialEntry: string) {
   return renderWithProviders(
-    <MemoryRouter initialEntries={[`/admin/${entityTypeSlug}`]}>
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <LocationProbe />
       <Routes>
         <Route path="/admin/:entityTypeSlug" element={<EntityRecordsPage />} />
         <Route
@@ -264,6 +274,63 @@ describe('EntityRecordsPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('No matching items')).toBeInTheDocument()
+    })
+  })
+
+  it('initializes the search box from the ?q= URL param', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    seedEntities([
+      { id: 1, entity_type_id: 1, slug: 'hello-world', is_deleted: false, deleted_at: null },
+    ])
+
+    renderRecordsPageAt('/admin/article?q=hello')
+
+    const searchBox = await screen.findByLabelText('Search…')
+    expect(searchBox).toHaveValue('hello')
+  })
+
+  it('reflects the search query in the URL when typing', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    seedEntities([
+      { id: 1, entity_type_id: 1, slug: 'hello-world', is_deleted: false, deleted_at: null },
+    ])
+
+    const user = userEvent.setup()
+    renderRecordsPage()
+
+    const searchBox = await screen.findByLabelText('Search…')
+    await user.type(searchBox, 'hello')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-search')).toHaveTextContent('q=hello')
+    })
+  })
+
+  it('filters records by the search query', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    seedEntities([
+      { id: 1, entity_type_id: 1, slug: 'alpha-post', is_deleted: false, deleted_at: null },
+      { id: 2, entity_type_id: 1, slug: 'beta-post', is_deleted: false, deleted_at: null },
+    ])
+
+    const user = userEvent.setup()
+    renderRecordsPage()
+
+    expect(await screen.findByText('Item #1')).toBeInTheDocument()
+    expect(screen.getByText('Item #2')).toBeInTheDocument()
+
+    await user.type(screen.getByLabelText('Search…'), 'alpha')
+
+    await waitFor(() => {
+      expect(screen.getByText('Item #1')).toBeInTheDocument()
+      expect(screen.queryByText('Item #2')).not.toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Clear search' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Item #1')).toBeInTheDocument()
+      expect(screen.getByText('Item #2')).toBeInTheDocument()
     })
   })
 

--- a/frontend/tests/msw/handlers/entity.ts
+++ b/frontend/tests/msw/handlers/entity.ts
@@ -132,6 +132,7 @@ export const entityHandlers = [
     const entityTypeIdParam = url.searchParams.get('entity_type_id')
     const entityTypeId = entityTypeIdParam === null ? null : Number(entityTypeIdParam)
     const statusParam = url.searchParams.get('status')
+    const queryParam = url.searchParams.get('q')
     const tagsParam = url.searchParams.get('tags')
     const tagSlugs =
       tagsParam === null
@@ -147,6 +148,13 @@ export const entityHandlers = [
 
     if (statusParam !== null) {
       filtered = filtered.filter((item) => item.status === statusParam)
+    }
+
+    // Full-text search across slug (partial, case-insensitive). The real API also
+    // searches text field values; the slug subset is enough to exercise the UI here.
+    if (queryParam !== null && queryParam.trim() !== '') {
+      const needle = queryParam.trim().toLowerCase()
+      filtered = filtered.filter((item) => (item.slug ?? '').toLowerCase().includes(needle))
     }
 
     if (tagSlugs.length > 0) {

--- a/tests/e2e/specs/20-entity-search.spec.ts
+++ b/tests/e2e/specs/20-entity-search.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Category: Entity Records — Full-text search form (#265)
+ *
+ * Verifies the Admin SPA entity records search box:
+ *  - filters the list via the `q` query param
+ *  - reflects the query in the URL (?q=) so searches are bookmarkable
+ *  - initializes the search box from a `?q=` URL on load
+ *
+ * All API calls are intercepted — no real backend required.
+ * Routes registered AFTER bypassLogin take LIFO priority over the
+ * default entity-types handler registered inside bypassLogin.
+ */
+
+import { test, expect } from '@playwright/test';
+import { bypassLogin, gotoAdmin } from '../fixtures/helpers.js';
+
+function makeEntityType(id: number, name: string, slug: string) {
+  return {
+    id,
+    name,
+    slug,
+    is_pinned: false,
+    labels: null,
+    permalink_pattern: null,
+    previous_permalink_pattern: null,
+  };
+}
+
+function makeEntity(id: number, entityTypeId: number, slug: string) {
+  return {
+    id,
+    entity_type_id: entityTypeId,
+    slug,
+    status: 'draft' as const,
+    published_at: null,
+    scheduled_at: null,
+    is_deleted: false,
+    deleted_at: null,
+    meta_title: null,
+    meta_description: null,
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-01T00:00:00Z',
+  };
+}
+
+const EMPTY_LIST = JSON.stringify({ items: [], limit: 20, offset: 0, total: 0 });
+
+/**
+ * Register all routes needed by the entity records page. The entities handler
+ * honors the `q` param (slug substring, case-insensitive) so the search box
+ * actually filters.
+ */
+async function setupRecordsPage(page: import('@playwright/test').Page) {
+  const entities = [makeEntity(1, 1, 'alpha-post'), makeEntity(2, 1, 'beta-post')];
+
+  await page.route('**/api/v1/entity-types**', (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [makeEntityType(1, 'Articles', 'articles')],
+          limit: 100,
+          offset: 0,
+        }),
+      });
+    }
+    return route.continue();
+  });
+
+  await page.route('**/api/v1/field-defs**', (route) =>
+    route.request().method() === 'GET'
+      ? route.fulfill({ status: 200, contentType: 'application/json', body: EMPTY_LIST })
+      : route.continue(),
+  );
+  await page.route('**/api/v1/text-fields**', (route) =>
+    route.request().method() === 'GET'
+      ? route.fulfill({ status: 200, contentType: 'application/json', body: EMPTY_LIST })
+      : route.continue(),
+  );
+  await page.route('**/api/v1/tags**', (route) =>
+    route.request().method() === 'GET'
+      ? route.fulfill({ status: 200, contentType: 'application/json', body: EMPTY_LIST })
+      : route.continue(),
+  );
+
+  await page.route('**/api/v1/entities**', (route) => {
+    if (route.request().method() !== 'GET') {
+      return route.continue();
+    }
+    const url = new URL(route.request().url());
+    const q = url.searchParams.get('q');
+    const filtered =
+      q !== null && q.trim() !== ''
+        ? entities.filter((e) => e.slug.toLowerCase().includes(q.trim().toLowerCase()))
+        : entities;
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: filtered, limit: 20, offset: 0, total: filtered.length }),
+    });
+  });
+}
+
+test.describe('Entity Records — search', () => {
+  test('20-01: search box filters records and reflects the query in the URL', async ({ page }) => {
+    await bypassLogin(page);
+    await setupRecordsPage(page);
+
+    await gotoAdmin(page, '/articles');
+    await expect(page.locator('h1')).toContainText('Articles', { timeout: 6000 });
+    await expect(page.locator('text=Item #1')).toBeVisible({ timeout: 6000 });
+    await expect(page.locator('text=Item #2')).toBeVisible();
+
+    await page.getByLabel('Search…').fill('alpha');
+
+    await expect(page).toHaveURL(/[?&]q=alpha/, { timeout: 6000 });
+    await expect(page.locator('text=Item #1')).toBeVisible();
+    await expect(page.locator('text=Item #2')).toHaveCount(0);
+  });
+
+  test('20-02: ?q= in the URL initializes the search box and filters on load', async ({ page }) => {
+    await bypassLogin(page);
+    await setupRecordsPage(page);
+
+    await gotoAdmin(page, '/articles?q=beta');
+
+    await expect(page.getByLabel('Search…')).toHaveValue('beta', { timeout: 6000 });
+    await expect(page.locator('text=Item #2')).toBeVisible();
+    await expect(page.locator('text=Item #1')).toHaveCount(0);
+  });
+
+  test('20-03: clearing the search restores all records and drops ?q=', async ({ page }) => {
+    await bypassLogin(page);
+    await setupRecordsPage(page);
+
+    await gotoAdmin(page, '/articles?q=alpha');
+    await expect(page.locator('text=Item #1')).toBeVisible({ timeout: 6000 });
+    await expect(page.locator('text=Item #2')).toHaveCount(0);
+
+    await page.getByLabel('Clear search').click();
+
+    await expect(page).not.toHaveURL(/[?&]q=/, { timeout: 6000 });
+    await expect(page.locator('text=Item #1')).toBeVisible();
+    await expect(page.locator('text=Item #2')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## 概要

Closes #265

Full-text search API (#129) は完成済みで、エンティティ一覧の検索フォーム（入力欄・クリアボタン・フィルターアコーディオンとの共存・`q` API 連携）も実装済みだった。残っていた Done 条件「クエリパラメーター `q=` を URL に反映（ブックマーク可能）」を実装する。

## 変更内容

- `use-manage-entities-page`: `searchQuery` を `useSearchParams` ベースに変更し、URL の `?q=` を source of truth にする（初期値を URL から読み、入力時は `replace` で URL 更新 → 履歴を汚さない）。`PublicBrowsePage` と同じパターン。
- `tests/msw/handlers/entity`: `q`（slug 部分一致・大文字小文字無視）フィルターを追加し、UI テストで実際に絞り込めるようにする。
- Vitest（`EntityRecordsPage.test.tsx`）: `?q=` からの初期化 / 入力時の URL 反映 / 絞り込みの 3 テストを追加（計 11 グリーン）。
- Playwright（`20-entity-search.spec.ts`）: 絞り込み＆URL 反映 / `?q=` 初期化 / クリアの 3 テストを追加。

## 検証

- `npx tsc --noEmit` — グリーン
- `eslint` / `prettier --check` — グリーン
- `vitest run EntityRecordsPage.test.tsx` — 11/11 グリーン
- `playwright test 20-entity-search.spec.ts` — 3/3 グリーン

## チェックリスト

- [x] Issue 紐付け（Closes #265）
- [x] 型チェック・lint・format 通過
- [x] Vitest + Playwright テスト追加・通過
- [x] ブックマーク可能（`?q=` 反映・初期化）