### PR TITLE
improvement(e2e): ボタン in-flight 状態検出を data-testid ベースに移行する (#279)

### DIFF
--- a/frontend/src/features/manage-entity-types/ui/EntityTypeCreateForm.tsx
+++ b/frontend/src/features/manage-entity-types/ui/EntityTypeCreateForm.tsx
@@ -70,7 +70,11 @@ export function EntityTypeCreateForm({
           )}
         />
         {serverErrorTitle !== null ? <Text muted>{serverErrorTitle}</Text> : null}
-        <Button type="submit" disabled={isSubmitting}>
+        <Button
+          type="submit"
+          disabled={isSubmitting}
+          data-testid={isSubmitting ? 'submit-in-flight' : 'submit-idle'}
+        >
           {isSubmitting
             ? t('admin.entityTypes.createForm.submitting')
             : t('admin.entityTypes.createForm.submit')}

--- a/frontend/src/features/manage-field-defs/ui/FieldDefCreateForm.tsx
+++ b/frontend/src/features/manage-field-defs/ui/FieldDefCreateForm.tsx
@@ -98,7 +98,11 @@ export function FieldDefCreateForm({
           )}
         />
         {serverErrorTitle !== null ? <Text muted>{serverErrorTitle}</Text> : null}
-        <Button type="submit" disabled={isSubmitting}>
+        <Button
+          type="submit"
+          disabled={isSubmitting}
+          data-testid={isSubmitting ? 'submit-in-flight' : 'submit-idle'}
+        >
           {isSubmitting
             ? t('admin.fieldDefs.createForm.submitting')
             : t('admin.fieldDefs.createForm.submit')}

--- a/frontend/src/features/manage-tags/ui/TagCreateForm.tsx
+++ b/frontend/src/features/manage-tags/ui/TagCreateForm.tsx
@@ -65,7 +65,11 @@ export function TagCreateForm({ isSubmitting, serverErrorTitle, onSubmit }: TagC
           )}
         />
         {serverErrorTitle !== null ? <Text muted>{serverErrorTitle}</Text> : null}
-        <Button type="submit" disabled={isSubmitting}>
+        <Button
+          type="submit"
+          disabled={isSubmitting}
+          data-testid={isSubmitting ? 'submit-in-flight' : 'submit-idle'}
+        >
           {isSubmitting ? t('admin.tags.createForm.submitting') : t('admin.tags.createForm.submit')}
         </Button>
       </Stack>

--- a/frontend/src/shared/ui/primitives/Button.tsx
+++ b/frontend/src/shared/ui/primitives/Button.tsx
@@ -11,6 +11,8 @@ export interface ButtonProps {
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
   onFocus?: (event: React.FocusEvent<HTMLButtonElement>) => void
   onBlur?: (event: React.FocusEvent<HTMLButtonElement>) => void
+  /** Stable hook for E2E tests; prefer this over matching on (i18n) button text. */
+  'data-testid'?: string
 }
 
 const variantClasses: Record<ButtonVariant, string> = {
@@ -39,6 +41,7 @@ export function Button({
   onClick,
   onFocus,
   onBlur,
+  'data-testid': dataTestId,
 }: ButtonProps) {
   const classes = [
     'inline-flex items-center justify-center rounded-md border font-sans font-medium transition-colors duration-fast ease-default',
@@ -58,6 +61,7 @@ export function Button({
       onClick={onClick}
       onFocus={onFocus}
       onBlur={onBlur}
+      data-testid={dataTestId}
     >
       {children}
     </button>

--- a/tests/e2e/specs/09-ui-states.spec.ts
+++ b/tests/e2e/specs/09-ui-states.spec.ts
@@ -51,13 +51,14 @@ test.describe('UI States', () => {
 
     await page.locator('input[id="entity-type-name"]').fill('Events');
     await page.locator('input[id="entity-type-slug"]').fill('events');
-    await page.locator('button:has-text("Create content type")').click();
+    await page.locator('[data-testid="submit-idle"]').click();
 
-    // While POST is in-flight, button text should change to submitting state
-    await expect(page.locator('button:has-text("Creating…")')).toBeVisible({ timeout: 3000 });
+    // While POST is in-flight, the submit button switches to the in-flight testid
+    // (detected via data-testid rather than the i18n label).
+    await expect(page.locator('[data-testid="submit-in-flight"]')).toBeVisible({ timeout: 3000 });
 
-    // After response, button returns to normal text
-    await expect(page.locator('button:has-text("Create content type")')).toBeVisible({ timeout: 6000 });
+    // After response, the button returns to its idle state
+    await expect(page.locator('[data-testid="submit-idle"]')).toBeVisible({ timeout: 6000 });
   });
 
   // ── 09-02: Form inputs disabled during entity type creation ────────────────
@@ -174,13 +175,13 @@ test.describe('UI States', () => {
 
     await page.locator('input[id="tag-name"]').fill('Tutorial');
     await page.locator('input[id="tag-slug"]').fill('tutorial');
-    await page.locator('button:has-text("Create tag")').click();
+    await page.locator('[data-testid="submit-idle"]').click();
 
-    // In-flight state
-    await expect(page.locator('button:has-text("Creating…")')).toBeVisible({ timeout: 3000 });
+    // In-flight state (detected via data-testid rather than the i18n label)
+    await expect(page.locator('[data-testid="submit-in-flight"]')).toBeVisible({ timeout: 3000 });
 
-    // After response
-    await expect(page.locator('button:has-text("Create tag")')).toBeVisible({ timeout: 6000 });
+    // After response, the button returns to its idle state
+    await expect(page.locator('[data-testid="submit-idle"]')).toBeVisible({ timeout: 6000 });
   });
 
   // ── 09-05: Error message does not stack — only one error instance ──────────

--- a/tests/e2e/specs/15-repetition.spec.ts
+++ b/tests/e2e/specs/15-repetition.spec.ts
@@ -295,18 +295,19 @@ test.describe('Repetition & Long-form Stability', () => {
 
     const nameInput = page.locator('input[id="entity-type-name"]');
     const slugInput = page.locator('input[id="entity-type-slug"]');
-    const submitBtn = page.locator('button:has-text("Create content type")');
-    // While POST is in-flight, the button text changes to "Creating…" (isSubmitting=true)
-    const inFlightBtn = page.locator('button:has-text("Creating…")');
+    const submitBtn = page.locator('[data-testid="submit-idle"]');
+    // While POST is in-flight, the submit button switches to the in-flight testid (isSubmitting=true).
+    // Detect via data-testid rather than the (i18n) button label so the test survives copy changes.
+    const inFlightBtn = page.locator('[data-testid="submit-in-flight"]');
 
     for (let i = 0; i < 5; i++) {
       await nameInput.fill(`Op${String(i + 1)}`);
       await slugInput.fill(`op${String(i + 1)}`);
 
-      // First click triggers the POST; wait for "Creating…" (confirms button is disabled)
+      // First click triggers the POST; wait for the in-flight state (confirms button is disabled)
       await submitBtn.click();
       await expect(inFlightBtn).toBeVisible({ timeout: 1000 }); // POST is in-flight
-      // Force-click the disabled "Creating…" button twice — should NOT trigger extra POSTs
+      // Force-click the disabled in-flight button twice — should NOT trigger extra POSTs
       await inFlightBtn.click({ force: true });
       await inFlightBtn.click({ force: true });
 


### PR DESCRIPTION
## 概要

Closes #279

E2E テストの送信ボタン in-flight 状態検出が `button:has-text("Creating…")` という i18n 翻訳文字列依存だったため、ボタンラベル変更・多言語対応・文言変更で壊れやすかった。状態を表す `data-testid` に移行する。

## 変更内容

### フロント
- `Button` プリミティブに optional な `data-testid` プロップを追加し、`<button>` に転送。
- 各 CreateForm の送信ボタンに状態を表す testid を付与：
  `data-testid={isSubmitting ? 'submit-in-flight' : 'submit-idle'}`
  - `EntityTypeCreateForm` / `TagCreateForm` / `FieldDefCreateForm`

### E2E
- `09-ui-states`（09-01 エンティティタイプ / 09-04 タグ）と `15-repetition`（15-05 ダブルサブミット防止）の in-flight 検出を `[data-testid="submit-in-flight"]` / `[data-testid="submit-idle"]` に置換。
- ボタンラベル自体は変更していないため、テキストでクリックする他のシナリオ（17/18/19 等）は影響なし。

## 検証
- `tsc --noEmit` / `eslint` / `prettier` グリーン
- 影響ページの Vitest（entity-types / tags）8/8 グリーン
- Playwright `09-ui-states` + `15-repetition` 14/14 グリーン

## チェックリスト
- [x] Issue 紐付け（Closes #279）
- [x] 型チェック・lint・format 通過
- [x] E2E（in-flight 検出）を data-testid ベースに移行・通過