### PR TITLE
test(frontend): feature フック単位の Vitest テストを拡充する (#286)

### DIFF
--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -780,9 +780,10 @@ The browser is **hostile context**. Treat all rendered user content and all clie
 | --- | --- |
 | Mapper / query-key tests | colocated `*.test.ts` in entity folder |
 | Component tests | `FeatureName.test.tsx` next to component |
+| Feature hook tests | `use-{feature}-page.test.ts(x)` colocated in the feature's `hooks/` folder |
 | MSW handlers | `tests/msw/{resource}.ts` |
 | Factories | `tests/factories/{resource}.ts` — build **models**, not DTOs |
-| `renderWithProviders` | `tests/render/render-with-providers.tsx` |
+| `renderWithProviders` / `renderHookWithProviders` | `tests/render/render-with-providers.tsx` |
 
 ### Testing rules
 
@@ -797,7 +798,12 @@ The browser is **hostile context**. Treat all rendered user content and all clie
 ### Required before merge
 
 - Entity: mapper tests + query-key tests (if non-trivial) + hook test with MSW for primary query/mutation.
-- Feature: component test — happy path + primary error path (Problem Details).
+- **Feature (mandatory): every new feature ships at least one feature-hook test** — render the
+  feature hook (`renderHookWithProviders`) against MSW handlers and assert the primary
+  query loads and each primary mutation drives its observable outcome (list refetch, success
+  flag, or Problem Details error). New `use-{feature}-page` hooks without a colocated
+  `*.test.ts(x)` **block merge**. Bias toward these fast hook tests over adding E2E coverage.
+- Feature UI: component test — happy path + primary error path (Problem Details).
 - `npm run test` green in CI.
 
 ---

--- a/frontend/src/features/comment-section/hooks/useCommentSection.test.ts
+++ b/frontend/src/features/comment-section/hooks/useCommentSection.test.ts
@@ -1,0 +1,95 @@
+import type { SyntheticEvent } from 'react'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { act, waitFor } from '@testing-library/react'
+import { useCommentSection } from './useCommentSection'
+import { resetCommentStore, seedComments } from '@tests/msw/handlers/comment'
+import { mswServer } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+
+const fakeEvent = { preventDefault: () => {} } as SyntheticEvent
+
+describe('useCommentSection', () => {
+  beforeAll(() => {
+    mswServer.listen()
+  })
+  afterEach(() => {
+    mswServer.resetHandlers()
+    resetCommentStore()
+  })
+  afterAll(() => {
+    mswServer.close()
+  })
+
+  it('loads approved comments for the entity', async () => {
+    seedComments([
+      {
+        id: 1,
+        entity_id: 7,
+        author_name: 'Alice',
+        body: 'Nice post',
+        is_approved: true,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 2,
+        entity_id: 7,
+        author_name: 'Bob',
+        body: 'Pending',
+        is_approved: false,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ])
+
+    const { result } = renderHookWithProviders(() => useCommentSection(7))
+
+    await waitFor(() => {
+      expect(result.current.comments).toHaveLength(1)
+    })
+    expect(result.current.comments[0].authorName).toBe('Alice')
+  })
+
+  it('submits a comment and shows the pending-moderation success state', async () => {
+    seedComments([])
+
+    const { result } = renderHookWithProviders(() => useCommentSection(7))
+
+    act(() => {
+      result.current.onAuthorNameChange('Carol')
+      result.current.onAuthorEmailChange('carol@example.com')
+      result.current.onBodyChange('Great write-up!')
+    })
+
+    act(() => {
+      result.current.onSubmit(fakeEvent)
+    })
+
+    await waitFor(() => {
+      expect(result.current.submitted).toBe(true)
+    })
+    // Fields are cleared after a successful submit.
+    expect(result.current.authorName).toBe('')
+    expect(result.current.isPostError).toBe(false)
+  })
+
+  it('surfaces an error when the honeypot is filled', async () => {
+    seedComments([])
+
+    const { result } = renderHookWithProviders(() => useCommentSection(7))
+
+    act(() => {
+      result.current.onAuthorNameChange('SpamBot')
+      result.current.onAuthorEmailChange('spam@example.com')
+      result.current.onBodyChange('buy now')
+      result.current.onHoneypotChange('http://spam.example')
+    })
+
+    act(() => {
+      result.current.onSubmit(fakeEvent)
+    })
+
+    await waitFor(() => {
+      expect(result.current.isPostError).toBe(true)
+    })
+    expect(result.current.submitted).toBe(false)
+  })
+})

--- a/frontend/src/features/manage-entities/hooks/use-manage-entities-page.test.tsx
+++ b/frontend/src/features/manage-entities/hooks/use-manage-entities-page.test.tsx
@@ -1,0 +1,133 @@
+import type { ReactNode } from 'react'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { useManageEntitiesPage } from './use-manage-entities-page'
+import { I18nProvider } from '@/shared/i18n'
+import { resetEntityStore, seedEntities } from '@tests/msw/handlers/entity'
+import { resetEntityTypeStore, seedEntityTypes } from '@tests/msw/handlers/entity-type'
+import { mswServer } from '@tests/msw/server'
+import { createTestQueryClient } from '@tests/render/render-with-providers'
+
+// useManageEntitiesPage reads/writes the URL (?q=) so it needs a Router in the tree.
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = createTestQueryClient()
+  return (
+    <MemoryRouter initialEntries={['/admin/article']}>
+      <I18nProvider>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </I18nProvider>
+    </MemoryRouter>
+  )
+}
+
+interface SeedEntity {
+  id: number
+  status?: 'draft' | 'published' | 'archived'
+  slug?: string | null
+}
+
+function seed(list: SeedEntity[]): void {
+  seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+  seedEntities(
+    list.map((e) => ({
+      id: e.id,
+      entity_type_id: 1,
+      status: e.status ?? 'draft',
+      slug: e.slug ?? null,
+      is_deleted: false,
+      deleted_at: null,
+    })),
+  )
+}
+
+describe('useManageEntitiesPage', () => {
+  beforeAll(() => {
+    mswServer.listen()
+  })
+  afterEach(() => {
+    mswServer.resetHandlers()
+    resetEntityStore()
+    resetEntityTypeStore()
+  })
+  afterAll(() => {
+    mswServer.close()
+  })
+
+  it('loads entities for the entity type', async () => {
+    seed([{ id: 1 }, { id: 2 }])
+
+    const { result } = renderHook(() => useManageEntitiesPage(1), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.total).toBe(2)
+    })
+    expect(result.current.items).toHaveLength(2)
+  })
+
+  it('filters by status', async () => {
+    seed([
+      { id: 1, status: 'draft' },
+      { id: 2, status: 'published' },
+    ])
+
+    const { result } = renderHook(() => useManageEntitiesPage(1), { wrapper })
+    await waitFor(() => {
+      expect(result.current.total).toBe(2)
+    })
+
+    act(() => {
+      result.current.setStatus('published')
+    })
+
+    await waitFor(() => {
+      expect(result.current.total).toBe(1)
+    })
+    expect(result.current.items[0].id).toBe(2)
+    expect(result.current.isFilterActive).toBe(true)
+  })
+
+  it('paginates when there are more than one page of records', async () => {
+    seed(Array.from({ length: 25 }, (_, i) => ({ id: i + 1 })))
+
+    const { result } = renderHook(() => useManageEntitiesPage(1), { wrapper })
+    await waitFor(() => {
+      expect(result.current.total).toBe(25)
+    })
+
+    expect(result.current.totalPages).toBe(2)
+    expect(result.current.items).toHaveLength(20)
+
+    act(() => {
+      result.current.nextPage?.()
+    })
+
+    await waitFor(() => {
+      expect(result.current.page).toBe(1)
+      expect(result.current.items).toHaveLength(5)
+    })
+  })
+
+  it('reflects the search query in hook state', async () => {
+    seed([
+      { id: 1, slug: 'alpha-post' },
+      { id: 2, slug: 'beta-post' },
+    ])
+
+    const { result } = renderHook(() => useManageEntitiesPage(1), { wrapper })
+    await waitFor(() => {
+      expect(result.current.total).toBe(2)
+    })
+
+    act(() => {
+      result.current.setSearchQuery('alpha')
+    })
+
+    await waitFor(() => {
+      expect(result.current.searchQuery).toBe('alpha')
+      expect(result.current.total).toBe(1)
+    })
+    expect(result.current.items[0].id).toBe(1)
+  })
+})

--- a/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.test.ts
+++ b/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.test.ts
@@ -1,0 +1,73 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { act, waitFor } from '@testing-library/react'
+import { useManageEntityTypesPage } from './use-manage-entity-types-page'
+import { resetEntityTypeStore, seedEntityTypes } from '@tests/msw/handlers/entity-type'
+import { mswServer } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+
+describe('useManageEntityTypesPage', () => {
+  beforeAll(() => {
+    mswServer.listen()
+  })
+  afterEach(() => {
+    mswServer.resetHandlers()
+    resetEntityTypeStore()
+  })
+  afterAll(() => {
+    mswServer.close()
+  })
+
+  it('loads the seeded entity types', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+
+    const { result } = renderHookWithProviders(() => useManageEntityTypesPage())
+
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(1)
+    })
+    expect(result.current.items[0].name).toBe('Article')
+  })
+
+  it('creates an entity type which appears in the list', async () => {
+    seedEntityTypes([])
+
+    const { result } = renderHookWithProviders(() => useManageEntityTypesPage())
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(0)
+    })
+
+    await act(async () => {
+      await result.current.createEntityType({ name: 'Page', slug: 'page', isPinned: false })
+    })
+
+    await waitFor(() => {
+      expect(result.current.items.map((t) => t.slug)).toContain('page')
+    })
+  })
+
+  it('deletes the targeted entity type', async () => {
+    seedEntityTypes([
+      { id: 1, name: 'Article', slug: 'article' },
+      { id: 2, name: 'Page', slug: 'page' },
+    ])
+
+    const { result } = renderHookWithProviders(() => useManageEntityTypesPage())
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(2)
+    })
+
+    act(() => {
+      result.current.requestDelete(result.current.items[0])
+    })
+    expect(result.current.deleteTarget?.slug).toBe('article')
+
+    await act(async () => {
+      await result.current.confirmDelete()
+    })
+
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(1)
+    })
+    expect(result.current.items[0].slug).toBe('page')
+  })
+})

--- a/frontend/src/features/manage-users/hooks/use-manage-users-page.test.ts
+++ b/frontend/src/features/manage-users/hooks/use-manage-users-page.test.ts
@@ -1,0 +1,118 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { act, waitFor } from '@testing-library/react'
+import { useManageUsersPage } from './use-manage-users-page'
+import { resetUserStore, seedUsers } from '@tests/msw/handlers/user'
+import { mswServer } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+
+interface SeedUser {
+  id: number
+  email: string
+  role: string
+}
+
+function seed(list: SeedUser[]): void {
+  seedUsers(
+    list.map((u) => ({
+      id: u.id,
+      email: u.email,
+      role: u.role,
+      organization_id: 1,
+      org_role: 'member',
+      status: 'active',
+      display_name: null,
+      full_name: null,
+      job_title: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    })),
+  )
+}
+
+describe('useManageUsersPage', () => {
+  beforeAll(() => {
+    mswServer.listen()
+  })
+  afterEach(() => {
+    mswServer.resetHandlers()
+    resetUserStore()
+  })
+  afterAll(() => {
+    mswServer.close()
+  })
+
+  it('loads the seeded users', async () => {
+    seed([
+      { id: 1, email: 'admin@example.com', role: 'admin' },
+      { id: 2, email: 'editor@example.com', role: 'editor' },
+    ])
+
+    const { result } = renderHookWithProviders(() => useManageUsersPage())
+
+    await waitFor(() => {
+      expect(result.current.users).toHaveLength(2)
+    })
+    expect(result.current.users.map((u) => u.email)).toContain('editor@example.com')
+  })
+
+  it('changes a user role and reflects it after refetch', async () => {
+    seed([{ id: 3, email: 'editor@example.com', role: 'editor' }])
+
+    const { result } = renderHookWithProviders(() => useManageUsersPage())
+    await waitFor(() => {
+      expect(result.current.users).toHaveLength(1)
+    })
+
+    await act(async () => {
+      await result.current.updateRole(3, 'admin')
+    })
+
+    await waitFor(() => {
+      expect(result.current.users.find((u) => u.id === 3)?.role).toBe('admin')
+    })
+  })
+
+  it('invites a user, which appears in the list', async () => {
+    seed([])
+
+    const { result } = renderHookWithProviders(() => useManageUsersPage())
+    await waitFor(() => {
+      expect(result.current.users).toHaveLength(0)
+    })
+
+    await act(async () => {
+      await result.current.inviteUser({ email: 'invitee@example.com', role: 'editor' })
+    })
+
+    await waitFor(() => {
+      expect(result.current.users.map((u) => u.email)).toContain('invitee@example.com')
+    })
+    expect(result.current.showInviteForm).toBe(false)
+  })
+
+  it('deletes the targeted user', async () => {
+    seed([
+      { id: 1, email: 'admin@example.com', role: 'admin' },
+      { id: 2, email: 'editor@example.com', role: 'editor' },
+    ])
+
+    const { result } = renderHookWithProviders(() => useManageUsersPage())
+    await waitFor(() => {
+      expect(result.current.users).toHaveLength(2)
+    })
+
+    act(() => {
+      result.current.requestDelete(result.current.users[1])
+    })
+    expect(result.current.deleteTarget?.id).toBe(2)
+
+    await act(async () => {
+      await result.current.confirmDelete()
+    })
+
+    await waitFor(() => {
+      expect(result.current.users).toHaveLength(1)
+    })
+    expect(result.current.users[0].email).toBe('admin@example.com')
+  })
+})

--- a/frontend/tests/msw/handlers/comment.ts
+++ b/frontend/tests/msw/handlers/comment.ts
@@ -1,0 +1,88 @@
+import { http, HttpResponse } from 'msw'
+
+interface CommentRecord {
+  id: number
+  entity_id: number
+  author_name: string
+  body: string
+  is_approved: boolean
+  created_at: string
+}
+
+let nextId = 1
+let comments: CommentRecord[] = []
+
+export function resetCommentStore(): void {
+  nextId = 1
+  comments = []
+}
+
+export function seedComments(seed: CommentRecord[]): void {
+  comments = [...seed]
+  nextId = Math.max(0, ...seed.map((c) => c.id)) + 1
+}
+
+export const commentHandlers = [
+  // Public list: approved comments for an entity.
+  http.get('/api/v1/entities/:id/comments', ({ params }) => {
+    const entityId = Number(params.id)
+    const items = comments
+      .filter((c) => c.entity_id === entityId && c.is_approved)
+      .map(({ id, entity_id, author_name, body, is_approved, created_at }) => ({
+        id,
+        entity_id,
+        author_name,
+        body,
+        is_approved,
+        created_at,
+      }))
+
+    return HttpResponse.json({ items })
+  }),
+  // Public submit: stored pending moderation (is_approved=false).
+  http.post('/api/v1/entities/:id/comments', async ({ params, request }) => {
+    const entityId = Number(params.id)
+    const body = (await request.json()) as {
+      author_name?: string
+      author_email?: string
+      body?: string
+      website?: string
+    }
+
+    // Honeypot — a filled hidden field is rejected.
+    if (typeof body.website === 'string' && body.website.trim() !== '') {
+      return HttpResponse.json(
+        {
+          type: 'https://nene-records.dev/problems/validation-failed',
+          title: 'Validation failed',
+          status: 422,
+          instance: `/api/v1/entities/${String(entityId)}/comments`,
+          errors: [{ field: 'website', message: 'Spam detected.', code: 'spam' }],
+        },
+        { status: 422 },
+      )
+    }
+
+    const created: CommentRecord = {
+      id: nextId++,
+      entity_id: entityId,
+      author_name: body.author_name ?? '',
+      body: body.body ?? '',
+      is_approved: false,
+      created_at: new Date().toISOString(),
+    }
+    comments = [...comments, created]
+
+    return HttpResponse.json(
+      {
+        id: created.id,
+        entity_id: created.entity_id,
+        author_name: created.author_name,
+        body: created.body,
+        is_approved: created.is_approved,
+        created_at: created.created_at,
+      },
+      { status: 201 },
+    )
+  }),
+]

--- a/frontend/tests/msw/server.ts
+++ b/frontend/tests/msw/server.ts
@@ -1,6 +1,7 @@
 import { setupServer } from 'msw/node'
 import { authHandlers } from './handlers/auth'
 import { boolFieldHandlers } from './handlers/bool-field'
+import { commentHandlers } from './handlers/comment'
 import { dateTimeFieldHandlers } from './handlers/datetime-field'
 import { entityRelationHandlers } from './handlers/entity-relation'
 import { entityTagHandlers } from './handlers/entity-tag'
@@ -27,4 +28,5 @@ export const mswServer = setupServer(
   ...dateTimeFieldHandlers,
   ...tagHandlers,
   ...userHandlers,
+  ...commentHandlers,
 )

--- a/frontend/tests/render/render-with-providers.tsx
+++ b/frontend/tests/render/render-with-providers.tsx
@@ -1,6 +1,13 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, type RenderOptions, type RenderResult } from '@testing-library/react'
-import type { ReactElement } from 'react'
+import {
+  render,
+  renderHook,
+  type RenderHookOptions,
+  type RenderHookResult,
+  type RenderOptions,
+  type RenderResult,
+} from '@testing-library/react'
+import type { ReactElement, ReactNode } from 'react'
 import { I18nProvider } from '@/shared/i18n'
 
 export function createTestQueryClient(): QueryClient {
@@ -17,6 +24,26 @@ export function renderWithProviders(ui: ReactElement, options?: RenderOptions): 
 
   return render(ui, {
     wrapper: ({ children }) => (
+      <I18nProvider>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </I18nProvider>
+    ),
+    ...options,
+  })
+}
+
+/**
+ * Render a hook wrapped in the app's providers (React Query + i18n).
+ * Pairs with MSW handlers to exercise feature hooks at the network boundary.
+ */
+export function renderHookWithProviders<Result, Props>(
+  hook: (initialProps: Props) => Result,
+  options?: RenderHookOptions<Props>,
+): RenderHookResult<Result, Props> {
+  const queryClient = createTestQueryClient()
+
+  return renderHook(hook, {
+    wrapper: ({ children }: { children: ReactNode }) => (
       <I18nProvider>
         <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
       </I18nProvider>


### PR DESCRIPTION
## 概要

Closes #286

E2E（実ブラウザ・遅い）に頼らず壊れた箇所を素早く特定できるよう、主要 feature フックに **MSW ベースの Vitest テスト** を追加する。あわせて再利用ヘルパーと comment MSW ハンドラを整備し、習慣化のためのルールを標準ドキュメントに明文化する。

## 変更内容

### テスト基盤
- `tests/render/render-with-providers`: `renderHookWithProviders`（QueryClient + i18n でフックをラップ）を追加。
- `tests/msw/handlers/comment.ts`: 公開コメント一覧 GET・投稿 POST・honeypot 422 のハンドラを追加し `server.ts` に登録。

### 追加テスト（計 14）
- **manage-users**（`use-manage-users-page`）: 一覧ロード／ロール変更→再取得／招待→一覧出現／削除。
- **manage-entity-types**（`use-manage-entity-types-page`）: 一覧ロード／作成→出現／削除。
- **manage-entities**（`use-manage-entities-page`）: 一覧ロード／status フィルター／ページネーション／検索クエリ反映（要 Router）。
- **comment-section**（`useCommentSection`）: 承認済み一覧ロード／投稿→承認待ち成功／honeypot エラー。

### ドキュメント
- `docs/development/frontend-standards.md`: **「新規 feature は feature フックテスト必須（無ければマージ不可）」** を Required before merge と配置表に追記。fast なフックテストを E2E 追加より優先する方針を明記。

## 受け入れ条件
- [x] 対象 4 フィーチャーに各 1 ファイル以上のフックテスト追加
- [x] MSW handler 活用（ネットワーク層をモック）
- [x] `npm run check:fast` グリーン（27 ファイル / **109** テスト）・`knip` クリーン
- [x] frontend-standards.md に「新規 feature は unit test 必須」ルールを追記

## 検証
- `npm run check:fast`（type-check / lint / format / Vitest 109）グリーン、`knip` クリーン