### PR TITLE
feat(media): ストレージ抽象化 + Local/S3互換ドライバ (#299 Phase A)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,14 @@ DB_CHARSET=utf8mb4
 #
 # --- Media storage (default: local disk under var/media) ---
 # MEDIA_STORAGE_DRIVER=local
+#
+# S3-compatible driver (AWS S3 / MinIO / Cloudflare R2):
+# MEDIA_STORAGE_DRIVER=s3
+# MEDIA_S3_BUCKET=nene-records-media
+# MEDIA_S3_PUBLIC_BASE_URL=https://cdn.example.com   # base URL clients fetch objects from
+# MEDIA_S3_REGION=us-east-1
+# MEDIA_S3_ACCESS_KEY=
+# MEDIA_S3_SECRET_KEY=
+# MEDIA_S3_PREFIX=                                    # optional key prefix inside the bucket
+# MEDIA_S3_ENDPOINT=                                  # set for MinIO/R2 (e.g. http://minio:9000)
+# MEDIA_S3_PATH_STYLE=false                           # true for MinIO

--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,6 @@ DB_CHARSET=utf8mb4
 # --- Mail (Docker Mailpit; production uses your host SMTP relay) ---
 # MAIL_DSN=smtp://mailpit:1025
 # MAIL_FROM=noreply@nene-records.local
+#
+# --- Media storage (default: local disk under var/media) ---
+# MEDIA_STORAGE_DRIVER=local

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,10 @@
     "license": "MIT",
     "require": {
         "php": ">=8.4.1 <9.0",
+        "async-aws/s3": "^3.3",
         "hideyukimori/nene2": "@dev",
         "league/commonmark": "^2.7",
+        "symfony/http-client": "^8.1",
         "symfony/mailer": "^8.0"
     },
     "repositories": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,145 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a27cdef20a9e04798685cd820daa90b",
+    "content-hash": "68b1d1df46d79f5a5a1081660c2ace82",
     "packages": [
+        {
+            "name": "async-aws/core",
+            "version": "1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/async-aws/core.git",
+                "reference": "70899695fcc7b23a9247926ff8b581668583b993"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/async-aws/core/zipball/70899695fcc7b23a9247926ff8b581668583b993",
+                "reference": "70899695fcc7b23a9247926ff8b581668583b993",
+                "shasum": ""
+            },
+            "require": {
+                "ext-hash": "*",
+                "ext-simplexml": "*",
+                "php": "^8.2",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3.0",
+                "symfony/http-client": "^4.4.16 || ^5.1.7 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/http-client-contracts": "^1.1.8 || ^2.0 || ^3.0",
+                "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
+            },
+            "conflict": {
+                "async-aws/s3": "<1.1",
+                "symfony/http-client": "5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.42",
+                "symfony/error-handler": "^7.3.2 || ^8.0",
+                "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.29-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "AsyncAws\\Core\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Core package to integrate with AWS. This is a lightweight AWS SDK provider by AsyncAws.",
+            "keywords": [
+                "amazon",
+                "async-aws",
+                "aws",
+                "sdk",
+                "sts"
+            ],
+            "support": {
+                "source": "https://github.com/async-aws/core/tree/1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/jderusse",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-18T17:06:10+00:00"
+        },
+        {
+            "name": "async-aws/s3",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/async-aws/s3.git",
+                "reference": "26bf7e498df4fd135fb2c32cbaa5ba92c0615fa3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/async-aws/s3/zipball/26bf7e498df4fd135fb2c32cbaa5ba92c0615fa3",
+                "reference": "26bf7e498df4fd135fb2c32cbaa5ba92c0615fa3",
+                "shasum": ""
+            },
+            "require": {
+                "async-aws/core": "^1.22",
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "ext-simplexml": "*",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.42",
+                "symfony/error-handler": "^7.3.2 || ^8.0",
+                "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "AsyncAws\\S3\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "S3 client, part of the AWS SDK provided by AsyncAws.",
+            "keywords": [
+                "amazon",
+                "async-aws",
+                "aws",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "source": "https://github.com/async-aws/s3/tree/3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/jderusse",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-29T10:05:33+00:00"
+        },
         {
             "name": "dflydev/dot-access-data",
             "version": "v3.0.3",
@@ -351,6 +488,12 @@
                 ],
                 "openapi:docs": [
                     "php tools/openapi-to-md.php"
+                ],
+                "howto:index": [
+                    "php tools/build-howto-index.php"
+                ],
+                "howto:frontmatter": [
+                    "php tools/validate-howto-frontmatter.php"
                 ],
                 "mcp": [
                     "php tools/validate-mcp-tools.php"
@@ -1057,6 +1200,55 @@
             "time": "2025-12-27T19:41:33+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "2.0.2",
             "source": {
@@ -1665,6 +1857,185 @@
                 }
             ],
             "time": "2026-01-05T13:30:16+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "68a48e4c31f63fcd1bdff997a85a09e55efe8cdb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/68a48e4c31f63fcd1bdff997a85a09e55efe8cdb",
+                "reference": "68a48e4c31f63fcd1bdff997a85a09e55efe8cdb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/http-client-contracts": "^3.7",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "amphp/amp": "<3",
+                "php-http/discovery": "<1.15"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "3.0"
+            },
+            "require-dev": {
+                "amphp/http-client": "^5.3.2",
+                "amphp/http-tunnel": "^2.0",
+                "guzzlehttp/guzzle": "^7.10",
+                "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
+                "psr/http-client": "^1.0",
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/rate-limiter": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides powerful methods to fetch HTTP resources synchronously or asynchronously",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-06T13:17:50+00:00"
         },
         {
             "name": "symfony/mailer",

--- a/src/Media/DeleteMediaHandler.php
+++ b/src/Media/DeleteMediaHandler.php
@@ -14,7 +14,6 @@ final readonly class DeleteMediaHandler
     public function __construct(
         private DeleteMediaUseCaseInterface $useCase,
         private ResponseFactoryInterface $responseFactory,
-        private string $storageRoot,
     ) {
     }
 
@@ -27,10 +26,7 @@ final readonly class DeleteMediaHandler
             throw new MediaNotFoundException($id);
         }
 
-        $this->useCase->execute(new DeleteMediaInput(
-            id: $id,
-            storageRoot: $this->storageRoot,
-        ));
+        $this->useCase->execute(new DeleteMediaInput(id: $id));
 
         return $this->responseFactory->createResponse(204);
     }

--- a/src/Media/DeleteMediaInput.php
+++ b/src/Media/DeleteMediaInput.php
@@ -8,7 +8,6 @@ final readonly class DeleteMediaInput
 {
     public function __construct(
         public int $id,
-        public string $storageRoot,
     ) {
     }
 }

--- a/src/Media/DeleteMediaUseCase.php
+++ b/src/Media/DeleteMediaUseCase.php
@@ -8,6 +8,7 @@ final readonly class DeleteMediaUseCase implements DeleteMediaUseCaseInterface
 {
     public function __construct(
         private MediaRepositoryInterface $media,
+        private StorageInterface $storage,
     ) {
     }
 
@@ -19,11 +20,8 @@ final readonly class DeleteMediaUseCase implements DeleteMediaUseCaseInterface
             throw new MediaNotFoundException($input->id);
         }
 
-        // Delete physical file (best-effort — don't fail if already removed)
-        $absolutePath = rtrim($input->storageRoot, '/') . '/' . ltrim($media->url, '/media/');
-        if (is_file($absolutePath)) {
-            @unlink($absolutePath);
-        }
+        // Best-effort: the storage driver tolerates an already-removed object.
+        $this->storage->delete($this->storage->keyFromUrl($media->url));
 
         $this->media->delete($input->id);
     }

--- a/src/Media/LocalStorage.php
+++ b/src/Media/LocalStorage.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+use RuntimeException;
+
+/**
+ * Filesystem-backed {@see StorageInterface}. Objects live under $root and are
+ * served by {@see ServeMediaHandler} at $urlPrefix (default "/media").
+ */
+final readonly class LocalStorage implements StorageInterface
+{
+    private string $root;
+    private string $urlPrefix;
+
+    public function __construct(string $root, string $urlPrefix = '/media')
+    {
+        $this->root = rtrim($root, '/');
+        $this->urlPrefix = '/' . trim($urlPrefix, '/');
+    }
+
+    public function writeFromUpload(string $key, string $tmpPath): void
+    {
+        $dest = $this->resolve($key);
+        $dir = dirname($dest);
+
+        if (!is_dir($dir) && !mkdir($dir, 0755, true) && !is_dir($dir)) {
+            throw new RuntimeException('Failed to create media directory: ' . $dir);
+        }
+
+        // Fall back to copy() in test environments where the source is not an
+        // actual HTTP upload and move_uploaded_file() therefore refuses it.
+        if (!move_uploaded_file($tmpPath, $dest) && !copy($tmpPath, $dest)) {
+            throw new RuntimeException('Failed to move uploaded file to: ' . $dest);
+        }
+    }
+
+    public function exists(string $key): bool
+    {
+        return is_file($this->resolve($key));
+    }
+
+    /**
+     * @return resource
+     */
+    public function readStream(string $key)
+    {
+        $handle = @fopen($this->resolve($key), 'rb');
+
+        if ($handle === false) {
+            throw new RuntimeException('Failed to open media object: ' . $key);
+        }
+
+        return $handle;
+    }
+
+    public function delete(string $key): void
+    {
+        $path = $this->resolve($key);
+
+        if (is_file($path)) {
+            @unlink($path);
+        }
+    }
+
+    public function size(string $key): int
+    {
+        $size = @filesize($this->resolve($key));
+
+        return $size === false ? 0 : $size;
+    }
+
+    public function mimeType(string $key): string
+    {
+        $mime = @mime_content_type($this->resolve($key));
+
+        return $mime === false ? 'application/octet-stream' : $mime;
+    }
+
+    public function publicUrl(string $key): string
+    {
+        return $this->urlPrefix . '/' . ltrim($key, '/');
+    }
+
+    public function keyFromUrl(string $url): string
+    {
+        $prefix = $this->urlPrefix . '/';
+
+        if (str_starts_with($url, $prefix)) {
+            return substr($url, strlen($prefix));
+        }
+
+        return ltrim($url, '/');
+    }
+
+    /**
+     * Resolve a storage key to an absolute path, rejecting traversal attempts.
+     */
+    private function resolve(string $key): string
+    {
+        $key = ltrim($key, '/');
+
+        if ($key === '' || str_contains($key, '..')) {
+            throw new RuntimeException('Invalid media storage key: ' . $key);
+        }
+
+        return $this->root . '/' . $key;
+    }
+}

--- a/src/Media/MediaServiceProvider.php
+++ b/src/Media/MediaServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Media;
 
+use AsyncAws\S3\S3Client;
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
@@ -34,7 +35,7 @@ final readonly class MediaServiceProvider implements ServiceProviderInterface
 
                     return match ($driver) {
                         'local' => new LocalStorage($projectRoot . '/var/media'),
-                        // S3-compatible driver lands in a follow-up (see #299 Phase A).
+                        's3' => self::createS3Storage(),
                         default => throw new LogicException('Unsupported media storage driver: ' . $driver),
                     };
                 },
@@ -238,5 +239,40 @@ final readonly class MediaServiceProvider implements ServiceProviderInterface
                     return new MediaRouteRegistrar($upload, $list, $delete, $serve);
                 },
             );
+    }
+
+    /**
+     * Build the S3-compatible driver from MEDIA_S3_* env vars. Supports AWS S3
+     * as well as MinIO / Cloudflare R2 via a custom endpoint + path-style.
+     */
+    private static function createS3Storage(): S3Storage
+    {
+        $bucket = (string) (getenv('MEDIA_S3_BUCKET') ?: '');
+        $publicBaseUrl = (string) (getenv('MEDIA_S3_PUBLIC_BASE_URL') ?: '');
+
+        if ($bucket === '' || $publicBaseUrl === '') {
+            throw new LogicException('MEDIA_S3_BUCKET and MEDIA_S3_PUBLIC_BASE_URL are required for the s3 driver.');
+        }
+
+        $config = ['region' => (string) (getenv('MEDIA_S3_REGION') ?: 'us-east-1')];
+
+        $endpoint = (string) (getenv('MEDIA_S3_ENDPOINT') ?: '');
+        if ($endpoint !== '') {
+            $config['endpoint'] = $endpoint;
+            $config['pathStyleEndpoint'] = filter_var(getenv('MEDIA_S3_PATH_STYLE'), FILTER_VALIDATE_BOOL) ? 'true' : 'false';
+        }
+
+        $accessKey = (string) (getenv('MEDIA_S3_ACCESS_KEY') ?: '');
+        if ($accessKey !== '') {
+            $config['accessKeyId'] = $accessKey;
+            $config['accessKeySecret'] = (string) (getenv('MEDIA_S3_SECRET_KEY') ?: '');
+        }
+
+        return new S3Storage(
+            new S3Client($config),
+            $bucket,
+            $publicBaseUrl,
+            (string) (getenv('MEDIA_S3_PREFIX') ?: ''),
+        );
     }
 }

--- a/src/Media/MediaServiceProvider.php
+++ b/src/Media/MediaServiceProvider.php
@@ -22,6 +22,24 @@ final readonly class MediaServiceProvider implements ServiceProviderInterface
     {
         $builder
             ->set(
+                StorageInterface::class,
+                static function (ContainerInterface $c): StorageInterface {
+                    $projectRoot = $c->get(RuntimeServiceProvider::PROJECT_ROOT);
+
+                    if (!is_string($projectRoot) || $projectRoot === '') {
+                        throw new LogicException('Project root service is invalid.');
+                    }
+
+                    $driver = getenv('MEDIA_STORAGE_DRIVER') ?: 'local';
+
+                    return match ($driver) {
+                        'local' => new LocalStorage($projectRoot . '/var/media'),
+                        // S3-compatible driver lands in a follow-up (see #299 Phase A).
+                        default => throw new LogicException('Unsupported media storage driver: ' . $driver),
+                    };
+                },
+            )
+            ->set(
                 MediaRepositoryInterface::class,
                 static function (ContainerInterface $c): MediaRepositoryInterface {
                     $query = $c->get(DatabaseQueryExecutorInterface::class);
@@ -42,19 +60,17 @@ final readonly class MediaServiceProvider implements ServiceProviderInterface
                 UploadMediaUseCaseInterface::class,
                 static function (ContainerInterface $c): UploadMediaUseCaseInterface {
                     $repository = $c->get(MediaRepositoryInterface::class);
-                    $projectRoot = $c->get(RuntimeServiceProvider::PROJECT_ROOT);
+                    $storage = $c->get(StorageInterface::class);
 
                     if (!$repository instanceof MediaRepositoryInterface) {
                         throw new LogicException('Media repository service is invalid.');
                     }
 
-                    if (!is_string($projectRoot) || $projectRoot === '') {
-                        throw new LogicException('Project root service is invalid.');
+                    if (!$storage instanceof StorageInterface) {
+                        throw new LogicException('Media storage service is invalid.');
                     }
 
-                    $storageRoot = $projectRoot . '/var/media';
-
-                    return new UploadMediaUseCase($repository, $storageRoot);
+                    return new UploadMediaUseCase($repository, $storage);
                 },
             )
             ->set(
@@ -73,12 +89,17 @@ final readonly class MediaServiceProvider implements ServiceProviderInterface
                 DeleteMediaUseCaseInterface::class,
                 static function (ContainerInterface $c): DeleteMediaUseCaseInterface {
                     $repository = $c->get(MediaRepositoryInterface::class);
+                    $storage = $c->get(StorageInterface::class);
 
                     if (!$repository instanceof MediaRepositoryInterface) {
                         throw new LogicException('Media repository service is invalid.');
                     }
 
-                    return new DeleteMediaUseCase($repository);
+                    if (!$storage instanceof StorageInterface) {
+                        throw new LogicException('Media storage service is invalid.');
+                    }
+
+                    return new DeleteMediaUseCase($repository, $storage);
                 },
             )
             ->set(
@@ -119,33 +140,28 @@ final readonly class MediaServiceProvider implements ServiceProviderInterface
                 DeleteMediaHandler::class,
                 static function (ContainerInterface $c): DeleteMediaHandler {
                     $useCase = $c->get(DeleteMediaUseCaseInterface::class);
-                    $projectRoot = $c->get(RuntimeServiceProvider::PROJECT_ROOT);
                     $responseFactory = $c->get(ResponseFactoryInterface::class);
 
                     if (!$useCase instanceof DeleteMediaUseCaseInterface) {
                         throw new LogicException('DeleteMedia use case service is invalid.');
                     }
 
-                    if (!is_string($projectRoot) || $projectRoot === '') {
-                        throw new LogicException('Project root service is invalid.');
-                    }
-
                     if (!$responseFactory instanceof ResponseFactoryInterface) {
                         throw new LogicException('Response factory service is invalid.');
                     }
 
-                    return new DeleteMediaHandler($useCase, $responseFactory, $projectRoot . '/var/media');
+                    return new DeleteMediaHandler($useCase, $responseFactory);
                 },
             )
             ->set(
                 ServeMediaHandler::class,
                 static function (ContainerInterface $c): ServeMediaHandler {
-                    $projectRoot = $c->get(RuntimeServiceProvider::PROJECT_ROOT);
+                    $storage = $c->get(StorageInterface::class);
                     $responseFactory = $c->get(ResponseFactoryInterface::class);
                     $streamFactory = $c->get(StreamFactoryInterface::class);
 
-                    if (!is_string($projectRoot) || $projectRoot === '') {
-                        throw new LogicException('Project root service is invalid.');
+                    if (!$storage instanceof StorageInterface) {
+                        throw new LogicException('Media storage service is invalid.');
                     }
 
                     if (!$responseFactory instanceof ResponseFactoryInterface) {
@@ -156,9 +172,7 @@ final readonly class MediaServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Stream factory service is invalid.');
                     }
 
-                    $storageRoot = $projectRoot . '/var/media';
-
-                    return new ServeMediaHandler($storageRoot, $responseFactory, $streamFactory);
+                    return new ServeMediaHandler($storage, $responseFactory, $streamFactory);
                 },
             )
             ->set(

--- a/src/Media/S3Storage.php
+++ b/src/Media/S3Storage.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+use AsyncAws\S3\S3Client;
+use RuntimeException;
+
+/**
+ * S3-compatible {@see StorageInterface} (AWS S3, MinIO, Cloudflare R2, ...).
+ *
+ * Objects live in $bucket under an optional $prefix. Because clients fetch
+ * objects directly from the bucket/CDN, {@see publicUrl()} returns an absolute
+ * URL built from $publicBaseUrl rather than the app's /media route.
+ */
+final readonly class S3Storage implements StorageInterface
+{
+    private string $publicBaseUrl;
+    private string $prefix;
+
+    public function __construct(
+        private S3Client $client,
+        private string $bucket,
+        string $publicBaseUrl,
+        string $prefix = '',
+    ) {
+        $this->publicBaseUrl = rtrim($publicBaseUrl, '/');
+        $this->prefix = $prefix === '' ? '' : trim($prefix, '/') . '/';
+    }
+
+    public function writeFromUpload(string $key, string $tmpPath): void
+    {
+        $body = @fopen($tmpPath, 'rb');
+
+        if ($body === false) {
+            throw new RuntimeException('Failed to open upload for S3 put: ' . $tmpPath);
+        }
+
+        $mime = mime_content_type($tmpPath);
+
+        $this->client->putObject([
+            'Bucket' => $this->bucket,
+            'Key' => $this->object($key),
+            'Body' => $body,
+            'ContentType' => $mime === false ? 'application/octet-stream' : $mime,
+        ])->resolve();
+    }
+
+    public function exists(string $key): bool
+    {
+        return $this->client->objectExists([
+            'Bucket' => $this->bucket,
+            'Key' => $this->object($key),
+        ])->isSuccess();
+    }
+
+    /**
+     * @return resource
+     */
+    public function readStream(string $key)
+    {
+        $result = $this->client->getObject([
+            'Bucket' => $this->bucket,
+            'Key' => $this->object($key),
+        ]);
+
+        return $result->getBody()->getContentAsResource();
+    }
+
+    public function delete(string $key): void
+    {
+        $this->client->deleteObject([
+            'Bucket' => $this->bucket,
+            'Key' => $this->object($key),
+        ])->resolve();
+    }
+
+    public function size(string $key): int
+    {
+        $length = $this->client->headObject([
+            'Bucket' => $this->bucket,
+            'Key' => $this->object($key),
+        ])->getContentLength();
+
+        return $length ?? 0;
+    }
+
+    public function mimeType(string $key): string
+    {
+        return $this->client->headObject([
+            'Bucket' => $this->bucket,
+            'Key' => $this->object($key),
+        ])->getContentType() ?? 'application/octet-stream';
+    }
+
+    public function publicUrl(string $key): string
+    {
+        return $this->publicBaseUrl . '/' . $this->object($key);
+    }
+
+    public function keyFromUrl(string $url): string
+    {
+        $base = $this->publicBaseUrl . '/';
+        $object = str_starts_with($url, $base) ? substr($url, strlen($base)) : ltrim($url, '/');
+
+        if ($this->prefix !== '' && str_starts_with($object, $this->prefix)) {
+            return substr($object, strlen($this->prefix));
+        }
+
+        return $object;
+    }
+
+    /** Map a storage key to the full object key inside the bucket. */
+    private function object(string $key): string
+    {
+        return $this->prefix . ltrim($key, '/');
+    }
+}

--- a/src/Media/ServeMediaHandler.php
+++ b/src/Media/ServeMediaHandler.php
@@ -13,7 +13,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 final readonly class ServeMediaHandler
 {
     public function __construct(
-        private string $storageRoot,
+        private StorageInterface $storage,
         private ResponseFactoryInterface $responseFactory,
         private StreamFactoryInterface $streamFactory,
     ) {
@@ -36,18 +36,17 @@ final readonly class ServeMediaHandler
             return $this->responseFactory->createResponse(404);
         }
 
-        $path = $this->storageRoot . '/' . $year . '/' . $month . '/' . $filename;
+        $key = $year . '/' . $month . '/' . $filename;
 
-        if (!is_file($path)) {
+        if (!$this->storage->exists($key)) {
             return $this->responseFactory->createResponse(404);
         }
 
-        $mimeType = mime_content_type($path) ?: 'application/octet-stream';
-        $stream = $this->streamFactory->createStreamFromFile($path);
+        $stream = $this->streamFactory->createStreamFromResource($this->storage->readStream($key));
 
         return $this->responseFactory->createResponse(200)
-            ->withHeader('Content-Type', $mimeType)
-            ->withHeader('Content-Length', (string) filesize($path))
+            ->withHeader('Content-Type', $this->storage->mimeType($key))
+            ->withHeader('Content-Length', (string) $this->storage->size($key))
             ->withHeader('Cache-Control', 'public, max-age=31536000, immutable')
             ->withBody($stream);
     }

--- a/src/Media/StorageInterface.php
+++ b/src/Media/StorageInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+/**
+ * Abstraction over the physical storage backing the media library.
+ *
+ * Keys are storage-relative paths such as "2026/06/abcdef.png" (no leading
+ * slash). Each driver owns the mapping between a key and the public URL that
+ * clients use to fetch the object ({@see publicUrl()} / {@see keyFromUrl()} are
+ * inverses), so callers never need to know whether storage is local disk, an
+ * S3-compatible bucket, or anything else.
+ */
+interface StorageInterface
+{
+    /**
+     * Move a freshly uploaded temp file into storage at $key.
+     *
+     * @throws \RuntimeException when the file cannot be stored.
+     */
+    public function writeFromUpload(string $key, string $tmpPath): void;
+
+    public function exists(string $key): bool;
+
+    /**
+     * Open a read stream for $key. The caller owns the returned resource.
+     *
+     * @return resource
+     *
+     * @throws \RuntimeException when the object cannot be opened.
+     */
+    public function readStream(string $key);
+
+    /**
+     * Remove the object at $key. Best-effort: a missing object is not an error.
+     */
+    public function delete(string $key): void;
+
+    public function size(string $key): int;
+
+    public function mimeType(string $key): string;
+
+    /** Public URL clients use to fetch the object at $key. */
+    public function publicUrl(string $key): string;
+
+    /** Inverse of {@see publicUrl()}: recover the storage key from a stored URL. */
+    public function keyFromUrl(string $url): string;
+}

--- a/src/Media/UploadMediaUseCase.php
+++ b/src/Media/UploadMediaUseCase.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Media;
 
-use RuntimeException;
-
 final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
 {
     /** @var list<string> */
@@ -41,7 +39,7 @@ final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
 
     public function __construct(
         private MediaRepositoryInterface $mediaRepository,
-        private string $storageRoot,
+        private StorageInterface $storage,
     ) {
     }
 
@@ -55,27 +53,13 @@ final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
             throw new MediaTooLargeException($input->size, self::MAX_SIZE_BYTES);
         }
 
-        $year = date('Y');
-        $month = date('m');
         $ext = $this->extensionForMimeType($input->mimeType);
         $storedName = bin2hex(random_bytes(16)) . '.' . $ext;
-        $relativePath = $year . '/' . $month . '/' . $storedName;
-        $absoluteDir = $this->storageRoot . '/' . $year . '/' . $month;
+        $key = date('Y') . '/' . date('m') . '/' . $storedName;
 
-        if (!is_dir($absoluteDir) && !mkdir($absoluteDir, 0755, true) && !is_dir($absoluteDir)) {
-            throw new RuntimeException('Failed to create media directory: ' . $absoluteDir);
-        }
+        $this->storage->writeFromUpload($key, $input->tmpPath);
 
-        $dest = $this->storageRoot . '/' . $relativePath;
-
-        if (!move_uploaded_file($input->tmpPath, $dest)) {
-            // Fallback for test environments where move_uploaded_file is not available
-            if (!copy($input->tmpPath, $dest)) {
-                throw new RuntimeException('Failed to move uploaded file to: ' . $dest);
-            }
-        }
-
-        $url = '/media/' . $relativePath;
+        $url = $this->storage->publicUrl($key);
         $now = date('Y-m-d H:i:s');
 
         $media = new Media(

--- a/tests/Media/LocalStorageTest.php
+++ b/tests/Media/LocalStorageTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Media;
+
+use NeNeRecords\Media\LocalStorage;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class LocalStorageTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->root = sys_get_temp_dir() . '/nene-storage-test-' . bin2hex(random_bytes(4));
+        mkdir($this->root, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->rmdirRecursive($this->root);
+    }
+
+    public function testWriteFromUploadStoresFileUnderKey(): void
+    {
+        $storage = new LocalStorage($this->root);
+        $tmp = $this->makeTempFile('hello world');
+
+        $storage->writeFromUpload('2026/06/abc.txt', $tmp);
+
+        self::assertTrue($storage->exists('2026/06/abc.txt'));
+        self::assertFileExists($this->root . '/2026/06/abc.txt');
+        self::assertSame(11, $storage->size('2026/06/abc.txt'));
+    }
+
+    public function testReadStreamReturnsStoredContents(): void
+    {
+        $storage = new LocalStorage($this->root);
+        $storage->writeFromUpload('2026/06/abc.txt', $this->makeTempFile('payload'));
+
+        $stream = $storage->readStream('2026/06/abc.txt');
+        $contents = stream_get_contents($stream);
+        fclose($stream);
+
+        self::assertSame('payload', $contents);
+    }
+
+    public function testDeleteRemovesObjectAndIsBestEffort(): void
+    {
+        $storage = new LocalStorage($this->root);
+        $storage->writeFromUpload('2026/06/abc.txt', $this->makeTempFile('x'));
+
+        $storage->delete('2026/06/abc.txt');
+        self::assertFalse($storage->exists('2026/06/abc.txt'));
+
+        // Deleting a missing object must not raise.
+        $storage->delete('2026/06/missing.txt');
+        self::assertFalse($storage->exists('2026/06/missing.txt'));
+    }
+
+    public function testPublicUrlAndKeyFromUrlAreInverses(): void
+    {
+        $storage = new LocalStorage($this->root);
+
+        self::assertSame('/media/2026/06/abc.png', $storage->publicUrl('2026/06/abc.png'));
+        self::assertSame('2026/06/abc.png', $storage->keyFromUrl('/media/2026/06/abc.png'));
+        self::assertSame('2026/06/abc.png', $storage->keyFromUrl($storage->publicUrl('2026/06/abc.png')));
+    }
+
+    public function testRejectsTraversalKeys(): void
+    {
+        $storage = new LocalStorage($this->root);
+
+        $this->expectException(RuntimeException::class);
+        $storage->writeFromUpload('../escape.txt', $this->makeTempFile('x'));
+    }
+
+    private function makeTempFile(string $contents): string
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'nene_src_');
+        self::assertIsString($tmp);
+        file_put_contents($tmp, $contents);
+
+        return $tmp;
+    }
+
+    private function rmdirRecursive(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $entries = scandir($dir);
+
+        if ($entries === false) {
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $entry;
+            is_dir($path) ? $this->rmdirRecursive($path) : unlink($path);
+        }
+
+        rmdir($dir);
+    }
+}

--- a/tests/Media/MediaHttpTest.php
+++ b/tests/Media/MediaHttpTest.php
@@ -11,6 +11,7 @@ use NeNeRecords\Media\DeleteMediaHandler;
 use NeNeRecords\Media\DeleteMediaUseCase;
 use NeNeRecords\Media\ListMediaHandler;
 use NeNeRecords\Media\ListMediaUseCase;
+use NeNeRecords\Media\LocalStorage;
 use NeNeRecords\Media\Media;
 use NeNeRecords\Media\MediaNotFoundExceptionHandler;
 use NeNeRecords\Media\MediaRouteRegistrar;
@@ -27,6 +28,7 @@ final class MediaHttpTest extends TestCase
     private Psr17Factory $factory;
     private InMemoryMediaRepository $repository;
     private string $storageRoot;
+    private LocalStorage $storage;
     private RequestHandlerInterface $application;
 
     protected function setUp(): void
@@ -36,6 +38,7 @@ final class MediaHttpTest extends TestCase
         $this->factory = new Psr17Factory();
         $this->storageRoot = sys_get_temp_dir() . '/nene-media-test-' . bin2hex(random_bytes(4));
         mkdir($this->storageRoot, 0755, true);
+        $this->storage = new LocalStorage($this->storageRoot);
 
         $this->repository = new InMemoryMediaRepository([
             new Media(
@@ -63,7 +66,7 @@ final class MediaHttpTest extends TestCase
 
         $registrar = new MediaRouteRegistrar(
             new UploadMediaHandler(
-                new UploadMediaUseCase($this->repository, $this->storageRoot),
+                new UploadMediaUseCase($this->repository, $this->storage),
                 $jsonResponse,
             ),
             new ListMediaHandler(
@@ -71,11 +74,10 @@ final class MediaHttpTest extends TestCase
                 $jsonResponse,
             ),
             new DeleteMediaHandler(
-                new DeleteMediaUseCase($this->repository),
+                new DeleteMediaUseCase($this->repository, $this->storage),
                 $this->factory,
-                $this->storageRoot,
             ),
-            new ServeMediaHandler($this->storageRoot, $this->factory, $this->factory),
+            new ServeMediaHandler($this->storage, $this->factory, $this->factory),
         );
 
         $this->application = (new RuntimeApplicationFactory(
@@ -145,10 +147,10 @@ final class MediaHttpTest extends TestCase
         $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
 
         $registrar = new MediaRouteRegistrar(
-            new UploadMediaHandler(new UploadMediaUseCase($emptyRepo, $this->storageRoot), $jsonResponse),
+            new UploadMediaHandler(new UploadMediaUseCase($emptyRepo, $this->storage), $jsonResponse),
             new ListMediaHandler(new ListMediaUseCase($emptyRepo), $jsonResponse),
-            new DeleteMediaHandler(new DeleteMediaUseCase($emptyRepo), $this->factory, $this->storageRoot),
-            new ServeMediaHandler($this->storageRoot, $this->factory, $this->factory),
+            new DeleteMediaHandler(new DeleteMediaUseCase($emptyRepo, $this->storage), $this->factory),
+            new ServeMediaHandler($this->storage, $this->factory, $this->factory),
         );
 
         $app = (new RuntimeApplicationFactory(

--- a/tests/Media/MediaUseCaseTest.php
+++ b/tests/Media/MediaUseCaseTest.php
@@ -6,6 +6,7 @@ namespace NeNeRecords\Tests\Media;
 
 use NeNeRecords\Media\DeleteMediaInput;
 use NeNeRecords\Media\DeleteMediaUseCase;
+use NeNeRecords\Media\LocalStorage;
 use NeNeRecords\Media\Media;
 use NeNeRecords\Media\MediaInvalidTypeException;
 use NeNeRecords\Media\MediaNotFoundException;
@@ -25,7 +26,7 @@ final class MediaUseCaseTest extends TestCase
         file_put_contents($tmpFile, 'fake image content');
 
         $mediaRepo = new InMemoryMediaRepository();
-        $useCase = new UploadMediaUseCase($mediaRepo, $storageRoot);
+        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot));
 
         $input = new UploadMediaInput(
             tmpPath: $tmpFile,
@@ -50,7 +51,7 @@ final class MediaUseCaseTest extends TestCase
     {
         $storageRoot = sys_get_temp_dir() . '/nene_media_test_' . uniqid('', true);
         $mediaRepo = new InMemoryMediaRepository();
-        $useCase = new UploadMediaUseCase($mediaRepo, $storageRoot);
+        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot));
 
         $input = new UploadMediaInput(
             tmpPath: '/tmp/irrelevant',
@@ -68,7 +69,7 @@ final class MediaUseCaseTest extends TestCase
     {
         $storageRoot = sys_get_temp_dir() . '/nene_media_test_' . uniqid('', true);
         $mediaRepo = new InMemoryMediaRepository();
-        $useCase = new UploadMediaUseCase($mediaRepo, $storageRoot);
+        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot));
 
         $tenMibPlusOne = 10 * 1024 * 1024 + 1;
 
@@ -96,12 +97,12 @@ final class MediaUseCaseTest extends TestCase
             createdAt: '2024-01-01 00:00:00',
         );
 
-        $mediaRepo = new InMemoryMediaRepository([$seeded]);
-        $useCase = new DeleteMediaUseCase($mediaRepo);
-
         $storageRoot = sys_get_temp_dir() . '/nene_no_file_' . uniqid('', true);
 
-        $useCase->execute(new DeleteMediaInput(id: 1, storageRoot: $storageRoot));
+        $mediaRepo = new InMemoryMediaRepository([$seeded]);
+        $useCase = new DeleteMediaUseCase($mediaRepo, new LocalStorage($storageRoot));
+
+        $useCase->execute(new DeleteMediaInput(id: 1));
 
         self::assertNull($mediaRepo->findById(1));
     }
@@ -109,10 +110,10 @@ final class MediaUseCaseTest extends TestCase
     public function testDeleteThrowsMediaNotFoundExceptionWhenMediaDoesNotExist(): void
     {
         $mediaRepo = new InMemoryMediaRepository();
-        $useCase = new DeleteMediaUseCase($mediaRepo);
+        $useCase = new DeleteMediaUseCase($mediaRepo, new LocalStorage(sys_get_temp_dir()));
 
         $this->expectException(MediaNotFoundException::class);
 
-        $useCase->execute(new DeleteMediaInput(id: 999, storageRoot: sys_get_temp_dir()));
+        $useCase->execute(new DeleteMediaInput(id: 999));
     }
 }

--- a/tests/Media/S3StorageTest.php
+++ b/tests/Media/S3StorageTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Media;
+
+use AsyncAws\S3\S3Client;
+use NeNeRecords\Media\S3Storage;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class S3StorageTest extends TestCase
+{
+    private const BASE_URL = 'https://cdn.example.com';
+
+    public function testPublicUrlAndKeyFromUrlAreInverses(): void
+    {
+        $storage = $this->storage(new MockHttpClient());
+
+        self::assertSame(self::BASE_URL . '/2026/06/a.png', $storage->publicUrl('2026/06/a.png'));
+        self::assertSame('2026/06/a.png', $storage->keyFromUrl(self::BASE_URL . '/2026/06/a.png'));
+        self::assertSame('2026/06/a.png', $storage->keyFromUrl($storage->publicUrl('2026/06/a.png')));
+    }
+
+    public function testPrefixIsAppliedToObjectKeysAndStrippedFromUrl(): void
+    {
+        $storage = $this->storage(new MockHttpClient(), prefix: 'media');
+
+        self::assertSame(self::BASE_URL . '/media/2026/06/a.png', $storage->publicUrl('2026/06/a.png'));
+        self::assertSame('2026/06/a.png', $storage->keyFromUrl(self::BASE_URL . '/media/2026/06/a.png'));
+    }
+
+    public function testSizeAndMimeTypeReadHeadObject(): void
+    {
+        $storage = $this->storage(new MockHttpClient(new MockResponse('', [
+            'response_headers' => ['content-length' => '4242', 'content-type' => 'image/png'],
+        ])));
+
+        self::assertSame(4242, $storage->size('2026/06/a.png'));
+    }
+
+    public function testReadStreamReturnsObjectBody(): void
+    {
+        $storage = $this->storage(new MockHttpClient(new MockResponse('binary-payload', [
+            'response_headers' => ['content-type' => 'image/png'],
+        ])));
+
+        $stream = $storage->readStream('2026/06/a.png');
+        $contents = stream_get_contents($stream);
+
+        self::assertSame('binary-payload', $contents);
+    }
+
+    public function testExistsReflectsHeadStatus(): void
+    {
+        $present = $this->storage(new MockHttpClient(new MockResponse('', ['http_code' => 200])));
+        self::assertTrue($present->exists('2026/06/a.png'));
+
+        $missing = $this->storage(new MockHttpClient(new MockResponse('', ['http_code' => 404])));
+        self::assertFalse($missing->exists('2026/06/missing.png'));
+    }
+
+    public function testWriteFromUploadPutsObjectUnderPrefixedKey(): void
+    {
+        $captured = [];
+        $client = new MockHttpClient(function (string $method, string $url) use (&$captured): MockResponse {
+            $captured['method'] = $method;
+            $captured['url'] = $url;
+
+            return new MockResponse('', ['http_code' => 200]);
+        });
+
+        $tmp = tempnam(sys_get_temp_dir(), 'nene_s3_');
+        self::assertIsString($tmp);
+        file_put_contents($tmp, 'data');
+
+        $this->storage($client, prefix: 'media')->writeFromUpload('2026/06/a.png', $tmp);
+        unlink($tmp);
+
+        self::assertSame('PUT', $captured['method']);
+        self::assertStringContainsString('/media/2026/06/a.png', $captured['url']);
+    }
+
+    private function storage(MockHttpClient $http, string $prefix = ''): S3Storage
+    {
+        $client = new S3Client(
+            ['region' => 'us-east-1', 'accessKeyId' => 'test', 'accessKeySecret' => 'test'],
+            null,
+            $http,
+        );
+
+        return new S3Storage($client, 'test-bucket', self::BASE_URL, $prefix);
+    }
+}


### PR DESCRIPTION
## 目的

Issue #299（WordPress 代替に向けたメディア基盤強化）の **Phase A**。メディアの物理保存をドライバ非依存に抽象化し、ローカルディスクと **S3互換ストレージ（AWS S3 / MinIO / Cloudflare R2）** を設定で切り替えられるようにする。今後のオンデマンド画像派生（Phase C）も、この StorageInterface 上に載せる。

## 変更内容

### ストレージ抽象化
- `StorageInterface` — `writeFromUpload` / `exists` / `readStream` / `delete` / `size` / `mimeType` / `publicUrl` / `keyFromUrl`。`publicUrl` と `keyFromUrl` は互いに逆変換で、URL↔キーのマッピングを各ドライバが own する
- `LocalStorage` — 従来の `var/media` 挙動を移植。パストラバーサル（`..`）拒否
- `S3Storage` — async-aws/s3 実装。prefix 対応、`publicUrl` は CDN/バケットURL。endpoint + path-style で S3互換サーバ（MinIO/R2）に対応

### リファクタ / 配線
- `UploadMediaUseCase` / `DeleteMediaUseCase` / `ServeMediaHandler` を `StorageInterface` 経由に変更し、`storageRoot` 直書きを排除
- `DeleteMediaInput` から `storageRoot` を削除（キーは `storage->keyFromUrl()` で解決）
- `MediaServiceProvider` でドライバを切替（`MEDIA_STORAGE_DRIVER`、既定 `local`／`s3`）
- 依存追加: `async-aws/s3` + `symfony/http-client`（フルSDKを避けた軽量な S3専用クライアント）
- `.env.example` に `MEDIA_STORAGE_DRIVER` / `MEDIA_S3_*` を追記

### テスト
- `LocalStorageTest` — 保存/読取/削除/URL逆変換/トラバーサル拒否
- `S3StorageTest` — MockHttpClient で put/head/get/exists を検証

## 検証

- `composer check` 全パス（PHPUnit 612 / PHPStan lv8 / CS-Fixer / OpenAPI / MCP）✅
- **Local**: 稼働スタックで upload `201` → serve `200` → delete `204` → 削除後 `404` ✅
- **S3**: 使い捨て MinIO 実機で round-trip 確認（put → exists → size/mime → readStream → delete）✅
- 公開URL・APIレスポンス形は不変（フロント影響なし）

## 補足

- `async-aws/s3` 追加時に `@dev` の NENE2 が dev-main へ巻き込まれたため、**lock を調整し NENE2 は元の固定 commit のまま据え置き**（このPRはメディア＋async-awsのみ）。NENE2 のアップグレードが必要なら別途。
- S3 利用時の削除は `keyFromUrl` で解決。将来 Phase B で `media.storage_key` を永続化すると、公開URLをCDNドメインに差し替えても削除が安定する。

Refs #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)