### PR TITLE
feat(media): オンデマンド画像派生（プリセット＋WebP/AVIF＋キャッシュ） (#299 Phase C)

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -6,7 +6,9 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip libicu-dev libsqlite3-dev \
-    && docker-php-ext-install pdo_mysql pdo_sqlite intl \
+        libjpeg-dev libpng-dev libwebp-dev libavif-dev libfreetype-dev \
+    && docker-php-ext-configure gd --with-jpeg --with-webp --with-avif --with-freetype \
+    && docker-php-ext-install pdo_mysql pdo_sqlite intl gd \
     && rm -rf /var/lib/apt/lists/* \
     && a2enmod rewrite headers \
     && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n' > /etc/apache2/conf-available/nene-records.conf \

--- a/src/Media/GdImageProcessor.php
+++ b/src/Media/GdImageProcessor.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+use RuntimeException;
+
+/**
+ * GD-backed {@see ImageProcessorInterface}. Preserves alpha and never upscales.
+ */
+final readonly class GdImageProcessor implements ImageProcessorInterface
+{
+    private const SUPPORTED_SOURCES = [
+        'image/jpeg',
+        'image/png',
+        'image/webp',
+        'image/gif',
+        'image/avif',
+    ];
+
+    public function __construct(
+        private int $quality = 80,
+    ) {
+    }
+
+    public function supportsSource(string $mimeType): bool
+    {
+        return in_array($mimeType, self::SUPPORTED_SOURCES, true);
+    }
+
+    public function resize(string $sourceBytes, int $maxWidth, string $format): string
+    {
+        $src = @imagecreatefromstring($sourceBytes);
+
+        if ($src === false) {
+            throw new RuntimeException('Failed to decode source image.');
+        }
+
+        try {
+            $srcWidth = imagesx($src);
+            $srcHeight = imagesy($src);
+
+            // Never upscale: cap the target width at the source width.
+            $targetWidth = max(1, min($maxWidth, $srcWidth));
+            $targetHeight = max(1, (int) round($srcHeight * $targetWidth / $srcWidth));
+
+            $dst = imagecreatetruecolor($targetWidth, $targetHeight);
+
+            if ($dst === false) {
+                throw new RuntimeException('Failed to allocate destination image.');
+            }
+
+            try {
+                // Preserve transparency for PNG/WebP/AVIF output.
+                imagealphablending($dst, false);
+                imagesavealpha($dst, true);
+                $transparent = imagecolorallocatealpha($dst, 0, 0, 0, 127);
+                if ($transparent !== false) {
+                    imagefill($dst, 0, 0, $transparent);
+                }
+
+                imagecopyresampled($dst, $src, 0, 0, 0, 0, $targetWidth, $targetHeight, $srcWidth, $srcHeight);
+
+                return $this->encode($dst, $format);
+            } finally {
+                imagedestroy($dst);
+            }
+        } finally {
+            imagedestroy($src);
+        }
+    }
+
+    private function encode(\GdImage $image, string $format): string
+    {
+        ob_start();
+
+        $ok = match ($format) {
+            self::FORMAT_WEBP => imagewebp($image, null, $this->quality),
+            self::FORMAT_AVIF => imageavif($image, null, $this->quality),
+            self::FORMAT_JPEG => imagejpeg($image, null, $this->quality),
+            self::FORMAT_PNG => imagepng($image),
+            default => throw new RuntimeException('Unsupported output format: ' . $format),
+        };
+
+        $bytes = ob_get_clean();
+
+        if (!$ok || $bytes === false || $bytes === '') {
+            throw new RuntimeException('Failed to encode image as ' . $format . '.');
+        }
+
+        return $bytes;
+    }
+}

--- a/src/Media/ImageProcessorInterface.php
+++ b/src/Media/ImageProcessorInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+/**
+ * Resizes and re-encodes raster images for on-demand derivative generation.
+ * Kept behind an interface so the GD implementation can be swapped for Imagick
+ * or an external service (imgproxy/Thumbor) without touching the HTTP layer.
+ */
+interface ImageProcessorInterface
+{
+    public const FORMAT_WEBP = 'webp';
+    public const FORMAT_AVIF = 'avif';
+    public const FORMAT_JPEG = 'jpeg';
+    public const FORMAT_PNG = 'png';
+
+    /** Whether the given source MIME type can be processed. */
+    public function supportsSource(string $mimeType): bool;
+
+    /**
+     * Resize $sourceBytes to fit within $maxWidth (never upscaling) and encode as
+     * $format (one of the FORMAT_* constants). Returns the encoded image bytes.
+     *
+     * @throws \RuntimeException when the source cannot be decoded or encoded.
+     */
+    public function resize(string $sourceBytes, int $maxWidth, string $format): string;
+}

--- a/src/Media/LocalStorage.php
+++ b/src/Media/LocalStorage.php
@@ -37,6 +37,20 @@ final readonly class LocalStorage implements StorageInterface
         }
     }
 
+    public function write(string $key, string $contents): void
+    {
+        $dest = $this->resolve($key);
+        $dir = dirname($dest);
+
+        if (!is_dir($dir) && !mkdir($dir, 0755, true) && !is_dir($dir)) {
+            throw new RuntimeException('Failed to create media directory: ' . $dir);
+        }
+
+        if (file_put_contents($dest, $contents) === false) {
+            throw new RuntimeException('Failed to write media object: ' . $key);
+        }
+    }
+
     public function exists(string $key): bool
     {
         return is_file($this->resolve($key));

--- a/src/Media/MediaImagePresets.php
+++ b/src/Media/MediaImagePresets.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+/**
+ * Whitelist of named derivative sizes. Restricting derivatives to a fixed set
+ * of presets prevents arbitrary-size generation from being used as a DoS / disk
+ * exhaustion vector.
+ */
+final class MediaImagePresets
+{
+    /** @var array<string, int> preset name => max width in pixels */
+    private const PRESETS = [
+        'thumb' => 160,
+        'sm' => 320,
+        'md' => 640,
+        'lg' => 1280,
+    ];
+
+    public static function isValid(string $name): bool
+    {
+        return isset(self::PRESETS[$name]);
+    }
+
+    public static function maxWidth(string $name): int
+    {
+        return self::PRESETS[$name] ?? throw new \InvalidArgumentException('Unknown image preset: ' . $name);
+    }
+
+    /** @return list<string> */
+    public static function names(): array
+    {
+        return array_keys(self::PRESETS);
+    }
+}

--- a/src/Media/MediaRouteRegistrar.php
+++ b/src/Media/MediaRouteRegistrar.php
@@ -15,6 +15,7 @@ final readonly class MediaRouteRegistrar
         private DeleteMediaHandler $deleteHandler,
         private ServeMediaHandler $serveHandler,
         private UpdateMediaAltHandler $updateAltHandler,
+        private ServeDerivativeHandler $serveDerivativeHandler,
     ) {
     }
 
@@ -25,11 +26,14 @@ final readonly class MediaRouteRegistrar
         $deleteHandler = $this->deleteHandler;
         $serveHandler = $this->serveHandler;
         $updateAltHandler = $this->updateAltHandler;
+        $serveDerivativeHandler = $this->serveDerivativeHandler;
 
         $router->post('/api/v1/media', static fn (ServerRequestInterface $request) => $uploadHandler->handle($request));
         $router->get('/api/v1/media', static fn (ServerRequestInterface $request) => $listHandler->handle($request));
         $router->patch('/api/v1/media/{id}', static fn (ServerRequestInterface $request) => $updateAltHandler->handle($request));
         $router->delete('/api/v1/media/{id}', static fn (ServerRequestInterface $request) => $deleteHandler->handle($request));
+        // 4-segment derivative route must be registered before the 3-segment original.
+        $router->get('/media/{preset}/{year}/{month}/{filename}', static fn (ServerRequestInterface $request) => $serveDerivativeHandler->handle($request));
         $router->get('/media/{year}/{month}/{filename}', static fn (ServerRequestInterface $request) => $serveHandler->handle($request));
     }
 }

--- a/src/Media/MediaServiceProvider.php
+++ b/src/Media/MediaServiceProvider.php
@@ -41,6 +41,10 @@ final readonly class MediaServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                ImageProcessorInterface::class,
+                static fn (ContainerInterface $c): ImageProcessorInterface => new GdImageProcessor(),
+            )
+            ->set(
                 MediaRepositoryInterface::class,
                 static function (ContainerInterface $c): MediaRepositoryInterface {
                     $query = $c->get(DatabaseQueryExecutorInterface::class);
@@ -206,6 +210,33 @@ final readonly class MediaServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                ServeDerivativeHandler::class,
+                static function (ContainerInterface $c): ServeDerivativeHandler {
+                    $storage = $c->get(StorageInterface::class);
+                    $processor = $c->get(ImageProcessorInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+                    $streamFactory = $c->get(StreamFactoryInterface::class);
+
+                    if (!$storage instanceof StorageInterface) {
+                        throw new LogicException('Media storage service is invalid.');
+                    }
+
+                    if (!$processor instanceof ImageProcessorInterface) {
+                        throw new LogicException('Image processor service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    if (!$streamFactory instanceof StreamFactoryInterface) {
+                        throw new LogicException('Stream factory service is invalid.');
+                    }
+
+                    return new ServeDerivativeHandler($storage, $processor, $responseFactory, $streamFactory);
+                },
+            )
+            ->set(
                 MediaInvalidTypeExceptionHandler::class,
                 static function (ContainerInterface $c): MediaInvalidTypeExceptionHandler {
                     $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
@@ -249,6 +280,7 @@ final readonly class MediaServiceProvider implements ServiceProviderInterface
                     $delete = $c->get(DeleteMediaHandler::class);
                     $serve = $c->get(ServeMediaHandler::class);
                     $updateAlt = $c->get(UpdateMediaAltHandler::class);
+                    $serveDerivative = $c->get(ServeDerivativeHandler::class);
 
                     if (!$upload instanceof UploadMediaHandler) {
                         throw new LogicException('UploadMedia handler service is invalid.');
@@ -270,7 +302,11 @@ final readonly class MediaServiceProvider implements ServiceProviderInterface
                         throw new LogicException('UpdateMediaAlt handler service is invalid.');
                     }
 
-                    return new MediaRouteRegistrar($upload, $list, $delete, $serve, $updateAlt);
+                    if (!$serveDerivative instanceof ServeDerivativeHandler) {
+                        throw new LogicException('ServeDerivative handler service is invalid.');
+                    }
+
+                    return new MediaRouteRegistrar($upload, $list, $delete, $serve, $updateAlt, $serveDerivative);
                 },
             );
     }

--- a/src/Media/S3Storage.php
+++ b/src/Media/S3Storage.php
@@ -47,6 +47,15 @@ final readonly class S3Storage implements StorageInterface
         ])->resolve();
     }
 
+    public function write(string $key, string $contents): void
+    {
+        $this->client->putObject([
+            'Bucket' => $this->bucket,
+            'Key' => $this->object($key),
+            'Body' => $contents,
+        ])->resolve();
+    }
+
     public function exists(string $key): bool
     {
         return $this->client->objectExists([

--- a/src/Media/ServeDerivativeHandler.php
+++ b/src/Media/ServeDerivativeHandler.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+/**
+ * On-demand image derivatives: GET /media/{preset}/{year}/{month}/{filename}.
+ *
+ * Generates the requested preset on the first request, caches it under a
+ * "derivatives/" prefix in storage, and serves the cached object thereafter.
+ * Output format is negotiated (?fm= override, then Accept: image/avif|webp,
+ * else the source format). Presets are whitelisted to bound generation cost.
+ */
+final readonly class ServeDerivativeHandler
+{
+    public function __construct(
+        private StorageInterface $storage,
+        private ImageProcessorInterface $processor,
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $preset = (string) ($parameters['preset'] ?? '');
+        $year = (string) ($parameters['year'] ?? '');
+        $month = (string) ($parameters['month'] ?? '');
+        $filename = (string) ($parameters['filename'] ?? '');
+
+        if (!MediaImagePresets::isValid($preset) || $this->hasTraversal($year, $month, $filename)) {
+            return $this->responseFactory->createResponse(404);
+        }
+
+        $originalKey = $year . '/' . $month . '/' . $filename;
+
+        if (!$this->storage->exists($originalKey)) {
+            return $this->responseFactory->createResponse(404);
+        }
+
+        $sourceMime = $this->storage->mimeType($originalKey);
+        if (!$this->processor->supportsSource($sourceMime)) {
+            return $this->responseFactory->createResponse(404);
+        }
+
+        $fm = $request->getQueryParams()['fm'] ?? null;
+        $format = $this->negotiateFormat(is_string($fm) ? $fm : null, $request->getHeaderLine('Accept'), $sourceMime);
+        [$mime, $ext] = $this->formatMeta($format);
+
+        $base = pathinfo($filename, PATHINFO_FILENAME);
+        $derivativeKey = "derivatives/{$preset}/{$format}/{$year}/{$month}/{$base}.{$ext}";
+
+        if (!$this->storage->exists($derivativeKey)) {
+            $original = stream_get_contents($this->storage->readStream($originalKey));
+            $derived = $this->processor->resize(
+                $original === false ? '' : $original,
+                MediaImagePresets::maxWidth($preset),
+                $format,
+            );
+            $this->storage->write($derivativeKey, $derived);
+        }
+
+        $etag = '"' . md5($derivativeKey) . '"';
+
+        if (trim($request->getHeaderLine('If-None-Match')) === $etag) {
+            return $this->responseFactory->createResponse(304)->withHeader('ETag', $etag);
+        }
+
+        $stream = $this->streamFactory->createStreamFromResource($this->storage->readStream($derivativeKey));
+
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', $mime)
+            ->withHeader('Content-Length', (string) $this->storage->size($derivativeKey))
+            ->withHeader('Cache-Control', 'public, max-age=31536000, immutable')
+            ->withHeader('ETag', $etag)
+            ->withBody($stream);
+    }
+
+    private function hasTraversal(string $year, string $month, string $filename): bool
+    {
+        return $year === '' || $month === '' || $filename === ''
+            || str_contains($year, '.') || str_contains($month, '.')
+            || str_contains($filename, '/') || str_contains($filename, '\\')
+            || str_contains($filename, '..');
+    }
+
+    private function negotiateFormat(?string $fm, string $accept, string $sourceMime): string
+    {
+        $allowed = [
+            ImageProcessorInterface::FORMAT_WEBP,
+            ImageProcessorInterface::FORMAT_AVIF,
+            ImageProcessorInterface::FORMAT_JPEG,
+            ImageProcessorInterface::FORMAT_PNG,
+        ];
+
+        if ($fm !== null && in_array($fm, $allowed, true)) {
+            return $fm;
+        }
+
+        if (str_contains($accept, 'image/avif')) {
+            return ImageProcessorInterface::FORMAT_AVIF;
+        }
+
+        if (str_contains($accept, 'image/webp')) {
+            return ImageProcessorInterface::FORMAT_WEBP;
+        }
+
+        return match ($sourceMime) {
+            'image/png' => ImageProcessorInterface::FORMAT_PNG,
+            'image/webp' => ImageProcessorInterface::FORMAT_WEBP,
+            'image/avif' => ImageProcessorInterface::FORMAT_AVIF,
+            default => ImageProcessorInterface::FORMAT_JPEG,
+        };
+    }
+
+    /** @return array{0: string, 1: string} [mime, extension] */
+    private function formatMeta(string $format): array
+    {
+        return match ($format) {
+            ImageProcessorInterface::FORMAT_WEBP => ['image/webp', 'webp'],
+            ImageProcessorInterface::FORMAT_AVIF => ['image/avif', 'avif'],
+            ImageProcessorInterface::FORMAT_PNG => ['image/png', 'png'],
+            default => ['image/jpeg', 'jpg'],
+        };
+    }
+}

--- a/src/Media/StorageInterface.php
+++ b/src/Media/StorageInterface.php
@@ -22,6 +22,13 @@ interface StorageInterface
      */
     public function writeFromUpload(string $key, string $tmpPath): void;
 
+    /**
+     * Write raw bytes to $key (used for cached image derivatives).
+     *
+     * @throws \RuntimeException when the object cannot be written.
+     */
+    public function write(string $key, string $contents): void;
+
     public function exists(string $key): bool;
 
     /**

--- a/tests/Media/GdImageProcessorTest.php
+++ b/tests/Media/GdImageProcessorTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Media;
+
+use NeNeRecords\Media\GdImageProcessor;
+use NeNeRecords\Media\ImageProcessorInterface;
+use PHPUnit\Framework\TestCase;
+
+final class GdImageProcessorTest extends TestCase
+{
+    /**
+     * @param positive-int $width
+     * @param positive-int $height
+     */
+    private function sourcePng(int $width, int $height): string
+    {
+        $image = imagecreatetruecolor($width, $height);
+        self::assertNotFalse($image);
+        $color = imagecolorallocate($image, 120, 30, 30);
+        self::assertNotFalse($color);
+        imagefilledrectangle($image, 0, 0, $width, $height, $color);
+
+        ob_start();
+        imagepng($image);
+        $bytes = (string) ob_get_clean();
+        imagedestroy($image);
+
+        return $bytes;
+    }
+
+    public function testResizeScalesDownPreservingAspectRatio(): void
+    {
+        $processor = new GdImageProcessor();
+        $out = $processor->resize($this->sourcePng(100, 50), 40, ImageProcessorInterface::FORMAT_PNG);
+
+        $info = getimagesizefromstring($out);
+        self::assertNotFalse($info);
+        self::assertSame(40, $info[0]);
+        self::assertSame(20, $info[1]);
+        self::assertSame(IMAGETYPE_PNG, $info[2]);
+    }
+
+    public function testResizeNeverUpscales(): void
+    {
+        $processor = new GdImageProcessor();
+        $out = $processor->resize($this->sourcePng(100, 50), 400, ImageProcessorInterface::FORMAT_PNG);
+
+        $info = getimagesizefromstring($out);
+        self::assertNotFalse($info);
+        self::assertSame(100, $info[0]);
+        self::assertSame(50, $info[1]);
+    }
+
+    public function testResizeEncodesWebp(): void
+    {
+        $processor = new GdImageProcessor();
+        $out = $processor->resize($this->sourcePng(80, 80), 40, ImageProcessorInterface::FORMAT_WEBP);
+
+        $info = getimagesizefromstring($out);
+        self::assertNotFalse($info);
+        self::assertSame(IMAGETYPE_WEBP, $info[2]);
+        self::assertSame(40, $info[0]);
+    }
+
+    public function testSupportsSourceAcceptsRasterImagesOnly(): void
+    {
+        $processor = new GdImageProcessor();
+
+        self::assertTrue($processor->supportsSource('image/png'));
+        self::assertTrue($processor->supportsSource('image/jpeg'));
+        self::assertFalse($processor->supportsSource('application/pdf'));
+        self::assertFalse($processor->supportsSource('image/svg+xml'));
+    }
+}

--- a/tests/Media/MediaHttpTest.php
+++ b/tests/Media/MediaHttpTest.php
@@ -9,12 +9,14 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
 use NeNeRecords\Media\DeleteMediaHandler;
 use NeNeRecords\Media\DeleteMediaUseCase;
+use NeNeRecords\Media\GdImageProcessor;
 use NeNeRecords\Media\ListMediaHandler;
 use NeNeRecords\Media\ListMediaUseCase;
 use NeNeRecords\Media\LocalStorage;
 use NeNeRecords\Media\Media;
 use NeNeRecords\Media\MediaNotFoundExceptionHandler;
 use NeNeRecords\Media\MediaRouteRegistrar;
+use NeNeRecords\Media\ServeDerivativeHandler;
 use NeNeRecords\Media\ServeMediaHandler;
 use NeNeRecords\Media\UpdateMediaAltHandler;
 use NeNeRecords\Media\UpdateMediaAltUseCase;
@@ -84,6 +86,7 @@ final class MediaHttpTest extends TestCase
                 new UpdateMediaAltUseCase($this->repository),
                 $jsonResponse,
             ),
+            new ServeDerivativeHandler($this->storage, new GdImageProcessor(), $this->factory, $this->factory),
         );
 
         $this->application = (new RuntimeApplicationFactory(
@@ -158,6 +161,7 @@ final class MediaHttpTest extends TestCase
             new DeleteMediaHandler(new DeleteMediaUseCase($emptyRepo, $this->storage), $this->factory),
             new ServeMediaHandler($this->storage, $this->factory, $this->factory),
             new UpdateMediaAltHandler(new UpdateMediaAltUseCase($emptyRepo), $jsonResponse),
+            new ServeDerivativeHandler($this->storage, new GdImageProcessor(), $this->factory, $this->factory),
         );
 
         $app = (new RuntimeApplicationFactory(
@@ -278,6 +282,89 @@ final class MediaHttpTest extends TestCase
         self::assertArrayHasKey('width', $item);
         self::assertArrayHasKey('height', $item);
         self::assertArrayHasKey('alt_text', $item);
+    }
+
+    // ── Derivatives ────────────────────────────────────────────────────────────
+
+    public function testDerivativeGeneratesResizedImageAndCachesIt(): void
+    {
+        $this->seedStorageImage('2026/05/pic.png', 800, 400);
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/media/sm/2026/05/pic.png'),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('image/png', $response->getHeaderLine('Content-Type'));
+
+        $info = getimagesizefromstring((string) $response->getBody());
+        self::assertNotFalse($info);
+        self::assertSame(320, $info[0], 'sm preset constrains width to 320');
+        self::assertSame(160, $info[1]);
+
+        self::assertFileExists($this->storageRoot . '/derivatives/sm/png/2026/05/pic.png');
+    }
+
+    public function testDerivativeNegotiatesWebpFromAcceptHeader(): void
+    {
+        $this->seedStorageImage('2026/05/pic.png', 200, 200);
+
+        $response = $this->application->handle(
+            $this->factory
+                ->createServerRequest('GET', 'https://example.test/media/thumb/2026/05/pic.png')
+                ->withHeader('Accept', 'image/avif,image/webp,image/*'),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        // libavif is not guaranteed in CI; AVIF is preferred but at least webp/avif, not png.
+        self::assertContains($response->getHeaderLine('Content-Type'), ['image/avif', 'image/webp']);
+    }
+
+    public function testDerivativeWithFormatOverrideReturnsWebp(): void
+    {
+        $this->seedStorageImage('2026/05/pic.png', 200, 200);
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/media/thumb/2026/05/pic.png?fm=webp'),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('image/webp', $response->getHeaderLine('Content-Type'));
+    }
+
+    public function testDerivativeWithUnknownPresetReturns404(): void
+    {
+        $this->seedStorageImage('2026/05/pic.png', 200, 200);
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/media/huge/2026/05/pic.png'),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testDerivativeForMissingOriginalReturns404(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/media/sm/2026/05/nope.png'),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    /**
+     * @param positive-int $width
+     * @param positive-int $height
+     */
+    private function seedStorageImage(string $key, int $width, int $height): void
+    {
+        $image = imagecreatetruecolor($width, $height);
+        self::assertNotFalse($image);
+        imagefilledrectangle($image, 0, 0, $width, $height, (int) imagecolorallocate($image, 10, 120, 200));
+        $dir = $this->storageRoot . '/' . dirname($key);
+        mkdir($dir, 0755, true);
+        imagepng($image, $this->storageRoot . '/' . $key);
+        imagedestroy($image);
     }
 
     /** @return array<string, mixed> */


### PR DESCRIPTION
## 目的

Issue #299 の **Phase C（本丸）**。元画像から派生（サムネ等）をリクエスト時に生成し、`StorageInterface` にキャッシュして配信する。WordPress のアップロード時固定サイズ生成（全サイズ即生成・サイズ追加で全再生成）と異なり、ストレージ効率とフォーマット移行性に優れる。

> ⚠️ **Stacked PR**: base は #301（Phase B）。#300 → #301 → 本PR の順でマージしてください。

## エンドポイント

`GET /media/{preset}/{year}/{month}/{filename}`（`?fm=webp|avif|jpeg|png` 任意）

- **プリセットをホワイトリスト化**（`thumb`160 / `sm`320 / `md`640 / `lg`1280）— 任意サイズ生成による DoS / ディスク枯渇を防止
- **フォーマットネゴシエーション**: `?fm=` 明示 → `Accept: image/avif|webp` → 元形式
- **初回生成 → `derivatives/{preset}/{format}/…` にキャッシュ → 以降は配信のみ**
- `Cache-Control: immutable` + **ETag**（`If-None-Match` で 304）
- 既存の公開配信ルートと同じく **パスベース・認証不要・DB非依存**（Issue の `/{id}/{preset}` から、org スコープ/DB結合を避けるため意図的に変更）

## 実装

- `ServeDerivativeHandler` — ルーティング／ネゴシエーション／キャッシュ／ETag
- `ImageProcessorInterface` + `GdImageProcessor` — リサイズ（**非拡大・アルファ保持**）と WebP/AVIF/JPEG/PNG エンコード。将来 Imagick / imgproxy に差し替え可能
- `MediaImagePresets` — プリセット集中管理（ホワイトリスト）
- `StorageInterface::write()` を追加（Local / S3 両ドライバ実装）— 派生のキャッシュ書き込み用
- `docker/php/Dockerfile` に **GD（jpeg/png/webp/avif/freetype）** を追加

## 検証

- **稼働スタックで round-trip**: 1000×500 をアップロード → `md`→640×320(png) / `sm`+Accept→**webp** / `thumb`?fm=webp / **ETag→304** / 不正プリセット→404 / `derivatives/` キャッシュ生成を確認 ✅
- `composer check` 全パス（PHPUnit **626** / PHPStan lv8 / CS-Fixer / OpenAPI / MCP）✅
- 公開バイナリ配信ルートは OpenAPI 非掲載（既存 serve ルートと同様）

## 補足 / 次

- 派生配信は現状アプリ経由。**CDN を前段に置けば immutable キャッシュがそのまま効く**。S3 ドライバ時も読み書きは S3 へ行く。
- **Phase D**: 公開ビューで `srcset`/`sizes` を本エンドポイントから出力 ＋ blurhash プレースホルダ（Phase B で見送った blurhash 生成もここで対に）。

Refs #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)