### PR TITLE
docs(rules): design-export/ をローカル専用・非追跡とするルールを追記する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Claude Code / AI agent guide for this repository. Cursor summaries live in `.cur
 - **Commits**: Conventional Commits; type/scope English, description/body Japanese, include `(#issue)`.
 - **PR**: purpose, changes, verification, checklist name, `Closes #n`.
 - **Secrets**: never commit `.env`, tokens, or credentials.
+- **design-export/**: local claudeDesign working directory — keep it untracked (kept out of git via local `.git/info/exclude`, not the shared `.gitignore`); never `git add` it.
 - **Framework**: NENE2 via Composer — read `vendor/hideyukimori/nene2/docs/` for runtime patterns.
 - **MCP**: tools go through OpenAPI HTTP boundary only.
 


### PR DESCRIPTION
## 目的

`design-export/` は claudeDesign 連携用のローカル作業ディレクトリ。追跡しない方針を CLAUDE.md の Quick Rules に明文化する。

## 変更内容

- CLAUDE.md「Quick Rules」に `design-export/` を非追跡とするルールを1行追加。
- 非追跡は共有 `.gitignore` ではなくローカルの `.git/info/exclude` で固定済み（個人/ローカル限定の関心事のため）。

## 検証

- ドキュメントのみの変更。`git check-ignore design-export/` で ignored を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)