### PR TITLE
feat(auth): セッショントークンを httpOnly Cookie へ移行（XSS耐性・#311前提） (#314)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -52,7 +52,10 @@ paths:
       tags:
         - Auth
       summary: Admin login
-      description: Authenticates with email/password and returns a bearer token.
+      description: >-
+        Authenticates with email/password. Sets the session token as an HttpOnly
+        `nene_session` cookie (SameSite=Lax) and also returns it in the body for
+        non-browser/machine clients.
       operationId: login
       requestBody:
         required: true
@@ -77,6 +80,16 @@ paths:
                 role: admin
         '401':
           $ref: '#/components/responses/InvalidCredentials'
+  /api/v1/auth/logout:
+    post:
+      tags:
+        - Auth
+      summary: Logout
+      description: Clears the session cookie. Open endpoint (no authentication required).
+      operationId: logout
+      responses:
+        '204':
+          description: Session cookie cleared.
   /health:
     get:
       tags:

--- a/frontend/src/entities/auth/index.ts
+++ b/frontend/src/entities/auth/index.ts
@@ -1,6 +1,6 @@
 export { authStore } from './model'
 export type { AuthSession } from './model'
-export { useLogin } from './mutations'
+export { useLogin, useLogout } from './mutations'
 export { hasCapability, isAdmin, isSuperadmin } from './capabilities'
 export type { Capability, UserRole } from './capabilities'
 export {

--- a/frontend/src/entities/auth/model.ts
+++ b/frontend/src/entities/auth/model.ts
@@ -1,11 +1,15 @@
+/**
+ * Non-secret session profile kept in localStorage for UI gating (role-based
+ * rendering, expiry checks). The actual session token lives in an HttpOnly
+ * cookie set by the API and is never readable from JS.
+ */
 export interface AuthSession {
-  token: string
   expiresAt: string
   email: string
   role: string
 }
 
-const STORAGE_KEY = 'nene_records_token'
+const STORAGE_KEY = 'nene_records_session'
 
 export const authStore = {
   getSession(): AuthSession | null {
@@ -29,10 +33,6 @@ export const authStore = {
 
   clearSession(): void {
     localStorage.removeItem(STORAGE_KEY)
-  },
-
-  getToken(): string | null {
-    return this.getSession()?.token ?? null
   },
 
   isAuthenticated(): boolean {

--- a/frontend/src/entities/auth/mutations.ts
+++ b/frontend/src/entities/auth/mutations.ts
@@ -6,15 +6,29 @@ import { authStore, type AuthSession } from './model'
 export function useLogin(): UseMutationResult<AuthSession, AppError, LoginRequestDto> {
   return useMutation({
     mutationFn: async (input) => {
+      // The API sets the session token as an HttpOnly cookie; we only keep the
+      // non-secret profile (the body token is ignored by the browser client).
       const dto = await apiClient.post<LoginResponseDto>('/api/v1/auth/login', input)
       const session: AuthSession = {
-        token: dto.token,
         expiresAt: dto.expires_at,
         email: dto.email,
         role: dto.role,
       }
       authStore.setSession(session)
       return session
+    },
+  })
+}
+
+export function useLogout(): UseMutationResult<void, AppError, void> {
+  return useMutation({
+    mutationFn: async () => {
+      try {
+        await apiClient.post('/api/v1/auth/logout', {})
+      } finally {
+        // Always clear the local profile, even if the network call fails.
+        authStore.clearSession()
+      }
     },
   })
 }

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -5,6 +5,7 @@ import {
   currentUserHasCapability,
   currentUserIsAdmin,
   currentUserIsSuperadmin,
+  useLogout,
 } from '@/entities/auth'
 import { getLocalizedEntityTypeName, usePinnedEntityTypes } from '@/entities/entity-type'
 import { LOCALES, SUPPORTED_LOCALE_IDS, useTranslation } from '@/shared/i18n'
@@ -98,9 +99,14 @@ export function AppShell() {
     }
   }, [sidebarOpen])
 
+  const logout = useLogout()
   const handleLogout = () => {
-    authStore.clearSession()
-    void navigate('/login')
+    // Clears the HttpOnly cookie server-side, then the local profile.
+    logout.mutate(undefined, {
+      onSettled: () => {
+        void navigate('/login')
+      },
+    })
   }
 
   const session = authStore.getSession()

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -4,6 +4,10 @@ import { AppError, parseProblemDetails } from '@/shared/api/errors'
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 
+// Custom header required by the API for cookie-authenticated mutations (CSRF
+// defense): a cross-site form post cannot set it without a CORS preflight.
+const CSRF_HEADER: Readonly<Record<string, string>> = { 'X-Requested-With': 'fetch' }
+
 interface RequestOptions {
   method?: HttpMethod
   body?: unknown
@@ -27,14 +31,11 @@ function handleErrorResponse(response: Response, path: string): void {
 async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
   const base = env.apiBaseUrl.replace(/\/$/, '')
   const url = `${base}${path}`
-  const headers: Record<string, string> = {}
+  const headers: Record<string, string> = { ...CSRF_HEADER }
   if (options.body !== undefined) {
     headers['Content-Type'] = 'application/json'
   }
-  const token = authStore.getToken()
-  if (token !== null) {
-    headers['Authorization'] = `Bearer ${token}`
-  }
+  // Auth travels in the HttpOnly session cookie (sent via credentials:'include').
 
   const response = await fetch(url, {
     method: options.method ?? 'GET',
@@ -75,15 +76,10 @@ export const apiClient = {
   async upload<T>(path: string, formData: FormData): Promise<T> {
     const base = env.apiBaseUrl.replace(/\/$/, '')
     const url = `${base}${path}`
-    const headers: Record<string, string> = {}
-    const token = authStore.getToken()
-    if (token !== null) {
-      headers['Authorization'] = `Bearer ${token}`
-    }
 
     const response = await fetch(url, {
       method: 'POST',
-      headers,
+      headers: { ...CSRF_HEADER },
       body: formData,
       credentials: 'include',
     })

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -15,9 +15,29 @@ export interface paths {
         put?: never;
         /**
          * Admin login
-         * @description Authenticates with email/password and returns a bearer token.
+         * @description Authenticates with email/password. Sets the session token as an HttpOnly `nene_session` cookie (SameSite=Lax) and also returns it in the body for non-browser/machine clients.
          */
         post: operations["login"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Logout
+         * @description Clears the session cookie. Open endpoint (no authentication required).
+         */
+        post: operations["logout"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2326,6 +2346,24 @@ export interface operations {
                 };
             };
             401: components["responses"]["InvalidCredentials"];
+        };
+    };
+    logout: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Session cookie cleared. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     getHealth: {

--- a/src/Auth/AdminApiAuthMiddleware.php
+++ b/src/Auth/AdminApiAuthMiddleware.php
@@ -53,16 +53,40 @@ final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
         }
 
         $authorization = $request->getHeaderLine('Authorization');
+        $credentialType = 'bearer';
 
-        if ($authorization === '') {
-            return $this->unauthorized($request, 'missing_token', 'No Bearer token was provided.');
+        if ($authorization !== '') {
+            if (!str_starts_with($authorization, 'Bearer ')) {
+                return $this->unauthorized($request, 'invalid_token', 'Authorization header must use the Bearer scheme.');
+            }
+
+            $token = substr($authorization, 7);
+        } else {
+            // Fall back to the HttpOnly session cookie (browser SPA).
+            $cookies = $request->getCookieParams();
+            $cookieToken = isset($cookies[SessionCookie::NAME]) && is_string($cookies[SessionCookie::NAME])
+                ? $cookies[SessionCookie::NAME]
+                : '';
+
+            if ($cookieToken === '') {
+                return $this->unauthorized($request, 'missing_token', 'No session token was provided.');
+            }
+
+            $token = $cookieToken;
+            $credentialType = 'cookie';
+
+            // CSRF: the cookie is sent automatically by the browser, so a
+            // cross-site form could trigger a state-changing request. Require a
+            // custom header that only same-origin JS sets — a cross-site form
+            // post cannot set it without a CORS preflight the API does not allow.
+            $method = strtoupper($request->getMethod());
+            if (
+                in_array($method, ['POST', 'PUT', 'PATCH', 'DELETE'], true)
+                && $request->getHeaderLine('X-Requested-With') === ''
+            ) {
+                return $this->forbiddenCsrf($request);
+            }
         }
-
-        if (!str_starts_with($authorization, 'Bearer ')) {
-            return $this->unauthorized($request, 'invalid_token', 'Authorization header must use the Bearer scheme.');
-        }
-
-        $token = substr($authorization, 7);
 
         try {
             $claims = $this->verifier->verify($token);
@@ -72,8 +96,19 @@ final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
 
         return $handler->handle(
             $request
-                ->withAttribute('nene2.auth.credential_type', 'bearer')
+                ->withAttribute('nene2.auth.credential_type', $credentialType)
                 ->withAttribute('nene2.auth.claims', $claims),
+        );
+    }
+
+    private function forbiddenCsrf(ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'csrf-protection',
+            'Forbidden',
+            403,
+            'Cookie-authenticated requests must include the X-Requested-With header.',
         );
     }
 

--- a/src/Auth/AuthRouteRegistrar.php
+++ b/src/Auth/AuthRouteRegistrar.php
@@ -11,13 +11,16 @@ final readonly class AuthRouteRegistrar
 {
     public function __construct(
         private LoginHandler $loginHandler,
+        private LogoutHandler $logoutHandler,
     ) {
     }
 
     public function __invoke(Router $router): void
     {
         $loginHandler = $this->loginHandler;
+        $logoutHandler = $this->logoutHandler;
 
         $router->post('/api/v1/auth/login', static fn (ServerRequestInterface $request) => $loginHandler->handle($request));
+        $router->post('/api/v1/auth/logout', static fn (ServerRequestInterface $request) => $logoutHandler->handle($request));
     }
 }

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -12,6 +12,7 @@ use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 
 final readonly class AuthServiceProvider implements ServiceProviderInterface
 {
@@ -66,6 +67,18 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                LogoutHandler::class,
+                static function (ContainerInterface $container): LogoutHandler {
+                    $responseFactory = $container->get(ResponseFactoryInterface::class);
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('ResponseFactoryInterface service is invalid.');
+                    }
+
+                    return new LogoutHandler($responseFactory);
+                },
+            )
+            ->set(
                 InvalidCredentialsExceptionHandler::class,
                 static function (ContainerInterface $container): InvalidCredentialsExceptionHandler {
                     $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
@@ -81,12 +94,17 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                 'nene-records.route_registrar.auth',
                 static function (ContainerInterface $container): AuthRouteRegistrar {
                     $loginHandler = $container->get(LoginHandler::class);
+                    $logoutHandler = $container->get(LogoutHandler::class);
 
                     if (!$loginHandler instanceof LoginHandler) {
                         throw new LogicException('LoginHandler service is invalid.');
                     }
 
-                    return new AuthRouteRegistrar($loginHandler);
+                    if (!$logoutHandler instanceof LogoutHandler) {
+                        throw new LogicException('LogoutHandler service is invalid.');
+                    }
+
+                    return new AuthRouteRegistrar($loginHandler, $logoutHandler);
                 },
             );
     }

--- a/src/Auth/LoginHandler.php
+++ b/src/Auth/LoginHandler.php
@@ -44,12 +44,17 @@ final readonly class LoginHandler
 
         $output = $this->useCase->execute(new LoginInput(email: $email, password: $password));
 
+        // Set the session token as an HttpOnly cookie so page JS can't read it.
+        // The token is still returned in the body for non-browser/machine clients.
+        $maxAge = $output->expiresAt - time();
+        $cookie = SessionCookie::build($output->token, $maxAge, SessionCookie::isSecureRequest($request));
+
         return $this->response->create([
             'token'      => $output->token,
             'expires_at' => (new DateTimeImmutable('@' . $output->expiresAt))->format(DateTimeInterface::ATOM),
             'email'      => $output->email,
             'role'       => $output->role,
             'org_id'     => $output->orgId,
-        ]);
+        ], 200, ['Set-Cookie' => $cookie]);
     }
 }

--- a/src/Auth/LogoutHandler.php
+++ b/src/Auth/LogoutHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Clears the session cookie. Open endpoint — expiring a cookie is harmless and
+ * must work even if the current token is already invalid.
+ */
+final readonly class LogoutHandler
+{
+    public function __construct(
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->responseFactory
+            ->createResponse(204)
+            ->withHeader('Set-Cookie', SessionCookie::clear(SessionCookie::isSecureRequest($request)));
+    }
+}

--- a/src/Auth/SessionCookie.php
+++ b/src/Auth/SessionCookie.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Auth;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Builds the Set-Cookie header for the session token.
+ *
+ * The token lives in an HttpOnly cookie so page JavaScript can never read it
+ * (XSS can't steal the session). SameSite=Lax + a required custom request header
+ * on cookie-authenticated mutations (see AdminApiAuthMiddleware) defends against
+ * CSRF. `Secure` is added only over HTTPS so the cookie still works on http
+ * localhost in development.
+ */
+final class SessionCookie
+{
+    public const NAME = 'nene_session';
+
+    public static function build(string $token, int $maxAgeSeconds, bool $secure): string
+    {
+        $maxAge = max(0, $maxAgeSeconds);
+
+        $parts = [
+            self::NAME . '=' . $token,
+            'Path=/',
+            'HttpOnly',
+            'SameSite=Lax',
+            'Max-Age=' . $maxAge,
+        ];
+
+        if ($secure) {
+            $parts[] = 'Secure';
+        }
+
+        return implode('; ', $parts);
+    }
+
+    /** A Set-Cookie value that immediately expires the session cookie. */
+    public static function clear(bool $secure): string
+    {
+        return self::build('', 0, $secure);
+    }
+
+    /** True when the request arrived over HTTPS (directly or via a trusted proxy). */
+    public static function isSecureRequest(ServerRequestInterface $request): bool
+    {
+        if (strtolower($request->getUri()->getScheme()) === 'https') {
+            return true;
+        }
+
+        return strtolower(trim($request->getHeaderLine('X-Forwarded-Proto'))) === 'https';
+    }
+}

--- a/tests/Auth/AdminApiAuthMiddlewareTest.php
+++ b/tests/Auth/AdminApiAuthMiddlewareTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Auth;
+
+use Nene2\Auth\TokenVerificationException;
+use Nene2\Auth\TokenVerifierInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use NeNeRecords\Auth\AdminApiAuthMiddleware;
+use NeNeRecords\Auth\SessionCookie;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class AdminApiAuthMiddlewareTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private AdminApiAuthMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new Psr17Factory();
+
+        $verifier = new class () implements TokenVerifierInterface {
+            /** @return array<string, mixed> */
+            public function verify(string $token): array
+            {
+                if ($token !== 'good') {
+                    throw new TokenVerificationException('Invalid token.');
+                }
+
+                return ['role' => 'admin', 'sub' => 'admin@example.com'];
+            }
+        };
+
+        $this->middleware = new AdminApiAuthMiddleware(
+            new ProblemDetailsResponseFactory($this->factory, $this->factory),
+            $verifier,
+        );
+    }
+
+    public function testBearerTokenStillAuthenticates(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('POST', 'https://example.test/api/v1/entities')
+            ->withHeader('Authorization', 'Bearer good');
+
+        self::assertSame(204, $this->middleware->process($request, $this->passThrough())->getStatusCode());
+    }
+
+    public function testCookieAuthenticatesSafeRequest(): void
+    {
+        // GET on an admin-only path is protected but needs no CSRF header.
+        $request = $this->factory
+            ->createServerRequest('GET', 'https://example.test/api/v1/users')
+            ->withCookieParams([SessionCookie::NAME => 'good']);
+
+        self::assertSame(204, $this->middleware->process($request, $this->passThrough())->getStatusCode());
+    }
+
+    public function testCookieMutationWithoutCustomHeaderIsRejectedAsCsrf(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('POST', 'https://example.test/api/v1/entities')
+            ->withCookieParams([SessionCookie::NAME => 'good']);
+
+        $response = $this->middleware->process($request, $this->passThrough());
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function testCookieMutationWithCustomHeaderPasses(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('POST', 'https://example.test/api/v1/entities')
+            ->withCookieParams([SessionCookie::NAME => 'good'])
+            ->withHeader('X-Requested-With', 'fetch');
+
+        self::assertSame(204, $this->middleware->process($request, $this->passThrough())->getStatusCode());
+    }
+
+    public function testMissingTokenReturns401(): void
+    {
+        $request = $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities');
+
+        self::assertSame(401, $this->middleware->process($request, $this->passThrough())->getStatusCode());
+    }
+
+    public function testInvalidTokenReturns401(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('POST', 'https://example.test/api/v1/entities')
+            ->withCookieParams([SessionCookie::NAME => 'bad'])
+            ->withHeader('X-Requested-With', 'fetch');
+
+        self::assertSame(401, $this->middleware->process($request, $this->passThrough())->getStatusCode());
+    }
+
+    private function passThrough(): RequestHandlerInterface
+    {
+        return new class () implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): \Psr\Http\Message\ResponseInterface
+            {
+                return new Response(204);
+            }
+        };
+    }
+}

--- a/tests/Auth/SessionCookieTest.php
+++ b/tests/Auth/SessionCookieTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Auth;
+
+use NeNeRecords\Auth\SessionCookie;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class SessionCookieTest extends TestCase
+{
+    public function testBuildSetsHttpOnlyLaxAndMaxAge(): void
+    {
+        $cookie = SessionCookie::build('tok', 3600, false);
+
+        self::assertStringContainsString('nene_session=tok', $cookie);
+        self::assertStringContainsString('HttpOnly', $cookie);
+        self::assertStringContainsString('SameSite=Lax', $cookie);
+        self::assertStringContainsString('Max-Age=3600', $cookie);
+        self::assertStringNotContainsString('Secure', $cookie);
+    }
+
+    public function testBuildAddsSecureOverHttps(): void
+    {
+        self::assertStringContainsString('Secure', SessionCookie::build('tok', 3600, true));
+    }
+
+    public function testClearExpiresImmediately(): void
+    {
+        self::assertStringContainsString('Max-Age=0', SessionCookie::clear(false));
+    }
+
+    public function testNegativeMaxAgeIsClampedToZero(): void
+    {
+        self::assertStringContainsString('Max-Age=0', SessionCookie::build('tok', -10, false));
+    }
+
+    public function testIsSecureRequestDetectsForwardedProto(): void
+    {
+        $factory = new Psr17Factory();
+        $http = $factory->createServerRequest('GET', 'http://example.test/');
+        $forwarded = $http->withHeader('X-Forwarded-Proto', 'https');
+
+        self::assertFalse(SessionCookie::isSecureRequest($http));
+        self::assertTrue(SessionCookie::isSecureRequest($forwarded));
+    }
+}

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -14,22 +14,22 @@
  *  - mockOrganizations() stubs GET /api/v1/organizations
  */
 
-import type { Page } from '@playwright/test';
+import type { Page } from "@playwright/test";
 import {
   ADMIN_TOKEN,
   DEFAULT_LOGIN_RESPONSE,
   ENTITY_TYPE_LIST_EMPTY,
   DASHBOARD_EMPTY,
-} from './api-mocks.js';
+} from "./api-mocks.js";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-export const BASE_URL = 'http://localhost:4173';
-export const LOGIN_URL = '/login';
-export const ADMIN_URL = '/admin';
-export const SUPERADMIN_URL = '/superadmin';
-/** localStorage key used by authStore */
-export const AUTH_STORAGE_KEY = 'nene_records_token';
+export const BASE_URL = "http://localhost:4173";
+export const LOGIN_URL = "/login";
+export const ADMIN_URL = "/admin";
+export const SUPERADMIN_URL = "/superadmin";
+/** localStorage key used by authStore (non-secret profile; token is an HttpOnly cookie) */
+export const AUTH_STORAGE_KEY = "nene_records_session";
 
 // ── Auth helpers ──────────────────────────────────────────────────────────────
 
@@ -40,11 +40,11 @@ export async function mockLoginEndpoint(
   page: Page,
   response: object = DEFAULT_LOGIN_RESPONSE,
 ): Promise<void> {
-  await page.route('**/api/v1/auth/login', (route) => {
-    if (route.request().method() === 'POST') {
+  await page.route("**/api/v1/auth/login", (route) => {
+    if (route.request().method() === "POST") {
       return route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(response),
       });
     }
@@ -65,20 +65,24 @@ export async function bypassLogin(
     entityTypes?: object;
   } = {},
 ): Promise<void> {
+  // Non-secret profile only; the real token would be an HttpOnly cookie. E2E
+  // specs mock the API, so no cookie is needed to satisfy authStore.
   const session: Record<string, unknown> = {
-    token: ADMIN_TOKEN,
-    expiresAt: '2099-01-01T00:00:00Z',
-    email: options.email ?? 'admin@example.com',
-    role: options.role ?? 'admin',
+    expiresAt: "2099-01-01T00:00:00Z",
+    email: options.email ?? "admin@example.com",
+    role: options.role ?? "admin",
   };
 
   // org_id を明示的に指定した場合のみセッションに含める（multi-tenancy テスト用）
-  if ('orgId' in options) {
-    session['orgId'] = options.orgId ?? null;
+  if ("orgId" in options) {
+    session["orgId"] = options.orgId ?? null;
   }
 
   // Mock entity-types list (used by sidebar in AppShell)
-  await mockEntityTypesEndpoint(page, options.entityTypes ?? ENTITY_TYPE_LIST_EMPTY);
+  await mockEntityTypesEndpoint(
+    page,
+    options.entityTypes ?? ENTITY_TYPE_LIST_EMPTY,
+  );
 
   // Navigate to set localStorage on the right origin
   await page.goto(BASE_URL);
@@ -93,18 +97,18 @@ export async function bypassLogin(
 /**
  * Navigate to the admin panel with auth already injected.
  */
-export async function gotoAdmin(page: Page, path = ''): Promise<void> {
+export async function gotoAdmin(page: Page, path = ""): Promise<void> {
   await page.goto(`${ADMIN_URL}${path}`);
   // Wait for the page to settle (React renders)
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState("networkidle");
 }
 
 /**
  * Navigate to the superadmin panel with auth already injected.
  */
-export async function gotoSuperadmin(page: Page, path = ''): Promise<void> {
+export async function gotoSuperadmin(page: Page, path = ""): Promise<void> {
   await page.goto(`${SUPERADMIN_URL}${path}`);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState("networkidle");
 }
 
 /**
@@ -112,8 +116,8 @@ export async function gotoSuperadmin(page: Page, path = ''): Promise<void> {
  */
 export async function loginAs(
   page: Page,
-  email = 'admin@example.com',
-  password = 'password',
+  email = "admin@example.com",
+  password = "password",
 ): Promise<void> {
   await page.goto(LOGIN_URL);
   await page.locator('input[type="email"]').fill(email);
@@ -125,12 +129,15 @@ export async function loginAs(
 
 // ── API mock helpers ───────────────────────────────────────────────────────────
 
-export async function mockEntityTypesEndpoint(page: Page, response: object): Promise<void> {
-  await page.route('**/api/v1/entity-types**', (route) => {
-    if (route.request().method() === 'GET') {
+export async function mockEntityTypesEndpoint(
+  page: Page,
+  response: object,
+): Promise<void> {
+  await page.route("**/api/v1/entity-types**", (route) => {
+    if (route.request().method() === "GET") {
       return route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(response),
       });
     }
@@ -138,12 +145,15 @@ export async function mockEntityTypesEndpoint(page: Page, response: object): Pro
   });
 }
 
-export async function mockDashboard(page: Page, response: object = DASHBOARD_EMPTY): Promise<void> {
-  await page.route('**/api/v1/dashboard', (route) => {
-    if (route.request().method() === 'GET') {
+export async function mockDashboard(
+  page: Page,
+  response: object = DASHBOARD_EMPTY,
+): Promise<void> {
+  await page.route("**/api/v1/dashboard", (route) => {
+    if (route.request().method() === "GET") {
       return route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(response),
       });
     }
@@ -151,12 +161,15 @@ export async function mockDashboard(page: Page, response: object = DASHBOARD_EMP
   });
 }
 
-export async function mockTagsEndpoint(page: Page, response: object): Promise<void> {
-  await page.route('**/api/v1/tags**', (route) => {
-    if (route.request().method() === 'GET') {
+export async function mockTagsEndpoint(
+  page: Page,
+  response: object,
+): Promise<void> {
+  await page.route("**/api/v1/tags**", (route) => {
+    if (route.request().method() === "GET") {
       return route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(response),
       });
     }
@@ -164,12 +177,15 @@ export async function mockTagsEndpoint(page: Page, response: object): Promise<vo
   });
 }
 
-export async function mockUsersEndpoint(page: Page, response: object): Promise<void> {
-  await page.route('**/api/v1/users**', (route) => {
-    if (route.request().method() === 'GET') {
+export async function mockUsersEndpoint(
+  page: Page,
+  response: object,
+): Promise<void> {
+  await page.route("**/api/v1/users**", (route) => {
+    if (route.request().method() === "GET") {
       return route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(response),
       });
     }
@@ -177,12 +193,15 @@ export async function mockUsersEndpoint(page: Page, response: object): Promise<v
   });
 }
 
-export async function mockOrganizationsEndpoint(page: Page, response: object): Promise<void> {
-  await page.route('**/api/v1/organizations**', (route) => {
-    if (route.request().method() === 'GET') {
+export async function mockOrganizationsEndpoint(
+  page: Page,
+  response: object,
+): Promise<void> {
+  await page.route("**/api/v1/organizations**", (route) => {
+    if (route.request().method() === "GET") {
       return route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(response),
       });
     }

--- a/tests/e2e/specs/16-auth-lifecycle.spec.ts
+++ b/tests/e2e/specs/16-auth-lifecycle.spec.ts
@@ -21,27 +21,27 @@
  *  - POST request also carries Authorization Bearer (not just GETs)
  */
 
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 import {
   bypassLogin,
   gotoAdmin,
   gotoSuperadmin,
   mockEntityTypesEndpoint,
-} from '../fixtures/helpers.js';
+} from "../fixtures/helpers.js";
 import {
   ADMIN_TOKEN,
   ENTITY_TYPE_LIST_EMPTY,
   ENTITY_TYPE_CREATED,
   TAG_LIST_EMPTY,
   USER_LIST_EMPTY,
-} from '../fixtures/api-mocks.js';
+} from "../fixtures/api-mocks.js";
 
 /** localStorage key used by authStore (mirrors helpers.ts AUTH_STORAGE_KEY) */
-const AUTH_KEY = 'nene_records_token';
+const AUTH_KEY = "nene_records_session";
 
 /** Injects a session directly into localStorage, bypassing bypassLogin helper. */
 async function injectSession(
-  page: import('@playwright/test').Page,
+  page: import("@playwright/test").Page,
   session: {
     token: string;
     expiresAt: string;
@@ -57,32 +57,34 @@ async function injectSession(
   );
 }
 
-test.describe('Auth Lifecycle', () => {
+test.describe("Auth Lifecycle", () => {
   // ── 16-01: Authorization Bearer forwarded on every entity-types GET ────────
 
-  test('16-01: Authorization Bearer header present on every entity-types GET after bypassLogin', async ({ page }) => {
+  test("16-01: CSRF header (X-Requested-With) present on every entity-types GET after bypassLogin", async ({
+    page,
+  }) => {
     await bypassLogin(page);
 
     const capturedAuthHeaders: string[] = [];
 
     // Register AFTER bypassLogin so this handler wins (LIFO priority)
-    await page.route('**/api/v1/entity-types**', (route) => {
-      const auth = route.request().headers()['authorization'] ?? '';
+    await page.route("**/api/v1/entity-types**", (route) => {
+      const auth = route.request().headers()["x-requested-with"] ?? "";
       capturedAuthHeaders.push(auth);
       return route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(ENTITY_TYPE_LIST_EMPTY),
       });
     });
 
-    await gotoAdmin(page, '/entity-types');
+    await gotoAdmin(page, "/entity-types");
 
     // At least the sidebar GET and the page GET were captured
     expect(capturedAuthHeaders.length).toBeGreaterThanOrEqual(1);
 
     // Every captured request must carry the exact Bearer token
-    const expected = `Bearer ${ADMIN_TOKEN}`;
+    const expected = "fetch";
     for (const h of capturedAuthHeaders) {
       expect(h).toBe(expected);
     }
@@ -90,18 +92,32 @@ test.describe('Auth Lifecycle', () => {
 
   // ── 16-02: Token persists in localStorage across 3 page navigations ────────
 
-  test('16-02: auth token persists in localStorage after navigating entity-types → tags → users', async ({ page }) => {
+  test("16-02: auth token persists in localStorage after navigating entity-types → tags → users", async ({
+    page,
+  }) => {
     await bypassLogin(page);
 
     // Stub all three endpoints
-    await page.route('**/api/v1/entity-types**', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ENTITY_TYPE_LIST_EMPTY) }),
+    await page.route("**/api/v1/entity-types**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(ENTITY_TYPE_LIST_EMPTY),
+      }),
     );
-    await page.route('**/api/v1/tags**', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(TAG_LIST_EMPTY) }),
+    await page.route("**/api/v1/tags**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(TAG_LIST_EMPTY),
+      }),
     );
-    await page.route('**/api/v1/users**', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(USER_LIST_EMPTY) }),
+    await page.route("**/api/v1/users**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(USER_LIST_EMPTY),
+      }),
     );
 
     const readToken = async () =>
@@ -112,33 +128,39 @@ test.describe('Auth Lifecycle', () => {
     expect(tokenInitial).not.toBeNull();
 
     // Navigate to entity-types
-    await gotoAdmin(page, '/entity-types');
+    await gotoAdmin(page, "/entity-types");
     const tokenAfterNav1 = await readToken();
     expect(tokenAfterNav1).toBe(tokenInitial);
 
     // Navigate to tags
-    await gotoAdmin(page, '/tags');
+    await gotoAdmin(page, "/tags");
     const tokenAfterNav2 = await readToken();
     expect(tokenAfterNav2).toBe(tokenInitial);
 
     // Navigate to users
-    await gotoAdmin(page, '/users');
+    await gotoAdmin(page, "/users");
     const tokenAfterNav3 = await readToken();
     expect(tokenAfterNav3).toBe(tokenInitial);
   });
 
   // ── 16-03: localStorage cleared → RequireAuth redirects to /login ─────────
 
-  test('16-03: localStorage cleared → navigating to /admin redirects to /login', async ({ page }) => {
+  test("16-03: localStorage cleared → navigating to /admin redirects to /login", async ({
+    page,
+  }) => {
     await bypassLogin(page);
 
-    await page.route('**/api/v1/entity-types**', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ENTITY_TYPE_LIST_EMPTY) }),
+    await page.route("**/api/v1/entity-types**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(ENTITY_TYPE_LIST_EMPTY),
+      }),
     );
 
     // Verify admin page loads while token present
-    await gotoAdmin(page, '/entity-types');
-    await expect(page.locator('h1')).toBeVisible({ timeout: 6000 });
+    await gotoAdmin(page, "/entity-types");
+    await expect(page.locator("h1")).toBeVisible({ timeout: 6000 });
 
     // Clear localStorage
     await page.evaluate((key) => {
@@ -146,136 +168,180 @@ test.describe('Auth Lifecycle', () => {
     }, AUTH_KEY);
 
     // Navigate to admin — RequireAuth fires and redirects to /login
-    await page.goto('http://localhost:4173/admin');
+    await page.goto("http://localhost:4173/admin");
     await expect(page).toHaveURL(/\/login/, { timeout: 6000 });
   });
 
   // ── 16-04: Session data stored before first gotoAdmin API call ─────────────
 
-  test('16-04: token stored in localStorage before first gotoAdmin call', async ({ page }) => {
+  test("16-04: token stored in localStorage before first gotoAdmin call", async ({
+    page,
+  }) => {
     // bypassLogin sets localStorage before gotoAdmin navigates
     await bypassLogin(page);
 
     // Check localStorage BEFORE calling gotoAdmin
-    const raw = await page.evaluate((key) => localStorage.getItem(key), AUTH_KEY);
+    const raw = await page.evaluate(
+      (key) => localStorage.getItem(key),
+      AUTH_KEY,
+    );
     expect(raw).not.toBeNull();
 
-    const session = JSON.parse(raw!) as { token: string; role: string; email: string };
-    expect(session.token).toBe(ADMIN_TOKEN);
-    expect(session.email).toBe('admin@example.com');
+    const session = JSON.parse(raw!) as Record<string, unknown>;
+    expect(session["email"]).toBe("admin@example.com");
+    // The token is an HttpOnly cookie, never stored in JS.
+    expect("token" in session).toBe(false);
   });
 
   // ── 16-05: Correct role stored in localStorage after bypassLogin ───────────
 
-  test('16-05: bypassLogin with editor role → role="editor" stored in localStorage', async ({ page }) => {
-    await bypassLogin(page, { role: 'editor', email: 'editor@example.com' });
+  test('16-05: bypassLogin with editor role → role="editor" stored in localStorage', async ({
+    page,
+  }) => {
+    await bypassLogin(page, { role: "editor", email: "editor@example.com" });
 
-    const raw = await page.evaluate((key) => localStorage.getItem(key), AUTH_KEY);
+    const raw = await page.evaluate(
+      (key) => localStorage.getItem(key),
+      AUTH_KEY,
+    );
     expect(raw).not.toBeNull();
 
-    const session = JSON.parse(raw!) as { token: string; role: string; email: string };
-    expect(session.role).toBe('editor');
-    expect(session.email).toBe('editor@example.com');
-    expect(session.token).toBe(ADMIN_TOKEN);
+    const session = JSON.parse(raw!) as Record<string, unknown>;
+    expect(session["role"]).toBe("editor");
+    expect(session["email"]).toBe("editor@example.com");
   });
 
   // ── 16-06: Expired token → RequireAuth redirects to /login ────────────────
 
-  test('16-06: expired token in localStorage → RequireAuth redirects to /login', async ({ page }) => {
+  test("16-06: expired token in localStorage → RequireAuth redirects to /login", async ({
+    page,
+  }) => {
     // Navigate to base origin first so we can set localStorage
-    await page.goto('http://localhost:4173');
+    await page.goto("http://localhost:4173");
 
     // Inject an expired session
     await injectSession(page, {
-      token: 'expired-token-xyz',
-      expiresAt: '2020-01-01T00:00:00Z', // well in the past
-      email: 'admin@example.com',
-      role: 'admin',
+      token: "expired-token-xyz",
+      expiresAt: "2020-01-01T00:00:00Z", // well in the past
+      email: "admin@example.com",
+      role: "admin",
     });
 
     // Navigate to admin — authStore.isAuthenticated() returns false (expired) → redirect
-    await page.goto('http://localhost:4173/admin');
+    await page.goto("http://localhost:4173/admin");
     await expect(page).toHaveURL(/\/login/, { timeout: 6000 });
   });
 
   // ── 16-07: Role switch admin → editor — editor sees no create form ─────────
 
-  test('16-07: switch from admin to editor role in localStorage → entity types create form disappears', async ({ page }) => {
+  test("16-07: switch from admin to editor role in localStorage → entity types create form disappears", async ({
+    page,
+  }) => {
     // ── Step 1: admin — create form visible ─────────────────────────────
-    await bypassLogin(page, { role: 'admin' });
+    await bypassLogin(page, { role: "admin" });
 
-    await page.route('**/api/v1/entity-types**', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ENTITY_TYPE_LIST_EMPTY) }),
+    await page.route("**/api/v1/entity-types**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(ENTITY_TYPE_LIST_EMPTY),
+      }),
     );
 
-    await gotoAdmin(page, '/entity-types');
-    await expect(page.locator('input[id="entity-type-name"]')).toBeVisible({ timeout: 6000 });
+    await gotoAdmin(page, "/entity-types");
+    await expect(page.locator('input[id="entity-type-name"]')).toBeVisible({
+      timeout: 6000,
+    });
 
     // ── Step 2: overwrite session with editor role ───────────────────────
     await injectSession(page, {
       token: ADMIN_TOKEN,
-      expiresAt: '2099-01-01T00:00:00Z',
-      email: 'editor@example.com',
-      role: 'editor',
+      expiresAt: "2099-01-01T00:00:00Z",
+      email: "editor@example.com",
+      role: "editor",
     });
 
     // Re-navigate so the app re-reads localStorage
-    await gotoAdmin(page, '/entity-types');
+    await gotoAdmin(page, "/entity-types");
 
     // Editor does not have manage_schema capability → no create form
-    await expect(page.locator('input[id="entity-type-name"]')).not.toBeVisible({ timeout: 6000 });
+    await expect(page.locator('input[id="entity-type-name"]')).not.toBeVisible({
+      timeout: 6000,
+    });
   });
 
   // ── 16-08: 401 API response → client clears session → redirect to /login ──
 
-  test('16-08: GET /entity-types returns 401 → authStore cleared → redirected to /login', async ({ page }) => {
+  test("16-08: GET /entity-types returns 401 → authStore cleared → redirected to /login", async ({
+    page,
+  }) => {
     await bypassLogin(page);
 
     // Register 401 handler AFTER bypassLogin (takes priority)
-    await page.route('**/api/v1/entity-types**', (route) =>
+    await page.route("**/api/v1/entity-types**", (route) =>
       route.fulfill({
         status: 401,
-        contentType: 'application/json',
-        body: JSON.stringify({ type: 'about:blank', title: 'Unauthorized', status: 401, detail: 'Token expired', instance: '/api/v1/entity-types' }),
+        contentType: "application/json",
+        body: JSON.stringify({
+          type: "about:blank",
+          title: "Unauthorized",
+          status: 401,
+          detail: "Token expired",
+          instance: "/api/v1/entity-types",
+        }),
       }),
     );
 
     // Navigate — RequireAuth passes (token valid), then sidebar GET → 401 → window.location.href = '/login'
-    await page.goto('http://localhost:4173/admin/entity-types');
+    await page.goto("http://localhost:4173/admin/entity-types");
 
     await expect(page).toHaveURL(/\/login/, { timeout: 10000 });
   });
 
   // ── 16-09: Multiple pages visited — every API request carries Authorization ─
 
-  test('16-09: visiting entity-types, tags, and users sequentially — all requests have Authorization header', async ({ page }) => {
+  test("16-09: visiting entity-types, tags, and users sequentially — all requests have Authorization header", async ({
+    page,
+  }) => {
     await bypassLogin(page);
 
     const capturedHeaders: string[] = [];
 
     // Register capture handlers AFTER bypassLogin (LIFO: higher priority)
-    await page.route('**/api/v1/entity-types**', (route) => {
-      capturedHeaders.push(route.request().headers()['authorization'] ?? '');
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ENTITY_TYPE_LIST_EMPTY) });
+    await page.route("**/api/v1/entity-types**", (route) => {
+      capturedHeaders.push(route.request().headers()["x-requested-with"] ?? "");
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(ENTITY_TYPE_LIST_EMPTY),
+      });
     });
-    await page.route('**/api/v1/tags**', (route) => {
-      capturedHeaders.push(route.request().headers()['authorization'] ?? '');
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(TAG_LIST_EMPTY) });
+    await page.route("**/api/v1/tags**", (route) => {
+      capturedHeaders.push(route.request().headers()["x-requested-with"] ?? "");
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(TAG_LIST_EMPTY),
+      });
     });
-    await page.route('**/api/v1/users**', (route) => {
-      capturedHeaders.push(route.request().headers()['authorization'] ?? '');
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(USER_LIST_EMPTY) });
+    await page.route("**/api/v1/users**", (route) => {
+      capturedHeaders.push(route.request().headers()["x-requested-with"] ?? "");
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(USER_LIST_EMPTY),
+      });
     });
 
-    await gotoAdmin(page, '/entity-types');
-    await gotoAdmin(page, '/tags');
-    await gotoAdmin(page, '/users');
+    await gotoAdmin(page, "/entity-types");
+    await gotoAdmin(page, "/tags");
+    await gotoAdmin(page, "/users");
 
     // Captured at least 3 headers (one per page-specific endpoint)
     expect(capturedHeaders.length).toBeGreaterThanOrEqual(3);
 
     // Every captured header must be the exact Bearer token
-    const expected = `Bearer ${ADMIN_TOKEN}`;
+    const expected = "fetch";
     for (const h of capturedHeaders) {
       expect(h).toBe(expected);
     }
@@ -283,46 +349,50 @@ test.describe('Auth Lifecycle', () => {
 
   // ── 16-10: POST request also carries Authorization Bearer ──────────────────
 
-  test('16-10: POST /entity-types carries Authorization Bearer token (not just GETs)', async ({ page }) => {
+  test("16-10: POST /entity-types carries the CSRF header (not just GETs)", async ({
+    page,
+  }) => {
     await bypassLogin(page);
 
     let postAuthHeader: string | undefined;
     let getAuthHeader: string | undefined;
 
-    await page.route('**/api/v1/entity-types**', (route) => {
+    await page.route("**/api/v1/entity-types**", (route) => {
       const method = route.request().method();
-      const auth = route.request().headers()['authorization'] ?? '';
+      const auth = route.request().headers()["x-requested-with"] ?? "";
 
-      if (method === 'POST') {
+      if (method === "POST") {
         postAuthHeader = auth;
         return route.fulfill({
           status: 201,
-          contentType: 'application/json',
+          contentType: "application/json",
           body: JSON.stringify(ENTITY_TYPE_CREATED),
         });
       }
-      if (method === 'GET') {
+      if (method === "GET") {
         getAuthHeader = auth;
         return route.fulfill({
           status: 200,
-          contentType: 'application/json',
+          contentType: "application/json",
           body: JSON.stringify(ENTITY_TYPE_LIST_EMPTY),
         });
       }
       return route.continue();
     });
 
-    await gotoAdmin(page, '/entity-types');
+    await gotoAdmin(page, "/entity-types");
 
     // Fill and submit the create form
-    await page.locator('input[id="entity-type-name"]').fill('TestType');
-    await page.locator('input[id="entity-type-slug"]').fill('testtype');
+    await page.locator('input[id="entity-type-name"]').fill("TestType");
+    await page.locator('input[id="entity-type-slug"]').fill("testtype");
     await page.locator('button:has-text("Create content type")').click();
 
     // Wait for the POST to complete (form resets)
-    await expect(page.locator('input[id="entity-type-name"]')).toHaveValue('', { timeout: 6000 });
+    await expect(page.locator('input[id="entity-type-name"]')).toHaveValue("", {
+      timeout: 6000,
+    });
 
-    const expected = `Bearer ${ADMIN_TOKEN}`;
+    const expected = "fetch";
     expect(getAuthHeader).toBe(expected);
     expect(postAuthHeader).toBe(expected);
   });


### PR DESCRIPTION
## 目的 / Why

トークンが `localStorage` にあると、同一オリジンで動く任意 JS が読み出してアカウント乗っ取りできる。#311（Custom Page：サンドボックスで JS を受け入れる）の**前提となる多層防御**として、トークンを **httpOnly Cookie** に移し JS から到達不能にする。

## 変更内容 / What

### Backend
- ログイン成功時に `Set-Cookie`（`HttpOnly` / `SameSite=Lax` / `Secure`(https時) / `Max-Age`）を付与（`SessionCookie` ヘルパー）。`token` は非ブラウザ/マシン用に body でも継続返却。
- `POST /api/v1/auth/logout`：Cookie を失効（`LogoutHandler`）。`/api/v1/auth/*` は常時オープン。
- `AdminApiAuthMiddleware`：`Authorization: Bearer` 無し時は **Cookie** からトークンを読む（Bearer はマシン/MCP 用に維持）。
- **CSRF**：Cookie 認証の状態変更リクエスト（POST/PUT/PATCH/DELETE）に **`X-Requested-With` ヘッダを必須**化。無ければ 403。（クロスサイトのフォームは送れず、CORS プリフライトで防がれる）

### Frontend
- `authStore`：トークンを保存せず**非機密プロフィール（email/role/expiresAt）のみ**保持。`getToken` 廃止、storage キーを `nene_records_session` に。
- `apiClient`：`Authorization` 付与を廃止し Cookie（`credentials:'include'`）に依存。全リクエストに `X-Requested-With: fetch` を付与。
- ログアウトは `useLogout`（新 endpoint 呼出→プロフィールクリア）。
- OpenAPI に logout 追加＋型再生成。

### CSRF 方式
SameSite=Lax ＋ カスタムヘッダ必須（owner 確定）。

## 受け入れ条件 / Acceptance
- ログイン後トークンは httpOnly Cookie に入り **JS（localStorage）から読めない** ✓
- Cookie で API 認証が通り、Bearer（マシン）も維持、ログアウトで失効 ✓
- CSRF 対策（X-Requested-With 必須）が有効 ✓

## 検証 / Verification
- `composer check`: **PHPUnit 661** / PHPStan L8 / CS-Fixer / OpenAPI / MCP 全グリーン
- `npm run check --prefix frontend`: type-check / lint / prettier / **129 tests** / knip / storybook 全グリーン
- 新規テスト: `SessionCookie`（5）、`AdminApiAuthMiddleware`（Bearer維持 / Cookie認証 / CSRF拒否 / カスタムヘッダ通過 / 401）。E2E（16-auth-lifecycle / helpers）を Cookie 方式へ改修。

> 注: Playwright E2E はゲート CI 外のため本環境では実行未確認。実機での E2E 再走を推奨。

## 関連
- #311 Custom Page（本改修が前提）

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)