### PR TITLE
feat(page): Custom Page 3B — iframe 自動高さ(postMessage) + SEOテキスト必須 (#318)

### DIFF
--- a/frontend/src/shared/ui/html/SandboxedBundle.test.tsx
+++ b/frontend/src/shared/ui/html/SandboxedBundle.test.tsx
@@ -18,10 +18,12 @@ describe('SandboxedBundle', () => {
     expect(sandbox).not.toContain('allow-same-origin')
   })
 
-  it('passes the raw html through srcdoc (no sanitization)', () => {
+  it('passes the raw html through srcdoc (no sanitization) and injects the height reporter', () => {
     const html = '<h1>Hi</h1><script>window.x=1</script>'
     const { container } = render(<SandboxedBundle html={html} />)
-    expect(container.querySelector('iframe')?.getAttribute('srcdoc')).toBe(html)
+    const srcdoc = container.querySelector('iframe')?.getAttribute('srcdoc') ?? ''
+    expect(srcdoc).toContain(html)
+    expect(srcdoc).toContain('nene:bundle-height')
   })
 
   it('renders nothing for empty input', () => {

--- a/frontend/src/shared/ui/html/SandboxedBundle.tsx
+++ b/frontend/src/shared/ui/html/SandboxedBundle.tsx
@@ -1,8 +1,36 @@
+import { useEffect, useRef, useState } from 'react'
+
 export interface SandboxedBundleProps {
   /** A full HTML document (may include <style> and <script>). */
   html: string
   className?: string
   title?: string
+}
+
+const HEIGHT_MESSAGE_TYPE = 'nene:bundle-height'
+const INITIAL_HEIGHT = 400
+const MAX_HEIGHT = 20000
+
+/**
+ * Script injected into the iframe document so it reports its content height to
+ * the parent. Authors don't need to add anything — we append this to their
+ * bundle. It posts to the opaque-origin parent via postMessage (which works
+ * cross-origin); the parent validates the source before trusting it.
+ */
+const HEIGHT_REPORTER = `<script>(function(){function r(){try{parent.postMessage({type:'${HEIGHT_MESSAGE_TYPE}',height:document.documentElement.scrollHeight},'*');}catch(e){}}window.addEventListener('load',r);if(window.ResizeObserver){new ResizeObserver(r).observe(document.documentElement);}else{window.addEventListener('resize',r);}r();})();</script>`
+
+function readReportedHeight(event: MessageEvent): number | null {
+  const data: unknown = event.data
+  if (typeof data !== 'object' || data === null) {
+    return null
+  }
+  const record = data as Record<string, unknown>
+  if (record['type'] !== HEIGHT_MESSAGE_TYPE) {
+    return null
+  }
+  const raw = record['height']
+  const height = typeof raw === 'number' ? raw : Number(raw)
+  return Number.isFinite(height) && height > 0 ? height : null
 }
 
 /**
@@ -14,25 +42,49 @@ export interface SandboxedBundleProps {
  * safe to accept arbitrary HTML/JS/CSS (e.g. from an external design tool) — the
  * isolation, not sanitization, is the security boundary.
  *
- * Auto-height (postMessage) and richer data binding are intentionally out of
- * scope here; a fixed min-height is used.
+ * The iframe auto-resizes to its content height via a postMessage handshake
+ * (see HEIGHT_REPORTER); the parent only trusts messages from this iframe's
+ * own window.
  */
 export function SandboxedBundle({
   html,
   className,
   title = 'Custom content',
 }: SandboxedBundleProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const [height, setHeight] = useState(INITIAL_HEIGHT)
+
+  useEffect(() => {
+    function onMessage(event: MessageEvent): void {
+      const iframe = iframeRef.current
+      // Only trust height reports coming from this iframe's own window.
+      if (iframe === null || event.source !== iframe.contentWindow) {
+        return
+      }
+      const reported = readReportedHeight(event)
+      if (reported !== null) {
+        setHeight(Math.min(reported, MAX_HEIGHT))
+      }
+    }
+
+    window.addEventListener('message', onMessage)
+    return () => {
+      window.removeEventListener('message', onMessage)
+    }
+  }, [])
+
   if (html.trim() === '') {
     return null
   }
 
   return (
     <iframe
+      ref={iframeRef}
       title={title}
-      srcDoc={html}
+      srcDoc={`${html}${HEIGHT_REPORTER}`}
       sandbox="allow-scripts"
       loading="lazy"
-      style={{ height: 600 }}
+      style={{ height }}
       className={className ?? 'w-full border-0'}
     />
   )

--- a/src/Entity/UpdateEntityHandler.php
+++ b/src/Entity/UpdateEntityHandler.php
@@ -69,6 +69,13 @@ final readonly class UpdateEntityHandler
             $errors[] = new ValidationError('layout', 'Unknown layout.', 'invalid');
         }
 
+        // A custom-layout page renders most content inside a sandboxed iframe,
+        // which crawlers attribute weakly. Require a meta description so the page
+        // always carries crawlable text (the dual-representation contract).
+        if ($layout === 'custom' && $metaDescription === null) {
+            $errors[] = new ValidationError('meta_description', 'Custom layout pages require a meta description.', 'required');
+        }
+
         if ($errors !== []) {
             throw new ValidationException($errors);
         }

--- a/tests/Entity/EntityHttpTest.php
+++ b/tests/Entity/EntityHttpTest.php
@@ -135,6 +135,53 @@ final class EntityHttpTest extends TestCase
         self::assertSame(422, $response->getStatusCode());
     }
 
+    public function testUpdateCustomLayoutWithoutMetaDescriptionReturns422(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Page', slug: 'page'));
+        $created = $this->decodeJson($this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody(
+                $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR)),
+            ),
+        ));
+        $id = (int) $created['id'];
+
+        $body = $this->factory->createStream(json_encode([
+            'entity_type_id' => $typeId,
+            'status' => 'draft',
+            'layout' => 'custom',
+        ], JSON_THROW_ON_ERROR));
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('PUT', "https://example.test/api/v1/entities/{$id}")->withBody($body),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function testUpdateCustomLayoutWithMetaDescriptionSucceeds(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Page', slug: 'page'));
+        $created = $this->decodeJson($this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody(
+                $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR)),
+            ),
+        ));
+        $id = (int) $created['id'];
+
+        $body = $this->factory->createStream(json_encode([
+            'entity_type_id' => $typeId,
+            'status' => 'draft',
+            'layout' => 'custom',
+            'meta_description' => 'A crawlable description of the page.',
+        ], JSON_THROW_ON_ERROR));
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('PUT', "https://example.test/api/v1/entities/{$id}")->withBody($body),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('custom', $payload['layout']);
+    }
+
     public function testAfterDeleteGetEntityReturns404(): void
     {
         $typeId = $this->entityTypes->save(new EntityType(name: 'Thing', slug: 'thing'));


### PR DESCRIPTION
## 目的 / Why

3A の `bundle`（サンドボックス iframe）＋ `custom` レイアウトを実用化・契約遵守させる:
1. 固定 600px → **コンテンツに応じた自動高さ**。
2. 二層表現の契約を **enforce 可能な最小形**で担保。

## 変更内容 / What

### Frontend
- `SandboxedBundle`：srcdoc に**高さ通知スクリプトを注入**（作者のコードは無改変）。content 高さを `{ type: 'nene:bundle-height', height }` で親へ postMessage（load / ResizeObserver）。親は **`event.source === iframe.contentWindow` と型を検証**してから iframe を自動リサイズ（不透明オリジン隔離は維持・上限クランプ）。

### Backend
- `custom` レイアウトのエンティティは **meta_description 必須**（空なら 422）。サンドボックス iframe はクローラに弱く帰属するため、クロール用テキストの存在を強制（二層表現契約）。自動クローキング判定は対象外（運用/レビュー領域）。

## 受け入れ条件 / Acceptance
- bundle の iframe がコンテンツ高さに自動リサイズ（隔離維持）✓
- `custom` レイアウトのエンティティは meta_description 無しでは保存できない ✓

## 検証 / Verification
- `composer check`: **PHPUnit 665** / PHPStan L8 / CS-Fixer / OpenAPI / MCP 全グリーン
- `npm run check --prefix frontend`: type-check / lint / prettier / test / knip / storybook 全グリーン
- 新規テスト: `SandboxedBundle`（高さ通知の注入・srcdoc透過・空）、Entity HTTP（custom＋meta空→422／meta有→通過）

> 注: 実際のリサイズ挙動は実ブラウザ依存（jsdom ではスクリプト未実行）のため、静的部分をテスト。実機での確認を推奨。

## 後続
- 3C：ClaudeDesign 連携（スコープ資格情報＋OpenAPI/MCP 経由編集）。関連: #311

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)