### PR TITLE
feat(field): フィールド領域(region)・表示順の管理UXを仕上げる（#309 follow）(#320)

### DIFF
--- a/frontend/src/features/manage-field-defs/ui/FieldDefCreateForm.tsx
+++ b/frontend/src/features/manage-field-defs/ui/FieldDefCreateForm.tsx
@@ -106,6 +106,41 @@ export function FieldDefCreateForm({
             </div>
           )}
         />
+        <Controller
+          name="region"
+          control={control}
+          render={({ field }) => (
+            <Select
+              id="field-def-region"
+              label={t('admin.region.label')}
+              disabled={isSubmitting}
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+            >
+              <option value="main">{t('admin.region.main')}</option>
+              <option value="sidebar">{t('admin.region.sidebar')}</option>
+              <option value="aside">{t('admin.region.aside')}</option>
+            </Select>
+          )}
+        />
+        <Controller
+          name="displayOrder"
+          control={control}
+          render={({ field }) => (
+            <Input
+              id="field-def-order"
+              type="number"
+              label={t('admin.fieldDefs.displayOrder')}
+              disabled={isSubmitting}
+              value={String(field.value)}
+              onChange={(e) => {
+                field.onChange(Number(e.target.value) || 0)
+              }}
+              onBlur={field.onBlur}
+            />
+          )}
+        />
         {serverErrorTitle !== null ? <Text muted>{serverErrorTitle}</Text> : null}
         <Button
           type="submit"

--- a/frontend/src/features/manage-field-defs/ui/FieldDefListPanel.tsx
+++ b/frontend/src/features/manage-field-defs/ui/FieldDefListPanel.tsx
@@ -2,7 +2,14 @@ import type { FieldDef } from '@/entities/field-def'
 import { useTranslation } from '@/shared/i18n'
 import type { MessageKey } from '@/shared/i18n'
 import type { FieldDataType } from '@/entities/field-def'
+import type { ContentRegion } from '@/shared/lib/resolve-layout'
 import { Button, Card, EmptyState, ErrorState, LoadingState, Stack, Text } from '@/shared/ui'
+
+const REGION_LABEL_KEYS: Record<ContentRegion, MessageKey> = {
+  main: 'admin.region.main',
+  sidebar: 'admin.region.sidebar',
+  aside: 'admin.region.aside',
+}
 
 const DATA_TYPE_LABEL_KEYS: Record<FieldDataType, MessageKey> = {
   text: 'admin.fieldDefs.dataType.text',
@@ -80,6 +87,7 @@ export function FieldDefListPanel({
             </Text>
             <Text as="span" muted>
               {t(DATA_TYPE_LABEL_KEYS[item.dataType])}
+              {item.region !== null ? ` · ${t(REGION_LABEL_KEYS[item.region])}` : ''}
             </Text>
           </Stack>
           <div className="flex items-center gap-inline-sm">


### PR DESCRIPTION
## 目的 / Why

#309（2/3カラム＋フィールド領域配置）で、**編集フォームのみ** region/表示順 UI を入れていた。作成フォームと一覧表示が未対応で、カラム機能の管理UXが途中だった。

## 変更内容 / What
- `FieldDefCreateForm`：**region セレクト＋表示順 Input** を追加（作成時に領域・順序を指定可能）。
- `FieldDefListPanel`：各フィールドに割り当て領域（sidebar/aside）を表示（main は既定なので省略）。

## 受け入れ条件 / Acceptance
- フィールド作成時に領域・表示順を指定できる ✓
- 一覧で各フィールドの領域が分かる ✓

## 検証 / Verification
- `npm run check --prefix frontend`: type-check / lint / prettier / test / knip / storybook 全グリーン
- フロントのみ（region/display_order は #309 で API 実装済み）

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)