### PR TITLE
fix(page): custom レイアウト変更でステータス更新失敗（meta必須を公開時のみに限定）(#322)

### DIFF
--- a/frontend/src/features/manage-entity-status/hooks/useEntityStatusPanel.ts
+++ b/frontend/src/features/manage-entity-status/hooks/useEntityStatusPanel.ts
@@ -11,6 +11,19 @@ import { useTranslation } from '@/shared/i18n'
 import type { PublicLayoutKey } from '@/shared/lib/resolve-layout'
 import { useToast } from '@/shared/ui'
 
+/** Prefer the server's validation message (e.g. "meta description required") over a generic toast. */
+function serverMessage(error: unknown, fallback: string): string {
+  if (typeof error === 'object' && error !== null) {
+    const e = error as {
+      errors?: ReadonlyArray<{ message?: string }>
+      detail?: string
+      title?: string
+    }
+    return e.errors?.[0]?.message ?? e.detail ?? e.title ?? fallback
+  }
+  return fallback
+}
+
 export interface EntityStatusPanelState {
   entity: Entity
   entityTypeSlug?: string
@@ -69,8 +82,8 @@ export function useEntityStatusPanel(
         // Preserve layout: the update endpoint is full-replace.
         layout: entity.layout,
       })
-    } catch {
-      showToast(t('admin.entityStatus.updateError'), 'error')
+    } catch (e) {
+      showToast(serverMessage(e, t('admin.entityStatus.updateError')), 'error')
     }
   }
 
@@ -101,8 +114,8 @@ export function useEntityStatusPanel(
         layout: nextLayout,
       })
       showToast(t('admin.entityStatus.layoutSaved'), 'success')
-    } catch {
-      showToast(t('admin.entityStatus.updateError'), 'error')
+    } catch (e) {
+      showToast(serverMessage(e, t('admin.entityStatus.updateError')), 'error')
     }
   }
 

--- a/src/Entity/UpdateEntityHandler.php
+++ b/src/Entity/UpdateEntityHandler.php
@@ -70,10 +70,11 @@ final readonly class UpdateEntityHandler
         }
 
         // A custom-layout page renders most content inside a sandboxed iframe,
-        // which crawlers attribute weakly. Require a meta description so the page
-        // always carries crawlable text (the dual-representation contract).
-        if ($layout === 'custom' && $metaDescription === null) {
-            $errors[] = new ValidationError('meta_description', 'Custom layout pages require a meta description.', 'required');
+        // which crawlers attribute weakly. Require a meta description so the
+        // *published* page always carries crawlable text (the dual-representation
+        // contract). Drafts are not crawled, so they may omit it while authoring.
+        if ($status === EntityStatus::Published && $layout === 'custom' && $metaDescription === null) {
+            $errors[] = new ValidationError('meta_description', 'Custom layout pages require a meta description before publishing.', 'required');
         }
 
         if ($errors !== []) {

--- a/tests/Entity/EntityHttpTest.php
+++ b/tests/Entity/EntityHttpTest.php
@@ -135,7 +135,29 @@ final class EntityHttpTest extends TestCase
         self::assertSame(422, $response->getStatusCode());
     }
 
-    public function testUpdateCustomLayoutWithoutMetaDescriptionReturns422(): void
+    public function testPublishingCustomLayoutWithoutMetaDescriptionReturns422(): void
+    {
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Page', slug: 'page'));
+        $created = $this->decodeJson($this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody(
+                $this->factory->createStream(json_encode(['entity_type_id' => $typeId], JSON_THROW_ON_ERROR)),
+            ),
+        ));
+        $id = (int) $created['id'];
+
+        $body = $this->factory->createStream(json_encode([
+            'entity_type_id' => $typeId,
+            'status' => 'published',
+            'layout' => 'custom',
+        ], JSON_THROW_ON_ERROR));
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('PUT', "https://example.test/api/v1/entities/{$id}")->withBody($body),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function testDraftCustomLayoutWithoutMetaDescriptionIsAllowed(): void
     {
         $typeId = $this->entityTypes->save(new EntityType(name: 'Page', slug: 'page'));
         $created = $this->decodeJson($this->application->handle(
@@ -154,7 +176,8 @@ final class EntityHttpTest extends TestCase
             $this->factory->createServerRequest('PUT', "https://example.test/api/v1/entities/{$id}")->withBody($body),
         );
 
-        self::assertSame(422, $response->getStatusCode());
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('custom', $this->decodeJson($response)['layout']);
     }
 
     public function testUpdateCustomLayoutWithMetaDescriptionSucceeds(): void


### PR DESCRIPTION
## 症状 / Bug

レイアウトを **custom** にすると「ステータスの更新に失敗しました」と出て保存できない（下書きでも）。

## 原因 / Cause

#318 の「`custom` レイアウトは meta_description 必須 → 422」が **ステータスに関係なく毎回発火**。ステータスパネルの `onChangeLayout` は現在のステータス＋現在の meta（未設定なら空）を送るため、下書きで custom を選んだだけで 422。さらに汎用トーストで理由が見えなかった。

## 修正 / Fix
- **Backend**：custom＋meta_description 必須を **`status=published` のときだけ**に限定（下書きはクロールされないので不要。公開時にクロール用テキストを担保する本来の意図に一致）。
- **Frontend**：レイアウト/ステータス更新失敗時に**サーバのバリデーションメッセージ**を表示（features は `shared/api` 直 import 不可のためエラーは duck-typing で読む）。

## 受け入れ条件 / Acceptance
- 下書きで custom レイアウトに変更・保存できる ✓
- 公開時に custom＋meta 空なら拒否され、理由が表示される ✓

## 検証 / Verification
- `composer check`: **PHPUnit 666** / PHPStan L8 / CS-Fixer / OpenAPI / MCP 全グリーン
- `npm run check --prefix frontend`: 全グリーン
- 新規テスト: 公開＋custom＋meta空→422、下書き＋custom＋meta空→200

## 関連
- #318

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)