### PR TITLE
chore(db): NENE2 サンプルの notes テーブルを削除する (#329)

### DIFF
--- a/database/migrations/20260613000001_drop_notes_sample_table.php
+++ b/database/migrations/20260613000001_drop_notes_sample_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class DropNotesSampleTable extends AbstractMigration
+{
+    /**
+     * `notes` is a leftover NENE2 sample table, unused by NeNe Records. Its
+     * original migration file is already gone, leaving an orphaned phinxlog
+     * entry; drop the table and clear that entry so `status` is clean.
+     *
+     * Uses up()/down() (not change()) because the phinxlog cleanup is not
+     * auto-reversible.
+     */
+    public function up(): void
+    {
+        $this->execute('DROP TABLE IF EXISTS notes');
+        $this->execute("DELETE FROM phinxlog WHERE version = '20260516000000'");
+    }
+
+    public function down(): void
+    {
+        // Recreate the sample table shape so the migration is reversible.
+        $this->table('notes')
+            ->addColumn('title', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('body', 'text', ['null' => false])
+            ->create();
+    }
+}


### PR DESCRIPTION
## 目的 / Why

NENE2 由来の未使用サンプル `notes` テーブルを削除する。NeNe Records では 0 行・FK 参照なし・`src`/`database` にコード参照なし。作成元マイグレーションは既に無く、`phinx status` に孤立エントリ `20260516000000 CreateNotesTable ** MISSING MIGRATION FILE **` が出ていた。

## 変更内容 / What

- マイグレーション `DropNotesSampleTable` を追加。
  - `up`: `DROP TABLE IF EXISTS notes` ＋ 孤立 phinxlog エントリ(`20260516000000`)を削除。
  - `down`: サンプル形状で `notes` を再作成（可逆性確保）。

## 受け入れ条件 / Acceptance
- [x] `notes` テーブルが削除される
- [x] `phinx status` に MISSING MIGRATION FILE 警告が出ない
- [x] `tags` / `entity_tags`（本体機能）は影響を受けない

## 検証 / Verification
- `composer test`: 675 tests グリーン / `composer cs`: グリーン
- ローカル DB へ適用し、notes 削除・MISSING 警告解消・tags/entity_tags 健在を確認

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)