### PR TITLE
feat(widgets): 目次(TOC) — 見出しアンカー + 目次ウィジェット（#324 Phase 3A）(#331)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -5221,7 +5221,7 @@ components:
           minimum: 1
         widget_type:
           type: string
-          enum: [recent-posts, menu]
+          enum: [recent-posts, menu, toc]
         region:
           type: string
           enum: [main, sidebar, aside]
@@ -5261,7 +5261,7 @@ components:
       properties:
         widget_type:
           type: string
-          enum: [recent-posts, menu]
+          enum: [recent-posts, menu, toc]
         region:
           type: string
           enum: [main, sidebar, aside]

--- a/frontend/src/entities/widget/model.ts
+++ b/frontend/src/entities/widget/model.ts
@@ -1,6 +1,6 @@
 import type { ContentRegion } from '@/shared/lib/resolve-layout'
 
-export type WidgetType = 'recent-posts' | 'menu'
+export type WidgetType = 'recent-posts' | 'menu' | 'toc'
 
 export interface Widget {
   id: number

--- a/frontend/src/features/manage-widgets/hooks/use-manage-widgets-page.ts
+++ b/frontend/src/features/manage-widgets/hooks/use-manage-widgets-page.ts
@@ -76,7 +76,9 @@ export function useManageWidgetsPage() {
     const settings =
       form.widgetType === 'menu'
         ? { location: form.menuLocation }
-        : { entityTypeSlug: form.entityTypeSlug, limit: form.limit }
+        : form.widgetType === 'toc'
+          ? {}
+          : { entityTypeSlug: form.entityTypeSlug, limit: form.limit }
     const input: WidgetInput = {
       widgetType: form.widgetType,
       region: form.region,

--- a/frontend/src/features/manage-widgets/ui/ManageWidgetsView.tsx
+++ b/frontend/src/features/manage-widgets/ui/ManageWidgetsView.tsx
@@ -6,7 +6,7 @@ import type { ContentRegion } from '@/shared/lib/resolve-layout'
 import { Button, Card, Input, Select, Stack, Text } from '@/shared/ui'
 import type { WidgetFormState } from '../hooks/use-manage-widgets-page'
 
-const WIDGET_TYPES: readonly WidgetType[] = ['recent-posts', 'menu']
+const WIDGET_TYPES: readonly WidgetType[] = ['recent-posts', 'menu', 'toc']
 
 export interface ManageWidgetsViewProps {
   widgets: Widget[]
@@ -112,7 +112,7 @@ export function ManageWidgetsView({
                 }}
               />
             </>
-          ) : (
+          ) : form.widgetType === 'menu' ? (
             <>
               <Text muted variant="caption">
                 {t('admin.widgets.menuSettings')}
@@ -132,6 +132,10 @@ export function ManageWidgetsView({
                 ))}
               </Select>
             </>
+          ) : (
+            <Text muted variant="caption">
+              {t('admin.widgets.tocSettings')}
+            </Text>
           )}
           <div className="flex items-center gap-inline-sm">
             <Button type="submit" disabled={isSubmitting}>

--- a/frontend/src/features/render-widgets/index.ts
+++ b/frontend/src/features/render-widgets/index.ts
@@ -1,1 +1,2 @@
 export { SiteWidgets } from './ui/SiteWidgets'
+export { PageContentContext, usePageContent } from './page-content-context'

--- a/frontend/src/features/render-widgets/page-content-context.ts
+++ b/frontend/src/features/render-widgets/page-content-context.ts
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react'
+
+/**
+ * Carries the current page's primary markdown so region-placed widgets (e.g. the
+ * TOC widget) can derive from the same content the main column renders. Empty by
+ * default for pages that have no markdown body. Provide it with
+ * `<PageContentContext.Provider value={markdown}>`.
+ */
+export const PageContentContext = createContext<string>('')
+
+export function usePageContent(): string {
+  return useContext(PageContentContext)
+}

--- a/frontend/src/features/render-widgets/ui/SiteWidgets.tsx
+++ b/frontend/src/features/render-widgets/ui/SiteWidgets.tsx
@@ -5,6 +5,7 @@ import type { ContentRegion } from '@/shared/lib/resolve-layout'
 import { Stack, Text } from '@/shared/ui'
 import { MenuWidget } from './MenuWidget'
 import { RecentPostsWidget } from './RecentPostsWidget'
+import { TocWidget } from './TocWidget'
 
 export interface SiteWidgetsProps {
   region: ContentRegion
@@ -14,6 +15,7 @@ export interface SiteWidgetsProps {
 const WIDGET_REGISTRY: Record<WidgetType, (widget: Widget) => ReactNode> = {
   'recent-posts': (widget) => <RecentPostsWidget widget={widget} />,
   menu: (widget) => <MenuWidget widget={widget} />,
+  toc: () => <TocWidget />,
 }
 
 /** Renders all site widgets placed into a given region, in order. */

--- a/frontend/src/features/render-widgets/ui/TocWidget.tsx
+++ b/frontend/src/features/render-widgets/ui/TocWidget.tsx
@@ -1,0 +1,11 @@
+import { TableOfContents } from '@/shared/ui/markdown'
+import { usePageContent } from '../page-content-context'
+
+/**
+ * Table-of-contents widget. Reads the current page's markdown from context and
+ * renders h2/h3 anchors. Renders nothing when the page has no such headings.
+ */
+export function TocWidget() {
+  const markdown = usePageContent()
+  return <TableOfContents markdown={markdown} />
+}

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
@@ -8,8 +8,10 @@ import {
   PublicRecordRegionGrid,
   usePublicViewEntityRecordPage,
 } from '@/features/public-view-entity-record'
+import { PageContentContext } from '@/features/render-widgets'
 import { useTranslation } from '@/shared/i18n'
 import { findEntityTypeBySlug } from '@/shared/lib/find-entity-type-by-slug'
+import { isMarkdownBodyField } from '@/shared/lib/is-markdown-body-field'
 import { type PublicLayoutKey, resolveLayout } from '@/shared/lib/resolve-layout'
 import {
   DEFAULT_PERMALINK_PATTERN,
@@ -73,6 +75,23 @@ function PublicRecordDetailContent({
   const variant = resolveLayout(entity?.layout ?? null, entityTypeDefaultLayout)
   const isMultiColLayout = variant === 'two-col' || variant === 'three-col'
 
+  // The page's markdown body feeds region widgets (e.g. the TOC widget) so they
+  // derive from the same content the main column renders.
+  const pageMarkdown = useMemo(
+    () =>
+      fieldRows
+        .filter(
+          (row) =>
+            row.kind === 'scalar' &&
+            row.dataType === 'text' &&
+            isMarkdownBodyField(row.fieldKey) &&
+            row.displayValue !== '—',
+        )
+        .map((row) => (row.kind === 'scalar' ? row.displayValue : ''))
+        .join('\n\n'),
+    [fieldRows],
+  )
+
   // Redirect if the current URL doesn't match the canonical URL for this entity.
   // This handles pattern changes (e.g. /{type}/{id} → /{type}/{slug}) transparently.
   const redirect = useCanonicalRedirect(
@@ -88,41 +107,45 @@ function PublicRecordDetailContent({
 
   return (
     <PublicLayout variant={variant} site={site}>
-      <Stack gap="md">
-        <Stack gap="sm">
-          <Link to={`/${entityTypeSlug}`}>
-            <Button variant="secondary" size="sm">
-              Back to {entityTypeName}
-            </Button>
-          </Link>
-          <Text as="h1" variant="heading-md">
-            {entityTypeName}
-          </Text>
+      <PageContentContext.Provider value={pageMarkdown}>
+        <Stack gap="md">
+          <Stack gap="sm">
+            <Link to={`/${entityTypeSlug}`}>
+              <Button variant="secondary" size="sm">
+                Back to {entityTypeName}
+              </Button>
+            </Link>
+            <Text as="h1" variant="heading-md">
+              {entityTypeName}
+            </Text>
+          </Stack>
+          {isMultiColLayout && !isLoading && !isError && entity !== null && fieldRows.length > 0 ? (
+            <PublicRecordRegionGrid
+              layout={variant}
+              entity={entity}
+              fieldRows={fieldRows}
+              entityTypeSlugById={entityTypeSlugById}
+              entityTypePatternById={entityTypePatternById}
+            />
+          ) : (
+            <PublicRecordDetailView
+              entity={entity}
+              fieldRows={fieldRows}
+              entityTypeSlugById={entityTypeSlugById}
+              entityTypePatternById={entityTypePatternById}
+              isLoading={isLoading}
+              isError={isError}
+              errorTitle={errorTitle}
+              onRetry={() => {
+                void refetch()
+              }}
+            />
+          )}
+          {entity !== null && !isLoading && !isError ? (
+            <CommentSection {...commentSection} />
+          ) : null}
         </Stack>
-        {isMultiColLayout && !isLoading && !isError && entity !== null && fieldRows.length > 0 ? (
-          <PublicRecordRegionGrid
-            layout={variant}
-            entity={entity}
-            fieldRows={fieldRows}
-            entityTypeSlugById={entityTypeSlugById}
-            entityTypePatternById={entityTypePatternById}
-          />
-        ) : (
-          <PublicRecordDetailView
-            entity={entity}
-            fieldRows={fieldRows}
-            entityTypeSlugById={entityTypeSlugById}
-            entityTypePatternById={entityTypePatternById}
-            isLoading={isLoading}
-            isError={isError}
-            errorTitle={errorTitle}
-            onRetry={() => {
-              void refetch()
-            }}
-          />
-        )}
-        {entity !== null && !isLoading && !isError ? <CommentSection {...commentSection} /> : null}
-      </Stack>
+      </PageContentContext.Provider>
     </PublicLayout>
   )
 }

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -2029,7 +2029,7 @@ export interface components {
         WidgetResponse: {
             id: number;
             /** @enum {string} */
-            widget_type: "recent-posts" | "menu";
+            widget_type: "recent-posts" | "menu" | "toc";
             /** @enum {string} */
             region: "main" | "sidebar" | "aside";
             display_order: number;
@@ -2048,7 +2048,7 @@ export interface components {
         };
         CreateWidgetRequest: {
             /** @enum {string} */
-            widget_type: "recent-posts" | "menu";
+            widget_type: "recent-posts" | "menu" | "toc";
             /** @enum {string} */
             region: "main" | "sidebar" | "aside";
             /** @default 0 */

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -59,7 +59,10 @@ export const en = {
   'admin.widgets.typeLabel': 'Widget type',
   'admin.widgets.type.recent-posts': 'Recent posts',
   'admin.widgets.type.menu': 'Menu',
+  'admin.widgets.type.toc': 'Table of contents',
   'admin.widgets.menuSettings': 'Menu settings',
+  'admin.widgets.tocSettings':
+    "Shows the current page's headings. No settings — it renders on pages that have headings.",
   'widgets.recentPosts.unconfigured': 'No content type configured.',
   'widgets.recentPosts.empty': 'No posts yet.',
   'widgets.menu.empty': 'No menu items yet.',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -52,7 +52,10 @@ export const ja: Partial<MessageCatalog> = {
   'admin.widgets.typeLabel': 'ウィジェットタイプ',
   'admin.widgets.type.recent-posts': '最近の投稿',
   'admin.widgets.type.menu': 'メニュー',
+  'admin.widgets.type.toc': '目次',
   'admin.widgets.menuSettings': 'メニューの設定',
+  'admin.widgets.tocSettings':
+    '現在ページの見出しを表示します。設定なし（見出しがあるページで描画）。',
   'widgets.recentPosts.unconfigured': 'コンテンツタイプが未設定です。',
   'widgets.recentPosts.empty': '投稿がまだありません。',
   'widgets.menu.empty': 'メニュー項目がまだありません。',

--- a/frontend/src/shared/lib/markdown-headings.test.ts
+++ b/frontend/src/shared/lib/markdown-headings.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { createSlugger, extractHeadings } from './markdown-headings'
+
+describe('createSlugger', () => {
+  it('slugifies and de-duplicates repeated text', () => {
+    const slug = createSlugger()
+    expect(slug('Getting Started')).toBe('getting-started')
+    expect(slug('Getting Started')).toBe('getting-started-1')
+    expect(slug('Getting Started')).toBe('getting-started-2')
+  })
+
+  it('falls back to "section" for symbol-only text', () => {
+    const slug = createSlugger()
+    expect(slug('***')).toBe('section')
+  })
+
+  it('keeps unicode letters', () => {
+    const slug = createSlugger()
+    expect(slug('概要 Overview')).toBe('概要-overview')
+  })
+})
+
+describe('extractHeadings', () => {
+  it('returns headings in document order with depth and slug', () => {
+    const md = ['# Title', '', '## Intro', '', '### Details', '', 'body'].join('\n')
+    expect(extractHeadings(md)).toEqual([
+      { depth: 1, text: 'Title', slug: 'title' },
+      { depth: 2, text: 'Intro', slug: 'intro' },
+      { depth: 3, text: 'Details', slug: 'details' },
+    ])
+  })
+
+  it('strips inline markdown from heading text', () => {
+    expect(extractHeadings('## **Bold** and [link](/x)')).toEqual([
+      { depth: 2, text: 'Bold and link', slug: 'bold-and-link' },
+    ])
+  })
+
+  it('ignores # characters inside fenced code blocks', () => {
+    const md = ['## Real', '', '```', '# not a heading', '```', '', '## Also Real'].join('\n')
+    expect(extractHeadings(md).map((h) => h.text)).toEqual(['Real', 'Also Real'])
+  })
+
+  it('de-duplicates identical headings across levels in order', () => {
+    const md = ['## Notes', '### Notes'].join('\n')
+    expect(extractHeadings(md).map((h) => h.slug)).toEqual(['notes', 'notes-1'])
+  })
+
+  it('ignores non-heading lines and trailing ATX hashes', () => {
+    expect(extractHeadings('## Heading ##\nnot # a heading')).toEqual([
+      { depth: 2, text: 'Heading', slug: 'heading' },
+    ])
+  })
+})

--- a/frontend/src/shared/lib/markdown-headings.ts
+++ b/frontend/src/shared/lib/markdown-headings.ts
@@ -1,0 +1,81 @@
+export interface MarkdownHeading {
+  /** Heading level: 1 for `#`, 2 for `##`, … 6 for `######`. */
+  depth: number
+  /** Visible heading text (inline markdown stripped). */
+  text: string
+  /** Unique slug used as the heading's anchor id. */
+  slug: string
+}
+
+/**
+ * Creates a stateful slugger that turns heading text into a URL-safe slug and
+ * de-duplicates repeats by appending `-1`, `-2`, … (GitHub-style).
+ */
+export function createSlugger(): (text: string) => string {
+  const seen = new Map<string, number>()
+
+  return (text: string): string => {
+    const base =
+      text
+        .toLowerCase()
+        .trim()
+        .replace(/[^\p{L}\p{N}\s-]/gu, '')
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-+|-+$/g, '') || 'section'
+
+    const count = seen.get(base) ?? 0
+    seen.set(base, count + 1)
+    return count === 0 ? base : `${base}-${String(count)}`
+  }
+}
+
+/** Removes the common inline markdown markers from a heading's raw text. */
+function stripInlineMarkdown(text: string): string {
+  return text
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1') // links / images → label
+    .replace(/[*_`~]/g, '') // emphasis / code / strike markers
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/**
+ * Extracts ATX headings (`#`…`######` at line start) from markdown in document
+ * order, assigning each a unique slug. Returns every level (1–6) so the slug
+ * numbering matches what the renderer assigns; callers filter by depth.
+ *
+ * Fenced code blocks (``` / ~~~) are skipped so `# comment` lines inside code
+ * are not treated as headings.
+ */
+export function extractHeadings(markdown: string): MarkdownHeading[] {
+  const slugify = createSlugger()
+  const headings: MarkdownHeading[] = []
+  let inFence = false
+
+  for (const rawLine of markdown.split('\n')) {
+    const trimmed = rawLine.trim()
+
+    if (/^(```|~~~)/.test(trimmed)) {
+      inFence = !inFence
+      continue
+    }
+    if (inFence) {
+      continue
+    }
+
+    const match = /^(#{1,6})\s+(.+?)\s*#*\s*$/.exec(rawLine)
+    if (match === null) {
+      continue
+    }
+
+    const depth = match[1].length
+    const text = stripInlineMarkdown(match[2])
+    if (text === '') {
+      continue
+    }
+
+    headings.push({ depth, text, slug: slugify(text) })
+  }
+
+  return headings
+}

--- a/frontend/src/shared/ui/markdown/PublicMarkdownContent.tsx
+++ b/frontend/src/shared/ui/markdown/PublicMarkdownContent.tsx
@@ -1,5 +1,6 @@
 import ReactMarkdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { extractHeadings } from '@/shared/lib/markdown-headings'
 import { ResponsiveImage } from '@/shared/ui/media/ResponsiveImage'
 import './markdown-content.css'
 
@@ -7,15 +8,27 @@ export interface PublicMarkdownContentProps {
   markdown: string
 }
 
-// Serve resized derivatives (srcset) for media-library images embedded in content.
-const COMPONENTS: Components = {
-  img: ({ src, alt }) =>
-    typeof src === 'string' ? <ResponsiveImage src={src} alt={alt ?? ''} /> : null,
-}
-
 export function PublicMarkdownContent({ markdown }: PublicMarkdownContentProps) {
   if (markdown.trim() === '') {
     return null
+  }
+
+  // Single source of truth for anchor ids (same list the TOC consumes). Headings
+  // render in document order, so a cursor assigns each the matching slug.
+  const headings = extractHeadings(markdown)
+  let cursor = 0
+  const nextHeadingId = (): string | undefined => headings[cursor++]?.slug
+
+  const components: Components = {
+    // Serve resized derivatives (srcset) for media-library images in content.
+    img: ({ src, alt }) =>
+      typeof src === 'string' ? <ResponsiveImage src={src} alt={alt ?? ''} /> : null,
+    h1: ({ children }) => <h1 id={nextHeadingId()}>{children}</h1>,
+    h2: ({ children }) => <h2 id={nextHeadingId()}>{children}</h2>,
+    h3: ({ children }) => <h3 id={nextHeadingId()}>{children}</h3>,
+    h4: ({ children }) => <h4 id={nextHeadingId()}>{children}</h4>,
+    h5: ({ children }) => <h5 id={nextHeadingId()}>{children}</h5>,
+    h6: ({ children }) => <h6 id={nextHeadingId()}>{children}</h6>,
   }
 
   return (
@@ -24,7 +37,7 @@ export function PublicMarkdownContent({ markdown }: PublicMarkdownContentProps) 
         remarkPlugins={[remarkGfm]}
         disallowedElements={['script', 'style', 'iframe', 'object', 'embed']}
         unwrapDisallowed
-        components={COMPONENTS}
+        components={components}
       >
         {markdown}
       </ReactMarkdown>

--- a/frontend/src/shared/ui/markdown/TableOfContents.tsx
+++ b/frontend/src/shared/ui/markdown/TableOfContents.tsx
@@ -1,0 +1,45 @@
+import { extractHeadings, type MarkdownHeading } from '@/shared/lib/markdown-headings'
+
+export interface TableOfContentsProps {
+  /** Markdown whose headings build the list. */
+  markdown: string
+  /** Shallowest heading level to include (inclusive). Default 2. */
+  minDepth?: number
+  /** Deepest heading level to include (inclusive). Default 3. */
+  maxDepth?: number
+}
+
+/**
+ * Renders an in-page table of contents from a markdown string's headings.
+ * Anchors point at the ids assigned by PublicMarkdownContent (same slugger),
+ * so both must derive from the same markdown. Renders nothing when empty.
+ */
+export function TableOfContents({ markdown, minDepth = 2, maxDepth = 3 }: TableOfContentsProps) {
+  const headings = extractHeadings(markdown).filter(
+    (heading) => heading.depth >= minDepth && heading.depth <= maxDepth,
+  )
+
+  if (headings.length === 0) {
+    return null
+  }
+
+  return (
+    <nav aria-label="Table of contents">
+      <ul className="flex flex-col gap-stack-xs">
+        {headings.map((heading: MarkdownHeading, index) => (
+          <li
+            key={`${heading.slug}-${String(index)}`}
+            style={{ paddingInlineStart: `${String((heading.depth - minDepth) * 12)}px` }}
+          >
+            <a
+              href={`#${heading.slug}`}
+              className="text-body text-accent underline hover:no-underline"
+            >
+              {heading.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/frontend/src/shared/ui/markdown/index.ts
+++ b/frontend/src/shared/ui/markdown/index.ts
@@ -1,2 +1,4 @@
 export { PublicMarkdownContent } from './PublicMarkdownContent'
 export type { PublicMarkdownContentProps } from './PublicMarkdownContent'
+export { TableOfContents } from './TableOfContents'
+export type { TableOfContentsProps } from './TableOfContents'

--- a/src/Widget/WidgetTypes.php
+++ b/src/Widget/WidgetTypes.php
@@ -8,12 +8,13 @@ namespace NeNeRecords\Widget;
  * Whitelist of widget types. Widgets are bounded, typed blocks (not a free-form
  * page builder): each type has a known renderer and settings shape. Phase 1
  * ships `recent-posts`; Phase 2 adds `menu` (renders a navigation location);
- * more (search, calendar, tag-cloud) follow.
+ * Phase 3 adds `toc` (table of contents for the current page); more (search,
+ * calendar, tag-cloud) follow.
  */
 final class WidgetTypes
 {
     /** @var list<string> */
-    private const TYPES = ['recent-posts', 'menu'];
+    private const TYPES = ['recent-posts', 'menu', 'toc'];
 
     public static function isValid(string $type): bool
     {


### PR DESCRIPTION
> [Epic #324](https://github.com/hideyukiMORI/nene-records/issues/324) の **Phase 3A**。独立した小機能（目次）。

## 目的 / Why

公開ページの Markdown 本文の見出しに安定アンカーが無く、ディープリンクや目次が作れなかった。Phase 1/2 の型付きウィジェット路線に乗せ、目次(TOC)を region に配置できるようにする。

## 変更内容 / What

### 見出しアンカー（基盤）
- `PublicMarkdownContent` が h1–h6 に slug 化した `id` を付与（共有 slugger で重複連番）。
- `extractHeadings(markdown)` を**単一の真実源**として追加（深さ・テキスト・slug を文書順）。レンダラと TOC が同じ slug を共有。

### 目次ウィジェット
- `WidgetTypes` / OpenAPI に `toc` を追加。
- TOC は「現ページの見出し」を参照するため `PageContentContext` を導入。公開レコード詳細ページが本文 Markdown を供給し、`TocWidget` が h2/h3 を `#slug` リンクで描画。**見出しが無ければ何も描画しない**。
- 再利用可能な `TableOfContents` を `shared/ui/markdown` に追加（インライン用途の基盤）。
- `manage-widgets` で `toc` タイプを選択可能に（設定なし）。i18n（en/ja）。

## 受け入れ条件 / Acceptance
- [x] 公開ページの見出しに id が付与され `#slug` でジャンプできる
- [x] region(sidebar/aside) に TOC ウィジェットを配置でき、現ページの h2/h3 が目次描画される
- [x] 見出しが無いページでは TOC ウィジェットは目次を描画しない

## 検証 / Verification
- `composer check`: **PHPUnit 675** / PHPStan L8 / CS-Fixer / OpenAPI / MCP 全グリーン
- `npm run check --prefix frontend`: type-check / lint / prettier / test / knip / storybook 全グリーン
- 新規テスト: `extractHeadings`（slug化・重複連番・コードフェンス除外・インライン除去）

## 後続（#324）
- Phase 3B: インライン目次の自動配置（本文先頭への TOC 挿入・表示制御）
- Phase 4: 検索 / Phase 5: 追加ウィジェット

Closes #331
Part of #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)