### PR TITLE
feat(widgets): 管理画面にレイアウト領域プレビュー(配置GUI) (#345)

### DIFF
--- a/frontend/src/features/manage-widgets/hooks/use-manage-widgets-page.ts
+++ b/frontend/src/features/manage-widgets/hooks/use-manage-widgets-page.ts
@@ -54,6 +54,12 @@ export function useManageWidgetsPage() {
     setForm(EMPTY_FORM)
   }, [])
 
+  // Start a fresh widget targeted at a region (used by the layout board).
+  const addToRegion = useCallback((region: ContentRegion) => {
+    setEditId(null)
+    setForm({ ...EMPTY_FORM, region })
+  }, [])
+
   const editWidget = useCallback((widget: Widget) => {
     setEditId(widget.id)
     setForm({
@@ -125,6 +131,7 @@ export function useManageWidgetsPage() {
     isSubmitting: createMutation.isPending || updateMutation.isPending,
     setField,
     resetForm,
+    addToRegion,
     editWidget,
     submit,
     remove,

--- a/frontend/src/features/manage-widgets/ui/ManageWidgetsView.tsx
+++ b/frontend/src/features/manage-widgets/ui/ManageWidgetsView.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from '@/shared/i18n'
 import type { ContentRegion } from '@/shared/lib/resolve-layout'
 import { Button, Card, Input, Select, Stack, Text } from '@/shared/ui'
 import type { WidgetFormState } from '../hooks/use-manage-widgets-page'
+import { WidgetRegionBoard } from './WidgetRegionBoard'
 
 const WIDGET_TYPES: readonly WidgetType[] = [
   'recent-posts',
@@ -24,6 +25,7 @@ export interface ManageWidgetsViewProps {
   isSubmitting: boolean
   setField: <K extends keyof WidgetFormState>(key: K, value: WidgetFormState[K]) => void
   resetForm: () => void
+  addToRegion: (region: ContentRegion) => void
   editWidget: (widget: Widget) => void
   submit: () => Promise<void>
   remove: (id: number) => Promise<void>
@@ -37,6 +39,7 @@ export function ManageWidgetsView({
   isSubmitting,
   setField,
   resetForm,
+  addToRegion,
   editWidget,
   submit,
   remove,
@@ -80,7 +83,6 @@ export function ManageWidgetsView({
           >
             <option value="sidebar">{t('admin.region.sidebar')}</option>
             <option value="aside">{t('admin.region.aside')}</option>
-            <option value="main">{t('admin.region.main')}</option>
           </Select>
           <Input
             id="widget-title"
@@ -195,55 +197,17 @@ export function ManageWidgetsView({
         </Stack>
       </Card>
 
-      <Stack gap="sm">
-        <Text as="h2" variant="heading-sm">
-          {t('admin.widgets.listTitle')}
-        </Text>
-        {widgets.length === 0 ? (
-          <Text muted>{t('admin.widgets.empty')}</Text>
-        ) : (
-          <ul className="flex flex-col gap-stack-xs">
-            {widgets.map((widget) => (
-              <Card
-                as="li"
-                key={widget.id}
-                padding="row"
-                className="flex items-center justify-between gap-inline-md"
-              >
-                <Stack gap="xs">
-                  <Text as="span" variant="heading-sm">
-                    {widget.title ?? widget.widgetType}
-                  </Text>
-                  <Text as="span" muted variant="caption">
-                    {t(`admin.region.${widget.region}`)} ·{' '}
-                    {t(`admin.widgets.type.${widget.widgetType}`)}
-                  </Text>
-                </Stack>
-                <div className="flex items-center gap-inline-sm">
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={() => {
-                      editWidget(widget)
-                    }}
-                  >
-                    {t('common.actions.edit')}
-                  </Button>
-                  <Button
-                    variant="danger"
-                    size="sm"
-                    onClick={() => {
-                      void remove(widget.id)
-                    }}
-                  >
-                    {t('common.actions.delete')}
-                  </Button>
-                </div>
-              </Card>
-            ))}
-          </ul>
-        )}
-      </Stack>
+      <WidgetRegionBoard
+        widgets={widgets}
+        editId={editId}
+        onAddToRegion={(region) => {
+          addToRegion(region)
+        }}
+        onEdit={editWidget}
+        onRemove={(id) => {
+          void remove(id)
+        }}
+      />
     </Stack>
   )
 }

--- a/frontend/src/features/manage-widgets/ui/WidgetRegionBoard.tsx
+++ b/frontend/src/features/manage-widgets/ui/WidgetRegionBoard.tsx
@@ -1,0 +1,144 @@
+import type { Widget } from '@/entities/widget'
+import { useTranslation } from '@/shared/i18n'
+import type { ContentRegion } from '@/shared/lib/resolve-layout'
+import { Button, Card, Stack, Text } from '@/shared/ui'
+
+export interface WidgetRegionBoardProps {
+  widgets: Widget[]
+  editId: number | null
+  onAddToRegion: (region: ContentRegion) => void
+  onEdit: (widget: Widget) => void
+  onRemove: (id: number) => void
+}
+
+const SECONDARY_REGIONS: readonly ContentRegion[] = ['sidebar', 'aside']
+
+// Mirrors the public three-column proportion (main 2 / sidebar 1 / aside 1).
+// Kept in a constant so the arbitrary Tailwind value is not a className literal.
+const BOARD_GRID_CLASS = 'grid grid-cols-1 gap-stack-md lg:grid-cols-[2fr_1fr_1fr]'
+
+/**
+ * Visual layout board: shows widgets grouped into the regions a public page
+ * renders (main = content, sidebar/aside = widget columns), in the same 2/1/1
+ * proportion as the public two/three-column layouts.
+ */
+export function WidgetRegionBoard({
+  widgets,
+  editId,
+  onAddToRegion,
+  onEdit,
+  onRemove,
+}: WidgetRegionBoardProps) {
+  const { t } = useTranslation()
+
+  const byRegion = (region: ContentRegion): Widget[] =>
+    widgets
+      .filter((widget) => widget.region === region)
+      .sort((a, b) => a.displayOrder - b.displayOrder || a.id - b.id)
+
+  const mainWidgets = byRegion('main')
+
+  const renderCard = (widget: Widget) => (
+    <Card
+      as="li"
+      key={widget.id}
+      padding="row"
+      className={`flex items-center justify-between gap-inline-sm ${
+        editId === widget.id ? 'ring-2 ring-accent' : ''
+      }`}
+    >
+      <Stack gap="xs">
+        <Text as="span" variant="heading-sm">
+          {widget.title ?? t(`admin.widgets.type.${widget.widgetType}`)}
+        </Text>
+        <Text as="span" muted variant="caption">
+          {t(`admin.widgets.type.${widget.widgetType}`)}
+        </Text>
+      </Stack>
+      <div className="flex items-center gap-inline-sm">
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => {
+            onEdit(widget)
+          }}
+        >
+          {t('common.actions.edit')}
+        </Button>
+        <Button
+          variant="danger"
+          size="sm"
+          onClick={() => {
+            onRemove(widget.id)
+          }}
+        >
+          {t('common.actions.delete')}
+        </Button>
+      </div>
+    </Card>
+  )
+
+  return (
+    <Stack gap="sm">
+      <Text as="h2" variant="heading-sm">
+        {t('admin.widgets.board.title')}
+      </Text>
+      <Text muted variant="caption">
+        {t('admin.widgets.board.layoutNote')}
+      </Text>
+
+      <div className={BOARD_GRID_CLASS}>
+        {/* main = record content, not a widget target */}
+        <Card className="flex flex-col gap-stack-sm border-dashed">
+          <Text as="span" variant="heading-sm">
+            {t('admin.region.main')}
+          </Text>
+          <div className="flex min-h-24 items-center justify-center rounded-md bg-surface px-inline-md py-stack-lg text-center">
+            <Text muted variant="caption">
+              {t('admin.widgets.board.mainContent')}
+            </Text>
+          </div>
+          {mainWidgets.length > 0 ? (
+            <Stack gap="xs">
+              <Text muted variant="caption">
+                {t('admin.widgets.board.mainNote')}
+              </Text>
+              <ul className="flex flex-col gap-stack-xs">{mainWidgets.map(renderCard)}</ul>
+            </Stack>
+          ) : null}
+        </Card>
+
+        {SECONDARY_REGIONS.map((region) => {
+          const regionWidgets = byRegion(region)
+          return (
+            <Card key={region} className="flex flex-col gap-stack-sm">
+              <div className="flex items-center justify-between gap-inline-sm">
+                <Text as="span" variant="heading-sm">
+                  {t(`admin.region.${region}`)}
+                </Text>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    onAddToRegion(region)
+                  }}
+                >
+                  {t('admin.widgets.board.addHere')}
+                </Button>
+              </div>
+              {regionWidgets.length === 0 ? (
+                <div className="flex min-h-24 items-center justify-center rounded-md border border-dashed border-border px-inline-md py-stack-lg text-center">
+                  <Text muted variant="caption">
+                    {t('admin.widgets.board.empty')}
+                  </Text>
+                </div>
+              ) : (
+                <ul className="flex flex-col gap-stack-xs">{regionWidgets.map(renderCard)}</ul>
+              )}
+            </Card>
+          )
+        })}
+      </div>
+    </Stack>
+  )
+}

--- a/frontend/src/pages/widgets/WidgetsPage.tsx
+++ b/frontend/src/pages/widgets/WidgetsPage.tsx
@@ -27,6 +27,7 @@ export function WidgetsPage() {
         isSubmitting={page.isSubmitting}
         setField={page.setField}
         resetForm={page.resetForm}
+        addToRegion={page.addToRegion}
         editWidget={page.editWidget}
         submit={page.submit}
         remove={page.remove}

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -73,6 +73,13 @@ export const en = {
   'admin.widgets.popularPostsSettings': 'Shows the most-viewed published records (last 30 days).',
   'admin.widgets.calendarSettings':
     'Shows a month calendar; days with posts link to their archive.',
+  'admin.widgets.board.title': 'Layout',
+  'admin.widgets.board.layoutNote':
+    'Sidebar and aside widgets appear on record pages that use a two- or three-column layout.',
+  'admin.widgets.board.mainContent': 'Record content (fields)',
+  'admin.widgets.board.mainNote': 'Widgets placed in main are not rendered on the public site.',
+  'admin.widgets.board.addHere': '+ Add here',
+  'admin.widgets.board.empty': 'No widgets in this region yet.',
   'widgets.recentPosts.unconfigured': 'No content type configured.',
   'widgets.recentPosts.empty': 'No posts yet.',
   'widgets.menu.empty': 'No menu items yet.',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -66,6 +66,13 @@ export const ja: Partial<MessageCatalog> = {
   'admin.widgets.popularPostsSettings': '閲覧の多い公開レコードを表示します（直近30日）。',
   'admin.widgets.calendarSettings':
     '月カレンダーを表示します。投稿のある日はアーカイブへのリンクになります。',
+  'admin.widgets.board.title': 'レイアウト',
+  'admin.widgets.board.layoutNote':
+    'サイドバー・アサイドのウィジェットは、2カラム/3カラムのレイアウトを使うレコードページで表示されます。',
+  'admin.widgets.board.mainContent': 'レコード本文（フィールド）',
+  'admin.widgets.board.mainNote': 'main に置いたウィジェットは公開サイトでは描画されません。',
+  'admin.widgets.board.addHere': '＋ ここに追加',
+  'admin.widgets.board.empty': 'この領域にウィジェットはまだありません。',
   'widgets.recentPosts.unconfigured': 'コンテンツタイプが未設定です。',
   'widgets.recentPosts.empty': '投稿がまだありません。',
   'widgets.menu.empty': 'メニュー項目がまだありません。',


### PR DESCRIPTION
## 目的 / Why

ウィジェット管理画面がフラットなリストで「どの領域に何があるか」直感的に分からなかった。WordPress のウィジェット画面のように**レイアウト領域を視覚化**する。

## 変更内容 / What

- `WidgetRegionBoard`：公開レイアウトと同じ比率（main 2 / sidebar 1 / aside 1）の領域カラムにウィジェットをカード表示。
  - `main` は「レコード本文」プレースホルダ（コンテンツ領域であることを明示）。
  - `sidebar` / `aside` に「＋ここに追加」ボタン → 作成フォームの region をプリセット。
  - 編集中のカードはリング強調。
- 作成/編集フォームの region 選択から `main` を除外（公開側で main のウィジェットは描画されないため）。
- 「sidebar/aside は 2/3カラムレイアウトのレコードページで表示される」旨の注記（反映条件の気づき導線）。
- hook に `addToRegion`、i18n（en/ja）。

## 受け入れ条件 / Acceptance
- [x] 領域ごとにウィジェットが視覚的に配置表示される
- [x] 「＋ここに追加」で対象領域がフォームにプリセットされる
- [x] 追加/編集/削除が引き続き動作する

## 検証 / Verification
- `npm run check --prefix frontend`: type-check / lint / prettier / test / knip / storybook 全グリーン
- backend 変更なし

## 後続
- 公開側でウィジェットが見える範囲の拡大（一覧ページのサイドバー化等）— 次の PR で対応予定。

Closes #345