### PR TITLE
feat(menu): 名前付きメニューのバックエンド基盤（#347 PR1・非破壊）

### DIFF
--- a/database/migrations/20260613000002_create_menus_table_and_backfill.php
+++ b/database/migrations/20260613000002_create_menus_table_and_backfill.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateMenusTableAndBackfill extends AbstractMigration
+{
+    /**
+     * Introduces named menus. `navigation_items.location` is kept for now so the
+     * existing frontend keeps working; a later migration drops it once the UI
+     * moves to menu_id. Existing items are grouped by (org, location) into a menu
+     * each, with the menu carrying the header/footer display location (side → no
+     * auto location; surfaced via a menu widget).
+     */
+    public function up(): void
+    {
+        $this->table('menus')
+            ->addColumn('organization_id', 'integer', ['null' => false, 'default' => 0, 'signed' => false])
+            ->addColumn('name', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('slug', 'string', ['limit' => 255, 'null' => false])
+            // header | footer | null (null = standalone, shown via a menu widget)
+            ->addColumn('location', 'string', ['limit' => 16, 'null' => true, 'default' => null])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['organization_id'])
+            ->addIndex(['organization_id', 'slug'], ['unique' => true])
+            ->create();
+
+        $this->table('navigation_items')
+            ->addColumn('menu_id', 'integer', ['null' => true, 'default' => null, 'after' => 'organization_id'])
+            ->addIndex(['menu_id'])
+            ->update();
+
+        $this->backfillMenus();
+    }
+
+    public function down(): void
+    {
+        $this->table('navigation_items')->removeColumn('menu_id')->update();
+        $this->table('menus')->drop()->save();
+    }
+
+    private function backfillMenus(): void
+    {
+        $now = date('Y-m-d H:i:s');
+        $labels = ['header' => 'Header', 'footer' => 'Footer', 'side' => 'Side'];
+        $connection = $this->getAdapter()->getConnection();
+
+        /** @var list<array{organization_id: int|string, location: string}> $buckets */
+        $buckets = $this->fetchAll('SELECT DISTINCT organization_id, location FROM navigation_items');
+
+        foreach ($buckets as $bucket) {
+            $orgId = (int) $bucket['organization_id'];
+            $location = (string) $bucket['location'];
+            $name = $labels[$location] ?? ucfirst($location);
+            // Menus auto-display only in header/footer; side becomes standalone.
+            $menuLocation = in_array($location, ['header', 'footer'], true) ? $location : null;
+
+            $this->execute(sprintf(
+                'INSERT INTO menus (organization_id, name, slug, location, created_at, updated_at) VALUES (%d, %s, %s, %s, %s, %s)',
+                $orgId,
+                $connection->quote($name),
+                $connection->quote($location),
+                $menuLocation === null ? 'NULL' : $connection->quote($menuLocation),
+                $connection->quote($now),
+                $connection->quote($now),
+            ));
+
+            $menuId = (int) $connection->lastInsertId();
+
+            $this->execute(sprintf(
+                'UPDATE navigation_items SET menu_id = %d WHERE organization_id = %d AND location = %s',
+                $menuId,
+                $orgId,
+                $connection->quote($location),
+            ));
+        }
+    }
+}

--- a/database/schema/menus.sql
+++ b/database/schema/menus.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS menus (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    organization_id INTEGER NOT NULL DEFAULT 0,
+    name TEXT NOT NULL,
+    slug TEXT NOT NULL,
+    location TEXT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+CREATE INDEX menus_org ON menus (organization_id);
+CREATE UNIQUE INDEX menus_org_slug ON menus (organization_id, slug);

--- a/database/schema/navigation_items.sql
+++ b/database/schema/navigation_items.sql
@@ -1,6 +1,7 @@
 CREATE TABLE IF NOT EXISTS navigation_items (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     organization_id INTEGER NOT NULL DEFAULT 0,
+    menu_id INTEGER NULL,
     label TEXT NOT NULL,
     url TEXT NOT NULL,
     location TEXT NOT NULL DEFAULT 'header',
@@ -10,3 +11,4 @@ CREATE TABLE IF NOT EXISTS navigation_items (
 );
 CREATE INDEX navigation_items_org ON navigation_items (organization_id);
 CREATE INDEX navigation_items_org_location ON navigation_items (organization_id, location);
+CREATE INDEX navigation_items_menu ON navigation_items (menu_id);

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2788,6 +2788,133 @@ paths:
                 type: string
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/menus:
+    get:
+      tags:
+        - Menus
+      summary: List menus
+      description: Returns all named menus.
+      operationId: listMenus
+      responses:
+        '200':
+          description: Menu list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MenuListResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Menus
+      summary: Create menu
+      description: Creates a new named menu.
+      operationId: createMenu
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateMenuRequest'
+      responses:
+        '201':
+          description: Created menu.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MenuResponse'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/menus/{id}:
+    put:
+      tags:
+        - Menus
+      summary: Update menu
+      description: Updates an existing menu by ID.
+      operationId: updateMenu
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Menu ID.
+          schema:
+            type: integer
+            minimum: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateMenuRequest'
+      responses:
+        '200':
+          description: Updated menu.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MenuResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - Menus
+      summary: Delete menu
+      description: Permanently deletes a menu by ID.
+      operationId: deleteMenu
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Menu ID.
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '204':
+          description: Deleted successfully.
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/public/menus:
+    get:
+      tags:
+        - PublicConsumer
+      summary: List public menus
+      description: Returns all named menus for the public site. No authentication required.
+      operationId: listPublicMenus
+      responses:
+        '200':
+          description: Menu list.
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+              example: public, max-age=300, stale-while-revalidate=3600
+            ETag:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MenuListResponse'
+        '304':
+          description: Not Modified — ETag matched, use cached response.
+          headers:
+            ETag:
+              schema:
+                type: string
+            Cache-Control:
+              schema:
+                type: string
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /api/v1/entities/{id}/preview-token:
     post:
       tags:
@@ -5379,6 +5506,7 @@ components:
         - label
         - url
         - location
+        - menu_id
         - display_order
         - created_at
         - updated_at
@@ -5396,6 +5524,11 @@ components:
           type: string
           enum: [header, footer, side]
           description: Where the item renders. `side` items are surfaced via a menu widget.
+        menu_id:
+          type:
+            - integer
+            - 'null'
+          description: Named menu this item belongs to (backfilled from location).
         display_order:
           type: integer
           minimum: 0
@@ -5457,6 +5590,76 @@ components:
           type: integer
           minimum: 0
           default: 0
+      additionalProperties: false
+    MenuResponse:
+      type: object
+      required:
+        - id
+        - name
+        - slug
+        - location
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: integer
+          minimum: 1
+        name:
+          type: string
+          minLength: 1
+        slug:
+          type: string
+          minLength: 1
+        location:
+          type:
+            - string
+            - 'null'
+          enum: [header, footer, null]
+          description: Where the menu auto-displays. `null` means it only shows via a menu widget.
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      additionalProperties: false
+    MenuListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/MenuResponse'
+      additionalProperties: false
+    CreateMenuRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+        location:
+          type:
+            - string
+            - 'null'
+          enum: [header, footer, null]
+      additionalProperties: false
+    UpdateMenuRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+        location:
+          type:
+            - string
+            - 'null'
+          enum: [header, footer, null]
       additionalProperties: false
 
 

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -1108,6 +1108,74 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/menus": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List menus
+         * @description Returns all named menus.
+         */
+        get: operations["listMenus"];
+        put?: never;
+        /**
+         * Create menu
+         * @description Creates a new named menu.
+         */
+        post: operations["createMenu"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/menus/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Update menu
+         * @description Updates an existing menu by ID.
+         */
+        put: operations["updateMenu"];
+        post?: never;
+        /**
+         * Delete menu
+         * @description Permanently deletes a menu by ID.
+         */
+        delete: operations["deleteMenu"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/public/menus": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List public menus
+         * @description Returns all named menus for the public site. No authentication required.
+         */
+        get: operations["listPublicMenus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/entities/{id}/preview-token": {
         parameters: {
             query?: never;
@@ -2099,6 +2167,8 @@ export interface components {
              * @enum {string}
              */
             location: "header" | "footer" | "side";
+            /** @description Named menu this item belongs to (backfilled from location). */
+            menu_id: number | null;
             display_order: number;
             /** Format: date-time */
             created_at: string;
@@ -2129,6 +2199,33 @@ export interface components {
             location: "header" | "footer" | "side";
             /** @default 0 */
             display_order: number;
+        };
+        MenuResponse: {
+            id: number;
+            name: string;
+            slug: string;
+            /**
+             * @description Where the menu auto-displays. `null` means it only shows via a menu widget.
+             * @enum {string|null}
+             */
+            location: "header" | "footer" | null;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        MenuListResponse: {
+            items: components["schemas"]["MenuResponse"][];
+        };
+        CreateMenuRequest: {
+            name: string;
+            /** @enum {string|null} */
+            location?: "header" | "footer" | null;
+        };
+        UpdateMenuRequest: {
+            name: string;
+            /** @enum {string|null} */
+            location?: "header" | "footer" | null;
         };
         WebhookResponse: {
             /** Format: int64 */
@@ -5122,6 +5219,139 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["NavigationItemListResponse"];
+                };
+            };
+            /** @description Not Modified — ETag matched, use cached response. */
+            304: {
+                headers: {
+                    ETag?: string;
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    listMenus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Menu list. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MenuListResponse"];
+                };
+            };
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    createMenu: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateMenuRequest"];
+            };
+        };
+        responses: {
+            /** @description Created menu. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MenuResponse"];
+                };
+            };
+            422: components["responses"]["ValidationFailed"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    updateMenu: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Menu ID. */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateMenuRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated menu. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MenuResponse"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationFailed"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    deleteMenu: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Menu ID. */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted successfully. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    listPublicMenus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Menu list. */
+            200: {
+                headers: {
+                    /** @example public, max-age=300, stale-while-revalidate=3600 */
+                    "Cache-Control"?: string;
+                    ETag?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MenuListResponse"];
                 };
             };
             /** @description Not Modified — ETag matched, use cached response. */

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -64,6 +64,9 @@ use NeNeRecords\Media\MediaNotFoundExceptionHandler;
 use NeNeRecords\Media\MediaRouteRegistrar;
 use NeNeRecords\Media\MediaServiceProvider;
 use NeNeRecords\Media\MediaTooLargeExceptionHandler;
+use NeNeRecords\Menu\MenuNotFoundExceptionHandler;
+use NeNeRecords\Menu\MenuRouteRegistrar;
+use NeNeRecords\Menu\MenuServiceProvider;
 use NeNeRecords\NavigationItem\NavigationItemNotFoundExceptionHandler;
 use NeNeRecords\NavigationItem\NavigationItemRouteRegistrar;
 use NeNeRecords\NavigationItem\NavigationItemServiceProvider;
@@ -154,6 +157,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new PublicRecordServiceProvider())
             ->addProvider(new SettingServiceProvider())
             ->addProvider(new NavigationItemServiceProvider())
+            ->addProvider(new MenuServiceProvider())
             ->addProvider(new WidgetServiceProvider())
             ->addProvider(new WebhookServiceProvider())
             ->addProvider(new PreviewTokenServiceProvider())
@@ -188,6 +192,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $publicRecord = $container->get('nene-records.route_registrar.public_record');
                     $setting = $container->get('nene-records.route_registrar.setting');
                     $navigationItem = $container->get('nene-records.route_registrar.navigation_item');
+                    $menu = $container->get('nene-records.route_registrar.menu');
                     $widget = $container->get('nene-records.route_registrar.widget');
                     $webhook = $container->get('nene-records.route_registrar.webhook');
                     $previewToken = $container->get('nene-records.route_registrar.preview_token');
@@ -220,6 +225,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !$publicRecord instanceof PublicRecordRouteRegistrar
                         || !$setting instanceof SettingRouteRegistrar
                         || !$navigationItem instanceof NavigationItemRouteRegistrar
+                        || !$menu instanceof MenuRouteRegistrar
                         || !$widget instanceof WidgetRouteRegistrar
                         || !$webhook instanceof WebhookRouteRegistrar
                         || !$previewToken instanceof PreviewTokenRouteRegistrar
@@ -256,6 +262,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $publicRecord,
                         $setting,
                         $navigationItem,
+                        $menu,
                         $widget,
                         $webhook,
                         $previewToken,
@@ -305,6 +312,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $mediaNotFound = $container->get(MediaNotFoundExceptionHandler::class);
                     $mediaInUse = $container->get(MediaInUseExceptionHandler::class);
                     $navigationItemNotFound = $container->get(NavigationItemNotFoundExceptionHandler::class);
+                    $menuNotFound = $container->get(MenuNotFoundExceptionHandler::class);
                     $widgetNotFound = $container->get(WidgetNotFoundExceptionHandler::class);
                     $webhookNotFound = $container->get(WebhookNotFoundExceptionHandler::class);
                     $previewTokenNotFound = $container->get(PreviewTokenNotFoundExceptionHandler::class);
@@ -353,6 +361,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $mediaNotFound,
                         $mediaInUse,
                         $navigationItemNotFound,
+                        $menuNotFound,
                         $widgetNotFound,
                         $webhookNotFound,
                         $previewTokenNotFound,
@@ -406,6 +415,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $mediaNotFound,
                         $mediaInUse,
                         $navigationItemNotFound,
+                        $menuNotFound,
                         $widgetNotFound,
                         $webhookNotFound,
                         $previewTokenNotFound,

--- a/src/Auth/AdminApiAuthMiddleware.php
+++ b/src/Auth/AdminApiAuthMiddleware.php
@@ -34,6 +34,7 @@ final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
     private const ADMIN_ONLY_PREFIXES = [
         '/api/v1/settings',
         '/api/v1/navigation-items',
+        '/api/v1/menus',
         '/api/v1/widgets',
         '/api/v1/media',
         '/api/v1/users',

--- a/src/Menu/CreateMenuHandler.php
+++ b/src/Menu/CreateMenuHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateMenuHandler
+{
+    public function __construct(
+        private CreateMenuUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+        $errors = [];
+
+        $name = trim((string) ($body['name'] ?? ''));
+        $location = $this->parseLocation($body['location'] ?? null);
+
+        if ($name === '') {
+            $errors[] = new ValidationError('name', 'Name is required.', 'required');
+        }
+
+        if (!MenuLocations::isValid($location)) {
+            $errors[] = new ValidationError('location', 'Location must be header, footer, or null.', 'invalid');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new CreateMenuInput(name: $name, location: $location));
+
+        return $this->response->create(MenuHttpMapper::toArray($output->menu), 201);
+    }
+
+    private function parseLocation(mixed $raw): ?string
+    {
+        if (!is_string($raw)) {
+            return null;
+        }
+        $value = trim($raw);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/src/Menu/CreateMenuInput.php
+++ b/src/Menu/CreateMenuInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+final readonly class CreateMenuInput
+{
+    public function __construct(
+        public string $name,
+        public ?string $location,
+    ) {
+    }
+}

--- a/src/Menu/CreateMenuOutput.php
+++ b/src/Menu/CreateMenuOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+final readonly class CreateMenuOutput
+{
+    public function __construct(
+        public Menu $menu,
+    ) {
+    }
+}

--- a/src/Menu/CreateMenuUseCase.php
+++ b/src/Menu/CreateMenuUseCase.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+final readonly class CreateMenuUseCase implements CreateMenuUseCaseInterface
+{
+    public function __construct(
+        private MenuRepositoryInterface $repository,
+    ) {
+    }
+
+    public function execute(CreateMenuInput $input): CreateMenuOutput
+    {
+        $slug = MenuSlug::unique(MenuSlug::fromName($input->name), $this->repository);
+
+        $menu = new Menu(
+            id: null,
+            name: $input->name,
+            slug: $slug,
+            location: $input->location,
+            createdAt: '',
+            updatedAt: '',
+        );
+
+        $id = $this->repository->save($menu);
+        $saved = $this->repository->findById($id);
+
+        if ($saved === null) {
+            throw new \RuntimeException('Failed to persist menu.');
+        }
+
+        return new CreateMenuOutput(menu: $saved);
+    }
+}

--- a/src/Menu/CreateMenuUseCaseInterface.php
+++ b/src/Menu/CreateMenuUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+interface CreateMenuUseCaseInterface
+{
+    public function execute(CreateMenuInput $input): CreateMenuOutput;
+}

--- a/src/Menu/DeleteMenuHandler.php
+++ b/src/Menu/DeleteMenuHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteMenuHandler
+{
+    public function __construct(
+        private DeleteMenuUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        $this->useCase->execute(new DeleteMenuInput($id));
+
+        return $this->response->createEmpty(204);
+    }
+}

--- a/src/Menu/DeleteMenuInput.php
+++ b/src/Menu/DeleteMenuInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+final readonly class DeleteMenuInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/Menu/DeleteMenuUseCase.php
+++ b/src/Menu/DeleteMenuUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+final readonly class DeleteMenuUseCase implements DeleteMenuUseCaseInterface
+{
+    public function __construct(
+        private MenuRepositoryInterface $repository,
+    ) {
+    }
+
+    public function execute(DeleteMenuInput $input): void
+    {
+        $existing = $this->repository->findById($input->id);
+
+        if ($existing === null) {
+            throw new MenuNotFoundException($input->id);
+        }
+
+        $this->repository->delete($input->id);
+    }
+}

--- a/src/Menu/DeleteMenuUseCaseInterface.php
+++ b/src/Menu/DeleteMenuUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+interface DeleteMenuUseCaseInterface
+{
+    public function execute(DeleteMenuInput $input): void;
+}

--- a/src/Menu/ListMenusHandler.php
+++ b/src/Menu/ListMenusHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListMenusHandler
+{
+    public function __construct(
+        private ListMenusUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $output = $this->useCase->execute();
+
+        return $this->response->create([
+            'items' => array_map(
+                static fn (Menu $menu) => MenuHttpMapper::toArray($menu),
+                $output->items,
+            ),
+        ]);
+    }
+}

--- a/src/Menu/ListMenusOutput.php
+++ b/src/Menu/ListMenusOutput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+final readonly class ListMenusOutput
+{
+    /** @param list<Menu> $items */
+    public function __construct(
+        public array $items,
+    ) {
+    }
+}

--- a/src/Menu/ListMenusUseCase.php
+++ b/src/Menu/ListMenusUseCase.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+final readonly class ListMenusUseCase implements ListMenusUseCaseInterface
+{
+    public function __construct(
+        private MenuRepositoryInterface $repository,
+    ) {
+    }
+
+    public function execute(): ListMenusOutput
+    {
+        return new ListMenusOutput(items: $this->repository->findAll());
+    }
+}

--- a/src/Menu/ListMenusUseCaseInterface.php
+++ b/src/Menu/ListMenusUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+interface ListMenusUseCaseInterface
+{
+    public function execute(): ListMenusOutput;
+}

--- a/src/Menu/ListPublicMenusHandler.php
+++ b/src/Menu/ListPublicMenusHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+use Nene2\Http\ConditionalGetHelper;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListPublicMenusHandler
+{
+    private const CACHE_CONTROL = 'public, max-age=300, stale-while-revalidate=3600';
+
+    public function __construct(
+        private ListMenusUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $output = $this->useCase->execute();
+
+        $data = [
+            'items' => array_map(
+                static fn (Menu $menu) => MenuHttpMapper::toArray($menu),
+                $output->items,
+            ),
+        ];
+
+        $etag = '"' . md5(json_encode($data, JSON_THROW_ON_ERROR)) . '"';
+
+        $notModified = ConditionalGetHelper::check($request, $this->responseFactory, $etag);
+        if ($notModified !== null) {
+            return $notModified->withHeader('Cache-Control', self::CACHE_CONTROL);
+        }
+
+        return $this->response->create($data, 200, [
+            'Cache-Control' => self::CACHE_CONTROL,
+            'ETag' => $etag,
+        ]);
+    }
+}

--- a/src/Menu/Menu.php
+++ b/src/Menu/Menu.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+final readonly class Menu
+{
+    public function __construct(
+        public ?int $id,
+        public string $name,
+        public string $slug,
+        /** header | footer | null (null = standalone, surfaced via a menu widget) */
+        public ?string $location,
+        public string $createdAt,
+        public string $updatedAt,
+    ) {
+    }
+}

--- a/src/Menu/MenuHttpMapper.php
+++ b/src/Menu/MenuHttpMapper.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+final readonly class MenuHttpMapper
+{
+    /** @return array<string, mixed> */
+    public static function toArray(Menu $menu): array
+    {
+        return [
+            'id' => $menu->id,
+            'name' => $menu->name,
+            'slug' => $menu->slug,
+            'location' => $menu->location,
+            'created_at' => $menu->createdAt,
+            'updated_at' => $menu->updatedAt,
+        ];
+    }
+}

--- a/src/Menu/MenuLocations.php
+++ b/src/Menu/MenuLocations.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+/**
+ * Where a named menu auto-displays. `header`/`footer` render in the public site
+ * chrome; `null` means the menu only appears where a menu widget references it.
+ */
+final class MenuLocations
+{
+    /** @var list<string> */
+    private const LOCATIONS = ['header', 'footer'];
+
+    public static function isValid(?string $location): bool
+    {
+        return $location === null || in_array($location, self::LOCATIONS, true);
+    }
+
+    /** @return list<string> */
+    public static function all(): array
+    {
+        return self::LOCATIONS;
+    }
+}

--- a/src/Menu/MenuNotFoundException.php
+++ b/src/Menu/MenuNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+use DomainException;
+
+final class MenuNotFoundException extends DomainException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("Menu #{$id} was not found.");
+    }
+}

--- a/src/Menu/MenuNotFoundExceptionHandler.php
+++ b/src/Menu/MenuNotFoundExceptionHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class MenuNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(\Throwable $e): bool
+    {
+        return $e instanceof MenuNotFoundException;
+    }
+
+    public function handle(\Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'not-found', 'Not Found', 404, $exception->getMessage());
+    }
+}

--- a/src/Menu/MenuRepositoryInterface.php
+++ b/src/Menu/MenuRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+interface MenuRepositoryInterface
+{
+    /** @return list<Menu> */
+    public function findAll(): array;
+
+    public function findById(int $id): ?Menu;
+
+    public function existsBySlug(string $slug, ?int $excludeId = null): bool;
+
+    public function save(Menu $menu): int;
+
+    public function update(Menu $menu): void;
+
+    public function delete(int $id): void;
+}

--- a/src/Menu/MenuRouteRegistrar.php
+++ b/src/Menu/MenuRouteRegistrar.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class MenuRouteRegistrar
+{
+    public function __construct(
+        private ListMenusHandler $listHandler,
+        private ListPublicMenusHandler $listPublicHandler,
+        private CreateMenuHandler $createHandler,
+        private UpdateMenuHandler $updateHandler,
+        private DeleteMenuHandler $deleteHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $list = $this->listHandler;
+        $listPublic = $this->listPublicHandler;
+        $create = $this->createHandler;
+        $update = $this->updateHandler;
+        $delete = $this->deleteHandler;
+
+        $router->get(
+            '/api/v1/menus',
+            static fn (ServerRequestInterface $request) => $list->handle($request),
+        );
+        $router->post(
+            '/api/v1/menus',
+            static fn (ServerRequestInterface $request) => $create->handle($request),
+        );
+        $router->put(
+            '/api/v1/menus/{id}',
+            static fn (ServerRequestInterface $request) => $update->handle($request),
+        );
+        $router->delete(
+            '/api/v1/menus/{id}',
+            static fn (ServerRequestInterface $request) => $delete->handle($request),
+        );
+        // Public endpoint (no auth required via ALWAYS_OPEN_PREFIXES)
+        $router->get(
+            '/api/v1/public/menus',
+            static fn (ServerRequestInterface $request) => $listPublic->handle($request),
+        );
+    }
+}

--- a/src/Menu/MenuServiceProvider.php
+++ b/src/Menu/MenuServiceProvider.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class MenuServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                MenuRepositoryInterface::class,
+                static function (ContainerInterface $container): MenuRepositoryInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    $orgId = $container->get('nene-records.org_id_holder');
+                    if (!$orgId instanceof RequestScopedHolder) {
+                        throw new LogicException('Org ID holder service is invalid.');
+                    }
+
+                    return new PdoMenuRepository($query, $orgId);
+                },
+            )
+            ->set(
+                ListMenusUseCaseInterface::class,
+                static function (ContainerInterface $container): ListMenusUseCaseInterface {
+                    $repo = $container->get(MenuRepositoryInterface::class);
+                    if (!$repo instanceof MenuRepositoryInterface) {
+                        throw new LogicException('Menu repository service is invalid.');
+                    }
+
+                    return new ListMenusUseCase($repo);
+                },
+            )
+            ->set(
+                CreateMenuUseCaseInterface::class,
+                static function (ContainerInterface $container): CreateMenuUseCaseInterface {
+                    $repo = $container->get(MenuRepositoryInterface::class);
+                    if (!$repo instanceof MenuRepositoryInterface) {
+                        throw new LogicException('Menu repository service is invalid.');
+                    }
+
+                    return new CreateMenuUseCase($repo);
+                },
+            )
+            ->set(
+                UpdateMenuUseCaseInterface::class,
+                static function (ContainerInterface $container): UpdateMenuUseCaseInterface {
+                    $repo = $container->get(MenuRepositoryInterface::class);
+                    if (!$repo instanceof MenuRepositoryInterface) {
+                        throw new LogicException('Menu repository service is invalid.');
+                    }
+
+                    return new UpdateMenuUseCase($repo);
+                },
+            )
+            ->set(
+                DeleteMenuUseCaseInterface::class,
+                static function (ContainerInterface $container): DeleteMenuUseCaseInterface {
+                    $repo = $container->get(MenuRepositoryInterface::class);
+                    if (!$repo instanceof MenuRepositoryInterface) {
+                        throw new LogicException('Menu repository service is invalid.');
+                    }
+
+                    return new DeleteMenuUseCase($repo);
+                },
+            )
+            ->set(
+                ListMenusHandler::class,
+                static function (ContainerInterface $container): ListMenusHandler {
+                    $useCase = $container->get(ListMenusUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+                    if (!$useCase instanceof ListMenusUseCaseInterface) {
+                        throw new LogicException('ListMenus use case service is invalid.');
+                    }
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListMenusHandler($useCase, $response);
+                },
+            )
+            ->set(
+                CreateMenuHandler::class,
+                static function (ContainerInterface $container): CreateMenuHandler {
+                    $useCase = $container->get(CreateMenuUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+                    if (!$useCase instanceof CreateMenuUseCaseInterface) {
+                        throw new LogicException('CreateMenu use case service is invalid.');
+                    }
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new CreateMenuHandler($useCase, $response);
+                },
+            )
+            ->set(
+                UpdateMenuHandler::class,
+                static function (ContainerInterface $container): UpdateMenuHandler {
+                    $useCase = $container->get(UpdateMenuUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+                    if (!$useCase instanceof UpdateMenuUseCaseInterface) {
+                        throw new LogicException('UpdateMenu use case service is invalid.');
+                    }
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new UpdateMenuHandler($useCase, $response);
+                },
+            )
+            ->set(
+                DeleteMenuHandler::class,
+                static function (ContainerInterface $container): DeleteMenuHandler {
+                    $useCase = $container->get(DeleteMenuUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+                    if (!$useCase instanceof DeleteMenuUseCaseInterface) {
+                        throw new LogicException('DeleteMenu use case service is invalid.');
+                    }
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new DeleteMenuHandler($useCase, $response);
+                },
+            )
+            ->set(
+                MenuNotFoundExceptionHandler::class,
+                static function (ContainerInterface $container): MenuNotFoundExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new MenuNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                ListPublicMenusHandler::class,
+                static function (ContainerInterface $container): ListPublicMenusHandler {
+                    $useCase = $container->get(ListMenusUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+                    $responseFactory = $container->get(ResponseFactoryInterface::class);
+                    if (!$useCase instanceof ListMenusUseCaseInterface) {
+                        throw new LogicException('ListMenus use case service is invalid.');
+                    }
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    return new ListPublicMenusHandler($useCase, $response, $responseFactory);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.menu',
+                static function (ContainerInterface $container): MenuRouteRegistrar {
+                    $list = $container->get(ListMenusHandler::class);
+                    $listPublic = $container->get(ListPublicMenusHandler::class);
+                    $create = $container->get(CreateMenuHandler::class);
+                    $update = $container->get(UpdateMenuHandler::class);
+                    $delete = $container->get(DeleteMenuHandler::class);
+
+                    if (!$list instanceof ListMenusHandler) {
+                        throw new LogicException('ListMenus handler service is invalid.');
+                    }
+                    if (!$listPublic instanceof ListPublicMenusHandler) {
+                        throw new LogicException('ListPublicMenus handler service is invalid.');
+                    }
+                    if (!$create instanceof CreateMenuHandler) {
+                        throw new LogicException('CreateMenu handler service is invalid.');
+                    }
+                    if (!$update instanceof UpdateMenuHandler) {
+                        throw new LogicException('UpdateMenu handler service is invalid.');
+                    }
+                    if (!$delete instanceof DeleteMenuHandler) {
+                        throw new LogicException('DeleteMenu handler service is invalid.');
+                    }
+
+                    return new MenuRouteRegistrar($list, $listPublic, $create, $update, $delete);
+                },
+            );
+    }
+}

--- a/src/Menu/MenuSlug.php
+++ b/src/Menu/MenuSlug.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+final class MenuSlug
+{
+    /** Slugifies a name, falling back to `menu` for symbol-only input. */
+    public static function fromName(string $name): string
+    {
+        $slug = strtolower(trim($name));
+        $slug = preg_replace('/[^\p{L}\p{N}]+/u', '-', $slug) ?? '';
+        $slug = trim($slug, '-');
+
+        return $slug === '' ? 'menu' : $slug;
+    }
+
+    /** Returns a slug not already used (per repository), appending -2, -3, … */
+    public static function unique(string $base, MenuRepositoryInterface $repository, ?int $excludeId = null): string
+    {
+        $slug = $base;
+        $suffix = 2;
+        while ($repository->existsBySlug($slug, $excludeId)) {
+            $slug = $base . '-' . $suffix;
+            ++$suffix;
+        }
+
+        return $slug;
+    }
+}

--- a/src/Menu/PdoMenuRepository.php
+++ b/src/Menu/PdoMenuRepository.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
+
+final readonly class PdoMenuRepository implements MenuRepositoryInterface
+{
+    /**
+     * @param RequestScopedHolder<int> $orgId
+     */
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private readonly RequestScopedHolder $orgId,
+    ) {
+    }
+
+    /** @return list<Menu> */
+    public function findAll(): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, name, slug, location, created_at, updated_at
+             FROM menus
+             WHERE organization_id = ?
+             ORDER BY id ASC',
+            [$this->orgId->get()],
+        );
+
+        return array_map($this->mapRow(...), $rows);
+    }
+
+    public function findById(int $id): ?Menu
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, name, slug, location, created_at, updated_at
+             FROM menus
+             WHERE id = ? AND organization_id = ?',
+            [$id, $this->orgId->get()],
+        );
+
+        return $row === null ? null : $this->mapRow($row);
+    }
+
+    public function existsBySlug(string $slug, ?int $excludeId = null): bool
+    {
+        if ($excludeId !== null) {
+            $row = $this->query->fetchOne(
+                'SELECT id FROM menus WHERE slug = ? AND organization_id = ? AND id != ?',
+                [$slug, $this->orgId->get(), $excludeId],
+            );
+        } else {
+            $row = $this->query->fetchOne(
+                'SELECT id FROM menus WHERE slug = ? AND organization_id = ?',
+                [$slug, $this->orgId->get()],
+            );
+        }
+
+        return $row !== null;
+    }
+
+    public function save(Menu $menu): int
+    {
+        $now = date('Y-m-d H:i:s');
+
+        $this->query->execute(
+            'INSERT INTO menus (organization_id, name, slug, location, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?)',
+            [$this->orgId->get(), $menu->name, $menu->slug, $menu->location, $now, $now],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function update(Menu $menu): void
+    {
+        $now = date('Y-m-d H:i:s');
+
+        $this->query->execute(
+            'UPDATE menus
+             SET name = ?, slug = ?, location = ?, updated_at = ?
+             WHERE id = ? AND organization_id = ?',
+            [$menu->name, $menu->slug, $menu->location, $now, $menu->id, $this->orgId->get()],
+        );
+    }
+
+    public function delete(int $id): void
+    {
+        $this->query->execute('DELETE FROM menus WHERE id = ? AND organization_id = ?', [$id, $this->orgId->get()]);
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): Menu
+    {
+        $location = $row['location'];
+
+        return new Menu(
+            id: (int) $row['id'],
+            name: (string) $row['name'],
+            slug: (string) $row['slug'],
+            location: $location === null ? null : (string) $location,
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/src/Menu/UpdateMenuHandler.php
+++ b/src/Menu/UpdateMenuHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateMenuHandler
+{
+    public function __construct(
+        private UpdateMenuUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        $body = JsonRequestBodyParser::parse($request);
+        $errors = [];
+
+        $name = trim((string) ($body['name'] ?? ''));
+        $location = is_string($body['location'] ?? null) && trim((string) $body['location']) !== ''
+            ? trim((string) $body['location'])
+            : null;
+
+        if ($name === '') {
+            $errors[] = new ValidationError('name', 'Name is required.', 'required');
+        }
+
+        if (!MenuLocations::isValid($location)) {
+            $errors[] = new ValidationError('location', 'Location must be header, footer, or null.', 'invalid');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new UpdateMenuInput(id: $id, name: $name, location: $location));
+
+        return $this->response->create(MenuHttpMapper::toArray($output->menu));
+    }
+}

--- a/src/Menu/UpdateMenuInput.php
+++ b/src/Menu/UpdateMenuInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+final readonly class UpdateMenuInput
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+        public ?string $location,
+    ) {
+    }
+}

--- a/src/Menu/UpdateMenuOutput.php
+++ b/src/Menu/UpdateMenuOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+final readonly class UpdateMenuOutput
+{
+    public function __construct(
+        public Menu $menu,
+    ) {
+    }
+}

--- a/src/Menu/UpdateMenuUseCase.php
+++ b/src/Menu/UpdateMenuUseCase.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+final readonly class UpdateMenuUseCase implements UpdateMenuUseCaseInterface
+{
+    public function __construct(
+        private MenuRepositoryInterface $repository,
+    ) {
+    }
+
+    public function execute(UpdateMenuInput $input): UpdateMenuOutput
+    {
+        $existing = $this->repository->findById($input->id);
+
+        if ($existing === null) {
+            throw new MenuNotFoundException($input->id);
+        }
+
+        // Keep the existing slug unless the name changed, then re-derive uniquely.
+        $slug = $existing->slug;
+        if ($input->name !== $existing->name) {
+            $slug = MenuSlug::unique(MenuSlug::fromName($input->name), $this->repository, $existing->id);
+        }
+
+        $this->repository->update(new Menu(
+            id: $existing->id,
+            name: $input->name,
+            slug: $slug,
+            location: $input->location,
+            createdAt: $existing->createdAt,
+            updatedAt: '',
+        ));
+
+        $saved = $this->repository->findById($input->id);
+
+        if ($saved === null) {
+            throw new \RuntimeException('Failed to reload menu after update.');
+        }
+
+        return new UpdateMenuOutput(menu: $saved);
+    }
+}

--- a/src/Menu/UpdateMenuUseCaseInterface.php
+++ b/src/Menu/UpdateMenuUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Menu;
+
+interface UpdateMenuUseCaseInterface
+{
+    public function execute(UpdateMenuInput $input): UpdateMenuOutput;
+}

--- a/src/NavigationItem/NavigationItem.php
+++ b/src/NavigationItem/NavigationItem.php
@@ -14,6 +14,9 @@ final readonly class NavigationItem
         public int $displayOrder,
         public string $createdAt,
         public string $updatedAt,
+        // Named menu this item belongs to (backfilled from location; the source
+        // of truth once the UI migrates off `location`).
+        public ?int $menuId = null,
     ) {
     }
 }

--- a/src/NavigationItem/NavigationItemHttpMapper.php
+++ b/src/NavigationItem/NavigationItemHttpMapper.php
@@ -14,6 +14,7 @@ final readonly class NavigationItemHttpMapper
             'label' => $item->label,
             'url' => $item->url,
             'location' => $item->location,
+            'menu_id' => $item->menuId,
             'display_order' => $item->displayOrder,
             'created_at' => $item->createdAt,
             'updated_at' => $item->updatedAt,

--- a/src/NavigationItem/PdoNavigationItemRepository.php
+++ b/src/NavigationItem/PdoNavigationItemRepository.php
@@ -22,7 +22,7 @@ final readonly class PdoNavigationItemRepository implements NavigationItemReposi
     public function findAll(): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT id, label, url, location, display_order, created_at, updated_at
+            'SELECT id, menu_id, label, url, location, display_order, created_at, updated_at
              FROM navigation_items
              WHERE organization_id = ?
              ORDER BY display_order ASC, id ASC',
@@ -35,7 +35,7 @@ final readonly class PdoNavigationItemRepository implements NavigationItemReposi
     public function findById(int $id): ?NavigationItem
     {
         $row = $this->query->fetchOne(
-            'SELECT id, label, url, location, display_order, created_at, updated_at
+            'SELECT id, menu_id, label, url, location, display_order, created_at, updated_at
              FROM navigation_items
              WHERE id = ? AND organization_id = ?',
             [$id, $this->orgId->get()],
@@ -49,9 +49,9 @@ final readonly class PdoNavigationItemRepository implements NavigationItemReposi
         $now = date('Y-m-d H:i:s');
 
         $this->query->execute(
-            'INSERT INTO navigation_items (organization_id, label, url, location, display_order, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?)',
-            [$this->orgId->get(), $item->label, $item->url, $item->location, $item->displayOrder, $now, $now],
+            'INSERT INTO navigation_items (organization_id, menu_id, label, url, location, display_order, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            [$this->orgId->get(), $item->menuId, $item->label, $item->url, $item->location, $item->displayOrder, $now, $now],
         );
 
         return $this->query->lastInsertId();
@@ -63,9 +63,9 @@ final readonly class PdoNavigationItemRepository implements NavigationItemReposi
 
         $this->query->execute(
             'UPDATE navigation_items
-             SET label = ?, url = ?, location = ?, display_order = ?, updated_at = ?
+             SET menu_id = ?, label = ?, url = ?, location = ?, display_order = ?, updated_at = ?
              WHERE id = ? AND organization_id = ?',
-            [$item->label, $item->url, $item->location, $item->displayOrder, $now, $item->id, $this->orgId->get()],
+            [$item->menuId, $item->label, $item->url, $item->location, $item->displayOrder, $now, $item->id, $this->orgId->get()],
         );
     }
 
@@ -85,6 +85,7 @@ final readonly class PdoNavigationItemRepository implements NavigationItemReposi
             displayOrder: (int) $row['display_order'],
             createdAt: (string) $row['created_at'],
             updatedAt: (string) $row['updated_at'],
+            menuId: $row['menu_id'] === null ? null : (int) $row['menu_id'],
         );
     }
 }

--- a/src/NavigationItem/UpdateNavigationItemUseCase.php
+++ b/src/NavigationItem/UpdateNavigationItemUseCase.php
@@ -27,6 +27,7 @@ final readonly class UpdateNavigationItemUseCase implements UpdateNavigationItem
             displayOrder: $input->displayOrder,
             createdAt: $existing->createdAt,
             updatedAt: '',
+            menuId: $existing->menuId,
         );
 
         $this->repository->update($updated);

--- a/tests/Menu/InMemoryMenuRepository.php
+++ b/tests/Menu/InMemoryMenuRepository.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Menu;
+
+use NeNeRecords\Menu\Menu;
+use NeNeRecords\Menu\MenuRepositoryInterface;
+
+final class InMemoryMenuRepository implements MenuRepositoryInterface
+{
+    /** @var array<int, Menu> */
+    private array $menus = [];
+
+    private int $nextId = 1;
+
+    /** @return list<Menu> */
+    public function findAll(): array
+    {
+        return array_values($this->menus);
+    }
+
+    public function findById(int $id): ?Menu
+    {
+        return $this->menus[$id] ?? null;
+    }
+
+    public function existsBySlug(string $slug, ?int $excludeId = null): bool
+    {
+        foreach ($this->menus as $menu) {
+            if ($menu->slug === $slug && $menu->id !== $excludeId) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function save(Menu $menu): int
+    {
+        $id = $this->nextId++;
+        $now = date('Y-m-d H:i:s');
+        $this->menus[$id] = new Menu(
+            id: $id,
+            name: $menu->name,
+            slug: $menu->slug,
+            location: $menu->location,
+            createdAt: $now,
+            updatedAt: $now,
+        );
+
+        return $id;
+    }
+
+    public function update(Menu $menu): void
+    {
+        $id = $menu->id;
+        if ($id === null || !isset($this->menus[$id])) {
+            return;
+        }
+
+        $now = date('Y-m-d H:i:s');
+        $this->menus[$id] = new Menu(
+            id: $id,
+            name: $menu->name,
+            slug: $menu->slug,
+            location: $menu->location,
+            createdAt: $this->menus[$id]->createdAt,
+            updatedAt: $now,
+        );
+    }
+
+    public function delete(int $id): void
+    {
+        unset($this->menus[$id]);
+    }
+}

--- a/tests/Menu/MenuHttpTest.php
+++ b/tests/Menu/MenuHttpTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Menu;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Menu\CreateMenuHandler;
+use NeNeRecords\Menu\CreateMenuUseCase;
+use NeNeRecords\Menu\DeleteMenuHandler;
+use NeNeRecords\Menu\DeleteMenuUseCase;
+use NeNeRecords\Menu\ListMenusHandler;
+use NeNeRecords\Menu\ListMenusUseCase;
+use NeNeRecords\Menu\ListPublicMenusHandler;
+use NeNeRecords\Menu\MenuNotFoundExceptionHandler;
+use NeNeRecords\Menu\MenuRouteRegistrar;
+use NeNeRecords\Menu\UpdateMenuHandler;
+use NeNeRecords\Menu\UpdateMenuUseCase;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class MenuHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $repository = new InMemoryMenuRepository();
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+
+        $registrar = new MenuRouteRegistrar(
+            new ListMenusHandler(new ListMenusUseCase($repository), $jsonResponse),
+            new ListPublicMenusHandler(new ListMenusUseCase($repository), $jsonResponse, $this->factory),
+            new CreateMenuHandler(new CreateMenuUseCase($repository), $jsonResponse),
+            new UpdateMenuHandler(new UpdateMenuUseCase($repository), $jsonResponse),
+            new DeleteMenuHandler(new DeleteMenuUseCase($repository), $jsonResponse),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [new MenuNotFoundExceptionHandler($problemDetails)],
+            routeRegistrars: [$registrar],
+        ))->create();
+    }
+
+    /** @param array<string, mixed> $body */
+    private function post(array $body): ResponseInterface
+    {
+        return $this->application->handle(
+            $this->factory
+                ->createServerRequest('POST', 'https://example.test/api/v1/menus')
+                ->withBody($this->factory->createStream(json_encode($body, JSON_THROW_ON_ERROR))),
+        );
+    }
+
+    public function testCreateMenuDerivesSlugAndReturns201(): void
+    {
+        $response = $this->post(['name' => 'Main Nav', 'location' => 'header']);
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame('Main Nav', $payload['name']);
+        self::assertSame('main-nav', $payload['slug']);
+        self::assertSame('header', $payload['location']);
+    }
+
+    public function testCreateMenuDeduplicatesSlug(): void
+    {
+        $this->post(['name' => 'Links']);
+        $second = $this->decodeJson($this->post(['name' => 'Links']));
+
+        self::assertSame('links-2', $second['slug']);
+    }
+
+    public function testCreateMenuAllowsNullLocation(): void
+    {
+        $payload = $this->decodeJson($this->post(['name' => 'Categories']));
+        self::assertNull($payload['location']);
+    }
+
+    public function testCreateMenuWithoutNameReturns422(): void
+    {
+        self::assertSame(422, $this->post(['location' => 'header'])->getStatusCode());
+    }
+
+    public function testCreateMenuWithUnknownLocationReturns422(): void
+    {
+        self::assertSame(422, $this->post(['name' => 'X', 'location' => 'nope'])->getStatusCode());
+    }
+
+    public function testListAndPublicListReturnMenus(): void
+    {
+        $this->post(['name' => 'One']);
+        $this->post(['name' => 'Two']);
+
+        foreach (['/api/v1/menus', '/api/v1/public/menus'] as $path) {
+            $payload = $this->decodeJson(
+                $this->application->handle($this->factory->createServerRequest('GET', "https://example.test{$path}")),
+            );
+            self::assertCount(2, $payload['items'], $path);
+        }
+    }
+
+    public function testUpdateMenu(): void
+    {
+        $created = $this->decodeJson($this->post(['name' => 'Old']));
+        $id = $created['id'];
+
+        $response = $this->application->handle(
+            $this->factory
+                ->createServerRequest('PUT', "https://example.test/api/v1/menus/{$id}")
+                ->withBody($this->factory->createStream(
+                    json_encode(['name' => 'New', 'location' => 'footer'], JSON_THROW_ON_ERROR),
+                )),
+        );
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('New', $payload['name']);
+        self::assertSame('footer', $payload['location']);
+    }
+
+    public function testUpdateMissingMenuReturns404(): void
+    {
+        $response = $this->application->handle(
+            $this->factory
+                ->createServerRequest('PUT', 'https://example.test/api/v1/menus/999')
+                ->withBody($this->factory->createStream(json_encode(['name' => 'X'], JSON_THROW_ON_ERROR))),
+        );
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testDeleteMenuReturns204(): void
+    {
+        $created = $this->decodeJson($this->post(['name' => 'Temp']));
+        $id = $created['id'];
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', "https://example.test/api/v1/menus/{$id}"),
+        );
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    /** @return array<string, mixed> */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $payload = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/tests/Menu/PdoMenuRepositoryTest.php
+++ b/tests/Menu/PdoMenuRepositoryTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Menu;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Menu\Menu;
+use NeNeRecords\Menu\PdoMenuRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PdoMenuRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $factory = new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene-records-test',
+            '',
+            'utf8',
+        ));
+
+        $this->executor = new PdoDatabaseQueryExecutor($factory);
+
+        $this->orgId = new RequestScopedHolder();
+        $this->orgId->set(0);
+
+        $path = dirname(__DIR__, 2) . '/database/schema/menus.sql';
+        self::assertFileExists($path);
+        $raw = trim((string) file_get_contents($path));
+
+        foreach (preg_split('/;\R/s', $raw) ?: [] as $chunk) {
+            $statement = trim($chunk);
+            if ($statement !== '') {
+                $this->executor->execute($statement);
+            }
+        }
+    }
+
+    public function testSaveAndFindById(): void
+    {
+        $repository = new PdoMenuRepository($this->executor, $this->orgId);
+        $id = $repository->save(new Menu(null, 'Main nav', 'main-nav', 'header', '', ''));
+
+        $found = $repository->findById($id);
+        self::assertNotNull($found);
+        self::assertSame('Main nav', $found->name);
+        self::assertSame('main-nav', $found->slug);
+        self::assertSame('header', $found->location);
+    }
+
+    public function testFindByIdSupportsNullLocation(): void
+    {
+        $repository = new PdoMenuRepository($this->executor, $this->orgId);
+        $id = $repository->save(new Menu(null, 'Categories', 'categories', null, '', ''));
+
+        $found = $repository->findById($id);
+        self::assertNotNull($found);
+        self::assertNull($found->location);
+    }
+
+    public function testExistsBySlug(): void
+    {
+        $repository = new PdoMenuRepository($this->executor, $this->orgId);
+        $id = $repository->save(new Menu(null, 'Footer', 'footer', 'footer', '', ''));
+
+        self::assertTrue($repository->existsBySlug('footer'));
+        self::assertFalse($repository->existsBySlug('footer', $id));
+        self::assertFalse($repository->existsBySlug('missing'));
+    }
+
+    public function testUpdateChangesFields(): void
+    {
+        $repository = new PdoMenuRepository($this->executor, $this->orgId);
+        $id = $repository->save(new Menu(null, 'Old', 'old', null, '', ''));
+        $existing = $repository->findById($id);
+        self::assertNotNull($existing);
+
+        $repository->update(new Menu($id, 'New', 'new', 'footer', $existing->createdAt, ''));
+
+        $updated = $repository->findById($id);
+        self::assertNotNull($updated);
+        self::assertSame('New', $updated->name);
+        self::assertSame('footer', $updated->location);
+    }
+
+    public function testDeleteRemovesMenu(): void
+    {
+        $repository = new PdoMenuRepository($this->executor, $this->orgId);
+        $id = $repository->save(new Menu(null, 'Temp', 'temp', null, '', ''));
+
+        $repository->delete($id);
+
+        self::assertNull($repository->findById($id));
+        self::assertSame([], $repository->findAll());
+    }
+}

--- a/tests/NavigationItem/InMemoryNavigationItemRepository.php
+++ b/tests/NavigationItem/InMemoryNavigationItemRepository.php
@@ -45,6 +45,7 @@ final class InMemoryNavigationItemRepository implements NavigationItemRepository
             displayOrder: $item->displayOrder,
             createdAt: $now,
             updatedAt: $now,
+            menuId: $item->menuId,
         );
 
         return $id;
@@ -67,6 +68,7 @@ final class InMemoryNavigationItemRepository implements NavigationItemRepository
             displayOrder: $item->displayOrder,
             createdAt: $this->items[$id]->createdAt,
             updatedAt: $now,
+            menuId: $item->menuId,
         );
     }
 


### PR DESCRIPTION
> [Epic #347](https://github.com/hideyukiMORI/nene-records/issues/347) の **PR1（バックエンド基盤・非破壊）**。

## 目的 / Why

ナビが「項目＋3固定 location」モデルで、メニューウィジェットが特定メニューを選べない問題（ユーザー指摘）の土台。WordPress 同様「名前付きメニュー＋表示場所」へ移行する第一歩。**この PR ではフロントは無改修**で従来通り動く。

## 変更内容 / What

### DB（マイグレーション）
- `menus` テーブル（id, organization_id, name, slug, location nullable, timestamps）。
- `navigation_items.menu_id` 追加。
- backfill: org ごとに既存 location（header/footer/side）からメニューを生成し menu_id を割当。`menu.location` は header/footer、side は null（ウィジェット専用）。
- `schema/menus.sql`・`navigation_items.sql` 更新。

### API
- Menu CRUD（list/create/update/delete）＋公開一覧。slug 自動生成・重複回避、location バリデーション。
- `/api/v1/menus`（admin・ManageSettings）＋ `/api/v1/public/menus`（公開 GET）。OpenAPI 追加。
- `NavigationItem` に `menu_id` を追加（レスポンスに出力、更新時は保持）。

## 後方互換
- `item.location` は残置。公開ヘッダー/フッター・メニューウィジェットは従来通り location で動作。
- PR2 でフロントを menu_id に切替、PR3 で location を撤去。

## 検証 / Verification
- `composer check`: **PHPUnit 690** / PHPStan L8 / CS-Fixer / OpenAPI / MCP 全グリーン
- `npm run check --prefix frontend`: 全グリーン（型再生成のみ）
- ローカル DB へマイグレーション適用し backfill を確認（Header/Footer メニュー生成＋ menu_id 割当）

Part of #347