### PR TITLE
feat(menu): メニューウィジェットを名前付きメニュー選択に切り替える（#347 PR2a）

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -5565,6 +5565,11 @@ components:
           type: string
           enum: [header, footer, side]
           default: header
+        menu_id:
+          type:
+            - integer
+            - 'null'
+          description: Named menu the item belongs to.
         display_order:
           type: integer
           minimum: 0
@@ -5586,6 +5591,11 @@ components:
           type: string
           enum: [header, footer, side]
           default: header
+        menu_id:
+          type:
+            - integer
+            - 'null'
+          description: Named menu the item belongs to. Omit to keep the current menu.
         display_order:
           type: integer
           minimum: 0

--- a/frontend/src/entities/menu/api-types.ts
+++ b/frontend/src/entities/menu/api-types.ts
@@ -1,0 +1,6 @@
+import type { components } from '@/shared/api/schema.gen'
+
+export type MenuDto = components['schemas']['MenuResponse']
+export type MenuListDto = components['schemas']['MenuListResponse']
+export type CreateMenuRequestDto = components['schemas']['CreateMenuRequest']
+export type UpdateMenuRequestDto = components['schemas']['UpdateMenuRequest']

--- a/frontend/src/entities/menu/index.ts
+++ b/frontend/src/entities/menu/index.ts
@@ -1,0 +1,5 @@
+export type { CreateMenuInput, Menu, MenuList, MenuLocation, UpdateMenuInput } from './model'
+export { MENU_LOCATIONS } from './model'
+export { menuKeys } from './query-keys'
+export { useMenuList, usePublicMenus } from './queries'
+export { useCreateMenu, useDeleteMenu, useUpdateMenu } from './mutations'

--- a/frontend/src/entities/menu/mapper.ts
+++ b/frontend/src/entities/menu/mapper.ts
@@ -1,0 +1,23 @@
+import type { MenuDto, MenuListDto } from './api-types'
+import type { Menu, MenuList, MenuLocation } from './model'
+
+function toLocation(value: string | null): MenuLocation | null {
+  return value === 'header' || value === 'footer' ? value : null
+}
+
+export function mapMenuDtoToModel(dto: MenuDto): Menu {
+  return {
+    id: dto.id,
+    name: dto.name,
+    slug: dto.slug,
+    location: toLocation(dto.location),
+    createdAt: dto.created_at,
+    updatedAt: dto.updated_at,
+  }
+}
+
+export function mapMenuListDtoToModel(dto: MenuListDto): MenuList {
+  return {
+    items: dto.items.map(mapMenuDtoToModel),
+  }
+}

--- a/frontend/src/entities/menu/model.ts
+++ b/frontend/src/entities/menu/model.ts
@@ -1,0 +1,27 @@
+export type MenuLocation = 'header' | 'footer'
+
+export const MENU_LOCATIONS: readonly MenuLocation[] = ['header', 'footer']
+
+export interface Menu {
+  id: number
+  name: string
+  slug: string
+  /** header / footer = auto-displayed; null = only via a menu widget. */
+  location: MenuLocation | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface MenuList {
+  items: Menu[]
+}
+
+export interface CreateMenuInput {
+  name: string
+  location: MenuLocation | null
+}
+
+export interface UpdateMenuInput {
+  name: string
+  location: MenuLocation | null
+}

--- a/frontend/src/entities/menu/mutations.ts
+++ b/frontend/src/entities/menu/mutations.ts
@@ -1,0 +1,52 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { MenuDto } from './api-types'
+import { mapMenuDtoToModel } from './mapper'
+import type { CreateMenuInput, Menu, UpdateMenuInput } from './model'
+import { menuKeys } from './query-keys'
+
+async function invalidate(queryClient: ReturnType<typeof useQueryClient>): Promise<void> {
+  await queryClient.invalidateQueries({ queryKey: menuKeys.all })
+}
+
+export function useCreateMenu(): UseMutationResult<Menu, AppError, CreateMenuInput> {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (input) => {
+      const dto = await apiClient.post<MenuDto>('/api/v1/menus', {
+        name: input.name,
+        location: input.location,
+      })
+      return mapMenuDtoToModel(dto)
+    },
+    onSuccess: () => invalidate(queryClient),
+  })
+}
+
+export function useUpdateMenu(): UseMutationResult<
+  Menu,
+  AppError,
+  { id: number; input: UpdateMenuInput }
+> {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ id, input }) => {
+      const dto = await apiClient.put<MenuDto>(`/api/v1/menus/${String(id)}`, {
+        name: input.name,
+        location: input.location,
+      })
+      return mapMenuDtoToModel(dto)
+    },
+    onSuccess: () => invalidate(queryClient),
+  })
+}
+
+export function useDeleteMenu(): UseMutationResult<void, AppError, number> {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (id) => {
+      await apiClient.delete(`/api/v1/menus/${String(id)}`)
+    },
+    onSuccess: () => invalidate(queryClient),
+  })
+}

--- a/frontend/src/entities/menu/queries.ts
+++ b/frontend/src/entities/menu/queries.ts
@@ -1,0 +1,26 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { apiClient, AppError } from '@/shared/api/client'
+import type { MenuListDto } from './api-types'
+import { mapMenuListDtoToModel } from './mapper'
+import type { MenuList } from './model'
+import { menuKeys } from './query-keys'
+
+export function useMenuList(): UseQueryResult<MenuList, AppError> {
+  return useQuery({
+    queryKey: menuKeys.adminList(),
+    queryFn: async ({ signal }) => {
+      const dto = await apiClient.get<MenuListDto>('/api/v1/menus', signal)
+      return mapMenuListDtoToModel(dto)
+    },
+  })
+}
+
+export function usePublicMenus(): UseQueryResult<MenuList, AppError> {
+  return useQuery({
+    queryKey: menuKeys.publicList(),
+    queryFn: async ({ signal }) => {
+      const dto = await apiClient.get<MenuListDto>('/api/v1/public/menus', signal)
+      return mapMenuListDtoToModel(dto)
+    },
+  })
+}

--- a/frontend/src/entities/menu/query-keys.ts
+++ b/frontend/src/entities/menu/query-keys.ts
@@ -1,0 +1,5 @@
+export const menuKeys = {
+  all: ['menus'] as const,
+  adminList: () => [...menuKeys.all, 'admin-list'] as const,
+  publicList: () => [...menuKeys.all, 'public-list'] as const,
+}

--- a/frontend/src/entities/navigation-item/api-types.ts
+++ b/frontend/src/entities/navigation-item/api-types.ts
@@ -5,6 +5,7 @@ export interface NavigationItemDto {
   label: string
   url: string
   location: NavLocation
+  menu_id: number | null
   display_order: number
   created_at: string
   updated_at: string

--- a/frontend/src/entities/navigation-item/mapper.ts
+++ b/frontend/src/entities/navigation-item/mapper.ts
@@ -7,6 +7,7 @@ export function mapNavigationItemDtoToModel(dto: NavigationItemDto): NavigationI
     label: dto.label,
     url: dto.url,
     location: dto.location,
+    menuId: dto.menu_id,
     displayOrder: dto.display_order,
     createdAt: dto.created_at,
     updatedAt: dto.updated_at,

--- a/frontend/src/entities/navigation-item/model.ts
+++ b/frontend/src/entities/navigation-item/model.ts
@@ -7,6 +7,7 @@ export interface NavigationItem {
   label: string
   url: string
   location: NavLocation
+  menuId: number | null
   displayOrder: number
   createdAt: string
   updatedAt: string
@@ -20,6 +21,7 @@ export interface CreateNavigationItemInput {
   label: string
   url: string
   location: NavLocation
+  menuId?: number | null
   displayOrder: number
 }
 
@@ -27,5 +29,6 @@ export interface UpdateNavigationItemInput {
   label: string
   url: string
   location: NavLocation
+  menuId?: number | null
   displayOrder: number
 }

--- a/frontend/src/entities/navigation-item/mutations.ts
+++ b/frontend/src/entities/navigation-item/mutations.ts
@@ -18,6 +18,7 @@ export function useCreateNavigationItem(): UseMutationResult<
         label: input.label,
         url: input.url,
         location: input.location,
+        ...(input.menuId !== undefined ? { menu_id: input.menuId } : {}),
         display_order: input.displayOrder,
       })
       return mapNavigationItemDtoToModel(dto)
@@ -42,6 +43,7 @@ export function useUpdateNavigationItem(): UseMutationResult<
         label: input.label,
         url: input.url,
         location: input.location,
+        ...(input.menuId !== undefined ? { menu_id: input.menuId } : {}),
         display_order: input.displayOrder,
       })
       return mapNavigationItemDtoToModel(dto)

--- a/frontend/src/features/manage-widgets/hooks/use-manage-widgets-page.ts
+++ b/frontend/src/features/manage-widgets/hooks/use-manage-widgets-page.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react'
 import { useEntityTypeList } from '@/entities/entity-type'
-import type { NavLocation } from '@/entities/navigation-item'
+import { useMenuList } from '@/entities/menu'
 import {
   useCreateWidget,
   useDeleteWidget,
@@ -18,7 +18,7 @@ export interface WidgetFormState {
   title: string
   entityTypeSlug: string
   limit: number
-  menuLocation: NavLocation
+  menuId: number | null
   searchPlaceholder: string
 }
 
@@ -28,13 +28,14 @@ const EMPTY_FORM: WidgetFormState = {
   title: '',
   entityTypeSlug: '',
   limit: 5,
-  menuLocation: 'side',
+  menuId: null,
   searchPlaceholder: '',
 }
 
 export function useManageWidgetsPage() {
   const listQuery = useWidgetList()
   const entityTypesQuery = useEntityTypeList()
+  const menusQuery = useMenuList()
   const createMutation = useCreateWidget()
   const updateMutation = useUpdateWidget()
   const deleteMutation = useDeleteWidget()
@@ -71,12 +72,7 @@ export function useManageWidgetsPage() {
           ? widget.settings['entityTypeSlug']
           : '',
       limit: typeof widget.settings['limit'] === 'number' ? widget.settings['limit'] : 5,
-      menuLocation:
-        widget.settings['location'] === 'header' ||
-        widget.settings['location'] === 'footer' ||
-        widget.settings['location'] === 'side'
-          ? widget.settings['location']
-          : 'side',
+      menuId: typeof widget.settings['menuId'] === 'number' ? widget.settings['menuId'] : null,
       searchPlaceholder:
         typeof widget.settings['placeholder'] === 'string' ? widget.settings['placeholder'] : '',
     })
@@ -85,7 +81,7 @@ export function useManageWidgetsPage() {
   const submit = useCallback(async () => {
     const settings =
       form.widgetType === 'menu'
-        ? { location: form.menuLocation }
+        ? { menuId: form.menuId }
         : form.widgetType === 'toc'
           ? {}
           : form.widgetType === 'search'
@@ -126,6 +122,7 @@ export function useManageWidgetsPage() {
     widgets: listQuery.data?.items ?? [],
     isLoading: listQuery.isLoading,
     entityTypes: entityTypesQuery.data?.items ?? [],
+    menus: menusQuery.data?.items ?? [],
     form,
     editId,
     isSubmitting: createMutation.isPending || updateMutation.isPending,

--- a/frontend/src/features/manage-widgets/ui/ManageWidgetsView.tsx
+++ b/frontend/src/features/manage-widgets/ui/ManageWidgetsView.tsx
@@ -1,5 +1,5 @@
 import type { EntityType } from '@/entities/entity-type'
-import { NAV_LOCATIONS, type NavLocation } from '@/entities/navigation-item'
+import type { Menu } from '@/entities/menu'
 import type { Widget, WidgetType } from '@/entities/widget'
 import { useTranslation } from '@/shared/i18n'
 import type { ContentRegion } from '@/shared/lib/resolve-layout'
@@ -20,6 +20,7 @@ const WIDGET_TYPES: readonly WidgetType[] = [
 export interface ManageWidgetsViewProps {
   widgets: Widget[]
   entityTypes: EntityType[]
+  menus: Menu[]
   form: WidgetFormState
   editId: number | null
   isSubmitting: boolean
@@ -34,6 +35,7 @@ export interface ManageWidgetsViewProps {
 export function ManageWidgetsView({
   widgets,
   entityTypes,
+  menus,
   form,
   editId,
   isSubmitting,
@@ -128,16 +130,17 @@ export function ManageWidgetsView({
                 {t('admin.widgets.menuSettings')}
               </Text>
               <Select
-                id="widget-menu-location"
-                label={t('admin.navigation.location')}
-                value={form.menuLocation}
+                id="widget-menu"
+                label={t('admin.widgets.menuLabel')}
+                value={form.menuId === null ? '' : String(form.menuId)}
                 onChange={(e) => {
-                  setField('menuLocation', e.target.value as NavLocation)
+                  setField('menuId', e.target.value === '' ? null : Number(e.target.value))
                 }}
               >
-                {NAV_LOCATIONS.map((location) => (
-                  <option key={location} value={location}>
-                    {t(`admin.navigation.location.${location}`)}
+                <option value="">{t('admin.widgets.menuPlaceholder')}</option>
+                {menus.map((menu) => (
+                  <option key={menu.id} value={String(menu.id)}>
+                    {menu.name}
                   </option>
                 ))}
               </Select>

--- a/frontend/src/features/render-widgets/ui/MenuWidget.tsx
+++ b/frontend/src/features/render-widgets/ui/MenuWidget.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
-import { usePublicNavigationItems, type NavLocation } from '@/entities/navigation-item'
+import { usePublicMenus } from '@/entities/menu'
+import { usePublicNavigationItems } from '@/entities/navigation-item'
 import { useTranslation } from '@/shared/i18n'
 import { Text } from '@/shared/ui'
 import type { Widget } from '@/entities/widget'
@@ -8,18 +9,27 @@ export interface MenuWidgetProps {
   widget: Widget
 }
 
-/** Renders navigation items for a configured location (default `side`) as links. */
+/**
+ * Renders a named menu's items as links. The menu is chosen by `settings.menuId`;
+ * legacy widgets configured with `settings.location` fall back to the menu whose
+ * slug matches that location (from the backfill).
+ */
 export function MenuWidget({ widget }: MenuWidgetProps) {
   const { t } = useTranslation()
-  const location: NavLocation =
-    widget.settings['location'] === 'header' ||
-    widget.settings['location'] === 'footer' ||
-    widget.settings['location'] === 'side'
-      ? widget.settings['location']
-      : 'side'
+  const { data: menusData } = usePublicMenus()
+  const { data: navData } = usePublicNavigationItems()
 
-  const { data } = usePublicNavigationItems()
-  const items = (data?.items ?? []).filter((item) => item.location === location)
+  const menus = menusData?.items ?? []
+  const settingsMenuId = widget.settings['menuId']
+  const legacyLocation = widget.settings['location']
+
+  let menuId: number | null = typeof settingsMenuId === 'number' ? settingsMenuId : null
+  if (menuId === null && typeof legacyLocation === 'string') {
+    menuId = menus.find((menu) => menu.slug === legacyLocation)?.id ?? null
+  }
+
+  const items =
+    menuId === null ? [] : (navData?.items ?? []).filter((item) => item.menuId === menuId)
 
   if (items.length === 0) {
     return (

--- a/frontend/src/pages/widgets/WidgetsPage.tsx
+++ b/frontend/src/pages/widgets/WidgetsPage.tsx
@@ -22,6 +22,7 @@ export function WidgetsPage() {
       <ManageWidgetsView
         widgets={page.widgets}
         entityTypes={page.entityTypes}
+        menus={page.menus}
         form={page.form}
         editId={page.editId}
         isSubmitting={page.isSubmitting}

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -2186,6 +2186,8 @@ export interface components {
              * @enum {string}
              */
             location: "header" | "footer" | "side";
+            /** @description Named menu the item belongs to. */
+            menu_id?: number | null;
             /** @default 0 */
             display_order: number;
         };
@@ -2197,6 +2199,8 @@ export interface components {
              * @enum {string}
              */
             location: "header" | "footer" | "side";
+            /** @description Named menu the item belongs to. Omit to keep the current menu. */
+            menu_id?: number | null;
             /** @default 0 */
             display_order: number;
         };

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -65,6 +65,8 @@ export const en = {
   'admin.widgets.type.popular-posts': 'Popular posts',
   'admin.widgets.type.calendar': 'Calendar',
   'admin.widgets.menuSettings': 'Menu settings',
+  'admin.widgets.menuLabel': 'Menu',
+  'admin.widgets.menuPlaceholder': 'Select a menu…',
   'admin.widgets.tocSettings':
     "Shows the current page's headings. No settings — it renders on pages that have headings.",
   'admin.widgets.searchSettings': 'Search settings',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -58,6 +58,8 @@ export const ja: Partial<MessageCatalog> = {
   'admin.widgets.type.popular-posts': '人気記事',
   'admin.widgets.type.calendar': 'カレンダー',
   'admin.widgets.menuSettings': 'メニューの設定',
+  'admin.widgets.menuLabel': 'メニュー',
+  'admin.widgets.menuPlaceholder': 'メニューを選択…',
   'admin.widgets.tocSettings':
     '現在ページの見出しを表示します。設定なし（見出しがあるページで描画）。',
   'admin.widgets.searchSettings': '検索の設定',

--- a/src/NavigationItem/CreateNavigationItemHandler.php
+++ b/src/NavigationItem/CreateNavigationItemHandler.php
@@ -30,6 +30,7 @@ final readonly class CreateNavigationItemHandler
         $displayOrder = isset($body['display_order']) && is_int($body['display_order'])
             ? $body['display_order']
             : 0;
+        $menuId = is_int($body['menu_id'] ?? null) ? $body['menu_id'] : null;
 
         if ($label === '') {
             $errors[] = new ValidationError('label', 'Label is required.', 'required');
@@ -48,6 +49,7 @@ final readonly class CreateNavigationItemHandler
         }
 
         $output = $this->useCase->execute(new CreateNavigationItemInput(
+            menuId: $menuId,
             label: $label,
             url: $url,
             location: $location,

--- a/src/NavigationItem/CreateNavigationItemInput.php
+++ b/src/NavigationItem/CreateNavigationItemInput.php
@@ -11,6 +11,7 @@ final readonly class CreateNavigationItemInput
         public string $url,
         public string $location,
         public int $displayOrder,
+        public ?int $menuId = null,
     ) {
     }
 }

--- a/src/NavigationItem/CreateNavigationItemUseCase.php
+++ b/src/NavigationItem/CreateNavigationItemUseCase.php
@@ -21,6 +21,7 @@ final readonly class CreateNavigationItemUseCase implements CreateNavigationItem
             displayOrder: $input->displayOrder,
             createdAt: '',
             updatedAt: '',
+            menuId: $input->menuId,
         );
 
         $id = $this->repository->save($item);

--- a/src/NavigationItem/UpdateNavigationItemHandler.php
+++ b/src/NavigationItem/UpdateNavigationItemHandler.php
@@ -34,6 +34,8 @@ final readonly class UpdateNavigationItemHandler
         $displayOrder = isset($body['display_order']) && is_int($body['display_order'])
             ? $body['display_order']
             : 0;
+        $menuIdProvided = array_key_exists('menu_id', $body);
+        $menuId = is_int($body['menu_id'] ?? null) ? $body['menu_id'] : null;
 
         if ($label === '') {
             $errors[] = new ValidationError('label', 'Label is required.', 'required');
@@ -57,6 +59,8 @@ final readonly class UpdateNavigationItemHandler
             url: $url,
             location: $location,
             displayOrder: $displayOrder,
+            menuId: $menuId,
+            menuIdProvided: $menuIdProvided,
         ));
 
         return $this->response->create(NavigationItemHttpMapper::toArray($output->item));

--- a/src/NavigationItem/UpdateNavigationItemInput.php
+++ b/src/NavigationItem/UpdateNavigationItemInput.php
@@ -12,6 +12,9 @@ final readonly class UpdateNavigationItemInput
         public string $url,
         public string $location,
         public int $displayOrder,
+        // menu_id is only changed when the client sends it; otherwise preserved.
+        public ?int $menuId = null,
+        public bool $menuIdProvided = false,
     ) {
     }
 }

--- a/src/NavigationItem/UpdateNavigationItemUseCase.php
+++ b/src/NavigationItem/UpdateNavigationItemUseCase.php
@@ -27,7 +27,7 @@ final readonly class UpdateNavigationItemUseCase implements UpdateNavigationItem
             displayOrder: $input->displayOrder,
             createdAt: $existing->createdAt,
             updatedAt: '',
-            menuId: $existing->menuId,
+            menuId: $input->menuIdProvided ? $input->menuId : $existing->menuId,
         );
 
         $this->repository->update($updated);


### PR DESCRIPTION
> [Epic #347](https://github.com/hideyukiMORI/nene-records/issues/347) 段階2の前半。ユーザー要望「ウィジェットで特定のメニューを選べない」の核心を解消する。

## 変更内容 / What

### Backend
- `navigation_items` の Create/Update が `menu_id` を受け付ける（Update は未指定なら既存値を保持）。OpenAPI 更新。

### Frontend
- `entities/menu`（model/api-types/mapper/queries/mutations）。`useMenuList` / `usePublicMenus` ＋ CRUD。
- `entities/navigation-item` に `menuId` を追加。
- **MenuWidget**：`settings.menuId` で対象メニューを選択（旧 `settings.location` は slug 一致でフォールバック）。項目は `item.menuId` で絞り込み。
- **manage-widgets**：メニュー設定を「location 選択」→「**メニュー選択(menuId)**」に変更。
- i18n（en/ja）。

## 後方互換
- ヘッダー/フッターと既存メニュー管理画面は当面 location ベースのまま。
- 旧メニューウィジェット（settings.location）は backfill 済みメニュー（slug=location）にフォールバックして従来通り表示。
- PR2b で管理画面を2階層化＋ヘッダー/フッターを `menu.location` 駆動へ、PR3 で `location` 撤去。

## 検証 / Verification
- `composer check`: **PHPUnit 690** / PHPStan L8 / CS-Fixer / OpenAPI / MCP 全グリーン
- `npm run check --prefix frontend`: type-check / lint / prettier / test / knip / storybook 全グリーン

Part of #347