### PR TITLE
feat(appearance): レイアウトタブを DnD ビルダー化（#352 スライス3）

### DIFF
--- a/frontend/src/features/manage-widgets/hooks/use-manage-widgets-page.ts
+++ b/frontend/src/features/manage-widgets/hooks/use-manage-widgets-page.ts
@@ -1,6 +1,6 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useEntityTypeList } from '@/entities/entity-type'
-import { useMenuList } from '@/entities/menu'
+import { useMenuList, type Menu } from '@/entities/menu'
 import {
   useCreateWidget,
   useDeleteWidget,
@@ -12,26 +12,38 @@ import {
 } from '@/entities/widget'
 import type { WidgetRegion } from '@/shared/lib/resolve-layout'
 
-export interface WidgetFormState {
-  widgetType: WidgetType
-  region: WidgetRegion
-  title: string
-  entityTypeSlug: string
-  limit: number
-  menuId: number | null
-  searchPlaceholder: string
+/** Default settings for a freshly added widget of `type`. */
+function defaultSettings(type: WidgetType, menus: Menu[]): Record<string, unknown> {
+  switch (type) {
+    case 'menu':
+      return { menuId: menus[0]?.id ?? null }
+    case 'recent-posts':
+      return { entityTypeSlug: '', limit: 5 }
+    case 'popular-posts':
+      return { limit: 5 }
+    case 'search':
+      return { placeholder: '' }
+    default:
+      return {}
+  }
 }
 
-const EMPTY_FORM: WidgetFormState = {
-  widgetType: 'recent-posts',
-  region: 'sidebar',
-  title: '',
-  entityTypeSlug: '',
-  limit: 5,
-  menuId: null,
-  searchPlaceholder: '',
+function toInput(w: Widget, overrides: Partial<WidgetInput> = {}): WidgetInput {
+  return {
+    widgetType: w.widgetType,
+    region: w.region,
+    displayOrder: w.displayOrder,
+    title: w.title,
+    settings: w.settings,
+    ...overrides,
+  }
 }
 
+/**
+ * Layout-tab state: the widget list plus drag-and-drop placement operations
+ * (add at index, move/reorder across regions) and inspector edits, all persisted
+ * through the widget API.
+ */
 export function useManageWidgetsPage() {
   const listQuery = useWidgetList()
   const entityTypesQuery = useEntityTypeList()
@@ -40,97 +52,104 @@ export function useManageWidgetsPage() {
   const updateMutation = useUpdateWidget()
   const deleteMutation = useDeleteWidget()
 
-  const [editId, setEditId] = useState<number | null>(null)
-  const [form, setForm] = useState<WidgetFormState>(EMPTY_FORM)
-
-  const setField = useCallback(
-    <K extends keyof WidgetFormState>(key: K, value: WidgetFormState[K]) => {
-      setForm((current) => ({ ...current, [key]: value }))
-    },
-    [],
-  )
-
-  const resetForm = useCallback(() => {
-    setEditId(null)
-    setForm(EMPTY_FORM)
-  }, [])
-
-  // Start a fresh widget targeted at a region (used by the layout board).
-  const addToRegion = useCallback((region: WidgetRegion) => {
-    setEditId(null)
-    setForm({ ...EMPTY_FORM, region })
-  }, [])
-
-  const editWidget = useCallback((widget: Widget) => {
-    setEditId(widget.id)
-    setForm({
-      widgetType: widget.widgetType,
-      region: widget.region,
-      title: widget.title ?? '',
-      entityTypeSlug:
-        typeof widget.settings['entityTypeSlug'] === 'string'
-          ? widget.settings['entityTypeSlug']
-          : '',
-      limit: typeof widget.settings['limit'] === 'number' ? widget.settings['limit'] : 5,
-      menuId: typeof widget.settings['menuId'] === 'number' ? widget.settings['menuId'] : null,
-      searchPlaceholder:
-        typeof widget.settings['placeholder'] === 'string' ? widget.settings['placeholder'] : '',
-    })
-  }, [])
-
-  const submit = useCallback(async () => {
-    const settings =
-      form.widgetType === 'menu'
-        ? { menuId: form.menuId }
-        : form.widgetType === 'toc'
-          ? {}
-          : form.widgetType === 'search'
-            ? { placeholder: form.searchPlaceholder.trim() }
-            : form.widgetType === 'tag-cloud'
-              ? {}
-              : form.widgetType === 'popular-posts'
-                ? { limit: form.limit }
-                : form.widgetType === 'calendar'
-                  ? {}
-                  : { entityTypeSlug: form.entityTypeSlug, limit: form.limit }
-    const input: WidgetInput = {
-      widgetType: form.widgetType,
-      region: form.region,
-      displayOrder: 0,
-      title: form.title.trim() === '' ? null : form.title.trim(),
-      settings,
-    }
-    if (editId !== null) {
-      await updateMutation.mutateAsync({ id: editId, input })
-    } else {
-      await createMutation.mutateAsync(input)
-    }
-    resetForm()
-  }, [createMutation, editId, form, resetForm, updateMutation])
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+  const widgets = useMemo(() => listQuery.data?.items ?? [], [listQuery.data?.items])
+  const menus = useMemo(() => menusQuery.data?.items ?? [], [menusQuery.data?.items])
 
   const remove = useCallback(
     async (id: number) => {
       await deleteMutation.mutateAsync(id)
-      if (editId === id) {
-        resetForm()
-      }
+      setSelectedId((s) => (s === id ? null : s))
     },
-    [deleteMutation, editId, resetForm],
+    [deleteMutation],
+  )
+
+  // Persist a region's desired widget order; only PUT widgets whose region or
+  // display_order actually changed.
+  const persistOrder = useCallback(
+    async (region: WidgetRegion, ordered: Widget[]) => {
+      await Promise.all(
+        ordered.map((w, index) =>
+          w.region === region && w.displayOrder === index
+            ? Promise.resolve(undefined)
+            : updateMutation.mutateAsync({
+                id: w.id,
+                input: toInput(w, { region, displayOrder: index }),
+              }),
+        ),
+      )
+    },
+    [updateMutation],
+  )
+
+  const addWidgetAt = useCallback(
+    async (type: WidgetType, region: WidgetRegion, index: number | null) => {
+      const created = await createMutation.mutateAsync({
+        widgetType: type,
+        region,
+        displayOrder: 9999,
+        title: null,
+        settings: defaultSettings(type, menus),
+      })
+      const list = widgets.filter((w) => w.region === region)
+      const at = index === null || index > list.length ? list.length : index
+      const ordered = [...list]
+      ordered.splice(at, 0, created)
+      await persistOrder(region, ordered)
+      setSelectedId(created.id)
+    },
+    [createMutation, menus, widgets, persistOrder],
+  )
+
+  const moveWidgetAt = useCallback(
+    async (id: number, region: WidgetRegion, index: number | null) => {
+      const moving = widgets.find((w) => w.id === id)
+      if (moving === undefined) return
+      const list = widgets.filter((w) => w.region === region && w.id !== id)
+      const at = index === null || index > list.length ? list.length : index
+      const ordered = [...list]
+      ordered.splice(at, 0, moving)
+      await persistOrder(region, ordered)
+    },
+    [widgets, persistOrder],
+  )
+
+  const updateSettings = useCallback(
+    async (id: number, patch: Record<string, unknown>) => {
+      const w = widgets.find((x) => x.id === id)
+      if (w === undefined) return
+      await updateMutation.mutateAsync({
+        id,
+        input: toInput(w, { settings: { ...w.settings, ...patch } }),
+      })
+    },
+    [widgets, updateMutation],
+  )
+
+  const updateTitle = useCallback(
+    async (id: number, title: string) => {
+      const w = widgets.find((x) => x.id === id)
+      if (w === undefined) return
+      await updateMutation.mutateAsync({
+        id,
+        input: toInput(w, { title: title.trim() === '' ? null : title.trim() }),
+      })
+    },
+    [widgets, updateMutation],
   )
 
   return {
-    widgets: listQuery.data?.items ?? [],
+    widgets,
     isLoading: listQuery.isLoading,
     entityTypes: entityTypesQuery.data?.items ?? [],
-    menus: menusQuery.data?.items ?? [],
-    form,
-    editId,
+    menus,
+    selectedId,
     isSubmitting: createMutation.isPending || updateMutation.isPending,
-    setField,
-    resetForm,
-    addToRegion,
-    editWidget,
-    submit,
+    select: setSelectedId,
+    addWidgetAt,
+    moveWidgetAt,
+    updateSettings,
+    updateTitle,
     remove,
   }
 }

--- a/frontend/src/features/manage-widgets/ui/ManageWidgetsView.tsx
+++ b/frontend/src/features/manage-widgets/ui/ManageWidgetsView.tsx
@@ -1,7 +1,4 @@
 import { useState } from 'react'
-import type { EntityType } from '@/entities/entity-type'
-import type { Menu } from '@/entities/menu'
-import type { Widget, WidgetType } from '@/entities/widget'
 import { useTranslation } from '@/shared/i18n'
 import {
   activeSideRegions,
@@ -9,51 +6,23 @@ import {
   saveLayoutConfig,
   type LayoutConfig,
 } from '@/shared/lib/layout-config'
-import { WIDGET_REGIONS, type WidgetRegion } from '@/shared/lib/resolve-layout'
-import { Button, Card, Input, Select, Stack, Text } from '@/shared/ui'
-import type { WidgetFormState } from '../hooks/use-manage-widgets-page'
+import type { WidgetRegion } from '@/shared/lib/resolve-layout'
+import { Button, Card, Stack, Text } from '@/shared/ui'
+import type { useManageWidgetsPage } from '../hooks/use-manage-widgets-page'
 import { LayoutConfigBar } from './LayoutConfigBar'
+import { WidgetInspector } from './WidgetInspector'
+import { WidgetPalette } from './WidgetPalette'
 import { WidgetRegionBoard } from './WidgetRegionBoard'
 
-const WIDGET_TYPES: readonly WidgetType[] = [
-  'recent-posts',
-  'menu',
-  'toc',
-  'search',
-  'tag-cloud',
-  'popular-posts',
-  'calendar',
-]
+// 3-pane workspace columns: palette | board | inspector.
+const WORKSPACE_CLASS =
+  'grid grid-cols-1 gap-stack-lg lg:grid-cols-[220px_1fr_280px] lg:items-start'
 
 export interface ManageWidgetsViewProps {
-  widgets: Widget[]
-  entityTypes: EntityType[]
-  menus: Menu[]
-  form: WidgetFormState
-  editId: number | null
-  isSubmitting: boolean
-  setField: <K extends keyof WidgetFormState>(key: K, value: WidgetFormState[K]) => void
-  resetForm: () => void
-  addToRegion: (region: WidgetRegion) => void
-  editWidget: (widget: Widget) => void
-  submit: () => Promise<void>
-  remove: (id: number) => Promise<void>
+  page: ReturnType<typeof useManageWidgetsPage>
 }
 
-export function ManageWidgetsView({
-  widgets,
-  entityTypes,
-  menus,
-  form,
-  editId,
-  isSubmitting,
-  setField,
-  resetForm,
-  addToRegion,
-  editWidget,
-  submit,
-  remove,
-}: ManageWidgetsViewProps) {
+export function ManageWidgetsView({ page }: ManageWidgetsViewProps) {
   const { t } = useTranslation()
   const [cfg, setCfgState] = useState<LayoutConfig>(() => loadLayoutConfig())
   const setCfg = (next: LayoutConfig) => {
@@ -61,12 +30,13 @@ export function ManageWidgetsView({
     saveLayoutConfig(next)
   }
 
-  // Widgets in side regions the current config does not render → hidden publicly.
   const active = activeSideRegions(cfg)
   const hiddenRegions = (['sidebar', 'aside'] as const).filter((r) => !active.includes(r))
-  const hiddenCount = widgets.filter((w) =>
+  const hiddenCount = page.widgets.filter((w) =>
     (hiddenRegions as readonly WidgetRegion[]).includes(w.region),
   ).length
+
+  const selected = page.widgets.find((w) => w.id === page.selectedId) ?? null
 
   return (
     <Stack gap="lg">
@@ -91,171 +61,54 @@ export function ManageWidgetsView({
           </Button>
         </Card>
       ) : null}
-      <Card
-        as="form"
-        onSubmit={(e) => {
-          e.preventDefault()
-          void submit()
-        }}
-      >
-        <Stack gap="md">
-          <Text as="h2" variant="heading-sm">
-            {editId !== null ? t('admin.widgets.editTitle') : t('admin.widgets.createTitle')}
-          </Text>
-          <Select
-            id="widget-type"
-            label={t('admin.widgets.typeLabel')}
-            value={form.widgetType}
-            onChange={(e) => {
-              setField('widgetType', e.target.value as WidgetType)
-            }}
-          >
-            {WIDGET_TYPES.map((type) => (
-              <option key={type} value={type}>
-                {t(`admin.widgets.type.${type}`)}
-              </option>
-            ))}
-          </Select>
-          <Select
-            id="widget-region"
-            label={t('admin.region.label')}
-            value={form.region}
-            onChange={(e) => {
-              setField('region', e.target.value as WidgetRegion)
-            }}
-          >
-            {WIDGET_REGIONS.map((region) => (
-              <option key={region} value={region}>
-                {t(`admin.region.${region}`)}
-              </option>
-            ))}
-          </Select>
-          <Input
-            id="widget-title"
-            label={t('admin.widgets.titleLabel')}
-            value={form.title}
-            onChange={(e) => {
-              setField('title', e.target.value)
-            }}
-          />
-          {form.widgetType === 'recent-posts' ? (
-            <>
-              <Text muted variant="caption">
-                {t('admin.widgets.recentPostsSettings')}
-              </Text>
-              <Select
-                id="widget-entity-type"
-                label={t('admin.widgets.entityTypeLabel')}
-                value={form.entityTypeSlug}
-                onChange={(e) => {
-                  setField('entityTypeSlug', e.target.value)
-                }}
-              >
-                <option value="">{t('admin.widgets.entityTypePlaceholder')}</option>
-                {entityTypes.map((type) => (
-                  <option key={String(type.id)} value={type.slug}>
-                    {type.name}
-                  </option>
-                ))}
-              </Select>
-              <Input
-                id="widget-limit"
-                type="number"
-                label={t('admin.widgets.limitLabel')}
-                value={String(form.limit)}
-                onChange={(e) => {
-                  setField('limit', Number(e.target.value) || 1)
-                }}
-              />
-            </>
-          ) : form.widgetType === 'menu' ? (
-            <>
-              <Text muted variant="caption">
-                {t('admin.widgets.menuSettings')}
-              </Text>
-              <Select
-                id="widget-menu"
-                label={t('admin.widgets.menuLabel')}
-                value={form.menuId === null ? '' : String(form.menuId)}
-                onChange={(e) => {
-                  setField('menuId', e.target.value === '' ? null : Number(e.target.value))
-                }}
-              >
-                <option value="">{t('admin.widgets.menuPlaceholder')}</option>
-                {menus.map((menu) => (
-                  <option key={menu.id} value={String(menu.id)}>
-                    {menu.name}
-                  </option>
-                ))}
-              </Select>
-            </>
-          ) : form.widgetType === 'toc' ? (
-            <Text muted variant="caption">
-              {t('admin.widgets.tocSettings')}
-            </Text>
-          ) : form.widgetType === 'search' ? (
-            <>
-              <Text muted variant="caption">
-                {t('admin.widgets.searchSettings')}
-              </Text>
-              <Input
-                id="widget-search-placeholder"
-                label={t('admin.widgets.searchPlaceholderLabel')}
-                value={form.searchPlaceholder}
-                onChange={(e) => {
-                  setField('searchPlaceholder', e.target.value)
-                }}
-              />
-            </>
-          ) : form.widgetType === 'tag-cloud' ? (
-            <Text muted variant="caption">
-              {t('admin.widgets.tagCloudSettings')}
-            </Text>
-          ) : form.widgetType === 'popular-posts' ? (
-            <>
-              <Text muted variant="caption">
-                {t('admin.widgets.popularPostsSettings')}
-              </Text>
-              <Input
-                id="widget-popular-limit"
-                type="number"
-                label={t('admin.widgets.limitLabel')}
-                value={String(form.limit)}
-                onChange={(e) => {
-                  setField('limit', Number(e.target.value) || 1)
-                }}
-              />
-            </>
-          ) : (
-            <Text muted variant="caption">
-              {t('admin.widgets.calendarSettings')}
-            </Text>
-          )}
-          <div className="flex items-center gap-inline-sm">
-            <Button type="submit" disabled={isSubmitting}>
-              {editId !== null ? t('common.actions.save') : t('admin.widgets.add')}
-            </Button>
-            {editId !== null ? (
-              <Button type="button" variant="secondary" onClick={resetForm}>
-                {t('common.actions.cancel')}
-              </Button>
-            ) : null}
-          </div>
-        </Stack>
-      </Card>
 
-      <WidgetRegionBoard
-        widgets={widgets}
-        editId={editId}
-        cfg={cfg}
-        onAddToRegion={(region) => {
-          addToRegion(region)
-        }}
-        onEdit={editWidget}
-        onRemove={(id) => {
-          void remove(id)
-        }}
-      />
+      <div className={WORKSPACE_CLASS}>
+        <WidgetPalette
+          onAdd={(type) => {
+            void page.addWidgetAt(type, 'sidebar', null)
+          }}
+        />
+
+        <WidgetRegionBoard
+          widgets={page.widgets}
+          menus={page.menus}
+          selectedId={page.selectedId}
+          cfg={cfg}
+          dnd
+          onAddToRegion={(region) => {
+            void page.addWidgetAt('menu', region, null)
+          }}
+          onSelect={page.select}
+          onRemove={(id) => {
+            void page.remove(id)
+          }}
+          onDrop={(region, index, payload) => {
+            if (payload.kind === 'new') {
+              void page.addWidgetAt(payload.type, region, index)
+            } else {
+              void page.moveWidgetAt(payload.id, region, index)
+            }
+          }}
+        />
+
+        <WidgetInspector
+          widget={selected}
+          menus={page.menus}
+          entityTypes={page.entityTypes}
+          onTitle={(id, title) => {
+            void page.updateTitle(id, title)
+          }}
+          onSettings={(id, patch) => {
+            void page.updateSettings(id, patch)
+          }}
+          onChangeRegion={(id, region) => {
+            void page.moveWidgetAt(id, region, null)
+          }}
+          onRemove={(id) => {
+            void page.remove(id)
+          }}
+        />
+      </div>
     </Stack>
   )
 }

--- a/frontend/src/features/manage-widgets/ui/WidgetInspector.tsx
+++ b/frontend/src/features/manage-widgets/ui/WidgetInspector.tsx
@@ -1,0 +1,162 @@
+import type { EntityType } from '@/entities/entity-type'
+import type { Menu } from '@/entities/menu'
+import type { Widget } from '@/entities/widget'
+import { useTranslation } from '@/shared/i18n'
+import { WIDGET_REGIONS, type WidgetRegion } from '@/shared/lib/resolve-layout'
+import { Button, Card, Input, Select, Text } from '@/shared/ui'
+import { WIDGET_CATALOG_BY_TYPE, type SettingDescriptor } from '../widget-catalog'
+
+export interface WidgetInspectorProps {
+  widget: Widget | null
+  menus: Menu[]
+  entityTypes: EntityType[]
+  onTitle: (id: number, title: string) => void
+  onSettings: (id: number, patch: Record<string, unknown>) => void
+  onChangeRegion: (id: number, region: WidgetRegion) => void
+  onRemove: (id: number) => void
+}
+
+export function WidgetInspector({
+  widget,
+  menus,
+  entityTypes,
+  onTitle,
+  onSettings,
+  onChangeRegion,
+  onRemove,
+}: WidgetInspectorProps) {
+  const { t } = useTranslation()
+
+  if (widget === null) {
+    return (
+      <Card className="flex flex-col gap-stack-xs">
+        <Text as="h2" variant="heading-sm">
+          {t('admin.layout.inspector')}
+        </Text>
+        <Text muted variant="caption">
+          {t('admin.layout.inspectorEmpty')}
+        </Text>
+      </Card>
+    )
+  }
+
+  const entry = WIDGET_CATALOG_BY_TYPE[widget.widgetType]
+
+  const renderField = (s: SettingDescriptor) => {
+    const value = widget.settings[s.key]
+    if (s.editor === 'menu') {
+      return (
+        <Select
+          key={s.key}
+          id={`insp-${s.key}`}
+          label={t(s.labelKey)}
+          value={typeof value === 'number' ? String(value) : ''}
+          onChange={(e) => {
+            onSettings(widget.id, { menuId: e.target.value === '' ? null : Number(e.target.value) })
+          }}
+        >
+          <option value="">{t('admin.widgets.menuPlaceholder')}</option>
+          {menus.map((m) => (
+            <option key={m.id} value={String(m.id)}>
+              {m.name}
+            </option>
+          ))}
+        </Select>
+      )
+    }
+    if (s.editor === 'enum' && s.key === 'entityTypeSlug') {
+      return (
+        <Select
+          key={s.key}
+          id={`insp-${s.key}`}
+          label={t(s.labelKey)}
+          value={typeof value === 'string' ? value : ''}
+          onChange={(e) => {
+            onSettings(widget.id, { entityTypeSlug: e.target.value })
+          }}
+        >
+          <option value="">{t('admin.widgets.entityTypePlaceholder')}</option>
+          {entityTypes.map((type) => (
+            <option key={String(type.id)} value={type.slug}>
+              {type.name}
+            </option>
+          ))}
+        </Select>
+      )
+    }
+    if (s.editor === 'int') {
+      return (
+        <Input
+          key={s.key}
+          id={`insp-${s.key}`}
+          type="number"
+          label={t(s.labelKey)}
+          value={String(typeof value === 'number' ? value : (s.def ?? 1))}
+          onChange={(e) => {
+            onSettings(widget.id, { [s.key]: Number(e.target.value) || 1 })
+          }}
+        />
+      )
+    }
+    return (
+      <Input
+        key={s.key}
+        id={`insp-${s.key}`}
+        label={t(s.labelKey)}
+        value={typeof value === 'string' ? value : ''}
+        onChange={(e) => {
+          onSettings(widget.id, { [s.key]: e.target.value })
+        }}
+      />
+    )
+  }
+
+  return (
+    <Card className="flex flex-col gap-stack-sm">
+      <Text as="h2" variant="heading-sm">
+        {t(entry.labelKey)}
+      </Text>
+      <Input
+        id="insp-title"
+        label={t('admin.widgets.titleLabel')}
+        value={widget.title ?? ''}
+        onChange={(e) => {
+          onTitle(widget.id, e.target.value)
+        }}
+      />
+      {entry.settings.map(renderField)}
+
+      <div>
+        <Text as="span" muted variant="caption">
+          {t('admin.region.label')}
+        </Text>
+        <div className="mt-1 flex flex-wrap gap-inline-xs">
+          {WIDGET_REGIONS.map((r) => (
+            <Button
+              key={r}
+              size="sm"
+              variant={widget.region === r ? 'primary' : 'secondary'}
+              onClick={() => {
+                onChangeRegion(widget.id, r)
+              }}
+            >
+              {t(`admin.region.${r}`)}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <Button
+          variant="danger"
+          size="sm"
+          onClick={() => {
+            onRemove(widget.id)
+          }}
+        >
+          {t('admin.widgets.board.deleteWidget')}
+        </Button>
+      </div>
+    </Card>
+  )
+}

--- a/frontend/src/features/manage-widgets/ui/WidgetPalette.tsx
+++ b/frontend/src/features/manage-widgets/ui/WidgetPalette.tsx
@@ -1,0 +1,57 @@
+import type { WidgetType } from '@/entities/widget'
+import { useTranslation } from '@/shared/i18n'
+import { Card, Stack, Text } from '@/shared/ui'
+import { WIDGET_CATALOG } from '../widget-catalog'
+import { setDragPayload, clearDragPayload } from './widget-dnd'
+
+export interface WidgetPaletteProps {
+  onAdd: (type: WidgetType) => void
+}
+
+/** Draggable widget chips. Drag onto a region to place; click to append. */
+export function WidgetPalette({ onAdd }: WidgetPaletteProps) {
+  const { t } = useTranslation()
+  return (
+    <Card className="flex flex-col gap-stack-sm">
+      <Text as="h2" variant="heading-sm">
+        {t('admin.layout.palette')}
+      </Text>
+      <Text as="span" muted variant="caption">
+        {t('admin.layout.paletteHint')}
+      </Text>
+      <ul className="flex flex-col gap-stack-xs">
+        {WIDGET_CATALOG.map((c) => (
+          <li key={c.type}>
+            <button
+              type="button"
+              draggable
+              onDragStart={(e) => {
+                setDragPayload({ kind: 'new', type: c.type })
+                e.dataTransfer.effectAllowed = 'copy'
+              }}
+              onDragEnd={() => {
+                clearDragPayload()
+              }}
+              onClick={() => {
+                onAdd(c.type)
+              }}
+              className="flex w-full cursor-grab items-center justify-between gap-inline-sm rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm text-left hover:bg-surface-overlay active:cursor-grabbing"
+            >
+              <Stack gap="xs">
+                <Text as="span" variant="body">
+                  {t(c.labelKey)}
+                </Text>
+                <Text as="span" muted variant="caption">
+                  {t(c.descKey)}
+                </Text>
+              </Stack>
+              <span aria-hidden className="text-text-muted">
+                ⠿
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  )
+}

--- a/frontend/src/features/manage-widgets/ui/WidgetRegionBoard.tsx
+++ b/frontend/src/features/manage-widgets/ui/WidgetRegionBoard.tsx
@@ -1,87 +1,164 @@
+import { useState, type DragEvent, type ReactNode } from 'react'
+import type { Menu } from '@/entities/menu'
 import type { Widget } from '@/entities/widget'
 import { useTranslation } from '@/shared/i18n'
 import { bodyColumns, type LayoutConfig } from '@/shared/lib/layout-config'
 import type { WidgetRegion } from '@/shared/lib/resolve-layout'
 import { Button, Card, Stack, Text } from '@/shared/ui'
+import { WIDGET_CATALOG_BY_TYPE } from '../widget-catalog'
+import {
+  clearDragPayload,
+  computeDropIndex,
+  getDragPayload,
+  setDragPayload,
+  type DragPayload,
+} from './widget-dnd'
 
 export interface WidgetRegionBoardProps {
   widgets: Widget[]
-  editId: number | null
+  menus: Menu[]
+  selectedId: number | null
   cfg: LayoutConfig
+  dnd: boolean
   onAddToRegion: (region: WidgetRegion) => void
-  onEdit: (widget: Widget) => void
+  onSelect: (id: number) => void
   onRemove: (id: number) => void
+  onDrop: (region: WidgetRegion, index: number, payload: DragPayload) => void
 }
 
-/**
- * Visual layout board mirroring the public page: a full-width header bar, the
- * record-detail body columns (driven by the layout config), and a full-width
- * footer bar. Each region (header/sidebar/aside/footer) accepts widgets; `main`
- * is record content.
- */
+const REGION_FLOW: Record<WidgetRegion, 'row' | 'col'> = {
+  header: 'row',
+  sidebar: 'col',
+  aside: 'col',
+  footer: 'col',
+}
+
 export function WidgetRegionBoard({
   widgets,
-  editId,
+  menus,
+  selectedId,
   cfg,
+  dnd,
   onAddToRegion,
-  onEdit,
+  onSelect,
   onRemove,
+  onDrop,
 }: WidgetRegionBoardProps) {
   const { t } = useTranslation()
+  const [hover, setHover] = useState<{ region: WidgetRegion; idx: number } | null>(null)
 
   const byRegion = (region: WidgetRegion): Widget[] =>
     widgets
-      .filter((widget) => widget.region === region)
+      .filter((w) => w.region === region)
       .sort((a, b) => a.displayOrder - b.displayOrder || a.id - b.id)
 
-  const renderCard = (widget: Widget) => (
+  const subLabel = (w: Widget): string => {
+    if (w.widgetType === 'menu') {
+      const m = menus.find((x) => x.id === w.settings['menuId'])
+      return `${t('admin.widgets.type.menu')} · ${m ? m.name : t('admin.widgets.menuPlaceholder')}`
+    }
+    return t(WIDGET_CATALOG_BY_TYPE[w.widgetType].labelKey)
+  }
+
+  const renderCard = (w: Widget) => (
     <Card
       as="li"
-      key={widget.id}
+      key={w.id}
       padding="row"
-      className={`flex items-center justify-between gap-inline-sm ${
-        editId === widget.id ? 'ring-2 ring-accent' : ''
+      data-wcard={w.id}
+      draggable={dnd}
+      onDragStart={
+        dnd
+          ? (e: DragEvent<HTMLElement>) => {
+              setDragPayload({ kind: 'move', id: w.id })
+              e.dataTransfer.effectAllowed = 'move'
+            }
+          : undefined
+      }
+      onDragEnd={
+        dnd
+          ? () => {
+              clearDragPayload()
+            }
+          : undefined
+      }
+      onClick={() => {
+        onSelect(w.id)
+      }}
+      className={`flex cursor-pointer items-center justify-between gap-inline-sm ${
+        selectedId === w.id ? 'ring-2 ring-accent' : ''
       }`}
     >
       <Stack gap="xs">
-        <Text as="span" variant="heading-sm">
-          {widget.title ?? t(`admin.widgets.type.${widget.widgetType}`)}
+        <Text as="span" variant="body">
+          {w.title && w.title.trim() !== ''
+            ? w.title
+            : t(WIDGET_CATALOG_BY_TYPE[w.widgetType].labelKey)}
         </Text>
         <Text as="span" muted variant="caption">
-          {t(`admin.widgets.type.${widget.widgetType}`)}
+          {subLabel(w)}
         </Text>
       </Stack>
-      <div className="flex items-center gap-inline-sm">
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={() => {
-            onEdit(widget)
-          }}
-        >
-          {t('common.actions.edit')}
-        </Button>
-        <Button
-          variant="danger"
-          size="sm"
-          onClick={() => {
-            onRemove(widget.id)
-          }}
-        >
-          {t('common.actions.delete')}
-        </Button>
-      </div>
+      <Button
+        variant="danger"
+        size="sm"
+        onClick={(e) => {
+          e.stopPropagation()
+          onRemove(w.id)
+        }}
+      >
+        {t('common.actions.delete')}
+      </Button>
     </Card>
   )
 
   const renderRegion = (region: WidgetRegion) => {
-    const regionWidgets = byRegion(region)
+    const list = byRegion(region)
+    const flow = REGION_FLOW[region]
+    const cond =
+      region === 'sidebar' || region === 'aside' ? t(`admin.layout.cond.${region}`) : null
+
+    const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+      if (!dnd || getDragPayload() === null) return
+      e.preventDefault()
+      const idx = computeDropIndex(e.currentTarget, e.clientX, e.clientY, flow)
+      setHover({ region, idx })
+    }
+    const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+      const payload = getDragPayload()
+      if (payload === null) return
+      e.preventDefault()
+      const idx = computeDropIndex(e.currentTarget, e.clientX, e.clientY, flow)
+      onDrop(region, idx, payload)
+      setHover(null)
+    }
+    const dropLine = (i: number) =>
+      hover !== null && hover.region === region && hover.idx === i ? (
+        <li key={`dl-${String(i)}`} aria-hidden className="h-0.5 rounded bg-accent" />
+      ) : null
+
+    const items: ReactNode[] = []
+    list.forEach((w, i) => {
+      const line = dropLine(i)
+      if (line !== null) items.push(line)
+      items.push(renderCard(w))
+    })
+    const endLine = dropLine(list.length)
+    if (endLine !== null) items.push(endLine)
+
     return (
       <Card className="flex flex-col gap-stack-sm">
         <div className="flex items-center justify-between gap-inline-sm">
-          <Text as="span" variant="heading-sm">
-            {t(`admin.region.${region}`)}
-          </Text>
+          <span className="flex flex-col">
+            <Text as="span" variant="heading-sm">
+              {t(`admin.region.${region}`)}
+            </Text>
+            {cond !== null ? (
+              <Text as="span" muted variant="caption">
+                {cond}
+              </Text>
+            ) : null}
+          </span>
           <Button
             variant="secondary"
             size="sm"
@@ -92,15 +169,31 @@ export function WidgetRegionBoard({
             {t('admin.widgets.board.addHere')}
           </Button>
         </div>
-        {regionWidgets.length === 0 ? (
-          <div className="flex min-h-16 items-center justify-center rounded-md border border-dashed border-border px-inline-md py-stack-md text-center">
-            <Text muted variant="caption">
-              {t('admin.widgets.board.empty')}
-            </Text>
-          </div>
-        ) : (
-          <ul className="flex flex-col gap-stack-xs">{regionWidgets.map(renderCard)}</ul>
-        )}
+        <div
+          onDragOver={handleDragOver}
+          onDragLeave={() => {
+            setHover((h) => (h !== null && h.region === region ? null : h))
+          }}
+          onDrop={handleDrop}
+        >
+          {list.length === 0 ? (
+            <div className="flex min-h-16 flex-col items-center justify-center gap-stack-xs rounded-md border border-dashed border-border px-inline-md py-stack-md text-center">
+              <Text muted variant="caption">
+                {dnd ? t('admin.layout.dropHere') : t('admin.widgets.board.empty')}
+              </Text>
+            </div>
+          ) : (
+            <ul
+              className={
+                flow === 'row'
+                  ? 'flex flex-row flex-wrap gap-inline-sm'
+                  : 'flex flex-col gap-stack-xs'
+              }
+            >
+              {items}
+            </ul>
+          )}
+        </div>
       </Card>
     )
   }

--- a/frontend/src/features/manage-widgets/ui/widget-dnd.ts
+++ b/frontend/src/features/manage-widgets/ui/widget-dnd.ts
@@ -1,0 +1,38 @@
+import type { WidgetType } from '@/entities/widget'
+
+/**
+ * Drag payload shared across components. dataTransfer is opaque during dragover,
+ * so the active payload is kept in a module ref (matches the prototype).
+ */
+export type DragPayload = { kind: 'new'; type: WidgetType } | { kind: 'move'; id: number }
+
+let current: DragPayload | null = null
+
+export function setDragPayload(p: DragPayload): void {
+  current = p
+}
+
+export function getDragPayload(): DragPayload | null {
+  return current
+}
+
+export function clearDragPayload(): void {
+  current = null
+}
+
+/** Index where a dropped item should land, based on pointer vs card midpoints. */
+export function computeDropIndex(
+  container: HTMLElement,
+  clientX: number,
+  clientY: number,
+  flow: 'row' | 'col',
+): number {
+  const cards = [...container.querySelectorAll('[data-wcard]')]
+  const pos = flow === 'row' ? clientX : clientY
+  for (let i = 0; i < cards.length; i++) {
+    const r = cards[i].getBoundingClientRect()
+    const mid = flow === 'row' ? r.left + r.width / 2 : r.top + r.height / 2
+    if (pos < mid) return i
+  }
+  return cards.length
+}

--- a/frontend/src/features/manage-widgets/widget-catalog.ts
+++ b/frontend/src/features/manage-widgets/widget-catalog.ts
@@ -1,0 +1,77 @@
+import type { WidgetType } from '@/entities/widget'
+import type { MessageKey } from '@/shared/i18n'
+
+export type SettingEditor = 'menu' | 'enum' | 'int' | 'text'
+
+export interface SettingDescriptor {
+  key: string
+  labelKey: MessageKey
+  editor: SettingEditor
+  options?: readonly string[]
+  def?: string | number
+}
+
+export interface WidgetCatalogEntry {
+  type: WidgetType
+  labelKey: MessageKey
+  descKey: MessageKey
+  settings: readonly SettingDescriptor[]
+}
+
+/**
+ * Widget catalog: drives the palette, the inspector's settings editor, and the
+ * add modal. Mirrors the backend WidgetTypes whitelist + DATA-MODEL settings.
+ */
+export const WIDGET_CATALOG: readonly WidgetCatalogEntry[] = [
+  {
+    type: 'menu',
+    labelKey: 'admin.widgets.type.menu',
+    descKey: 'admin.widgets.menuSettings',
+    settings: [{ key: 'menuId', labelKey: 'admin.widgets.menuLabel', editor: 'menu' }],
+  },
+  {
+    type: 'recent-posts',
+    labelKey: 'admin.widgets.type.recent-posts',
+    descKey: 'admin.widgets.recentPostsSettings',
+    settings: [
+      { key: 'entityTypeSlug', labelKey: 'admin.widgets.entityTypeLabel', editor: 'enum' },
+      { key: 'limit', labelKey: 'admin.widgets.limitLabel', editor: 'int', def: 5 },
+    ],
+  },
+  {
+    type: 'search',
+    labelKey: 'admin.widgets.type.search',
+    descKey: 'admin.widgets.searchSettings',
+    settings: [
+      { key: 'placeholder', labelKey: 'admin.widgets.searchPlaceholderLabel', editor: 'text' },
+    ],
+  },
+  {
+    type: 'tag-cloud',
+    labelKey: 'admin.widgets.type.tag-cloud',
+    descKey: 'admin.widgets.tagCloudSettings',
+    settings: [],
+  },
+  {
+    type: 'popular-posts',
+    labelKey: 'admin.widgets.type.popular-posts',
+    descKey: 'admin.widgets.popularPostsSettings',
+    settings: [{ key: 'limit', labelKey: 'admin.widgets.limitLabel', editor: 'int', def: 5 }],
+  },
+  {
+    type: 'calendar',
+    labelKey: 'admin.widgets.type.calendar',
+    descKey: 'admin.widgets.calendarSettings',
+    settings: [],
+  },
+  {
+    type: 'toc',
+    labelKey: 'admin.widgets.type.toc',
+    descKey: 'admin.widgets.tocSettings',
+    settings: [],
+  },
+]
+
+export const WIDGET_CATALOG_BY_TYPE: Record<WidgetType, WidgetCatalogEntry> = Object.fromEntries(
+  WIDGET_CATALOG.map((c) => [c.type, c]),
+) as Record<WidgetType, WidgetCatalogEntry>

--- a/frontend/src/pages/appearance/AppearanceLayoutPage.tsx
+++ b/frontend/src/pages/appearance/AppearanceLayoutPage.tsx
@@ -10,22 +10,7 @@ type AppearanceTab = 'layout' | 'menus'
 
 function LayoutTab() {
   const page = useManageWidgetsPage()
-  return (
-    <ManageWidgetsView
-      widgets={page.widgets}
-      entityTypes={page.entityTypes}
-      menus={page.menus}
-      form={page.form}
-      editId={page.editId}
-      isSubmitting={page.isSubmitting}
-      setField={page.setField}
-      resetForm={page.resetForm}
-      addToRegion={page.addToRegion}
-      editWidget={page.editWidget}
-      submit={page.submit}
-      remove={page.remove}
-    />
-  )
+  return <ManageWidgetsView page={page} />
 }
 
 function MenusTab() {

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -84,6 +84,15 @@ export const en = {
   'admin.layoutCfg.hiddenWarning':
     '{{count}} widget(s) in {{regions}} are not shown on public pages with the current {{columns}}-column layout.',
   'admin.layoutCfg.makeThreeCol': 'Use 3 columns',
+  'admin.layout.palette': 'Widgets',
+  'admin.layout.paletteHint': 'Drag onto a region, or click to add.',
+  'admin.layout.inspector': 'Inspector',
+  'admin.layout.inspectorEmpty':
+    'Select a placed widget to edit its heading, settings, and region.',
+  'admin.layout.dropHere': 'Drag widgets here',
+  'admin.layout.cond.sidebar': 'Shows on 2/3-column record pages',
+  'admin.layout.cond.aside': 'Shows on 3-column record pages',
+  'admin.widgets.board.deleteWidget': 'Delete this widget',
   'admin.widgets.pageTitle': 'Widgets',
   'admin.widgets.pageDescription': 'Blocks placed into sidebar / aside columns of public pages.',
   'admin.widgets.createTitle': 'Add widget',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -77,6 +77,15 @@ export const ja: Partial<MessageCatalog> = {
   'admin.layoutCfg.hiddenWarning':
     '{{regions}} にある {{count}} 件のウィジェットは、現在の {{columns}}カラム構成では公開ページに表示されません。',
   'admin.layoutCfg.makeThreeCol': '3カラムにする',
+  'admin.layout.palette': 'ウィジェット',
+  'admin.layout.paletteHint': '領域へドラッグ、またはクリックで追加。',
+  'admin.layout.inspector': 'インスペクタ',
+  'admin.layout.inspectorEmpty':
+    '配置済みのウィジェットを選ぶと、見出し・設定・領域を編集できます。',
+  'admin.layout.dropHere': 'ここにドラッグして配置',
+  'admin.layout.cond.sidebar': '2/3カラムのレコードページで表示',
+  'admin.layout.cond.aside': '3カラムのレコードページで表示',
+  'admin.widgets.board.deleteWidget': 'このウィジェットを削除',
   'admin.widgets.pageTitle': 'ウィジェット',
   'admin.widgets.pageDescription': '公開ページのサイドバー / アサイド カラムに配置するブロック。',
   'admin.widgets.createTitle': 'ウィジェットを追加',


### PR DESCRIPTION
> [Epic #352](https://github.com/hideyukiMORI/nene-records/issues/352) レイアウトビルダーの **スライス3**（DnD）。

## 変更内容
レイアウトタブを **パレット / 領域ボード / インスペクタ** の3ペインに刷新。

- **WidgetPalette**: カタログをドラッグ可能チップで列挙。領域へドラッグ＝配置、クリック＝サイドバーに追加。
- **WidgetRegionBoard（DnD）**: 配置済みカードのドラッグで**領域間移動・領域内並べ替え**、**ドロップ位置インジケータ線**、領域の**表示条件バッジ**（sidebar=2/3カラム, aside=3カラム）、空状態ガイド。header/footer=横、side=縦。cfg で body 段組み描画。
- **WidgetInspector**: 選択ウィジェットの見出し・タイプ別設定（カタログ駆動）・領域・削除。
- `widget-catalog`（型/設定スキーマ）・`widget-dnd`（payload／ドロップindex）。
- hook: `addWidgetAt` / `moveWidgetAt`（display_order 再採番で永続）/ `updateSettings` / `updateTitle` / `select` / `remove`。旧フォームロジック撤去。i18n（en/ja）。

## 受け入れ基準（該当分）
- [x] ドラッグ配置: パレット→領域ドロップ追加、領域間移動、領域内並べ替え、ドロップ位置インジケータ
- [x] インスペクタで見出し・設定・領域を編集すると即反映
- [x] 表示条件バッジ（sidebar/aside）/ 空領域ガイド

## 注記
- フォーム/プレビューモード、モバイルでの DnD 無効化＋タップ編集は後続スライス（4,5）。
- cfg は localStorage（サイト設定永続化＋公開反映はスライス6）。

## 検証
- `npm run check --prefix frontend` 全グリーン（backend 変更なし）

Part of #352