### PR TITLE
feat(appearance): プレビューモード + モード切替（#352 スライス4）

### DIFF
--- a/frontend/src/features/manage-widgets/ui/LayoutPreview.tsx
+++ b/frontend/src/features/manage-widgets/ui/LayoutPreview.tsx
@@ -1,0 +1,161 @@
+import type { ReactNode } from 'react'
+import type { Menu } from '@/entities/menu'
+import type { Widget } from '@/entities/widget'
+import { useTranslation } from '@/shared/i18n'
+import { bodyColumns, type LayoutConfig } from '@/shared/lib/layout-config'
+import type { WidgetRegion } from '@/shared/lib/resolve-layout'
+
+export type PreviewPage = 'home' | 'record'
+
+export interface LayoutPreviewProps {
+  widgets: Widget[]
+  menus: Menu[]
+  cfg: LayoutConfig
+  page: PreviewPage
+  selectedId: number | null
+}
+
+const SAMPLE_POSTS = ['Midnight Drift EP', 'Glass Harbor', 'Neon Tide', 'Slow Static', 'Aurora']
+const SAMPLE_TAGS = ['House', 'Techno', 'Ambient', 'Dub', 'Lo-fi']
+
+function MiniWidget({ w, menus, horizontal }: { w: Widget; menus: Menu[]; horizontal: boolean }) {
+  const inner = (): ReactNode => {
+    switch (w.widgetType) {
+      case 'menu': {
+        const menu = menus.find((m) => m.id === w.settings['menuId'])
+        const links = menu ? ['Home', 'Releases', 'Artists'] : []
+        if (menu === undefined) return <span className="text-caption text-danger">⚠ menu</span>
+        return (
+          <ul className={horizontal ? 'flex flex-row gap-inline-sm' : 'flex flex-col gap-stack-xs'}>
+            {links.map((l) => (
+              <li key={l} className="text-caption text-accent">
+                {l}
+              </li>
+            ))}
+          </ul>
+        )
+      }
+      case 'recent-posts':
+      case 'popular-posts':
+        return (
+          <ul className="flex flex-col gap-stack-xs">
+            {SAMPLE_POSTS.slice(0, 4).map((p) => (
+              <li key={p} className="text-caption text-accent">
+                {p}
+              </li>
+            ))}
+          </ul>
+        )
+      case 'search':
+        return (
+          <div className="rounded-sm border border-border px-inline-sm py-stack-xs text-caption text-text-muted">
+            {typeof w.settings['placeholder'] === 'string' && w.settings['placeholder'] !== ''
+              ? w.settings['placeholder']
+              : '検索…'}
+          </div>
+        )
+      case 'tag-cloud':
+        return (
+          <div className="flex flex-wrap gap-inline-xs">
+            {SAMPLE_TAGS.map((tg) => (
+              <span
+                key={tg}
+                className="rounded-full border border-border px-inline-sm text-caption"
+              >
+                {tg}
+              </span>
+            ))}
+          </div>
+        )
+      case 'calendar':
+        return (
+          <div className="grid grid-cols-7 gap-px">
+            {Array.from({ length: 28 }).map((_, i) => (
+              <span
+                key={i}
+                className={`h-2 rounded-sm ${[4, 9, 17, 23].includes(i) ? 'bg-accent' : 'bg-surface-overlay'}`}
+              />
+            ))}
+          </div>
+        )
+      case 'toc':
+        return (
+          <ul className="flex flex-col gap-stack-xs">
+            {['概要', 'トラックリスト', 'クレジット'].map((tg) => (
+              <li key={tg} className="text-caption text-accent">
+                {tg}
+              </li>
+            ))}
+          </ul>
+        )
+      default:
+        return <div className="h-2 w-3/4 rounded-sm bg-surface-overlay" />
+    }
+  }
+  return (
+    <div className="min-w-0">
+      {w.title !== null && w.title.trim() !== '' ? (
+        <p className="mb-0.5 text-caption font-medium">{w.title}</p>
+      ) : null}
+      {inner()}
+    </div>
+  )
+}
+
+/** Compact mock of the public page reflecting current widgets and layout config. */
+export function LayoutPreview({ widgets, menus, cfg, page, selectedId }: LayoutPreviewProps) {
+  const { t } = useTranslation()
+  const inRegion = (r: WidgetRegion): Widget[] =>
+    widgets
+      .filter((w) => w.region === r)
+      .sort((a, b) => a.displayOrder - b.displayOrder || a.id - b.id)
+
+  const cols: readonly (WidgetRegion | 'main')[] = page === 'record' ? bodyColumns(cfg) : ['main']
+
+  const renderWidget = (w: Widget, horizontal: boolean) => (
+    <div key={w.id} className={`rounded-sm p-1 ${w.id === selectedId ? 'ring-2 ring-accent' : ''}`}>
+      <MiniWidget w={w} menus={menus} horizontal={horizontal} />
+    </div>
+  )
+
+  return (
+    <div className="overflow-hidden rounded-md border border-border bg-surface-raised text-text-primary">
+      <header className="flex items-center gap-inline-md border-b border-border px-inline-md py-stack-sm">
+        <span className="font-chrome text-body font-semibold">NeNe Records</span>
+        <div className="ml-auto flex flex-wrap items-center gap-inline-md">
+          {inRegion('header').map((w) => renderWidget(w, true))}
+        </div>
+      </header>
+      <div
+        className="grid gap-stack-md p-inline-md"
+        style={{ gridTemplateColumns: cols.map((c) => (c === 'main' ? '2fr' : '1fr')).join(' ') }}
+      >
+        {cols.map((c) =>
+          c === 'main' ? (
+            <div key="main" className="flex flex-col gap-stack-xs">
+              <p className="text-heading-sm">
+                {page === 'record' ? 'Midnight Drift EP' : 'NeNe Records'}
+              </p>
+              <div className="h-2 w-11/12 rounded-sm bg-surface-overlay" />
+              <div className="h-2 w-full rounded-sm bg-surface-overlay" />
+              <div className="h-2 w-3/4 rounded-sm bg-surface-overlay" />
+            </div>
+          ) : (
+            <div key={c} className="flex flex-col gap-stack-sm">
+              {inRegion(c).length > 0 ? (
+                inRegion(c).map((w) => renderWidget(w, false))
+              ) : (
+                <span className="text-center text-caption text-text-muted">
+                  — {t(`admin.region.${c}`)} —
+                </span>
+              )}
+            </div>
+          ),
+        )}
+      </div>
+      <footer className="flex flex-wrap items-center gap-inline-md border-t border-border px-inline-md py-stack-sm">
+        {inRegion('footer').map((w) => renderWidget(w, true))}
+      </footer>
+    </div>
+  )
+}

--- a/frontend/src/features/manage-widgets/ui/ManageWidgetsView.tsx
+++ b/frontend/src/features/manage-widgets/ui/ManageWidgetsView.tsx
@@ -10,6 +10,7 @@ import type { WidgetRegion } from '@/shared/lib/resolve-layout'
 import { Button, Card, Stack, Text } from '@/shared/ui'
 import type { useManageWidgetsPage } from '../hooks/use-manage-widgets-page'
 import { LayoutConfigBar } from './LayoutConfigBar'
+import { LayoutPreview, type PreviewPage } from './LayoutPreview'
 import { WidgetInspector } from './WidgetInspector'
 import { WidgetPalette } from './WidgetPalette'
 import { WidgetRegionBoard } from './WidgetRegionBoard'
@@ -17,6 +18,10 @@ import { WidgetRegionBoard } from './WidgetRegionBoard'
 // 3-pane workspace columns: palette | board | inspector.
 const WORKSPACE_CLASS =
   'grid grid-cols-1 gap-stack-lg lg:grid-cols-[220px_1fr_280px] lg:items-start'
+const PREVIEW_CLASS = 'grid grid-cols-1 gap-stack-lg lg:grid-cols-[1fr_1.3fr] lg:items-start'
+
+type LayoutMode = 'dnd' | 'preview'
+const MODE_LS_KEY = 'nene_layout_mode'
 
 export interface ManageWidgetsViewProps {
   page: ReturnType<typeof useManageWidgetsPage>
@@ -30,6 +35,21 @@ export function ManageWidgetsView({ page }: ManageWidgetsViewProps) {
     saveLayoutConfig(next)
   }
 
+  const [mode, setMode] = useState<LayoutMode>(() =>
+    localStorage.getItem(MODE_LS_KEY) === 'preview' ? 'preview' : 'dnd',
+  )
+  const changeMode = (next: LayoutMode) => {
+    setMode(next)
+    localStorage.setItem(MODE_LS_KEY, next)
+  }
+  const [previewPage, setPreviewPage] = useState<PreviewPage>('record')
+
+  const segBtn = (on: boolean): string =>
+    [
+      'px-inline-md py-stack-xs text-body',
+      on ? 'bg-accent text-text-inverse' : 'bg-surface-raised hover:bg-surface-overlay',
+    ].join(' ')
+
   const active = activeSideRegions(cfg)
   const hiddenRegions = (['sidebar', 'aside'] as const).filter((r) => !active.includes(r))
   const hiddenCount = page.widgets.filter((w) =>
@@ -40,6 +60,29 @@ export function ManageWidgetsView({ page }: ManageWidgetsViewProps) {
 
   return (
     <Stack gap="lg">
+      <div className="flex items-center justify-end">
+        <span className="inline-flex overflow-hidden rounded-md border border-border">
+          <button
+            type="button"
+            className={segBtn(mode === 'dnd')}
+            onClick={() => {
+              changeMode('dnd')
+            }}
+          >
+            {t('admin.layout.modeDnd')}
+          </button>
+          <button
+            type="button"
+            className={segBtn(mode === 'preview')}
+            onClick={() => {
+              changeMode('preview')
+            }}
+          >
+            {t('admin.layout.modePreview')}
+          </button>
+        </span>
+      </div>
+
       <LayoutConfigBar cfg={cfg} setCfg={setCfg} />
       {hiddenCount > 0 ? (
         <Card className="flex flex-wrap items-center gap-inline-md border-warn">
@@ -62,53 +105,112 @@ export function ManageWidgetsView({ page }: ManageWidgetsViewProps) {
         </Card>
       ) : null}
 
-      <div className={WORKSPACE_CLASS}>
-        <WidgetPalette
-          onAdd={(type) => {
-            void page.addWidgetAt(type, 'sidebar', null)
-          }}
-        />
+      {mode === 'dnd' ? (
+        <div className={WORKSPACE_CLASS}>
+          <WidgetPalette
+            onAdd={(type) => {
+              void page.addWidgetAt(type, 'sidebar', null)
+            }}
+          />
 
-        <WidgetRegionBoard
-          widgets={page.widgets}
-          menus={page.menus}
-          selectedId={page.selectedId}
-          cfg={cfg}
-          dnd
-          onAddToRegion={(region) => {
-            void page.addWidgetAt('menu', region, null)
-          }}
-          onSelect={page.select}
-          onRemove={(id) => {
-            void page.remove(id)
-          }}
-          onDrop={(region, index, payload) => {
-            if (payload.kind === 'new') {
-              void page.addWidgetAt(payload.type, region, index)
-            } else {
-              void page.moveWidgetAt(payload.id, region, index)
-            }
-          }}
-        />
+          <WidgetRegionBoard
+            widgets={page.widgets}
+            menus={page.menus}
+            selectedId={page.selectedId}
+            cfg={cfg}
+            dnd
+            onAddToRegion={(region) => {
+              void page.addWidgetAt('menu', region, null)
+            }}
+            onSelect={page.select}
+            onRemove={(id) => {
+              void page.remove(id)
+            }}
+            onDrop={(region, index, payload) => {
+              if (payload.kind === 'new') {
+                void page.addWidgetAt(payload.type, region, index)
+              } else {
+                void page.moveWidgetAt(payload.id, region, index)
+              }
+            }}
+          />
 
-        <WidgetInspector
-          widget={selected}
-          menus={page.menus}
-          entityTypes={page.entityTypes}
-          onTitle={(id, title) => {
-            void page.updateTitle(id, title)
-          }}
-          onSettings={(id, patch) => {
-            void page.updateSettings(id, patch)
-          }}
-          onChangeRegion={(id, region) => {
-            void page.moveWidgetAt(id, region, null)
-          }}
-          onRemove={(id) => {
-            void page.remove(id)
-          }}
-        />
-      </div>
+          <WidgetInspector
+            widget={selected}
+            menus={page.menus}
+            entityTypes={page.entityTypes}
+            onTitle={(id, title) => {
+              void page.updateTitle(id, title)
+            }}
+            onSettings={(id, patch) => {
+              void page.updateSettings(id, patch)
+            }}
+            onChangeRegion={(id, region) => {
+              void page.moveWidgetAt(id, region, null)
+            }}
+            onRemove={(id) => {
+              void page.remove(id)
+            }}
+          />
+        </div>
+      ) : (
+        <div className={PREVIEW_CLASS}>
+          <WidgetRegionBoard
+            widgets={page.widgets}
+            menus={page.menus}
+            selectedId={page.selectedId}
+            cfg={cfg}
+            dnd={false}
+            onAddToRegion={(region) => {
+              void page.addWidgetAt('menu', region, null)
+            }}
+            onSelect={page.select}
+            onRemove={(id) => {
+              void page.remove(id)
+            }}
+            onDrop={() => undefined}
+          />
+          <Stack gap="sm">
+            <div className="flex items-center justify-between gap-inline-md">
+              <Text as="span" variant="heading-sm">
+                {t('admin.layout.previewTitle')}
+              </Text>
+              <span className="inline-flex overflow-hidden rounded-md border border-border">
+                <button
+                  type="button"
+                  className={segBtn(previewPage === 'home')}
+                  onClick={() => {
+                    setPreviewPage('home')
+                  }}
+                >
+                  {t('admin.layout.previewHome')}
+                </button>
+                <button
+                  type="button"
+                  className={segBtn(previewPage === 'record')}
+                  onClick={() => {
+                    setPreviewPage('record')
+                  }}
+                >
+                  {t('admin.layout.previewRecord')}
+                </button>
+              </span>
+            </div>
+            <LayoutPreview
+              widgets={page.widgets}
+              menus={page.menus}
+              cfg={cfg}
+              page={previewPage}
+              selectedId={page.selectedId}
+            />
+            <Text as="span" muted variant="caption">
+              {previewPage === 'home'
+                ? t('admin.layout.previewHomeNote')
+                : t('admin.layout.previewRecordNote', { columns: String(cfg.columns) })}
+            </Text>
+          </Stack>
+        </div>
+      )}
     </Stack>
   )
 }

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -90,6 +90,13 @@ export const en = {
   'admin.layout.inspectorEmpty':
     'Select a placed widget to edit its heading, settings, and region.',
   'admin.layout.dropHere': 'Drag widgets here',
+  'admin.layout.modeDnd': 'Drag & drop',
+  'admin.layout.modePreview': 'Preview',
+  'admin.layout.previewTitle': 'Live preview',
+  'admin.layout.previewHome': 'Home',
+  'admin.layout.previewRecord': 'Record detail',
+  'admin.layout.previewHomeNote': 'The index is always 1 column — sidebar/aside do not appear.',
+  'admin.layout.previewRecordNote': '{{columns}}-column record detail layout.',
   'admin.layout.cond.sidebar': 'Shows on 2/3-column record pages',
   'admin.layout.cond.aside': 'Shows on 3-column record pages',
   'admin.widgets.board.deleteWidget': 'Delete this widget',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -83,6 +83,13 @@ export const ja: Partial<MessageCatalog> = {
   'admin.layout.inspectorEmpty':
     '配置済みのウィジェットを選ぶと、見出し・設定・領域を編集できます。',
   'admin.layout.dropHere': 'ここにドラッグして配置',
+  'admin.layout.modeDnd': 'ドラッグ配置',
+  'admin.layout.modePreview': 'プレビュー',
+  'admin.layout.previewTitle': 'ライブプレビュー',
+  'admin.layout.previewHome': 'トップ',
+  'admin.layout.previewRecord': 'レコード詳細',
+  'admin.layout.previewHomeNote': 'トップは常に1カラム — サイドバー／アサイドは出ません。',
+  'admin.layout.previewRecordNote': '{{columns}}カラムのレコード詳細レイアウト。',
   'admin.layout.cond.sidebar': '2/3カラムのレコードページで表示',
   'admin.layout.cond.aside': '3カラムのレコードページで表示',
   'admin.widgets.board.deleteWidget': 'このウィジェットを削除',


### PR DESCRIPTION
> [Epic #352](https://github.com/hideyukiMORI/nene-records/issues/352) レイアウトビルダーの **スライス4**。

仕様の推奨「最低限 A:DnD と C:プレビュー」に沿って、モード切替とライブプレビューを追加。

## 変更内容
- **モード切替セグメント**（ドラッグ配置 / プレビュー・localStorage `nene_layout_mode`）。
- **プレビューモード**: 左=領域ボード（非DnD・選択でハイライト）、右=`LayoutPreview`（公開ページの縮小モック）。
  - トップ / レコード詳細 を切替（cfg の段組みを反映。トップは常に1カラム）。
  - 選択中ウィジェットをプレビュー内でハイライト。
- **LayoutPreview**: header(横) / body(cfg 段組み) / footer。各ウィジェットの簡易描画（menu/recent/popular/search/tag-cloud/calendar/toc）。i18n（en/ja）。

## 受け入れ基準（該当分）
- [x] プレビューで公開ページの段組みが構成どおり描画され、トップ/レコード詳細を切替できる
- [x] 選択中ウィジェットがプレビューでハイライト

## 注記
- フォームモード（モーダル追加）は仕様上オプションのため省略（DnD で代替）。
- ツアー/ヘルプ/レスポンシブ/テーマ=スライス5、cfg backend＋公開反映=スライス6。

## 検証
- `npm run check --prefix frontend` 全グリーン（backend 変更なし）

Part of #352