### PR TITLE
docs(theming): 公開サイト テーマのトークン契約＋アセット契約 (#367 Phase 0)

### DIFF
--- a/docs/theming/examples/consumer.manifest.json
+++ b/docs/theming/examples/consumer.manifest.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "../public-theme.schema.json",
+  "id": "consumer",
+  "name": "Terracotta",
+  "version": "1.0.0",
+  "author": "NeNe Records",
+  "description": "Built-in reference theme — warm terracotta paper (light) / warm near-black paper (dark). Mirrors consumer-brand.css.",
+  "supportsModes": ["light", "dark"],
+  "fonts": [
+    {
+      "family": "Saira Semi Condensed",
+      "role": "display",
+      "source": "fontsource",
+      "weights": [400, 500, 600]
+    },
+    {
+      "family": "Inter",
+      "role": "body",
+      "source": "fontsource",
+      "weights": [400, 500, 600]
+    },
+    {
+      "family": "Space Grotesk",
+      "role": "chrome",
+      "source": "fontsource",
+      "weights": [500, 600]
+    },
+    {
+      "family": "JetBrains Mono",
+      "role": "mono",
+      "source": "fontsource",
+      "weights": [400]
+    }
+  ],
+  "tokens": {
+    "light": {
+      "color-surface": "oklch(97.5% 0.012 75)",
+      "color-surface-raised": "oklch(99.5% 0.008 75)",
+      "color-surface-overlay": "oklch(94% 0.02 75)",
+      "color-surface-sunken": "oklch(95.5% 0.016 70)",
+      "color-text-primary": "oklch(24% 0.03 55)",
+      "color-text-muted": "oklch(48% 0.03 55)",
+      "color-text-inverse": "oklch(99% 0.005 75)",
+      "color-border": "oklch(86% 0.02 75)",
+      "color-border-strong": "oklch(78% 0.025 70)",
+      "color-focus-ring": "oklch(68% 0.12 45)",
+      "color-accent": "oklch(58% 0.14 45)",
+      "color-accent-hover": "oklch(52% 0.14 45)",
+      "color-accent-weak": "color-mix(in oklch, var(--color-accent) 12%, var(--color-surface-raised))",
+      "color-on-accent": "oklch(99% 0.005 75)",
+      "color-brand-violet": "oklch(56% 0.24 300)",
+      "color-danger": "oklch(52% 0.2 25)",
+      "color-danger-hover": "oklch(46% 0.2 25)",
+      "color-ok": "oklch(55% 0.13 150)",
+      "color-warn": "oklch(70% 0.15 75)",
+      "color-info": "oklch(55% 0.13 250)",
+      "shadow-sm": "0 1px 2px oklch(40% 0.04 60 / 0.08)",
+      "shadow-md": "0 6px 22px oklch(40% 0.04 60 / 0.1)",
+      "shadow-lg": "0 22px 50px oklch(38% 0.05 55 / 0.16)",
+      "color-scheme": "light"
+    },
+    "dark": {
+      "color-surface": "oklch(18% 0.012 55)",
+      "color-surface-raised": "oklch(22% 0.014 55)",
+      "color-surface-overlay": "oklch(27% 0.016 50)",
+      "color-surface-sunken": "oklch(15% 0.011 55)",
+      "color-text-primary": "oklch(94% 0.012 75)",
+      "color-text-muted": "oklch(68% 0.022 60)",
+      "color-text-inverse": "oklch(20% 0.02 50)",
+      "color-border": "oklch(32% 0.016 55)",
+      "color-border-strong": "oklch(42% 0.02 55)",
+      "color-focus-ring": "oklch(74% 0.13 45)",
+      "color-accent": "oklch(70% 0.15 45)",
+      "color-accent-hover": "oklch(77% 0.15 45)",
+      "color-accent-weak": "color-mix(in oklch, var(--color-accent) 16%, var(--color-surface-raised))",
+      "color-on-accent": "oklch(20% 0.04 45)",
+      "color-brand-violet": "oklch(72% 0.18 300)",
+      "color-danger": "oklch(66% 0.18 25)",
+      "color-danger-hover": "oklch(72% 0.18 25)",
+      "color-ok": "oklch(72% 0.14 150)",
+      "color-warn": "oklch(80% 0.14 80)",
+      "color-info": "oklch(74% 0.12 250)",
+      "shadow-sm": "0 1px 2px oklch(0% 0 0 / 0.4)",
+      "shadow-md": "0 8px 26px oklch(0% 0 0 / 0.5)",
+      "shadow-lg": "0 24px 56px oklch(0% 0 0 / 0.62)",
+      "color-scheme": "dark"
+    }
+  },
+  "knobs": {
+    "accent": { "light": "oklch(58% 0.14 45)", "dark": "oklch(70% 0.15 45)" },
+    "surface": {
+      "light": "oklch(97.5% 0.012 75)",
+      "dark": "oklch(18% 0.012 55)"
+    },
+    "fontDisplay": "Saira Semi Condensed",
+    "fontBody": "Inter",
+    "fontMono": "JetBrains Mono",
+    "baseFontSize": "1.0625rem",
+    "typeScale": 1.18,
+    "density": "comfortable",
+    "radius": "soft"
+  },
+  "assets": {
+    "preview": {
+      "light": "screenshots/light.png",
+      "dark": "screenshots/dark.png"
+    },
+    "hero": "assets/hero.png",
+    "logo": "assets/nene-mark.svg"
+  }
+}

--- a/docs/theming/public-theme-contract.md
+++ b/docs/theming/public-theme-contract.md
@@ -1,0 +1,200 @@
+# 公開サイト テーマ契約（Public Theme Contract）
+
+> 正本ドキュメント。公開サイト（consumer フロント）のテーマが満たすべき**トークン契約**と**アセット契約**を定義する。WordPress の `theme.json` 相当。
+>
+> - 親エピック: #367 / 本書: #368（Phase 0）
+> - 検証用スキーマ: [`public-theme.schema.json`](./public-theme.schema.json)
+> - スコープは**公開サイトのみ**（`.nene-public` / `[data-theme='consumer*']`）。管理 UI のトークンには一切影響させない。
+
+---
+
+## 1. 原則
+
+1. **テーマ＝トークン値（＋既存クラスへの上乗せ CSS ＋アセット）**。`public-site.css` のコンポーネント定義は無改修。色・余白・フォント・角丸・影はすべて `var(--*)` 経由なので、トークンの差し替えだけで見た目が変わる。
+2. **DOM 構造・マークアップはテーマの管轄外**（既存 Layout 軸 = `PublicLayouts.php` の責務）。テーマは構造を変えない。
+3. **light / dark 両対応が必須**。各テーマは `[data-theme='<id>']`（light）と `[data-theme='<id>-dark']`（dark）の 2 セットを提供する。
+4. **配信はサーバ生成 CSS / 静的 CSS のみ**。テーマは任意 JS を持ち込まない（インライン JS 不使用 = JWT が localStorage にあるための制約）。
+5. **色は OKLCH + `color-mix`** を基本とする（既存 consumer テーマに準拠）。
+
+## 2. トークン分類（3 区分）
+
+| 区分                | 意味                                             | 誰が決めるか      |
+| ------------------- | ------------------------------------------------ | ----------------- |
+| **Knob（ノブ）**    | カスタマイザで管理者が調整できる上位パラメータ   | 管理者（Phase 2） |
+| **Derived（派生）** | ノブから自動計算されるトークン（`color-mix` 等） | システム          |
+| **Fixed（固定）**   | テーマが値を持つが管理者は触らない               | テーマ作者        |
+
+ノブを最小化し、残りは派生・固定にすることで「壊れにくさ」と「量産しやすさ」を両立する。
+
+---
+
+## 3. カラートークン（light / dark 各セット）
+
+`[data-theme='<id>']` / `[data-theme='<id>-dark']` に定義する。
+
+| トークン                                       | 用途                            | 区分     | 派生元 / 備考                                   |
+| ---------------------------------------------- | ------------------------------- | -------- | ----------------------------------------------- |
+| `--color-surface`                              | 基本背景（紙）                  | Knob     | dark/light の base paper                        |
+| `--color-surface-raised`                       | 一段持ち上げた面（カード）      | Derived  | surface から明度 +Δ                             |
+| `--color-surface-overlay`                      | オーバーレイ/コード地           | Derived  | surface から                                    |
+| `--color-surface-sunken`                       | 沈んだ面                        | Derived  | surface から                                    |
+| `--color-text-primary`                         | 本文                            | Knob     | surface に対し AA 以上                          |
+| `--color-text-muted`                           | 補助テキスト                    | Derived  | primary から明度寄せ                            |
+| `--color-text-inverse`                         | 反転テキスト                    | Derived  | surface 反転                                    |
+| `--color-border`                               | 罫線                            | Derived  | surface から                                    |
+| `--color-border-strong`                        | 強い罫線                        | Derived  | border から                                     |
+| `--color-focus-ring`                           | フォーカス輪郭色                | Derived  | accent から                                     |
+| `--color-accent`                               | ブランド/アクセント             | **Knob** | 主要ノブ                                        |
+| `--color-accent-hover`                         | ホバー                          | Derived  | accent の明度調整                               |
+| `--color-accent-weak`                          | 淡いアクセント地                | Derived  | `color-mix(accent, surface-raised)`             |
+| `--color-on-accent`                            | アクセント上の文字              | Derived  | accent に対し AA                                |
+| `--color-brand-violet`                         | ロゴ専用色（UI アクセントと別） | Fixed    | ロゴのみ                                        |
+| `--color-danger` / `--color-danger-hover`      | 危険                            | Fixed    |                                                 |
+| `--color-ok` / `--color-warn` / `--color-info` | ステータス                      | Fixed    |                                                 |
+| `--shadow-sm` / `--shadow-md` / `--shadow-lg`  | 影                              | Fixed    | dark はより深い                                 |
+| `--shadow-focus`                               | フォーカスリング影              | Fixed    | ※現状グローバル継承。テーマで定義することを推奨 |
+| `color-scheme`                                 | `light` / `dark`                | Fixed    | フォームコントロール等の OS 連動                |
+
+### 派生ルール（Derived の計算）
+
+- `--color-accent-hover` = light は accent を暗く（L −6 程度）/ dark は明るく（L +7 程度）。
+- `--color-accent-weak` = `color-mix(in oklch, var(--color-accent) 12%(light)/16%(dark), var(--color-surface-raised))`。
+- `--color-focus-ring` = accent と同 hue で彩度/明度を確保した値。
+- surface 系の raised/overlay/sunken は base surface から明度オフセットで導出（light は上げ、dark は段階）。
+- **アクセシビリティ必須**: `text-primary`/`on-accent` は背景に対し WCAG AA（4.5:1）以上。検証は Phase 3 バリデータで自動化。
+
+---
+
+## 4. タイポグラフィトークン（`.nene-public` ルート）
+
+| トークン                               | 既定                       | 区分    | 備考                          |
+| -------------------------------------- | -------------------------- | ------- | ----------------------------- |
+| `--font-sans`                          | `'Inter','Noto Sans JP',…` | Knob    | 本文フォント                  |
+| `--font-display`                       | `'Saira Semi Condensed',…` | Knob    | 見出しフォント                |
+| `--font-chrome`                        | `'Space Grotesk',…`        | Knob    | ボタン/UI ラベル              |
+| `--font-mono`                          | `'JetBrains Mono',…`       | Knob    | コード                        |
+| `--text-overline` … `--text-display`   | §下表                      | Derived | baseFontSize × scale から導出 |
+| `--leading-tight/heading/body`         | 1.07 / 1.16 / 1.68         | Fixed   |                               |
+| `--weight-normal/medium/semibold/bold` | 400/500/600/600            | Fixed   | ※同梱ウェイトは 600 まで      |
+| `--tracking-display/overline`          | -0.015em / 0.14em          | Fixed   |                               |
+
+### 現行タイプスケール（既定値）
+
+```
+--text-overline 0.75rem    --text-h3 1.25rem
+--text-meta     0.8125rem  --text-h2 clamp(1.5rem, 1.1rem + 1.6vw, 2.125rem)
+--text-body-sm  0.9375rem  --text-h1 clamp(1.6rem, 1.2rem + 1.6vw, 2.35rem)
+--text-body     1.0625rem  --text-display clamp(2.5rem, 1.6rem + 4.4vw, 4.85rem)
+```
+
+ノブ `baseFontSize`（既定 1.0625rem）と `typeScale`（既定 ≈1.18）から `--text-*` を再計算する。clamp の流動下限/上限も baseFontSize に比例。
+
+---
+
+## 5. スペース / レイアウトトークン
+
+| トークン                    | 既定                                      | 区分                        |
+| --------------------------- | ----------------------------------------- | --------------------------- |
+| `--space-2xs … --space-2xl` | 0.25 / 0.5 / 0.75 / 1 / 1.5 / 2.5 / 4 rem | Derived（density ノブから） |
+| `--space-section`           | `clamp(3.5rem, 2rem + 6vw, 7rem)`         | Derived                     |
+| `--gutter`                  | `clamp(1.25rem, 0.5rem + 3vw, 2.5rem)`    | Fixed                       |
+| `--measure`                 | `72ch`                                    | Knob（本文計測幅）          |
+| `--content-w`               | `1180px`                                  | Fixed                       |
+
+`density`（compact / cozy / comfortable）ノブが `--space-*` 全体を一括スケール。
+
+## 6. 角丸 / モーショントークン
+
+| トークン            | 既定                      | 区分                               |
+| ------------------- | ------------------------- | ---------------------------------- |
+| `--radius-sm/md/lg` | 6 / 12 / 20 px            | Knob（`radius`: sharp/soft/round） |
+| `--radius-full`     | 9999px                    | Fixed                              |
+| `--ease`            | `cubic-bezier(.4,0,.2,1)` | Fixed                              |
+| `--dur-fast/normal` | 120ms / 220ms             | Fixed                              |
+
+---
+
+## 7. カスタマイザ ノブ一覧（Phase 2 が公開する上位パラメータ）
+
+| ノブ                                    | 型                             | 影響するトークン                                  |
+| --------------------------------------- | ------------------------------ | ------------------------------------------------- |
+| `accent`                                | color                          | accent / -hover / -weak / -on-accent / focus-ring |
+| `surface`                               | color（light/dark 各）         | surface / -raised / -overlay / -sunken            |
+| `textPrimary`                           | color                          | text-primary / -muted（派生）                     |
+| `fontDisplay` / `fontBody` / `fontMono` | font（許可リスト）             | `--font-display` / `--font-sans` / `--font-mono`  |
+| `baseFontSize`                          | length(rem)                    | `--text-*`（再計算）                              |
+| `typeScale`                             | number(ratio)                  | `--text-*`（再計算）                              |
+| `density`                               | enum(compact/cozy/comfortable) | `--space-*`                                       |
+| `radius`                                | enum(sharp/soft/round)         | `--radius-sm/md/lg`                               |
+| `logo`                                  | asset(image/svg)               | ロゴ表示                                          |
+| `heroImage`                             | asset(image)                   | hero 背景                                         |
+| `background`                            | asset(image)                   | サイト背景（任意）                                |
+
+- ノブ上書きは**テーマ別・light/dark 別**に Setting ストアへ保存し、解決後に `.nene-public { --… }` をサーバ生成 CSS で注入する。
+- 画像系ノブは**メディアライブラリ**（オンデマンド派生・#299）連携。
+
+---
+
+## 8. アセット契約
+
+テーマは CSS だけでなく画像 / SVG を伴う。後付けを避けるため Phase 0 で定義する。
+
+### 8.1 アセットスロット
+
+| スロット     | 用途                             | 描画先       | light/dark 別 |
+| ------------ | -------------------------------- | ------------ | ------------- |
+| `preview`    | テーマ選択カードのスクショ       | 管理画面のみ | 可            |
+| `hero`       | hero 背景画像                    | 公開サイト   | 可            |
+| `background` | サイト背景（任意）               | 公開サイト   | 可            |
+| `logo`       | ブランドマーク                   | 公開サイト   | 可            |
+| `decoration` | 装飾シェイプ/テクスチャ/SVG      | 公開サイト   | 可            |
+| `icons`      | テーマ独自アイコンセット（任意） | 公開サイト   | —             |
+
+### 8.2 参照経路（この 2 つに限定）
+
+テーマはマークアップを持たないため、アセットは次の経路でのみ参照する。
+
+1. **CSS** の `background-image` / `mask-image`
+   - `background-image: url("data:image/svg+xml,…")` … 装飾背景（色は焼き付く）。
+   - `mask-image: url(…)` + `background: var(--color-accent)` … 単色 SVG を**テーマ色で recolor**。
+   - data URI またはテーマバンドル**相対 URL**のみ。
+2. **manifest のアセット URL** を第一者コンポーネント（hero 等）が読む。
+
+### 8.3 配信 / 解決
+
+- ビルトインテーマ: frontend 静的ビルド（Vite がハッシュ付与）。
+- インポート / 第三者テーマ: **メディアライブラリに格納し自オリジンから配信**。manifest はアセットマップ（スロット → URL/相対パス、light/dark 別）を持つ。
+
+### 8.4 セキュリティ規約
+
+- **外部 `url()` / 外部 `@import` 禁止**（hotlink 不可。Phase 3 バリデータで強制）。
+- 第三者の **SVG は必ずサニタイズ**: `<script>`・`on*` ハンドラ・外部参照（`xlink:href` 等）を除去。**インライン DOM 投入は禁止**（`<img>` / `background` / `mask` のみ）。
+- アセットの**サイズ上限**を設ける（例: ラスタ画像 ≤ 1MB、SVG ≤ 64KB）。
+
+---
+
+## 9. テーマ bundle 形式（Phase 1/3 で利用）
+
+```
+<theme-id>/
+├─ manifest.json        ← §10 スキーマ準拠（id/name/fonts/tokens/assets…）
+├─ tokens.css           ← [data-theme='<id>'] と [data-theme='<id>-dark']
+├─ components.css        （任意・既存クラスへの上乗せのみ。新規 DOM 構造は持たない）
+├─ assets/              ← hero / logo / decoration / icons …
+└─ screenshots/         ← preview（light/dark/mobile）
+```
+
+## 10. 検証スキーマ
+
+`manifest.json` は [`public-theme.schema.json`](./public-theme.schema.json) で検証する。CSS（tokens.css / components.css）は Phase 3 バリデータで以下を検査:
+
+- `.nene-public` / `[data-theme='<id>*']` スコープ強制（スコープ外セレクタ禁止）。
+- 外部 `url()` / `@import` 禁止、危険プロパティ排除。
+- 必須トークンの網羅（§3〜6）と light/dark 両セット存在。
+- コントラスト AA 検証（text/on-accent）。
+
+---
+
+## 付録 A. 既存 consumer テーマの位置づけ
+
+現行 `consumer-brand.css`（`[data-theme='consumer'/'consumer-dark']`）＋ `public-site.css` のスケール定義が、本契約の**リファレンス実装（ビルトイン既定テーマ）**。Phase 1 でこれを本契約の bundle 形式へ再表現する（最小例）。

--- a/docs/theming/public-theme.schema.json
+++ b/docs/theming/public-theme.schema.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nene-records.dev/schemas/public-theme.schema.json",
+  "title": "Public Theme Manifest",
+  "description": "Manifest for a NeNe Records public-site theme. See public-theme-contract.md (#368 / epic #367). Scope is the public site only (.nene-public / [data-theme='consumer*']).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "name", "version", "supportsModes", "tokens"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "id": {
+      "type": "string",
+      "description": "Theme id. Used as [data-theme='<id>'] (light) and [data-theme='<id>-dark'] (dark).",
+      "pattern": "^[a-z][a-z0-9-]{1,40}$"
+    },
+    "name": { "type": "string", "minLength": 1, "maxLength": 80 },
+    "version": {
+      "type": "string",
+      "description": "Semantic version.",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "author": { "type": "string", "maxLength": 120 },
+    "description": { "type": "string", "maxLength": 500 },
+    "supportsModes": {
+      "type": "array",
+      "description": "Themes MUST support both light and dark.",
+      "items": { "enum": ["light", "dark"] },
+      "minItems": 2,
+      "uniqueItems": true,
+      "contains": { "const": "light" },
+      "allOf": [{ "contains": { "const": "dark" } }]
+    },
+    "fonts": {
+      "type": "array",
+      "description": "Fonts the theme uses. Self-hosted or from the allowlist; no external @import.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["family", "role", "source"],
+        "properties": {
+          "family": { "type": "string", "minLength": 1 },
+          "role": { "enum": ["display", "body", "chrome", "mono"] },
+          "source": { "enum": ["fontsource", "selfhost", "system"] },
+          "weights": {
+            "type": "array",
+            "items": { "type": "integer", "minimum": 100, "maximum": 900 },
+            "uniqueItems": true
+          }
+        }
+      }
+    },
+    "tokens": {
+      "type": "object",
+      "description": "CSS custom property values per mode (without the leading --). Keys must be contract tokens; values are CSS values (oklch / color-mix / clamp / length …).",
+      "additionalProperties": false,
+      "required": ["light", "dark"],
+      "properties": {
+        "light": { "$ref": "#/$defs/tokenSet" },
+        "dark": { "$ref": "#/$defs/tokenSet" }
+      }
+    },
+    "knobs": {
+      "type": "object",
+      "description": "Optional default values for the customizer knobs (admin-editable). Omitted knobs fall back to derivations from the token set.",
+      "additionalProperties": false,
+      "properties": {
+        "accent": { "$ref": "#/$defs/colorPerMode" },
+        "surface": { "$ref": "#/$defs/colorPerMode" },
+        "textPrimary": { "$ref": "#/$defs/colorPerMode" },
+        "fontDisplay": { "type": "string" },
+        "fontBody": { "type": "string" },
+        "fontMono": { "type": "string" },
+        "baseFontSize": { "type": "string", "pattern": "^[0-9.]+(rem|px)$" },
+        "typeScale": { "type": "number", "minimum": 1.0, "maximum": 1.6 },
+        "density": { "enum": ["compact", "cozy", "comfortable"] },
+        "radius": { "enum": ["sharp", "soft", "round"] }
+      }
+    },
+    "assets": {
+      "type": "object",
+      "description": "Asset slots. Values are bundle-relative paths (no external URLs). Per-mode slots may use {light,dark}.",
+      "additionalProperties": false,
+      "properties": {
+        "preview": { "$ref": "#/$defs/assetPerMode" },
+        "hero": { "$ref": "#/$defs/assetPerMode" },
+        "background": { "$ref": "#/$defs/assetPerMode" },
+        "logo": { "$ref": "#/$defs/assetPerMode" },
+        "decoration": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/assetRef" }
+        },
+        "icons": { "$ref": "#/$defs/assetRef" }
+      }
+    }
+  },
+  "$defs": {
+    "tokenSet": {
+      "type": "object",
+      "description": "Map of contract token name (no leading --) to CSS value. Required tokens enforced here; extra contract tokens allowed.",
+      "required": [
+        "color-surface",
+        "color-surface-raised",
+        "color-surface-overlay",
+        "color-surface-sunken",
+        "color-text-primary",
+        "color-text-muted",
+        "color-text-inverse",
+        "color-border",
+        "color-border-strong",
+        "color-focus-ring",
+        "color-accent",
+        "color-accent-hover",
+        "color-accent-weak",
+        "color-on-accent",
+        "color-brand-violet",
+        "color-danger",
+        "color-danger-hover",
+        "color-ok",
+        "color-warn",
+        "color-info",
+        "shadow-sm",
+        "shadow-md",
+        "shadow-lg",
+        "color-scheme"
+      ],
+      "propertyNames": { "pattern": "^[a-z][a-z0-9-]*$" },
+      "additionalProperties": { "type": "string", "minLength": 1 }
+    },
+    "colorPerMode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["light", "dark"],
+      "properties": {
+        "light": { "type": "string", "minLength": 1 },
+        "dark": { "type": "string", "minLength": 1 }
+      }
+    },
+    "assetRef": {
+      "type": "string",
+      "description": "Bundle-relative path. External URLs (http/https/protocol-relative) and data: are rejected here; data URIs belong in CSS, not the manifest.",
+      "pattern": "^(?!https?:)(?!//)(?!data:)[A-Za-z0-9._/-]+\\.(png|jpg|jpeg|webp|avif|svg)$"
+    },
+    "assetPerMode": {
+      "oneOf": [
+        { "$ref": "#/$defs/assetRef" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "light": { "$ref": "#/$defs/assetRef" },
+            "dark": { "$ref": "#/$defs/assetRef" }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## 目的
公開サイトテーマ機能（エピック #367）の前提となる**正本契約**を定義する（Phase 0）。WordPress の `theme.json` 相当。

## 変更
- **`docs/theming/public-theme-contract.md`**: 全トークン（color / typography / space / radius / motion）の型・既定値・**3区分（Knob/Derived/Fixed）**・派生ルール（accent→hover/weak は color-mix 自動 等）・**light/dark 必須**・カスタマイザのノブ一覧を定義。さらに**アセット契約**（スロット / CSS参照経路 / 配信・解決 / SVGサニタイズ / サイズ上限）を規定。
- **`docs/theming/public-theme.schema.json`**: manifest 検証用 JSON Schema（draft 2020-12）。必須トークン網羅・light/dark両対応・外部URL/データURI禁止のアセットパス等を強制。
- **`docs/theming/examples/consumer.manifest.json`**: 既存 consumer テーマを契約形式で表現した最小例。

## 検証
- 3つの JSON/MD は prettier 整形済み。
- example を JSON Schema で検証 → **valid**。
- ネガティブテスト（外部URLアセット / light のみ / 必須トークン欠落）が**正しく reject** されることを確認。

## スコープ
公開サイトのみ（`.nene-public` / `[data-theme='consumer*']`）。管理UIトークンとは分離。ドキュメントのみ・実装変更なし。

Part of #367
Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)