### PR TITLE
feat(public): 公開サイト テーマのレジストリ化＋アクティブテーマ設定 (#367 Phase 1 スライス1)

### DIFF
--- a/database/migrations/20260616000000_add_active_theme_setting.php
+++ b/database/migrations/20260616000000_add_active_theme_setting.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Seed the `active_theme` public setting — the public site's selected theme id
+ * (epic #367 / Phase 1 #370). Defaults to the built-in `consumer` theme. The
+ * public frontend reads this and applies `[data-theme='<id>']`.
+ */
+final class AddActiveThemeSetting extends AbstractMigration
+{
+    public function up(): void
+    {
+        $now = date('Y-m-d H:i:s');
+        $this->table('setting_defs')->insert([
+            [
+                'setting_key' => 'active_theme',
+                'data_type' => 'text',
+                'default_value' => 'consumer',
+                'is_public' => 1,
+                'label' => 'Public site theme',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+        ])->saveData();
+    }
+
+    public function down(): void
+    {
+        $this->execute("DELETE FROM setting_defs WHERE setting_key = 'active_theme'");
+    }
+}

--- a/frontend/src/pages/consumer/PublicShell.tsx
+++ b/frontend/src/pages/consumer/PublicShell.tsx
@@ -4,6 +4,7 @@ import { Outlet } from 'react-router-dom'
 import { usePublicNavigationItems } from '@/entities/navigation-item'
 import { publicSettingsToMap, usePublicSettings } from '@/entities/setting'
 import type { PublicSite } from './public-site-context'
+import { resolvePublicThemeId } from './public-themes'
 
 function useSiteDocumentMeta(siteName: string, metaDescription: string): void {
   useEffect(() => {
@@ -43,6 +44,7 @@ export function PublicShell() {
     metaDescription: settings.default_meta_description ?? '',
     footerMarkdown: settings.footer_markdown ?? '',
     navItems,
+    activeTheme: resolvePublicThemeId(settings.active_theme),
   }
 
   useSiteDocumentMeta(site.siteName, site.metaDescription)

--- a/frontend/src/pages/consumer/PublicSiteShell.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.tsx
@@ -102,7 +102,7 @@ export function PublicSiteShell({
   withAside = false,
   children,
 }: PublicSiteShellProps) {
-  const { mode, resolvedTheme, setMode } = useConsumerTheme()
+  const { mode, resolvedTheme, setMode } = useConsumerTheme(site.activeTheme)
   const [drawerOpen, setDrawerOpen] = useState(false)
 
   // Render `sidebar` / `aside` regions as side columns when widgets are placed

--- a/frontend/src/pages/consumer/public-site-context.ts
+++ b/frontend/src/pages/consumer/public-site-context.ts
@@ -17,6 +17,8 @@ export interface PublicSite {
   metaDescription: string
   footerMarkdown: string
   navItems: PublicSiteNavItem[]
+  /** Admin-selected public-site theme id (`active_theme` setting). */
+  activeTheme: string
 }
 
 export function usePublicSite(): PublicSite {

--- a/frontend/src/pages/consumer/public-themes.test.ts
+++ b/frontend/src/pages/consumer/public-themes.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_PUBLIC_THEME_ID, PUBLIC_THEMES, resolvePublicThemeId } from './public-themes'
+
+describe('resolvePublicThemeId', () => {
+  it('returns a known theme id unchanged', () => {
+    expect(resolvePublicThemeId('consumer')).toBe('consumer')
+  })
+
+  it('falls back to the default for unknown / empty / nullish values', () => {
+    expect(resolvePublicThemeId('does-not-exist')).toBe(DEFAULT_PUBLIC_THEME_ID)
+    expect(resolvePublicThemeId('')).toBe(DEFAULT_PUBLIC_THEME_ID)
+    expect(resolvePublicThemeId(null)).toBe(DEFAULT_PUBLIC_THEME_ID)
+    expect(resolvePublicThemeId(undefined)).toBe(DEFAULT_PUBLIC_THEME_ID)
+  })
+
+  it('default theme id is registered', () => {
+    expect(PUBLIC_THEMES.some((theme) => theme.id === DEFAULT_PUBLIC_THEME_ID)).toBe(true)
+  })
+})

--- a/frontend/src/pages/consumer/public-themes.ts
+++ b/frontend/src/pages/consumer/public-themes.ts
@@ -1,0 +1,29 @@
+/**
+ * Registry of built-in public-site themes (epic #367 / Phase 1 #370).
+ *
+ * A theme is a set of design-token values scoped under `[data-theme='<id>']`
+ * (light) and `[data-theme='<id>-dark']` (dark). The active theme is chosen by
+ * the site admin via the `active_theme` public setting; the visitor light/dark
+ * toggle (see use-consumer-theme.ts) picks the mode within the active theme.
+ *
+ * For now `consumer` is the sole built-in (consumer-brand.css). Additional
+ * themes register here as their token CSS lands, per the contract in
+ * docs/theming/public-theme-contract.md.
+ */
+export interface PublicThemeMeta {
+  /** Theme id — used as the `[data-theme]` base value. */
+  id: string
+  /** Human label for the admin theme picker. */
+  name: string
+}
+
+export const PUBLIC_THEMES: readonly PublicThemeMeta[] = [{ id: 'consumer', name: 'Terracotta' }]
+
+export const DEFAULT_PUBLIC_THEME_ID = 'consumer'
+
+/** Normalise a stored value to a known theme id, falling back to the default. */
+export function resolvePublicThemeId(value: string | null | undefined): string {
+  return PUBLIC_THEMES.some((theme) => theme.id === value)
+    ? (value as string)
+    : DEFAULT_PUBLIC_THEME_ID
+}

--- a/frontend/src/pages/consumer/use-consumer-theme.ts
+++ b/frontend/src/pages/consumer/use-consumer-theme.ts
@@ -1,18 +1,21 @@
 import { useCallback, useEffect, useState } from 'react'
+import { DEFAULT_PUBLIC_THEME_ID } from './public-themes'
 
 /**
  * Public-site color theme controller (light / dark / auto).
  *
- * - `mode` is the user's choice, persisted in localStorage.
- * - `resolvedTheme` is the concrete `[data-theme]` value to apply
- *   (`consumer` | `consumer-dark`); `auto` follows `prefers-color-scheme`.
+ * - `mode` is the visitor's choice, persisted in localStorage.
+ * - `resolvedTheme` is the concrete `[data-theme]` value to apply for the
+ *   admin-selected theme: `<baseThemeId>` (light) or `<baseThemeId>-dark`;
+ *   `auto` follows `prefers-color-scheme`.
  *
  * The caller applies `data-theme={resolvedTheme}` and `data-theme-mode={mode}`
  * to its root element. Setting `data-theme-mode` disables the no-JS OS-dark
  * fallback in consumer-brand.css (the controller now owns resolution).
  */
 export type ThemeMode = 'light' | 'dark' | 'auto'
-export type ConsumerTheme = 'consumer' | 'consumer-dark'
+/** Resolved `[data-theme]` value, e.g. `consumer` or `consumer-dark`. */
+export type ConsumerTheme = string
 
 const STORAGE_KEY = 'nene_public_theme_mode'
 const DARK_QUERY = '(prefers-color-scheme: dark)'
@@ -21,13 +24,6 @@ function prefersDark(): boolean {
   return typeof window !== 'undefined' && typeof window.matchMedia === 'function'
     ? window.matchMedia(DARK_QUERY).matches
     : false
-}
-
-function resolveTheme(mode: ThemeMode): ConsumerTheme {
-  if (mode === 'auto') {
-    return prefersDark() ? 'consumer-dark' : 'consumer'
-  }
-  return mode === 'dark' ? 'consumer-dark' : 'consumer'
 }
 
 function readStoredMode(): ThemeMode {
@@ -44,7 +40,9 @@ export interface ConsumerThemeController {
   setMode: (mode: ThemeMode) => void
 }
 
-export function useConsumerTheme(): ConsumerThemeController {
+export function useConsumerTheme(
+  baseThemeId: string = DEFAULT_PUBLIC_THEME_ID,
+): ConsumerThemeController {
   const [mode, setModeState] = useState<ThemeMode>(readStoredMode)
   // Track the OS preference so `auto` can live-update. Initialised synchronously
   // so the first paint already matches the system.
@@ -72,8 +70,8 @@ export function useConsumerTheme(): ConsumerThemeController {
     }
   }, [])
 
-  const resolvedTheme: ConsumerTheme =
-    mode === 'auto' ? (systemDark ? 'consumer-dark' : 'consumer') : resolveTheme(mode)
+  const isDark = mode === 'auto' ? systemDark : mode === 'dark'
+  const resolvedTheme: ConsumerTheme = isDark ? `${baseThemeId}-dark` : baseThemeId
 
   return { mode, resolvedTheme, setMode }
 }

--- a/frontend/tests/render/PublicSiteTestProvider.tsx
+++ b/frontend/tests/render/PublicSiteTestProvider.tsx
@@ -7,6 +7,7 @@ const TEST_SITE: PublicSite = {
   metaDescription: '',
   footerMarkdown: '',
   navItems: [],
+  activeTheme: 'consumer',
 }
 
 /**


### PR DESCRIPTION
## 目的
公開サイトのテーマを複数化する基盤（エピック #367 / Phase 1 #370）。本PRは**スライス1＝レジストリ＋アクティブテーマ設定の配線**。既定 `consumer` で**後方互換・見た目の回帰なし**。トークン契約は #368 準拠。

## 変更
- **`public-themes.ts`**: ビルトインテーマのレジストリ（現状 `consumer`）＋ `resolvePublicThemeId`（未知/空/nullは既定へフォールバック）。
- **`active_theme` 公開設定**を追加（マイグレーション・text・public・既定 `consumer`）。
- **`PublicShell`**: `active_theme` を読み `PublicSite.activeTheme` に解決して Outlet context へ。
- **`useConsumerTheme(baseThemeId)`**: テーマidで一般化し `<id>` / `<id>-dark` を解決（light/dark トグルは従来どおり）。**`PublicSiteShell`** が `site.activeTheme` を適用。
- テスト: `resolvePublicThemeId` ユニットテスト、テストプロバイダに `activeTheme` 追加。

## 検証
- フロント `npm run check`: **170 tests green**（type-check / lint / prettier / test / knip / storybook）。
- バックエンド `composer test`: **691 tests green**。マイグレーション適用確認済み。

## スコープ / 後続
- スコープは公開サイトのみ（`.nene-public` / `[data-theme='consumer*']`）。管理UIトークンと分離。
- **管理UI（テーマ選択カード）は次スライス**（UX 検討が必要なため分離）。
- 追加テーマの token CSS は Phase 3（ClaudeDesign 量産）で投入予定。

Part of #367