### PR TITLE
feat(theming): MDオーサリング契約＋2つ目テーマ Aurora (#367 Phase 3)

### DIFF
--- a/docs/theming/examples/aurora.theme.md
+++ b/docs/theming/examples/aurora.theme.md
@@ -1,0 +1,38 @@
+# Theme: Aurora
+
+## Meta
+
+- id: aurora
+- modes: light, dark
+- concept: クールで静かなテック系。冷たい紙にティール/シアンのアクセント。テラコッタ（consumer）と対極の色温度で、テーマ切替の差が一目で分かる。
+- author: NeNe Records
+
+## Color
+
+- accent: ティール〜シアン（oklch ≈ 62% 0.13 200）
+- surface (light): 冷たいごく明るいグレー（oklch ≈ 98% 0.006 230）
+- surface (dark): 深い青寄りの黒（oklch ≈ 17% 0.02 250）
+- text: 既定（surface から AA 導出。light は青みの濃いインク、dark は冷白）
+- mood: cool
+
+## Typography
+
+- display: "Saira Semi Condensed"
+- body: "Inter"
+- mono: "JetBrains Mono"
+- baseFontSize: 1.0625rem
+- typeScale: 1.18
+
+## Shape & density
+
+- density: comfortable
+- radius: round
+
+## Assets
+
+- hero: 既定（プレースホルダ。装飾画像は同梱しない）
+- logo: 既定（NeneMark を流用）
+
+## References
+
+- consumer（Terracotta）の暖色に対し、こちらは寒色で「静かな技術ブログ」を想定。

--- a/docs/theming/examples/ink.theme.md
+++ b/docs/theming/examples/ink.theme.md
@@ -1,0 +1,45 @@
+# Theme: Ink
+
+<!--
+記入例（2作目）。brief-template.theme.md を埋めたもの。
+consumer（暖色・soft・comfortable）／ aurora（寒色・round・comfortable）に対し、
+ink は「無彩色・sharp・compact」。3者で mood / radius / density の振れ幅を示す教材。
+-->
+
+## Meta
+
+- id: ink
+- modes: light, dark
+- concept: 高コントラストのモノクロ・エディトリアル。明るい紙に近黒インク＋コバルトの差し色。情報密度高め・シャープでミニマル。ドキュメント／ニュース系の硬派なトーン。
+- author: NeNe Records
+
+## Color
+
+- accent: コバルトブルー（oklch ≈ 50% 0.16 255）
+- surface (light): ほぼ純白の中立グレー（oklch ≈ 99% 0.002 250）
+- surface (dark): 中立の近黒（oklch ≈ 16% 0.004 250）
+- text: 高コントラスト（light=近黒 / dark=近白、彩度ほぼ 0）
+- mood: neutral
+
+## Typography
+
+- display: "Space Grotesk" # aurora の Saira とは変える＝幾何学的でシャープ
+- body: "Inter"
+- mono: "JetBrains Mono"
+- baseFontSize: 1rem # やや小さめ＝高密度
+- typeScale: 1.2 # 見出しの階層を強める
+
+## Shape & density
+
+- density: compact
+- radius: sharp
+
+## Assets
+
+- hero: 既定（装飾画像なし・タイポ主体）
+- logo: 既定（NeneMark を流用）
+
+## References
+
+- consumer（暖色・soft）／ aurora（寒色・round）に対し、ink は無彩色・sharp・compact。
+  3 テーマで mood / radius / density / display フォントの選択肢の幅を示す。

--- a/docs/theming/theme-authoring.md
+++ b/docs/theming/theme-authoring.md
@@ -110,4 +110,9 @@ authoring.md ──(ClaudeDesign / 作者)──▶ theme bundle ──(validate
 
 ## 7. 例
 
-実例のオーサリング MD: [`examples/aurora.theme.md`](./examples/aurora.theme.md)。
+実例のオーサリング MD（記入済みブリーフ）:
+
+- [`examples/aurora.theme.md`](./examples/aurora.theme.md) … 寒色・round・comfortable。
+- [`examples/ink.theme.md`](./examples/ink.theme.md) … 無彩色・sharp・compact（別の display フォント）。
+
+`consumer`（暖色・soft）も含め、`mood` / `radius` / `density` / フォント選択の振れ幅の参考に。

--- a/docs/theming/theme-authoring.md
+++ b/docs/theming/theme-authoring.md
@@ -1,0 +1,113 @@
+# テーマ オーサリング契約（MD → テーマ bundle）
+
+> ClaudeDesign（や人間の作者）が **Markdown 仕様を書く → テーマ bundle が生成される** ための入力契約。Phase 3（#373）/ エピック #367。
+>
+> - 値・トークンの正本: [`public-theme-contract.md`](./public-theme-contract.md)
+> - manifest スキーマ: [`public-theme.schema.json`](./public-theme.schema.json)
+> - 検査: `npm run validate:themes --prefix frontend`（`npm run check` にも組込み済み）
+
+---
+
+## 1. ねらい
+
+「MD を渡せば正確にテーマが組み上がる」状態にする。入力（作者が書く MD）と出力（生成される bundle）の境界を固定し、出力は必ずバリデータを通す。これにより**安全に量産**できる。
+
+```
+authoring.md ──(ClaudeDesign / 作者)──▶ theme bundle ──(validate:themes)──▶ 登録
+```
+
+## 2. 入力＝オーサリング MD の形式
+
+1 テーマ = 1 つの `*.theme.md`。次の見出しを**この順で**含める。値は具体値でも方向性でもよい（曖昧な指定は §4 の派生ルールで補完）。
+
+```markdown
+# Theme: <表示名>
+
+## Meta
+
+- id: <kebab-case> # [data-theme] のベース値
+- modes: light, dark # 両対応必須
+- concept: <1〜2行のコンセプト（雰囲気・用途）>
+- author: <任意>
+
+## Color
+
+- accent: <色の方向性 or oklch 値> # 主要ノブ
+- surface (light): <紙の地（明）>
+- surface (dark): <紙の地（暗）>
+- text: <本文色の方向性（任意・既定は surface から AA 導出）>
+- mood: warm | cool | neutral # 影・ボーダーの色温度
+
+## Typography
+
+- display: <見出しフォント> # 例: "Saira Semi Condensed"
+- body: <本文フォント>
+- mono: <コードフォント>
+- baseFontSize: <例 1.0625rem>
+- typeScale: <1.0〜1.6 の比率>
+
+## Shape & density
+
+- density: compact | cozy | comfortable
+- radius: sharp | soft | round
+
+## Assets (任意)
+
+- hero: <記述 or 同梱ファイル名>
+- logo: <同梱ファイル名 / svg>
+- decoration: <装飾の方向性>
+
+## References (任意)
+
+- <ムードボード / 参考リンク / 既存サイト 等>
+```
+
+> フォントは**許可リスト / セルフホスト**のみ（外部 `@import` 不可）。指定外フォントは同梱が必要。
+
+## 3. 出力＝テーマ bundle
+
+オーサリング MD から次を生成する（[`public-theme-contract.md`](./public-theme-contract.md) §9 準拠）。
+
+```
+<theme-id>/
+├─ manifest.json     # public-theme.schema.json 準拠（id/name/supportsModes/fonts/tokens/assets…）
+├─ tokens.css        # [data-theme='<id>'] と [data-theme='<id>-dark'] の 2 ブロック
+├─ components.css    # 任意・既存クラスへの上乗せのみ（新規 DOM 構造なし）
+├─ assets/           # hero / logo / decoration …（外部 url 不可・同梱 or data URI）
+└─ screenshots/      # preview（light/dark/mobile）
+```
+
+## 4. 変換規則（MD → トークン）
+
+- **Knob のみ作者が決める**。**Derived は契約 §3 の派生式で自動生成**する：
+  - `accent` → `accent-hover`（light: L−6 / dark: L+7）, `accent-weak`（`color-mix` 12%/16%）, `on-accent`（AA 確保）, `focus-ring`。
+  - `surface` → `surface-raised/-overlay/-sunken`（明度オフセット）, `border`/`border-strong`, `text-muted`。
+  - `baseFontSize`＋`typeScale` → `--text-*` 一式（clamp の下限/上限も比例）。
+  - `density` → `--space-*` 一括スケール。`radius` → `--radius-sm/md/lg`。
+  - `mood` → 影・ボーダーの色温度。
+- **light/dark 双方**を必ず出力。`color-scheme` も各モードで設定。
+- **アクセシビリティ**: `text-primary` / `on-accent` は背景に対し WCAG AA（4.5:1）。
+
+## 5. 受け入れ（必須）
+
+生成 bundle は次を満たすこと。CI（`npm run check`）でも強制される。
+
+- `validateManifest`（schema）に合格。
+- `validateThemeCss`（スコープ強制 / `@import` 禁止 / 外部 `url()` 禁止 / 危険構文排除）に合格。
+- 必須トークン網羅・light/dark 両セット存在。
+- （順次対応）コントラスト AA・SVG サニタイズ。
+
+## 6. 登録
+
+検査を通った bundle を組み込む。
+
+1. `tokens.css` を `frontend/src/shared/ui/theme/themes/<id>.css` として配置し、`frontend/src/pages/consumer/consumer-theme.css` から `@import`（`[data-theme]` スコープなので非アクティブ時は無害）。
+2. `frontend/src/shared/lib/public-themes.ts` の `PUBLIC_THEMES` に id / name / preview を追加。
+3. `manifest.json`（と任意のスクショ）を `docs/theming/themes/<id>/` に置く。
+4. `npm run validate:themes` で緑を確認。
+
+> 第三者テーマ（Tier 2）も同じ契約・同じ検査を通す。任意 JS は不可（宣言的設定のみ）。
+
+## 7. 例
+
+実例のオーサリング MD: [`examples/aurora.theme.md`](./examples/aurora.theme.md)。

--- a/docs/theming/themes/aurora/manifest.json
+++ b/docs/theming/themes/aurora/manifest.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "../../public-theme.schema.json",
+  "id": "aurora",
+  "name": "Aurora",
+  "version": "1.0.0",
+  "author": "NeNe Records",
+  "description": "Cool, quiet tech theme — teal/cyan accent on cool paper. Authored from examples/aurora.theme.md; the counterpoint to consumer (Terracotta).",
+  "supportsModes": ["light", "dark"],
+  "fonts": [
+    {
+      "family": "Saira Semi Condensed",
+      "role": "display",
+      "source": "fontsource",
+      "weights": [400, 500, 600]
+    },
+    {
+      "family": "Inter",
+      "role": "body",
+      "source": "fontsource",
+      "weights": [400, 500, 600]
+    },
+    {
+      "family": "JetBrains Mono",
+      "role": "mono",
+      "source": "fontsource",
+      "weights": [400]
+    }
+  ],
+  "tokens": {
+    "light": {
+      "color-surface": "oklch(98% 0.006 230)",
+      "color-surface-raised": "oklch(99.5% 0.004 230)",
+      "color-surface-overlay": "oklch(94.5% 0.012 230)",
+      "color-surface-sunken": "oklch(96% 0.01 235)",
+      "color-text-primary": "oklch(24% 0.03 250)",
+      "color-text-muted": "oklch(48% 0.03 245)",
+      "color-text-inverse": "oklch(99% 0.004 230)",
+      "color-border": "oklch(88% 0.012 230)",
+      "color-border-strong": "oklch(80% 0.018 235)",
+      "color-focus-ring": "oklch(68% 0.13 215)",
+      "color-accent": "oklch(62% 0.13 200)",
+      "color-accent-hover": "oklch(56% 0.13 200)",
+      "color-accent-weak": "color-mix(in oklch, var(--color-accent) 12%, var(--color-surface-raised))",
+      "color-on-accent": "oklch(99% 0.004 230)",
+      "color-brand-violet": "oklch(56% 0.24 300)",
+      "color-danger": "oklch(52% 0.2 25)",
+      "color-danger-hover": "oklch(46% 0.2 25)",
+      "color-ok": "oklch(55% 0.13 150)",
+      "color-warn": "oklch(70% 0.15 75)",
+      "color-info": "oklch(55% 0.13 250)",
+      "shadow-sm": "0 1px 2px oklch(40% 0.04 250 / 0.08)",
+      "shadow-md": "0 6px 22px oklch(40% 0.04 250 / 0.1)",
+      "shadow-lg": "0 22px 50px oklch(38% 0.05 250 / 0.16)",
+      "color-scheme": "light"
+    },
+    "dark": {
+      "color-surface": "oklch(17% 0.02 250)",
+      "color-surface-raised": "oklch(21% 0.022 250)",
+      "color-surface-overlay": "oklch(26% 0.024 248)",
+      "color-surface-sunken": "oklch(14% 0.018 250)",
+      "color-text-primary": "oklch(94% 0.012 230)",
+      "color-text-muted": "oklch(68% 0.02 235)",
+      "color-text-inverse": "oklch(20% 0.02 250)",
+      "color-border": "oklch(32% 0.022 250)",
+      "color-border-strong": "oklch(42% 0.026 250)",
+      "color-focus-ring": "oklch(74% 0.13 210)",
+      "color-accent": "oklch(72% 0.13 200)",
+      "color-accent-hover": "oklch(79% 0.13 200)",
+      "color-accent-weak": "color-mix(in oklch, var(--color-accent) 16%, var(--color-surface-raised))",
+      "color-on-accent": "oklch(20% 0.04 250)",
+      "color-brand-violet": "oklch(72% 0.18 300)",
+      "color-danger": "oklch(66% 0.18 25)",
+      "color-danger-hover": "oklch(72% 0.18 25)",
+      "color-ok": "oklch(72% 0.14 150)",
+      "color-warn": "oklch(80% 0.14 80)",
+      "color-info": "oklch(74% 0.12 250)",
+      "shadow-sm": "0 1px 2px oklch(0% 0 0 / 0.4)",
+      "shadow-md": "0 8px 26px oklch(0% 0 0 / 0.5)",
+      "shadow-lg": "0 24px 56px oklch(0% 0 0 / 0.62)",
+      "color-scheme": "dark"
+    }
+  },
+  "knobs": {
+    "accent": { "light": "oklch(62% 0.13 200)", "dark": "oklch(72% 0.13 200)" },
+    "surface": {
+      "light": "oklch(98% 0.006 230)",
+      "dark": "oklch(17% 0.02 250)"
+    },
+    "fontDisplay": "Saira Semi Condensed",
+    "fontBody": "Inter",
+    "fontMono": "JetBrains Mono",
+    "baseFontSize": "1.0625rem",
+    "typeScale": 1.18,
+    "density": "comfortable",
+    "radius": "round"
+  }
+}

--- a/frontend/scripts/validate-themes.ts
+++ b/frontend/scripts/validate-themes.ts
@@ -29,7 +29,7 @@ function findManifests(dir: string): string[] {
     const full = join(dir, entry.name)
     if (entry.isDirectory()) {
       out.push(...findManifests(full))
-    } else if (entry.name.endsWith('.manifest.json')) {
+    } else if (entry.name === 'manifest.json' || entry.name.endsWith('.manifest.json')) {
       out.push(full)
     }
   }

--- a/frontend/src/pages/consumer/consumer-theme.css
+++ b/frontend/src/pages/consumer/consumer-theme.css
@@ -1,1 +1,2 @@
 @import '../../shared/ui/theme/themes/consumer-brand.css';
+@import '../../shared/ui/theme/themes/aurora.css';

--- a/frontend/src/shared/lib/public-themes.ts
+++ b/frontend/src/shared/lib/public-themes.ts
@@ -29,6 +29,15 @@ export const PUBLIC_THEMES: readonly PublicThemeMeta[] = [
       accent: 'oklch(58% 0.14 45)',
     },
   },
+  {
+    id: 'aurora',
+    name: 'Aurora',
+    preview: {
+      surface: 'oklch(98% 0.006 230)',
+      raised: 'oklch(99.5% 0.004 230)',
+      accent: 'oklch(62% 0.13 200)',
+    },
+  },
 ]
 
 export const DEFAULT_PUBLIC_THEME_ID = 'consumer'

--- a/frontend/src/shared/lib/theme-bundle/validate-manifest.test.ts
+++ b/frontend/src/shared/lib/theme-bundle/validate-manifest.test.ts
@@ -13,10 +13,15 @@ function readJson(fromFrontend: string): Record<string, unknown> {
 
 const schema = readJson('../docs/theming/public-theme.schema.json')
 const exampleManifest = readJson('../docs/theming/examples/consumer.manifest.json')
+const auroraManifest = readJson('../docs/theming/themes/aurora/manifest.json')
 
 describe('validateManifest', () => {
   it('accepts the built-in consumer example manifest', () => {
     expect(validateManifest(exampleManifest, schema)).toEqual([])
+  })
+
+  it('accepts the Aurora theme manifest', () => {
+    expect(validateManifest(auroraManifest, schema)).toEqual([])
   })
 
   it('rejects a manifest missing a required token (no color-accent in dark)', () => {

--- a/frontend/src/shared/lib/theme-bundle/validate-theme-css.test.ts
+++ b/frontend/src/shared/lib/theme-bundle/validate-theme-css.test.ts
@@ -8,10 +8,18 @@ const consumerCss = readFileSync(
   resolve(process.cwd(), 'src/shared/ui/theme/themes/consumer-brand.css'),
   'utf8',
 )
+const auroraCss = readFileSync(
+  resolve(process.cwd(), 'src/shared/ui/theme/themes/aurora.css'),
+  'utf8',
+)
 
 describe('validateThemeCss', () => {
   it('accepts the built-in consumer-brand.css (scoped, no external refs)', () => {
     expect(validateThemeCss(consumerCss, { themeId: 'consumer' })).toEqual([])
+  })
+
+  it('accepts the built-in aurora.css (scoped, no external refs)', () => {
+    expect(validateThemeCss(auroraCss, { themeId: 'aurora' })).toEqual([])
   })
 
   it('accepts theme-scoped and .nene-public selectors', () => {

--- a/frontend/src/shared/ui/theme/themes/aurora.css
+++ b/frontend/src/shared/ui/theme/themes/aurora.css
@@ -1,0 +1,91 @@
+/* ============================================================================
+   NeNe Records — Public site theme: Aurora (light + dark)
+   ----------------------------------------------------------------------------
+   Cool, quiet tech feel — teal/cyan accent on cool paper. The deliberate
+   counterpoint to `consumer` (warm terracotta), so switching themes reads at a
+   glance. Authored from docs/theming/examples/aurora.theme.md per the token
+   contract; scoped under [data-theme='aurora'] / [data-theme='aurora-dark'].
+   ========================================================================== */
+
+/* ── LIGHT — cool near-white paper ───────────────────────────────────────── */
+[data-theme='aurora'] {
+  /* surface */
+  --color-surface: oklch(98% 0.006 230);
+  --color-surface-raised: oklch(99.5% 0.004 230);
+  --color-surface-overlay: oklch(94.5% 0.012 230);
+  --color-surface-sunken: oklch(96% 0.01 235);
+
+  /* text */
+  --color-text-primary: oklch(24% 0.03 250);
+  --color-text-muted: oklch(48% 0.03 245);
+  --color-text-inverse: oklch(99% 0.004 230);
+
+  /* line */
+  --color-border: oklch(88% 0.012 230);
+  --color-border-strong: oklch(80% 0.018 235);
+  --color-focus-ring: oklch(68% 0.13 215);
+
+  /* brand — teal */
+  --color-accent: oklch(62% 0.13 200);
+  --color-accent-hover: oklch(56% 0.13 200);
+  --color-accent-weak: color-mix(in oklch, var(--color-accent) 12%, var(--color-surface-raised));
+  --color-on-accent: oklch(99% 0.004 230);
+
+  /* brand mark — NENE2 violet (logo only) */
+  --color-brand-violet: oklch(56% 0.24 300);
+
+  /* status */
+  --color-danger: oklch(52% 0.2 25);
+  --color-danger-hover: oklch(46% 0.2 25);
+  --color-ok: oklch(55% 0.13 150);
+  --color-warn: oklch(70% 0.15 75);
+  --color-info: oklch(55% 0.13 250);
+
+  /* shadow — cool-tinted, soft in light */
+  --shadow-sm: 0 1px 2px oklch(40% 0.04 250 / 0.08);
+  --shadow-md: 0 6px 22px oklch(40% 0.04 250 / 0.1);
+  --shadow-lg: 0 22px 50px oklch(38% 0.05 250 / 0.16);
+
+  color-scheme: light;
+}
+
+/* ── DARK — deep blue-black paper ────────────────────────────────────────── */
+[data-theme='aurora-dark'] {
+  /* surface */
+  --color-surface: oklch(17% 0.02 250);
+  --color-surface-raised: oklch(21% 0.022 250);
+  --color-surface-overlay: oklch(26% 0.024 248);
+  --color-surface-sunken: oklch(14% 0.018 250);
+
+  /* text */
+  --color-text-primary: oklch(94% 0.012 230);
+  --color-text-muted: oklch(68% 0.02 235);
+  --color-text-inverse: oklch(20% 0.02 250);
+
+  /* line */
+  --color-border: oklch(32% 0.022 250);
+  --color-border-strong: oklch(42% 0.026 250);
+  --color-focus-ring: oklch(74% 0.13 210);
+
+  /* brand — lifted teal, dark text rides on top */
+  --color-accent: oklch(72% 0.13 200);
+  --color-accent-hover: oklch(79% 0.13 200);
+  --color-accent-weak: color-mix(in oklch, var(--color-accent) 16%, var(--color-surface-raised));
+  --color-on-accent: oklch(20% 0.04 250);
+
+  --color-brand-violet: oklch(72% 0.18 300);
+
+  /* status — lifted for dark legibility */
+  --color-danger: oklch(66% 0.18 25);
+  --color-danger-hover: oklch(72% 0.18 25);
+  --color-ok: oklch(72% 0.14 150);
+  --color-warn: oklch(80% 0.14 80);
+  --color-info: oklch(74% 0.12 250);
+
+  /* shadow — deep, near-black */
+  --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.4);
+  --shadow-md: 0 8px 26px oklch(0% 0 0 / 0.5);
+  --shadow-lg: 0 24px 56px oklch(0% 0 0 / 0.62);
+
+  color-scheme: dark;
+}


### PR DESCRIPTION
## 目的
「**MD を渡せばテーマが組み上がる**」入力契約を定め（Phase 3 続き）、その契約で**実テーマを1本量産**してパイプライン（契約→bundle→バリデータ→登録）を実証する。エピック #367 / #373。

## 変更
### (a) オーサリング契約
- **`docs/theming/theme-authoring.md`**: オーサリング MD の形式・出力 bundle 構成・変換規則（Knob→Derived の派生）・受け入れ条件・登録手順。
- **`docs/theming/examples/aurora.theme.md`**: 実例のオーサリング MD。

### (c) 2つ目テーマ Aurora（上記契約で作成）
- **`frontend/src/shared/ui/theme/themes/aurora.css`**: `[data-theme='aurora'/'aurora-dark']` のトークン（クール/ティール。consumer の暖色と対極で切替が一目で分かる）。`consumer-theme.css` から `@import`（スコープ済みで非アクティブ時は無害）。
- **`public-themes.ts`**: `PUBLIC_THEMES` に `aurora` を登録 → 管理画面「外観 > テーマ」で **Terracotta / Aurora の2択**に。
- **`docs/theming/themes/aurora/manifest.json`**: 契約準拠 manifest（schema 検証 pass）。
- バリデータの CLI/テストを aurora 込みに拡張（CLI が `manifest.json` も拾うよう修正）。

## 検証
- `npm run check`: green（186 tests / **validate:themes** が consumer・aurora 両方を検査して pass）。
- aurora の実 CSS をスコープ/安全性チェックの対象に追加（テスト緑）。

## 効果 / 後続
- これでテーマ切替が**実際に体感できる**（2テーマ）。パイプラインが一周回ったことの実証。
- 後続: バリデータ強化（コントラストAA / SVGサニタイズ）、インポータ（bundle→src 自動生成で manifest/CSS の二重管理を解消）。

Part of #367