### PR TITLE
feat(public): Reading テーマ用 serif (Source Serif 4) をセルフホスト同梱 (#367 Phase 3)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@fontsource/noto-sans-jp": "^5.2.9",
         "@fontsource/noto-sans-sc": "^5.2.9",
         "@fontsource/saira-semi-condensed": "^5.2.7",
+        "@fontsource/source-serif-4": "^5.2.9",
         "@fontsource/space-grotesk": "^5.2.10",
         "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.90.11",
@@ -1189,6 +1190,15 @@
       "version": "5.2.7",
       "resolved": "https://registry.npmjs.org/@fontsource/saira-semi-condensed/-/saira-semi-condensed-5.2.7.tgz",
       "integrity": "sha512-igQz2iKmaHOUN7UmqJHaofuFXSS2jQQ72dlWyIQYL1pDtpZkj5wANeKo2CLr2tRH2btzosBnidGrQQPeFDZkZw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/source-serif-4": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/source-serif-4/-/source-serif-4-5.2.9.tgz",
+      "integrity": "sha512-er/Pym9emsEVJNf947umJ4kXarXfsiN6CN7kTYinefKRaHLwiquiiHOZvKvxWgkV8JMCf3pV3g0NcsPFpVCH9w==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,7 @@
     "@fontsource/noto-sans-jp": "^5.2.9",
     "@fontsource/noto-sans-sc": "^5.2.9",
     "@fontsource/saira-semi-condensed": "^5.2.7",
+    "@fontsource/source-serif-4": "^5.2.9",
     "@fontsource/space-grotesk": "^5.2.10",
     "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.90.11",

--- a/frontend/src/pages/consumer/PublicShell.tsx
+++ b/frontend/src/pages/consumer/PublicShell.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from 'react'
 import './consumer-theme.css'
+import './public-fonts'
 import { Outlet } from 'react-router-dom'
 import { usePublicNavigationItems } from '@/entities/navigation-item'
 import { publicSettingsToMap, usePublicSettings } from '@/entities/setting'

--- a/frontend/src/pages/consumer/public-fonts.ts
+++ b/frontend/src/pages/consumer/public-fonts.ts
@@ -1,0 +1,12 @@
+/**
+ * 公開サイト用フォント (@fontsource 同梱 = セルフホスト・外部リクエストなし)。
+ * `PublicShell` からのみインポートし、admin バンドル (`src/fonts.ts`) には混ぜない。
+ *
+ * Source Serif 4: 「Reading」テーマの serif 本文。許可リスト外フォントは
+ * テーマ契約どおりここにセルフホスト同梱する（外部 @import 不可）。
+ * 既定テーマ (consumer / aurora) が使う Inter / Saira / Space Grotesk /
+ * JetBrains は現状 admin の fonts.ts 経由で読まれる。
+ */
+import '@fontsource/source-serif-4/latin-400.css'
+import '@fontsource/source-serif-4/latin-400-italic.css'
+import '@fontsource/source-serif-4/latin-600.css'


### PR DESCRIPTION
## 目的
4作目「Reading」テーマ（読み物・タイポ主導）の **serif 本文**を、テーマ契約どおり**セルフホスト**で用意する（外部 @import なし）。Google Fonts を直接DLする代わりに、既存と同じ **@fontsource** 方式（ローカル woff2 同梱）で入れる。

## 変更
- `@fontsource/source-serif-4` を **dependencies** に追加（他の @fontsource と同じ扱い）。
- `src/pages/consumer/public-fonts.ts` を新設し **`PublicShell` から読込**（latin 400 / 600 / 400-italic）。admin 専用の `src/fonts.ts` には混ぜない＝serif を admin バンドルに載せない。

## なぜ
- contract §「フォントは許可リスト/セルフホストのみ・外部 @import 不可」を満たす。
- これで Reading の brief を **(a) serif 採用**で確定でき、ClaudeDesign が `tokens.css` の本文を `Source Serif 4` で生成できる。

## 検証
- `npm run check`: green（186 tests / validate:themes / knip / storybook）。

## 後続
- 本PRは**フォント同梱のみ**。Reading テーマ本体（tokens.css / manifest / レジストリ登録）は brief（`design-export/nene-theme-handoff/brief-reading.theme.md`）から ClaudeDesign が生成 → 検査 → 登録。

Part of #367