### PR TITLE
feat(public): ClaudeDesign 製 Reading テーマを取り込む (#367 Phase 3)

### DIFF
--- a/docs/theming/themes/reading/components.css
+++ b/docs/theming/themes/reading/components.css
@@ -1,0 +1,63 @@
+/* ============================================================================
+   NeNe Records — Public site theme: Reading — type overlay
+   ----------------------------------------------------------------------------
+   Reading's differentiator is the *reading experience*, not hue. These rules
+   re-express the typography knobs (baseFontSize 1.125rem, typeScale 1.2,
+   serif body, wide measure, loose leading) as token overrides, scoped to the
+   theme so they only apply when [data-theme='reading'|'reading-dark'] is set.
+
+   No new DOM structure — only overrides of contract tokens consumed by the
+   existing public-site.css. Selector carries `.nene-public` so it outranks the
+   base `.nene-public` type scale and stays inside the validator's scope rule.
+   `--font-sans` points at the self-hosted Source Serif 4 (@fontsource).
+   ========================================================================== */
+
+.nene-public[data-theme="reading"],
+.nene-public[data-theme="reading-dark"] {
+  /* fonts — serif body, condensed display, mono code */
+  --font-sans:
+    "Source Serif 4", "Noto Serif JP", Georgia, "Times New Roman", serif;
+  --font-display: "Saira Semi Condensed", system-ui, -apple-system, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", monospace;
+
+  /* type scale — recomputed from baseFontSize 1.125rem × typeScale 1.2 */
+  --text-overline: 0.78rem;
+  --text-meta: 0.84rem;
+  --text-body-sm: 0.98rem;
+  --text-body: 1.125rem;
+  --text-h3: 1.4rem;
+  --text-h2: clamp(1.6rem, 1.15rem + 1.7vw, 2.35rem);
+  --text-h1: clamp(1.8rem, 1.3rem + 1.9vw, 2.7rem);
+  --text-display: clamp(2.8rem, 1.7rem + 4.8vw, 5.4rem);
+
+  /* reading rhythm — looser body leading, wider measure */
+  --leading-body: 1.72;
+  --measure: 76ch;
+}
+
+/* Serif body wants slightly tighter tracking on the big display so the
+   condensed heading still reads as a unit against the larger serif body. */
+.nene-public[data-theme="reading"] .hero__title,
+.nene-public[data-theme="reading-dark"] .hero__title {
+  letter-spacing: -0.02em;
+}
+
+/* Long-form prose is the headline use case: give it generous measure + leading
+   and treat blockquotes as an italic serif aside rather than a display pull. */
+.nene-public[data-theme="reading"] .prose,
+.nene-public[data-theme="reading-dark"] .prose,
+.nene-public[data-theme="reading"] .markdown-body,
+.nene-public[data-theme="reading-dark"] .markdown-body {
+  font-size: 1.1875rem;
+  line-height: var(--leading-body);
+}
+.nene-public[data-theme="reading"] .prose blockquote,
+.nene-public[data-theme="reading-dark"] .prose blockquote,
+.nene-public[data-theme="reading"] .markdown-body blockquote,
+.nene-public[data-theme="reading-dark"] .markdown-body blockquote {
+  font-family: var(--font-sans);
+  font-style: italic;
+  font-weight: var(--weight-normal);
+  font-size: 1.3125rem;
+  color: var(--color-text-muted);
+}

--- a/docs/theming/themes/reading/manifest.json
+++ b/docs/theming/themes/reading/manifest.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "../../public-theme.schema.json",
+  "id": "reading",
+  "name": "Reading",
+  "version": "1.0.0",
+  "author": "NeNe Records",
+  "description": "Reading-first theme — warm cream paper, a quiet low-chroma brown ink accent used only for links/emphasis, serif body (Source Serif 4), larger type, a wide measure and loose leading. Authored from brief-reading.theme.md; differs from consumer/aurora/ink by reading experience rather than hue.",
+  "supportsModes": ["light", "dark"],
+  "fonts": [
+    {
+      "family": "Saira Semi Condensed",
+      "role": "display",
+      "source": "fontsource",
+      "weights": [400, 500, 600]
+    },
+    {
+      "family": "Source Serif 4",
+      "role": "body",
+      "source": "fontsource",
+      "weights": [400, 600]
+    },
+    {
+      "family": "JetBrains Mono",
+      "role": "mono",
+      "source": "fontsource",
+      "weights": [400]
+    }
+  ],
+  "tokens": {
+    "light": {
+      "color-surface": "oklch(97% 0.02 85)",
+      "color-surface-raised": "oklch(99% 0.014 85)",
+      "color-surface-overlay": "oklch(93.5% 0.03 82)",
+      "color-surface-sunken": "oklch(95% 0.026 80)",
+      "color-text-primary": "oklch(23% 0.028 62)",
+      "color-text-muted": "oklch(47% 0.032 60)",
+      "color-text-inverse": "oklch(99% 0.008 85)",
+      "color-border": "oklch(87% 0.024 82)",
+      "color-border-strong": "oklch(79% 0.028 78)",
+      "color-focus-ring": "oklch(58% 0.09 60)",
+      "color-accent": "oklch(46% 0.07 58)",
+      "color-accent-hover": "oklch(40% 0.07 58)",
+      "color-accent-weak": "color-mix(in oklch, var(--color-accent) 12%, var(--color-surface-raised))",
+      "color-on-accent": "oklch(99% 0.008 85)",
+      "color-brand-violet": "oklch(56% 0.24 300)",
+      "color-danger": "oklch(52% 0.2 25)",
+      "color-danger-hover": "oklch(46% 0.2 25)",
+      "color-ok": "oklch(55% 0.13 150)",
+      "color-warn": "oklch(70% 0.15 75)",
+      "color-info": "oklch(55% 0.13 250)",
+      "shadow-sm": "0 1px 2px oklch(40% 0.04 70 / 0.08)",
+      "shadow-md": "0 6px 22px oklch(40% 0.04 70 / 0.1)",
+      "shadow-lg": "0 22px 50px oklch(38% 0.05 65 / 0.16)",
+      "shadow-focus": "0 0 0 3px color-mix(in oklch, var(--color-focus-ring) 30%, transparent)",
+      "color-scheme": "light"
+    },
+    "dark": {
+      "color-surface": "oklch(18% 0.012 70)",
+      "color-surface-raised": "oklch(22% 0.014 70)",
+      "color-surface-overlay": "oklch(27% 0.016 68)",
+      "color-surface-sunken": "oklch(15% 0.011 70)",
+      "color-text-primary": "oklch(93% 0.016 85)",
+      "color-text-muted": "oklch(67% 0.024 75)",
+      "color-text-inverse": "oklch(20% 0.02 65)",
+      "color-border": "oklch(32% 0.016 70)",
+      "color-border-strong": "oklch(42% 0.02 70)",
+      "color-focus-ring": "oklch(70% 0.08 65)",
+      "color-accent": "oklch(72% 0.075 68)",
+      "color-accent-hover": "oklch(79% 0.075 68)",
+      "color-accent-weak": "color-mix(in oklch, var(--color-accent) 16%, var(--color-surface-raised))",
+      "color-on-accent": "oklch(20% 0.03 65)",
+      "color-brand-violet": "oklch(72% 0.18 300)",
+      "color-danger": "oklch(66% 0.18 25)",
+      "color-danger-hover": "oklch(72% 0.18 25)",
+      "color-ok": "oklch(72% 0.14 150)",
+      "color-warn": "oklch(80% 0.14 80)",
+      "color-info": "oklch(74% 0.12 250)",
+      "shadow-sm": "0 1px 2px oklch(0% 0 0 / 0.4)",
+      "shadow-md": "0 8px 26px oklch(0% 0 0 / 0.5)",
+      "shadow-lg": "0 24px 56px oklch(0% 0 0 / 0.62)",
+      "shadow-focus": "0 0 0 3px color-mix(in oklch, var(--color-focus-ring) 32%, transparent)",
+      "color-scheme": "dark"
+    }
+  },
+  "knobs": {
+    "accent": { "light": "oklch(46% 0.07 58)", "dark": "oklch(72% 0.075 68)" },
+    "surface": {
+      "light": "oklch(97% 0.02 85)",
+      "dark": "oklch(18% 0.012 70)"
+    },
+    "fontDisplay": "Saira Semi Condensed",
+    "fontBody": "Source Serif 4",
+    "fontMono": "JetBrains Mono",
+    "baseFontSize": "1.125rem",
+    "typeScale": 1.2,
+    "density": "comfortable",
+    "radius": "soft"
+  }
+}

--- a/docs/theming/themes/reading/preview.html
+++ b/docs/theming/themes/reading/preview.html
@@ -1,0 +1,223 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Reading theme — preview</title>
+
+<!-- Preview-only font loading. In the real app these are self-hosted via
+     @fontsource (public-fonts.ts); the bundle CSS carries no external url(). -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Saira+Semi+Condensed:wght@400;500;600&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;1,8..60,400&family=JetBrains+Mono&display=swap" rel="stylesheet" />
+
+<!-- The consuming component stylesheet (unchanged). Colors come from the theme. -->
+<link rel="stylesheet" href="../uploads/nene-theme-handoff/reference/public-site.css" />
+<!-- The Reading theme bundle -->
+<link rel="stylesheet" href="tokens.css" />
+<link rel="stylesheet" href="components.css" />
+
+<style>
+  /* Preview chrome only — not part of the theme bundle. */
+  html, body { margin: 0; background: var(--color-surface); }
+  .nene-public { --font-chrome: 'Saira Semi Condensed', system-ui, sans-serif; }
+</style>
+</head>
+<body>
+<div class="nene-public" id="site" data-theme="reading" data-theme-mode="light">
+
+  <!-- ── Header ─────────────────────────────────────────────────────────── -->
+  <header class="hd">
+    <div class="wrap hd__in">
+      <a class="brand" href="#">
+        <span class="brand__mark">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M5 19V5l14 14V5" />
+          </svg>
+        </span>
+        <span class="brand__text">
+          <span class="brand__name">NeNe Records</span>
+          <span class="brand__tag">読み物アーカイブ</span>
+        </span>
+      </a>
+      <nav class="hd__nav">
+        <a class="navlink" aria-current="page" href="#">ホーム</a>
+        <a class="navlink" href="#">エッセイ</a>
+        <a class="navlink" href="#">レビュー</a>
+        <a class="navlink" href="#">アーカイブ</a>
+        <div class="themesw" role="group" aria-label="テーマ">
+          <button class="themesw__btn" data-set="light" aria-pressed="true" title="Light">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M2 12h2M20 12h2M5 5l1.5 1.5M17.5 17.5L19 19M19 5l-1.5 1.5M6.5 17.5L5 19"/></svg>
+          </button>
+          <button class="themesw__btn" data-set="dark" aria-pressed="false" title="Dark">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z"/></svg>
+          </button>
+        </div>
+        <a class="btn btn--primary" href="#">購読する</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="wrap">
+
+    <!-- ── Hero (typography-led) ────────────────────────────────────────── -->
+    <section class="hero">
+      <div class="hero__grid">
+        <div>
+          <p class="eyebrow hero__kicker">Essay · 読書のための設計</p>
+          <h1 class="hero__title">静かな紙の上で、<em>長い文章</em>を気持ちよく読む。</h1>
+          <p class="hero__lead">Reading テーマは色で主張しません。暖かいクリームの紙、大きめの serif 本文、広い計測幅とゆったりした行間で、読むことそのものに集中できる設計です。</p>
+          <div class="hero__cta">
+            <a class="btn btn--primary" href="#">最新号を読む</a>
+            <a class="btn btn--ghost" href="#">テーマについて</a>
+          </div>
+          <div class="hero__meta">
+            <div class="hero__stat"><b>76ch</b><span>本文計測幅</span></div>
+            <div class="hero__stat"><b>1.72</b><span>行間（leading）</span></div>
+            <div class="hero__stat"><b>Serif</b><span>Source Serif 4</span></div>
+          </div>
+        </div>
+        <div class="hero__art">
+          <div class="hero__art-frame">
+            <div class="eyecatch" data-label="hero illustration" style="width:100%"></div>
+            <span class="hero__art-tag"><b>◆</b> typography-first</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Long-form article (the showcase) ─────────────────────────────── -->
+    <div class="layout is-2col">
+      <article class="article layout__main">
+        <div class="article__metarow">
+          <span class="tbadge">essay</span>
+          <span class="meta">2026年6月16日</span>
+          <span class="dot"></span>
+          <span class="meta">読了 8分</span>
+        </div>
+        <h2 class="article__title">余白と行間が、読み手の呼吸を決める</h2>
+        <div class="article__byline">
+          <span class="article__avatar">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 20c1.5-4 5-6 8-6s6.5 2 8 6"/></svg>
+          </span>
+          <span>編集部</span>
+          <span class="dot"></span>
+          <span>Typography Notes</span>
+        </div>
+
+        <div class="article__hero eyecatch" data-label="article cover"></div>
+
+        <div class="prose">
+          <p>本文を serif にするだけでは、読み物にはなりません。一行の長さ、行と行のあいだ、段落の間隔——そうした目に見えにくい余白の設計こそが、読み手の呼吸を決めます。Reading テーマは、その三つを同時に整えることを起点にしています。</p>
+          <p>一行は約 76 文字分まで広げ、行間は 1.72 までゆるめました。やや大きめの本文（1.125rem）と組み合わせると、視線が次の行頭へ戻るときの迷いが減り、長い文章でも疲れにくくなります。色は意図的に抑え、リンクと強調にだけ静かなブラウンのインクを差します。</p>
+          <blockquote>読みやすさは装飾ではなく、構造である。文字の大きさより、文字と文字のあいだに宿る。</blockquote>
+          <h2>見出しは引き締めて、雑誌の手触りを残す</h2>
+          <p>本文が serif でゆったりしているぶん、見出しには Saira Semi Condensed を使って密度とリズムを与えます。柔らかい本文と引き締まった見出しの対比が、ページ全体に編集された印象をつくります。</p>
+          <ul>
+            <li>本文 — Source Serif 4（セルフホスト同梱）</li>
+            <li>見出し — Saira Semi Condensed</li>
+            <li>コード／メタ — JetBrains Mono</li>
+          </ul>
+          <h3>ダークでも紙の温度を保つ</h3>
+          <p>暗いモードでは、冷たい黒ではなくセピア寄りの近黒を地にしています。アクセントは同じブラウンの色相のまま明度だけを持ち上げ、リンクは <a href="#">この通り</a> 読みやすさを保ちます。<code>--measure</code> や <code>--leading-body</code> はモードに依らず一定です。</p>
+        </div>
+
+        <div class="article__tags">
+          <span class="eyebrow">Tags</span>
+          <a class="tag" href="#">typography</a>
+          <a class="tag" href="#">reading</a>
+          <a class="tag" href="#">serif</a>
+        </div>
+      </article>
+
+      <!-- ── Sidebar ───────────────────────────────────────────────────── -->
+      <aside class="aside">
+        <div class="search">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
+          <input type="search" placeholder="記事を検索…" />
+        </div>
+        <div class="widget">
+          <h3 class="widget__title">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20V10M18 20V4M6 20v-4"/></svg>
+            よく読まれている
+          </h3>
+          <ul class="poplist">
+            <li><span class="poplist__rank">1</span><div><a class="poplist__t" href="#">行間設計の基礎</a><div class="poplist__m">エッセイ · 6分</div></div></li>
+            <li><span class="poplist__rank">2</span><div><a class="poplist__t" href="#">本文 serif の選び方</a><div class="poplist__m">レビュー · 9分</div></div></li>
+            <li><span class="poplist__rank">3</span><div><a class="poplist__t" href="#">計測幅と読書速度</a><div class="poplist__m">ノート · 4分</div></div></li>
+          </ul>
+        </div>
+        <div class="widget">
+          <h3 class="widget__title">タグ</h3>
+          <div class="tags">
+            <a class="tag" href="#">essay <b>24</b></a>
+            <a class="tag" href="#">review <b>18</b></a>
+            <a class="tag" href="#">type <b>11</b></a>
+            <a class="tag" href="#">archive <b>7</b></a>
+          </div>
+        </div>
+      </aside>
+    </div>
+
+    <!-- ── Related card grid ────────────────────────────────────────────── -->
+    <section class="section">
+      <div class="section__head">
+        <div>
+          <p class="eyebrow">More to read</p>
+          <h2 class="section__title">関連する読み物</h2>
+        </div>
+        <a class="section__link" href="#">すべて見る
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        </a>
+      </div>
+      <div class="cardgrid">
+        <a class="card" href="#">
+          <div class="card__media eyecatch" data-label="cover"></div>
+          <div class="card__metarow"><span class="tbadge">review</span><span class="meta">5分</span></div>
+          <h3 class="card__title">紙の白さは、ほんの少し暖かいほうがいい</h3>
+          <p class="card__excerpt">純白よりわずかにクリームへ寄せると、長時間の読書で目に優しくなります。</p>
+        </a>
+        <a class="card" href="#">
+          <div class="card__media eyecatch" data-label="cover"></div>
+          <div class="card__metarow"><span class="tbadge">essay</span><span class="meta">7分</span></div>
+          <h3 class="card__title">アクセント色を「面」で使わない理由</h3>
+          <p class="card__excerpt">読み物では色は脇役。リンクと強調にだけ静かに効かせます。</p>
+        </a>
+        <a class="card" href="#">
+          <div class="card__media eyecatch" data-label="cover"></div>
+          <div class="card__metarow"><span class="tbadge">note</span><span class="meta">3分</span></div>
+          <h3 class="card__title">ダークモードの黒を、冷やしすぎない</h3>
+          <p class="card__excerpt">セピア寄りの近黒は、紙の温度を夜にも持ち越します。</p>
+        </a>
+      </div>
+    </section>
+  </main>
+
+  <!-- ── Footer ───────────────────────────────────────────────────────── -->
+  <footer class="ft">
+    <div class="wrap">
+      <div class="ft__bar">
+        <small>© 2026 NeNe Records — <span class="mono">theme: reading</span></small>
+        <small class="mono">light / dark · serif body · 76ch</small>
+      </div>
+    </div>
+  </footer>
+</div>
+
+<script>
+  // Preview-only theme toggle. The real site flips data-theme via its own
+  // controller; here we swap between the light and dark token sets.
+  const site = document.getElementById('site');
+  document.querySelectorAll('.themesw__btn').forEach((b) => {
+    b.addEventListener('click', () => {
+      const mode = b.dataset.set;
+      site.dataset.theme = mode === 'dark' ? 'reading-dark' : 'reading';
+      site.dataset.themeMode = mode;
+      document.querySelectorAll('.themesw__btn').forEach((x) =>
+        x.setAttribute('aria-pressed', String(x === b))
+      );
+    });
+  });
+</script>
+</body>
+</html>

--- a/docs/theming/themes/reading/tokens.css
+++ b/docs/theming/themes/reading/tokens.css
@@ -1,0 +1,108 @@
+/* ============================================================================
+   NeNe Records — Public site theme: Reading (light + dark)
+   ----------------------------------------------------------------------------
+   A reading-first theme. Where consumer/aurora/ink differ by hue & shape,
+   Reading differs by *reading experience*: warm cream paper, a quiet low-chroma
+   ink accent used only for links/emphasis (never as a fill field), serif body,
+   larger type, a wider measure and looser leading (see components.css).
+   Authored from uploads/brief-reading.theme.md per the token contract;
+   scoped under [data-theme='reading'] / [data-theme='reading-dark'].
+   ========================================================================== */
+
+/* ── LIGHT — warm cream paper ────────────────────────────────────────────── */
+[data-theme="reading"] {
+  /* surface */
+  --color-surface: oklch(97% 0.02 85);
+  --color-surface-raised: oklch(99% 0.014 85);
+  --color-surface-overlay: oklch(93.5% 0.03 82);
+  --color-surface-sunken: oklch(95% 0.026 80);
+
+  /* text — warm near-black, well above AA */
+  --color-text-primary: oklch(23% 0.028 62);
+  --color-text-muted: oklch(47% 0.032 60);
+  --color-text-inverse: oklch(99% 0.008 85);
+
+  /* line */
+  --color-border: oklch(87% 0.024 82);
+  --color-border-strong: oklch(79% 0.028 78);
+  --color-focus-ring: oklch(58% 0.09 60);
+
+  /* accent — quiet brown ink (links/emphasis only) */
+  --color-accent: oklch(46% 0.07 58);
+  --color-accent-hover: oklch(40% 0.07 58);
+  --color-accent-weak: color-mix(
+    in oklch,
+    var(--color-accent) 12%,
+    var(--color-surface-raised)
+  );
+  --color-on-accent: oklch(99% 0.008 85);
+
+  /* brand mark — NENE2 violet (logo only, distinct from the UI accent) */
+  --color-brand-violet: oklch(56% 0.24 300);
+
+  /* status */
+  --color-danger: oklch(52% 0.2 25);
+  --color-danger-hover: oklch(46% 0.2 25);
+  --color-ok: oklch(55% 0.13 150);
+  --color-warn: oklch(70% 0.15 75);
+  --color-info: oklch(55% 0.13 250);
+
+  /* shadow — warm-tinted, soft in light */
+  --shadow-sm: 0 1px 2px oklch(40% 0.04 70 / 0.08);
+  --shadow-md: 0 6px 22px oklch(40% 0.04 70 / 0.1);
+  --shadow-lg: 0 22px 50px oklch(38% 0.05 65 / 0.16);
+  --shadow-focus: 0 0 0 3px
+    color-mix(in oklch, var(--color-focus-ring) 30%, transparent);
+
+  color-scheme: light;
+}
+
+/* ── DARK — warm sepia near-black paper ──────────────────────────────────────
+   Hue kept in the warm 65–85 family so the cream/sepia warmth survives. Accent
+   is the same quiet brown with lightness lifted (L46 → L72) for AA on dark;
+   text-on-accent flips to warm-dark. */
+[data-theme="reading-dark"] {
+  /* surface */
+  --color-surface: oklch(18% 0.012 70);
+  --color-surface-raised: oklch(22% 0.014 70);
+  --color-surface-overlay: oklch(27% 0.016 68);
+  --color-surface-sunken: oklch(15% 0.011 70);
+
+  /* text — cream, well above AA */
+  --color-text-primary: oklch(93% 0.016 85);
+  --color-text-muted: oklch(67% 0.024 75);
+  --color-text-inverse: oklch(20% 0.02 65);
+
+  /* line */
+  --color-border: oklch(32% 0.016 70);
+  --color-border-strong: oklch(42% 0.02 70);
+  --color-focus-ring: oklch(70% 0.08 65);
+
+  /* accent — lifted quiet brown, dark text rides on top */
+  --color-accent: oklch(72% 0.075 68);
+  --color-accent-hover: oklch(79% 0.075 68);
+  --color-accent-weak: color-mix(
+    in oklch,
+    var(--color-accent) 16%,
+    var(--color-surface-raised)
+  );
+  --color-on-accent: oklch(20% 0.03 65);
+
+  --color-brand-violet: oklch(72% 0.18 300);
+
+  /* status — lifted for dark legibility */
+  --color-danger: oklch(66% 0.18 25);
+  --color-danger-hover: oklch(72% 0.18 25);
+  --color-ok: oklch(72% 0.14 150);
+  --color-warn: oklch(80% 0.14 80);
+  --color-info: oklch(74% 0.12 250);
+
+  /* shadow — deep, near-black */
+  --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.4);
+  --shadow-md: 0 8px 26px oklch(0% 0 0 / 0.5);
+  --shadow-lg: 0 24px 56px oklch(0% 0 0 / 0.62);
+  --shadow-focus: 0 0 0 3px
+    color-mix(in oklch, var(--color-focus-ring) 32%, transparent);
+
+  color-scheme: dark;
+}

--- a/frontend/src/pages/consumer/consumer-theme.css
+++ b/frontend/src/pages/consumer/consumer-theme.css
@@ -1,2 +1,4 @@
 @import '../../shared/ui/theme/themes/consumer-brand.css';
 @import '../../shared/ui/theme/themes/aurora.css';
+@import '../../shared/ui/theme/themes/reading.css';
+@import '../../shared/ui/theme/themes/reading.components.css';

--- a/frontend/src/shared/lib/public-themes.ts
+++ b/frontend/src/shared/lib/public-themes.ts
@@ -38,6 +38,15 @@ export const PUBLIC_THEMES: readonly PublicThemeMeta[] = [
       accent: 'oklch(62% 0.13 200)',
     },
   },
+  {
+    id: 'reading',
+    name: 'Reading',
+    preview: {
+      surface: 'oklch(97% 0.02 85)',
+      raised: 'oklch(99% 0.014 85)',
+      accent: 'oklch(46% 0.07 58)',
+    },
+  },
 ]
 
 export const DEFAULT_PUBLIC_THEME_ID = 'consumer'

--- a/frontend/src/shared/lib/theme-bundle/validate-manifest.test.ts
+++ b/frontend/src/shared/lib/theme-bundle/validate-manifest.test.ts
@@ -14,6 +14,7 @@ function readJson(fromFrontend: string): Record<string, unknown> {
 const schema = readJson('../docs/theming/public-theme.schema.json')
 const exampleManifest = readJson('../docs/theming/examples/consumer.manifest.json')
 const auroraManifest = readJson('../docs/theming/themes/aurora/manifest.json')
+const readingManifest = readJson('../docs/theming/themes/reading/manifest.json')
 
 describe('validateManifest', () => {
   it('accepts the built-in consumer example manifest', () => {
@@ -22,6 +23,10 @@ describe('validateManifest', () => {
 
   it('accepts the Aurora theme manifest', () => {
     expect(validateManifest(auroraManifest, schema)).toEqual([])
+  })
+
+  it('accepts the Reading theme manifest', () => {
+    expect(validateManifest(readingManifest, schema)).toEqual([])
   })
 
   it('rejects a manifest missing a required token (no color-accent in dark)', () => {

--- a/frontend/src/shared/lib/theme-bundle/validate-theme-css.test.ts
+++ b/frontend/src/shared/lib/theme-bundle/validate-theme-css.test.ts
@@ -12,6 +12,14 @@ const auroraCss = readFileSync(
   resolve(process.cwd(), 'src/shared/ui/theme/themes/aurora.css'),
   'utf8',
 )
+const readingCss = readFileSync(
+  resolve(process.cwd(), 'src/shared/ui/theme/themes/reading.css'),
+  'utf8',
+)
+const readingComponentsCss = readFileSync(
+  resolve(process.cwd(), 'src/shared/ui/theme/themes/reading.components.css'),
+  'utf8',
+)
 
 describe('validateThemeCss', () => {
   it('accepts the built-in consumer-brand.css (scoped, no external refs)', () => {
@@ -20,6 +28,11 @@ describe('validateThemeCss', () => {
 
   it('accepts the built-in aurora.css (scoped, no external refs)', () => {
     expect(validateThemeCss(auroraCss, { themeId: 'aurora' })).toEqual([])
+  })
+
+  it('accepts the built-in reading theme css (tokens + components, scoped)', () => {
+    expect(validateThemeCss(readingCss, { themeId: 'reading' })).toEqual([])
+    expect(validateThemeCss(readingComponentsCss, { themeId: 'reading' })).toEqual([])
   })
 
   it('accepts theme-scoped and .nene-public selectors', () => {

--- a/frontend/src/shared/ui/theme/themes/reading.components.css
+++ b/frontend/src/shared/ui/theme/themes/reading.components.css
@@ -1,0 +1,62 @@
+/* ============================================================================
+   NeNe Records — Public site theme: Reading — type overlay
+   ----------------------------------------------------------------------------
+   Reading's differentiator is the *reading experience*, not hue. These rules
+   re-express the typography knobs (baseFontSize 1.125rem, typeScale 1.2,
+   serif body, wide measure, loose leading) as token overrides, scoped to the
+   theme so they only apply when [data-theme='reading'|'reading-dark'] is set.
+
+   No new DOM structure — only overrides of contract tokens consumed by the
+   existing public-site.css. Selector carries `.nene-public` so it outranks the
+   base `.nene-public` type scale and stays inside the validator's scope rule.
+   `--font-sans` points at the self-hosted Source Serif 4 (@fontsource).
+   ========================================================================== */
+
+.nene-public[data-theme='reading'],
+.nene-public[data-theme='reading-dark'] {
+  /* fonts — serif body, condensed display, mono code */
+  --font-sans: 'Source Serif 4', 'Noto Serif JP', Georgia, 'Times New Roman', serif;
+  --font-display: 'Saira Semi Condensed', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, 'SFMono-Regular', monospace;
+
+  /* type scale — recomputed from baseFontSize 1.125rem × typeScale 1.2 */
+  --text-overline: 0.78rem;
+  --text-meta: 0.84rem;
+  --text-body-sm: 0.98rem;
+  --text-body: 1.125rem;
+  --text-h3: 1.4rem;
+  --text-h2: clamp(1.6rem, 1.15rem + 1.7vw, 2.35rem);
+  --text-h1: clamp(1.8rem, 1.3rem + 1.9vw, 2.7rem);
+  --text-display: clamp(2.8rem, 1.7rem + 4.8vw, 5.4rem);
+
+  /* reading rhythm — looser body leading, wider measure */
+  --leading-body: 1.72;
+  --measure: 76ch;
+}
+
+/* Serif body wants slightly tighter tracking on the big display so the
+   condensed heading still reads as a unit against the larger serif body. */
+.nene-public[data-theme='reading'] .hero__title,
+.nene-public[data-theme='reading-dark'] .hero__title {
+  letter-spacing: -0.02em;
+}
+
+/* Long-form prose is the headline use case: give it generous measure + leading
+   and treat blockquotes as an italic serif aside rather than a display pull. */
+.nene-public[data-theme='reading'] .prose,
+.nene-public[data-theme='reading-dark'] .prose,
+.nene-public[data-theme='reading'] .markdown-body,
+.nene-public[data-theme='reading-dark'] .markdown-body {
+  font-size: 1.1875rem;
+  line-height: var(--leading-body);
+}
+.nene-public[data-theme='reading'] .prose blockquote,
+.nene-public[data-theme='reading-dark'] .prose blockquote,
+.nene-public[data-theme='reading'] .markdown-body blockquote,
+.nene-public[data-theme='reading-dark'] .markdown-body blockquote {
+  font-family: var(--font-sans);
+  font-style: italic;
+  font-weight: var(--weight-normal);
+  font-size: 1.3125rem;
+  color: var(--color-text-muted);
+}

--- a/frontend/src/shared/ui/theme/themes/reading.css
+++ b/frontend/src/shared/ui/theme/themes/reading.css
@@ -1,0 +1,98 @@
+/* ============================================================================
+   NeNe Records — Public site theme: Reading (light + dark)
+   ----------------------------------------------------------------------------
+   A reading-first theme. Where consumer/aurora/ink differ by hue & shape,
+   Reading differs by *reading experience*: warm cream paper, a quiet low-chroma
+   ink accent used only for links/emphasis (never as a fill field), serif body,
+   larger type, a wider measure and looser leading (see components.css).
+   Authored from uploads/brief-reading.theme.md per the token contract;
+   scoped under [data-theme='reading'] / [data-theme='reading-dark'].
+   ========================================================================== */
+
+/* ── LIGHT — warm cream paper ────────────────────────────────────────────── */
+[data-theme='reading'] {
+  /* surface */
+  --color-surface: oklch(97% 0.02 85);
+  --color-surface-raised: oklch(99% 0.014 85);
+  --color-surface-overlay: oklch(93.5% 0.03 82);
+  --color-surface-sunken: oklch(95% 0.026 80);
+
+  /* text — warm near-black, well above AA */
+  --color-text-primary: oklch(23% 0.028 62);
+  --color-text-muted: oklch(47% 0.032 60);
+  --color-text-inverse: oklch(99% 0.008 85);
+
+  /* line */
+  --color-border: oklch(87% 0.024 82);
+  --color-border-strong: oklch(79% 0.028 78);
+  --color-focus-ring: oklch(58% 0.09 60);
+
+  /* accent — quiet brown ink (links/emphasis only) */
+  --color-accent: oklch(46% 0.07 58);
+  --color-accent-hover: oklch(40% 0.07 58);
+  --color-accent-weak: color-mix(in oklch, var(--color-accent) 12%, var(--color-surface-raised));
+  --color-on-accent: oklch(99% 0.008 85);
+
+  /* brand mark — NENE2 violet (logo only, distinct from the UI accent) */
+  --color-brand-violet: oklch(56% 0.24 300);
+
+  /* status */
+  --color-danger: oklch(52% 0.2 25);
+  --color-danger-hover: oklch(46% 0.2 25);
+  --color-ok: oklch(55% 0.13 150);
+  --color-warn: oklch(70% 0.15 75);
+  --color-info: oklch(55% 0.13 250);
+
+  /* shadow — warm-tinted, soft in light */
+  --shadow-sm: 0 1px 2px oklch(40% 0.04 70 / 0.08);
+  --shadow-md: 0 6px 22px oklch(40% 0.04 70 / 0.1);
+  --shadow-lg: 0 22px 50px oklch(38% 0.05 65 / 0.16);
+  --shadow-focus: 0 0 0 3px color-mix(in oklch, var(--color-focus-ring) 30%, transparent);
+
+  color-scheme: light;
+}
+
+/* ── DARK — warm sepia near-black paper ──────────────────────────────────────
+   Hue kept in the warm 65–85 family so the cream/sepia warmth survives. Accent
+   is the same quiet brown with lightness lifted (L46 → L72) for AA on dark;
+   text-on-accent flips to warm-dark. */
+[data-theme='reading-dark'] {
+  /* surface */
+  --color-surface: oklch(18% 0.012 70);
+  --color-surface-raised: oklch(22% 0.014 70);
+  --color-surface-overlay: oklch(27% 0.016 68);
+  --color-surface-sunken: oklch(15% 0.011 70);
+
+  /* text — cream, well above AA */
+  --color-text-primary: oklch(93% 0.016 85);
+  --color-text-muted: oklch(67% 0.024 75);
+  --color-text-inverse: oklch(20% 0.02 65);
+
+  /* line */
+  --color-border: oklch(32% 0.016 70);
+  --color-border-strong: oklch(42% 0.02 70);
+  --color-focus-ring: oklch(70% 0.08 65);
+
+  /* accent — lifted quiet brown, dark text rides on top */
+  --color-accent: oklch(72% 0.075 68);
+  --color-accent-hover: oklch(79% 0.075 68);
+  --color-accent-weak: color-mix(in oklch, var(--color-accent) 16%, var(--color-surface-raised));
+  --color-on-accent: oklch(20% 0.03 65);
+
+  --color-brand-violet: oklch(72% 0.18 300);
+
+  /* status — lifted for dark legibility */
+  --color-danger: oklch(66% 0.18 25);
+  --color-danger-hover: oklch(72% 0.18 25);
+  --color-ok: oklch(72% 0.14 150);
+  --color-warn: oklch(80% 0.14 80);
+  --color-info: oklch(74% 0.12 250);
+
+  /* shadow — deep, near-black */
+  --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.4);
+  --shadow-md: 0 8px 26px oklch(0% 0 0 / 0.5);
+  --shadow-lg: 0 24px 56px oklch(0% 0 0 / 0.62);
+  --shadow-focus: 0 0 0 3px color-mix(in oklch, var(--color-focus-ring) 32%, transparent);
+
+  color-scheme: dark;
+}


### PR DESCRIPTION
## 目的
MDオーサリング契約（`brief-reading.theme.md`）から **ClaudeDesign が生成した 3テーマ目「Reading」** を検査・登録する。これで **brief → bundle → validate → 登録** のパイプラインが実データで一周した。エピック #367 / #373。

## 変更
- **`docs/theming/themes/reading/`**: 納品 bundle（`manifest.json` / `tokens.css` / `components.css` / `preview.html`）。`npm run validate:themes` 全項目 pass。
- **`frontend/.../themes/reading.css` + `reading.components.css`**: app 用コピー。`consumer-theme.css` から `@import`。serif 本文は #378 で同梱済みの **Source Serif 4**。
- **`public-themes.ts`**: `PUBLIC_THEMES` に `reading` を登録 → 外観>テーマが **Terracotta / Aurora / Reading の3択**に。
- バリデータのテストに reading の manifest/CSS を追加。

## Reading の特徴（読書体験で差別化）
暖かいクリーム紙、低彩度の茶インク（リンク/強調のみ）、**serif 本文（Source Serif 4）**、`baseFontSize 1.125rem × scale 1.2`、`--measure 76ch`、`--leading-body 1.72`。components.css はこれらをテーマスコープのトークン上書きで表現（新規 DOM なし）。

## 検証
- `npm run check`: green（188 tests / validate:themes が 3テーマ pass / knip / storybook）。

## ⚠ 既知の別件（このPRの範囲外）
実際に画面でテーマを切り替える `PUT /api/v1/settings/active_theme` は、**設定のマルチテナント・シード漏れ**（`setting_defs` が org 0 のみ・実 org は 1）で現状 404。Reading テーマ自体は `data-theme='reading'` で正しく描画される。切替の有効化はその org 不具合の修正後（別 issue 予定）。

Part of #367