### PR TITLE
feat(public): テーマ切替の即時反映＋FOUC解消 (#367)

### DIFF
--- a/frontend/src/pages/consumer/PublicShell.tsx
+++ b/frontend/src/pages/consumer/PublicShell.tsx
@@ -4,7 +4,11 @@ import './public-fonts'
 import { Outlet } from 'react-router-dom'
 import { usePublicNavigationItems } from '@/entities/navigation-item'
 import { publicSettingsToMap, usePublicSettings } from '@/entities/setting'
-import { resolvePublicThemeId } from '@/shared/lib/public-themes'
+import {
+  readStoredActiveTheme,
+  resolvePublicThemeId,
+  storeActiveTheme,
+} from '@/shared/lib/public-themes'
 import type { PublicSite } from './public-site-context'
 
 function useSiteDocumentMeta(siteName: string, metaDescription: string): void {
@@ -39,13 +43,27 @@ export function PublicShell() {
     [publicSettingsQuery.data?.items],
   )
 
+  // Apply the last-known theme synchronously on first paint, then reconcile with
+  // the fetched setting — avoids a default→saved theme flash (FOUC) while the
+  // public settings request is in flight. Derived (no state): use the stored
+  // theme until settings settle, then the resolved value (which we persist for
+  // the next first paint).
+  const settingsSettled = publicSettingsQuery.data !== undefined
+  const resolvedTheme = resolvePublicThemeId(settings.active_theme)
+  const activeTheme = settingsSettled ? resolvedTheme : readStoredActiveTheme()
+  useEffect(() => {
+    if (settingsSettled) {
+      storeActiveTheme(resolvedTheme)
+    }
+  }, [settingsSettled, resolvedTheme])
+
   const site: PublicSite = {
     siteName: settings.site_name ?? 'NeNe Records',
     tagline: settings.tagline ?? '',
     metaDescription: settings.default_meta_description ?? '',
     footerMarkdown: settings.footer_markdown ?? '',
     navItems,
-    activeTheme: resolvePublicThemeId(settings.active_theme),
+    activeTheme,
   }
 
   useSiteDocumentMeta(site.siteName, site.metaDescription)

--- a/frontend/src/shared/lib/public-themes.ts
+++ b/frontend/src/shared/lib/public-themes.ts
@@ -57,3 +57,22 @@ export function resolvePublicThemeId(value: string | null | undefined): string {
     ? (value as string)
     : DEFAULT_PUBLIC_THEME_ID
 }
+
+// The last theme the site resolved to, cached so the first paint can apply it
+// synchronously while the public settings request is still in flight — avoids a
+// default→saved theme flash (FOUC) for returning visitors.
+const ACTIVE_THEME_STORAGE_KEY = 'nene_public_active_theme'
+
+export function readStoredActiveTheme(): string {
+  if (typeof window === 'undefined') {
+    return DEFAULT_PUBLIC_THEME_ID
+  }
+  return resolvePublicThemeId(window.localStorage.getItem(ACTIVE_THEME_STORAGE_KEY))
+}
+
+export function storeActiveTheme(themeId: string): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+  window.localStorage.setItem(ACTIVE_THEME_STORAGE_KEY, resolvePublicThemeId(themeId))
+}

--- a/src/Setting/ListPublicSettingsHandler.php
+++ b/src/Setting/ListPublicSettingsHandler.php
@@ -12,7 +12,11 @@ use Psr\Http\Message\ServerRequestInterface;
 
 final readonly class ListPublicSettingsHandler
 {
-    private const CACHE_CONTROL = 'public, max-age=300, stale-while-revalidate=3600';
+    // Settings drive the public site's identity and active theme, so an admin
+    // change must reflect promptly. `max-age=0, must-revalidate` keeps the
+    // response cacheable but forces an ETag revalidation on every request — a
+    // cheap 304 when unchanged, immediate pickup when it changes.
+    private const CACHE_CONTROL = 'public, max-age=0, must-revalidate';
 
     public function __construct(
         private ListPublicSettingsUseCaseInterface $useCase,

--- a/tests/PublicRecord/PublicCacheHttpTest.php
+++ b/tests/PublicRecord/PublicCacheHttpTest.php
@@ -183,8 +183,11 @@ final class PublicCacheHttpTest extends TestCase
         );
 
         self::assertSame(200, $response->getStatusCode());
+        // Settings revalidate on every request (ETag/304) so admin changes —
+        // e.g. the active theme — reflect promptly instead of being cached 5 min.
         self::assertStringContainsString('public', $response->getHeaderLine('Cache-Control'));
-        self::assertStringContainsString('max-age=300', $response->getHeaderLine('Cache-Control'));
+        self::assertStringContainsString('max-age=0', $response->getHeaderLine('Cache-Control'));
+        self::assertStringContainsString('must-revalidate', $response->getHeaderLine('Cache-Control'));
         self::assertNotEmpty($response->getHeaderLine('ETag'));
     }
 


### PR DESCRIPTION
## 目的
公開サイトでテーマ切替が即時反映されない／初回に既定色がちらつく問題を改善する（エピック #367 仕上げ）。

## 変更
### 1. FOUC 解消（frontend）
- 直近の選択テーマを **localStorage** に保持（`readStoredActiveTheme` / `storeActiveTheme`）。
- `PublicShell` は公開設定の取得前（初回ペイント）に**保存済みテーマ**で `data-theme` を当て、取得完了後に解決値へ寄せて永続化。
- → 「既定 consumer（オレンジ）→ 保存テーマ」の一瞬のちらつきが消える。state を増やさず派生値で実装。

### 2. 即時反映（backend）
- 公開設定の `Cache-Control` を `max-age=300, stale-while-revalidate=3600` から **`public, max-age=0, must-revalidate`** へ。
- ETag による 304 再検証は維持 → **変更時は即時反映**・未変更時は軽量な 304（5分キャッシュで切替が遅延する問題を解消）。
- `PublicCacheHttpTest` を新ヘッダに更新。

## 検証
- frontend `npm run check`: green（188 tests）。
- backend `composer check`: green（691 tests / PHPStan lv8 / CS-Fixer）。
- 実機: `GET /api/v1/public/settings` が `max-age=0, must-revalidate` を返し、`If-None-Match` で **304** を確認。

## 補足
- 同じ 5 分キャッシュは navigation / widgets / menus / public record にも残存（本PRは設定のみ）。必要なら別途同様に調整可能。

Part of #367