### PR TITLE
docs(theming): 幅トークンをテーマ差別化レバーに (#367)

### DIFF
--- a/docs/theming/class-hooks.md
+++ b/docs/theming/class-hooks.md
@@ -72,4 +72,5 @@
 - **タイポの表情**: 見出しの `text-transform` / `letter-spacing`、`.eyebrow` `.meta` を `--font-mono` 等へ。
 - **リズム**: `--space-*` 上書きで密度を変える。`.section__head` に罫線。
 - **グリッド**: `.cardgrid` / `.types` の `grid-template-columns` を変えて版面の密度・列数を変える（DOM はそのまま）。
+- **幅でメリハリ（重要）**: `--content-w`（`.wrap` のページ全体幅）/ `--measure`（本文幅）/ `--gutter`（左右余白）/ `.layout.is-2col` のサイド列幅をテーマごとに変える。全テーマ同じ幅だと印象が似るので、狭め＋広い余白＝親密、広め＝情報密度、で空気感を変える。
 - 禁止: 外部 `url()` / `@import` / 任意 JS / 新規 DOM 前提のスタイル。

--- a/docs/theming/public-theme-contract.md
+++ b/docs/theming/public-theme-contract.md
@@ -97,11 +97,26 @@
 | --------------------------- | ----------------------------------------- | --------------------------- |
 | `--space-2xs … --space-2xl` | 0.25 / 0.5 / 0.75 / 1 / 1.5 / 2.5 / 4 rem | Derived（density ノブから） |
 | `--space-section`           | `clamp(3.5rem, 2rem + 6vw, 7rem)`         | Derived                     |
-| `--gutter`                  | `clamp(1.25rem, 0.5rem + 3vw, 2.5rem)`    | Fixed                       |
+| `--gutter`                  | `clamp(1.25rem, 0.5rem + 3vw, 2.5rem)`    | **Knob（左右余白）**        |
 | `--measure`                 | `72ch`                                    | Knob（本文計測幅）          |
-| `--content-w`               | `1180px`                                  | Fixed                       |
+| `--content-w`               | `1180px`                                  | **Knob（ページ全体幅）**    |
 
 `density`（compact / cozy / comfortable）ノブが `--space-*` 全体を一括スケール。
+
+### 幅でメリハリを出す（テーマ間の差別化レバー）
+
+`--content-w`（`.wrap` の `max-width`＝ページ全体幅）/ `--measure`（本文計測幅）/ `--gutter`（左右余白）/ `.layout.is-2col` のサイド列幅は、**テーマごとに変えてよい**。全テーマが同じ幅だと印象が似るため、版面の広い・狭い・余白の多寡で空気感を変える（例: 読み物系は狭め＋広い余白で親密に、構造系は広めで情報密度高く）。`components.css` でスコープ内上書きする:
+
+```css
+.nene-public[data-theme^="myid"] {
+  --content-w: 1040px;
+  --measure: 66ch;
+  --gutter: clamp(1.5rem, 1rem + 4vw, 3.5rem);
+}
+.nene-public[data-theme^="myid"] .layout.is-2col {
+  grid-template-columns: minmax(0, 1fr) 280px;
+}
+```
 
 ## 6. 角丸 / モーショントークン
 


### PR DESCRIPTION
## 目的
全テーマが同じ幅（`--content-w: 1180px`）だと印象が似る。**コンテナ幅でメリハリ**を付けられることを規約に明文化し、ClaudeDesign が幅を変えて差別化できるようにする。

## 変更（docs のみ）
- `public-theme-contract.md` §5: `--content-w` / `--gutter` を **Fixed → Knob** に再分類し、「幅でメリハリを出す」節を追加（`--content-w` / `--measure` / `--gutter` / `.layout` サイド列をテーマスコープで上書きする例つき）。
- `class-hooks.md`: L2 のコツに「幅でメリハリ」を追加。

`.wrap { max-width: var(--content-w) }` なので、テーマが scope 内で `--content-w` を上書きすればページ全体幅が変わる（実装変更不要・既に可能なものを契約として明文化）。

Part of #367