### PR TITLE
feat(public): カスタマイザに surface/text の per-mode 色 (#367 Phase 2)

### DIFF
--- a/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
+++ b/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
@@ -22,6 +22,31 @@ function Field({ label, children }: { label: string; children: ReactNode }) {
   )
 }
 
+function ColorInput({
+  value,
+  onChange,
+  ariaLabel,
+  disabled,
+}: {
+  value: string | undefined
+  onChange: (value: string) => void
+  ariaLabel: string
+  disabled: boolean
+}) {
+  return (
+    <input
+      type="color"
+      className="h-8 w-14 cursor-pointer rounded-sm border border-border bg-surface"
+      value={value ?? '#888888'}
+      disabled={disabled}
+      onChange={(event) => {
+        onChange(event.target.value)
+      }}
+      aria-label={ariaLabel}
+    />
+  )
+}
+
 function Select({
   value,
   options,
@@ -79,17 +104,61 @@ export function ThemeCustomizeView({
 
         <Stack gap="sm">
           <Field label={t('admin.themeCustomize.accent')}>
-            <input
-              type="color"
-              className="h-8 w-14 cursor-pointer rounded-sm border border-border bg-surface"
-              value={draft.accent ?? '#000000'}
+            <ColorInput
+              value={draft.accent}
               disabled={disabled}
-              onChange={(event) => {
-                setKnob('accent', event.target.value)
+              ariaLabel={t('admin.themeCustomize.accent')}
+              onChange={(v) => {
+                setKnob('accent', v)
               }}
-              aria-label={t('admin.themeCustomize.accent')}
             />
           </Field>
+          <div className="flex items-center justify-between gap-inline-md">
+            <span className="font-chrome text-caption font-semibold text-text-primary">
+              {t('admin.themeCustomize.surface')}
+            </span>
+            <span className="flex items-center gap-inline-sm">
+              <ColorInput
+                value={draft.surface?.light}
+                disabled={disabled}
+                ariaLabel={`${t('admin.themeCustomize.surface')} (light)`}
+                onChange={(v) => {
+                  setKnob('surface', { ...draft.surface, light: v })
+                }}
+              />
+              <ColorInput
+                value={draft.surface?.dark}
+                disabled={disabled}
+                ariaLabel={`${t('admin.themeCustomize.surface')} (dark)`}
+                onChange={(v) => {
+                  setKnob('surface', { ...draft.surface, dark: v })
+                }}
+              />
+            </span>
+          </div>
+          <div className="flex items-center justify-between gap-inline-md">
+            <span className="font-chrome text-caption font-semibold text-text-primary">
+              {t('admin.themeCustomize.text')}
+            </span>
+            <span className="flex items-center gap-inline-sm">
+              <ColorInput
+                value={draft.text?.light}
+                disabled={disabled}
+                ariaLabel={`${t('admin.themeCustomize.text')} (light)`}
+                onChange={(v) => {
+                  setKnob('text', { ...draft.text, light: v })
+                }}
+              />
+              <ColorInput
+                value={draft.text?.dark}
+                disabled={disabled}
+                ariaLabel={`${t('admin.themeCustomize.text')} (dark)`}
+                onChange={(v) => {
+                  setKnob('text', { ...draft.text, dark: v })
+                }}
+              />
+            </span>
+          </div>
           <Field label={t('admin.themeCustomize.font')}>
             <Select
               value={draft.fontBody}

--- a/frontend/src/pages/consumer/PublicShell.tsx
+++ b/frontend/src/pages/consumer/PublicShell.tsx
@@ -10,7 +10,7 @@ import {
   storeActiveTheme,
 } from '@/shared/lib/public-themes'
 import {
-  overrideStyleForTheme,
+  overrideCssForTheme,
   readStoredThemeOverridesRaw,
   storeThemeOverridesRaw,
 } from '@/shared/lib/theme-customization'
@@ -72,7 +72,7 @@ export function PublicShell() {
     footerMarkdown: settings.footer_markdown ?? '',
     navItems,
     activeTheme,
-    themeOverrideStyle: overrideStyleForTheme(overridesRaw, activeTheme),
+    themeOverrideCss: overrideCssForTheme(overridesRaw, activeTheme),
   }
 
   useSiteDocumentMeta(site.siteName, site.metaDescription)

--- a/frontend/src/pages/consumer/PublicSiteShell.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.tsx
@@ -139,12 +139,8 @@ export function PublicSiteShell({
   const footerTypeLinks = types.slice(0, 4)
 
   return (
-    <div
-      className="nene-public"
-      data-theme={resolvedTheme}
-      data-theme-mode={mode}
-      style={site.themeOverrideStyle}
-    >
+    <div className="nene-public" data-theme={resolvedTheme} data-theme-mode={mode}>
+      {site.themeOverrideCss !== '' ? <style>{site.themeOverrideCss}</style> : null}
       <header className="hd">
         <div className="wrap hd__in">
           <Brand siteName={site.siteName} tagline={site.tagline} />

--- a/frontend/src/pages/consumer/public-site-context.ts
+++ b/frontend/src/pages/consumer/public-site-context.ts
@@ -19,8 +19,8 @@ export interface PublicSite {
   navItems: PublicSiteNavItem[]
   /** Admin-selected public-site theme id (`active_theme` setting). */
   activeTheme: string
-  /** Customizer overrides for the active theme, as CSS custom properties. */
-  themeOverrideStyle: Record<string, string>
+  /** Customizer overrides for the active theme, as a scoped CSS stylesheet. */
+  themeOverrideCss: string
 }
 
 export function usePublicSite(): PublicSite {

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -62,6 +62,8 @@ export const en = {
   'admin.themeCustomize.intro': 'Tweak the “{theme}” theme. Empty = theme default.',
   'admin.themeCustomize.themeDefault': 'Theme default',
   'admin.themeCustomize.accent': 'Accent color',
+  'admin.themeCustomize.surface': 'Surface (light / dark)',
+  'admin.themeCustomize.text': 'Text (light / dark)',
   'admin.themeCustomize.font': 'Body font',
   'admin.themeCustomize.width': 'Content width',
   'admin.themeCustomize.gutter': 'Side margin',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -55,6 +55,8 @@ export const ja: Partial<MessageCatalog> = {
   'admin.themeCustomize.intro': '「{theme}」テーマを微調整します。未設定＝テーマ既定。',
   'admin.themeCustomize.themeDefault': 'テーマ既定',
   'admin.themeCustomize.accent': 'アクセント色',
+  'admin.themeCustomize.surface': '背景（light / dark）',
+  'admin.themeCustomize.text': '文字（light / dark）',
   'admin.themeCustomize.font': '本文フォント',
   'admin.themeCustomize.width': 'コンテンツ幅',
   'admin.themeCustomize.gutter': '左右余白',

--- a/frontend/src/shared/lib/theme-customization.test.ts
+++ b/frontend/src/shared/lib/theme-customization.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { overrideStyleForTheme, resolveOverrideStyle } from './theme-customization'
+import {
+  buildOverrideCss,
+  overrideCssForTheme,
+  resolveModeColors,
+  resolveOverrideStyle,
+} from './theme-customization'
 
 describe('resolveOverrideStyle', () => {
   it('emits known CSS variables for valid knob values', () => {
@@ -53,17 +58,45 @@ describe('resolveOverrideStyle', () => {
   })
 })
 
-describe('overrideStyleForTheme', () => {
-  const raw = JSON.stringify({ aurora: { contentWidth: 'wide' }, reading: { radius: 'round' } })
+describe('resolveModeColors', () => {
+  it('derives the surface family + muted text per mode (validated hex only)', () => {
+    const light = resolveModeColors(
+      { surface: { light: '#ffffff', dark: '#101010' }, text: { light: '#222222' } },
+      'light',
+    )
+    expect(light['--color-surface']).toBe('#ffffff')
+    expect(light['--color-surface-raised']).toContain('color-mix')
+    expect(light['--color-text-primary']).toBe('#222222')
+    expect(light['--color-text-muted']).toContain('transparent')
 
-  it('returns the resolved style for the requested theme only', () => {
-    expect(overrideStyleForTheme(raw, 'aurora')).toEqual({ '--content-w': '1320px' })
-    expect(overrideStyleForTheme(raw, 'reading')['--radius-md']).toBe('18px')
+    const dark = resolveModeColors({ surface: { light: '#fff', dark: '#101010' } }, 'dark')
+    expect(dark['--color-surface']).toBe('#101010')
+    // no text override for dark → not emitted
+    expect(dark['--color-text-primary']).toBeUndefined()
   })
 
-  it('returns empty for unknown theme or invalid JSON', () => {
-    expect(overrideStyleForTheme(raw, 'consumer')).toEqual({})
-    expect(overrideStyleForTheme('not json', 'aurora')).toEqual({})
-    expect(overrideStyleForTheme(undefined, 'aurora')).toEqual({})
+  it('ignores invalid hex', () => {
+    expect(resolveModeColors({ surface: { light: 'rgb(0,0,0)' } }, 'light')).toEqual({})
+  })
+})
+
+describe('buildOverrideCss / overrideCssForTheme', () => {
+  it('scopes mode-agnostic vars to both modes and colours per mode', () => {
+    const css = buildOverrideCss(
+      { contentWidth: 'wide', surface: { light: '#ffffff', dark: '#101010' } },
+      'aurora',
+    )
+    expect(css).toContain(".nene-public[data-theme='aurora']")
+    expect(css).toContain(".nene-public[data-theme='aurora-dark']")
+    expect(css).toContain('--content-w: 1320px;')
+    expect(css).toContain('--color-surface: #ffffff;')
+    expect(css).toContain('--color-surface: #101010;')
+  })
+
+  it('returns the css for the requested theme only, empty otherwise', () => {
+    const raw = JSON.stringify({ aurora: { radius: 'round' } })
+    expect(overrideCssForTheme(raw, 'aurora')).toContain('--radius-md')
+    expect(overrideCssForTheme(raw, 'consumer')).toBe('')
+    expect(overrideCssForTheme('not json', 'aurora')).toBe('')
   })
 })

--- a/frontend/src/shared/lib/theme-customization.ts
+++ b/frontend/src/shared/lib/theme-customization.ts
@@ -30,6 +30,16 @@ export interface ThemeOverrides {
   typeScale?: string
   /** Spacing density preset (see DENSITY_OPTIONS). Scales `--space-*`. */
   density?: string
+  /** Paper / surface colour, per mode (hex). Derives the surface family. */
+  surface?: ColorPair
+  /** Body text ink colour, per mode (hex). Derives `--color-text-muted`. */
+  text?: ColorPair
+}
+
+/** A colour value per light/dark mode (hex). */
+export interface ColorPair {
+  light?: string
+  dark?: string
 }
 
 export interface KnobOption {
@@ -209,14 +219,80 @@ export function parseThemeOverrides(raw: string | undefined): Record<string, The
   }
 }
 
-/** Resolved inline style for one theme's overrides (empty object if none). */
-export function overrideStyleForTheme(
-  raw: string | undefined,
-  themeId: string,
-): Record<string, string> {
-  const byTheme = parseThemeOverrides(raw)
-  const forTheme = byTheme[themeId]
-  return forTheme ? resolveOverrideStyle(forTheme) : {}
+type Mode = 'light' | 'dark'
+
+/**
+ * Per-mode colour overrides (surface family + text). These MUST be mode-scoped
+ * because a light surface would break dark mode and vice-versa. The surface
+ * family and muted text are derived from the chosen colours via `color-mix`.
+ */
+export function resolveModeColors(overrides: ThemeOverrides, mode: Mode): Record<string, string> {
+  const style: Record<string, string> = {}
+
+  const surface = overrides.surface?.[mode]
+  if (typeof surface === 'string' && HEX_COLOR.test(surface)) {
+    style['--color-surface'] = surface
+    style['--color-surface-raised'] =
+      mode === 'light'
+        ? `color-mix(in oklch, ${surface}, white 55%)`
+        : `color-mix(in oklch, ${surface}, white 6%)`
+    style['--color-surface-overlay'] =
+      mode === 'light'
+        ? `color-mix(in oklch, ${surface}, black 6%)`
+        : `color-mix(in oklch, ${surface}, white 12%)`
+    style['--color-surface-sunken'] =
+      mode === 'light'
+        ? `color-mix(in oklch, ${surface}, black 3%)`
+        : `color-mix(in oklch, ${surface}, black 30%)`
+    style['--color-border'] =
+      mode === 'light'
+        ? `color-mix(in oklch, ${surface}, black 16%)`
+        : `color-mix(in oklch, ${surface}, white 14%)`
+    style['--color-border-strong'] =
+      mode === 'light'
+        ? `color-mix(in oklch, ${surface}, black 26%)`
+        : `color-mix(in oklch, ${surface}, white 24%)`
+  }
+
+  const text = overrides.text?.[mode]
+  if (typeof text === 'string' && HEX_COLOR.test(text)) {
+    style['--color-text-primary'] = text
+    style['--color-text-muted'] = `color-mix(in oklch, ${text}, transparent 32%)`
+  }
+
+  return style
+}
+
+function cssVarsBlock(selector: string, vars: Record<string, string>): string {
+  const entries = Object.entries(vars)
+  if (entries.length === 0) {
+    return ''
+  }
+  const body = entries.map(([key, value]) => `  ${key}: ${value};`).join('\n')
+  return `${selector} {\n${body}\n}\n`
+}
+
+/**
+ * Build the full override stylesheet for one theme: mode-agnostic vars on both
+ * `[data-theme='<id>']` and `-dark`, plus per-mode colours on each. Returns ''
+ * when there are no overrides. Values are validated upstream, so the emitted
+ * CSS only ever contains known variables and safe values.
+ */
+export function buildOverrideCss(overrides: ThemeOverrides, themeId: string): string {
+  const light = `.nene-public[data-theme='${themeId}']`
+  const dark = `.nene-public[data-theme='${themeId}-dark']`
+
+  const agnostic = resolveOverrideStyle(overrides)
+  let css = cssVarsBlock(`${light},\n${dark}`, agnostic)
+  css += cssVarsBlock(light, resolveModeColors(overrides, 'light'))
+  css += cssVarsBlock(dark, resolveModeColors(overrides, 'dark'))
+  return css
+}
+
+/** Build the override stylesheet for the requested theme from stored JSON. */
+export function overrideCssForTheme(raw: string | undefined, themeId: string): string {
+  const forTheme = parseThemeOverrides(raw)[themeId]
+  return forTheme ? buildOverrideCss(forTheme, themeId) : ''
 }
 
 // Cache the raw overrides JSON so the first paint can apply them synchronously

--- a/frontend/tests/render/PublicSiteTestProvider.tsx
+++ b/frontend/tests/render/PublicSiteTestProvider.tsx
@@ -8,7 +8,7 @@ const TEST_SITE: PublicSite = {
   footerMarkdown: '',
   navItems: [],
   activeTheme: 'consumer',
-  themeOverrideStyle: {},
+  themeOverrideCss: '',
 }
 
 /**


### PR DESCRIPTION
## 目的
テーマカスタマイザ（#372）に **surface（背景紙）/ text（本文インク）の色ノブ**を追加。色は light/dark で別値が要るため、上書き適用を**インライン style（モード非依存）→ 注入 `<style>`（per-mode セレクタ）**へ拡張。

## 変更（frontend のみ）
- **`theme-customization.ts`**:
  - `resolveModeColors(overrides, mode)`: surface から raised/overlay/sunken/border を `color-mix` で派生、text から muted を派生（各モード別）。
  - `buildOverrideCss(overrides, themeId)`: `[data-theme='<id>']` と `'-dark'` に分けて emit（mode-agnostic は両方に）。`overrideCssForTheme`。
  - `surface` / `text` は `ColorPair`（light/dark）。値は **hex 検証済みのみ emit**（インジェクション不可）。
- **適用方式**: `PublicShell` が `themeOverrideCss`（文字列）を渡し、`PublicSiteShell` が `.nene-public` 内に `<style>` を描画（旧インライン style は撤去）。FOUC 対策（localStorage）は維持。
- **管理UI**: surface（light/dark）/ text（light/dark）のカラー入力を追加。i18n（en/ja）。
- ユニットテスト追加。

## 検証
- `npm run check`: green（197 tests / validate:themes / knip / storybook）。

## 後続スライス（#372 残り）
- 画像ノブ（logo/hero、メディアライブラリ連携）。
- ライブプレビュー（iframe）。

Part of #367