### PR TITLE
docs(theming): スタイルフラグ＆プリセット仕様＋manifest flags スキーマ (#390 / #367)

### DIFF
--- a/docs/theming/public-theme.schema.json
+++ b/docs/theming/public-theme.schema.json
@@ -76,6 +76,19 @@
         "radius": { "enum": ["sharp", "soft", "round"] }
       }
     },
+    "flags": {
+      "type": "object",
+      "description": "Structural style flags (enumerated). Applied as data-* attributes on .nene-public; implemented once in base CSS (no DOM change). See theme-flags.md.",
+      "additionalProperties": false,
+      "properties": {
+        "feedLayout": { "enum": ["grid", "list", "magazine"] },
+        "cardStyle": { "enum": ["flat", "bordered", "shadowed", "framed"] },
+        "media": { "enum": ["plain", "duotone", "grayscale", "framed"] },
+        "hero": { "enum": ["standard", "fullbleed", "minimal"] },
+        "sectionRule": { "enum": ["none", "hairline", "heavy"] },
+        "eyebrow": { "enum": ["plain", "caps", "barred"] }
+      }
+    },
     "assets": {
       "type": "object",
       "description": "Asset slots. Values are bundle-relative paths (no external URLs). Per-mode slots may use {light,dark}.",

--- a/docs/theming/theme-flags.md
+++ b/docs/theming/theme-flags.md
@@ -1,0 +1,111 @@
+# 公開サイト テーマ — スタイルフラグ＆プリセット（ハイブリッドモデル）
+
+> 正本ドキュメント。テーマを **列挙パラメータ（tokens プリセット）＋スタイルフラグ** の **JSON データ**で定義し、**汎用エンジン（base CSS）が1回だけ実装**する。bespoke `components.css` は Pro の escape hatch として残す。
+>
+> - 親: #390（#367）。関連: [`public-theme-contract.md`](./public-theme-contract.md)（tokens）/ [`class-hooks.md`](./class-hooks.md)（クラス）/ [`public-theme.schema.json`](./public-theme.schema.json)（manifest スキーマ）。
+> - WordPress `theme.json` / スタイルバリエーション相当。**DOM は変えない**（フラグは CSS で実装）。
+
+---
+
+## 1. 2層モデル
+
+| 層                  | 形式                      | 誰が作る            | 役割                                         |
+| ------------------- | ------------------------- | ------------------- | -------------------------------------------- |
+| **A. プリセット層** | **JSON**（tokens＋flags） | ClaudeCode / 管理者 | 定番デザインを量産・調整。汎用エンジンが実装 |
+| **B. escape hatch** | bespoke `components.css`  | ClaudeDesign        | 語彙外の唯一無二デザイン。Pro に隠す         |
+
+A だけでも「WP の定番テーマ」級は出せる。語彙に収まらない時だけ B。
+
+## 2. スタイルフラグ語彙（v1）
+
+各フラグは `.nene-public` の **`data-*` 属性**になり、base CSS が実装する（`DOM は不変`）。値は**列挙**。未指定＝テーマ既定（フラグ無し＝現行の見た目）。
+
+| フラグ        | data 属性      | 値                                              | 効果（base CSS が実装）                                                                                                            |
+| ------------- | -------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `feedLayout`  | `data-feed`    | `grid` \| `list` \| `magazine`                  | 最新フィードの版面。grid=均等カード / list=横長行（`.cardgrid`→1カラム化、`.card`を行化）/ magazine=フィーチャー＋グリッド（現行） |
+| `cardStyle`   | `data-cards`   | `flat` \| `bordered` \| `shadowed` \| `framed`  | `.card` の意匠（枠/影/額装）                                                                                                       |
+| `media`       | `data-media`   | `plain` \| `duotone` \| `grayscale` \| `framed` | `.card__media` / `.featured__media` / `.article__hero` の見せ方（`filter`/枠）                                                     |
+| `hero`        | `data-hero`    | `standard` \| `fullbleed` \| `minimal`          | `.hero` 構図（minimal=アート省略・タイポ主体 / fullbleed=幅広）                                                                    |
+| `sectionRule` | `data-rule`    | `none` \| `hairline` \| `heavy`                 | `.section__head` の区切り罫                                                                                                        |
+| `eyebrow`     | `data-eyebrow` | `plain` \| `caps` \| `barred`                   | `.eyebrow` の表情（小型キャップス/バー）                                                                                           |
+
+> 追加フラグは本表に追記して語彙を拡張する。実装は base CSS（`public-site.css` 近傍の専用ファイル）に集約。
+
+### 適用フロー
+
+```
+theme.manifest.flags ┐
+                     ├─(merge: 上書き優先)→ resolved flags → .nene-public data-* 属性 → base CSS
+admin overrides.flags ┘
+```
+
+- tokens（色/幅/余白…）は従来どおり CSS 変数。flags は構造選択で `data-*`。両者は独立に効く。
+- base CSS 例:
+
+```css
+.nene-public[data-feed="list"] .cardgrid {
+  grid-template-columns: 1fr;
+}
+.nene-public[data-feed="list"] .card {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-lg);
+}
+.nene-public[data-cards="bordered"] .card {
+  border: 1px solid var(--color-border);
+  padding: var(--space-md);
+}
+.nene-public[data-media="grayscale"] .card__media {
+  filter: grayscale(1);
+}
+```
+
+## 3. JSON 定義（manifest 拡張）
+
+manifest に任意の `flags` を追加（[`public-theme.schema.json`](./public-theme.schema.json) に定義）:
+
+```json
+{
+  "id": "myzine",
+  "name": "My Zine",
+  "supportsModes": ["light", "dark"],
+  "tokens": { "light": { … }, "dark": { … } },
+  "flags": { "feedLayout": "list", "cardStyle": "bordered", "media": "grayscale", "sectionRule": "hairline" }
+}
+```
+
+- `flags` の各キーは §2 の enum のみ（バリデータが検証）。
+- これだけで版面が変わる＝**CSS を書かずに JSON でテーマ量産**できる。
+
+### カスタマイザ（`theme_overrides`）でも flags
+
+管理者の上書き（`theme_overrides` JSON）にも `flags` を持てる（テーマ既定を上書き）。token ノブと同じ流儀。
+
+## 4. simple / pro モード（カスタマイザ）
+
+- **simple**: 列挙ノブ（色/幅/余白/サイズ/角丸＝S/M/L 等）＋ **flags のプルダウン**（grid/list 等）。非エンジニア向け。
+- **pro**: 生トークンの細指定・bespoke `components.css` の利用。普段は折りたたみ/別タブに隠す。
+
+## 5. バリデーション
+
+- manifest の `flags` は **enum チェック**（不正値は reject）。`validate:themes` に組込み。
+- bespoke `components.css`（B層）は従来どおりスコープ/安全性チェック。
+
+## 6. 既存との関係・移行
+
+- 既存 3 テーマ（consumer / aurora / reading）は bespoke `components.css`（B層）。当面そのまま。語彙が育ったら **フラグで再表現できる部分は JSON へ寄せ**、残りを Pro bespoke に。
+- tokens 契約（[`public-theme-contract.md`](./public-theme-contract.md)）・アセット契約は不変。flags は**構造選択の追加レイヤ**。
+
+## 7. 甘くない点（明記）
+
+- **語彙の天井**: 本当に新規な版面は flags に収まらない → escape hatch（B）必須。
+- **エンジンの初期コスト**: 全フラグ×バリアントの base CSS を先に作り込む（light/dark × レスポンシブの掛け算）。
+- **組合せの破綻**: 自由組合せで不格好になりうる → プリセット/推奨組合せでガード。
+
+## 8. 実装スライス（#390）
+
+1. 本ドキュメント＋ `flags` スキーマ（←本PR）。
+2. 汎用エンジン v1: `feedLayout`(grid/list) ＋ `cardStyle` を base CSS 実装＋ `flags`→`data-*` 配線。
+3. フラグ拡充（media / hero / sectionRule / eyebrow）。
+4. カスタマイザ simple/pro 分割＋ flags UI ＋ validator enum。
+5. ClaudeCode で JSON テーマ量産。


### PR DESCRIPTION
## 目的
ハイブリッドモデル（**JSONプリセット＋汎用エンジン**、bespoke `components.css` は Pro escape hatch）の**設計正本**（#390 スライス1）。ClaudeDesign/Code が JSON テーマを量産するための仕様。

## 変更（docs のみ）
- **`docs/theming/theme-flags.md`**: 2層モデル／**スタイルフラグ語彙 v1**（`feedLayout` grid·list·magazine / `cardStyle` / `media` / `hero` / `sectionRule` / `eyebrow`）／`data-*` マッピングと適用フロー（DOM不変）／JSON 定義例／simple·pro モード／バリデーション／既存テーマとの関係・移行／甘くない点／実装スライス。
- **`public-theme.schema.json`**: manifest に任意の `flags`（enum）を追加。

## 検証
- `npm run validate:themes`: 既存3テーマ pass（`flags` は任意なので影響なし）。prettier OK。

## 後続（#390）
2. 汎用エンジン v1（`feedLayout` grid/list ＋ `cardStyle` を base CSS 実装＋ `data-*` 配線）→「JSONフラグだけで版面が変わる」を実証。
3. フラグ拡充 / 4. simple·pro UI＋validator enum / 5. JSONテーマ量産。

Part of #367