### PR TITLE
feat(public): スタイルフラグ汎用エンジン v1（feedLayout/cardStyle）(#390 / #367)

### DIFF
--- a/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
+++ b/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import { useTranslation } from '@/shared/i18n'
 import {
   DENSITY_OPTIONS,
+  FLAG_DEFS,
   FONT_OPTIONS,
   FONT_SIZE_OPTIONS,
   GUTTER_OPTIONS,
@@ -226,6 +227,26 @@ export function ThemeCustomizeView({
               placeholder={themePlaceholder}
               onChange={(v) => {
                 setKnob('density', v)
+              }}
+            />
+          </Field>
+          <Field label={t('admin.themeCustomize.feedLayout')}>
+            <Select
+              value={draft.flags?.feedLayout}
+              options={FLAG_DEFS.feedLayout.options}
+              placeholder={themePlaceholder}
+              onChange={(v) => {
+                setKnob('flags', { ...draft.flags, feedLayout: v })
+              }}
+            />
+          </Field>
+          <Field label={t('admin.themeCustomize.cardStyle')}>
+            <Select
+              value={draft.flags?.cardStyle}
+              options={FLAG_DEFS.cardStyle.options}
+              placeholder={themePlaceholder}
+              onChange={(v) => {
+                setKnob('flags', { ...draft.flags, cardStyle: v })
               }}
             />
           </Field>

--- a/frontend/src/pages/consumer/PublicShell.tsx
+++ b/frontend/src/pages/consumer/PublicShell.tsx
@@ -10,6 +10,7 @@ import {
   storeActiveTheme,
 } from '@/shared/lib/public-themes'
 import {
+  flagAttrsForTheme,
   overrideCssForTheme,
   readStoredThemeOverridesRaw,
   storeThemeOverridesRaw,
@@ -73,6 +74,7 @@ export function PublicShell() {
     navItems,
     activeTheme,
     themeOverrideCss: overrideCssForTheme(overridesRaw, activeTheme),
+    themeFlagAttrs: flagAttrsForTheme(overridesRaw, activeTheme),
   }
 
   useSiteDocumentMeta(site.siteName, site.metaDescription)

--- a/frontend/src/pages/consumer/PublicSiteShell.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.tsx
@@ -139,7 +139,12 @@ export function PublicSiteShell({
   const footerTypeLinks = types.slice(0, 4)
 
   return (
-    <div className="nene-public" data-theme={resolvedTheme} data-theme-mode={mode}>
+    <div
+      className="nene-public"
+      data-theme={resolvedTheme}
+      data-theme-mode={mode}
+      {...site.themeFlagAttrs}
+    >
       {site.themeOverrideCss !== '' ? <style>{site.themeOverrideCss}</style> : null}
       <header className="hd">
         <div className="wrap hd__in">

--- a/frontend/src/pages/consumer/public-site-context.ts
+++ b/frontend/src/pages/consumer/public-site-context.ts
@@ -21,6 +21,8 @@ export interface PublicSite {
   activeTheme: string
   /** Customizer overrides for the active theme, as a scoped CSS stylesheet. */
   themeOverrideCss: string
+  /** Structural style-flag `data-*` attributes for the active theme. */
+  themeFlagAttrs: Record<string, string>
 }
 
 export function usePublicSite(): PublicSite {

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -1646,3 +1646,63 @@
     animation: none !important;
   }
 }
+
+/* ── Style flags (preset engine) ──────────────────────────────────────────
+   Structural variations selected by theme/customizer flags and applied as
+   data-* attributes on .nene-public (see docs/theming/theme-flags.md).
+   Implemented once here; themes/JSON just opt in. No DOM changes. */
+
+/* feedLayout=list — the latest feed becomes full-width rows (grid areas keep
+   the flat card markup: media | meta/title/excerpt). */
+.nene-public[data-feed='list'] .cardgrid {
+  grid-template-columns: 1fr;
+  gap: var(--space-md);
+}
+.nene-public[data-feed='list'] .card {
+  display: grid;
+  grid-template-columns: minmax(150px, 230px) 1fr;
+  grid-template-areas: 'media meta' 'media title' 'media excerpt';
+  align-items: start;
+  gap: var(--space-2xs) var(--space-lg);
+}
+.nene-public[data-feed='list'] .card > a:first-child {
+  grid-area: media;
+}
+.nene-public[data-feed='list'] .card__metarow {
+  grid-area: meta;
+}
+.nene-public[data-feed='list'] .card__title {
+  grid-area: title;
+}
+.nene-public[data-feed='list'] .card__excerpt {
+  grid-area: excerpt;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+}
+@media (max-width: 560px) {
+  .nene-public[data-feed='list'] .card {
+    grid-template-columns: 1fr;
+    grid-template-areas: 'media' 'meta' 'title' 'excerpt';
+  }
+}
+
+/* cardStyle — card surface treatment. flat = default (no rule). */
+.nene-public[data-cards='bordered'] .card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-raised);
+  padding: var(--space-md);
+}
+.nene-public[data-cards='shadowed'] .card {
+  border-radius: var(--radius-md);
+  background: var(--color-surface-raised);
+  padding: var(--space-md);
+  box-shadow: var(--shadow-md);
+}
+.nene-public[data-cards='framed'] .card {
+  border: 1px solid var(--color-border-strong);
+  border-top: 3px solid var(--color-accent);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-raised);
+  padding: var(--space-md);
+}

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -71,6 +71,8 @@ export const en = {
   'admin.themeCustomize.fontSize': 'Font size',
   'admin.themeCustomize.typeScale': 'Type scale',
   'admin.themeCustomize.density': 'Density',
+  'admin.themeCustomize.feedLayout': 'Feed layout',
+  'admin.themeCustomize.cardStyle': 'Card style',
   'admin.themeCustomize.save': 'Save',
   'admin.themeCustomize.saving': 'Saving…',
   'admin.themeCustomize.reset': 'Reset',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -64,6 +64,8 @@ export const ja: Partial<MessageCatalog> = {
   'admin.themeCustomize.fontSize': '文字サイズ',
   'admin.themeCustomize.typeScale': '見出しスケール',
   'admin.themeCustomize.density': '密度',
+  'admin.themeCustomize.feedLayout': 'フィード版面',
+  'admin.themeCustomize.cardStyle': 'カード意匠',
   'admin.themeCustomize.save': '保存',
   'admin.themeCustomize.saving': '保存中…',
   'admin.themeCustomize.reset': 'リセット',

--- a/frontend/src/shared/lib/theme-customization.test.ts
+++ b/frontend/src/shared/lib/theme-customization.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildOverrideCss,
+  flagAttrsForTheme,
   overrideCssForTheme,
+  resolveFlagAttrs,
   resolveModeColors,
   resolveOverrideStyle,
 } from './theme-customization'
@@ -98,5 +100,27 @@ describe('buildOverrideCss / overrideCssForTheme', () => {
     expect(overrideCssForTheme(raw, 'aurora')).toContain('--radius-md')
     expect(overrideCssForTheme(raw, 'consumer')).toBe('')
     expect(overrideCssForTheme('not json', 'aurora')).toBe('')
+  })
+})
+
+describe('resolveFlagAttrs / flagAttrsForTheme', () => {
+  it('maps valid flags to data-* attributes; overrides win over defaults', () => {
+    const attrs = resolveFlagAttrs(
+      { feedLayout: 'grid' },
+      { feedLayout: 'list', cardStyle: 'bordered' },
+    )
+    expect(attrs).toEqual({ 'data-feed': 'list', 'data-cards': 'bordered' })
+  })
+
+  it('drops unknown flags / invalid values', () => {
+    expect(resolveFlagAttrs(undefined, { feedLayout: 'spaceship', cardStyle: 'flat' })).toEqual({
+      'data-cards': 'flat',
+    })
+  })
+
+  it('reads flags from stored overrides JSON for the theme', () => {
+    const raw = JSON.stringify({ reading: { flags: { feedLayout: 'list' } } })
+    expect(flagAttrsForTheme(raw, 'reading')).toEqual({ 'data-feed': 'list' })
+    expect(flagAttrsForTheme(raw, 'aurora')).toEqual({})
   })
 })

--- a/frontend/src/shared/lib/theme-customization.ts
+++ b/frontend/src/shared/lib/theme-customization.ts
@@ -34,6 +34,8 @@ export interface ThemeOverrides {
   surface?: ColorPair
   /** Body text ink colour, per mode (hex). Derives `--color-text-muted`. */
   text?: ColorPair
+  /** Structural style flags (applied as data-* attributes; see theme-flags.md). */
+  flags?: ThemeFlags
 }
 
 /** A colour value per light/dark mode (hex). */
@@ -41,6 +43,71 @@ export interface ColorPair {
   light?: string
   dark?: string
 }
+
+/** Structural style flags — enumerated; implemented once in base CSS. */
+export interface ThemeFlags {
+  feedLayout?: string
+  cardStyle?: string
+  media?: string
+  hero?: string
+  sectionRule?: string
+  eyebrow?: string
+}
+
+/** flag key → { data attribute, allowed values }. Mirrors theme-flags.md §2. */
+export const FLAG_DEFS: Record<keyof ThemeFlags, { attr: string; options: readonly KnobOption[] }> =
+  {
+    feedLayout: {
+      attr: 'data-feed',
+      options: [
+        { value: 'grid', label: 'Grid' },
+        { value: 'list', label: 'List' },
+        { value: 'magazine', label: 'Magazine' },
+      ],
+    },
+    cardStyle: {
+      attr: 'data-cards',
+      options: [
+        { value: 'flat', label: 'Flat' },
+        { value: 'bordered', label: 'Bordered' },
+        { value: 'shadowed', label: 'Shadowed' },
+        { value: 'framed', label: 'Framed' },
+      ],
+    },
+    media: {
+      attr: 'data-media',
+      options: [
+        { value: 'plain', label: 'Plain' },
+        { value: 'duotone', label: 'Duotone' },
+        { value: 'grayscale', label: 'Grayscale' },
+        { value: 'framed', label: 'Framed' },
+      ],
+    },
+    hero: {
+      attr: 'data-hero',
+      options: [
+        { value: 'standard', label: 'Standard' },
+        { value: 'fullbleed', label: 'Full bleed' },
+        { value: 'minimal', label: 'Minimal' },
+      ],
+    },
+    sectionRule: {
+      attr: 'data-rule',
+      options: [
+        { value: 'none', label: 'None' },
+        { value: 'hairline', label: 'Hairline' },
+        { value: 'heavy', label: 'Heavy' },
+      ],
+    },
+    eyebrow: {
+      attr: 'data-eyebrow',
+      options: [
+        { value: 'plain', label: 'Plain' },
+        { value: 'caps', label: 'Caps' },
+        { value: 'barred', label: 'Barred' },
+      ],
+    },
+  }
 
 export interface KnobOption {
   value: string
@@ -293,6 +360,38 @@ export function buildOverrideCss(overrides: ThemeOverrides, themeId: string): st
 export function overrideCssForTheme(raw: string | undefined, themeId: string): string {
   const forTheme = parseThemeOverrides(raw)[themeId]
   return forTheme ? buildOverrideCss(forTheme, themeId) : ''
+}
+
+/**
+ * Resolve style flags into `data-*` attributes for the `.nene-public` root.
+ * Only known flags with allowed enum values are emitted; base CSS implements
+ * the actual look (no DOM change). `themeDefaults` are the theme's built-in
+ * flags; `overrides` (admin) win.
+ */
+export function resolveFlagAttrs(
+  themeDefaults: ThemeFlags | undefined,
+  overrides: ThemeFlags | undefined,
+): Record<string, string> {
+  const merged: ThemeFlags = { ...themeDefaults, ...overrides }
+  const attrs: Record<string, string> = {}
+  for (const key of Object.keys(FLAG_DEFS) as Array<keyof ThemeFlags>) {
+    const def = FLAG_DEFS[key]
+    const value = merged[key]
+    if (typeof value === 'string' && def.options.some((option) => option.value === value)) {
+      attrs[def.attr] = value
+    }
+  }
+  return attrs
+}
+
+/** Resolve flag data-* attributes for a theme from stored overrides JSON. */
+export function flagAttrsForTheme(
+  raw: string | undefined,
+  themeId: string,
+  themeDefaults?: ThemeFlags,
+): Record<string, string> {
+  const forTheme = parseThemeOverrides(raw)[themeId]
+  return resolveFlagAttrs(themeDefaults, forTheme?.flags)
 }
 
 // Cache the raw overrides JSON so the first paint can apply them synchronously

--- a/frontend/tests/render/PublicSiteTestProvider.tsx
+++ b/frontend/tests/render/PublicSiteTestProvider.tsx
@@ -9,6 +9,7 @@ const TEST_SITE: PublicSite = {
   navItems: [],
   activeTheme: 'consumer',
   themeOverrideCss: '',
+  themeFlagAttrs: {},
 }
 
 /**


### PR DESCRIPTION
## 目的
ハイブリッドモデルのスライス2。**JSON のスタイルフラグだけで版面が変わる**ことを実証（汎用エンジン v1）。DOM 不変・CSS のみ。

## 変更（frontend のみ）
- **`theme-customization.ts`**: `ThemeFlags` 型＋ `FLAG_DEFS`（flag→`data-*`＋enum）。`resolveFlagAttrs` / `flagAttrsForTheme`（テーマ既定 × 管理者上書きをマージし、**検証済み enum のみ** `data-*` 化）。`ThemeOverrides` に `flags` を追加。
- **配線**: `PublicShell` → `PublicSiteShell` が `themeFlagAttrs` を `.nene-public` に spread。
- **`public-site.css`（エンジン）**: `data-feed='list'`（フィードをグリッド→**横長行**。grid-areas で flat カード対応＋レスポンシブ折返し）、`data-cards=bordered/shadowed/framed`。
- **カスタマイザ**: `feedLayout` / `cardStyle` のプルダウンを追加。i18n（en/ja）。
- ユニットテスト追加。

## 確認
外観>テーマ>カスタマイズで **Feed layout=List** / **Card style=Bordered** を選び保存 → 公開トップのフィードが**横長リスト＋枠付きカード**に変わる（同じ DOM のまま）。

## 検証
- `npm run check`: green（200 tests / validate:themes / knip / storybook）。

## 後続（#390）
- media / hero / sectionRule / eyebrow の実装。
- カスタマイザ simple/pro 分割＋ validator の flags enum 検証。
- ClaudeCode で JSON テーマ量産。

Part of #367