### PR TITLE
feat(public): ヘッダー/フッターの chrome 設定（ロゴ・著作権）Phase 1 (#398)

### DIFF
--- a/database/migrations/20260617000000_add_chrome_settings.php
+++ b/database/migrations/20260617000000_add_chrome_settings.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Header/footer "chrome" settings — Phase 1 (#398).
+ *
+ * Adds two public, typed settings the public-site shell renders theme-agnostically:
+ *  - logo_media_id  : media reference (resolved to a URL in the public settings API);
+ *                     empty → the shell falls back to the built-in brand mark.
+ *  - copyright_text : free text with `{year}` / `{site}` tokens substituted at render.
+ *
+ * `setting_defs` is org-scoped (see SeedDefaultSettingsForExistingOrgs), so the
+ * defs must be inserted per organization. Idempotent: skips (org, key) pairs
+ * that already exist.
+ */
+final class AddChromeSettings extends AbstractMigration
+{
+    /** @var list<array{setting_key: string, data_type: string, default_value: string, is_public: int, label: string}> */
+    private const CHROME_SETTINGS = [
+        ['setting_key' => 'logo_media_id', 'data_type' => 'media', 'default_value' => '', 'is_public' => 1, 'label' => 'Logo'],
+        ['setting_key' => 'copyright_text', 'data_type' => 'text', 'default_value' => '© {year} {site}', 'is_public' => 1, 'label' => 'Copyright'],
+    ];
+
+    public function up(): void
+    {
+        if (!$this->hasTable('organizations') || !$this->hasTable('setting_defs')) {
+            return;
+        }
+
+        $pdo = $this->getAdapter()->getConnection();
+        $now = date('Y-m-d H:i:s');
+
+        $orgs = $pdo->query('SELECT id FROM organizations ORDER BY id ASC')->fetchAll(PDO::FETCH_COLUMN);
+
+        $check = $pdo->prepare('SELECT id FROM setting_defs WHERE organization_id = ? AND setting_key = ?');
+        $insert = $pdo->prepare(
+            'INSERT INTO setting_defs (organization_id, setting_key, data_type, default_value, is_public, label, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        );
+
+        foreach ($orgs as $orgIdRaw) {
+            $orgId = (int) $orgIdRaw;
+            foreach (self::CHROME_SETTINGS as $setting) {
+                $check->execute([$orgId, $setting['setting_key']]);
+                if ($check->fetch() !== false) {
+                    continue;
+                }
+                $insert->execute([
+                    $orgId,
+                    $setting['setting_key'],
+                    $setting['data_type'],
+                    $setting['default_value'],
+                    $setting['is_public'],
+                    $setting['label'],
+                    $now,
+                    $now,
+                ]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        $this->execute(
+            "DELETE FROM setting_defs WHERE setting_key IN ('logo_media_id', 'copyright_text')",
+        );
+    }
+}

--- a/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.tsx
+++ b/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.tsx
@@ -1,7 +1,11 @@
 import { useState } from 'react'
+import { useMediaList } from '@/entities/media'
 import type { SettingItem, SettingRevision } from '@/entities/setting'
 import { useTranslation } from '@/shared/i18n'
 import { Button, Card, ErrorState, LoadingState, Stack, Text, Textarea } from '@/shared/ui'
+
+const inputClass =
+  'rounded-md border border-border bg-surface px-inline-sm py-stack-sm font-sans text-body text-text-primary shadow-sm focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-50'
 
 // ── Revisions panel (props-driven) ───────────────────────────────────────────
 
@@ -38,6 +42,69 @@ function SettingRevisionsPanel({ revisions, isLoading, isError }: SettingRevisio
   )
 }
 
+// ── Media setting field (logo) ───────────────────────────────────────────────
+
+interface MediaSettingFieldProps {
+  item: SettingItem
+  isSaving: boolean
+  canManageSettings: boolean
+  onSave: (settingKey: string, value: string) => Promise<void>
+}
+
+/**
+ * A `media`-type setting stores a media id. Pick from the image library (a
+ * preview + a simple select); the public site resolves the id to a URL.
+ */
+function MediaSettingField({ item, isSaving, canManageSettings, onSave }: MediaSettingFieldProps) {
+  const { t } = useTranslation()
+  const mediaList = useMediaList()
+  const [value, setValue] = useState(item.value)
+  const images = (mediaList.data?.items ?? []).filter((m) => m.mimeType.startsWith('image/'))
+  const selected = images.find((m) => String(m.id) === value)
+  const dirty = value !== item.value
+
+  return (
+    <div className="flex items-center gap-stack-sm">
+      <span className="grid h-10 w-10 shrink-0 place-items-center overflow-hidden rounded-sm border border-border bg-surface-sunken">
+        {selected !== undefined ? (
+          <img src={selected.url} alt="" className="h-full w-full object-cover" />
+        ) : (
+          <Text muted variant="caption">
+            —
+          </Text>
+        )}
+      </span>
+      <select
+        value={value}
+        disabled={isSaving || !canManageSettings || mediaList.isLoading}
+        onChange={(e) => {
+          setValue(e.target.value)
+        }}
+        className={`flex-1 ${inputClass}`}
+      >
+        <option value="">{t('admin.settings.media.none')}</option>
+        {images.map((m) => (
+          <option key={m.id} value={String(m.id)}>
+            {m.originalName}
+          </option>
+        ))}
+      </select>
+      {canManageSettings ? (
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={isSaving || !dirty}
+          onClick={() => {
+            void onSave(item.settingKey, value)
+          }}
+        >
+          {isSaving ? t('admin.settings.saving') : t('admin.settings.save')}
+        </Button>
+      ) : null}
+    </div>
+  )
+}
+
 // ── Setting card (local form state only) ─────────────────────────────────────
 
 interface SettingCardProps {
@@ -68,9 +135,6 @@ function SettingCard({
   const inputId = `setting-${item.settingKey}`
   const dirty = value !== item.value
 
-  const inputClass =
-    'rounded-md border border-border bg-surface px-inline-sm py-stack-sm font-sans text-body text-text-primary shadow-sm focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-50'
-
   return (
     <Card as="section">
       {/* ── Header row: label + history toggle ── */}
@@ -88,7 +152,14 @@ function SettingCard({
       </div>
 
       {/* ── Field ── */}
-      {item.dataType === 'markdown' ? (
+      {item.dataType === 'media' ? (
+        <MediaSettingField
+          item={item}
+          isSaving={isSaving}
+          canManageSettings={canManageSettings}
+          onSave={onSave}
+        />
+      ) : item.dataType === 'markdown' ? (
         <div className="flex flex-col gap-stack-sm">
           <Text muted variant="caption">
             Markdown ·{' '}

--- a/frontend/src/pages/consumer/PublicShell.tsx
+++ b/frontend/src/pages/consumer/PublicShell.tsx
@@ -71,6 +71,8 @@ export function PublicShell() {
     tagline: settings.tagline ?? '',
     metaDescription: settings.default_meta_description ?? '',
     footerMarkdown: settings.footer_markdown ?? '',
+    logo: settings.logo_media_id ?? '',
+    copyrightText: settings.copyright_text ?? '',
     navItems,
     activeTheme,
     themeOverrideCss: overrideCssForTheme(overridesRaw, activeTheme),

--- a/frontend/src/pages/consumer/PublicSiteShell.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.tsx
@@ -67,11 +67,15 @@ function ThemeSwitch({ mode, onMode }: { mode: ThemeMode; onMode: (mode: ThemeMo
   )
 }
 
-function Brand({ siteName, tagline }: { siteName: string; tagline?: string }) {
+function Brand({ siteName, tagline, logo }: { siteName: string; tagline?: string; logo?: string }) {
   return (
     <Link className="brand" to="/">
       <span className="brand__mark">
-        <NeneMark size={22} />
+        {logo !== undefined && logo !== '' ? (
+          <img className="brand__logo" src={logo} alt={siteName} />
+        ) : (
+          <NeneMark size={22} />
+        )}
       </span>
       <span className="brand__text">
         <span className="brand__name">{siteName}</span>
@@ -81,6 +85,15 @@ function Brand({ siteName, tagline }: { siteName: string; tagline?: string }) {
       </span>
     </Link>
   )
+}
+
+/** Footer copyright: substitute `{year}`/`{site}` tokens, fall back to a default. */
+function renderCopyright(template: string, siteName: string): string {
+  const year = String(new Date().getFullYear())
+  if (template.trim() === '') {
+    return `© ${year} ${siteName}`
+  }
+  return template.replaceAll('{year}', year).replaceAll('{site}', siteName)
 }
 
 /**
@@ -148,7 +161,7 @@ export function PublicSiteShell({
       {site.themeOverrideCss !== '' ? <style>{site.themeOverrideCss}</style> : null}
       <header className="hd">
         <div className="wrap hd__in">
-          <Brand siteName={site.siteName} tagline={site.tagline} />
+          <Brand siteName={site.siteName} tagline={site.tagline} logo={site.logo} />
           <nav className="hd__nav" aria-label="Primary">
             {navLinks.map((link) => (
               <Link
@@ -200,7 +213,7 @@ export function PublicSiteShell({
       <footer className="ft">
         <div className="wrap ft__grid">
           <div className="ft__brand">
-            <Brand siteName={site.siteName} />
+            <Brand siteName={site.siteName} logo={site.logo} />
             {site.footerMarkdown !== '' ? <p className="ft__free">{site.footerMarkdown}</p> : null}
           </div>
           <div className="ft__col">
@@ -228,9 +241,7 @@ export function PublicSiteShell({
           </div>
         </div>
         <div className="wrap ft__bar">
-          <small>
-            © {new Date().getFullYear()} {site.siteName}
-          </small>
+          <small>{renderCopyright(site.copyrightText, site.siteName)}</small>
           <small className="mono">Powered by NENE2 · {'>>'}</small>
         </div>
       </footer>

--- a/frontend/src/pages/consumer/public-site-context.ts
+++ b/frontend/src/pages/consumer/public-site-context.ts
@@ -16,6 +16,10 @@ export interface PublicSite {
   tagline: string
   metaDescription: string
   footerMarkdown: string
+  /** Logo image URL (`logo_media_id` resolved server-side); '' → brand mark. */
+  logo: string
+  /** Footer copyright text; `{year}`/`{site}` tokens substituted at render. */
+  copyrightText: string
   navItems: PublicSiteNavItem[]
   /** Admin-selected public-site theme id (`active_theme` setting). */
   activeTheme: string

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -156,6 +156,13 @@
   height: 22px;
   color: var(--color-brand-violet);
 }
+/* Admin-set logo image (logo_media_id). Fills the mark; cover keeps it tidy. */
+.nene-public .brand__logo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: inherit;
+}
 .nene-public .brand__text {
   display: flex;
   flex-direction: column;

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -589,6 +589,7 @@ export const en = {
   'admin.settings.error': 'Could not load site settings.',
   'admin.settings.save': 'Save',
   'admin.settings.saving': 'Saving…',
+  'admin.settings.media.none': 'No image',
   'admin.settings.visibility.public': 'Public',
   'admin.settings.visibility.adminOnly': 'Admin only',
   'admin.settings.history.show': 'Show history',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -590,6 +590,7 @@ export const ja: Partial<MessageCatalog> = {
   'admin.settings.error': 'サイト設定を読み込めませんでした。',
   'admin.settings.save': '保存',
   'admin.settings.saving': '保存中…',
+  'admin.settings.media.none': '画像なし',
   'admin.settings.visibility.public': '公開',
   'admin.settings.visibility.adminOnly': '管理者のみ',
   'admin.settings.history.show': '履歴を表示',

--- a/frontend/tests/render/PublicSiteTestProvider.tsx
+++ b/frontend/tests/render/PublicSiteTestProvider.tsx
@@ -6,6 +6,8 @@ const TEST_SITE: PublicSite = {
   tagline: '',
   metaDescription: '',
   footerMarkdown: '',
+  logo: '',
+  copyrightText: '',
   navItems: [],
   activeTheme: 'consumer',
   themeOverrideCss: '',

--- a/src/Setting/ListPublicSettingsUseCase.php
+++ b/src/Setting/ListPublicSettingsUseCase.php
@@ -4,15 +4,45 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Setting;
 
+use NeNeRecords\Media\MediaRepositoryInterface;
+
 final readonly class ListPublicSettingsUseCase implements ListPublicSettingsUseCaseInterface
 {
     public function __construct(
         private SettingRepositoryInterface $settings,
+        private MediaRepositoryInterface $media,
     ) {
     }
 
     public function execute(): ListPublicSettingsOutput
     {
-        return new ListPublicSettingsOutput(items: $this->settings->findPublicEntries());
+        $items = array_map(
+            fn (SettingEntry $entry): SettingEntry => $this->resolve($entry),
+            $this->settings->findPublicEntries(),
+        );
+
+        return new ListPublicSettingsOutput(items: $items);
+    }
+
+    /**
+     * `media`-type settings store a media id; the public site needs a URL.
+     * Resolve it here so the response stays a flat key→string map (and the
+     * shell can render an `<img>` directly). Unset / missing media → ''.
+     */
+    private function resolve(SettingEntry $entry): SettingEntry
+    {
+        if ($entry->def->dataType !== 'media') {
+            return $entry;
+        }
+
+        $url = '';
+        if ($entry->effectiveValue !== '') {
+            $media = $this->media->findById((int) $entry->effectiveValue);
+            if ($media !== null) {
+                $url = $media->url;
+            }
+        }
+
+        return new SettingEntry($entry->def, $url, $entry->storedValue);
     }
 }

--- a/src/Setting/SettingServiceProvider.php
+++ b/src/Setting/SettingServiceProvider.php
@@ -12,6 +12,7 @@ use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Media\MediaRepositoryInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 
@@ -58,7 +59,13 @@ final readonly class SettingServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Setting repository service is invalid.');
                     }
 
-                    return new ListPublicSettingsUseCase($settings);
+                    $media = $container->get(MediaRepositoryInterface::class);
+
+                    if (!$media instanceof MediaRepositoryInterface) {
+                        throw new LogicException('Media repository service is invalid.');
+                    }
+
+                    return new ListPublicSettingsUseCase($settings, $media);
                 },
             )
             ->set(

--- a/src/Setting/SettingValueValidator.php
+++ b/src/Setting/SettingValueValidator.php
@@ -7,7 +7,7 @@ namespace NeNeRecords\Setting;
 final class SettingValueValidator
 {
     /** @var list<string> */
-    private const SUPPORTED_DATA_TYPES = ['text', 'markdown', 'bool', 'url'];
+    private const SUPPORTED_DATA_TYPES = ['text', 'markdown', 'bool', 'url', 'media'];
 
     public static function normalize(string $dataType, string $value): string
     {
@@ -26,6 +26,7 @@ final class SettingValueValidator
         match ($dataType) {
             'bool' => self::validateBool($value),
             'url' => self::validateUrl($value),
+            'media' => self::validateMedia($value),
             'text', 'markdown' => null,
             default => self::assertSupportedDataType($dataType),
         };
@@ -62,6 +63,21 @@ final class SettingValueValidator
 
         if (filter_var($value, FILTER_VALIDATE_URL) === false) {
             throw new SettingValueInvalidException('URL setting value must be a valid URL.');
+        }
+    }
+
+    /**
+     * A media setting stores a media id (resolved to a URL in the public API).
+     * Empty clears it; otherwise it must be a positive integer.
+     */
+    private static function validateMedia(string $value): void
+    {
+        if ($value === '') {
+            return;
+        }
+
+        if (filter_var($value, FILTER_VALIDATE_INT) === false || (int) $value <= 0) {
+            throw new SettingValueInvalidException('Media setting value must be a media id.');
         }
     }
 }

--- a/tests/PreviewToken/PreviewTokenHttpTest.php
+++ b/tests/PreviewToken/PreviewTokenHttpTest.php
@@ -31,6 +31,7 @@ use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
 use NeNeRecords\Tests\EnumField\InMemoryEnumFieldRepository;
 use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
 use NeNeRecords\Tests\IntField\InMemoryIntFieldRepository;
+use NeNeRecords\Tests\Media\InMemoryMediaRepository;
 use NeNeRecords\Tests\Setting\InMemorySettingRepository;
 use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
 use NeNeRecords\TextField\TextField;
@@ -67,7 +68,7 @@ final class PreviewTokenHttpTest extends TestCase
             new TextField(entityId: 10, fieldKey: 'title', value: 'Draft Article', id: 1),
         ], $this->entities);
 
-        $publicSettings = new ListPublicSettingsUseCase(new InMemorySettingRepository());
+        $publicSettings = new ListPublicSettingsUseCase(new InMemorySettingRepository(), new InMemoryMediaRepository());
 
         $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
         $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);

--- a/tests/PublicRecord/GetPublicRecordViewUseCaseTest.php
+++ b/tests/PublicRecord/GetPublicRecordViewUseCaseTest.php
@@ -21,6 +21,7 @@ use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
 use NeNeRecords\Tests\EnumField\InMemoryEnumFieldRepository;
 use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
 use NeNeRecords\Tests\IntField\InMemoryIntFieldRepository;
+use NeNeRecords\Tests\Media\InMemoryMediaRepository;
 use NeNeRecords\Tests\Setting\InMemorySettingRepository;
 use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
 use NeNeRecords\TextField\TextField;
@@ -57,7 +58,7 @@ final class GetPublicRecordViewUseCaseTest extends TestCase
             new InMemoryBoolFieldRepository(),
             new InMemoryDateTimeFieldRepository(),
             new InMemoryEntityRelationRepository(),
-            new ListPublicSettingsUseCase(new InMemorySettingRepository()),
+            new ListPublicSettingsUseCase(new InMemorySettingRepository(), new InMemoryMediaRepository()),
         );
 
         $output = $useCase->execute(new GetPublicRecordViewInput('article', 'hello-world'));
@@ -83,7 +84,7 @@ final class GetPublicRecordViewUseCaseTest extends TestCase
             new InMemoryBoolFieldRepository(),
             new InMemoryDateTimeFieldRepository(),
             new InMemoryEntityRelationRepository(),
-            new ListPublicSettingsUseCase(new InMemorySettingRepository()),
+            new ListPublicSettingsUseCase(new InMemorySettingRepository(), new InMemoryMediaRepository()),
         );
 
         $this->expectException(PublicEntityTypeNotFoundException::class);
@@ -106,7 +107,7 @@ final class GetPublicRecordViewUseCaseTest extends TestCase
             new InMemoryBoolFieldRepository(),
             new InMemoryDateTimeFieldRepository(),
             new InMemoryEntityRelationRepository(),
-            new ListPublicSettingsUseCase(new InMemorySettingRepository()),
+            new ListPublicSettingsUseCase(new InMemorySettingRepository(), new InMemoryMediaRepository()),
         );
 
         $this->expectException(PublicRecordNotFoundException::class);

--- a/tests/PublicRecord/PublicCacheHttpTest.php
+++ b/tests/PublicRecord/PublicCacheHttpTest.php
@@ -31,6 +31,7 @@ use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
 use NeNeRecords\Tests\EnumField\InMemoryEnumFieldRepository;
 use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
 use NeNeRecords\Tests\IntField\InMemoryIntFieldRepository;
+use NeNeRecords\Tests\Media\InMemoryMediaRepository;
 use NeNeRecords\Tests\NavigationItem\InMemoryNavigationItemRepository;
 use NeNeRecords\Tests\Setting\InMemorySettingRepository;
 use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
@@ -67,7 +68,7 @@ final class PublicCacheHttpTest extends TestCase
         ], $entities);
 
         $settingRepo = new InMemorySettingRepository();
-        $publicSettings = new ListPublicSettingsUseCase($settingRepo);
+        $publicSettings = new ListPublicSettingsUseCase($settingRepo, new InMemoryMediaRepository());
 
         $navRepo = new InMemoryNavigationItemRepository();
         $navRepo->save(new NavigationItem(id: null, label: 'Home', url: '/', displayOrder: 0, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z'));

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -31,6 +31,7 @@ use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
 use NeNeRecords\Tests\EnumField\InMemoryEnumFieldRepository;
 use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
 use NeNeRecords\Tests\IntField\InMemoryIntFieldRepository;
+use NeNeRecords\Tests\Media\InMemoryMediaRepository;
 use NeNeRecords\Tests\Setting\InMemorySettingRepository;
 use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
 use NeNeRecords\TextField\TextField;
@@ -67,7 +68,7 @@ final class PublicRecordHttpTest extends TestCase
             new TextField(entityId: 10, fieldKey: 'body', value: "## Sample\n\n**bold** line", id: 2),
         ], $entities);
 
-        $publicSettings = new ListPublicSettingsUseCase(new InMemorySettingRepository());
+        $publicSettings = new ListPublicSettingsUseCase(new InMemorySettingRepository(), new InMemoryMediaRepository());
 
         $useCase = new GetPublicRecordViewUseCase(
             $entityTypes,

--- a/tests/Setting/ListPublicSettingsMediaTest.php
+++ b/tests/Setting/ListPublicSettingsMediaTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Setting;
+
+use NeNeRecords\Media\Media;
+use NeNeRecords\Setting\ListPublicSettingsUseCase;
+use NeNeRecords\Setting\SettingDef;
+use NeNeRecords\Tests\Media\InMemoryMediaRepository;
+use PHPUnit\Framework\TestCase;
+
+final class ListPublicSettingsMediaTest extends TestCase
+{
+    public function testMediaSettingResolvesToUrl(): void
+    {
+        $settings = new InMemorySettingRepository([
+            new SettingDef('logo_media_id', 'media', '', true, 'Logo'),
+        ]);
+        $settings->applyValueDirect('logo_media_id', '7', null);
+
+        $media = new InMemoryMediaRepository([
+            new Media(
+                id: 7,
+                originalName: 'logo.png',
+                storedName: 'logo.png',
+                mimeType: 'image/png',
+                size: 100,
+                url: '/media/2026/06/logo.png',
+                createdAt: '2026-06-17 00:00:00',
+            ),
+        ]);
+
+        $output = (new ListPublicSettingsUseCase($settings, $media))->execute();
+
+        $this->assertSame('/media/2026/06/logo.png', $this->valueOf($output->items, 'logo_media_id'));
+    }
+
+    public function testUnsetOrMissingMediaResolvesToEmpty(): void
+    {
+        $settings = new InMemorySettingRepository([
+            new SettingDef('logo_media_id', 'media', '', true, 'Logo'),
+        ]);
+        // value points at a media id that does not exist
+        $settings->applyValueDirect('logo_media_id', '999', null);
+
+        $output = (new ListPublicSettingsUseCase($settings, new InMemoryMediaRepository()))->execute();
+
+        $this->assertSame('', $this->valueOf($output->items, 'logo_media_id'));
+    }
+
+    /**
+     * @param list<\NeNeRecords\Setting\SettingEntry> $items
+     */
+    private function valueOf(array $items, string $key): ?string
+    {
+        foreach ($items as $entry) {
+            if ($entry->def->settingKey === $key) {
+                return $entry->effectiveValue;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Setting/SettingHttpTest.php
+++ b/tests/Setting/SettingHttpTest.php
@@ -18,6 +18,7 @@ use NeNeRecords\Setting\SettingKeyNotFoundExceptionHandler;
 use NeNeRecords\Setting\SettingRouteRegistrar;
 use NeNeRecords\Setting\SettingValueInvalidExceptionHandler;
 use NeNeRecords\Setting\UpdateSettingHandler;
+use NeNeRecords\Tests\Media\InMemoryMediaRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -58,7 +59,7 @@ final class SettingHttpTest extends TestCase
 
         $registrar = new SettingRouteRegistrar(
             new ListSettingsHandler(new ListSettingsUseCase($this->repository), $jsonResponse),
-            new ListPublicSettingsHandler(new ListPublicSettingsUseCase($this->repository), $jsonResponse, $this->factory),
+            new ListPublicSettingsHandler(new ListPublicSettingsUseCase($this->repository, new InMemoryMediaRepository()), $jsonResponse, $this->factory),
             new UpdateSettingHandler(new InMemoryUpdateSettingUseCase($this->repository), $jsonResponse),
             new ListSettingRevisionsHandler(new ListSettingRevisionsUseCase($this->repository), $jsonResponse),
         );


### PR DESCRIPTION
## 目的
公開サイトのヘッダー/フッターで編集できなかった **ロゴ**と**著作権表記**を管理画面から設定できるようにする（Phase 1）。方針は「型付き設定を個別追加し、シェルはテーマ非依存に描画・テーマは見た目だけ当てる」（既存 `site_name`/`footer_markdown` と同じ流儀＝自由度と安定の両立）。

## 変更内容

### バックエンド
- `setting_defs` に 2 キーを **per-org 冪等**で追加（`AddChromeSettings`）：
  - `logo_media_id`（新 data_type **`media`** ＝メディアライブラリ #299 参照）
  - `copyright_text`（text・既定 `© {year} {site}`）
- `SettingValueValidator` に `media` 型（空 or 正の整数=メディアid）を追加。
- 公開設定 API で `media` 型を **id→URL に解決**（`ListPublicSettingsUseCase` に `MediaRepository` を注入）。レスポンスは従来どおり `key→string` のまま＝契約不変・キャッシュ/ETag 据え置き。将来の hero/OG 画像にも再利用可能。

### フロントエンド
- `PublicShell` が `logo`（解決済みURL）/ `copyrightText` を site context に追加。
- `PublicSiteShell`：ロゴ画像があれば `.brand__mark` に `<img>`、無ければ `NeneMark` SVG に**フォールバック**（常に壊れない）。フッター著作権は `{year}`/`{site}` を置換、未設定は現行書式。
- 管理サイト設定に `media` 型の**画像ピッカー**（プレビュー＋select）を追加。
- `.brand__logo` の base CSS、i18n（`admin.settings.media.none`）。

### テーマ
- シェルがテーマ非依存に描画。テーマは既存クラスフック（`.brand__mark`/`.ft__free`/`.ft__bar`）で見た目だけ＝17テーマに内容ロジックを足さない。

## 非スコープ（Phase 2 以降）
- ヘッダー/フッターのメニューロケーション化（"Content/Browse" 撤去）／ソーシャルリンクの型付きリスト。
- 注釈は既存 `footer_markdown` で対応済み。

## 検証
- ✅ backend：PHPStan / CS-Fixer / OpenAPI / PHPUnit **693** 緑（メディア解決の単体テスト追加）
- ✅ frontend：type-check / lint / prettier / test **200** 緑
- ✅ ライブ：公開設定 API が `logo_media_id`（id→URL 解決）/ `copyright_text` を返すことを確認
- ✅ ロゴ未設定でも SVG フォールバックで壊れない

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)