### PR TITLE
feat(public): トップフィードの列数フラグ feedColumns (#402)

### DIFF
--- a/docs/theming/public-theme.schema.json
+++ b/docs/theming/public-theme.schema.json
@@ -82,6 +82,7 @@
       "additionalProperties": false,
       "properties": {
         "feedLayout": { "enum": ["grid", "list", "magazine"] },
+        "feedColumns": { "enum": ["auto", "2", "3", "4"] },
         "cardStyle": { "enum": ["flat", "bordered", "shadowed", "framed"] },
         "media": { "enum": ["plain", "duotone", "grayscale", "framed"] },
         "hero": { "enum": ["standard", "fullbleed", "minimal"] },

--- a/docs/theming/theme-flags.md
+++ b/docs/theming/theme-flags.md
@@ -23,6 +23,7 @@ A だけでも「WP の定番テーマ」級は出せる。語彙に収まらな
 | フラグ        | data 属性      | 値                                              | 効果（base CSS が実装）                                                                                                            |
 | ------------- | -------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | `feedLayout`  | `data-feed`    | `grid` \| `list` \| `magazine`                  | 最新フィードの版面。grid=均等カード / list=横長行（`.cardgrid`→1カラム化、`.card`を行化）/ magazine=フィーチャー＋グリッド（現行） |
+| `feedColumns` | `data-feed-cols` | `auto` \| `2` \| `3` \| `4`                   | グリッドフィードの列数。auto=幅に応じた auto-fill（現行）/ 2・3・4=固定列（`.layout__main` のコンテナ幅で段階縮小）。`feedLayout=list` 時は無効 |
 | `cardStyle`   | `data-cards`   | `flat` \| `bordered` \| `shadowed` \| `framed`  | `.card` の意匠（枠/影/額装）                                                                                                       |
 | `media`       | `data-media`   | `plain` \| `duotone` \| `grayscale` \| `framed` | `.card__media` / `.featured__media` / `.article__hero` の見せ方（`filter`/枠）                                                     |
 | `hero`        | `data-hero`    | `standard` \| `fullbleed` \| `minimal`          | `.hero` 構図（minimal=アート省略・タイポ主体 / fullbleed=幅広）                                                                    |

--- a/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
+++ b/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
@@ -201,6 +201,16 @@ export function ThemeCustomizeView({
               }}
             />
           </Field>
+          <Field label={t('admin.themeCustomize.feedColumns')}>
+            <Select
+              value={draft.flags?.feedColumns}
+              options={FLAG_DEFS.feedColumns.options}
+              placeholder={themePlaceholder}
+              onChange={(v) => {
+                setKnob('flags', { ...draft.flags, feedColumns: v })
+              }}
+            />
+          </Field>
           <Field label={t('admin.themeCustomize.cardStyle')}>
             <Select
               value={draft.flags?.cardStyle}

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -1659,6 +1659,33 @@
    data-* attributes on .nene-public (see docs/theming/theme-flags.md).
    Implemented once here; themes/JSON just opt in. No DOM changes. */
 
+/* feedColumns — fix the grid feed to N columns (auto = default auto-fill).
+   Guarded so it never fights feedLayout=list (which is a 1-column row mode).
+   .layout__main is a size container, so columns collapse as the column narrows
+   — fixed counts never crush the cards. */
+.nene-public[data-feed-cols='2']:not([data-feed='list']) .cardgrid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.nene-public[data-feed-cols='3']:not([data-feed='list']) .cardgrid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.nene-public[data-feed-cols='4']:not([data-feed='list']) .cardgrid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+@container (max-width: 760px) {
+  .nene-public[data-feed-cols='3']:not([data-feed='list']) .cardgrid,
+  .nene-public[data-feed-cols='4']:not([data-feed='list']) .cardgrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@container (max-width: 460px) {
+  .nene-public[data-feed-cols='2']:not([data-feed='list']) .cardgrid,
+  .nene-public[data-feed-cols='3']:not([data-feed='list']) .cardgrid,
+  .nene-public[data-feed-cols='4']:not([data-feed='list']) .cardgrid {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* feedLayout=list — the latest feed becomes full-width rows (grid areas keep
    the flat card markup: media | meta/title/excerpt). */
 .nene-public[data-feed='list'] .cardgrid {

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -72,6 +72,7 @@ export const en = {
   'admin.themeCustomize.typeScale': 'Type scale',
   'admin.themeCustomize.density': 'Density',
   'admin.themeCustomize.feedLayout': 'Feed layout',
+  'admin.themeCustomize.feedColumns': 'Feed columns',
   'admin.themeCustomize.cardStyle': 'Card style',
   'admin.themeCustomize.media': 'Imagery',
   'admin.themeCustomize.hero': 'Hero',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -65,6 +65,7 @@ export const ja: Partial<MessageCatalog> = {
   'admin.themeCustomize.typeScale': '見出しスケール',
   'admin.themeCustomize.density': '密度',
   'admin.themeCustomize.feedLayout': 'フィード版面',
+  'admin.themeCustomize.feedColumns': 'フィード列数',
   'admin.themeCustomize.cardStyle': 'カード意匠',
   'admin.themeCustomize.media': 'メディア',
   'admin.themeCustomize.hero': 'ヒーロー',

--- a/frontend/src/shared/lib/theme-customization.ts
+++ b/frontend/src/shared/lib/theme-customization.ts
@@ -47,6 +47,7 @@ export interface ColorPair {
 /** Structural style flags — enumerated; implemented once in base CSS. */
 export interface ThemeFlags {
   feedLayout?: string
+  feedColumns?: string
   cardStyle?: string
   media?: string
   hero?: string
@@ -63,6 +64,15 @@ export const FLAG_DEFS: Record<keyof ThemeFlags, { attr: string; options: readon
         { value: 'grid', label: 'Grid' },
         { value: 'list', label: 'List' },
         { value: 'magazine', label: 'Magazine' },
+      ],
+    },
+    feedColumns: {
+      attr: 'data-feed-cols',
+      options: [
+        { value: 'auto', label: 'Auto' },
+        { value: '2', label: '2' },
+        { value: '3', label: '3' },
+        { value: '4', label: '4' },
       ],
     },
     cardStyle: {


### PR DESCRIPTION
## 目的
トップの最新フィード（グリッド）の**列数**を明示指定できるようにする。現状は `repeat(auto-fill, minmax(258px,1fr))` で列数が自動のみ。

## 変更内容
#390 のスタイルフラグエンジンに **`feedColumns`**（`data-feed-cols`）を追加：
- 値: `auto`（既定・現行の auto-fill）/ `2` / `3` / `4`
- base CSS（`public-site.css`）で固定列を実装。`.layout__main` はサイズコンテナなので**コンテナ幅で段階縮小**（760px で 3/4→2、460px で →1）＝固定列でもカードが潰れない。
- `feedLayout=list` 時は `:not([data-feed='list'])` ガードで無効（list は1列行モードのため）。
- `FLAG_DEFS` / `ThemeFlags` に追加（`resolveFlagAttrs` が自動で `data-*` を付与）。
- `public-theme.schema.json` の flags enum に追加（validator が検証）。
- カスタマイザに「フィード列数」プルダウン＋ en/ja i18n。
- `theme-flags.md` 語彙表を更新。

テーマ manifest の `flags` からも、管理カスタマイザからも指定可能。

## 検証
- ✅ type-check / lint / prettier
- ✅ `npm run validate:themes`（schema 変更後も全27 bundle 合格）
- ✅ unit テスト（theme-customization / manage-appearance）緑
- ✅ dev サーバ HMR クリーン

Refs #402 #390 #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)