### PR TITLE
fix(public): feedColumns に 1 列追加・効きを明確化 (#402)

### DIFF
--- a/docs/theming/public-theme.schema.json
+++ b/docs/theming/public-theme.schema.json
@@ -82,7 +82,7 @@
       "additionalProperties": false,
       "properties": {
         "feedLayout": { "enum": ["grid", "list", "magazine"] },
-        "feedColumns": { "enum": ["auto", "2", "3", "4"] },
+        "feedColumns": { "enum": ["auto", "1", "2", "3", "4"] },
         "cardStyle": { "enum": ["flat", "bordered", "shadowed", "framed"] },
         "media": { "enum": ["plain", "duotone", "grayscale", "framed"] },
         "hero": { "enum": ["standard", "fullbleed", "minimal"] },

--- a/docs/theming/theme-flags.md
+++ b/docs/theming/theme-flags.md
@@ -23,7 +23,7 @@ A だけでも「WP の定番テーマ」級は出せる。語彙に収まらな
 | フラグ        | data 属性      | 値                                              | 効果（base CSS が実装）                                                                                                            |
 | ------------- | -------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | `feedLayout`  | `data-feed`    | `grid` \| `list` \| `magazine`                  | 最新フィードの版面。grid=均等カード / list=横長行（`.cardgrid`→1カラム化、`.card`を行化）/ magazine=フィーチャー＋グリッド（現行） |
-| `feedColumns` | `data-feed-cols` | `auto` \| `2` \| `3` \| `4`                   | グリッドフィードの列数。auto=幅に応じた auto-fill（現行）/ 2・3・4=固定列（`.layout__main` のコンテナ幅で段階縮小）。`feedLayout=list` 時は無効 |
+| `feedColumns` | `data-feed-cols` | `auto` \| `1` \| `2` \| `3` \| `4`            | グリッドフィードの列数。auto=幅に応じた auto-fill（現行）/ 1〜4=固定列（デスクトップ/タブレットは尊重、スマホ幅 ≤430px で 1 列に畳む。4 は ≤620px で 2 列）。`feedLayout=list` 時は無効 |
 | `cardStyle`   | `data-cards`   | `flat` \| `bordered` \| `shadowed` \| `framed`  | `.card` の意匠（枠/影/額装）                                                                                                       |
 | `media`       | `data-media`   | `plain` \| `duotone` \| `grayscale` \| `framed` | `.card__media` / `.featured__media` / `.article__hero` の見せ方（`filter`/枠）                                                     |
 | `hero`        | `data-hero`    | `standard` \| `fullbleed` \| `minimal`          | `.hero` 構図（minimal=アート省略・タイポ主体 / fullbleed=幅広）                                                                    |

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -1659,10 +1659,13 @@
    data-* attributes on .nene-public (see docs/theming/theme-flags.md).
    Implemented once here; themes/JSON just opt in. No DOM changes. */
 
-/* feedColumns — fix the grid feed to N columns (auto = default auto-fill).
-   Guarded so it never fights feedLayout=list (which is a 1-column row mode).
-   .layout__main is a size container, so columns collapse as the column narrows
-   — fixed counts never crush the cards. */
+/* feedColumns — fix the grid feed to an exact column count (auto = default
+   auto-fill). Guarded so it never fights feedLayout=list (a 1-column row mode).
+   The chosen count is respected on desktop/tablet; .layout__main is a size
+   container, so we only fold multi-column feeds down to one on phone widths. */
+.nene-public[data-feed-cols='1']:not([data-feed='list']) .cardgrid {
+  grid-template-columns: 1fr;
+}
 .nene-public[data-feed-cols='2']:not([data-feed='list']) .cardgrid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
@@ -1672,13 +1675,14 @@
 .nene-public[data-feed-cols='4']:not([data-feed='list']) .cardgrid {
   grid-template-columns: repeat(4, minmax(0, 1fr));
 }
-@container (max-width: 760px) {
-  .nene-public[data-feed-cols='3']:not([data-feed='list']) .cardgrid,
+/* 4 columns get crowded first — step to 2 on a narrow-ish column. */
+@container (max-width: 620px) {
   .nene-public[data-feed-cols='4']:not([data-feed='list']) .cardgrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
-@container (max-width: 460px) {
+/* phone width: any fixed multi-column feed folds to a single column. */
+@container (max-width: 430px) {
   .nene-public[data-feed-cols='2']:not([data-feed='list']) .cardgrid,
   .nene-public[data-feed-cols='3']:not([data-feed='list']) .cardgrid,
   .nene-public[data-feed-cols='4']:not([data-feed='list']) .cardgrid {

--- a/frontend/src/shared/lib/theme-customization.ts
+++ b/frontend/src/shared/lib/theme-customization.ts
@@ -70,6 +70,7 @@ export const FLAG_DEFS: Record<keyof ThemeFlags, { attr: string; options: readon
       attr: 'data-feed-cols',
       options: [
         { value: 'auto', label: 'Auto' },
+        { value: '1', label: '1' },
         { value: '2', label: '2' },
         { value: '3', label: '3' },
         { value: '4', label: '4' },


### PR DESCRIPTION
## 背景
`feedColumns` を入れたが、「1 にできない」「変化しないように見える」との指摘。

## 原因
コンテナ collapse が積極的すぎた（`@container ≤760px` で 3/4→2）。home フィードの main 列幅だと、選んだ「3」が 760px 以下に入って 2 列へ畳まれ、その幅での auto（≈2列）と同じ見た目になり、変化が分からなかった。

## 修正
- **`1` を追加**（`auto / 1 / 2 / 3 / 4`）。schema enum・カスタマイザ・doc に反映。
- **明示した列数はデスクトップ/タブレットで尊重**。スマホ幅（コンテナ ≤430px）でのみ全多列を 1 列へ。4 列のみ ≤620px で 2 列に。
- これで 2/3/4/1 の選択が画面でちゃんと変わる。

## 検証
- ✅ type-check / lint / prettier / validate:themes（全27合格）/ unit テスト緑
- ✅ dev HMR クリーン

Refs #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)