### PR TITLE
feat(admin): テーマカスタマイザの保存トースト (#367)

### DIFF
--- a/frontend/src/features/manage-appearance/hooks/useThemeCustomizePage.ts
+++ b/frontend/src/features/manage-appearance/hooks/useThemeCustomizePage.ts
@@ -1,7 +1,9 @@
 import { useState } from 'react'
 import { useUpdateSetting, useSettingList } from '@/entities/setting'
+import { useTranslation } from '@/shared/i18n'
 import { resolvePublicThemeId } from '@/shared/lib/public-themes'
 import { parseThemeOverrides, type ThemeOverrides } from '@/shared/lib/theme-customization'
+import { useToast } from '@/shared/ui'
 
 const ACTIVE_THEME_KEY = 'active_theme'
 const OVERRIDES_KEY = 'theme_overrides'
@@ -34,6 +36,8 @@ function clean(overrides: ThemeOverrides): ThemeOverrides {
 export function useThemeCustomizePage(): ThemeCustomizePageState {
   const settingsQuery = useSettingList()
   const updateSetting = useUpdateSetting()
+  const { showToast } = useToast()
+  const { t } = useTranslation()
 
   const items = settingsQuery.data?.items
   const themeId = resolvePublicThemeId(
@@ -71,7 +75,17 @@ export function useThemeCustomizePage(): ThemeCustomizePageState {
     if (Object.keys(cleaned).length > 0) {
       next[themeId] = cleaned
     }
-    updateSetting.mutate({ settingKey: OVERRIDES_KEY, input: { value: JSON.stringify(next) } })
+    updateSetting.mutate(
+      { settingKey: OVERRIDES_KEY, input: { value: JSON.stringify(next) } },
+      {
+        onSuccess: () => {
+          showToast(t('admin.themeCustomize.saved'), 'success')
+        },
+        onError: () => {
+          showToast(t('admin.themeCustomize.saveError'), 'error')
+        },
+      },
+    )
   }
 
   return {

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -80,6 +80,8 @@ export const en = {
   'admin.themeCustomize.eyebrow': 'Eyebrow',
   'admin.themeCustomize.basic': 'Basics',
   'admin.themeCustomize.advanced': 'Advanced',
+  'admin.themeCustomize.saved': 'Customization saved',
+  'admin.themeCustomize.saveError': 'Could not save customization',
   'admin.themeCustomize.save': 'Save',
   'admin.themeCustomize.saving': 'Saving…',
   'admin.themeCustomize.reset': 'Reset',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -73,6 +73,8 @@ export const ja: Partial<MessageCatalog> = {
   'admin.themeCustomize.eyebrow': 'アイブロウ',
   'admin.themeCustomize.basic': '基本',
   'admin.themeCustomize.advanced': '詳細設定',
+  'admin.themeCustomize.saved': 'カスタマイズを保存しました',
+  'admin.themeCustomize.saveError': 'カスタマイズを保存できませんでした',
   'admin.themeCustomize.save': '保存',
   'admin.themeCustomize.saving': '保存中…',
   'admin.themeCustomize.reset': 'リセット',


### PR DESCRIPTION
## 背景
テーマカスタマイザの「保存」ボタンを押しても無反応で、保存されたか分かりづらかった。

## 変更
- 保存成功/失敗時に**トースト**を表示（既存の `useToast` / `AppShell` の `ToastProvider`）。
- `useThemeCustomizePage` の保存 mutate に `onSuccess`/`onError` を追加。reset も同じ persist を通るのでフィードバックされる。
- i18n: `admin.themeCustomize.saved`（カスタマイズを保存しました）/ `.saveError`（保存できませんでした）en/ja。

## 検証
- ✅ type-check / lint / prettier / unit テスト緑

Refs #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)