### PR TITLE
fix(public): 公開 chrome の即時反映（widgets/menus/navigation キャッシュ）(#406)

### DIFF
--- a/src/Menu/ListPublicMenusHandler.php
+++ b/src/Menu/ListPublicMenusHandler.php
@@ -12,7 +12,10 @@ use Psr\Http\Message\ServerRequestInterface;
 
 final readonly class ListPublicMenusHandler
 {
-    private const CACHE_CONTROL = 'public, max-age=300, stale-while-revalidate=3600';
+    // Admin menu edits must reflect promptly on the public site, so revalidate
+    // every request (cheap 304 via ETag when unchanged) instead of serving a
+    // stale 5-minute cache. Mirrors ListPublicSettingsHandler.
+    private const CACHE_CONTROL = 'public, max-age=0, must-revalidate';
 
     public function __construct(
         private ListMenusUseCaseInterface $useCase,

--- a/src/NavigationItem/ListPublicNavigationItemsHandler.php
+++ b/src/NavigationItem/ListPublicNavigationItemsHandler.php
@@ -12,7 +12,10 @@ use Psr\Http\Message\ServerRequestInterface;
 
 final readonly class ListPublicNavigationItemsHandler
 {
-    private const CACHE_CONTROL = 'public, max-age=300, stale-while-revalidate=3600';
+    // Admin navigation edits must reflect promptly on the public site, so
+    // revalidate every request (cheap 304 via ETag when unchanged) instead of
+    // serving a stale 5-minute cache. Mirrors ListPublicSettingsHandler.
+    private const CACHE_CONTROL = 'public, max-age=0, must-revalidate';
 
     public function __construct(
         private ListNavigationItemsUseCaseInterface $useCase,

--- a/src/Widget/ListPublicWidgetsHandler.php
+++ b/src/Widget/ListPublicWidgetsHandler.php
@@ -12,7 +12,10 @@ use Psr\Http\Message\ServerRequestInterface;
 
 final readonly class ListPublicWidgetsHandler
 {
-    private const CACHE_CONTROL = 'public, max-age=300, stale-while-revalidate=3600';
+    // Admin layout/widget edits must reflect promptly on the public site, so
+    // revalidate every request (cheap 304 via ETag when unchanged) instead of
+    // serving a stale 5-minute cache. Mirrors ListPublicSettingsHandler.
+    private const CACHE_CONTROL = 'public, max-age=0, must-revalidate';
 
     public function __construct(
         private ListWidgetsUseCaseInterface $useCase,

--- a/tests/PublicRecord/PublicCacheHttpTest.php
+++ b/tests/PublicRecord/PublicCacheHttpTest.php
@@ -219,7 +219,8 @@ final class PublicCacheHttpTest extends TestCase
 
         self::assertSame(200, $response->getStatusCode());
         self::assertStringContainsString('public', $response->getHeaderLine('Cache-Control'));
-        self::assertStringContainsString('max-age=300', $response->getHeaderLine('Cache-Control'));
+        self::assertStringContainsString('max-age=0', $response->getHeaderLine('Cache-Control'));
+        self::assertStringContainsString('must-revalidate', $response->getHeaderLine('Cache-Control'));
         self::assertNotEmpty($response->getHeaderLine('ETag'));
     }
 


### PR DESCRIPTION
## 現象
外観 > レイアウトでウィジェットを削除（メニュー/ナビ変更も）しても、公開サイトに最大5分反映されない。例：サイドバーのウィジェットを全消ししてもトップが2カラムのまま。

## 原因
公開 chrome の3ハンドラが `Cache-Control: public, max-age=300, stale-while-revalidate=3600`。ブラウザが最大5分キャッシュを使うため遅延。

## 修正
設定 API（`ListPublicSettingsHandler`）と同様に **`public, max-age=0, must-revalidate`** に変更：
- `ListPublicWidgetsHandler` / `ListPublicMenusHandler` / `ListPublicNavigationItemsHandler`
- いずれも ETag 対応済み → 変化なしは安価な 304、変化時は即時反映。
- 既存テストのキャッシュ assertion を更新。

これで「サイドバーのウィジェットを全消し → トップが即1カラム」になります（**トップの列数は領域のウィジェット有無で決まる仕様**）。

## 補足（別件・未対応）
管理の「レイアウト設定（カラム数 1/2/3）」は**トップ公開には未接続**（トップは widget 有無で列が決まる）。レイアウト設定をトップにも接続するかは別 Issue で検討可。

## 検証
- ✅ PHPStan / CS-Fixer
- ✅ PHPUnit（Widget/Menu/Navigation/PublicCache 52 tests）
- ✅ ライブ：`/api/v1/public/widgets` が `max-age=0, must-revalidate` を返す

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)