### PR TITLE
feat(public): トップのサイドバー/アサイド有無を公開接続 (#408)

### DIFF
--- a/database/migrations/20260617000001_add_layout_config_setting.php
+++ b/database/migrations/20260617000001_add_layout_config_setting.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Per-page public layout config — Phase A (#408).
+ *
+ * Adds a public `layout_config` setting (JSON) so the top page's column layout
+ * (sidebar / aside on/off) is configured in the admin layout builder and applied
+ * to the public site — previously the builder only kept it in localStorage.
+ *
+ * Default mirrors the prior public behaviour: home = 2 columns (a sidebar may
+ * show when sidebar widgets exist; no aside), record = 3 (record detail still
+ * uses its own per-entity/type layout publicly; this is the admin preview seed).
+ *
+ * `setting_defs` is org-scoped, so insert per organization (idempotent).
+ */
+final class AddLayoutConfigSetting extends AbstractMigration
+{
+    private const SETTING_KEY = 'layout_config';
+    private const DEFAULT_VALUE = '{"home":{"columns":2,"mainPos":"left","swap":false},"record":{"columns":3,"mainPos":"left","swap":false}}';
+
+    public function up(): void
+    {
+        if (!$this->hasTable('organizations') || !$this->hasTable('setting_defs')) {
+            return;
+        }
+
+        $pdo = $this->getAdapter()->getConnection();
+        $now = date('Y-m-d H:i:s');
+
+        $orgs = $pdo->query('SELECT id FROM organizations ORDER BY id ASC')->fetchAll(PDO::FETCH_COLUMN);
+
+        $check = $pdo->prepare('SELECT id FROM setting_defs WHERE organization_id = ? AND setting_key = ?');
+        $insert = $pdo->prepare(
+            'INSERT INTO setting_defs (organization_id, setting_key, data_type, default_value, is_public, label, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        );
+
+        foreach ($orgs as $orgIdRaw) {
+            $orgId = (int) $orgIdRaw;
+            $check->execute([$orgId, self::SETTING_KEY]);
+            if ($check->fetch() !== false) {
+                continue;
+            }
+            $insert->execute([
+                $orgId,
+                self::SETTING_KEY,
+                'text',
+                self::DEFAULT_VALUE,
+                1,
+                'Layout',
+                $now,
+                $now,
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        $this->execute("DELETE FROM setting_defs WHERE setting_key = 'layout_config'");
+    }
+}

--- a/frontend/src/features/manage-widgets/ui/ManageWidgetsView.tsx
+++ b/frontend/src/features/manage-widgets/ui/ManageWidgetsView.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react'
+import { useUpdateSetting, useSettingList } from '@/entities/setting'
 import { useTranslation } from '@/shared/i18n'
 import { setChromeRail } from '@/shared/lib/chrome-rail'
 import {
   allActiveSideRegions,
-  loadLayoutConfig,
-  saveLayoutConfig,
+  parseLayoutConfig,
   type LayoutConfig,
   type LayoutPageKey,
   type PageLayout,
@@ -33,10 +33,24 @@ export interface ManageWidgetsViewProps {
 
 export function ManageWidgetsView({ page }: ManageWidgetsViewProps) {
   const { t } = useTranslation()
-  const [cfg, setCfgState] = useState<LayoutConfig>(() => loadLayoutConfig())
+
+  // Layout config is a public setting (`layout_config`) so the top page's
+  // columns apply to the public site — not just this admin browser. Edits
+  // persist immediately; the draft re-syncs when the stored value loads/changes.
+  const settingsQuery = useSettingList()
+  const updateSetting = useUpdateSetting()
+  const storedLayout = settingsQuery.data?.items.find(
+    (item) => item.settingKey === 'layout_config',
+  )?.value
+  const [cfg, setCfgState] = useState<LayoutConfig>(() => parseLayoutConfig(storedLayout))
+  const [syncedLayout, setSyncedLayout] = useState(storedLayout)
+  if (storedLayout !== syncedLayout) {
+    setSyncedLayout(storedLayout)
+    setCfgState(parseLayoutConfig(storedLayout))
+  }
   const setCfg = (next: LayoutConfig) => {
     setCfgState(next)
-    saveLayoutConfig(next)
+    updateSetting.mutate({ settingKey: 'layout_config', input: { value: JSON.stringify(next) } })
   }
 
   const [mode, setMode] = useState<LayoutMode>(() =>

--- a/frontend/src/pages/consumer/PublicIndexPage.tsx
+++ b/frontend/src/pages/consumer/PublicIndexPage.tsx
@@ -1,4 +1,5 @@
 import { PublicHomeBody, PublicHomeHero, usePublicHomePage } from '@/features/public-home'
+import { activeSideRegions } from '@/shared/lib/layout-config'
 import { PublicSiteShell } from './PublicSiteShell'
 import { usePublicSite } from './public-site-context'
 
@@ -24,10 +25,16 @@ export function PublicIndexPage() {
 
   const browseHref = types[0]?.href ?? '/search'
 
+  // Top-page columns come from the admin layout config (layout_config.home):
+  // a side region renders when the config enables it AND it has widgets.
+  const homeSides = activeSideRegions(site.homeLayout)
+
   return (
     <PublicSiteShell
       site={site}
       isHome
+      withSidebar={homeSides.includes('sidebar')}
+      withAside={homeSides.includes('aside')}
       hero={
         <PublicHomeHero
           siteName={site.siteName}

--- a/frontend/src/pages/consumer/PublicShell.tsx
+++ b/frontend/src/pages/consumer/PublicShell.tsx
@@ -4,6 +4,7 @@ import './public-fonts'
 import { Outlet } from 'react-router-dom'
 import { usePublicNavigationItems } from '@/entities/navigation-item'
 import { publicSettingsToMap, usePublicSettings } from '@/entities/setting'
+import { parseLayoutConfig } from '@/shared/lib/layout-config'
 import {
   readStoredActiveTheme,
   resolvePublicThemeId,
@@ -73,6 +74,7 @@ export function PublicShell() {
     footerMarkdown: settings.footer_markdown ?? '',
     logo: settings.logo_media_id ?? '',
     copyrightText: settings.copyright_text ?? '',
+    homeLayout: parseLayoutConfig(settings.layout_config).home,
     navItems,
     activeTheme,
     themeOverrideCss: overrideCssForTheme(overridesRaw, activeTheme),

--- a/frontend/src/pages/consumer/public-site-context.ts
+++ b/frontend/src/pages/consumer/public-site-context.ts
@@ -1,4 +1,5 @@
 import { useOutletContext } from 'react-router-dom'
+import type { PageLayout } from '@/shared/lib/layout-config'
 
 export interface PublicSiteNavItem {
   id: number
@@ -20,6 +21,8 @@ export interface PublicSite {
   logo: string
   /** Footer copyright text; `{year}`/`{site}` tokens substituted at render. */
   copyrightText: string
+  /** Top-page column layout (`layout_config.home`) — drives sidebar/aside on home. */
+  homeLayout: PageLayout
   navItems: PublicSiteNavItem[]
   /** Admin-selected public-site theme id (`active_theme` setting). */
   activeTheme: string

--- a/frontend/src/shared/lib/layout-config.ts
+++ b/frontend/src/shared/lib/layout-config.ts
@@ -102,11 +102,21 @@ export function migrateLayoutConfig(raw: unknown): LayoutConfig {
   return { home: { ...DEFAULT_PAGE_LAYOUT.home }, record: { ...DEFAULT_PAGE_LAYOUT.record } }
 }
 
+/** Coerce a stored JSON string (e.g. the `layout_config` setting) into a config. */
+export function parseLayoutConfig(raw: string | null | undefined): LayoutConfig {
+  if (raw === null || raw === undefined || raw === '') {
+    return migrateLayoutConfig(null)
+  }
+  try {
+    return migrateLayoutConfig(JSON.parse(raw))
+  } catch {
+    return migrateLayoutConfig(null)
+  }
+}
+
 export function loadLayoutConfig(): LayoutConfig {
   try {
-    const raw = localStorage.getItem(LS_KEY)
-    if (raw === null) return migrateLayoutConfig(null)
-    return migrateLayoutConfig(JSON.parse(raw))
+    return parseLayoutConfig(localStorage.getItem(LS_KEY))
   } catch {
     return migrateLayoutConfig(null)
   }

--- a/frontend/tests/render/PublicSiteTestProvider.tsx
+++ b/frontend/tests/render/PublicSiteTestProvider.tsx
@@ -8,6 +8,7 @@ const TEST_SITE: PublicSite = {
   footerMarkdown: '',
   logo: '',
   copyrightText: '',
+  homeLayout: { columns: 2, mainPos: 'left', swap: false },
   navItems: [],
   activeTheme: 'consumer',
   themeOverrideCss: '',


### PR DESCRIPTION
## 背景
管理「外観 > レイアウト」のページ別カラム数（home/record）は **localStorage のみ**で、バックエンド未保存・公開未接続だった（`layout-config.ts` のコメント参照）。そのため「トップだけサイドバー有/無」が公開に効かず、トップの列は widget 有無だけで決まっていた。

## 変更（スコープA：カラム数→サイドバー/アサイド有無）
- **backend**: `setting_defs` に `layout_config`（text/JSON, `is_public=1`）を per-org 冪等で追加。既定 `home=2`（サイドバー可・アサイド無し＝**現行挙動維持**）/ `record=3`。公開設定 API で配信。
- **public**: `PublicShell` が `layout_config` を解析し `home` の `PageLayout` を site context へ。`PublicIndexPage` が `activeSideRegions(home)` から `withSidebar`/`withAside` を渡す。空領域は従来どおり畳む。
- **admin**: `ManageWidgetsView` の cfg を localStorage → `layout_config` 設定の読み書きに（編集は即保存・ストア値ロード時に再同期）。
- **lib**: `parseLayoutConfig(raw)` を追加。

→ 「トップ=2カラム（サイドバー有）/ 1カラム（無し）」が公開に効く。先日のキャッシュ即時反映(#406)と併せ、変更がすぐ反映。

## 非スコープ
- `mainPos`/`swap`（主栏位置・左右入替）の公開反映。
- record の公開接続（record は既存の per-entity/type レイアウトのまま）。

## 検証
- ✅ backend: PHPStan / CS / PHPUnit（Setting/PublicCache/PublicRecord/Widget 82）緑、マイグレーション適用・公開設定に `layout_config` 出力を確認。
- ✅ frontend: type-check / lint / prettier / test 79 緑。
- ℹ️ dev に出た ThemeTab のフック順 warning は、別PR(#405)のフックを hot-edit した際の HMR 偽陽性（フルリロード・CI では解消）。本変更とは無関係。

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)