### PR TITLE
fix(admin): レイアウトのウィジェット選択/DnD が効かない（Card の DOM 属性 forward）(#410)

### DIFF
--- a/frontend/src/shared/ui/components/Card.tsx
+++ b/frontend/src/shared/ui/components/Card.tsx
@@ -1,9 +1,9 @@
-import type { ReactNode } from 'react'
+import type { HTMLAttributes, ReactNode } from 'react'
 
 export type CardPadding = 'none' | 'row' | 'md' | 'lg'
 export type CardElement = 'div' | 'li' | 'section' | 'article' | 'form'
 
-export interface CardProps {
+export interface CardProps extends HTMLAttributes<HTMLElement> {
   as?: CardElement
   /** `row` for list items, `md` (default) for cards, `lg` for section panels. */
   padding?: CardPadding
@@ -11,8 +11,6 @@ export interface CardProps {
   interactive?: boolean
   className?: string
   children: ReactNode
-  /** Only used with `as="form"`. */
-  onSubmit?: React.ComponentPropsWithoutRef<'form'>['onSubmit']
 }
 
 const paddingClasses: Record<CardPadding, string> = {
@@ -27,6 +25,11 @@ const paddingClasses: Record<CardPadding, string> = {
  * rounded, shadowed `--surface-raised` box. List rows, stat tiles, form
  * panels and section blocks all share this so borders/radius/elevation
  * are defined once. Choose `padding` per density; pass `className` for layout.
+ *
+ * Extends the root element's HTML attributes, so callers can attach interaction
+ * props (onClick, draggable, onDragStart/End, data-*, etc.); they are forwarded
+ * to the chosen element. This is what makes a Card row clickable / draggable
+ * (e.g. the layout builder's widget cards).
  */
 export function Card({
   as: Component = 'div',
@@ -34,7 +37,7 @@ export function Card({
   interactive = false,
   className,
   children,
-  onSubmit,
+  ...rest
 }: CardProps) {
   const classes = [
     'rounded-md border border-border bg-surface-raised shadow-sm',
@@ -46,7 +49,7 @@ export function Card({
     .join(' ')
 
   return (
-    <Component className={classes} onSubmit={Component === 'form' ? onSubmit : undefined}>
+    <Component className={classes} {...rest}>
       {children}
     </Component>
   )


### PR DESCRIPTION
## 現象
外観 > レイアウト（DnD ビルダー）で、配置済みウィジェットを **クリックしても選択できない**（→ インスペクタで設定できない）／**DnD で並べ替えできない**。削除ボタンだけ効く。

## 原因
`WidgetRegionBoard` は `<Card as="li" onClick draggable onDragStart onDragEnd data-wcard …>` を使うが、共有 `Card` が `as/padding/interactive/className/children/onSubmit` しか受け取らず、**onClick・draggable・ドラッグハンドラ・data-* を DOM に forward していなかった**。削除は別の `Button` コンポーネントなので効いていた（症状が「削除だけ効く」と一致）。

## 修正
`CardProps` を `React.HTMLAttributes<HTMLElement>` 継承にし、残り props を root 要素へ spread。これでカード行がクリック/ドラッグ可能になる。既存の Card 利用は superset なので非互換なし。

## 検証
- ✅ type-check（`data-wcard`/onClick/draggable が正しく型付け・forward される）
- ✅ lint / prettier
- ✅ unit テスト 200 緑（Card は全体で多用されるため全テスト実行）

※ 本件は先日のレイアウト公開接続(#408)とは無関係の既存バグ。

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)