### PR TITLE
fix(entity): 一覧APIに meta を含め抜粋表示を有効化 (#414)

### DIFF
--- a/src/Entity/ListEntitiesHandler.php
+++ b/src/Entity/ListEntitiesHandler.php
@@ -80,6 +80,8 @@ final readonly class ListEntitiesHandler
                         'deleted_at' => $item->deletedAtIso,
                         'created_at' => $item->createdAtIso,
                         'updated_at' => $item->updatedAtIso,
+                        'meta_title' => $item->metaTitle,
+                        'meta_description' => $item->metaDescription,
                     ],
                     $output->items,
                 ),

--- a/src/Entity/ListEntitiesUseCase.php
+++ b/src/Entity/ListEntitiesUseCase.php
@@ -37,6 +37,8 @@ final readonly class ListEntitiesUseCase implements ListEntitiesUseCaseInterface
                 scheduledAtIso: $entity->scheduledAt?->format(DateTimeInterface::ATOM),
                 createdAtIso: $entity->createdAt?->format(DateTimeInterface::ATOM),
                 updatedAtIso: $entity->updatedAt?->format(DateTimeInterface::ATOM),
+                metaTitle: $entity->metaTitle,
+                metaDescription: $entity->metaDescription,
             );
         }, $rows);
 

--- a/src/Entity/ListEntityItem.php
+++ b/src/Entity/ListEntityItem.php
@@ -17,6 +17,8 @@ final readonly class ListEntityItem
         public ?string $scheduledAtIso = null,
         public ?string $createdAtIso = null,
         public ?string $updatedAtIso = null,
+        public ?string $metaTitle = null,
+        public ?string $metaDescription = null,
     ) {
     }
 }


### PR DESCRIPTION
## 現象
最近の投稿ウィジェット（#413）と公開トップのフィードで**抜粋が表示されない**。

## 原因
抜粋は記事の SEO メタ説明（`meta_description`）を使うが、**エンティティ一覧 API（`/api/v1/entities`）が `meta_title`/`meta_description` を返していなかった**。
- `entities` テーブルにカラムはあり、list クエリも SELECT 済み。
- だが `ListEntityItem` DTO に meta フィールドが無く、`ListEntitiesHandler` の出力配列にも無かった → フロントの `dto.meta_description` が常に undefined。

## 修正（backend のみ）
- `ListEntityItem` に `metaTitle`/`metaDescription` 追加。
- `ListEntitiesUseCase` で `$entity->metaTitle`/`metaDescription` を渡す。
- `ListEntitiesHandler` の list 出力に `meta_title`/`meta_description` 追加。
- フロントの list マッパーは既に meta をマップ済み → **変更不要**。

これで SEO メタ説明のある記事は recent-posts ウィジェット＆フィードで抜粋が出る。

## 補足
SEO メタ説明が未設定の記事は引き続き抜粋なし（フィードと同じ仕様）。本文先頭N文字へのフォールバックが必要なら別途（本文フィールドの取得が要る）。

## 検証
- ✅ OpenAPI / PHPStan / CS / PHPUnit（Entity 172 tests）
- ✅ ライブ：`/api/v1/entities` が `meta_description` を返すことを確認

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)