### PR TITLE
feat(entity): 抜粋をサーバ算出（auto/body/meta）＋注釈 (#412 Phase B)

### DIFF
--- a/database/migrations/20260617000002_add_excerpt_settings.php
+++ b/database/migrations/20260617000002_add_excerpt_settings.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Excerpt source settings (#414 / #412 Phase B).
+ *
+ * The server computes a record `excerpt` (entity list `?include=excerpt`) used by
+ * the public feed and post-list widgets. These admin settings drive it:
+ *  - excerpt_source : auto | body | meta  (auto = meta description if set, else body)
+ *  - excerpt_length : max characters (markdown stripped)
+ *
+ * Server-internal config (not needed by the public payload), so is_public = 0.
+ * Org-scoped, inserted per organization (idempotent).
+ */
+final class AddExcerptSettings extends AbstractMigration
+{
+    /** @var list<array{setting_key: string, data_type: string, default_value: string, label: string}> */
+    private const SETTINGS = [
+        ['setting_key' => 'excerpt_source', 'data_type' => 'text', 'default_value' => 'auto', 'label' => 'Excerpt source (auto / body / meta)'],
+        ['setting_key' => 'excerpt_length', 'data_type' => 'text', 'default_value' => '160', 'label' => 'Excerpt length (characters)'],
+    ];
+
+    public function up(): void
+    {
+        if (!$this->hasTable('organizations') || !$this->hasTable('setting_defs')) {
+            return;
+        }
+
+        $pdo = $this->getAdapter()->getConnection();
+        $now = date('Y-m-d H:i:s');
+
+        $orgs = $pdo->query('SELECT id FROM organizations ORDER BY id ASC')->fetchAll(PDO::FETCH_COLUMN);
+
+        $check = $pdo->prepare('SELECT id FROM setting_defs WHERE organization_id = ? AND setting_key = ?');
+        $insert = $pdo->prepare(
+            'INSERT INTO setting_defs (organization_id, setting_key, data_type, default_value, is_public, label, created_at, updated_at)
+             VALUES (?, ?, ?, ?, 0, ?, ?, ?)',
+        );
+
+        foreach ($orgs as $orgIdRaw) {
+            $orgId = (int) $orgIdRaw;
+            foreach (self::SETTINGS as $s) {
+                $check->execute([$orgId, $s['setting_key']]);
+                if ($check->fetch() !== false) {
+                    continue;
+                }
+                $insert->execute([
+                    $orgId,
+                    $s['setting_key'],
+                    $s['data_type'],
+                    $s['default_value'],
+                    $s['label'],
+                    $now,
+                    $now,
+                ]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        $this->execute("DELETE FROM setting_defs WHERE setting_key IN ('excerpt_source', 'excerpt_length')");
+    }
+}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -4377,6 +4377,12 @@ components:
           type:
             - string
             - 'null'
+        excerpt:
+          type: string
+          description: >-
+            Server-computed plain-text teaser. Present only when the list is
+            requested with `?include=excerpt` (used by the public feed and
+            post-list widgets). Source/length follow the excerpt_* settings.
         created_at:
           type:
             - string

--- a/frontend/src/entities/entity/api-types.ts
+++ b/frontend/src/entities/entity/api-types.ts
@@ -14,6 +14,8 @@ export interface EntityDto {
   deleted_at: string | null
   meta_title: string | null
   meta_description: string | null
+  /** Server-computed teaser; present only when listed with `?include=excerpt`. */
+  excerpt?: string | null
   created_at: string | null
   updated_at: string | null
 }

--- a/frontend/src/entities/entity/mapper.ts
+++ b/frontend/src/entities/entity/mapper.ts
@@ -33,6 +33,7 @@ export function mapEntityDtoToModel(dto: EntityDto): Entity {
     deletedAt: dto.deleted_at,
     metaTitle: dto.meta_title,
     metaDescription: dto.meta_description,
+    excerpt: dto.excerpt,
     createdAt: dto.created_at,
     updatedAt: dto.updated_at,
   }

--- a/frontend/src/entities/entity/model.ts
+++ b/frontend/src/entities/entity/model.ts
@@ -16,6 +16,8 @@ export interface Entity {
   deletedAt: string | null
   metaTitle: string | null
   metaDescription: string | null
+  /** Server-computed teaser; present only when listed with `include=excerpt`. */
+  excerpt?: string | null
   createdAt: string | null
   updatedAt: string | null
 }

--- a/frontend/src/entities/entity/queries.ts
+++ b/frontend/src/entities/entity/queries.ts
@@ -45,6 +45,9 @@ export function useEntityList(
           search.set(`relation.${fieldKey}`, String(targetEntityId))
         }
       }
+      if (params.include !== undefined && params.include !== '') {
+        search.set('include', params.include)
+      }
       const dto = await apiClient.get<EntityListDto>(
         `/api/v1/entities?${search.toString()}`,
         signal,
@@ -74,6 +77,7 @@ export function usePublicLatestEntities(options?: {
         status: 'published',
         sort: 'published_at',
         order: 'desc',
+        include: 'excerpt',
       })
       const dto = await apiClient.get<EntityListDto>(
         `/api/v1/entities?${search.toString()}`,

--- a/frontend/src/entities/entity/query-keys.ts
+++ b/frontend/src/entities/entity/query-keys.ts
@@ -16,6 +16,8 @@ export interface EntityListParams {
   q?: string
   sortKey?: EntitySortKey
   sortOrder?: EntitySortOrder
+  /** `'excerpt'` to request the server-computed teaser on each item. */
+  include?: string
 }
 
 export const entityKeys = {

--- a/frontend/src/features/manage-entity-status/ui/EntitySeoPanel.tsx
+++ b/frontend/src/features/manage-entity-status/ui/EntitySeoPanel.tsx
@@ -44,16 +44,21 @@ export function EntitySeoPanel({
           />
         </Stack>
 
-        <Textarea
-          id="entity-meta-description"
-          label={t('admin.entitySeo.metaDescription')}
-          value={metaDescription}
-          onChange={(e) => {
-            onMetaDescriptionChange(e.target.value)
-          }}
-          placeholder={t('admin.entitySeo.metaDescription.placeholder')}
-          rows={3}
-        />
+        <Stack gap="xs">
+          <Textarea
+            id="entity-meta-description"
+            label={t('admin.entitySeo.metaDescription')}
+            value={metaDescription}
+            onChange={(e) => {
+              onMetaDescriptionChange(e.target.value)
+            }}
+            placeholder={t('admin.entitySeo.metaDescription.placeholder')}
+            rows={3}
+          />
+          <Text as="p" muted variant="caption">
+            {t('admin.entitySeo.metaDescription.help')}
+          </Text>
+        </Stack>
 
         <div className="flex items-center gap-inline-sm">
           <Button variant="secondary" size="sm" disabled={isPending} onClick={onSave}>

--- a/frontend/src/features/manage-widgets/hooks/use-manage-widgets-page.ts
+++ b/frontend/src/features/manage-widgets/hooks/use-manage-widgets-page.ts
@@ -20,13 +20,7 @@ function defaultSettings(type: WidgetType, menus: Menu[]): Record<string, unknow
     case 'menu':
       return { menuId: menus[0]?.id ?? null }
     case 'recent-posts':
-      return {
-        entityTypeSlug: '',
-        limit: 5,
-        showDate: false,
-        showExcerpt: false,
-        excerptLength: 80,
-      }
+      return { entityTypeSlug: '', limit: 5, showDate: false, showExcerpt: false }
     case 'popular-posts':
       return { limit: 5, showDate: false }
     case 'search':

--- a/frontend/src/features/manage-widgets/widget-catalog.ts
+++ b/frontend/src/features/manage-widgets/widget-catalog.ts
@@ -38,12 +38,6 @@ export const WIDGET_CATALOG: readonly WidgetCatalogEntry[] = [
       { key: 'limit', labelKey: 'admin.widgets.limitLabel', editor: 'int', def: 5 },
       { key: 'showDate', labelKey: 'admin.widgets.showDateLabel', editor: 'bool' },
       { key: 'showExcerpt', labelKey: 'admin.widgets.showExcerptLabel', editor: 'bool' },
-      {
-        key: 'excerptLength',
-        labelKey: 'admin.widgets.excerptLengthLabel',
-        editor: 'int',
-        def: 80,
-      },
     ],
   },
   {

--- a/frontend/src/features/public-home/hooks/use-public-home-page.ts
+++ b/frontend/src/features/public-home/hooks/use-public-home-page.ts
@@ -92,7 +92,7 @@ export function usePublicHomePage(): PublicHomeViewModel {
       return {
         id,
         title,
-        excerpt: entity.metaDescription?.trim() ?? '',
+        excerpt: entity.excerpt?.trim() ?? '',
         publishedLabel: formatPublishedDate(entity.publishedAt),
         typeSlug,
         typeName: type?.name ?? typeSlug,

--- a/frontend/src/features/render-widgets/hooks/use-recent-posts.ts
+++ b/frontend/src/features/render-widgets/hooks/use-recent-posts.ts
@@ -26,8 +26,8 @@ export function useRecentPosts(entityTypeSlug: string, limit: number) {
   const entityTypeId = entityType !== undefined ? Number(entityType.id) : 0
 
   const listParams = useMemo(
-    () =>
-      defaultEntityListParams(
+    () => ({
+      ...defaultEntityListParams(
         entityTypeId,
         [],
         {},
@@ -37,6 +37,8 @@ export function useRecentPosts(entityTypeSlug: string, limit: number) {
         'published_at',
         'desc',
       ),
+      include: 'excerpt',
+    }),
     [entityTypeId],
   )
   const entityListQuery = useEntityList(listParams, { enabled: entityTypeId > 0 })
@@ -61,7 +63,7 @@ export function useRecentPosts(entityTypeSlug: string, limit: number) {
           publishedAt: entity.publishedAt ?? null,
         }),
         publishedAt: entity.publishedAt ?? null,
-        excerpt: entity.metaDescription?.trim() ?? '',
+        excerpt: entity.excerpt ?? '',
       }
     })
   }, [

--- a/frontend/src/features/render-widgets/ui/RecentPostsWidget.tsx
+++ b/frontend/src/features/render-widgets/ui/RecentPostsWidget.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom'
 import type { Widget } from '@/entities/widget'
 import { useTranslation } from '@/shared/i18n'
-import { formatPostDate, truncateExcerpt } from '@/shared/lib/widget-post-meta'
+import { formatPostDate } from '@/shared/lib/widget-post-meta'
 import { Text } from '@/shared/ui'
 import { useRecentPosts } from '../hooks/use-recent-posts'
 
@@ -18,9 +18,6 @@ export function RecentPostsWidget({ widget }: RecentPostsWidgetProps) {
   const limit = typeof rawLimit === 'number' && rawLimit > 0 ? rawLimit : 5
   const showDate = widget.settings['showDate'] === true
   const showExcerpt = widget.settings['showExcerpt'] === true
-  const rawExcerptLength = widget.settings['excerptLength']
-  const excerptLength =
-    typeof rawExcerptLength === 'number' && rawExcerptLength > 0 ? rawExcerptLength : 80
 
   const { items } = useRecentPosts(entityTypeSlug, limit)
 
@@ -44,7 +41,7 @@ export function RecentPostsWidget({ widget }: RecentPostsWidgetProps) {
     <ul className="flex flex-col gap-stack-sm">
       {items.map((item) => {
         const date = showDate ? formatPostDate(item.publishedAt, locale) : ''
-        const excerpt = showExcerpt ? truncateExcerpt(item.excerpt, excerptLength) : ''
+        const excerpt = showExcerpt ? item.excerpt : ''
         return (
           <li key={item.id} className="flex flex-col gap-stack-xs">
             <Link

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -178,7 +178,6 @@ export const en = {
   'admin.widgets.limitLabel': 'Number of posts',
   'admin.widgets.showDateLabel': 'Show published date',
   'admin.widgets.showExcerptLabel': 'Show excerpt',
-  'admin.widgets.excerptLengthLabel': 'Excerpt length',
   'admin.widgets.add': 'Add',
   'admin.widgets.typeLabel': 'Widget type',
   'admin.widgets.type.recent-posts': 'Recent posts',
@@ -576,6 +575,8 @@ export const en = {
   'admin.entitySeo.metaTitle.placeholder': 'Override page title for search engines…',
   'admin.entitySeo.metaDescription': 'Meta description',
   'admin.entitySeo.metaDescription.placeholder': 'Override meta description for search engines…',
+  'admin.entitySeo.metaDescription.help':
+    'A short summary for search results. It can also appear as the excerpt in the feed and post-list widgets — if left blank, the start of the body is used instead.',
   'admin.entitySeo.save': 'Save SEO',
   'admin.entitySeo.saving': 'Saving…',
   'admin.entitySeo.saveSuccess': 'SEO settings saved.',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -170,7 +170,6 @@ export const ja: Partial<MessageCatalog> = {
   'admin.widgets.limitLabel': '表示件数',
   'admin.widgets.showDateLabel': '投稿日を表示',
   'admin.widgets.showExcerptLabel': '抜粋を表示',
-  'admin.widgets.excerptLengthLabel': '抜粋の文字数',
   'admin.widgets.add': '追加',
   'admin.widgets.typeLabel': 'ウィジェットタイプ',
   'admin.widgets.type.recent-posts': '最近の投稿',
@@ -577,6 +576,8 @@ export const ja: Partial<MessageCatalog> = {
   'admin.entitySeo.metaTitle.placeholder': '検索エンジン向けのページタイトルを上書き…',
   'admin.entitySeo.metaDescription': 'メタディスクリプション',
   'admin.entitySeo.metaDescription.placeholder': '検索エンジン向けのメタ説明を上書き…',
+  'admin.entitySeo.metaDescription.help':
+    '検索結果に出る短い説明です。フィードや投稿一覧ウィジェットの抜粋にも使われます（空欄なら本文の先頭が代わりに使われます）。',
   'admin.entitySeo.save': 'SEO を保存',
   'admin.entitySeo.saving': '保存中…',
   'admin.entitySeo.saveSuccess': 'SEO 設定を保存しました。',

--- a/frontend/src/shared/lib/widget-post-meta.ts
+++ b/frontend/src/shared/lib/widget-post-meta.ts
@@ -1,7 +1,7 @@
 /**
- * Shared helpers for the post-list widgets (recent / popular) optional
- * date + excerpt lines. Kept tiny and locale-aware so both widgets render
- * the same way.
+ * Shared helper for the post-list widgets (recent / popular): a locale-aware
+ * published-date line. The excerpt itself is computed server-side now
+ * (`?include=excerpt`), so widgets only format the date here.
  */
 
 /** Format an ISO timestamp for the locale; '' when missing / unparseable. */
@@ -14,13 +14,4 @@ export function formatPostDate(iso: string | null, locale: string): string {
     return ''
   }
   return date.toLocaleDateString(locale, { year: 'numeric', month: 'short', day: 'numeric' })
-}
-
-/** Trim an excerpt to at most `length` chars, adding an ellipsis when cut. */
-export function truncateExcerpt(text: string, length: number): string {
-  const trimmed = text.trim()
-  if (length <= 0 || trimmed.length <= length) {
-    return trimmed
-  }
-  return `${trimmed.slice(0, length).trimEnd()}…`
 }

--- a/src/Entity/EntityServiceProvider.php
+++ b/src/Entity/EntityServiceProvider.php
@@ -12,6 +12,7 @@ use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
+use NeNeRecords\Setting\SettingRepositoryInterface;
 use NeNeRecords\TextField\TextFieldRepositoryInterface;
 use NeNeRecords\Webhook\WebhookDispatcherInterface;
 use Psr\Container\ContainerInterface;
@@ -167,7 +168,22 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
                         throw new LogicException('JSON response factory service is invalid.');
                     }
 
-                    return new ListEntitiesHandler($useCase, $response);
+                    $textFields = $c->get(TextFieldRepositoryInterface::class);
+                    $settings = $c->get(SettingRepositoryInterface::class);
+
+                    if (!$textFields instanceof TextFieldRepositoryInterface) {
+                        throw new LogicException('Text field repository service is invalid.');
+                    }
+
+                    if (!$settings instanceof SettingRepositoryInterface) {
+                        throw new LogicException('Setting repository service is invalid.');
+                    }
+
+                    return new ListEntitiesHandler(
+                        $useCase,
+                        $response,
+                        new ExcerptResolver($textFields, $settings),
+                    );
                 },
             )
             ->set(

--- a/src/Entity/ExcerptResolver.php
+++ b/src/Entity/ExcerptResolver.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+use NeNeRecords\Setting\SettingRepositoryInterface;
+use NeNeRecords\TextField\TextFieldRepositoryInterface;
+
+/**
+ * Resolves a plain-text excerpt for a page of listed entities, applying the
+ * site's `excerpt_source` / `excerpt_length` settings:
+ *  - meta : the SEO meta description.
+ *  - body : the markdown `body` field, stripped to text.
+ *  - auto : meta description if set, otherwise the body (default).
+ *
+ * Body values are fetched once for the whole page (findByEntityIds), so this
+ * stays a single extra query regardless of page size.
+ */
+final readonly class ExcerptResolver
+{
+    private const BODY_FIELD_KEY = 'body';
+
+    public function __construct(
+        private TextFieldRepositoryInterface $textFields,
+        private SettingRepositoryInterface $settings,
+    ) {
+    }
+
+    /**
+     * @param list<ListEntityItem> $items
+     *
+     * @return array<int, string> entityId => excerpt
+     */
+    public function resolve(array $items): array
+    {
+        if ($items === []) {
+            return [];
+        }
+
+        $source = $this->setting('excerpt_source', 'auto');
+        $length = (int) $this->setting('excerpt_length', '160');
+        if ($length <= 0) {
+            $length = 160;
+        }
+
+        $bodyByEntity = $source === 'meta' ? [] : $this->loadBodies($items);
+
+        $excerpts = [];
+        foreach ($items as $item) {
+            $meta = trim($item->metaDescription ?? '');
+            $body = $bodyByEntity[$item->id] ?? '';
+            $excerpts[$item->id] = match ($source) {
+                'meta' => MarkdownExcerpt::truncate($meta, $length),
+                'body' => MarkdownExcerpt::fromMarkdown($body, $length),
+                default => $meta !== ''
+                    ? MarkdownExcerpt::truncate($meta, $length)
+                    : MarkdownExcerpt::fromMarkdown($body, $length),
+            };
+        }
+
+        return $excerpts;
+    }
+
+    /**
+     * @param list<ListEntityItem> $items
+     *
+     * @return array<int, string> entityId => markdown body value
+     */
+    private function loadBodies(array $items): array
+    {
+        $ids = array_map(static fn (ListEntityItem $i): int => $i->id, $items);
+        $bodies = [];
+        foreach ($this->textFields->findByEntityIds($ids) as $field) {
+            if ($field->fieldKey === self::BODY_FIELD_KEY && !isset($bodies[$field->entityId])) {
+                $bodies[$field->entityId] = $field->value;
+            }
+        }
+
+        return $bodies;
+    }
+
+    private function setting(string $key, string $default): string
+    {
+        $value = $this->settings->findValueByKey($key);
+        if ($value !== null && $value->value !== null && trim($value->value) !== '') {
+            return trim($value->value);
+        }
+
+        $def = $this->settings->findDefByKey($key);
+        if ($def !== null && $def->defaultValue !== null) {
+            return $def->defaultValue;
+        }
+
+        return $default;
+    }
+}

--- a/src/Entity/ListEntitiesHandler.php
+++ b/src/Entity/ListEntitiesHandler.php
@@ -16,6 +16,7 @@ final readonly class ListEntitiesHandler
     public function __construct(
         private ListEntitiesUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private ExcerptResolver $excerpts,
     ) {
     }
 
@@ -66,23 +67,36 @@ final readonly class ListEntitiesHandler
             ),
         ));
 
+        // `?include=excerpt` adds a server-computed teaser (used by the public
+        // feed and post-list widgets). Off by default so the admin list stays lean.
+        $include = $request->getQueryParams()['include'] ?? '';
+        $wantExcerpt = is_string($include) && in_array('excerpt', explode(',', $include), true);
+        $excerptByEntity = $wantExcerpt ? $this->excerpts->resolve($output->items) : [];
+
         return $this->response->create(
             (new PaginationResponse(
                 items: array_map(
-                    static fn (ListEntityItem $item) => [
-                        'id' => $item->id,
-                        'entity_type_id' => $item->entityTypeId,
-                        'slug' => $item->slug,
-                        'status' => $item->status,
-                        'published_at' => $item->publishedAtIso,
-                        'scheduled_at' => $item->scheduledAtIso,
-                        'is_deleted' => $item->isDeleted,
-                        'deleted_at' => $item->deletedAtIso,
-                        'created_at' => $item->createdAtIso,
-                        'updated_at' => $item->updatedAtIso,
-                        'meta_title' => $item->metaTitle,
-                        'meta_description' => $item->metaDescription,
-                    ],
+                    function (ListEntityItem $item) use ($wantExcerpt, $excerptByEntity) {
+                        $row = [
+                            'id' => $item->id,
+                            'entity_type_id' => $item->entityTypeId,
+                            'slug' => $item->slug,
+                            'status' => $item->status,
+                            'published_at' => $item->publishedAtIso,
+                            'scheduled_at' => $item->scheduledAtIso,
+                            'is_deleted' => $item->isDeleted,
+                            'deleted_at' => $item->deletedAtIso,
+                            'created_at' => $item->createdAtIso,
+                            'updated_at' => $item->updatedAtIso,
+                            'meta_title' => $item->metaTitle,
+                            'meta_description' => $item->metaDescription,
+                        ];
+                        if ($wantExcerpt) {
+                            $row['excerpt'] = $excerptByEntity[$item->id] ?? '';
+                        }
+
+                        return $row;
+                    },
                     $output->items,
                 ),
                 limit: $output->limit,

--- a/src/Entity/MarkdownExcerpt.php
+++ b/src/Entity/MarkdownExcerpt.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+/**
+ * Derives a plain-text excerpt from a markdown body: strips the common markdown
+ * syntax to readable text, collapses whitespace, and truncates to a length.
+ * Deliberately lightweight (no full markdown parse) — it only needs to produce a
+ * teaser, not faithful rendering.
+ */
+final class MarkdownExcerpt
+{
+    public static function fromMarkdown(string $markdown, int $length): string
+    {
+        return self::truncate(self::stripMarkdown($markdown), $length);
+    }
+
+    /** Trim plain text to at most `length` chars, adding an ellipsis when cut. */
+    public static function truncate(string $text, int $length): string
+    {
+        $text = trim($text);
+        if ($length <= 0 || mb_strlen($text) <= $length) {
+            return $text;
+        }
+
+        return rtrim(mb_substr($text, 0, $length)) . '…';
+    }
+
+    private static function stripMarkdown(string $markdown): string
+    {
+        $s = $markdown;
+        $s = preg_replace('/```.*?```/s', ' ', $s) ?? $s;        // fenced code
+        $s = preg_replace('/`([^`]*)`/', '$1', $s) ?? $s;        // inline code
+        $s = preg_replace('/!\[([^\]]*)\]\([^)]*\)/', '$1', $s) ?? $s; // images → alt
+        $s = preg_replace('/\[([^\]]*)\]\([^)]*\)/', '$1', $s) ?? $s;  // links → text
+        $s = preg_replace('/^\s{0,3}(#{1,6}|>|[-*+]|\d+\.)\s+/m', '', $s) ?? $s; // block markers
+        $s = preg_replace('/[*_~]+/', '', $s) ?? $s;             // emphasis
+        $s = preg_replace('/<[^>]+>/', '', $s) ?? $s;            // html tags
+        $s = preg_replace('/\s+/', ' ', $s) ?? $s;               // collapse whitespace
+
+        return trim($s);
+    }
+}

--- a/tests/BoolField/BoolFieldHttpTest.php
+++ b/tests/BoolField/BoolFieldHttpTest.php
@@ -25,6 +25,7 @@ use NeNeRecords\Entity\DeleteEntityHandler;
 use NeNeRecords\Entity\DeleteEntityUseCase;
 use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
 use NeNeRecords\Entity\EntityRouteRegistrar;
+use NeNeRecords\Entity\ExcerptResolver;
 use NeNeRecords\Entity\ExportEntitiesHandler;
 use NeNeRecords\Entity\GetEntityByIdHandler;
 use NeNeRecords\Entity\GetEntityByIdUseCase;
@@ -48,6 +49,7 @@ use NeNeRecords\FieldDef\FieldTypeMismatchExceptionHandler;
 use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
 use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
 use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use NeNeRecords\Tests\Setting\InMemorySettingRepository;
 use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
@@ -81,7 +83,7 @@ final class BoolFieldHttpTest extends TestCase
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),
             new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),

--- a/tests/DateTimeField/DateTimeFieldHttpTest.php
+++ b/tests/DateTimeField/DateTimeFieldHttpTest.php
@@ -25,6 +25,7 @@ use NeNeRecords\Entity\DeleteEntityHandler;
 use NeNeRecords\Entity\DeleteEntityUseCase;
 use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
 use NeNeRecords\Entity\EntityRouteRegistrar;
+use NeNeRecords\Entity\ExcerptResolver;
 use NeNeRecords\Entity\ExportEntitiesHandler;
 use NeNeRecords\Entity\GetEntityByIdHandler;
 use NeNeRecords\Entity\GetEntityByIdUseCase;
@@ -48,6 +49,7 @@ use NeNeRecords\FieldDef\FieldTypeMismatchExceptionHandler;
 use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
 use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
 use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use NeNeRecords\Tests\Setting\InMemorySettingRepository;
 use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
@@ -81,7 +83,7 @@ final class DateTimeFieldHttpTest extends TestCase
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),
             new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),

--- a/tests/Entity/EntityFilterHttpTest.php
+++ b/tests/Entity/EntityFilterHttpTest.php
@@ -14,6 +14,7 @@ use NeNeRecords\Entity\DeleteEntityUseCase;
 use NeNeRecords\Entity\Entity;
 use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
 use NeNeRecords\Entity\EntityRouteRegistrar;
+use NeNeRecords\Entity\ExcerptResolver;
 use NeNeRecords\Entity\ExportEntitiesHandler;
 use NeNeRecords\Entity\GetEntityByIdHandler;
 use NeNeRecords\Entity\GetEntityByIdUseCase;
@@ -31,6 +32,7 @@ use NeNeRecords\Entity\UpdateEntityHandler;
 use NeNeRecords\Entity\UpdateEntityUseCase;
 use NeNeRecords\EntityType\EntityTypeNotFoundExceptionHandler;
 use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use NeNeRecords\Tests\Setting\InMemorySettingRepository;
 use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
@@ -69,7 +71,7 @@ final class EntityFilterHttpTest extends TestCase
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $entityTypes), $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),
             new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),

--- a/tests/Entity/EntityHttpTest.php
+++ b/tests/Entity/EntityHttpTest.php
@@ -13,6 +13,7 @@ use NeNeRecords\Entity\DeleteEntityHandler;
 use NeNeRecords\Entity\DeleteEntityUseCase;
 use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
 use NeNeRecords\Entity\EntityRouteRegistrar;
+use NeNeRecords\Entity\ExcerptResolver;
 use NeNeRecords\Entity\ExportEntitiesHandler;
 use NeNeRecords\Entity\GetEntityByIdHandler;
 use NeNeRecords\Entity\GetEntityByIdUseCase;
@@ -31,6 +32,7 @@ use NeNeRecords\Entity\UpdateEntityUseCase;
 use NeNeRecords\EntityType\EntityType;
 use NeNeRecords\EntityType\EntityTypeNotFoundExceptionHandler;
 use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use NeNeRecords\Tests\Setting\InMemorySettingRepository;
 use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
@@ -62,7 +64,7 @@ final class EntityHttpTest extends TestCase
             new CreateEntityHandler($createUseCase, $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),
             new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),

--- a/tests/Entity/EntityRevisionHttpTest.php
+++ b/tests/Entity/EntityRevisionHttpTest.php
@@ -13,6 +13,7 @@ use NeNeRecords\Entity\DeleteEntityHandler;
 use NeNeRecords\Entity\DeleteEntityUseCase;
 use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
 use NeNeRecords\Entity\EntityRouteRegistrar;
+use NeNeRecords\Entity\ExcerptResolver;
 use NeNeRecords\Entity\ExportEntitiesHandler;
 use NeNeRecords\Entity\GetEntityByIdHandler;
 use NeNeRecords\Entity\GetEntityByIdUseCase;
@@ -31,6 +32,7 @@ use NeNeRecords\Entity\UpdateEntityUseCase;
 use NeNeRecords\EntityType\EntityType;
 use NeNeRecords\EntityType\EntityTypeNotFoundExceptionHandler;
 use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use NeNeRecords\Tests\Setting\InMemorySettingRepository;
 use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
@@ -62,7 +64,7 @@ final class EntityRevisionHttpTest extends TestCase
             new CreateEntityHandler($createUseCase, $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),
             new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),

--- a/tests/Entity/ExcerptResolverTest.php
+++ b/tests/Entity/ExcerptResolverTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Entity;
+
+use NeNeRecords\Entity\ExcerptResolver;
+use NeNeRecords\Entity\ListEntityItem;
+use NeNeRecords\Entity\MarkdownExcerpt;
+use NeNeRecords\Setting\SettingDef;
+use NeNeRecords\Tests\Setting\InMemorySettingRepository;
+use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
+use NeNeRecords\TextField\TextField;
+use PHPUnit\Framework\TestCase;
+
+final class ExcerptResolverTest extends TestCase
+{
+    public function testMarkdownStripFlattensSyntax(): void
+    {
+        $md = "# Heading\n\nSome **bold** and a [link](https://x). More text.";
+        self::assertSame('Heading Some bold and a link. More text.', MarkdownExcerpt::fromMarkdown($md, 999));
+    }
+
+    public function testTruncateAddsEllipsis(): void
+    {
+        self::assertSame('abcde…', MarkdownExcerpt::truncate('abcdefghij', 5));
+        self::assertSame('short', MarkdownExcerpt::truncate('short', 99));
+    }
+
+    public function testAutoPrefersMetaThenBody(): void
+    {
+        $items = [
+            $this->item(1, 'Meta summary here'),
+            $this->item(2, null), // no meta → falls back to body
+        ];
+        $resolver = $this->resolver(
+            bodies: [2 => "## Body title\n\nBody **paragraph** text."],
+            source: 'auto',
+        );
+
+        $out = $resolver->resolve($items);
+
+        self::assertSame('Meta summary here', $out[1]);
+        self::assertSame('Body title Body paragraph text.', $out[2]);
+    }
+
+    public function testBodySourceIgnoresMeta(): void
+    {
+        $items = [$this->item(1, 'Meta summary')];
+        $out = $this->resolver(bodies: [1 => 'Plain body.'], source: 'body')->resolve($items);
+        self::assertSame('Plain body.', $out[1]);
+    }
+
+    public function testMetaSourceIgnoresBody(): void
+    {
+        $items = [$this->item(1, 'Meta only')];
+        $out = $this->resolver(bodies: [1 => 'Body ignored.'], source: 'meta')->resolve($items);
+        self::assertSame('Meta only', $out[1]);
+    }
+
+    private function item(int $id, ?string $metaDescription): ListEntityItem
+    {
+        return new ListEntityItem(
+            id: $id,
+            entityTypeId: 1,
+            slug: 's' . $id,
+            status: 'published',
+            publishedAtIso: null,
+            isDeleted: false,
+            deletedAtIso: null,
+            metaDescription: $metaDescription,
+        );
+    }
+
+    /**
+     * @param array<int, string> $bodies entityId => markdown body
+     */
+    private function resolver(array $bodies, string $source): ExcerptResolver
+    {
+        $seed = [];
+        $id = 1;
+        foreach ($bodies as $entityId => $value) {
+            $seed[] = new TextField(entityId: $entityId, fieldKey: 'body', value: $value, id: $id++);
+        }
+
+        $settings = new InMemorySettingRepository([
+            new SettingDef('excerpt_source', 'text', 'auto', false, 'Excerpt source'),
+            new SettingDef('excerpt_length', 'text', '160', false, 'Excerpt length'),
+        ]);
+        $settings->applyValueDirect('excerpt_source', $source, null);
+
+        return new ExcerptResolver(new InMemoryTextFieldRepository($seed), $settings);
+    }
+}

--- a/tests/Entity/ScheduledPublishHttpTest.php
+++ b/tests/Entity/ScheduledPublishHttpTest.php
@@ -16,6 +16,7 @@ use NeNeRecords\Entity\Entity;
 use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
 use NeNeRecords\Entity\EntityRouteRegistrar;
 use NeNeRecords\Entity\EntityStatus;
+use NeNeRecords\Entity\ExcerptResolver;
 use NeNeRecords\Entity\ExportEntitiesHandler;
 use NeNeRecords\Entity\GetEntityByIdHandler;
 use NeNeRecords\Entity\GetEntityByIdUseCase;
@@ -34,6 +35,7 @@ use NeNeRecords\Entity\UpdateEntityUseCase;
 use NeNeRecords\EntityType\EntityType;
 use NeNeRecords\EntityType\EntityTypeNotFoundExceptionHandler;
 use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use NeNeRecords\Tests\Setting\InMemorySettingRepository;
 use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
@@ -62,7 +64,7 @@ final class ScheduledPublishHttpTest extends TestCase
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),
             new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),

--- a/tests/EnumField/EnumFieldHttpTest.php
+++ b/tests/EnumField/EnumFieldHttpTest.php
@@ -13,6 +13,7 @@ use NeNeRecords\Entity\DeleteEntityHandler;
 use NeNeRecords\Entity\DeleteEntityUseCase;
 use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
 use NeNeRecords\Entity\EntityRouteRegistrar;
+use NeNeRecords\Entity\ExcerptResolver;
 use NeNeRecords\Entity\ExportEntitiesHandler;
 use NeNeRecords\Entity\GetEntityByIdHandler;
 use NeNeRecords\Entity\GetEntityByIdUseCase;
@@ -48,6 +49,7 @@ use NeNeRecords\FieldDef\FieldTypeMismatchExceptionHandler;
 use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
 use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
 use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use NeNeRecords\Tests\Setting\InMemorySettingRepository;
 use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
@@ -81,7 +83,7 @@ final class EnumFieldHttpTest extends TestCase
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),
             new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),

--- a/tests/IntField/IntFieldHttpTest.php
+++ b/tests/IntField/IntFieldHttpTest.php
@@ -13,6 +13,7 @@ use NeNeRecords\Entity\DeleteEntityHandler;
 use NeNeRecords\Entity\DeleteEntityUseCase;
 use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
 use NeNeRecords\Entity\EntityRouteRegistrar;
+use NeNeRecords\Entity\ExcerptResolver;
 use NeNeRecords\Entity\ExportEntitiesHandler;
 use NeNeRecords\Entity\GetEntityByIdHandler;
 use NeNeRecords\Entity\GetEntityByIdUseCase;
@@ -48,6 +49,7 @@ use NeNeRecords\IntField\UpdateIntFieldUseCase;
 use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
 use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
 use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use NeNeRecords\Tests\Setting\InMemorySettingRepository;
 use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
@@ -81,7 +83,7 @@ final class IntFieldHttpTest extends TestCase
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),
             new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),

--- a/tests/TextField/TextFieldHttpTest.php
+++ b/tests/TextField/TextFieldHttpTest.php
@@ -13,6 +13,7 @@ use NeNeRecords\Entity\DeleteEntityHandler;
 use NeNeRecords\Entity\DeleteEntityUseCase;
 use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
 use NeNeRecords\Entity\EntityRouteRegistrar;
+use NeNeRecords\Entity\ExcerptResolver;
 use NeNeRecords\Entity\ExportEntitiesHandler;
 use NeNeRecords\Entity\GetEntityByIdHandler;
 use NeNeRecords\Entity\GetEntityByIdUseCase;
@@ -36,6 +37,7 @@ use NeNeRecords\FieldDef\FieldTypeMismatchExceptionHandler;
 use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
 use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
 use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use NeNeRecords\Tests\Setting\InMemorySettingRepository;
 use NeNeRecords\TextField\CreateTextFieldHandler;
 use NeNeRecords\TextField\CreateTextFieldUseCase;
 use NeNeRecords\TextField\DeleteTextFieldHandler;
@@ -80,7 +82,7 @@ final class TextFieldHttpTest extends TestCase
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, $this->textFields, $this->factory),
             new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),


### PR DESCRIPTION
## 目的
抜粋を「SEO メタ説明だけ」から、**本文フォールバック＋ソース選択**に拡張する（相談の Phase A＋B フル）。WordPress 同様、メタ説明が無くても本文先頭が抜粋に使われる。

## A. 注釈（初心者向け）
- `EntitySeoPanel` のメタ説明欄に注釈：「検索結果用の説明。空なら本文の先頭が抜粋に使われます」（en/ja）。

## B. サーバ算出の抜粋
- 一覧 API に **`?include=excerpt`** を追加 → サーバが `excerpt` を返す（`ExcerptResolver`）。
  - ソース：サイト設定 **`excerpt_source`**（`auto`/`body`/`meta`、既定 `auto`＝メタ説明があればそれ、無ければ本文先頭）。
  - 長さ：**`excerpt_length`**（既定160）。本文は markdown 除去して切り詰め（`MarkdownExcerpt`）。
  - 本文は `findByEntityIds` でページ単位に **1クエリ**取得。`include` 未指定の admin 一覧は従来どおり（excerpt 無し・追加コストなし）。
  - 設定2件を per-org 冪等マイグレーションで追加。
- フロント：entity 型/mapper に `excerpt` 追加。公開フィード＆ recent-posts ウィジェットが `include=excerpt` を付け、`entity.excerpt` を表示。**per-widget の excerptLength は撤去**（グローバル設定に一本化）。

## アーキテクチャの要点
抜粋算出は**サーバ側に集約**。フロントは markdown 除去やフィールド推測をせず `entity.excerpt` を出すだけ。フィードとウィジェットで一貫。

## 検証
- ✅ backend 698 / frontend 200、PHPStan / CS / OpenAPI 緑
- ✅ `ExcerptResolver` 単体テスト（auto/body/meta＋markdown 除去）
- ✅ ライブ：`include=excerpt` で本文フォールバックを確認

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)