### PR TITLE
fix(public): 記事/固定ページ遷移時にトップへスクロール (#417)

### DIFF
--- a/frontend/src/pages/consumer/PublicShell.tsx
+++ b/frontend/src/pages/consumer/PublicShell.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react'
 import './consumer-theme.css'
 import './public-fonts'
-import { Outlet } from 'react-router-dom'
+import { Outlet, ScrollRestoration } from 'react-router-dom'
 import { usePublicNavigationItems } from '@/entities/navigation-item'
 import { publicSettingsToMap, usePublicSettings } from '@/entities/setting'
 import { parseLayoutConfig } from '@/shared/lib/layout-config'
@@ -86,5 +86,14 @@ export function PublicShell() {
   // PublicShell only resolves site-wide data and the document meta. The visual
   // scaffold (header / footer / drawer / theme) is the magazine PublicSiteShell,
   // rendered per page so a record can still opt into a chrome-less `bare` layout.
-  return <Outlet context={site} />
+  //
+  // ScrollRestoration scopes scroll handling to the public site: a new
+  // navigation (e.g. into a record/page) jumps to the top, while back/forward
+  // restores the previous position — without changing the admin's behaviour.
+  return (
+    <>
+      <ScrollRestoration />
+      <Outlet context={site} />
+    </>
+  )
 }


### PR DESCRIPTION
## 現象
あちこちのリンクから記事や固定ページに遷移すると、ページ先頭に移動せず前のスクロール位置のまま表示され、途中から始まったように見える。

## 原因
データルーター（`createBrowserRouter`）だが `<ScrollRestoration />` が無く、SPA 遷移でスクロール位置がリセットされない。

## 修正
公開レイアウト `PublicShell` に `<ScrollRestoration />` を追加：
- 新規遷移（PUSH）→ 先頭へ。
- 戻る/進む（POP）→ 位置復元。
- 公開ルートに限定（PublicShell のみマウント）＝ admin/superadmin の挙動は不変。

## 検証
- ✅ type-check / lint / prettier / unit（consumer 12）緑、HMR クリーン

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)