### PR TITLE
feat(theme): ランタイムテーマ backend + OpenAPI/MCP (#423 Phase B+C)

### DIFF
--- a/database/migrations/20260618000001_create_themes_table.php
+++ b/database/migrations/20260618000001_create_themes_table.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Db\Adapter\MysqlAdapter;
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * ランタイムテーマ（#423 Phase B）。
+ *
+ * ClaudeDesign が MCP（= OpenAPI 境界）経由で登録する**データ駆動テーマ**を保持。
+ * `manifest` は public-theme.schema.json 準拠の JSON（tokens/flags/knobs…）。
+ * `theme_key`(= manifest.id) / `name` / `version` は一覧・一意制約用に列へ複製。
+ * org スコープ（マルチテナント）。built-in 静的テーマとは id 名前空間を分離する
+ * （`source='runtime'`）。設計: docs/theming/runtime-themes.md。
+ */
+final class CreateThemesTable extends AbstractMigration
+{
+    public function up(): void
+    {
+        $this->table('themes')
+            ->addColumn('organization_id', 'integer', ['null' => false, 'default' => 0, 'signed' => false])
+            ->addColumn('theme_key', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('name', 'string', ['limit' => 80, 'null' => false])
+            ->addColumn('version', 'string', ['limit' => 32, 'null' => false, 'default' => '1.0.0'])
+            ->addColumn('source', 'string', ['limit' => 16, 'null' => false, 'default' => 'runtime'])
+            ->addColumn('manifest', 'text', ['null' => false, 'limit' => MysqlAdapter::TEXT_LONG])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['organization_id'])
+            ->addIndex(['organization_id', 'theme_key'], ['unique' => true])
+            ->create();
+    }
+
+    public function down(): void
+    {
+        $this->table('themes')->drop()->save();
+    }
+}

--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -1137,6 +1137,202 @@
             "responseSchemaRef": "#/components/schemas/SettingRevisionListResponse"
         },
         {
+            "name": "listThemes",
+            "title": "List Runtime Themes",
+            "description": "List all runtime (data-driven) public-site themes for the organization.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "listThemes",
+                "method": "GET",
+                "path": "/api/v1/themes"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": [],
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/ThemeListResponse"
+        },
+        {
+            "name": "createTheme",
+            "title": "Create Runtime Theme",
+            "description": "Register a new runtime public-site theme. The input is the theme manifest (tokens + flags). The server validates structure and sanitises token values before storing; unsafe CSS and reserved ids are rejected.",
+            "safety": "write",
+            "source": {
+                "type": "openapi",
+                "operationId": "createTheme",
+                "method": "POST",
+                "path": "/api/v1/themes"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9-]{1,40}$",
+                        "description": "Theme key/id. Must not collide with a built-in theme."
+                    },
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 80
+                    },
+                    "version": {
+                        "type": "string",
+                        "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                    },
+                    "supportsModes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "light",
+                                "dark"
+                            ]
+                        },
+                        "description": "Must include both light and dark."
+                    },
+                    "tokens": {
+                        "type": "object",
+                        "description": "Per-mode CSS tokens: {\"light\":{token:value,\u2026},\"dark\":{\u2026}}. Keys are contract tokens; values must be safe CSS (no ;{}<>, url(), @import)."
+                    },
+                    "flags": {
+                        "type": "object",
+                        "description": "Optional structural style flags (enumerated; e.g. feedLayout, headerLayout)."
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "version",
+                    "supportsModes",
+                    "tokens"
+                ],
+                "additionalProperties": true
+            },
+            "responseSchemaRef": null
+        },
+        {
+            "name": "getTheme",
+            "title": "Get Runtime Theme",
+            "description": "Get a single runtime theme by its key.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "getTheme",
+                "method": "GET",
+                "path": "/api/v1/themes/{key}"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9-]{1,40}$",
+                        "description": "Theme key."
+                    }
+                },
+                "required": [
+                    "key"
+                ],
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/ThemeResponse"
+        },
+        {
+            "name": "updateTheme",
+            "title": "Update Runtime Theme",
+            "description": "Replace an existing runtime theme manifest. The manifest id must match the key in the path.",
+            "safety": "write",
+            "source": {
+                "type": "openapi",
+                "operationId": "updateTheme",
+                "method": "PUT",
+                "path": "/api/v1/themes/{key}"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9-]{1,40}$",
+                        "description": "Theme key (must equal the manifest id)."
+                    },
+                    "id": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9-]{1,40}$",
+                        "description": "Theme key/id. Must not collide with a built-in theme."
+                    },
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 80
+                    },
+                    "version": {
+                        "type": "string",
+                        "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                    },
+                    "supportsModes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "light",
+                                "dark"
+                            ]
+                        },
+                        "description": "Must include both light and dark."
+                    },
+                    "tokens": {
+                        "type": "object",
+                        "description": "Per-mode CSS tokens: {\"light\":{token:value,\u2026},\"dark\":{\u2026}}. Keys are contract tokens; values must be safe CSS (no ;{}<>, url(), @import)."
+                    },
+                    "flags": {
+                        "type": "object",
+                        "description": "Optional structural style flags (enumerated; e.g. feedLayout, headerLayout)."
+                    }
+                },
+                "required": [
+                    "key",
+                    "id",
+                    "name",
+                    "version",
+                    "supportsModes",
+                    "tokens"
+                ],
+                "additionalProperties": true
+            },
+            "responseSchemaRef": "#/components/schemas/ThemeResponse"
+        },
+        {
+            "name": "deleteTheme",
+            "title": "Delete Runtime Theme",
+            "description": "Permanently delete a runtime theme by its key.",
+            "safety": "destructive",
+            "source": {
+                "type": "openapi",
+                "operationId": "deleteTheme",
+                "method": "DELETE",
+                "path": "/api/v1/themes/{key}"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9-]{1,40}$",
+                        "description": "Theme key."
+                    }
+                },
+                "required": [
+                    "key"
+                ],
+                "additionalProperties": false
+            },
+            "responseSchemaRef": null
+        },
+        {
             "name": "listTextFields",
             "title": "List Text Fields",
             "description": "List text field values with optional entity or entity type filters.",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -46,6 +46,8 @@ tags:
     description: Webhook endpoints for entity create/update/delete event notifications.
   - name: Users
     description: User account management (admin only) and self-service password change.
+  - name: Themes
+    description: Runtime (data-driven) public-site themes, registrable over MCP. See docs/theming/runtime-themes.md.
 paths:
   /api/v1/auth/login:
     post:
@@ -2874,6 +2876,141 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/themes:
+    get:
+      tags:
+        - Themes
+      summary: List runtime themes
+      description: Returns all runtime (data-driven) themes for the organization.
+      operationId: listThemes
+      responses:
+        '200':
+          description: Theme list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThemeListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Themes
+      summary: Create runtime theme
+      description: >-
+        Registers a new runtime theme. The request body is the theme manifest
+        (public-theme.schema.json shape). The server validates structure and
+        sanitises token values before storing; only known CSS variables with
+        safe values are ever emitted to the public site.
+      operationId: createTheme
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ThemeManifest'
+      responses:
+        '201':
+          description: Created theme.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThemeResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/themes/{key}:
+    get:
+      tags:
+        - Themes
+      summary: Get runtime theme
+      description: Returns a single runtime theme by its key.
+      operationId: getTheme
+      parameters:
+        - name: key
+          in: path
+          required: true
+          description: Theme key (manifest id).
+          schema:
+            type: string
+            pattern: '^[a-z][a-z0-9-]{1,40}$'
+      responses:
+        '200':
+          description: Theme.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThemeResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      tags:
+        - Themes
+      summary: Update runtime theme
+      description: >-
+        Replaces an existing runtime theme's manifest. The manifest `id` must
+        match the key in the URL (renaming means delete + create).
+      operationId: updateTheme
+      parameters:
+        - name: key
+          in: path
+          required: true
+          description: Theme key (manifest id).
+          schema:
+            type: string
+            pattern: '^[a-z][a-z0-9-]{1,40}$'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ThemeManifest'
+      responses:
+        '200':
+          description: Updated theme.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThemeResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - Themes
+      summary: Delete runtime theme
+      description: Permanently deletes a runtime theme by its key.
+      operationId: deleteTheme
+      parameters:
+        - name: key
+          in: path
+          required: true
+          description: Theme key (manifest id).
+          schema:
+            type: string
+            pattern: '^[a-z][a-z0-9-]{1,40}$'
+      responses:
+        '204':
+          description: Deleted successfully.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /api/v1/public/menus:
     get:
       tags:
@@ -5655,6 +5792,100 @@ components:
             - string
             - 'null'
           enum: [header, footer, null]
+      additionalProperties: false
+
+    ThemeTokenSet:
+      type: object
+      description: >-
+        Map of contract token name (no leading --) to a CSS value. Values are
+        sanitised server-side; only safe CSS is emitted to the public site.
+      additionalProperties:
+        type: string
+        minLength: 1
+    ThemeManifest:
+      type: object
+      description: Runtime theme manifest (public-theme.schema.json shape).
+      required:
+        - id
+        - name
+        - version
+        - supportsModes
+        - tokens
+      properties:
+        id:
+          type: string
+          pattern: '^[a-z][a-z0-9-]{1,40}$'
+        name:
+          type: string
+          minLength: 1
+          maxLength: 80
+        version:
+          type: string
+          pattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
+        supportsModes:
+          type: array
+          items:
+            type: string
+            enum: [light, dark]
+          minItems: 2
+        tokens:
+          type: object
+          required:
+            - light
+            - dark
+          properties:
+            light:
+              $ref: '#/components/schemas/ThemeTokenSet'
+            dark:
+              $ref: '#/components/schemas/ThemeTokenSet'
+          additionalProperties: false
+        flags:
+          type: object
+          additionalProperties:
+            type: string
+        knobs:
+          type: object
+          additionalProperties: true
+        fonts:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+      additionalProperties: true
+    ThemeResponse:
+      type: object
+      required:
+        - theme_key
+        - name
+        - version
+        - manifest
+        - created_at
+        - updated_at
+      properties:
+        theme_key:
+          type: string
+        name:
+          type: string
+        version:
+          type: string
+        manifest:
+          $ref: '#/components/schemas/ThemeManifest'
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      additionalProperties: false
+    ThemeListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ThemeResponse'
       additionalProperties: false
 
 

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -1156,6 +1156,58 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/themes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List runtime themes
+         * @description Returns all runtime (data-driven) themes for the organization.
+         */
+        get: operations["listThemes"];
+        put?: never;
+        /**
+         * Create runtime theme
+         * @description Registers a new runtime theme. The request body is the theme manifest (public-theme.schema.json shape). The server validates structure and sanitises token values before storing; only known CSS variables with safe values are ever emitted to the public site.
+         */
+        post: operations["createTheme"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/themes/{key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get runtime theme
+         * @description Returns a single runtime theme by its key.
+         */
+        get: operations["getTheme"];
+        /**
+         * Update runtime theme
+         * @description Replaces an existing runtime theme's manifest. The manifest `id` must match the key in the URL (renaming means delete + create).
+         */
+        put: operations["updateTheme"];
+        post?: never;
+        /**
+         * Delete runtime theme
+         * @description Permanently deletes a runtime theme by its key.
+         */
+        delete: operations["deleteTheme"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/public/menus": {
         parameters: {
             query?: never;
@@ -1736,6 +1788,8 @@ export interface components {
             deleted_at: string | null;
             meta_title: string | null;
             meta_description: string | null;
+            /** @description Server-computed plain-text teaser. Present only when the list is requested with `?include=excerpt` (used by the public feed and post-list widgets). Source/length follow the excerpt_* settings. */
+            excerpt?: string;
             /** Format: date-time */
             created_at: string | null;
             /** Format: date-time */
@@ -2215,6 +2269,45 @@ export interface components {
             name: string;
             /** @enum {string|null} */
             location?: "header" | "footer" | null;
+        };
+        /** @description Map of contract token name (no leading --) to a CSS value. Values are sanitised server-side; only safe CSS is emitted to the public site. */
+        ThemeTokenSet: {
+            [key: string]: string;
+        };
+        /** @description Runtime theme manifest (public-theme.schema.json shape). */
+        ThemeManifest: {
+            id: string;
+            name: string;
+            version: string;
+            supportsModes: ("light" | "dark")[];
+            tokens: {
+                light: components["schemas"]["ThemeTokenSet"];
+                dark: components["schemas"]["ThemeTokenSet"];
+            };
+            flags?: {
+                [key: string]: string;
+            };
+            knobs?: {
+                [key: string]: unknown;
+            };
+            fonts?: {
+                [key: string]: unknown;
+            }[];
+        } & {
+            [key: string]: unknown;
+        };
+        ThemeResponse: {
+            theme_key: string;
+            name: string;
+            version: string;
+            manifest: components["schemas"]["ThemeManifest"];
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        ThemeListResponse: {
+            items: components["schemas"]["ThemeResponse"][];
         };
         WebhookResponse: {
             /** Format: int64 */
@@ -5315,6 +5408,136 @@ export interface operations {
                 };
                 content?: never;
             };
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    listThemes: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Theme list. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ThemeListResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    createTheme: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ThemeManifest"];
+            };
+        };
+        responses: {
+            /** @description Created theme. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ThemeResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            422: components["responses"]["ValidationFailed"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    getTheme: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Theme key (manifest id). */
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Theme. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ThemeResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    updateTheme: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Theme key (manifest id). */
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ThemeManifest"];
+            };
+        };
+        responses: {
+            /** @description Updated theme. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ThemeResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationFailed"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    deleteTheme: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Theme key (manifest id). */
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted successfully. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
             404: components["responses"]["NotFound"];
             500: components["responses"]["InternalServerError"];
         };

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -99,6 +99,9 @@ use NeNeRecords\Tag\TagSlugConflictExceptionHandler;
 use NeNeRecords\TextField\TextFieldNotFoundExceptionHandler;
 use NeNeRecords\TextField\TextFieldRouteRegistrar;
 use NeNeRecords\TextField\TextFieldServiceProvider;
+use NeNeRecords\Theme\ThemeNotFoundExceptionHandler;
+use NeNeRecords\Theme\ThemeRouteRegistrar;
+use NeNeRecords\Theme\ThemeServiceProvider;
 use NeNeRecords\User\CannotDeleteSelfExceptionHandler;
 use NeNeRecords\User\EmailVerificationTokenExceptionHandler;
 use NeNeRecords\User\InvalidCurrentPasswordExceptionHandler;
@@ -169,7 +172,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new OrganizationServiceProvider())
             ->addProvider(new SystemConfigServiceProvider())
             ->addProvider(new DataMigrationServiceProvider())
-            ->addProvider(new OrgExportServiceProvider());
+            ->addProvider(new OrgExportServiceProvider())
+            ->addProvider(new ThemeServiceProvider());
 
         $builder
             ->set(
@@ -206,6 +210,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $systemConfig = $container->get(SystemConfigRouteRegistrar::class);
                     $dataMigration = $container->get(DataMigrationRouteRegistrar::class);
                     $orgExport     = $container->get(OrgExportRouteRegistrar::class);
+                    $theme = $container->get('nene-records.route_registrar.theme');
 
                     if (
                         !$entityType instanceof EntityTypeRouteRegistrar
@@ -239,6 +244,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !$systemConfig instanceof SystemConfigRouteRegistrar
                         || !$dataMigration instanceof DataMigrationRouteRegistrar
                         || !$orgExport instanceof OrgExportRouteRegistrar
+                        || !$theme instanceof ThemeRouteRegistrar
                     ) {
                         throw new LogicException('Route registrar service is invalid.');
                     }
@@ -275,6 +281,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $systemConfig,
                         $dataMigration,
                         $orgExport,
+                        $theme,
                     ];
                 },
             )
@@ -328,6 +335,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $organizationNotFound = $container->get(OrganizationNotFoundExceptionHandler::class);
                     $organizationSlugConflict = $container->get(OrganizationSlugConflictExceptionHandler::class);
                     $notificationChannelNotFound = $container->get(NotificationChannelNotFoundExceptionHandler::class);
+                    $themeNotFound = $container->get(ThemeNotFoundExceptionHandler::class);
 
                     foreach ([
                         $entityTypeNotFound,
@@ -377,6 +385,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $organizationNotFound,
                         $organizationSlugConflict,
                         $notificationChannelNotFound,
+                        $themeNotFound,
                     ] as $handler) {
                         if (!$handler instanceof DomainExceptionHandlerInterface) {
                             throw new LogicException('Exception handler service is invalid.');
@@ -431,6 +440,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $organizationNotFound,
                         $organizationSlugConflict,
                         $notificationChannelNotFound,
+                        $themeNotFound,
                     ];
                 },
             );

--- a/src/Auth/AdminApiAuthMiddleware.php
+++ b/src/Auth/AdminApiAuthMiddleware.php
@@ -40,6 +40,7 @@ final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
         '/api/v1/users',
         '/api/v1/admin/comments',
         '/api/v1/organizations',
+        '/api/v1/themes',
     ];
 
     public function __construct(

--- a/src/Theme/CreateThemeHandler.php
+++ b/src/Theme/CreateThemeHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateThemeHandler
+{
+    public function __construct(
+        private CreateThemeUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        // The request body IS the theme manifest. The use case validates it
+        // (ThemeManifestValidator) before persisting.
+        $manifest = JsonRequestBodyParser::parse($request);
+
+        $output = $this->useCase->execute(new CreateThemeInput(manifest: $manifest));
+
+        return $this->response->create(ThemeHttpMapper::toArray($output->theme), 201);
+    }
+}

--- a/src/Theme/CreateThemeInput.php
+++ b/src/Theme/CreateThemeInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+final readonly class CreateThemeInput
+{
+    /** @param array<string, mixed> $manifest */
+    public function __construct(
+        public array $manifest,
+    ) {
+    }
+}

--- a/src/Theme/CreateThemeOutput.php
+++ b/src/Theme/CreateThemeOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+final readonly class CreateThemeOutput
+{
+    public function __construct(
+        public Theme $theme,
+    ) {
+    }
+}

--- a/src/Theme/CreateThemeUseCase.php
+++ b/src/Theme/CreateThemeUseCase.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+
+final readonly class CreateThemeUseCase implements CreateThemeUseCaseInterface
+{
+    public function __construct(
+        private ThemeRepositoryInterface $repository,
+    ) {
+    }
+
+    public function execute(CreateThemeInput $input): CreateThemeOutput
+    {
+        ThemeManifestValidator::validate($input->manifest);
+
+        $key = (string) $input->manifest['id'];
+
+        if ($this->repository->existsByKey($key)) {
+            throw new ValidationException([
+                new ValidationError('id', "A theme with id '{$key}' already exists.", 'conflict'),
+            ]);
+        }
+
+        $theme = new Theme(
+            id: null,
+            themeKey: $key,
+            name: (string) $input->manifest['name'],
+            version: (string) $input->manifest['version'],
+            manifest: $input->manifest,
+            createdAt: '',
+            updatedAt: '',
+        );
+
+        $this->repository->save($theme);
+        $saved = $this->repository->findByKey($key);
+
+        if ($saved === null) {
+            throw new \RuntimeException('Failed to persist theme.');
+        }
+
+        return new CreateThemeOutput(theme: $saved);
+    }
+}

--- a/src/Theme/CreateThemeUseCaseInterface.php
+++ b/src/Theme/CreateThemeUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+interface CreateThemeUseCaseInterface
+{
+    public function execute(CreateThemeInput $input): CreateThemeOutput;
+}

--- a/src/Theme/DeleteThemeHandler.php
+++ b/src/Theme/DeleteThemeHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteThemeHandler
+{
+    public function __construct(
+        private DeleteThemeUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $key = (string) ($parameters['key'] ?? '');
+
+        $this->useCase->execute(new DeleteThemeInput($key));
+
+        return $this->response->createEmpty(204);
+    }
+}

--- a/src/Theme/DeleteThemeInput.php
+++ b/src/Theme/DeleteThemeInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+final readonly class DeleteThemeInput
+{
+    public function __construct(
+        public string $themeKey,
+    ) {
+    }
+}

--- a/src/Theme/DeleteThemeUseCase.php
+++ b/src/Theme/DeleteThemeUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+final readonly class DeleteThemeUseCase implements DeleteThemeUseCaseInterface
+{
+    public function __construct(
+        private ThemeRepositoryInterface $repository,
+    ) {
+    }
+
+    public function execute(DeleteThemeInput $input): void
+    {
+        $existing = $this->repository->findByKey($input->themeKey);
+
+        if ($existing === null) {
+            throw new ThemeNotFoundException($input->themeKey);
+        }
+
+        $this->repository->deleteByKey($input->themeKey);
+    }
+}

--- a/src/Theme/DeleteThemeUseCaseInterface.php
+++ b/src/Theme/DeleteThemeUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+interface DeleteThemeUseCaseInterface
+{
+    public function execute(DeleteThemeInput $input): void;
+}

--- a/src/Theme/GetThemeHandler.php
+++ b/src/Theme/GetThemeHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetThemeHandler
+{
+    public function __construct(
+        private ThemeRepositoryInterface $repository,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $key = (string) ($parameters['key'] ?? '');
+
+        $theme = $this->repository->findByKey($key);
+
+        if ($theme === null) {
+            throw new ThemeNotFoundException($key);
+        }
+
+        return $this->response->create(ThemeHttpMapper::toArray($theme));
+    }
+}

--- a/src/Theme/ListThemesHandler.php
+++ b/src/Theme/ListThemesHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListThemesHandler
+{
+    public function __construct(
+        private ListThemesUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $output = $this->useCase->execute();
+
+        return $this->response->create([
+            'items' => array_map(
+                static fn (Theme $theme) => ThemeHttpMapper::toArray($theme),
+                $output->items,
+            ),
+        ]);
+    }
+}

--- a/src/Theme/ListThemesOutput.php
+++ b/src/Theme/ListThemesOutput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+final readonly class ListThemesOutput
+{
+    /** @param list<Theme> $items */
+    public function __construct(
+        public array $items,
+    ) {
+    }
+}

--- a/src/Theme/ListThemesUseCase.php
+++ b/src/Theme/ListThemesUseCase.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+final readonly class ListThemesUseCase implements ListThemesUseCaseInterface
+{
+    public function __construct(
+        private ThemeRepositoryInterface $repository,
+    ) {
+    }
+
+    public function execute(): ListThemesOutput
+    {
+        return new ListThemesOutput(items: $this->repository->findAll());
+    }
+}

--- a/src/Theme/ListThemesUseCaseInterface.php
+++ b/src/Theme/ListThemesUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+interface ListThemesUseCaseInterface
+{
+    public function execute(): ListThemesOutput;
+}

--- a/src/Theme/PdoThemeRepository.php
+++ b/src/Theme/PdoThemeRepository.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
+
+final readonly class PdoThemeRepository implements ThemeRepositoryInterface
+{
+    /**
+     * @param RequestScopedHolder<int> $orgId
+     */
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    /** @return list<Theme> */
+    public function findAll(): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, theme_key, name, version, manifest, created_at, updated_at
+             FROM themes
+             WHERE organization_id = ?
+             ORDER BY name ASC',
+            [$this->orgId->get()],
+        );
+
+        return array_map($this->mapRow(...), $rows);
+    }
+
+    public function findByKey(string $themeKey): ?Theme
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, theme_key, name, version, manifest, created_at, updated_at
+             FROM themes
+             WHERE theme_key = ? AND organization_id = ?',
+            [$themeKey, $this->orgId->get()],
+        );
+
+        return $row === null ? null : $this->mapRow($row);
+    }
+
+    public function existsByKey(string $themeKey): bool
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id FROM themes WHERE theme_key = ? AND organization_id = ?',
+            [$themeKey, $this->orgId->get()],
+        );
+
+        return $row !== null;
+    }
+
+    public function save(Theme $theme): int
+    {
+        $now = date('Y-m-d H:i:s');
+
+        $this->query->execute(
+            'INSERT INTO themes (organization_id, theme_key, name, version, source, manifest, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $this->orgId->get(),
+                $theme->themeKey,
+                $theme->name,
+                $theme->version,
+                'runtime',
+                self::encode($theme->manifest),
+                $now,
+                $now,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function update(Theme $theme): void
+    {
+        $now = date('Y-m-d H:i:s');
+
+        $this->query->execute(
+            'UPDATE themes
+             SET name = ?, version = ?, manifest = ?, updated_at = ?
+             WHERE theme_key = ? AND organization_id = ?',
+            [
+                $theme->name,
+                $theme->version,
+                self::encode($theme->manifest),
+                $now,
+                $theme->themeKey,
+                $this->orgId->get(),
+            ],
+        );
+    }
+
+    public function deleteByKey(string $themeKey): void
+    {
+        $this->query->execute(
+            'DELETE FROM themes WHERE theme_key = ? AND organization_id = ?',
+            [$themeKey, $this->orgId->get()],
+        );
+    }
+
+    /** @param array<string, mixed> $manifest */
+    private static function encode(array $manifest): string
+    {
+        return json_encode($manifest, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '{}';
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): Theme
+    {
+        $decoded = json_decode((string) $row['manifest'], true);
+        /** @var array<string, mixed> $manifest */
+        $manifest = is_array($decoded) ? $decoded : [];
+
+        return new Theme(
+            id: (int) $row['id'],
+            themeKey: (string) $row['theme_key'],
+            name: (string) $row['name'],
+            version: (string) $row['version'],
+            manifest: $manifest,
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/src/Theme/Theme.php
+++ b/src/Theme/Theme.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+/**
+ * A runtime (data-driven) public-site theme (#423). The `manifest` is the
+ * validated public-theme.schema.json document (tokens / flags / knobs …);
+ * `themeKey` / `name` / `version` are denormalised from it for listing and
+ * uniqueness. See docs/theming/runtime-themes.md.
+ */
+final readonly class Theme
+{
+    /**
+     * @param array<string, mixed> $manifest
+     */
+    public function __construct(
+        public ?int $id,
+        public string $themeKey,
+        public string $name,
+        public string $version,
+        public array $manifest,
+        public string $createdAt,
+        public string $updatedAt,
+    ) {
+    }
+}

--- a/src/Theme/ThemeHttpMapper.php
+++ b/src/Theme/ThemeHttpMapper.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+final readonly class ThemeHttpMapper
+{
+    /** @return array<string, mixed> */
+    public static function toArray(Theme $theme): array
+    {
+        return [
+            'theme_key' => $theme->themeKey,
+            'name' => $theme->name,
+            'version' => $theme->version,
+            'manifest' => $theme->manifest,
+            'created_at' => $theme->createdAt,
+            'updated_at' => $theme->updatedAt,
+        ];
+    }
+}

--- a/src/Theme/ThemeManifestValidator.php
+++ b/src/Theme/ThemeManifestValidator.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+
+/**
+ * Validates a runtime theme manifest before it is stored / served (#423).
+ *
+ * Mirrors docs/theming/public-theme.schema.json AND adds the runtime safety the
+ * JSON schema cannot express: because token values are emitted verbatim as
+ * `--key: <value>;` inside a scoped `<style>` on the public site, an untrusted
+ * value could break out of the declaration / stylesheet. So every token value
+ * is constrained to safe CSS (no `;{}<>`, no `url(`/`@import`/`expression(`/
+ * `javascript:`), and token keys are allowlisted by pattern. This is the crux
+ * of letting ClaudeDesign register themes over MCP. See runtime-themes.md §6.
+ */
+final class ThemeManifestValidator
+{
+    private const ID_PATTERN = '/^[a-z][a-z0-9-]{1,40}$/';
+    private const VERSION_PATTERN = '/^[0-9]+\.[0-9]+\.[0-9]+$/';
+    private const TOKEN_KEY_PATTERN = '/^[a-z][a-z0-9-]*$/';
+
+    /** Required contract tokens per mode (mirrors schema $defs.tokenSet.required). */
+    private const REQUIRED_TOKENS = [
+        'color-surface', 'color-surface-raised', 'color-surface-overlay', 'color-surface-sunken',
+        'color-text-primary', 'color-text-muted', 'color-text-inverse',
+        'color-border', 'color-border-strong', 'color-focus-ring',
+        'color-accent', 'color-accent-hover', 'color-accent-weak', 'color-on-accent',
+        'color-brand-violet', 'color-danger', 'color-danger-hover',
+        'color-ok', 'color-warn', 'color-info',
+        'shadow-sm', 'shadow-md', 'shadow-lg', 'color-scheme',
+    ];
+
+    /** Structural style-flag enums (mirrors theme-customization.ts FLAG_DEFS). */
+    private const FLAG_ENUMS = [
+        'feedLayout' => ['grid', 'list', 'magazine'],
+        'feedColumns' => ['auto', '1', '2', '3', '4'],
+        'cardStyle' => ['flat', 'bordered', 'shadowed', 'framed'],
+        'media' => ['plain', 'duotone', 'grayscale', 'framed'],
+        'hero' => ['standard', 'fullbleed', 'minimal'],
+        'sectionRule' => ['none', 'hairline', 'heavy'],
+        'eyebrow' => ['plain', 'caps', 'barred'],
+        'headerSearch' => ['show', 'hide'],
+        'headerTheme' => ['show', 'hide'],
+        'headerTagline' => ['show', 'hide'],
+        'headerLayout' => ['nav-right', 'classic', 'centered', 'minimal'],
+        'headerNavAlign' => ['start', 'center', 'end'],
+        'headerDensity' => ['compact', 'regular', 'tall'],
+        'headerWidth' => ['boxed', 'full'],
+        'headerSticky' => ['sticky', 'none'],
+    ];
+
+    /**
+     * Built-in (static) theme ids — runtime themes must not shadow them.
+     * Mirrors frontend/src/shared/lib/public-themes.ts PUBLIC_THEMES + the
+     * authoring bundles under themes/. Keep in sync when built-ins change.
+     */
+    private const RESERVED_KEYS = [
+        'consumer', 'aurora', 'reading', 'noir', 'botanical', 'pastel',
+        'newsprint', 'academia', 'coastal', 'funk',
+        'synthwave', 'terminal', 'western', 'y2k',
+    ];
+
+    private const MAX_TOKEN_VALUE_LEN = 200;
+
+    /**
+     * @param array<string, mixed> $manifest
+     *
+     * @throws ValidationException when the manifest is malformed or unsafe
+     */
+    public static function validate(array $manifest): void
+    {
+        $errors = [];
+
+        $id = $manifest['id'] ?? null;
+        if (!is_string($id) || preg_match(self::ID_PATTERN, $id) !== 1) {
+            $errors[] = new ValidationError('id', 'Theme id must match ^[a-z][a-z0-9-]{1,40}$.', 'invalid');
+        } elseif (in_array($id, self::RESERVED_KEYS, true)) {
+            $errors[] = new ValidationError('id', "Theme id '{$id}' is reserved by a built-in theme.", 'reserved');
+        }
+
+        $name = $manifest['name'] ?? null;
+        if (!is_string($name) || trim($name) === '' || mb_strlen($name) > 80) {
+            $errors[] = new ValidationError('name', 'Name is required (1–80 chars).', 'invalid');
+        }
+
+        $version = $manifest['version'] ?? null;
+        if (!is_string($version) || preg_match(self::VERSION_PATTERN, $version) !== 1) {
+            $errors[] = new ValidationError('version', 'Version must be semver (e.g. 1.0.0).', 'invalid');
+        }
+
+        self::validateModes($manifest['supportsModes'] ?? null, $errors);
+        self::validateTokens($manifest['tokens'] ?? null, $errors);
+        self::validateFlags($manifest['flags'] ?? null, $errors);
+        self::validateFonts($manifest['fonts'] ?? null, $errors);
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+    }
+
+    /**
+     * @param list<ValidationError> $errors
+     */
+    private static function validateModes(mixed $modes, array &$errors): void
+    {
+        if (!is_array($modes) || !in_array('light', $modes, true) || !in_array('dark', $modes, true)) {
+            $errors[] = new ValidationError('supportsModes', 'supportsModes must include both light and dark.', 'invalid');
+        }
+    }
+
+    /**
+     * @param list<ValidationError> $errors
+     */
+    private static function validateTokens(mixed $tokens, array &$errors): void
+    {
+        if (!is_array($tokens) || !isset($tokens['light']) || !isset($tokens['dark'])) {
+            $errors[] = new ValidationError('tokens', 'tokens.light and tokens.dark are required.', 'required');
+
+            return;
+        }
+
+        foreach (['light', 'dark'] as $mode) {
+            $set = $tokens[$mode];
+            if (!is_array($set)) {
+                $errors[] = new ValidationError("tokens.{$mode}", 'Token set must be an object.', 'invalid');
+
+                continue;
+            }
+
+            foreach (self::REQUIRED_TOKENS as $required) {
+                if (!array_key_exists($required, $set)) {
+                    $errors[] = new ValidationError("tokens.{$mode}.{$required}", 'Required token is missing.', 'required');
+                }
+            }
+
+            foreach ($set as $key => $value) {
+                $field = "tokens.{$mode}." . (is_string($key) ? $key : '?');
+                if (!is_string($key) || preg_match(self::TOKEN_KEY_PATTERN, $key) !== 1) {
+                    $errors[] = new ValidationError($field, 'Token name must match ^[a-z][a-z0-9-]*$.', 'invalid');
+
+                    continue;
+                }
+                if (!is_string($value) || !self::isSafeCssValue($value)) {
+                    $errors[] = new ValidationError($field, 'Token value is empty or contains unsafe CSS.', 'unsafe');
+                }
+            }
+        }
+    }
+
+    /**
+     * @param list<ValidationError> $errors
+     */
+    private static function validateFlags(mixed $flags, array &$errors): void
+    {
+        if ($flags === null) {
+            return;
+        }
+        if (!is_array($flags)) {
+            $errors[] = new ValidationError('flags', 'flags must be an object.', 'invalid');
+
+            return;
+        }
+        foreach ($flags as $key => $value) {
+            if (!is_string($key) || !array_key_exists($key, self::FLAG_ENUMS)) {
+                $errors[] = new ValidationError('flags.' . (is_string($key) ? $key : '?'), 'Unknown flag.', 'invalid');
+
+                continue;
+            }
+            if (!is_string($value) || !in_array($value, self::FLAG_ENUMS[$key], true)) {
+                $errors[] = new ValidationError("flags.{$key}", 'Value is not in the allowed set.', 'invalid');
+            }
+        }
+    }
+
+    /**
+     * @param list<ValidationError> $errors
+     */
+    private static function validateFonts(mixed $fonts, array &$errors): void
+    {
+        if ($fonts === null) {
+            return;
+        }
+        if (!is_array($fonts)) {
+            $errors[] = new ValidationError('fonts', 'fonts must be an array.', 'invalid');
+
+            return;
+        }
+        foreach ($fonts as $i => $font) {
+            // Runtime themes may only use bundled fonts; self-hosted files need a
+            // deploy, so they cannot be registered over MCP (runtime-themes.md §6).
+            $source = is_array($font) ? ($font['source'] ?? null) : null;
+            if (!in_array($source, ['fontsource', 'system'], true)) {
+                $errors[] = new ValidationError("fonts.{$i}.source", 'Runtime fonts must be fontsource or system.', 'invalid');
+            }
+        }
+    }
+
+    /**
+     * A token value is safe when it carries no characters that could break out
+     * of `--key: <value>;` or the enclosing `<style>`, and no external/script
+     * constructs. Allows oklch()/hex/clamp()/color-mix()/lengths/keywords.
+     */
+    public static function isSafeCssValue(string $value): bool
+    {
+        $trimmed = trim($value);
+        if ($trimmed === '' || mb_strlen($trimmed) > self::MAX_TOKEN_VALUE_LEN) {
+            return false;
+        }
+        // Declaration / stylesheet break-out characters.
+        if (preg_match('/[;{}<>\\\\`]/', $trimmed) === 1) {
+            return false;
+        }
+        // External / script-bearing constructs (case-insensitive).
+        $lower = strtolower($trimmed);
+        foreach (['url(', '@import', 'expression(', 'javascript:', '/*', '*/'] as $needle) {
+            if (str_contains($lower, $needle)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Theme/ThemeNotFoundException.php
+++ b/src/Theme/ThemeNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use DomainException;
+
+final class ThemeNotFoundException extends DomainException
+{
+    public function __construct(string $themeKey)
+    {
+        parent::__construct("Theme '{$themeKey}' was not found.");
+    }
+}

--- a/src/Theme/ThemeNotFoundExceptionHandler.php
+++ b/src/Theme/ThemeNotFoundExceptionHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ThemeNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(\Throwable $e): bool
+    {
+        return $e instanceof ThemeNotFoundException;
+    }
+
+    public function handle(\Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'not-found', 'Not Found', 404, $exception->getMessage());
+    }
+}

--- a/src/Theme/ThemeRepositoryInterface.php
+++ b/src/Theme/ThemeRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+interface ThemeRepositoryInterface
+{
+    /** @return list<Theme> */
+    public function findAll(): array;
+
+    public function findByKey(string $themeKey): ?Theme;
+
+    public function existsByKey(string $themeKey): bool;
+
+    public function save(Theme $theme): int;
+
+    public function update(Theme $theme): void;
+
+    public function deleteByKey(string $themeKey): void;
+}

--- a/src/Theme/ThemeRouteRegistrar.php
+++ b/src/Theme/ThemeRouteRegistrar.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ThemeRouteRegistrar
+{
+    public function __construct(
+        private ListThemesHandler $listHandler,
+        private GetThemeHandler $getHandler,
+        private CreateThemeHandler $createHandler,
+        private UpdateThemeHandler $updateHandler,
+        private DeleteThemeHandler $deleteHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $list = $this->listHandler;
+        $get = $this->getHandler;
+        $create = $this->createHandler;
+        $update = $this->updateHandler;
+        $delete = $this->deleteHandler;
+
+        $router->get(
+            '/api/v1/themes',
+            static fn (ServerRequestInterface $request) => $list->handle($request),
+        );
+        $router->post(
+            '/api/v1/themes',
+            static fn (ServerRequestInterface $request) => $create->handle($request),
+        );
+        $router->get(
+            '/api/v1/themes/{key}',
+            static fn (ServerRequestInterface $request) => $get->handle($request),
+        );
+        $router->put(
+            '/api/v1/themes/{key}',
+            static fn (ServerRequestInterface $request) => $update->handle($request),
+        );
+        $router->delete(
+            '/api/v1/themes/{key}',
+            static fn (ServerRequestInterface $request) => $delete->handle($request),
+        );
+    }
+}

--- a/src/Theme/ThemeServiceProvider.php
+++ b/src/Theme/ThemeServiceProvider.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use Psr\Container\ContainerInterface;
+
+final readonly class ThemeServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                ThemeRepositoryInterface::class,
+                static function (ContainerInterface $container): ThemeRepositoryInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    $orgId = $container->get('nene-records.org_id_holder');
+                    if (!$orgId instanceof RequestScopedHolder) {
+                        throw new LogicException('Org ID holder service is invalid.');
+                    }
+
+                    return new PdoThemeRepository($query, $orgId);
+                },
+            )
+            ->set(
+                ListThemesUseCaseInterface::class,
+                static function (ContainerInterface $container): ListThemesUseCaseInterface {
+                    $repo = $container->get(ThemeRepositoryInterface::class);
+                    if (!$repo instanceof ThemeRepositoryInterface) {
+                        throw new LogicException('Theme repository service is invalid.');
+                    }
+
+                    return new ListThemesUseCase($repo);
+                },
+            )
+            ->set(
+                CreateThemeUseCaseInterface::class,
+                static function (ContainerInterface $container): CreateThemeUseCaseInterface {
+                    $repo = $container->get(ThemeRepositoryInterface::class);
+                    if (!$repo instanceof ThemeRepositoryInterface) {
+                        throw new LogicException('Theme repository service is invalid.');
+                    }
+
+                    return new CreateThemeUseCase($repo);
+                },
+            )
+            ->set(
+                UpdateThemeUseCaseInterface::class,
+                static function (ContainerInterface $container): UpdateThemeUseCaseInterface {
+                    $repo = $container->get(ThemeRepositoryInterface::class);
+                    if (!$repo instanceof ThemeRepositoryInterface) {
+                        throw new LogicException('Theme repository service is invalid.');
+                    }
+
+                    return new UpdateThemeUseCase($repo);
+                },
+            )
+            ->set(
+                DeleteThemeUseCaseInterface::class,
+                static function (ContainerInterface $container): DeleteThemeUseCaseInterface {
+                    $repo = $container->get(ThemeRepositoryInterface::class);
+                    if (!$repo instanceof ThemeRepositoryInterface) {
+                        throw new LogicException('Theme repository service is invalid.');
+                    }
+
+                    return new DeleteThemeUseCase($repo);
+                },
+            )
+            ->set(
+                ListThemesHandler::class,
+                static function (ContainerInterface $container): ListThemesHandler {
+                    $useCase = $container->get(ListThemesUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+                    if (!$useCase instanceof ListThemesUseCaseInterface) {
+                        throw new LogicException('ListThemes use case service is invalid.');
+                    }
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListThemesHandler($useCase, $response);
+                },
+            )
+            ->set(
+                GetThemeHandler::class,
+                static function (ContainerInterface $container): GetThemeHandler {
+                    $repo = $container->get(ThemeRepositoryInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+                    if (!$repo instanceof ThemeRepositoryInterface) {
+                        throw new LogicException('Theme repository service is invalid.');
+                    }
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new GetThemeHandler($repo, $response);
+                },
+            )
+            ->set(
+                CreateThemeHandler::class,
+                static function (ContainerInterface $container): CreateThemeHandler {
+                    $useCase = $container->get(CreateThemeUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+                    if (!$useCase instanceof CreateThemeUseCaseInterface) {
+                        throw new LogicException('CreateTheme use case service is invalid.');
+                    }
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new CreateThemeHandler($useCase, $response);
+                },
+            )
+            ->set(
+                UpdateThemeHandler::class,
+                static function (ContainerInterface $container): UpdateThemeHandler {
+                    $useCase = $container->get(UpdateThemeUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+                    if (!$useCase instanceof UpdateThemeUseCaseInterface) {
+                        throw new LogicException('UpdateTheme use case service is invalid.');
+                    }
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new UpdateThemeHandler($useCase, $response);
+                },
+            )
+            ->set(
+                DeleteThemeHandler::class,
+                static function (ContainerInterface $container): DeleteThemeHandler {
+                    $useCase = $container->get(DeleteThemeUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+                    if (!$useCase instanceof DeleteThemeUseCaseInterface) {
+                        throw new LogicException('DeleteTheme use case service is invalid.');
+                    }
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new DeleteThemeHandler($useCase, $response);
+                },
+            )
+            ->set(
+                ThemeNotFoundExceptionHandler::class,
+                static function (ContainerInterface $container): ThemeNotFoundExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new ThemeNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.theme',
+                static function (ContainerInterface $container): ThemeRouteRegistrar {
+                    $list = $container->get(ListThemesHandler::class);
+                    $get = $container->get(GetThemeHandler::class);
+                    $create = $container->get(CreateThemeHandler::class);
+                    $update = $container->get(UpdateThemeHandler::class);
+                    $delete = $container->get(DeleteThemeHandler::class);
+
+                    if (!$list instanceof ListThemesHandler) {
+                        throw new LogicException('ListThemes handler service is invalid.');
+                    }
+                    if (!$get instanceof GetThemeHandler) {
+                        throw new LogicException('GetTheme handler service is invalid.');
+                    }
+                    if (!$create instanceof CreateThemeHandler) {
+                        throw new LogicException('CreateTheme handler service is invalid.');
+                    }
+                    if (!$update instanceof UpdateThemeHandler) {
+                        throw new LogicException('UpdateTheme handler service is invalid.');
+                    }
+                    if (!$delete instanceof DeleteThemeHandler) {
+                        throw new LogicException('DeleteTheme handler service is invalid.');
+                    }
+
+                    return new ThemeRouteRegistrar($list, $get, $create, $update, $delete);
+                },
+            );
+    }
+}

--- a/src/Theme/UpdateThemeHandler.php
+++ b/src/Theme/UpdateThemeHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateThemeHandler
+{
+    public function __construct(
+        private UpdateThemeUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $key = (string) ($parameters['key'] ?? '');
+
+        $manifest = JsonRequestBodyParser::parse($request);
+
+        $output = $this->useCase->execute(new UpdateThemeInput(themeKey: $key, manifest: $manifest));
+
+        return $this->response->create(ThemeHttpMapper::toArray($output->theme));
+    }
+}

--- a/src/Theme/UpdateThemeInput.php
+++ b/src/Theme/UpdateThemeInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+final readonly class UpdateThemeInput
+{
+    /** @param array<string, mixed> $manifest */
+    public function __construct(
+        public string $themeKey,
+        public array $manifest,
+    ) {
+    }
+}

--- a/src/Theme/UpdateThemeOutput.php
+++ b/src/Theme/UpdateThemeOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+final readonly class UpdateThemeOutput
+{
+    public function __construct(
+        public Theme $theme,
+    ) {
+    }
+}

--- a/src/Theme/UpdateThemeUseCase.php
+++ b/src/Theme/UpdateThemeUseCase.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+
+final readonly class UpdateThemeUseCase implements UpdateThemeUseCaseInterface
+{
+    public function __construct(
+        private ThemeRepositoryInterface $repository,
+    ) {
+    }
+
+    public function execute(UpdateThemeInput $input): UpdateThemeOutput
+    {
+        $existing = $this->repository->findByKey($input->themeKey);
+
+        if ($existing === null) {
+            throw new ThemeNotFoundException($input->themeKey);
+        }
+
+        ThemeManifestValidator::validate($input->manifest);
+
+        // The key is immutable on update; renaming means delete + create.
+        if ((string) $input->manifest['id'] !== $input->themeKey) {
+            throw new ValidationException([
+                new ValidationError('id', 'Manifest id must match the theme key in the URL.', 'mismatch'),
+            ]);
+        }
+
+        $this->repository->update(new Theme(
+            id: $existing->id,
+            themeKey: $input->themeKey,
+            name: (string) $input->manifest['name'],
+            version: (string) $input->manifest['version'],
+            manifest: $input->manifest,
+            createdAt: $existing->createdAt,
+            updatedAt: '',
+        ));
+
+        $saved = $this->repository->findByKey($input->themeKey);
+
+        if ($saved === null) {
+            throw new \RuntimeException('Failed to reload theme after update.');
+        }
+
+        return new UpdateThemeOutput(theme: $saved);
+    }
+}

--- a/src/Theme/UpdateThemeUseCaseInterface.php
+++ b/src/Theme/UpdateThemeUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+interface UpdateThemeUseCaseInterface
+{
+    public function execute(UpdateThemeInput $input): UpdateThemeOutput;
+}

--- a/tests/Theme/InMemoryThemeRepository.php
+++ b/tests/Theme/InMemoryThemeRepository.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Theme;
+
+use NeNeRecords\Theme\Theme;
+use NeNeRecords\Theme\ThemeRepositoryInterface;
+
+final class InMemoryThemeRepository implements ThemeRepositoryInterface
+{
+    /** @var array<string, Theme> keyed by themeKey */
+    private array $themes = [];
+
+    private int $nextId = 1;
+
+    /** @return list<Theme> */
+    public function findAll(): array
+    {
+        return array_values($this->themes);
+    }
+
+    public function findByKey(string $themeKey): ?Theme
+    {
+        return $this->themes[$themeKey] ?? null;
+    }
+
+    public function existsByKey(string $themeKey): bool
+    {
+        return isset($this->themes[$themeKey]);
+    }
+
+    public function save(Theme $theme): int
+    {
+        $id = $this->nextId++;
+        $now = date('Y-m-d H:i:s');
+        $this->themes[$theme->themeKey] = new Theme(
+            id: $id,
+            themeKey: $theme->themeKey,
+            name: $theme->name,
+            version: $theme->version,
+            manifest: $theme->manifest,
+            createdAt: $now,
+            updatedAt: $now,
+        );
+
+        return $id;
+    }
+
+    public function update(Theme $theme): void
+    {
+        if (!isset($this->themes[$theme->themeKey])) {
+            return;
+        }
+        $existing = $this->themes[$theme->themeKey];
+        $this->themes[$theme->themeKey] = new Theme(
+            id: $existing->id,
+            themeKey: $theme->themeKey,
+            name: $theme->name,
+            version: $theme->version,
+            manifest: $theme->manifest,
+            createdAt: $existing->createdAt,
+            updatedAt: date('Y-m-d H:i:s'),
+        );
+    }
+
+    public function deleteByKey(string $themeKey): void
+    {
+        unset($this->themes[$themeKey]);
+    }
+}

--- a/tests/Theme/ThemeManifestFixture.php
+++ b/tests/Theme/ThemeManifestFixture.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Theme;
+
+/**
+ * Builds a valid runtime theme manifest for tests (all required contract tokens
+ * with safe CSS values). Pass overrides to mutate specific fields.
+ */
+final class ThemeManifestFixture
+{
+    private const REQUIRED_TOKENS = [
+        'color-surface', 'color-surface-raised', 'color-surface-overlay', 'color-surface-sunken',
+        'color-text-primary', 'color-text-muted', 'color-text-inverse',
+        'color-border', 'color-border-strong', 'color-focus-ring',
+        'color-accent', 'color-accent-hover', 'color-accent-weak', 'color-on-accent',
+        'color-brand-violet', 'color-danger', 'color-danger-hover',
+        'color-ok', 'color-warn', 'color-info',
+        'shadow-sm', 'shadow-md', 'shadow-lg', 'color-scheme',
+    ];
+
+    /**
+     * @param array<string, mixed> $overrides
+     *
+     * @return array<string, mixed>
+     */
+    public static function valid(array $overrides = []): array
+    {
+        $manifest = [
+            'id' => 'midnight',
+            'name' => 'Midnight',
+            'version' => '1.0.0',
+            'supportsModes' => ['light', 'dark'],
+            'tokens' => [
+                'light' => self::tokenSet('light'),
+                'dark' => self::tokenSet('dark'),
+            ],
+            'flags' => ['feedLayout' => 'grid', 'headerSearch' => 'hide'],
+        ];
+
+        return array_merge($manifest, $overrides);
+    }
+
+    /** @return array<string, string> */
+    private static function tokenSet(string $mode): array
+    {
+        $set = [];
+        foreach (self::REQUIRED_TOKENS as $token) {
+            $set[$token] = match ($token) {
+                'color-scheme' => $mode,
+                'shadow-sm', 'shadow-md', 'shadow-lg' => '0 1px 2px rgba(0,0,0,0.1)',
+                default => 'oklch(60% 0.1 250)',
+            };
+        }
+
+        return $set;
+    }
+}

--- a/tests/Theme/ThemeManifestValidatorTest.php
+++ b/tests/Theme/ThemeManifestValidatorTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Theme;
+
+use Nene2\Validation\ValidationException;
+use NeNeRecords\Theme\ThemeManifestValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ThemeManifestValidatorTest extends TestCase
+{
+    public function testValidManifestPasses(): void
+    {
+        ThemeManifestValidator::validate(ThemeManifestFixture::valid());
+        $this->addToAssertionCount(1);
+    }
+
+    /** @param array<string, mixed> $manifest */
+    #[DataProvider('provideInvalidManifests')]
+    public function testInvalidManifestThrows(array $manifest): void
+    {
+        $this->expectException(ValidationException::class);
+        ThemeManifestValidator::validate($manifest);
+    }
+
+    /** @return iterable<string, array{array<string, mixed>}> */
+    public static function provideInvalidManifests(): iterable
+    {
+        yield 'bad id' => [ThemeManifestFixture::valid(['id' => 'Bad Id!'])];
+        yield 'reserved id' => [ThemeManifestFixture::valid(['id' => 'aurora'])];
+        yield 'empty name' => [ThemeManifestFixture::valid(['name' => ''])];
+        yield 'bad version' => [ThemeManifestFixture::valid(['version' => 'v1'])];
+        yield 'missing dark mode' => [ThemeManifestFixture::valid(['supportsModes' => ['light']])];
+        yield 'unknown flag' => [ThemeManifestFixture::valid(['flags' => ['bogus' => 'x']])];
+        yield 'bad flag value' => [ThemeManifestFixture::valid(['flags' => ['feedLayout' => 'spaceship']])];
+
+        $missingToken = ThemeManifestFixture::valid();
+        unset($missingToken['tokens']['light']['color-accent']);
+        yield 'missing required token' => [$missingToken];
+
+        $badKey = ThemeManifestFixture::valid();
+        $badKey['tokens']['light']['Bad_Key'] = 'oklch(60% 0.1 250)';
+        yield 'bad token key' => [$badKey];
+
+        $selfhostFont = ThemeManifestFixture::valid(['fonts' => [['family' => 'X', 'role' => 'body', 'source' => 'selfhost']]]);
+        yield 'selfhost font' => [$selfhostFont];
+    }
+
+    /** Unsafe token values that could break out of `--key: value;` / <style>. */
+    #[DataProvider('provideUnsafeValues')]
+    public function testUnsafeTokenValueRejected(string $value): void
+    {
+        $manifest = ThemeManifestFixture::valid();
+        $manifest['tokens']['light']['color-accent'] = $value;
+
+        $this->expectException(ValidationException::class);
+        ThemeManifestValidator::validate($manifest);
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function provideUnsafeValues(): iterable
+    {
+        yield 'semicolon breakout' => ['red; } body { display:none'];
+        yield 'brace' => ['red}'];
+        yield 'url()' => ['url(https://evil.test/x.png)'];
+        yield '@import' => ['@import "https://evil.test"'];
+        yield 'expression' => ['expression(alert(1))'];
+        yield 'angle bracket' => ['</style><script>'];
+        yield 'comment' => ['red /* x */'];
+        yield 'empty' => [''];
+    }
+
+    #[DataProvider('provideSafeValues')]
+    public function testSafeValuesAccepted(string $value): void
+    {
+        self::assertTrue(ThemeManifestValidator::isSafeCssValue($value));
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function provideSafeValues(): iterable
+    {
+        yield 'oklch' => ['oklch(97% 0.012 75)'];
+        yield 'hex' => ['#1a2b3c'];
+        yield 'color-mix' => ['color-mix(in oklch, #fff, #000 12%)'];
+        yield 'clamp' => ['clamp(1rem, 0.5rem + 2vw, 2rem)'];
+        yield 'keyword' => ['dark'];
+    }
+}

--- a/tests/Theme/ThemeUseCaseTest.php
+++ b/tests/Theme/ThemeUseCaseTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Theme;
+
+use Nene2\Validation\ValidationException;
+use NeNeRecords\Theme\CreateThemeInput;
+use NeNeRecords\Theme\CreateThemeUseCase;
+use NeNeRecords\Theme\DeleteThemeInput;
+use NeNeRecords\Theme\DeleteThemeUseCase;
+use NeNeRecords\Theme\ListThemesUseCase;
+use NeNeRecords\Theme\ThemeNotFoundException;
+use NeNeRecords\Theme\UpdateThemeInput;
+use NeNeRecords\Theme\UpdateThemeUseCase;
+use PHPUnit\Framework\TestCase;
+
+final class ThemeUseCaseTest extends TestCase
+{
+    public function testCreatePersistsValidManifestAndListsIt(): void
+    {
+        $repo = new InMemoryThemeRepository();
+        $create = new CreateThemeUseCase($repo);
+
+        $output = $create->execute(new CreateThemeInput(ThemeManifestFixture::valid()));
+
+        self::assertSame('midnight', $output->theme->themeKey);
+        self::assertSame('Midnight', $output->theme->name);
+
+        $list = (new ListThemesUseCase($repo))->execute();
+        self::assertCount(1, $list->items);
+    }
+
+    public function testCreateRejectsInvalidManifest(): void
+    {
+        $repo = new InMemoryThemeRepository();
+        $create = new CreateThemeUseCase($repo);
+
+        $this->expectException(ValidationException::class);
+        $create->execute(new CreateThemeInput(ThemeManifestFixture::valid(['version' => 'bad'])));
+    }
+
+    public function testCreateRejectsDuplicateKey(): void
+    {
+        $repo = new InMemoryThemeRepository();
+        $create = new CreateThemeUseCase($repo);
+        $create->execute(new CreateThemeInput(ThemeManifestFixture::valid()));
+
+        $this->expectException(ValidationException::class);
+        $create->execute(new CreateThemeInput(ThemeManifestFixture::valid()));
+    }
+
+    public function testUpdateChangesManifest(): void
+    {
+        $repo = new InMemoryThemeRepository();
+        (new CreateThemeUseCase($repo))->execute(new CreateThemeInput(ThemeManifestFixture::valid()));
+
+        $update = new UpdateThemeUseCase($repo);
+        $output = $update->execute(new UpdateThemeInput(
+            themeKey: 'midnight',
+            manifest: ThemeManifestFixture::valid(['name' => 'Midnight 2', 'version' => '1.1.0']),
+        ));
+
+        self::assertSame('Midnight 2', $output->theme->name);
+        self::assertSame('1.1.0', $output->theme->version);
+    }
+
+    public function testUpdateRejectsKeyMismatch(): void
+    {
+        $repo = new InMemoryThemeRepository();
+        (new CreateThemeUseCase($repo))->execute(new CreateThemeInput(ThemeManifestFixture::valid()));
+
+        $this->expectException(ValidationException::class);
+        (new UpdateThemeUseCase($repo))->execute(new UpdateThemeInput(
+            themeKey: 'midnight',
+            manifest: ThemeManifestFixture::valid(['id' => 'other-key']),
+        ));
+    }
+
+    public function testUpdateMissingThrowsNotFound(): void
+    {
+        $repo = new InMemoryThemeRepository();
+
+        $this->expectException(ThemeNotFoundException::class);
+        (new UpdateThemeUseCase($repo))->execute(new UpdateThemeInput(
+            themeKey: 'midnight',
+            manifest: ThemeManifestFixture::valid(),
+        ));
+    }
+
+    public function testDeleteRemovesTheme(): void
+    {
+        $repo = new InMemoryThemeRepository();
+        (new CreateThemeUseCase($repo))->execute(new CreateThemeInput(ThemeManifestFixture::valid()));
+
+        (new DeleteThemeUseCase($repo))->execute(new DeleteThemeInput('midnight'));
+
+        self::assertFalse($repo->existsByKey('midnight'));
+    }
+
+    public function testDeleteMissingThrowsNotFound(): void
+    {
+        $repo = new InMemoryThemeRepository();
+
+        $this->expectException(ThemeNotFoundException::class);
+        (new DeleteThemeUseCase($repo))->execute(new DeleteThemeInput('nope'));
+    }
+}

--- a/tools/generate-mcp-tools.php
+++ b/tools/generate-mcp-tools.php
@@ -121,6 +121,32 @@ $idOnly = [
     ],
 ];
 
+// Runtime theme manifest fields (public-theme.schema.json shape). The request
+// body IS the manifest; token values are sanitised server-side. See #423.
+$themeManifestProps = [
+    'id' => [
+        'type' => 'string',
+        'pattern' => '^[a-z][a-z0-9-]{1,40}$',
+        'description' => 'Theme key/id. Must not collide with a built-in theme.',
+    ],
+    'name' => ['type' => 'string', 'minLength' => 1, 'maxLength' => 80],
+    'version' => ['type' => 'string', 'pattern' => '^[0-9]+\\.[0-9]+\\.[0-9]+$'],
+    'supportsModes' => [
+        'type' => 'array',
+        'items' => ['type' => 'string', 'enum' => ['light', 'dark']],
+        'description' => 'Must include both light and dark.',
+    ],
+    'tokens' => [
+        'type' => 'object',
+        'description' => 'Per-mode CSS tokens: {"light":{token:value,…},"dark":{…}}. Keys are contract tokens; values must be safe CSS (no ;{}<>, url(), @import).',
+    ],
+    'flags' => [
+        'type' => 'object',
+        'description' => 'Optional structural style flags (enumerated; e.g. feedLayout, headerLayout).',
+    ],
+];
+$themeManifestRequired = ['id', 'name', 'version', 'supportsModes', 'tokens'];
+
 $tools = [
     readTool(
         'getHealth',
@@ -709,6 +735,83 @@ $tools = [
             'offset' => ['type' => 'integer', 'minimum' => 0],
         ],
         '#/components/schemas/SettingRevisionListResponse',
+        ['key'],
+    ),
+    readTool(
+        'listThemes',
+        'List Runtime Themes',
+        'List all runtime (data-driven) public-site themes for the organization.',
+        'listThemes',
+        'GET',
+        '/api/v1/themes',
+        [],
+        '#/components/schemas/ThemeListResponse',
+    ),
+    readTool(
+        'createTheme',
+        'Create Runtime Theme',
+        'Register a new runtime public-site theme. The input is the theme manifest (tokens + flags). The server validates structure and sanitises token values before storing; unsafe CSS and reserved ids are rejected.',
+        'createTheme',
+        'POST',
+        '/api/v1/themes',
+        $themeManifestProps,
+        null,
+        $themeManifestRequired,
+        true,
+    ),
+    readTool(
+        'getTheme',
+        'Get Runtime Theme',
+        'Get a single runtime theme by its key.',
+        'getTheme',
+        'GET',
+        '/api/v1/themes/{key}',
+        [
+            'key' => [
+                'type' => 'string',
+                'pattern' => '^[a-z][a-z0-9-]{1,40}$',
+                'description' => 'Theme key.',
+            ],
+        ],
+        '#/components/schemas/ThemeResponse',
+        ['key'],
+    ),
+    readTool(
+        'updateTheme',
+        'Update Runtime Theme',
+        'Replace an existing runtime theme manifest. The manifest id must match the key in the path.',
+        'updateTheme',
+        'PUT',
+        '/api/v1/themes/{key}',
+        array_merge(
+            [
+                'key' => [
+                    'type' => 'string',
+                    'pattern' => '^[a-z][a-z0-9-]{1,40}$',
+                    'description' => 'Theme key (must equal the manifest id).',
+                ],
+            ],
+            $themeManifestProps,
+        ),
+        '#/components/schemas/ThemeResponse',
+        array_merge(['key'], $themeManifestRequired),
+        true,
+    ),
+    readTool(
+        'deleteTheme',
+        'Delete Runtime Theme',
+        'Permanently delete a runtime theme by its key.',
+        'deleteTheme',
+        'DELETE',
+        '/api/v1/themes/{key}',
+        [
+            'key' => [
+                'type' => 'string',
+                'pattern' => '^[a-z][a-z0-9-]{1,40}$',
+                'description' => 'Theme key.',
+            ],
+        ],
+        null,
         ['key'],
     ),
 ];


### PR DESCRIPTION
## 目的

ClaudeDesign が **MCP 経由でテーマを登録・量産**できるランタイムテーマ基盤（#423）。backend（Phase B）＋ OpenAPI/MCP 公開（Phase C）。設計: `docs/theming/runtime-themes.md`。

## Phase B — backend

- マイグレーション `create_themes_table`（org スコープ・`manifest` JSON・`UNIQUE(org, theme_key)`）
- `src/Theme/`：`Theme` / Repository / CRUD UseCase・Handler・Input/Output / RouteRegistrar / ServiceProvider / NotFound 例外（Menu モジュールに準拠）
- **`ThemeManifestValidator`（セキュリティ核）**：スキーマ準拠の構造検証＋トークン値サニタイズ（既知キーのみ・`;{}<>`/`url(`/`@import`/`expression(` 等を遮断）、予約 id・selfhost フォント拒否
- `/api/v1/themes` を `ADMIN_ONLY_PREFIXES` に追加（GET も認証必須）

## Phase C — OpenAPI / MCP

- `docs/openapi/openapi.yaml` に themes CRUD ＋ `ThemeManifest` / `ThemeResponse` / `ThemeListResponse` スキーマ
- `tools/generate-mcp-tools.php` に 5 ツール追加 → `composer mcp:generate` で再生成：
  - `listThemes`(read) / `createTheme`(write) / `getTheme`(read) / `updateTheme`(write) / `deleteTheme`(destructive)
- フロント型 codegen（`schema.gen.ts`）

→ **ClaudeDesign が MCP の `createTheme` でテーマを登録できる**ようになった（公開サイトへの実適用は Phase D）。

## 検証

- `composer check` ✅ — PHPUnit **730**（新規 32）/ PHPStan L8 / CS / OpenAPI / MCP（**65 tools**）
- フロント `type-check` / `lint` / `test`（**214**）✅
- 実機：未認証 `GET/POST /api/v1/themes` → 401

## スコープ外（後続）

- **Phase D**: 公開サイトのランタイム適用（`buildThemeStylesheet`・合成カタログ・`/api/v1/public/themes`）
- **Phase E**: 管理 UI ＋ ClaudeDesign 連携運用

Refs #423