### PR TITLE
feat(theme): runtime テーマの初回ペイントFOUCを解消する (#423)

### DIFF
--- a/docs/theming/runtime-themes.md
+++ b/docs/theming/runtime-themes.md
@@ -122,7 +122,7 @@ POST /api/v1/themes  { manifest JSON }   ← MCP(write)
 1. ✅ 本ドキュメント＋ Issue（方向確定）。
 2. ✅ **backend**: `themes` テーブル（マイグレーション）＋ Repository ＋ CRUD UseCase/Handler ＋ サーバ側バリデータ（スキーマ＋値サニタイズ）＋ org スコープ。（#423 Phase B）
 3. ✅ **OpenAPI ＋ MCP**: エンドポイント定義 → `npm run codegen`（フロント型）＋ `composer mcp:generate`（MCP ツール）。（#423 Phase C）
-4. 🟡 **公開適用（end-to-end）**: `/api/v1/public/themes`（公開・ETag）＋ `buildThemeStylesheet`（トークン→スコープ `<style>`、値ガード）＋ PublicShell で runtime active テーマを適用、assetRef 検証、`swatchFromManifest`（§8 B案）まで実装（#423 Phase D）。**残**: 管理ピッカーの合成カタログ表示、FOUC キャッシュ（runtime テーマの初回ペイント）。
+4. ✅ **公開適用（end-to-end）**: `/api/v1/public/themes`（公開・ETag）＋ `buildThemeStylesheet`（トークン→スコープ `<style>`、値ガード）＋ PublicShell で runtime active テーマを適用、assetRef 検証、`swatchFromManifest`（§8 B案）（#423 Phase D）。**FOUC キャッシュ**：runtime テーマの CSS＋flag attrs を localStorage（`nene_public_runtime_theme`）に先行保存し、settings/themes 両クエリ settle 前は初回ペイントへ同期適用（`readStoredRuntimeTheme`/`storeRuntimeTheme`）。
 5. ✅ 管理 UI：テーマピッカーに runtime テーマを**合成表示**（built-in＋runtime、`swatchFromManifest` でカード）、active 解決を runtime キー対応、採用は `active_theme` 書込み。runtime カードに**編集（manifest JSON エディタ・サーバ再検証）／削除（確認ダイアログ）**を追加（#423 Phase E）。
 6. ⬜ サムネ A案（media_id）opt-in：manifest 解決＋ピッカー `<img>`（#426）。
 7. ⬜ ClaudeDesign 連携：MCP 資格情報・ブリーフ→manifest の運用手順。

--- a/frontend/src/pages/consumer/PublicShell.tsx
+++ b/frontend/src/pages/consumer/PublicShell.tsx
@@ -7,7 +7,12 @@ import { publicSettingsToMap, usePublicSettings } from '@/entities/setting'
 import { usePublicThemes } from '@/entities/theme'
 import { parseHeaderConfig } from '@/shared/lib/header-config'
 import { parseLayoutConfig } from '@/shared/lib/layout-config'
-import { buildThemeStylesheet, type RuntimeTheme } from '@/shared/lib/runtime-themes'
+import {
+  buildThemeStylesheet,
+  readStoredRuntimeTheme,
+  type RuntimeTheme,
+  storeRuntimeTheme,
+} from '@/shared/lib/runtime-themes'
 import {
   readStoredActiveTheme,
   resolvePublicThemeId,
@@ -68,33 +73,56 @@ export function PublicShell() {
     [publicThemesQuery.data?.items],
   )
 
+  // Resolving a runtime active theme needs both the settings (active_theme) and
+  // the runtime theme list. Until both settle we use the last-known cached
+  // values so a runtime active theme doesn't flash the default on first paint.
   const settingsSettled = publicSettingsQuery.data !== undefined
-  const runtimeActive = settingsSettled
+  const themesSettled = publicThemesQuery.data !== undefined
+  const bothSettled = settingsSettled && themesSettled
+
+  const runtimeActive = bothSettled
     ? runtimeThemes.find((theme) => theme.theme_key === settings.active_theme)
     : undefined
   // A runtime active theme keeps its own key; otherwise resolve to a built-in.
   const resolvedTheme = runtimeActive
     ? runtimeActive.theme_key
     : resolvePublicThemeId(settings.active_theme)
-  const activeTheme = settingsSettled ? resolvedTheme : readStoredActiveTheme()
+  const activeTheme = bothSettled ? resolvedTheme : readStoredActiveTheme()
   // Customizer overrides: stored raw applied on first paint, fetched value after.
-  const overridesRaw = settingsSettled ? settings.theme_overrides : readStoredThemeOverridesRaw()
-  useEffect(() => {
-    if (settingsSettled) {
-      storeActiveTheme(resolvedTheme)
-      storeThemeOverridesRaw(settings.theme_overrides)
-    }
-  }, [settingsSettled, resolvedTheme, settings.theme_overrides])
+  const overridesRaw = bothSettled ? settings.theme_overrides : readStoredThemeOverridesRaw()
 
   // Runtime theme: emit its full token set as a scoped stylesheet, and apply its
   // structural flags as data-* attributes (manifest flags win, like a theme's
-  // built-in flags). Built-in themes keep static CSS, so these stay empty.
-  const runtimeThemeCss = runtimeActive
+  // built-in flags). Built-in themes keep static CSS, so these stay empty. The
+  // live values are authoritative once both queries settle; before that we read
+  // the FOUC cache.
+  const liveRuntimeThemeCss = runtimeActive
     ? buildThemeStylesheet(runtimeActive.theme_key, runtimeActive.manifest)
     : ''
-  const runtimeFlagAttrs = runtimeActive
+  const liveRuntimeFlagAttrs = runtimeActive
     ? resolveFlagAttrs(runtimeActive.manifest.flags, undefined)
     : {}
+  const cachedRuntimeTheme = readStoredRuntimeTheme()
+  const runtimeThemeCss = bothSettled ? liveRuntimeThemeCss : cachedRuntimeTheme.css
+  const runtimeFlagAttrs = bothSettled ? liveRuntimeFlagAttrs : cachedRuntimeTheme.flags
+
+  const liveRuntimeFlagsJson = JSON.stringify(liveRuntimeFlagAttrs)
+  useEffect(() => {
+    if (bothSettled) {
+      storeActiveTheme(resolvedTheme)
+      storeThemeOverridesRaw(settings.theme_overrides)
+      storeRuntimeTheme({
+        css: liveRuntimeThemeCss,
+        flags: JSON.parse(liveRuntimeFlagsJson) as Record<string, string>,
+      })
+    }
+  }, [
+    bothSettled,
+    resolvedTheme,
+    settings.theme_overrides,
+    liveRuntimeThemeCss,
+    liveRuntimeFlagsJson,
+  ])
 
   const site: PublicSite = {
     siteName: settings.site_name ?? 'NeNe Records',

--- a/frontend/src/shared/lib/runtime-themes.test.ts
+++ b/frontend/src/shared/lib/runtime-themes.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import {
   buildThemeStylesheet,
   isSafeTokenValue,
+  readStoredRuntimeTheme,
   type RuntimeThemeManifest,
+  storeRuntimeTheme,
   swatchFromManifest,
 } from './runtime-themes'
 
@@ -65,6 +67,29 @@ describe('isSafeTokenValue', () => {
     expect(isSafeTokenValue('url(x)')).toBe(false)
     expect(isSafeTokenValue('</style>')).toBe(false)
     expect(isSafeTokenValue('')).toBe(false)
+  })
+})
+
+describe('runtime theme FOUC cache', () => {
+  afterEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('round-trips css + flags', () => {
+    storeRuntimeTheme({
+      css: ".nene-public[data-theme='x']{--a:red;}",
+      flags: { 'data-feed': 'list' },
+    })
+    expect(readStoredRuntimeTheme()).toEqual({
+      css: ".nene-public[data-theme='x']{--a:red;}",
+      flags: { 'data-feed': 'list' },
+    })
+  })
+
+  it('returns empty defaults when unset or malformed', () => {
+    expect(readStoredRuntimeTheme()).toEqual({ css: '', flags: {} })
+    window.localStorage.setItem('nene_public_runtime_theme', 'not json')
+    expect(readStoredRuntimeTheme()).toEqual({ css: '', flags: {} })
   })
 })
 

--- a/frontend/src/shared/lib/runtime-themes.ts
+++ b/frontend/src/shared/lib/runtime-themes.ts
@@ -72,6 +72,61 @@ export function buildThemeStylesheet(themeKey: string, manifest: RuntimeThemeMan
   return emitTokens(themeKey, light) + emitTokens(`${themeKey}-dark`, dark)
 }
 
+// ── First-paint (FOUC) cache ───────────────────────────────────────────────
+// Runtime themes are fetched async (React Query), so on first paint the
+// stylesheet isn't ready and a non-built-in active theme would flash the
+// default. We cache the resolved CSS + flag attrs in localStorage (same
+// FOUC-avoidance the customizer overrides use) and apply them synchronously
+// until the live fetch settles. Built-in themes cache empty values.
+
+const RUNTIME_THEME_STORAGE_KEY = 'nene_public_runtime_theme'
+
+export interface StoredRuntimeTheme {
+  /** Scoped `<style>` body for the active runtime theme ('' for built-in). */
+  css: string
+  /** Structural flag `data-*` attributes from the active runtime theme's manifest. */
+  flags: Record<string, string>
+}
+
+const EMPTY_STORED: StoredRuntimeTheme = { css: '', flags: {} }
+
+export function readStoredRuntimeTheme(): StoredRuntimeTheme {
+  if (typeof window === 'undefined') {
+    return EMPTY_STORED
+  }
+  try {
+    const raw = window.localStorage.getItem(RUNTIME_THEME_STORAGE_KEY)
+    if (raw === null) {
+      return EMPTY_STORED
+    }
+    const data = JSON.parse(raw) as unknown
+    if (typeof data !== 'object' || data === null) {
+      return EMPTY_STORED
+    }
+    const record = data as Record<string, unknown>
+    return {
+      css: typeof record.css === 'string' ? record.css : '',
+      flags:
+        typeof record.flags === 'object' && record.flags !== null
+          ? (record.flags as Record<string, string>)
+          : {},
+    }
+  } catch {
+    return EMPTY_STORED
+  }
+}
+
+export function storeRuntimeTheme(value: StoredRuntimeTheme): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+  try {
+    window.localStorage.setItem(RUNTIME_THEME_STORAGE_KEY, JSON.stringify(value))
+  } catch {
+    // Ignore quota / serialization errors — the cache is best-effort.
+  }
+}
+
 /** Derive the picker's 3-colour swatch from the light token set (#426 B). */
 export function swatchFromManifest(manifest: RuntimeThemeManifest): {
   surface: string


### PR DESCRIPTION
## 目的

runtime（データ駆動）テーマは非同期取得（React Query）のため、active が runtime テーマだと**初回ペイントで既定テーマが一瞬出る（FOUC）**。これを解消。

## 変更内容

- `shared/lib/runtime-themes.ts`：`readStoredRuntimeTheme` / `storeRuntimeTheme`（localStorage `nene_public_runtime_theme` に CSS＋flag attrs を保存。SSR/quota ガード付き）。
- `PublicShell`：解決を **settings＋themes 両クエリ settle** でゲート。両 settle 前は**キャッシュを同期適用**（runtime テーマの色/フラグが初回から出る）。両 settle 後にライブ値で確定し再保存。既存の `theme_overrides` 先行適用と同方式。
- built-in テーマはキャッシュ空（従来どおり静的CSSで FOUC 無し）。

## 検証

- frontend `type-check`/`lint`/`format`/`test`（**224**、cache round-trip/malformed テスト追加）✅

## 補足

active が built-in でも両クエリ待ちになるが、stored 値で初回ペイントを賄うため体感の遅延・フラッシュ無し。themes クエリは小さく settings と並列。

Refs #423