### PR TITLE
feat(theme): runtime テーマのサムネを media_id で解決する (#426 A案)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -5901,6 +5901,7 @@ components:
         - name
         - version
         - manifest
+        - thumbnail_url
         - created_at
         - updated_at
       properties:
@@ -5912,6 +5913,12 @@ components:
           type: string
         manifest:
           $ref: '#/components/schemas/ThemeManifest'
+        thumbnail_url:
+          type: string
+          description: >-
+            Resolved preview image URL from `manifest.assets.preview` (a media
+            id). Empty when there is no preview; the picker then derives a colour
+            swatch from the theme's tokens.
         created_at:
           type: string
           format: date-time

--- a/docs/theming/runtime-themes.md
+++ b/docs/theming/runtime-themes.md
@@ -124,7 +124,7 @@ POST /api/v1/themes  { manifest JSON }   ← MCP(write)
 3. ✅ **OpenAPI ＋ MCP**: エンドポイント定義 → `npm run codegen`（フロント型）＋ `composer mcp:generate`（MCP ツール）。（#423 Phase C）
 4. 🟡 **公開適用（end-to-end）**: `/api/v1/public/themes`（公開・ETag）＋ `buildThemeStylesheet`（トークン→スコープ `<style>`、値ガード）＋ PublicShell で runtime active テーマを適用、assetRef 検証、`swatchFromManifest`（§8 B案）まで実装（#423 Phase D）。**残**: 管理ピッカーの合成カタログ表示、FOUC キャッシュ（runtime テーマの初回ペイント）。
 5. ✅ 管理 UI：テーマピッカーに runtime テーマを**合成表示**（built-in＋runtime、`swatchFromManifest` でカード）、active 解決を runtime キー対応、採用は `active_theme` 書込み。runtime カードに**編集（manifest JSON エディタ・サーバ再検証）／削除（確認ダイアログ）**を追加（#423 Phase E）。
-6. ⬜ サムネ A案（media_id）opt-in：manifest 解決＋ピッカー `<img>`（#426）。
+6. ✅ サムネ A案（media_id）opt-in：`ThemeThumbnailResolver` が `assets.preview`(media_id) を URL 解決し `thumbnail_url` をレスポンスに付与、ピッカーが `<img>` 表示（未指定は B 案スワッチ）（#426）。
 7. ⬜ ClaudeDesign 連携：MCP 資格情報・ブリーフ→manifest の運用手順。
 
 ## 11. 関連

--- a/frontend/src/features/manage-appearance/hooks/usePublicThemePage.ts
+++ b/frontend/src/features/manage-appearance/hooks/usePublicThemePage.ts
@@ -39,7 +39,11 @@ export interface PublicThemePageState {
   isMutating: boolean
 }
 
-/** Adapt a stored runtime theme into a picker card (swatch from its tokens). */
+/**
+ * Adapt a stored runtime theme into a picker card. Uses the server-resolved
+ * `thumbnail_url` (from `assets.preview` media id, #426 A) when present;
+ * otherwise the card falls back to a swatch derived from the theme's tokens.
+ */
 function runtimeThemeMeta(theme: ThemeDto): PublicThemeMeta {
   const manifest = theme.manifest as RuntimeThemeManifest
   return {
@@ -50,6 +54,7 @@ function runtimeThemeMeta(theme: ThemeDto): PublicThemeMeta {
     version: theme.version,
     createdAt: theme.created_at.slice(0, 10),
     preview: swatchFromManifest(manifest),
+    thumbnail: theme.thumbnail_url !== '' ? theme.thumbnail_url : undefined,
   }
 }
 

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -2325,6 +2325,8 @@ export interface components {
             name: string;
             version: string;
             manifest: components["schemas"]["ThemeManifest"];
+            /** @description Resolved preview image URL from `manifest.assets.preview` (a media id). Empty when there is no preview; the picker then derives a colour swatch from the theme's tokens. */
+            thumbnail_url: string;
             /** Format: date-time */
             created_at: string;
             /** Format: date-time */

--- a/src/Theme/CreateThemeHandler.php
+++ b/src/Theme/CreateThemeHandler.php
@@ -14,6 +14,7 @@ final readonly class CreateThemeHandler
     public function __construct(
         private CreateThemeUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private ThemeThumbnailResolver $thumbnails,
     ) {
     }
 
@@ -25,6 +26,9 @@ final readonly class CreateThemeHandler
 
         $output = $this->useCase->execute(new CreateThemeInput(manifest: $manifest));
 
-        return $this->response->create(ThemeHttpMapper::toArray($output->theme), 201);
+        return $this->response->create(
+            ThemeHttpMapper::toArray($output->theme, $this->thumbnails->resolve($output->theme->manifest)),
+            201,
+        );
     }
 }

--- a/src/Theme/GetThemeHandler.php
+++ b/src/Theme/GetThemeHandler.php
@@ -14,6 +14,7 @@ final readonly class GetThemeHandler
     public function __construct(
         private ThemeRepositoryInterface $repository,
         private JsonResponseFactory $response,
+        private ThemeThumbnailResolver $thumbnails,
     ) {
     }
 
@@ -28,6 +29,8 @@ final readonly class GetThemeHandler
             throw new ThemeNotFoundException($key);
         }
 
-        return $this->response->create(ThemeHttpMapper::toArray($theme));
+        return $this->response->create(
+            ThemeHttpMapper::toArray($theme, $this->thumbnails->resolve($theme->manifest)),
+        );
     }
 }

--- a/src/Theme/ListPublicThemesHandler.php
+++ b/src/Theme/ListPublicThemesHandler.php
@@ -25,6 +25,7 @@ final readonly class ListPublicThemesHandler
         private ListThemesUseCaseInterface $useCase,
         private JsonResponseFactory $response,
         private ResponseFactoryInterface $responseFactory,
+        private ThemeThumbnailResolver $thumbnails,
     ) {
     }
 
@@ -34,7 +35,7 @@ final readonly class ListPublicThemesHandler
 
         $data = [
             'items' => array_map(
-                static fn (Theme $theme) => ThemeHttpMapper::toArray($theme),
+                fn (Theme $theme) => ThemeHttpMapper::toArray($theme, $this->thumbnails->resolve($theme->manifest)),
                 $output->items,
             ),
         ];

--- a/src/Theme/ListThemesHandler.php
+++ b/src/Theme/ListThemesHandler.php
@@ -13,6 +13,7 @@ final readonly class ListThemesHandler
     public function __construct(
         private ListThemesUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private ThemeThumbnailResolver $thumbnails,
     ) {
     }
 
@@ -22,7 +23,7 @@ final readonly class ListThemesHandler
 
         return $this->response->create([
             'items' => array_map(
-                static fn (Theme $theme) => ThemeHttpMapper::toArray($theme),
+                fn (Theme $theme) => ThemeHttpMapper::toArray($theme, $this->thumbnails->resolve($theme->manifest)),
                 $output->items,
             ),
         ]);

--- a/src/Theme/ThemeHttpMapper.php
+++ b/src/Theme/ThemeHttpMapper.php
@@ -7,13 +7,14 @@ namespace NeNeRecords\Theme;
 final readonly class ThemeHttpMapper
 {
     /** @return array<string, mixed> */
-    public static function toArray(Theme $theme): array
+    public static function toArray(Theme $theme, string $thumbnailUrl = ''): array
     {
         return [
             'theme_key' => $theme->themeKey,
             'name' => $theme->name,
             'version' => $theme->version,
             'manifest' => $theme->manifest,
+            'thumbnail_url' => $thumbnailUrl,
             'created_at' => $theme->createdAt,
             'updated_at' => $theme->updatedAt,
         ];

--- a/src/Theme/ThemeServiceProvider.php
+++ b/src/Theme/ThemeServiceProvider.php
@@ -11,6 +11,7 @@ use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Media\MediaRepositoryInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 
@@ -19,6 +20,17 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
     public function register(ContainerBuilder $builder): void
     {
         $builder
+            ->set(
+                ThemeThumbnailResolver::class,
+                static function (ContainerInterface $container): ThemeThumbnailResolver {
+                    $media = $container->get(MediaRepositoryInterface::class);
+                    if (!$media instanceof MediaRepositoryInterface) {
+                        throw new LogicException('Media repository service is invalid.');
+                    }
+
+                    return new ThemeThumbnailResolver($media);
+                },
+            )
             ->set(
                 ThemeRepositoryInterface::class,
                 static function (ContainerInterface $container): ThemeRepositoryInterface {
@@ -84,14 +96,18 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $container): ListThemesHandler {
                     $useCase = $container->get(ListThemesUseCaseInterface::class);
                     $response = $container->get(JsonResponseFactory::class);
+                    $thumbnails = $container->get(ThemeThumbnailResolver::class);
                     if (!$useCase instanceof ListThemesUseCaseInterface) {
                         throw new LogicException('ListThemes use case service is invalid.');
                     }
                     if (!$response instanceof JsonResponseFactory) {
                         throw new LogicException('JSON response factory service is invalid.');
                     }
+                    if (!$thumbnails instanceof ThemeThumbnailResolver) {
+                        throw new LogicException('Theme thumbnail resolver service is invalid.');
+                    }
 
-                    return new ListThemesHandler($useCase, $response);
+                    return new ListThemesHandler($useCase, $response, $thumbnails);
                 },
             )
             ->set(
@@ -99,14 +115,18 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $container): GetThemeHandler {
                     $repo = $container->get(ThemeRepositoryInterface::class);
                     $response = $container->get(JsonResponseFactory::class);
+                    $thumbnails = $container->get(ThemeThumbnailResolver::class);
                     if (!$repo instanceof ThemeRepositoryInterface) {
                         throw new LogicException('Theme repository service is invalid.');
                     }
                     if (!$response instanceof JsonResponseFactory) {
                         throw new LogicException('JSON response factory service is invalid.');
                     }
+                    if (!$thumbnails instanceof ThemeThumbnailResolver) {
+                        throw new LogicException('Theme thumbnail resolver service is invalid.');
+                    }
 
-                    return new GetThemeHandler($repo, $response);
+                    return new GetThemeHandler($repo, $response, $thumbnails);
                 },
             )
             ->set(
@@ -114,14 +134,18 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $container): CreateThemeHandler {
                     $useCase = $container->get(CreateThemeUseCaseInterface::class);
                     $response = $container->get(JsonResponseFactory::class);
+                    $thumbnails = $container->get(ThemeThumbnailResolver::class);
                     if (!$useCase instanceof CreateThemeUseCaseInterface) {
                         throw new LogicException('CreateTheme use case service is invalid.');
                     }
                     if (!$response instanceof JsonResponseFactory) {
                         throw new LogicException('JSON response factory service is invalid.');
                     }
+                    if (!$thumbnails instanceof ThemeThumbnailResolver) {
+                        throw new LogicException('Theme thumbnail resolver service is invalid.');
+                    }
 
-                    return new CreateThemeHandler($useCase, $response);
+                    return new CreateThemeHandler($useCase, $response, $thumbnails);
                 },
             )
             ->set(
@@ -129,14 +153,18 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $container): UpdateThemeHandler {
                     $useCase = $container->get(UpdateThemeUseCaseInterface::class);
                     $response = $container->get(JsonResponseFactory::class);
+                    $thumbnails = $container->get(ThemeThumbnailResolver::class);
                     if (!$useCase instanceof UpdateThemeUseCaseInterface) {
                         throw new LogicException('UpdateTheme use case service is invalid.');
                     }
                     if (!$response instanceof JsonResponseFactory) {
                         throw new LogicException('JSON response factory service is invalid.');
                     }
+                    if (!$thumbnails instanceof ThemeThumbnailResolver) {
+                        throw new LogicException('Theme thumbnail resolver service is invalid.');
+                    }
 
-                    return new UpdateThemeHandler($useCase, $response);
+                    return new UpdateThemeHandler($useCase, $response, $thumbnails);
                 },
             )
             ->set(
@@ -160,6 +188,7 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                     $useCase = $container->get(ListThemesUseCaseInterface::class);
                     $response = $container->get(JsonResponseFactory::class);
                     $responseFactory = $container->get(ResponseFactoryInterface::class);
+                    $thumbnails = $container->get(ThemeThumbnailResolver::class);
                     if (!$useCase instanceof ListThemesUseCaseInterface) {
                         throw new LogicException('ListThemes use case service is invalid.');
                     }
@@ -169,8 +198,11 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                     if (!$responseFactory instanceof ResponseFactoryInterface) {
                         throw new LogicException('Response factory service is invalid.');
                     }
+                    if (!$thumbnails instanceof ThemeThumbnailResolver) {
+                        throw new LogicException('Theme thumbnail resolver service is invalid.');
+                    }
 
-                    return new ListPublicThemesHandler($useCase, $response, $responseFactory);
+                    return new ListPublicThemesHandler($useCase, $response, $responseFactory, $thumbnails);
                 },
             )
             ->set(

--- a/src/Theme/ThemeThumbnailResolver.php
+++ b/src/Theme/ThemeThumbnailResolver.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use NeNeRecords\Media\MediaRepositoryInterface;
+
+/**
+ * Resolves a runtime theme's `assets.preview` media id into a URL for the
+ * picker thumbnail (#426 A案). The manifest stores a media id (uploaded via the
+ * Media API); we resolve it to a URL here, like `logo_media_id` in settings.
+ * Returns '' when there is no preview, an unresolved id, or a non-media value
+ * (bundle paths cannot be hosted by runtime themes).
+ */
+final readonly class ThemeThumbnailResolver
+{
+    public function __construct(
+        private MediaRepositoryInterface $media,
+    ) {
+    }
+
+    /** @param array<string, mixed> $manifest */
+    public function resolve(array $manifest): string
+    {
+        $assets = $manifest['assets'] ?? null;
+        if (!is_array($assets)) {
+            return '';
+        }
+
+        $id = self::extractMediaId($assets['preview'] ?? null);
+        if ($id === null) {
+            return '';
+        }
+
+        $media = $this->media->findById($id);
+
+        return $media === null ? '' : $media->url;
+    }
+
+    /** A media id is a positive int, or the light/dark int of a per-mode object. */
+    private static function extractMediaId(mixed $preview): ?int
+    {
+        if (is_int($preview)) {
+            return $preview > 0 ? $preview : null;
+        }
+        if (is_array($preview)) {
+            foreach (['light', 'dark'] as $mode) {
+                $value = $preview[$mode] ?? null;
+                if (is_int($value) && $value > 0) {
+                    return $value;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Theme/UpdateThemeHandler.php
+++ b/src/Theme/UpdateThemeHandler.php
@@ -15,6 +15,7 @@ final readonly class UpdateThemeHandler
     public function __construct(
         private UpdateThemeUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private ThemeThumbnailResolver $thumbnails,
     ) {
     }
 
@@ -27,6 +28,8 @@ final readonly class UpdateThemeHandler
 
         $output = $this->useCase->execute(new UpdateThemeInput(themeKey: $key, manifest: $manifest));
 
-        return $this->response->create(ThemeHttpMapper::toArray($output->theme));
+        return $this->response->create(
+            ThemeHttpMapper::toArray($output->theme, $this->thumbnails->resolve($output->theme->manifest)),
+        );
     }
 }

--- a/tests/Theme/ThemeThumbnailResolverTest.php
+++ b/tests/Theme/ThemeThumbnailResolverTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Theme;
+
+use NeNeRecords\Media\Media;
+use NeNeRecords\Tests\Media\InMemoryMediaRepository;
+use NeNeRecords\Theme\ThemeThumbnailResolver;
+use PHPUnit\Framework\TestCase;
+
+final class ThemeThumbnailResolverTest extends TestCase
+{
+    private function media(int $id, string $url): Media
+    {
+        return new Media(
+            id: $id,
+            originalName: 'preview.webp',
+            storedName: 'preview.webp',
+            mimeType: 'image/webp',
+            size: 1234,
+            url: $url,
+            createdAt: '2026-06-18 00:00:00',
+        );
+    }
+
+    public function testResolvesMediaIdToUrl(): void
+    {
+        $repo = new InMemoryMediaRepository([$this->media(7, '/media/preview-7.webp')]);
+        $resolver = new ThemeThumbnailResolver($repo);
+
+        self::assertSame(
+            '/media/preview-7.webp',
+            $resolver->resolve(['assets' => ['preview' => 7]]),
+        );
+    }
+
+    public function testResolvesPerModeLightMediaId(): void
+    {
+        $repo = new InMemoryMediaRepository([$this->media(3, '/media/light.webp')]);
+        $resolver = new ThemeThumbnailResolver($repo);
+
+        self::assertSame(
+            '/media/light.webp',
+            $resolver->resolve(['assets' => ['preview' => ['light' => 3, 'dark' => 9]]]),
+        );
+    }
+
+    public function testReturnsEmptyForMissingMediaOrNoPreview(): void
+    {
+        $resolver = new ThemeThumbnailResolver(new InMemoryMediaRepository());
+
+        self::assertSame('', $resolver->resolve([]));
+        self::assertSame('', $resolver->resolve(['assets' => []]));
+        self::assertSame('', $resolver->resolve(['assets' => ['preview' => 99]]));
+        // Bundle path (string) is not a media id → empty (runtime can't host files).
+        self::assertSame('', $resolver->resolve(['assets' => ['preview' => 'thumbs/x.webp']]));
+    }
+}


### PR DESCRIPTION
## 目的

runtime テーマのサムネ **A案（任意・実写）** を実装。`manifest.assets.preview`（media_id）をサーバが URL 解決し、ピッカーが `<img>` 表示。未指定は B案（tokens 由来スワッチ）にフォールバック。#426 / #423。

## 変更内容

**backend**
- `ThemeThumbnailResolver`：`assets.preview`（media_id・per-mode int 対応）→ Media URL 解決（`logo_media_id` と同流儀）。未解決/非media値は `''`。
- `ThemeHttpMapper` に `thumbnail_url` を追加。全 theme ハンドラ（list / get / create / update / public）に resolver を配線。
- OpenAPI `ThemeResponse.thumbnail_url`（required）。

**frontend**
- `usePublicThemePage`：`thumbnail_url` があれば `PublicThemeMeta.thumbnail` に設定 → 既存 `ThemeThumb` が `<img>`、無ければスワッチ。
- 型 codegen 再生成。

## セキュリティ

画像は外部URL/`data:` 不可（Phase D の assetRef 検証）。runtime は **media_id 参照のみ**＝既存 Media のアップロード経路を再利用、MCP でバイナリは送らない。

## 検証

- backend `composer check` ✅（PHPUnit **741**／PHPStan L8／CS／OpenAPI／MCP）— `ThemeThumbnailResolverTest` 追加
- frontend `type-check`／`lint`／`test`（**224**）✅
- **e2e 実機**：theme に `assets.preview:1` 投入 → 公開エンドポイントが `thumbnail_url` を実 media URL に解決（確認・クリーンアップ済み）

Refs #426 #423