### PR TITLE
feat(theme): 計算プレビュー MCP（previewTheme）(#433)

### DIFF
--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -1214,6 +1214,65 @@
             "responseSchemaRef": null
         },
         {
+            "name": "previewTheme",
+            "title": "Preview Runtime Theme",
+            "description": "Compute a no-browser preview of a theme manifest: returns the tokens that would render (safe-filtered), the ones dropped, and WCAG contrast for key pairs (light/dark). Non-persistent \u2014 use to self-correct contrast/quality before createTheme/updateTheme.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "previewTheme",
+                "method": "POST",
+                "path": "/api/v1/themes/preview"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9-]{1,40}$",
+                        "description": "Theme key/id. Must not collide with a built-in theme."
+                    },
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 80
+                    },
+                    "version": {
+                        "type": "string",
+                        "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                    },
+                    "supportsModes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "light",
+                                "dark"
+                            ]
+                        },
+                        "description": "Must include both light and dark."
+                    },
+                    "tokens": {
+                        "type": "object",
+                        "description": "Per-mode CSS tokens: {\"light\":{token:value,\u2026},\"dark\":{\u2026}}. Keys are contract tokens; values must be safe CSS (no ;{}<>, url(), @import)."
+                    },
+                    "flags": {
+                        "type": "object",
+                        "description": "Optional structural style flags (enumerated; e.g. feedLayout, headerLayout)."
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "version",
+                    "supportsModes",
+                    "tokens"
+                ],
+                "additionalProperties": true
+            },
+            "responseSchemaRef": "#/components/schemas/ThemePreviewResponse"
+        },
+        {
             "name": "getTheme",
             "title": "Get Runtime Theme",
             "description": "Get a single runtime theme by its key.",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2923,6 +2923,35 @@ paths:
           $ref: '#/components/responses/ValidationFailed'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/themes/preview:
+    post:
+      tags:
+        - Themes
+      summary: Preview a theme manifest (computed)
+      description: >-
+        Non-persistent dry-run: validates a manifest and returns the tokens that
+        would actually render (safe-filtered), the ones dropped, and WCAG
+        contrast for key pairs in both modes. Lets ClaudeDesign self-correct
+        before committing via createTheme/updateTheme. Always 200 — issues are
+        reported in the body. See theme-preview.md.
+      operationId: previewTheme
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ThemeManifest'
+      responses:
+        '200':
+          description: Computed preview report.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThemePreviewResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /api/v1/themes/{key}:
     get:
       tags:
@@ -5935,6 +5964,65 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ThemeResponse'
+      additionalProperties: false
+    ThemePreviewResponse:
+      type: object
+      description: Computed (no-browser) preview of a theme manifest (#433).
+      required:
+        - valid
+        - errors
+        - applied
+        - dropped
+        - contrast
+        - warnings
+      properties:
+        valid:
+          type: boolean
+          description: Whether the manifest passes structural validation.
+        errors:
+          type: array
+          description: Validation errors (empty when valid).
+          items:
+            type: object
+            additionalProperties: true
+        applied:
+          type: object
+          description: Per-mode tokens that would actually render (safe-filtered).
+          properties:
+            light:
+              type: object
+              additionalProperties:
+                type: string
+            dark:
+              type: object
+              additionalProperties:
+                type: string
+          additionalProperties: false
+        dropped:
+          type: array
+          description: Tokens removed by the safety filter, with reason.
+          items:
+            type: object
+            additionalProperties: true
+        contrast:
+          type: object
+          description: WCAG contrast rows per mode (pair / ratio / aa / aaa / computable).
+          properties:
+            light:
+              type: array
+              items:
+                type: object
+                additionalProperties: true
+            dark:
+              type: array
+              items:
+                type: object
+                additionalProperties: true
+          additionalProperties: false
+        warnings:
+          type: array
+          items:
+            type: string
       additionalProperties: false
 
 

--- a/docs/theming/claudedesign-runtime-themes.md
+++ b/docs/theming/claudedesign-runtime-themes.md
@@ -45,6 +45,7 @@
 - **バージョン**: 改訂ごとに `version` を semver で上げる（運用上の追跡用）。
 - **冪等性**: 同一 manifest の再 PUT は無害。
 - **削除**: `deleteTheme`。active_theme に採用中の key を消す前に別テーマへ切替える（公開側は built-in 既定へフォールバック）。
+- **コミット前プレビュー（推奨）**: `createTheme`/`updateTheme` の前に **`previewTheme`（計算プレビュー・非永続）** を回す。`POST /api/v1/themes/preview` に manifest を渡すと、実際に効くトークン（`applied`）／落ちた値（`dropped`）／**WCAG コントラスト**（text/surface・on-accent/accent… の AA/AAA 判定）を返す。**AA 未達・dropped・warnings があれば自己修正→再 preview**、OK で初めて commit。ブラウザ無し。視覚スクショは Phase 2（将来）。設計: [`theme-preview.md`](./theme-preview.md)。
 
 ## 4. 検証で弾かれるもの（§6 安全規則）
 

--- a/docs/theming/theme-preview.md
+++ b/docs/theming/theme-preview.md
@@ -1,0 +1,96 @@
+# テーマ計算プレビュー（MCP `previewTheme`）— 設計
+
+> ClaudeDesign が manifest を**結果を見ずに**書いている（盲目オーサリング）状態を、**ブラウザ不要の計算プレビュー**で閉じる（#433 / 親 #423）。コミット前にコントラスト不足・破綻・落ちる値を自己修正できる。
+> 関連: [`runtime-themes.md`](./runtime-themes.md) / [`claudedesign-runtime-themes.md`](./claudedesign-runtime-themes.md) / [`public-theme.schema.json`](./public-theme.schema.json)。
+
+---
+
+## 1. なぜ計算プレビューか（Phase 1）
+
+- 盲目オーサリングの**8割の失敗は「読めない配色・コントラスト不足・ダーク反転ミス・値が落ちる」**。これらは**ピクセルを見なくても数値で判定できる**。
+- ブラウザ（headless）は重いインフラ。まず純関数で安く閉ループを作り、視覚確認（Phase 2/スクショ）の投資判断材料にする。
+
+## 2. 重要な前提：入力はフルトークン manifest
+
+built-in テーマの base トークンは**フロントの CSS ファイル**であり、サーバ（PHP）にとって**データではない**。よって「built-in＋override の最終色」はブラウザ（`getComputedStyle`）無しに解決できない → **Phase 2 送り**。
+
+本 Phase は **フルトークンを持つ manifest を入力**にする。runtime テーマは常にフルトークンを持つので、これが正しいスコープ。既存 runtime テーマの調整は `getTheme` → tokens を編集 → `previewTheme`（編集後 manifest）→ `updateTheme` の流れ。
+
+## 3. エンドポイント / MCP
+
+| | |
+| --- | --- |
+| HTTP | `POST /api/v1/themes/preview`（ADMIN_ONLY・**非永続**） |
+| MCP | `previewTheme`（`safety: read`／非破壊） |
+| 入力 | `ThemePreviewRequest` = manifest（`createTheme` と同形） |
+| 出力 | `ThemePreviewResponse`（下記） |
+
+非永続＝DB に触れない（保存は `createTheme`/`updateTheme`）。
+
+## 4. レスポンス
+
+```jsonc
+{
+  "valid": false,                      // 構造検証の合否（preview は極力 200 で報告）
+  "errors": [{ "field": "tokens.dark.color-accent", "message": "…", "code": "unsafe" }],
+  "applied": {                         // 描画相当の安全フィルタ後に実際に効くトークン
+    "light": { "color-surface": "oklch(98% 0.01 250)", "...": "…" },
+    "dark":  { "...": "…" }
+  },
+  "dropped": [                         // フィルタで落ちたキー（理由つき）
+    { "mode": "light", "token": "color-accent", "reason": "unsafe-value" }
+  ],
+  "contrast": {                        // WCAG コントラスト（§5）
+    "light": [
+      { "pair": "text-primary/surface", "ratio": 8.9, "aa": true, "aaa": true, "computable": true }
+    ],
+    "dark":  [ "…" ]
+  },
+  "warnings": ["tokens.light.color-info uses color-mix(): contrast not computed"]
+}
+```
+
+## 5. コントラスト判定（WCAG）
+
+各モード（light/dark）で次のペアを計算:
+
+| ペア | 用途 | 基準 |
+| --- | --- | --- |
+| `text-primary / surface` | 本文可読性 | AA 4.5 / AAA 7.0 |
+| `text-muted / surface` | 補助文字 | AA 4.5 |
+| `text-primary / surface-raised` | カード上の本文 | AA 4.5 |
+| `on-accent / accent` | ボタン文字 | AA 4.5 |
+| `accent / surface` | アクセントの視認 | 3.0（UI 部品） |
+| `border-strong / surface` | 罫線の視認 | 3.0 |
+
+- 比率 = (L_light + 0.05) / (L_dark + 0.05)。`aa`/`aaa` は基準充足の真偽。
+- **色解析**: `#hex` と `oklch(L C H)` を sRGB 相対輝度へ変換して計算。`color-mix()`/`var()`/gradient 等は `computable:false`＋warning（契約色トークンは大半 oklch/hex なので実用上カバー）。
+- oklch→sRGB は oklab 経由（標準係数）→ 線形 sRGB → 相対輝度。
+
+## 6. セキュリティ
+
+- 入力トークン値は**既存サニタイズ（`ThemeManifestValidator::isSafeCssValue`）を再利用**。`applied` は実描画と同じ「安全な値のみ」、落ちた値は `dropped` で明示。
+- 非永続・org 認証・生CSS不可は runtime と同じ契約。
+
+## 7. ClaudeDesign の使い方
+
+```
+getTheme(key) → manifest 取得
+  └─ tokens/flags を調整
+       └─ previewTheme(manifest) → contrast/dropped/warnings を読む
+            ├─ AA 未達や dropped があれば自己修正 → 再 previewTheme
+            └─ OK なら updateTheme(key, manifest)   ※新規は createTheme
+```
+
+## 8. Phase 2（別 Issue・本書スコープ外）
+
+- headless スクショ：正準マークアップ＋候補 `<style>` を Node/Playwright で描画→PNG（light/dark・PC/SP）。マルチモーダルで“見る”。
+- built-in＋override の視覚確認もここ（`getComputedStyle` で base 解決）。
+
+## 9. 実装スライス
+
+1. ✅ 本ドキュメント＋ Issue（#433）。
+2. ✅ `ColorContrast`（oklch/hex→相対輝度→比率）＋単体テスト。
+3. ✅ `PreviewThemeUseCase`/`PreviewThemeHandler`（validate を捕捉して報告・applied/dropped・contrast）＋ route `POST /api/v1/themes/preview` ＋ DI。
+4. ✅ OpenAPI（`ThemePreviewResponse`）＋ `composer mcp:generate`（`previewTheme`・safety read）＋ codegen。
+5. ✅ 運用 doc（`claudedesign-runtime-themes.md` §7）に preview ループを追記。

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -1180,6 +1180,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/themes/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Preview a theme manifest (computed)
+         * @description Non-persistent dry-run: validates a manifest and returns the tokens that would actually render (safe-filtered), the ones dropped, and WCAG contrast for key pairs in both modes. Lets ClaudeDesign self-correct before committing via createTheme/updateTheme. Always 200 — issues are reported in the body. See theme-preview.md.
+         */
+        post: operations["previewTheme"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/themes/{key}": {
         parameters: {
             query?: never;
@@ -2334,6 +2354,38 @@ export interface components {
         };
         ThemeListResponse: {
             items: components["schemas"]["ThemeResponse"][];
+        };
+        /** @description Computed (no-browser) preview of a theme manifest (#433). */
+        ThemePreviewResponse: {
+            /** @description Whether the manifest passes structural validation. */
+            valid: boolean;
+            /** @description Validation errors (empty when valid). */
+            errors: {
+                [key: string]: unknown;
+            }[];
+            /** @description Per-mode tokens that would actually render (safe-filtered). */
+            applied: {
+                light?: {
+                    [key: string]: string;
+                };
+                dark?: {
+                    [key: string]: string;
+                };
+            };
+            /** @description Tokens removed by the safety filter, with reason. */
+            dropped: {
+                [key: string]: unknown;
+            }[];
+            /** @description WCAG contrast rows per mode (pair / ratio / aa / aaa / computable). */
+            contrast: {
+                light?: {
+                    [key: string]: unknown;
+                }[];
+                dark?: {
+                    [key: string]: unknown;
+                }[];
+            };
+            warnings: string[];
         };
         WebhookResponse: {
             /** Format: int64 */
@@ -5484,6 +5536,32 @@ export interface operations {
             };
             401: components["responses"]["Unauthorized"];
             422: components["responses"]["ValidationFailed"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    previewTheme: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ThemeManifest"];
+            };
+        };
+        responses: {
+            /** @description Computed preview report. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ThemePreviewResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
             500: components["responses"]["InternalServerError"];
         };
     };

--- a/src/Theme/ColorContrast.php
+++ b/src/Theme/ColorContrast.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+/**
+ * WCAG contrast for theme token values (#433). Parses the two colour formats the
+ * token contract actually uses — `#hex` and `oklch(L C H)` — into a WCAG
+ * relative luminance, then computes the contrast ratio. Values it cannot parse
+ * (color-mix(), var(), gradients) return null so the caller can report
+ * "not computed" rather than guess.
+ */
+final class ColorContrast
+{
+    /**
+     * Contrast ratio (1–21) between two colours, or null if either is
+     * uncomputable. ratio = (Llighter + 0.05) / (Ldarker + 0.05).
+     */
+    public static function ratio(string $a, string $b): ?float
+    {
+        $la = self::relativeLuminance($a);
+        $lb = self::relativeLuminance($b);
+        if ($la === null || $lb === null) {
+            return null;
+        }
+        $hi = max($la, $lb);
+        $lo = min($la, $lb);
+
+        return ($hi + 0.05) / ($lo + 0.05);
+    }
+
+    /** WCAG relative luminance for a `#hex` or `oklch()` colour; null otherwise. */
+    public static function relativeLuminance(string $color): ?float
+    {
+        $value = strtolower(trim($color));
+
+        $rgb = self::parseHex($value) ?? self::parseOklch($value);
+        if ($rgb === null) {
+            return null;
+        }
+
+        [$r, $g, $b] = $rgb;
+
+        return 0.2126 * $r + 0.7152 * $g + 0.0722 * $b;
+    }
+
+    /**
+     * Parse `#rgb` / `#rrggbb` (alpha ignored) into linear-light sRGB [0,1]^3.
+     *
+     * @return array{float, float, float}|null
+     */
+    private static function parseHex(string $value): ?array
+    {
+        if (preg_match('/^#([0-9a-f]{3}|[0-9a-f]{6})([0-9a-f]{2})?$/', $value, $m) !== 1) {
+            return null;
+        }
+        $hex = $m[1];
+        if (strlen($hex) === 3) {
+            $hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
+        }
+        $r = (int) hexdec(substr($hex, 0, 2)) / 255;
+        $g = (int) hexdec(substr($hex, 2, 2)) / 255;
+        $b = (int) hexdec(substr($hex, 4, 2)) / 255;
+
+        return [self::srgbToLinear($r), self::srgbToLinear($g), self::srgbToLinear($b)];
+    }
+
+    /**
+     * Parse `oklch(L C H)` (L as 0-1 or %, optional /alpha) into linear-light
+     * sRGB [0,1]^3, via oklab (Björn Ottosson's matrices).
+     *
+     * @return array{float, float, float}|null
+     */
+    private static function parseOklch(string $value): ?array
+    {
+        if (preg_match('/^oklch\(\s*([0-9.]+%?)\s+([0-9.]+)\s+([0-9.]+)(?:deg)?\s*(?:\/[^)]*)?\)$/', $value, $m) !== 1) {
+            return null;
+        }
+
+        $lRaw = $m[1];
+        if (str_ends_with($lRaw, '%')) {
+            $l = (float) rtrim($lRaw, '%') / 100;
+        } else {
+            $lNum = (float) $lRaw;
+            $l = $lNum > 1.0 ? $lNum / 100 : $lNum;
+        }
+        $c = (float) $m[2];
+        $hDeg = (float) $m[3];
+        $h = deg2rad($hDeg);
+
+        $a = $c * cos($h);
+        $b = $c * sin($h);
+
+        $lp = $l + 0.3963377774 * $a + 0.2158037573 * $b;
+        $mp = $l - 0.1055613458 * $a - 0.0638541728 * $b;
+        $sp = $l - 0.0894841775 * $a - 1.2914855480 * $b;
+
+        $l3 = $lp ** 3;
+        $m3 = $mp ** 3;
+        $s3 = $sp ** 3;
+
+        $r = 4.0767416621 * $l3 - 3.3077115913 * $m3 + 0.2309699292 * $s3;
+        $g = -1.2684380046 * $l3 + 2.6097574011 * $m3 - 0.3413193965 * $s3;
+        $bl = -0.0041960863 * $l3 - 0.7034186147 * $m3 + 1.7076147010 * $s3;
+
+        return [self::clamp01($r), self::clamp01($g), self::clamp01($bl)];
+    }
+
+    /** sRGB channel (0-1) → linear-light. */
+    private static function srgbToLinear(float $c): float
+    {
+        return $c <= 0.04045 ? $c / 12.92 : (($c + 0.055) / 1.055) ** 2.4;
+    }
+
+    private static function clamp01(float $c): float
+    {
+        return max(0.0, min(1.0, $c));
+    }
+}

--- a/src/Theme/PreviewThemeHandler.php
+++ b/src/Theme/PreviewThemeHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Computed theme preview (#433): the request body is a manifest; returns the
+ * contrast/quality report without persisting. Always 200 (issues are reported
+ * in the body), so ClaudeDesign can iterate before committing via createTheme.
+ */
+final readonly class PreviewThemeHandler
+{
+    public function __construct(
+        private PreviewThemeUseCase $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $manifest = JsonRequestBodyParser::parse($request);
+
+        $output = $this->useCase->execute(new PreviewThemeInput(manifest: $manifest));
+
+        return $this->response->create($output->toArray());
+    }
+}

--- a/src/Theme/PreviewThemeInput.php
+++ b/src/Theme/PreviewThemeInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+final readonly class PreviewThemeInput
+{
+    /** @param array<string, mixed> $manifest */
+    public function __construct(
+        public array $manifest,
+    ) {
+    }
+}

--- a/src/Theme/PreviewThemeOutput.php
+++ b/src/Theme/PreviewThemeOutput.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+/**
+ * Computed (no-browser) preview of a theme manifest (#433): structural validity,
+ * the tokens that would actually render (safe-filtered), the ones dropped, and
+ * WCAG contrast for key pairs per mode.
+ */
+final readonly class PreviewThemeOutput
+{
+    /**
+     * @param list<array{field: string, message: string, code: string}> $errors
+     * @param array{light: array<string, string>, dark: array<string, string>} $applied
+     * @param list<array{mode: string, token: string, reason: string}> $dropped
+     * @param array{light: list<array<string, mixed>>, dark: list<array<string, mixed>>} $contrast
+     * @param list<string> $warnings
+     */
+    public function __construct(
+        public bool $valid,
+        public array $errors,
+        public array $applied,
+        public array $dropped,
+        public array $contrast,
+        public array $warnings,
+    ) {
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'valid' => $this->valid,
+            'errors' => $this->errors,
+            'applied' => $this->applied,
+            'dropped' => $this->dropped,
+            'contrast' => $this->contrast,
+            'warnings' => $this->warnings,
+        ];
+    }
+}

--- a/src/Theme/PreviewThemeUseCase.php
+++ b/src/Theme/PreviewThemeUseCase.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use Nene2\Validation\ValidationException;
+
+/**
+ * Computes a no-browser preview of a theme manifest (#433): validates (reporting
+ * rather than rejecting), determines which token values would actually render
+ * (safe-filtered, mirroring the public `<style>` emit), and computes WCAG
+ * contrast for key pairs in both modes. Pure — no persistence, no I/O.
+ */
+final class PreviewThemeUseCase
+{
+    private const TOKEN_KEY_PATTERN = '/^[a-z][a-z0-9-]*$/';
+
+    /** [foreground token, background token, AA threshold, short label]. */
+    private const PAIRS = [
+        ['color-text-primary', 'color-surface', 4.5, 'text-primary/surface'],
+        ['color-text-muted', 'color-surface', 4.5, 'text-muted/surface'],
+        ['color-text-primary', 'color-surface-raised', 4.5, 'text-primary/surface-raised'],
+        ['color-on-accent', 'color-accent', 4.5, 'on-accent/accent'],
+        ['color-accent', 'color-surface', 3.0, 'accent/surface'],
+        ['color-border-strong', 'color-surface', 3.0, 'border-strong/surface'],
+    ];
+
+    public function execute(PreviewThemeInput $input): PreviewThemeOutput
+    {
+        $errors = [];
+        try {
+            ThemeManifestValidator::validate($input->manifest);
+        } catch (ValidationException $e) {
+            foreach ($e->errors() as $error) {
+                $errors[] = ['field' => $error->field, 'message' => $error->message, 'code' => $error->code];
+            }
+        }
+
+        $warnings = [];
+        $dropped = [];
+        $applied = [
+            'light' => $this->applyMode($input->manifest, 'light', $dropped),
+            'dark' => $this->applyMode($input->manifest, 'dark', $dropped),
+        ];
+
+        $contrast = [
+            'light' => $this->contrastForMode($applied['light'], $warnings, 'light'),
+            'dark' => $this->contrastForMode($applied['dark'], $warnings, 'dark'),
+        ];
+
+        return new PreviewThemeOutput(
+            valid: $errors === [],
+            errors: $errors,
+            applied: $applied,
+            dropped: $dropped,
+            contrast: $contrast,
+            warnings: $warnings,
+        );
+    }
+
+    /**
+     * Keep only the token values that would actually render (valid key + safe
+     * value), recording the rest in $dropped.
+     *
+     * @param array<string, mixed> $manifest
+     * @param list<array{mode: string, token: string, reason: string}> $dropped
+     *
+     * @return array<string, string>
+     */
+    private function applyMode(array $manifest, string $mode, array &$dropped): array
+    {
+        $tokens = $manifest['tokens'][$mode] ?? null;
+        if (!is_array($tokens)) {
+            return [];
+        }
+
+        $applied = [];
+        foreach ($tokens as $key => $value) {
+            if (!is_string($key) || preg_match(self::TOKEN_KEY_PATTERN, $key) !== 1) {
+                $dropped[] = ['mode' => $mode, 'token' => is_string($key) ? $key : '?', 'reason' => 'invalid-key'];
+
+                continue;
+            }
+            if (!is_string($value)) {
+                $dropped[] = ['mode' => $mode, 'token' => $key, 'reason' => 'non-string'];
+
+                continue;
+            }
+            if (!ThemeManifestValidator::isSafeCssValue($value)) {
+                $dropped[] = ['mode' => $mode, 'token' => $key, 'reason' => 'unsafe-value'];
+
+                continue;
+            }
+            $applied[$key] = $value;
+        }
+
+        return $applied;
+    }
+
+    /**
+     * @param array<string, string> $tokens
+     * @param list<string> $warnings
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function contrastForMode(array $tokens, array &$warnings, string $mode): array
+    {
+        $result = [];
+        foreach (self::PAIRS as [$fg, $bg, $threshold, $label]) {
+            $fgValue = $tokens[$fg] ?? null;
+            $bgValue = $tokens[$bg] ?? null;
+            if ($fgValue === null || $bgValue === null) {
+                $result[] = ['pair' => $label, 'computable' => false, 'reason' => 'missing-token'];
+
+                continue;
+            }
+            $ratio = ColorContrast::ratio($fgValue, $bgValue);
+            if ($ratio === null) {
+                $result[] = ['pair' => $label, 'computable' => false, 'reason' => 'unparseable-color'];
+                $warnings[] = "{$mode} {$label}: colour not parseable (e.g. color-mix/var), contrast not computed";
+
+                continue;
+            }
+            $rounded = round($ratio, 2);
+            $result[] = [
+                'pair' => $label,
+                'ratio' => $rounded,
+                'aa' => $ratio >= $threshold,
+                'aaa' => $ratio >= 7.0,
+                'computable' => true,
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/src/Theme/ThemeRouteRegistrar.php
+++ b/src/Theme/ThemeRouteRegistrar.php
@@ -16,6 +16,7 @@ final readonly class ThemeRouteRegistrar
         private UpdateThemeHandler $updateHandler,
         private DeleteThemeHandler $deleteHandler,
         private ListPublicThemesHandler $listPublicHandler,
+        private PreviewThemeHandler $previewHandler,
     ) {
     }
 
@@ -27,6 +28,7 @@ final readonly class ThemeRouteRegistrar
         $update = $this->updateHandler;
         $delete = $this->deleteHandler;
         $listPublic = $this->listPublicHandler;
+        $preview = $this->previewHandler;
 
         $router->get(
             '/api/v1/themes',
@@ -35,6 +37,11 @@ final readonly class ThemeRouteRegistrar
         $router->post(
             '/api/v1/themes',
             static fn (ServerRequestInterface $request) => $create->handle($request),
+        );
+        // Computed preview (non-persistent dry-run): contrast/quality report.
+        $router->post(
+            '/api/v1/themes/preview',
+            static fn (ServerRequestInterface $request) => $preview->handle($request),
         );
         $router->get(
             '/api/v1/themes/{key}',

--- a/src/Theme/ThemeServiceProvider.php
+++ b/src/Theme/ThemeServiceProvider.php
@@ -206,6 +206,25 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                PreviewThemeUseCase::class,
+                static fn (ContainerInterface $container): PreviewThemeUseCase => new PreviewThemeUseCase(),
+            )
+            ->set(
+                PreviewThemeHandler::class,
+                static function (ContainerInterface $container): PreviewThemeHandler {
+                    $useCase = $container->get(PreviewThemeUseCase::class);
+                    $response = $container->get(JsonResponseFactory::class);
+                    if (!$useCase instanceof PreviewThemeUseCase) {
+                        throw new LogicException('PreviewTheme use case service is invalid.');
+                    }
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new PreviewThemeHandler($useCase, $response);
+                },
+            )
+            ->set(
                 ThemeNotFoundExceptionHandler::class,
                 static function (ContainerInterface $container): ThemeNotFoundExceptionHandler {
                     $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
@@ -225,6 +244,7 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                     $update = $container->get(UpdateThemeHandler::class);
                     $delete = $container->get(DeleteThemeHandler::class);
                     $listPublic = $container->get(ListPublicThemesHandler::class);
+                    $preview = $container->get(PreviewThemeHandler::class);
 
                     if (!$list instanceof ListThemesHandler) {
                         throw new LogicException('ListThemes handler service is invalid.');
@@ -244,8 +264,11 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                     if (!$listPublic instanceof ListPublicThemesHandler) {
                         throw new LogicException('ListPublicThemes handler service is invalid.');
                     }
+                    if (!$preview instanceof PreviewThemeHandler) {
+                        throw new LogicException('PreviewTheme handler service is invalid.');
+                    }
 
-                    return new ThemeRouteRegistrar($list, $get, $create, $update, $delete, $listPublic);
+                    return new ThemeRouteRegistrar($list, $get, $create, $update, $delete, $listPublic, $preview);
                 },
             );
     }

--- a/tests/Theme/ColorContrastTest.php
+++ b/tests/Theme/ColorContrastTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Theme;
+
+use NeNeRecords\Theme\ColorContrast;
+use PHPUnit\Framework\TestCase;
+
+final class ColorContrastTest extends TestCase
+{
+    public function testHexBlackOnWhiteIsMaxContrast(): void
+    {
+        $ratio = ColorContrast::ratio('#000000', '#ffffff');
+        self::assertNotNull($ratio);
+        self::assertEqualsWithDelta(21.0, $ratio, 0.05);
+    }
+
+    public function testOklchWhiteAndBlackMatchHex(): void
+    {
+        $ratio = ColorContrast::ratio('oklch(0% 0 0)', 'oklch(100% 0 0)');
+        self::assertNotNull($ratio);
+        self::assertEqualsWithDelta(21.0, $ratio, 0.1);
+    }
+
+    public function testShorthandHexParses(): void
+    {
+        self::assertEqualsWithDelta(21.0, (float) ColorContrast::ratio('#000', '#fff'), 0.05);
+    }
+
+    public function testSameColourIsOne(): void
+    {
+        self::assertEqualsWithDelta(1.0, (float) ColorContrast::ratio('#345678', '#345678'), 0.001);
+    }
+
+    public function testOklchMidContrastIsReasonable(): void
+    {
+        // Near-black ink on near-white paper → should comfortably pass AA (>= 4.5).
+        $ratio = ColorContrast::ratio('oklch(22% 0.02 250)', 'oklch(98% 0.01 250)');
+        self::assertNotNull($ratio);
+        self::assertGreaterThan(7.0, $ratio);
+    }
+
+    public function testUncomputableValuesReturnNull(): void
+    {
+        self::assertNull(ColorContrast::relativeLuminance('color-mix(in oklch, #fff, #000 40%)'));
+        self::assertNull(ColorContrast::relativeLuminance('var(--x)'));
+        self::assertNull(ColorContrast::ratio('#fff', 'not-a-color'));
+    }
+}

--- a/tests/Theme/PreviewThemeUseCaseTest.php
+++ b/tests/Theme/PreviewThemeUseCaseTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Theme;
+
+use NeNeRecords\Theme\PreviewThemeInput;
+use NeNeRecords\Theme\PreviewThemeUseCase;
+use PHPUnit\Framework\TestCase;
+
+final class PreviewThemeUseCaseTest extends TestCase
+{
+    public function testValidManifestReportsComputableContrast(): void
+    {
+        $output = (new PreviewThemeUseCase())->execute(
+            new PreviewThemeInput(ThemeManifestFixture::valid()),
+        );
+
+        self::assertTrue($output->valid);
+        self::assertSame([], $output->errors);
+        self::assertArrayHasKey('color-surface', $output->applied['light']);
+        // Every pair present for light, and at least one computed.
+        self::assertNotEmpty($output->contrast['light']);
+        $computable = array_filter(
+            $output->contrast['light'],
+            static fn (array $row) => ($row['computable'] ?? false) === true,
+        );
+        self::assertNotEmpty($computable);
+    }
+
+    public function testHighContrastPairPassesAa(): void
+    {
+        $manifest = ThemeManifestFixture::valid();
+        $manifest['tokens']['light']['color-text-primary'] = 'oklch(20% 0.02 250)';
+        $manifest['tokens']['light']['color-surface'] = 'oklch(98% 0.01 250)';
+
+        $output = (new PreviewThemeUseCase())->execute(new PreviewThemeInput($manifest));
+
+        $row = $this->pair($output->contrast['light'], 'text-primary/surface');
+        self::assertTrue($row['computable']);
+        self::assertTrue($row['aa']);
+        self::assertGreaterThan(7.0, $row['ratio']);
+    }
+
+    public function testUnsafeValueIsDroppedAndReportedInvalid(): void
+    {
+        $manifest = ThemeManifestFixture::valid();
+        $manifest['tokens']['light']['color-accent'] = 'red; } body{}';
+
+        $output = (new PreviewThemeUseCase())->execute(new PreviewThemeInput($manifest));
+
+        self::assertFalse($output->valid); // validator flags the unsafe value
+        $droppedTokens = array_map(static fn (array $d) => $d['token'], $output->dropped);
+        self::assertContains('color-accent', $droppedTokens);
+    }
+
+    public function testColorMixIsUncomputableWithWarning(): void
+    {
+        $manifest = ThemeManifestFixture::valid();
+        $manifest['tokens']['light']['color-surface'] = 'color-mix(in oklch, #fff, #000 10%)';
+
+        $output = (new PreviewThemeUseCase())->execute(new PreviewThemeInput($manifest));
+
+        $row = $this->pair($output->contrast['light'], 'text-primary/surface');
+        self::assertFalse($row['computable']);
+        self::assertNotEmpty($output->warnings);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     *
+     * @return array<string, mixed>
+     */
+    private function pair(array $rows, string $label): array
+    {
+        foreach ($rows as $row) {
+            if (($row['pair'] ?? null) === $label) {
+                return $row;
+            }
+        }
+        self::fail("contrast pair {$label} not found");
+    }
+}

--- a/tools/generate-mcp-tools.php
+++ b/tools/generate-mcp-tools.php
@@ -759,6 +759,22 @@ $tools = [
         $themeManifestRequired,
         true,
     ),
+    // Non-mutating dry-run despite POST → safety 'read' (overrides the method default).
+    array_merge(
+        readTool(
+            'previewTheme',
+            'Preview Runtime Theme',
+            'Compute a no-browser preview of a theme manifest: returns the tokens that would render (safe-filtered), the ones dropped, and WCAG contrast for key pairs (light/dark). Non-persistent — use to self-correct contrast/quality before createTheme/updateTheme.',
+            'previewTheme',
+            'POST',
+            '/api/v1/themes/preview',
+            $themeManifestProps,
+            '#/components/schemas/ThemePreviewResponse',
+            $themeManifestRequired,
+            true,
+        ),
+        ['safety' => 'read'],
+    ),
     readTool(
         'getTheme',
         'Get Runtime Theme',


### PR DESCRIPTION
## 目的

ClaudeDesign は manifest を**結果を見ずに**書いている（盲目オーサリング）。**ブラウザ不要の計算プレビュー**で、コミット前にコントラスト不足・破綻・落ちる値を自己修正できるようにする（閉ループ Phase 1）。設計: `docs/theming/theme-preview.md`。

## 変更内容

- **`POST /api/v1/themes/preview`**（ADMIN_ONLY・**非永続**・常に 200）／ MCP **`previewTheme`**（safety **read**）。
- 入力＝manifest。出力 `ThemePreviewResponse`：
  - `valid` ＋ `errors[]`（検証は捕捉して報告）
  - `applied.{light,dark}`（描画相当の安全フィルタ後）＋ `dropped[]`（落ちた値・理由）
  - `contrast.{light,dark}[]`：**WCAG 比率＋AA/AAA**（text/surface・text/raised・on-accent/accent・accent/surface・border/surface）
  - `warnings[]`
- **`ColorContrast`**：`oklch()`/`#hex`→相対輝度→比率。`color-mix()`/`var()`/gradient は `computable:false`＋warning。
- OpenAPI＋`composer mcp:generate`＋codegen。運用 doc に preview ループ追記。

## スコープの前提

built-in テーマの base トークンは CSS（データでない）ため「built-in＋override の最終色」は本Phase対象外 → **フルトークン manifest を入力**（runtime テーマは常にフルトークン）。視覚スクショ／built-in+override の確認は **Phase 2（headless・別Issue）**。

## 検証

- backend `composer check` ✅（PHPUnit **751**＝新規10／PHPStan L8／CS／OpenAPI／MCP **66 tools**）
  - ColorContrast：黒/白=21、oklch=hex 一致、color-mix=null 等を単体検証
- frontend `type-check`/`lint` ✅（codegen 同期）

Closes #433
Refs #423