### PR TITLE
docs: 2026-06-19 開発日報

### DIFF
--- a/docs/daily-reports/2026-06-19.md
+++ b/docs/daily-reports/2026-06-19.md
@@ -1,0 +1,80 @@
+# NeNe Records 開発日報
+
+**日付:** 2026-06-19（金）
+**プロジェクト:** NeNe Records（NENE2 ベース API-first CMS）
+**フェーズ:** ヘッダーのグリッド化（#419）→ ランタイムテーマ epic（#423）→ Claude.ai MCP コネクタ（#437）
+**ブランチ:** `main`（下記マージ済み PR 群）＋ オープン: `feat/433-theme-preview`(#434) / `docs/435-claudedesign-mcp-guide`(#436) / `feat/mcp-bridge`(#438)
+
+---
+
+## 本日の概要
+
+午前はヘッダーを「ウィジット的にパターン選択」できる方向で議論 → **行×ゾーンのグリッド文法**に落とし込み、頻度調査（WPパターン/ビルダー/実サイト）で裏取りしつつ実装（#419 Phase A/B/C）。午後は「ClaudeDesign がテーマを自走で増やせる MCP」という発想から、**ランタイムテーマ epic（#423）** を設計〜実装〜運用ドキュメントまで一気通貫で完成。さらに「盲目オーサリング」を閉じる**計算プレビュー（#433）**、ClaudeDesign 向け **MCP 実践ガイド（#435）**、Claude.ai に繋ぐための**リモート MCP ブリッジ（#437）**まで到達。**マージ 10 PR / オープン 3 PR**。バック `composer check`・フロント `npm run check` は常時グリーン維持。
+
+---
+
+## 完了した作業（マージ済み）
+
+### A. ヘッダーのグリッドモデル化（#419）
+
+WordPress テーマのヘッダーを構造解析 → 「3行×3ゾーン＋要素パレット＋モディファイア」の有限文法に整理。頻度調査3系統（バックグラウンドのサブエージェントで並行 → WebFetch 制約が判明し主系統は WP REST API＋公式ドキュメントへ）で `classic`/`nav-right` が95%、`centered` が次点と裏取り。
+
+| PR | 内容 |
+| --- | --- |
+| #420 | 要素 ON/OFF フラグ（検索/テーマ切替/タグライン）— 既存スタイルフラグ機構に追加 |
+| #421 | 骨格プリセット（nav-right/classic/centered/minimal）＋ nav寄せ/密度/幅/sticky＋頻度調査統合 |
+| #422 | Top バー＋CTA（`header_config` 設定）＋管理ライブプレビュー |
+
+### B. ランタイムテーマ epic（#423・A〜G 完了）
+
+テーマを「ビルド時の静的 CSS」から「DB の manifest JSON（MCP で登録）」へ拡張。**register（MCP）→ ピッカー表示 → 採用で公開即反映（再ビルド無し）→ 編集/削除** が稼働。
+
+| PR | スライス |
+| --- | --- |
+| #424 | 設計 doc（`runtime-themes.md`） |
+| #425 | backend（`themes` テーブル＋CRUD＋`ThemeManifestValidator`）＋ OpenAPI/MCP（`createTheme` 他） |
+| #428 | 公開適用（`/api/v1/public/themes`・`buildThemeStylesheet`・assetRef検証）＋ 管理ピッカー合成（編集/削除） |
+| #429 | runtime テーマの FOUC キャッシュ |
+| #427/#430 | サムネ B案（自動スワッチ）/ A案（media_id 解決 `thumbnail_url`） |
+| #432 | ClaudeDesign 連携運用 doc |
+
+**セキュリティの核**: 公開 `<style>` に出すのは「既知トークン × 検証済み値のみ」。値サニタイズ（`;{}<>`/`url(`/`@import` 等を遮断）＋ assetRef 検証（外部URL/`data:` 拒否）＋ org 分離＋認証ゲート。
+
+---
+
+## 進行中（オープン PR）
+
+| PR | 内容 | 状態 |
+| --- | --- | --- |
+| #434 | **計算プレビュー MCP**（`previewTheme`）— oklch/hex→WCAGコントラスト、`applied`/`dropped`/`warnings`。盲目オーサリング解消 Phase 1 | 実装・全テスト緑、未マージ |
+| #436 | **ClaudeDesign 向け MCP 実践ガイド**（6ツール・黄金ループ・レシピ） | doc、未マージ |
+| #438 | **Claude.ai 用 MCP ブリッジ**（`mcp-bridge/`）＋手順＋引き継ぎ | ローカル動作確認済み、未マージ |
+
+---
+
+## 重要な発見・判断
+
+- **MCP ツールは OpenAPI から手動キュレーション**（`tools/generate-mcp-tools.php`）。`tools.json` の `source:openapi` はメタ情報で、ツール追加はビルダーに追記が必要。
+- **built-in テーマの base トークンは CSS（データでない）** → 「built-in＋override の最終色」はサーバで解決不能。計算プレビューは**フルトークン manifest 入力**に限定（runtime テーマは常にフルトークン）。視覚スクショ/built-in は将来 Phase 2（headless）。
+- **`tools.json` ≠ MCP サーバ**。Claude.ai Connector には「公開到達可能なリモート MCP サーバ URL」が要る → 薄いブリッジを新設（Streamable HTTP・tools.json→API proxy）。`localhost`/VPN は不可。
+- bespoke CSS ギャップの criticality 評価: 量産＝低、シグネチャ級1:1複製＝中。**フラグ語彙を育てる**のが複利で効くレバー、と整理。
+
+## ハマりどころ（記録）
+
+- **スタックPR のカスケード・クローズ**: 根元PRを `--delete-branch` でマージすると上位スタックPRが自動クローズ＆reopen不可。今後は「上位の base を先に付け替える」か「--delete-branch を後で」。
+- **admin リソースは `ADMIN_ONLY_PREFIXES` に追加しないと GET が素通し**（`/api/v1/themes` で踏んだ。`AdminApiAuthMiddleware`）。
+- **マイグレーションはコンテナ内で実行**（host から `mysql` 名前解決不可）。
+- サブエージェントの WebFetch がツールレベルで拒否（メインスレッドは可）。
+
+## 検証
+
+- バック `composer check`：PHPUnit **751**（最終）/ PHPStan L8 / CS / OpenAPI / MCP（**66 tools**）すべてグリーン。
+- フロント `type-check`/`lint`/`format`/`test`（**224**）グリーン。
+- ランタイムテーマ・サムネ解決・公開エンドポイントは **DB 投入による実機 e2e** も確認。
+- MCP ブリッジは `initialize → initialized → tools/list` をローカル検証。
+
+## 次の一手
+
+1. オープン PR（#434 → #436 → #438）をマージ。
+2. **Claude.ai 連携の実地検証**：`cloudflared` 導入 → トンネル → Custom Connector 登録（read系で疎通）。手順は [`integrations/mcp-connector.md`](../integrations/mcp-connector.md)、再開は [`todo/handoff-2026-06-19-mcp-connector.md`](../todo/handoff-2026-06-19-mcp-connector.md)。
+3. 余力で計算プレビュー Phase 2（headless スクショ）や、フラグ語彙の拡充（bespoke→flag 昇華）。


### PR DESCRIPTION
ヘッダーのグリッド化(#419)→ランタイムテーマ epic(#423 A-G)→計算プレビュー(#433)→ClaudeDesign MCP ガイド(#435)→Claude.ai 用 MCP ブリッジ(#437) の日報。マージ10PR・オープン3PR。