### PR TITLE
feat(theme): ClaudeDesign 向け in-band テーマオーサリングガイド MCP ツール (#440)

### DIFF
--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -1137,6 +1137,24 @@
             "responseSchemaRef": "#/components/schemas/SettingRevisionListResponse"
         },
         {
+            "name": "getThemeAuthoringGuide",
+            "title": "Theme Authoring Guide",
+            "description": "Read this FIRST before creating or updating a runtime theme. Returns the manifest contract (required tokens, flag enums, token value rules, reserved ids), recipes, common mistakes and a minimal valid example manifest. Derived from the server validator so it matches exactly what createTheme/updateTheme enforce.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "getThemeAuthoringGuide",
+                "method": "GET",
+                "path": "/api/v1/themes/authoring-guide"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": [],
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/ThemeAuthoringGuideResponse"
+        },
+        {
             "name": "listThemes",
             "title": "List Runtime Themes",
             "description": "List all runtime (data-driven) public-site themes for the organization.",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2923,6 +2923,29 @@ paths:
           $ref: '#/components/responses/ValidationFailed'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/themes/authoring-guide:
+    get:
+      tags:
+        - Themes
+      summary: Theme authoring guide
+      description: >-
+        In-band guide for AI agents (ClaudeDesign) registering runtime themes
+        over MCP. Returns the manifest contract (required tokens, flag enums,
+        token value rules, reserved ids), recipes and a minimal valid example —
+        derived from the server-side validator so it never drifts from what is
+        enforced. See #440.
+      operationId: getThemeAuthoringGuide
+      responses:
+        '200':
+          description: Authoring guide.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThemeAuthoringGuideResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /api/v1/themes/{key}:
     get:
       tags:
@@ -5935,6 +5958,46 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ThemeResponse'
+      additionalProperties: false
+    ThemeAuthoringGuideResponse:
+      type: object
+      description: >-
+        Machine-usable guide for authoring runtime themes over MCP. The
+        `contract` block is derived from the server-side validator.
+      required:
+        - summary
+        - authentication
+        - contract
+        - recipes
+        - exampleManifest
+        - commonMistakes
+        - relatedTools
+      properties:
+        summary:
+          type: string
+        authentication:
+          type: string
+        contract:
+          type: object
+          description: >-
+            What a manifest must satisfy: required tokens, flag enums, token
+            value rules, reserved ids and id/version patterns.
+          additionalProperties: true
+        recipes:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        exampleManifest:
+          $ref: '#/components/schemas/ThemeManifest'
+        commonMistakes:
+          type: array
+          items:
+            type: string
+        relatedTools:
+          type: object
+          additionalProperties:
+            type: string
       additionalProperties: false
 
 

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -1180,6 +1180,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/themes/authoring-guide": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Theme authoring guide
+         * @description In-band guide for AI agents (ClaudeDesign) registering runtime themes over MCP. Returns the manifest contract (required tokens, flag enums, token value rules, reserved ids), recipes and a minimal valid example — derived from the server-side validator so it never drifts from what is enforced. See #440.
+         */
+        get: operations["getThemeAuthoringGuide"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/themes/{key}": {
         parameters: {
             query?: never;
@@ -2334,6 +2354,23 @@ export interface components {
         };
         ThemeListResponse: {
             items: components["schemas"]["ThemeResponse"][];
+        };
+        /** @description Machine-usable guide for authoring runtime themes over MCP. The `contract` block is derived from the server-side validator. */
+        ThemeAuthoringGuideResponse: {
+            summary: string;
+            authentication: string;
+            /** @description What a manifest must satisfy: required tokens, flag enums, token value rules, reserved ids and id/version patterns. */
+            contract: {
+                [key: string]: unknown;
+            };
+            recipes: {
+                [key: string]: unknown;
+            }[];
+            exampleManifest: components["schemas"]["ThemeManifest"];
+            commonMistakes: string[];
+            relatedTools: {
+                [key: string]: string;
+            };
         };
         WebhookResponse: {
             /** Format: int64 */
@@ -5484,6 +5521,28 @@ export interface operations {
             };
             401: components["responses"]["Unauthorized"];
             422: components["responses"]["ValidationFailed"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    getThemeAuthoringGuide: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Authoring guide. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ThemeAuthoringGuideResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
             500: components["responses"]["InternalServerError"];
         };
     };

--- a/src/Theme/ThemeAuthoringGuide.php
+++ b/src/Theme/ThemeAuthoringGuide.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+/**
+ * Builds the structured, in-band authoring guide ClaudeDesign reads over MCP
+ * before registering a runtime theme (#440).
+ *
+ * The human-facing prose lives in docs/theming/claudedesign-mcp-guide.md, but an
+ * agent connected through the MCP bridge cannot read the repository — so this
+ * returns the machine-usable contract (required tokens, flag enums, value rules,
+ * reserved ids) plus recipes and a minimal example. Everything contract-related
+ * is derived from {@see ThemeManifestValidator::contract()} so it can never drift
+ * from what the server actually enforces.
+ */
+final class ThemeAuthoringGuide
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function build(): array
+    {
+        $contract = ThemeManifestValidator::contract();
+
+        return [
+            'summary' => 'How to author and register a runtime (data-driven) public-site theme over MCP. '
+                . 'A theme is a manifest: id/name/version + per-mode CSS tokens (light & dark) + optional structural flags. '
+                . 'Token values are emitted verbatim into a scoped <style> on the public site, so they are sanitised: '
+                . 'only safe CSS passes. Build the manifest, then call createTheme (or updateTheme to replace one).',
+            'authentication' => 'All theme tools require an authenticated admin token; the MCP bridge already attaches it. '
+                . 'Data is organization-scoped (JWT org_id).',
+            'contract' => $contract,
+            'recipes' => self::recipes(),
+            'exampleManifest' => self::exampleManifest($contract['requiredTokens']),
+            'commonMistakes' => [
+                'Omitting a required token in light OR dark — both modes must carry the full set.',
+                'Using url(), @import, or a semicolon/braces in a token value — rejected as unsafe CSS (422).',
+                'Reusing a built-in theme id (see contract.reservedIds) — rejected as reserved (422).',
+                'Pointing an asset at an external URL or data: URI — only a media id or bundle-relative path is allowed.',
+                'A flag value outside its enum (see contract.flags) — rejected as invalid.',
+            ],
+            'relatedTools' => [
+                'listThemes' => 'List existing runtime themes for the org.',
+                'getTheme' => 'Fetch one runtime theme by key.',
+                'createTheme' => 'Register a new runtime theme from a manifest.',
+                'updateTheme' => 'Replace an existing theme manifest (id must equal the key).',
+                'deleteTheme' => 'Delete a runtime theme by key.',
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private static function recipes(): array
+    {
+        return [
+            [
+                'title' => 'Create a new theme',
+                'steps' => [
+                    'Pick an id matching the id pattern that is not in contract.reservedIds.',
+                    'Fill tokens.light and tokens.dark with every token in contract.requiredTokens (safe CSS values).',
+                    'Optionally set structural flags from contract.flags.',
+                    'Call createTheme with the manifest. A 422 lists exactly which fields failed.',
+                ],
+            ],
+            [
+                'title' => 'Adjust an existing theme\'s colors',
+                'steps' => [
+                    'getTheme to fetch the current manifest.',
+                    'Edit the token values you want to change (keep all required tokens present).',
+                    'Call updateTheme with the full manifest; id must equal the key.',
+                ],
+            ],
+            [
+                'title' => 'Fix unreadable button/accent text',
+                'steps' => [
+                    'Ensure color-on-accent contrasts with color-accent (and the same in dark mode).',
+                    'Re-submit via updateTheme.',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * A minimal manifest that passes {@see ThemeManifestValidator::validate()}.
+     * Token values are illustrative placeholders — replace them with the real
+     * palette. Generated from the required-token list so it always stays complete.
+     *
+     * @param list<string> $requiredTokens
+     *
+     * @return array<string, mixed>
+     */
+    private static function exampleManifest(array $requiredTokens): array
+    {
+        return [
+            'id' => 'example-theme',
+            'name' => 'Example Theme',
+            'version' => '1.0.0',
+            'supportsModes' => ['light', 'dark'],
+            'tokens' => [
+                'light' => self::sampleTokens($requiredTokens, 'light'),
+                'dark' => self::sampleTokens($requiredTokens, 'dark'),
+            ],
+            'flags' => [
+                'feedLayout' => 'grid',
+                'cardStyle' => 'bordered',
+            ],
+        ];
+    }
+
+    /**
+     * @param list<string> $requiredTokens
+     *
+     * @return array<string, string>
+     */
+    private static function sampleTokens(array $requiredTokens, string $mode): array
+    {
+        $tokens = [];
+        foreach ($requiredTokens as $key) {
+            $tokens[$key] = match (true) {
+                $key === 'color-scheme' => $mode,
+                str_starts_with($key, 'shadow-') => '0 1px 2px rgba(0, 0, 0, 0.08)',
+                default => $mode === 'light' ? '#1a1a1a' : '#f5f5f5',
+            };
+        }
+
+        return $tokens;
+    }
+}

--- a/src/Theme/ThemeAuthoringGuideHandler.php
+++ b/src/Theme/ThemeAuthoringGuideHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Serves the in-band theme authoring guide (#440) so ClaudeDesign can learn the
+ * manifest contract, rules, recipes and a valid example over MCP — without
+ * reading the repository.
+ */
+final readonly class ThemeAuthoringGuideHandler
+{
+    public function __construct(
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->response->create(ThemeAuthoringGuide::build());
+    }
+}

--- a/src/Theme/ThemeManifestValidator.php
+++ b/src/Theme/ThemeManifestValidator.php
@@ -70,6 +70,43 @@ final class ThemeManifestValidator
     private const MAX_TOKEN_VALUE_LEN = 200;
 
     /**
+     * Substrings that make a token value unsafe (external / script-bearing).
+     * Extracted so the authoring guide (#440) can expose them verbatim.
+     *
+     * @var list<string>
+     */
+    private const UNSAFE_VALUE_SUBSTRINGS = ['url(', '@import', 'expression(', 'javascript:', '/*', '*/'];
+
+    /** Break-out characters rejected in any token value. */
+    private const UNSAFE_VALUE_CHARS = ';{}<>\\`';
+
+    /**
+     * Contract that ClaudeDesign must satisfy to register a theme over MCP.
+     * Derived from this validator so the authoring guide can never drift from
+     * what is actually enforced (#440).
+     *
+     * @return array<string, mixed>
+     */
+    public static function contract(): array
+    {
+        return [
+            'idPattern' => self::ID_PATTERN,
+            'versionPattern' => self::VERSION_PATTERN,
+            'tokenKeyPattern' => self::TOKEN_KEY_PATTERN,
+            'assetRefPattern' => self::ASSET_REF_PATTERN,
+            'requiredTokens' => self::REQUIRED_TOKENS,
+            'flags' => self::FLAG_ENUMS,
+            'reservedIds' => self::RESERVED_KEYS,
+            'tokenValueRules' => [
+                'maxLength' => self::MAX_TOKEN_VALUE_LEN,
+                'forbiddenChars' => self::UNSAFE_VALUE_CHARS,
+                'forbiddenSubstrings' => self::UNSAFE_VALUE_SUBSTRINGS,
+            ],
+            'fontSources' => ['fontsource', 'system'],
+        ];
+    }
+
+    /**
      * @param array<string, mixed> $manifest
      *
      * @throws ValidationException when the manifest is malformed or unsafe
@@ -265,12 +302,12 @@ final class ThemeManifestValidator
             return false;
         }
         // Declaration / stylesheet break-out characters.
-        if (preg_match('/[;{}<>\\\\`]/', $trimmed) === 1) {
+        if (preg_match('/[' . preg_quote(self::UNSAFE_VALUE_CHARS, '/') . ']/', $trimmed) === 1) {
             return false;
         }
         // External / script-bearing constructs (case-insensitive).
         $lower = strtolower($trimmed);
-        foreach (['url(', '@import', 'expression(', 'javascript:', '/*', '*/'] as $needle) {
+        foreach (self::UNSAFE_VALUE_SUBSTRINGS as $needle) {
             if (str_contains($lower, $needle)) {
                 return false;
             }

--- a/src/Theme/ThemeRouteRegistrar.php
+++ b/src/Theme/ThemeRouteRegistrar.php
@@ -16,6 +16,7 @@ final readonly class ThemeRouteRegistrar
         private UpdateThemeHandler $updateHandler,
         private DeleteThemeHandler $deleteHandler,
         private ListPublicThemesHandler $listPublicHandler,
+        private ThemeAuthoringGuideHandler $authoringGuideHandler,
     ) {
     }
 
@@ -27,7 +28,14 @@ final readonly class ThemeRouteRegistrar
         $update = $this->updateHandler;
         $delete = $this->deleteHandler;
         $listPublic = $this->listPublicHandler;
+        $authoringGuide = $this->authoringGuideHandler;
 
+        // In-band authoring guide for MCP agents (#440). The router prioritises
+        // this static path over /themes/{key} (fewer path params win).
+        $router->get(
+            '/api/v1/themes/authoring-guide',
+            static fn (ServerRequestInterface $request) => $authoringGuide->handle($request),
+        );
         $router->get(
             '/api/v1/themes',
             static fn (ServerRequestInterface $request) => $list->handle($request),

--- a/src/Theme/ThemeServiceProvider.php
+++ b/src/Theme/ThemeServiceProvider.php
@@ -206,6 +206,17 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                ThemeAuthoringGuideHandler::class,
+                static function (ContainerInterface $container): ThemeAuthoringGuideHandler {
+                    $response = $container->get(JsonResponseFactory::class);
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ThemeAuthoringGuideHandler($response);
+                },
+            )
+            ->set(
                 ThemeNotFoundExceptionHandler::class,
                 static function (ContainerInterface $container): ThemeNotFoundExceptionHandler {
                     $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
@@ -225,6 +236,7 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                     $update = $container->get(UpdateThemeHandler::class);
                     $delete = $container->get(DeleteThemeHandler::class);
                     $listPublic = $container->get(ListPublicThemesHandler::class);
+                    $authoringGuide = $container->get(ThemeAuthoringGuideHandler::class);
 
                     if (!$list instanceof ListThemesHandler) {
                         throw new LogicException('ListThemes handler service is invalid.');
@@ -244,8 +256,11 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                     if (!$listPublic instanceof ListPublicThemesHandler) {
                         throw new LogicException('ListPublicThemes handler service is invalid.');
                     }
+                    if (!$authoringGuide instanceof ThemeAuthoringGuideHandler) {
+                        throw new LogicException('ThemeAuthoringGuide handler service is invalid.');
+                    }
 
-                    return new ThemeRouteRegistrar($list, $get, $create, $update, $delete, $listPublic);
+                    return new ThemeRouteRegistrar($list, $get, $create, $update, $delete, $listPublic, $authoringGuide);
                 },
             );
     }

--- a/tests/Theme/ThemeAuthoringGuideTest.php
+++ b/tests/Theme/ThemeAuthoringGuideTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Theme;
+
+use NeNeRecords\Theme\ThemeAuthoringGuide;
+use NeNeRecords\Theme\ThemeManifestValidator;
+use PHPUnit\Framework\TestCase;
+
+final class ThemeAuthoringGuideTest extends TestCase
+{
+    public function testGuideExposesTheValidatorContract(): void
+    {
+        $guide = ThemeAuthoringGuide::build();
+
+        self::assertSame(ThemeManifestValidator::contract(), $guide['contract']);
+        self::assertContains('color-accent', $guide['contract']['requiredTokens']);
+        self::assertArrayHasKey('feedLayout', $guide['contract']['flags']);
+    }
+
+    public function testExampleManifestPassesValidation(): void
+    {
+        $guide = ThemeAuthoringGuide::build();
+
+        // The advertised example must be something createTheme would accept,
+        // otherwise the guide teaches ClaudeDesign to fail (#440).
+        ThemeManifestValidator::validate($guide['exampleManifest']);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testGuideListsTheThemeToolsAndIsActionable(): void
+    {
+        $guide = ThemeAuthoringGuide::build();
+
+        self::assertArrayHasKey('createTheme', $guide['relatedTools']);
+        self::assertArrayHasKey('updateTheme', $guide['relatedTools']);
+        self::assertNotEmpty($guide['recipes']);
+        self::assertNotEmpty($guide['commonMistakes']);
+        self::assertNotSame('', $guide['summary']);
+    }
+}

--- a/tools/generate-mcp-tools.php
+++ b/tools/generate-mcp-tools.php
@@ -738,6 +738,16 @@ $tools = [
         ['key'],
     ),
     readTool(
+        'getThemeAuthoringGuide',
+        'Theme Authoring Guide',
+        'Read this FIRST before creating or updating a runtime theme. Returns the manifest contract (required tokens, flag enums, token value rules, reserved ids), recipes, common mistakes and a minimal valid example manifest. Derived from the server validator so it matches exactly what createTheme/updateTheme enforce.',
+        'getThemeAuthoringGuide',
+        'GET',
+        '/api/v1/themes/authoring-guide',
+        [],
+        '#/components/schemas/ThemeAuthoringGuideResponse',
+    ),
+    readTool(
         'listThemes',
         'List Runtime Themes',
         'List all runtime (data-driven) public-site themes for the organization.',


### PR DESCRIPTION
## 目的

MCP 越しに接続する ClaudeDesign は**リポジトリを読めない**ため、テーマ manifest の契約・ルール・コツを取得する手段が無かった（`docs/theming/claudedesign-mcp-guide.md` は人間向け）。read 系 MCP ツールで **in-band** に学べるようにする。`previewTheme`(#434) が「作った後の動的チェック」なのに対し、本ツールは「作る前の静的契約」を提供して両輪になる。

## 変更点

- **新ツール `getThemeAuthoringGuide`**（`GET /api/v1/themes/authoring-guide`）。構造化レスポンス：`summary / authentication / contract / recipes / exampleManifest / commonMistakes / relatedTools`。
- `ThemeManifestValidator::contract()` を追加し、必須トークン・flag enum・値サニタイズ規則・予約 id・各パターンを**正本として公開**。ガイドはここから導出するので `createTheme`/`updateTheme` が強制する内容と **drift しない**。
- 既存サニタイズ定数（禁止文字・禁止部分文字列）を const へ抽出（挙動不変）。
- `ThemeAuthoringGuide` が**バリデータを通る最小サンプル manifest** を必須トークンから自動生成。
- OpenAPI に path + `ThemeAuthoringGuideResponse`、`tools/generate-mcp-tools.php` に追記（**66 tools**）、フロント型再生成。

## 検証

- `composer check`：PHPUnit **744** / PHPStan L8 / CS / OpenAPI / MCP すべてグリーン。
- `npm run check`：tsc / lint / **224 tests** / Storybook グリーン。
- 実機：ガイド `200`、静的ルートが `{key}` より優先、無認証 `401`。
- **ドッグフード**：`exampleManifest` が `ThemeManifestValidator::validate()` を通ることをテストで保証。

## チェックリスト

- [x] Issue 紐付け（Closes #440）
- [x] CLAUDE.md「MCP tools go through OpenAPI HTTP boundary only」準拠（ブリッジ合成ツールにしない）
- [x] `/api/v1/themes` プレフィックス＝`ADMIN_ONLY_PREFIXES` で認証必須を維持
- [x] バック/フロント品質ゲート緑

関連: #423 #434 #435 #436 #438

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)