### PR TITLE
feat(theme): オーサリングガイドに意味レベルの知識を追加する (#442)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -5968,8 +5968,11 @@ components:
         - summary
         - authentication
         - contract
+        - tokenDocs
+        - flagDocs
         - recipes
         - exampleManifest
+        - optionalFields
         - commonMistakes
         - relatedTools
       properties:
@@ -5983,6 +5986,19 @@ components:
             What a manifest must satisfy: required tokens, flag enums, token
             value rules, reserved ids and id/version patterns.
           additionalProperties: true
+        tokenDocs:
+          type: object
+          description: >-
+            Per required-token semantics: { purpose, pairsWith }. pairsWith names
+            the token this one must contrast against (or empty).
+          additionalProperties:
+            type: object
+            additionalProperties: true
+        flagDocs:
+          type: object
+          description: What each structural flag controls.
+          additionalProperties:
+            type: string
         recipes:
           type: array
           items:
@@ -5990,6 +6006,10 @@ components:
             additionalProperties: true
         exampleManifest:
           $ref: '#/components/schemas/ThemeManifest'
+        optionalFields:
+          type: object
+          description: Shapes and examples for the optional fonts and assets blocks.
+          additionalProperties: true
         commonMistakes:
           type: array
           items:

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -2363,10 +2363,24 @@ export interface components {
             contract: {
                 [key: string]: unknown;
             };
+            /** @description Per required-token semantics: { purpose, pairsWith }. pairsWith names the token this one must contrast against (or empty). */
+            tokenDocs: {
+                [key: string]: {
+                    [key: string]: unknown;
+                };
+            };
+            /** @description What each structural flag controls. */
+            flagDocs: {
+                [key: string]: string;
+            };
             recipes: {
                 [key: string]: unknown;
             }[];
             exampleManifest: components["schemas"]["ThemeManifest"];
+            /** @description Shapes and examples for the optional fonts and assets blocks. */
+            optionalFields: {
+                [key: string]: unknown;
+            };
             commonMistakes: string[];
             relatedTools: {
                 [key: string]: string;

--- a/src/Theme/ThemeAuthoringGuide.php
+++ b/src/Theme/ThemeAuthoringGuide.php
@@ -6,17 +6,74 @@ namespace NeNeRecords\Theme;
 
 /**
  * Builds the structured, in-band authoring guide ClaudeDesign reads over MCP
- * before registering a runtime theme (#440).
+ * before registering a runtime theme (#440, enriched in #442).
  *
  * The human-facing prose lives in docs/theming/claudedesign-mcp-guide.md, but an
  * agent connected through the MCP bridge cannot read the repository — so this
  * returns the machine-usable contract (required tokens, flag enums, value rules,
- * reserved ids) plus recipes and a minimal example. Everything contract-related
- * is derived from {@see ThemeManifestValidator::contract()} so it can never drift
- * from what the server actually enforces.
+ * reserved ids) AND the semantic knowledge needed to author a *good* theme, not
+ * just a valid one: what each token means, which tokens must contrast, what each
+ * flag controls, a realistic example, and the fonts/assets shapes.
+ *
+ * Contract data is derived from {@see ThemeManifestValidator::contract()}; the
+ * per-token/flag docs are static knowledge, kept aligned by a test that asserts
+ * their keys match the contract (so adding a token forces a doc update).
  */
 final class ThemeAuthoringGuide
 {
+    /**
+     * Per required-token semantics + a realistic value for each mode.
+     * [purpose, pairsWith (token to contrast against, or ''), light, dark].
+     * Keys MUST stay equal to ThemeManifestValidator::contract().requiredTokens.
+     *
+     * @var array<string, array{string, string, string, string}>
+     */
+    private const TOKEN_SPECS = [
+        'color-surface' => ['Base page background.', 'color-text-primary', '#ffffff', '#0f1115'],
+        'color-surface-raised' => ['Background for raised cards/panels above the page.', 'color-text-primary', '#f7f8fa', '#171a21'],
+        'color-surface-overlay' => ['Background for overlays (modals, menus, popovers).', 'color-text-primary', '#ffffff', '#1c2027'],
+        'color-surface-sunken' => ['Background for inset/well areas below the page.', 'color-text-primary', '#eef0f3', '#0b0d11'],
+        'color-text-primary' => ['Primary body and heading text.', 'color-surface', '#1a1d23', '#f3f4f6'],
+        'color-text-muted' => ['Secondary text (captions, meta, placeholders).', 'color-surface', '#5b6472', '#9ca3af'],
+        'color-text-inverse' => ['Text shown on strong/dark fills.', '', '#ffffff', '#0f1115'],
+        'color-border' => ['Default hairline borders and dividers.', '', '#e4e7ec', '#2a2f3a'],
+        'color-border-strong' => ['Emphasised borders (active/focused inputs).', '', '#cfd4dc', '#3a414f'],
+        'color-focus-ring' => ['Keyboard focus ring; must stay visible on surfaces.', 'color-surface', '#2563eb', '#60a5fa'],
+        'color-accent' => ['Primary brand/action color (buttons, links).', 'color-on-accent', '#2563eb', '#3b82f6'],
+        'color-accent-hover' => ['Accent color on hover/active.', 'color-on-accent', '#1d4ed8', '#60a5fa'],
+        'color-accent-weak' => ['Tinted accent background (chips, subtle highlights).', 'color-text-primary', '#dbeafe', '#1e293b'],
+        'color-on-accent' => ['Text/icon color on top of color-accent; must contrast it.', 'color-accent', '#ffffff', '#ffffff'],
+        'color-brand-violet' => ['Secondary brand accent (violet).', '', '#7c3aed', '#a78bfa'],
+        'color-danger' => ['Destructive/error color.', 'color-text-inverse', '#dc2626', '#ef4444'],
+        'color-danger-hover' => ['Danger color on hover/active.', 'color-text-inverse', '#b91c1c', '#f87171'],
+        'color-ok' => ['Success/positive state color.', '', '#16a34a', '#22c55e'],
+        'color-warn' => ['Warning state color.', '', '#d97706', '#f59e0b'],
+        'color-info' => ['Informational state color.', '', '#0ea5e9', '#38bdf8'],
+        'shadow-sm' => ['Small elevation shadow (subtle lift).', '', '0 1px 2px rgba(0, 0, 0, 0.06)', '0 1px 2px rgba(0, 0, 0, 0.4)'],
+        'shadow-md' => ['Medium elevation shadow (cards, dropdowns).', '', '0 4px 12px rgba(0, 0, 0, 0.10)', '0 4px 12px rgba(0, 0, 0, 0.5)'],
+        'shadow-lg' => ['Large elevation shadow (modals, popovers).', '', '0 12px 32px rgba(0, 0, 0, 0.16)', '0 12px 32px rgba(0, 0, 0, 0.6)'],
+        'color-scheme' => ["CSS color-scheme keyword for the mode: 'light' in light, 'dark' in dark.", '', 'light', 'dark'],
+    ];
+
+    /** What each structural flag controls. Keys MUST equal contract().flags keys. */
+    private const FLAG_DOCS = [
+        'feedLayout' => 'How the post feed is arranged (grid / list / magazine).',
+        'feedColumns' => 'Column count of the feed grid; auto = responsive.',
+        'cardStyle' => 'Visual treatment of cards (flat / bordered / shadowed / framed).',
+        'media' => 'Image/thumbnail rendering treatment (plain / duotone / grayscale / framed).',
+        'hero' => 'Top hero/banner layout (standard / fullbleed / minimal).',
+        'sectionRule' => 'Divider style between sections (none / hairline / heavy).',
+        'eyebrow' => 'Style of the small kicker label above titles (plain / caps / barred).',
+        'headerSearch' => 'Show or hide the header search control.',
+        'headerTheme' => 'Show or hide the header light/dark toggle.',
+        'headerTagline' => 'Show or hide the site tagline in the header.',
+        'headerLayout' => 'Header skeleton preset (nav-right / classic / centered / minimal).',
+        'headerNavAlign' => 'Alignment of the nav within the header (start / center / end).',
+        'headerDensity' => 'Vertical density/height of the header (compact / regular / tall).',
+        'headerWidth' => 'Header content width (boxed / full-bleed).',
+        'headerSticky' => 'Whether the header sticks to the top on scroll (sticky / none).',
+    ];
+
     /**
      * @return array<string, mixed>
      */
@@ -26,15 +83,21 @@ final class ThemeAuthoringGuide
 
         return [
             'summary' => 'How to author and register a runtime (data-driven) public-site theme over MCP. '
-                . 'A theme is a manifest: id/name/version + per-mode CSS tokens (light & dark) + optional structural flags. '
-                . 'Token values are emitted verbatim into a scoped <style> on the public site, so they are sanitised: '
-                . 'only safe CSS passes. Build the manifest, then call createTheme (or updateTheme to replace one).',
+                . 'A theme is a manifest: id/name/version + per-mode CSS tokens (light & dark) + optional structural flags, '
+                . 'fonts and assets. Token values are emitted verbatim into a scoped <style> on the public site, so they are '
+                . 'sanitised: only safe CSS passes. Read tokenDocs for what each token means and which must contrast, copy '
+                . 'exampleManifest as a starting palette, then call createTheme (or updateTheme to replace one).',
             'authentication' => 'All theme tools require an authenticated admin token; the MCP bridge already attaches it. '
                 . 'Data is organization-scoped (JWT org_id).',
             'contract' => $contract,
+            'tokenDocs' => self::tokenDocs(),
+            'flagDocs' => self::FLAG_DOCS,
             'recipes' => self::recipes(),
-            'exampleManifest' => self::exampleManifest($contract['requiredTokens']),
+            'exampleManifest' => self::exampleManifest(),
+            'optionalFields' => self::optionalFields(),
             'commonMistakes' => [
+                'Inverting modes: light mode must use light surfaces + dark text; dark mode the opposite.',
+                'Low contrast: color-text-primary must read on color-surface, and color-on-accent on color-accent (see tokenDocs pairsWith).',
                 'Omitting a required token in light OR dark — both modes must carry the full set.',
                 'Using url(), @import, or a semicolon/braces in a token value — rejected as unsafe CSS (422).',
                 'Reusing a built-in theme id (see contract.reservedIds) — rejected as reserved (422).',
@@ -52,6 +115,19 @@ final class ThemeAuthoringGuide
     }
 
     /**
+     * @return array<string, array{purpose: string, pairsWith: string}>
+     */
+    private static function tokenDocs(): array
+    {
+        $docs = [];
+        foreach (self::TOKEN_SPECS as $token => [$purpose, $pairsWith]) {
+            $docs[$token] = ['purpose' => $purpose, 'pairsWith' => $pairsWith];
+        }
+
+        return $docs;
+    }
+
+    /**
      * @return list<array<string, mixed>>
      */
     private static function recipes(): array
@@ -61,8 +137,9 @@ final class ThemeAuthoringGuide
                 'title' => 'Create a new theme',
                 'steps' => [
                     'Pick an id matching the id pattern that is not in contract.reservedIds.',
-                    'Fill tokens.light and tokens.dark with every token in contract.requiredTokens (safe CSS values).',
-                    'Optionally set structural flags from contract.flags.',
+                    'Start from exampleManifest; restyle each token using tokenDocs for meaning and contrast pairs.',
+                    'Keep every token in contract.requiredTokens present in BOTH light and dark.',
+                    'Optionally set structural flags from contract.flags (see flagDocs).',
                     'Call createTheme with the manifest. A 422 lists exactly which fields failed.',
                 ],
             ],
@@ -85,48 +162,61 @@ final class ThemeAuthoringGuide
     }
 
     /**
-     * A minimal manifest that passes {@see ThemeManifestValidator::validate()}.
-     * Token values are illustrative placeholders — replace them with the real
-     * palette. Generated from the required-token list so it always stays complete.
-     *
-     * @param list<string> $requiredTokens
+     * A realistic manifest that passes {@see ThemeManifestValidator::validate()}:
+     * light = light surfaces + dark text, dark = the inverse, accent paired with
+     * a contrasting on-accent. Generated from TOKEN_SPECS so it always covers the
+     * full required-token set.
      *
      * @return array<string, mixed>
      */
-    private static function exampleManifest(array $requiredTokens): array
+    private static function exampleManifest(): array
     {
+        $light = [];
+        $dark = [];
+        foreach (self::TOKEN_SPECS as $token => [, , $lightValue, $darkValue]) {
+            $light[$token] = $lightValue;
+            $dark[$token] = $darkValue;
+        }
+
         return [
             'id' => 'example-theme',
             'name' => 'Example Theme',
             'version' => '1.0.0',
             'supportsModes' => ['light', 'dark'],
-            'tokens' => [
-                'light' => self::sampleTokens($requiredTokens, 'light'),
-                'dark' => self::sampleTokens($requiredTokens, 'dark'),
-            ],
+            'tokens' => ['light' => $light, 'dark' => $dark],
             'flags' => [
                 'feedLayout' => 'grid',
                 'cardStyle' => 'bordered',
+                'headerLayout' => 'nav-right',
             ],
         ];
     }
 
     /**
-     * @param list<string> $requiredTokens
+     * Shapes for the optional fonts/assets blocks (omitted from exampleManifest
+     * to keep it minimal). Runtime themes may only use bundled fonts.
      *
-     * @return array<string, string>
+     * @return array<string, mixed>
      */
-    private static function sampleTokens(array $requiredTokens, string $mode): array
+    private static function optionalFields(): array
     {
-        $tokens = [];
-        foreach ($requiredTokens as $key) {
-            $tokens[$key] = match (true) {
-                $key === 'color-scheme' => $mode,
-                str_starts_with($key, 'shadow-') => '0 1px 2px rgba(0, 0, 0, 0.08)',
-                default => $mode === 'light' ? '#1a1a1a' : '#f5f5f5',
-            };
-        }
-
-        return $tokens;
+        return [
+            'fonts' => [
+                'shape' => '{ family, role, source, weights? }',
+                'roles' => ['display', 'body', 'chrome', 'mono'],
+                'sources' => ['fontsource', 'system'],
+                'note' => "Runtime themes may only use 'fontsource' or 'system' (self-hosted files need a deploy). family is a font name, weights is an optional list of 100–900.",
+                'example' => [
+                    ['family' => 'Inter', 'role' => 'body', 'source' => 'fontsource', 'weights' => [400, 600, 700]],
+                    ['family' => 'Space Grotesk', 'role' => 'display', 'source' => 'fontsource'],
+                ],
+            ],
+            'assets' => [
+                'slots' => ['preview', 'hero', 'background'],
+                'value' => 'A media id (positive integer) or a safe bundle-relative path. Never an external URL or data: URI. A per-mode object {light, dark} is allowed.',
+                'note' => 'assets.preview drives the theme picker thumbnail.',
+                'example' => ['preview' => 123],
+            ],
+        ];
     }
 }

--- a/tests/Theme/ThemeAuthoringGuideTest.php
+++ b/tests/Theme/ThemeAuthoringGuideTest.php
@@ -29,6 +29,41 @@ final class ThemeAuthoringGuideTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    public function testExampleManifestIsRealisticNotPlaceholder(): void
+    {
+        $tokens = ThemeAuthoringGuide::build()['exampleManifest']['tokens'];
+
+        // Light mode must read (text != surface), and modes must differ — guards
+        // against the misleading "all one colour / inverted modes" example (#442).
+        self::assertNotSame($tokens['light']['color-surface'], $tokens['light']['color-text-primary']);
+        self::assertNotSame($tokens['light']['color-surface'], $tokens['dark']['color-surface']);
+        self::assertNotSame($tokens['light']['color-accent'], $tokens['light']['color-on-accent']);
+    }
+
+    public function testTokenAndFlagDocsCoverTheWholeContractNoDrift(): void
+    {
+        $guide = ThemeAuthoringGuide::build();
+        $contract = ThemeManifestValidator::contract();
+
+        // If a token/flag is added to the validator, these force a doc update.
+        self::assertEqualsCanonicalizing(
+            $contract['requiredTokens'],
+            array_keys($guide['tokenDocs']),
+        );
+        self::assertEqualsCanonicalizing(
+            array_keys($contract['flags']),
+            array_keys($guide['flagDocs']),
+        );
+    }
+
+    public function testOptionalFieldsDocumentFontsAndAssets(): void
+    {
+        $optional = ThemeAuthoringGuide::build()['optionalFields'];
+
+        self::assertSame(['fontsource', 'system'], $optional['fonts']['sources']);
+        self::assertArrayHasKey('preview', $optional['assets']['example']);
+    }
+
     public function testGuideListsTheThemeToolsAndIsActionable(): void
     {
         $guide = ThemeAuthoringGuide::build();


### PR DESCRIPTION
## 目的

#440 で `getThemeAuthoringGuide` は「422 を踏まない妥当な manifest」を作れるようにしたが、「良い／意図通りのテーマ」を ClaudeDesign が自走で作るには意味レベルの知識が不足していた。それを補う。

## 変更点

- **tokenDocs**：必須トークンごとに用途＋対比ペア（`pairsWith`）。`color-on-accent↔color-accent` など「必ず対比させる組」を機械可読に。
- **flagDocs**：各 flag が何を制御するかの辞書。
- **exampleManifest を現実的な配色に差し替え**：light=明るい面+暗い文字 / dark=その逆、accent と on-accent を対比。旧サンプルの「全トークン同色・モード反転」を解消。
- **optionalFields**：`fonts`（`{family, role, source, weights?}`、runtime は source=fontsource/system のみ）と `assets`（preview=media id 等）の形＋例。
- OpenAPI `ThemeAuthoringGuideResponse` を追従。

## drift 防止（テスト）

- `tokenDocs`/`flagDocs` のキー集合が `ThemeManifestValidator::contract()` と一致（トークン追加時にドキュメント更新を強制）。
- サンプルが `validate()` を通る（ドッグフード継続）。
- light が可読（text≠surface）かつモードが反転していないことを保証。

## 検証

- `composer check`（PHPUnit / PHPStan L8 / CS / OpenAPI / MCP）グリーン。
- `npm run check`（tsc / lint / 224 tests / Storybook）グリーン。
- 実機で `tokenDocs`/`flagDocs`/`optionalFields`/現実的サンプルの返却を確認。

関連: #440 #441 #434

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)