### PR TITLE
feat(theme): MCP に描画モデル(renderModel)と listMedia を追加する (#444)

### DIFF
--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -1137,6 +1137,24 @@
             "responseSchemaRef": "#/components/schemas/SettingRevisionListResponse"
         },
         {
+            "name": "listMedia",
+            "title": "List Media",
+            "description": "List uploaded media items (newest first). Use this to find the media id for a theme manifest assets.preview / hero / background slot.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "listMedia",
+                "method": "GET",
+                "path": "/api/v1/media"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": [],
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/MediaListResponse"
+        },
+        {
             "name": "getThemeAuthoringGuide",
             "title": "Theme Authoring Guide",
             "description": "Read this FIRST before creating or updating a runtime theme. Returns the manifest contract (required tokens, flag enums, token value rules, reserved ids), recipes, common mistakes and a minimal valid example manifest. Derived from the server validator so it matches exactly what createTheme/updateTheme enforce.",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -6056,6 +6056,7 @@ components:
         - summary
         - authentication
         - contract
+        - renderModel
         - tokenDocs
         - flagDocs
         - recipes
@@ -6073,6 +6074,14 @@ components:
           description: >-
             What a manifest must satisfy: required tokens, flag enums, token
             value rules, reserved ids and id/version patterns.
+          additionalProperties: true
+        renderModel:
+          type: object
+          description: >-
+            How a runtime theme actually renders: base engine + tokens (CSS
+            vars) + flags (data-* attributes). Includes the optional engine
+            tokens beyond the colour contract, flag→attribute map and the
+            WCAG AA contrast target.
           additionalProperties: true
         tokenDocs:
           type: object

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -2415,6 +2415,10 @@ export interface components {
             contract: {
                 [key: string]: unknown;
             };
+            /** @description How a runtime theme actually renders: base engine + tokens (CSS vars) + flags (data-* attributes). Includes the optional engine tokens beyond the colour contract, flag→attribute map and the WCAG AA contrast target. */
+            renderModel: {
+                [key: string]: unknown;
+            };
             /** @description Per required-token semantics: { purpose, pairsWith }. pairsWith names the token this one must contrast against (or empty). */
             tokenDocs: {
                 [key: string]: {

--- a/mcp-bridge/server.mjs
+++ b/mcp-bridge/server.mjs
@@ -61,8 +61,11 @@ function normaliseSchema(schema) {
   return s
 }
 
+// In 'themes' scope, expose theme tools plus the read-only media tools an agent
+// needs to resolve assets.preview media ids (never media write/delete).
+const THEMES_SCOPE_EXTRA = new Set(['listMedia', 'getMediaById'])
 const tools = catalogue.tools
-  .filter((t) => (SCOPE === 'all' ? true : /theme/i.test(t.name)))
+  .filter((t) => (SCOPE === 'all' ? true : /theme/i.test(t.name) || THEMES_SCOPE_EXTRA.has(t.name)))
   .filter((t) => (READONLY ? t.safety === 'read' : true))
   .map((t) => ({
     name: t.name,

--- a/src/Theme/ThemeAuthoringGuide.php
+++ b/src/Theme/ThemeAuthoringGuide.php
@@ -75,6 +75,87 @@ final class ThemeAuthoringGuide
     ];
 
     /**
+     * flag key → the data-* attribute the base engine reads it as.
+     * Keys MUST equal contract().flags; values MUST mirror the frontend
+     * theme-customization.ts FLAG_DEFS (a test asserts both).
+     */
+    private const FLAG_ATTRS = [
+        'feedLayout' => 'data-feed',
+        'feedColumns' => 'data-feed-cols',
+        'cardStyle' => 'data-cards',
+        'media' => 'data-media',
+        'hero' => 'data-hero',
+        'sectionRule' => 'data-rule',
+        'eyebrow' => 'data-eyebrow',
+        'headerSearch' => 'data-header-search',
+        'headerTheme' => 'data-header-theme',
+        'headerTagline' => 'data-header-tagline',
+        'headerLayout' => 'data-header',
+        'headerNavAlign' => 'data-header-nav',
+        'headerDensity' => 'data-header-density',
+        'headerWidth' => 'data-header-width',
+        'headerSticky' => 'data-header-sticky',
+    ];
+
+    /**
+     * Optional engine tokens beyond the required colour contract. A runtime
+     * theme MAY override any of these (the engine reads them as var(--token));
+     * omit them to inherit the engine defaults. [group, drives]. The set MUST
+     * cover every non-contract var the base engine (public-site.css) reads — a
+     * test enforces that, so the menu never drifts from the engine.
+     *
+     * @var array<string, array{string, string}>
+     */
+    private const OPTIONAL_TOKENS = [
+        // Layout
+        'content-w' => ['layout', 'Max width of the page container.'],
+        'gutter' => ['layout', 'Horizontal page gutter.'],
+        'measure' => ['layout', 'Prose line length (readable measure).'],
+        // Type families
+        'font-display' => ['fontFamily', 'Font stack for display/headings.'],
+        'font-sans' => ['fontFamily', 'Font stack for body text.'],
+        'font-mono' => ['fontFamily', 'Font stack for monospace.'],
+        // Type sizes
+        'text-display' => ['fontSize', 'Hero/display size.'],
+        'text-h1' => ['fontSize', 'H1 size.'],
+        'text-h2' => ['fontSize', 'H2 size.'],
+        'text-h3' => ['fontSize', 'H3 size.'],
+        'text-body' => ['fontSize', 'Body text size.'],
+        'text-body-sm' => ['fontSize', 'Small body text size.'],
+        'text-meta' => ['fontSize', 'Meta/caption size.'],
+        'text-overline' => ['fontSize', 'Overline/eyebrow size.'],
+        // Line height / tracking / weight
+        'leading-tight' => ['typography', 'Line-height for tight blocks.'],
+        'leading-heading' => ['typography', 'Line-height for headings.'],
+        'leading-body' => ['typography', 'Line-height for body.'],
+        'tracking-display' => ['typography', 'Letter-spacing for display text.'],
+        'tracking-overline' => ['typography', 'Letter-spacing for overlines.'],
+        'weight-medium' => ['typography', 'Medium font weight.'],
+        'weight-semibold' => ['typography', 'Semibold font weight.'],
+        'weight-bold' => ['typography', 'Bold font weight.'],
+        // Spacing scale
+        'space-2xs' => ['spacing', 'Spacing step 2xs.'],
+        'space-xs' => ['spacing', 'Spacing step xs.'],
+        'space-sm' => ['spacing', 'Spacing step sm.'],
+        'space-md' => ['spacing', 'Spacing step md.'],
+        'space-lg' => ['spacing', 'Spacing step lg.'],
+        'space-xl' => ['spacing', 'Spacing step xl.'],
+        'space-2xl' => ['spacing', 'Spacing step 2xl.'],
+        'space-section' => ['spacing', 'Vertical rhythm between sections.'],
+        // Radii
+        'radius-sm' => ['radius', 'Small corner radius.'],
+        'radius-md' => ['radius', 'Medium corner radius.'],
+        'radius-lg' => ['radius', 'Large corner radius.'],
+        'radius-full' => ['radius', 'Pill/circular radius.'],
+        // Motion
+        'dur-fast' => ['motion', 'Fast transition duration.'],
+        'dur-normal' => ['motion', 'Normal transition duration.'],
+        'ease' => ['motion', 'Default easing function.'],
+        // Elevation (shadow-sm/md/lg are in the required contract)
+        'shadow-focus' => ['elevation', 'Focus-ring shadow.'],
+    ];
+
+    /**
      * @return array<string, mixed>
      */
     public static function build(): array
@@ -90,6 +171,7 @@ final class ThemeAuthoringGuide
             'authentication' => 'All theme tools require an authenticated admin token; the MCP bridge already attaches it. '
                 . 'Data is organization-scoped (JWT org_id).',
             'contract' => $contract,
+            'renderModel' => self::renderModel($contract['requiredTokens']),
             'tokenDocs' => self::tokenDocs(),
             'flagDocs' => self::FLAG_DOCS,
             'recipes' => self::recipes(),
@@ -125,6 +207,40 @@ final class ThemeAuthoringGuide
         }
 
         return $docs;
+    }
+
+    /**
+     * How a registered runtime theme actually renders, so ClaudeDesign reasons
+     * about it without the repo (#444). A runtime theme is NOT a bespoke
+     * stylesheet: it restyles a fixed base engine via CSS variables + structural
+     * data-attributes. Built-in themes' per-theme structural CSS is unavailable.
+     *
+     * @param list<string> $requiredTokens
+     *
+     * @return array<string, mixed>
+     */
+    private static function renderModel(array $requiredTokens): array
+    {
+        $optional = [];
+        foreach (self::OPTIONAL_TOKENS as $token => [$group, $drives]) {
+            $optional[$token] = ['group' => $group, 'drives' => $drives];
+        }
+
+        return [
+            'premise' => 'A runtime theme renders as: the fixed base engine stylesheet (public-site.css) '
+                . '+ your tokens (emitted as CSS custom properties) + your structural flags (emitted as '
+                . 'data-* attributes the engine reads). There is NO per-theme structural CSS: built-in themes '
+                . 'ship a *.components.css, but runtime themes cannot — you style by setting tokens and flags only.',
+            'cssVarRule' => "Each token `foo` is emitted as `--foo` on `.nene-public[data-theme='<id>']` "
+                . '(and `<id>-dark` for the dark set); the engine consumes it via var(--foo).',
+            'tokenScope' => 'requiredTokens must be set in both light and dark. You MAY also override any '
+                . 'optionalTokens below (the engine reads them too); omit them to keep the engine defaults.',
+            'requiredTokens' => $requiredTokens,
+            'optionalTokens' => $optional,
+            'flagAttributes' => self::FLAG_ATTRS,
+            'contrastTarget' => 'WCAG AA: 4.5:1 for body text, 3:1 for large text and UI/borders. '
+                . 'Use previewTheme to compute actual ratios before committing.',
+        ];
     }
 
     /**

--- a/tests/Theme/ThemeAuthoringGuideTest.php
+++ b/tests/Theme/ThemeAuthoringGuideTest.php
@@ -74,4 +74,51 @@ final class ThemeAuthoringGuideTest extends TestCase
         self::assertNotEmpty($guide['commonMistakes']);
         self::assertNotSame('', $guide['summary']);
     }
+
+    public function testRenderModelDescribesTheEngineContract(): void
+    {
+        $rm = ThemeAuthoringGuide::build()['renderModel'];
+
+        self::assertNotSame('', $rm['premise']);
+        self::assertStringContainsString('public-site.css', $rm['premise']);
+        self::assertStringContainsString('AA', $rm['contrastTarget']);
+        self::assertSame(ThemeManifestValidator::contract()['requiredTokens'], $rm['requiredTokens']);
+    }
+
+    public function testFlagAttributesMatchTheFrontendDefs(): void
+    {
+        $attrs = ThemeAuthoringGuide::build()['renderModel']['flagAttributes'];
+        $contract = ThemeManifestValidator::contract();
+
+        // Same flags as the contract, and each attribute string must appear in
+        // the frontend FLAG_DEFS source — so a rename there fails this test.
+        self::assertEqualsCanonicalizing(array_keys($contract['flags']), array_keys($attrs));
+        $frontend = self::readFrontend('src/shared/lib/theme-customization.ts');
+        foreach ($attrs as $flag => $attr) {
+            self::assertStringContainsString("attr: '{$attr}'", $frontend, "flag {$flag}");
+        }
+    }
+
+    public function testOptionalTokensCoverEveryEngineVarNoDrift(): void
+    {
+        $rm = ThemeAuthoringGuide::build()['renderModel'];
+        $documented = array_merge($rm['requiredTokens'], array_keys($rm['optionalTokens']));
+
+        // Every var(--x) the base engine reads must be a token an author can set.
+        $css = self::readFrontend('src/pages/consumer/public-site.css');
+        preg_match_all('/var\(--([a-z0-9-]+)\)/', $css, $matches);
+        $engineVars = array_values(array_unique($matches[1]));
+        self::assertNotEmpty($engineVars);
+
+        $missing = array_diff($engineVars, $documented);
+        self::assertSame([], array_values($missing), 'undocumented engine vars: ' . implode(', ', $missing));
+    }
+
+    private static function readFrontend(string $relative): string
+    {
+        $path = dirname(__DIR__, 2) . '/frontend/' . $relative;
+        self::assertFileExists($path);
+
+        return (string) file_get_contents($path);
+    }
 }

--- a/tools/generate-mcp-tools.php
+++ b/tools/generate-mcp-tools.php
@@ -738,6 +738,16 @@ $tools = [
         ['key'],
     ),
     readTool(
+        'listMedia',
+        'List Media',
+        'List uploaded media items (newest first). Use this to find the media id for a theme manifest assets.preview / hero / background slot.',
+        'listMedia',
+        'GET',
+        '/api/v1/media',
+        [],
+        '#/components/schemas/MediaListResponse',
+    ),
+    readTool(
         'getThemeAuthoringGuide',
         'Theme Authoring Guide',
         'Read this FIRST before creating or updating a runtime theme. Returns the manifest contract (required tokens, flag enums, token value rules, reserved ids), recipes, common mistakes and a minimal valid example manifest. Derived from the server validator so it matches exactly what createTheme/updateTheme enforce.',


### PR DESCRIPTION
## 目的

ClaudeDesign は MCP 経由で manifest と authoring-guide しか取れず、**ランタイムテーマが実際にどう描画されるか**が分からず推測で組んでいた。実ソース調査で確定した描画モデルを in-band で供給する。

## 確定した実態（実ソース由来）
- 描画：`runtime-themes.ts` がトークンを `--<token>` として `.nene-public[data-theme='id']` に注入 → `public-site.css`（base engine）が `var(--token)` で消費。`*.components.css` は組み込み専用でランタイム不可。
- engine が読む CSS 変数は 55個。`runtime-themes.ts`/バリデータは契約パターンに合う任意トークンを出力＝**色契約24だけでなく engine 全変数を上書き可**（方針: 全公開）。

## 変更
- `getThemeAuthoringGuide` に **renderModel**：premise / cssVarRule / requiredTokens / optionalTokens（38・group+drives）/ flagAttributes（15）/ contrastTarget（AA）。
- **listMedia** を MCP tool 化（assets.preview の media id 発見）。ブリッジ themes スコープに read media を許可（write は出さない）。
- OpenAPI `ThemeAuthoringGuideResponse` に renderModel。

## drift 防止（テスト）
- flagAttributes のキー==contract.flags、値が `theme-customization.ts` の `attr:` と一致。
- optionalTokens∪requiredTokens が `public-site.css` の全 `var(--…)` を被覆。
- 既存のドッグフード（example が validate を通る）継続。

## 検証
- `composer check`（PHPUnit/PHPStan L8/CS/OpenAPI/MCP）グリーン。
- `npm run check`（tsc/lint/224 tests/Storybook）グリーン。
- 実機：renderModel（38 optional・flag→attr・AA）と listMedia（bridge 8 tools）を確認。

関連: #440 #442 #434 #438

Closes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)