### PR TITLE
feat(theme): renderModel に availableFonts、createTheme/updateTheme に fonts/assets を追加 (#446)

### DIFF
--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -1236,6 +1236,19 @@
                     "flags": {
                         "type": "object",
                         "description": "Optional structural style flags (enumerated; e.g. feedLayout, headerLayout)."
+                    },
+                    "fonts": {
+                        "type": "array",
+                        "description": "Optional metadata list of {family, role, source} (source must be fontsource or system). Note: does NOT load fonts at runtime \u2014 the public site only renders families bundled in the authoring guide renderModel.fonts.available; set those via the font-* tokens.",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "assets": {
+                        "type": "object",
+                        "description": "Optional asset slots (preview/hero/background). Each value is a media id (positive integer, from listMedia) or a safe bundle-relative path. assets.preview drives the picker thumbnail.",
+                        "additionalProperties": true
                     }
                 },
                 "required": [
@@ -1295,6 +1308,19 @@
                     "flags": {
                         "type": "object",
                         "description": "Optional structural style flags (enumerated; e.g. feedLayout, headerLayout)."
+                    },
+                    "fonts": {
+                        "type": "array",
+                        "description": "Optional metadata list of {family, role, source} (source must be fontsource or system). Note: does NOT load fonts at runtime \u2014 the public site only renders families bundled in the authoring guide renderModel.fonts.available; set those via the font-* tokens.",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "assets": {
+                        "type": "object",
+                        "description": "Optional asset slots (preview/hero/background). Each value is a media id (positive integer, from listMedia) or a safe bundle-relative path. assets.preview drives the picker thumbnail.",
+                        "additionalProperties": true
                     }
                 },
                 "required": [
@@ -1386,6 +1412,19 @@
                     "flags": {
                         "type": "object",
                         "description": "Optional structural style flags (enumerated; e.g. feedLayout, headerLayout)."
+                    },
+                    "fonts": {
+                        "type": "array",
+                        "description": "Optional metadata list of {family, role, source} (source must be fontsource or system). Note: does NOT load fonts at runtime \u2014 the public site only renders families bundled in the authoring guide renderModel.fonts.available; set those via the font-* tokens.",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "assets": {
+                        "type": "object",
+                        "description": "Optional asset slots (preview/hero/background). Each value is a media id (positive integer, from listMedia) or a safe bundle-relative path. assets.preview drives the picker thumbnail.",
+                        "additionalProperties": true
                     }
                 },
                 "required": [

--- a/src/Theme/ThemeAuthoringGuide.php
+++ b/src/Theme/ThemeAuthoringGuide.php
@@ -156,6 +156,35 @@ final class ThemeAuthoringGuide
     ];
 
     /**
+     * Fonts actually bundled into the public site (frontend public-fonts.ts), so
+     * runtime themes can only use these via --font-* tokens — anything else
+     * silently falls back (#446). [family (as used in CSS), fontsource slug, kind].
+     * A test asserts each slug is imported in public-fonts.ts.
+     *
+     * @var list<array{family: string, slug: string, kind: string}>
+     */
+    private const AVAILABLE_FONTS = [
+        ['family' => 'Bricolage Grotesque', 'slug' => 'bricolage-grotesque', 'kind' => 'display'],
+        ['family' => 'Archivo', 'slug' => 'archivo', 'kind' => 'display'],
+        ['family' => 'Oswald', 'slug' => 'oswald', 'kind' => 'display'],
+        ['family' => 'Saira Condensed', 'slug' => 'saira-condensed', 'kind' => 'display'],
+        ['family' => 'Source Serif 4', 'slug' => 'source-serif-4', 'kind' => 'serif'],
+        ['family' => 'EB Garamond', 'slug' => 'eb-garamond', 'kind' => 'serif'],
+        ['family' => 'Playfair Display', 'slug' => 'playfair-display', 'kind' => 'serif'],
+        ['family' => 'Shippori Mincho', 'slug' => 'shippori-mincho', 'kind' => 'serif (JP)'],
+        ['family' => 'Nunito', 'slug' => 'nunito', 'kind' => 'sans (rounded)'],
+        ['family' => 'Nunito Sans', 'slug' => 'nunito-sans', 'kind' => 'sans'],
+        ['family' => 'Varela Round', 'slug' => 'varela-round', 'kind' => 'sans (rounded)'],
+        ['family' => 'Fredoka', 'slug' => 'fredoka', 'kind' => 'display (rounded)'],
+        ['family' => 'Space Mono', 'slug' => 'space-mono', 'kind' => 'mono'],
+        ['family' => 'Orbitron', 'slug' => 'orbitron', 'kind' => 'display (techno)'],
+        ['family' => 'Poiret One', 'slug' => 'poiret-one', 'kind' => 'display (thin)'],
+        ['family' => 'Bangers', 'slug' => 'bangers', 'kind' => 'display (comic)'],
+        ['family' => 'Rye', 'slug' => 'rye', 'kind' => 'display (western)'],
+        ['family' => 'UnifrakturCook', 'slug' => 'unifrakturcook', 'kind' => 'display (blackletter)'],
+    ];
+
+    /**
      * @return array<string, mixed>
      */
     public static function build(): array
@@ -240,6 +269,19 @@ final class ThemeAuthoringGuide
             'flagAttributes' => self::FLAG_ATTRS,
             'contrastTarget' => 'WCAG AA: 4.5:1 for body text, 3:1 for large text and UI/borders. '
                 . 'Use previewTheme to compute actual ratios before committing.',
+            'fonts' => [
+                'note' => 'The public site only renders fonts that are bundled (listed in availableFonts) '
+                    . 'or generic system fonts. Set --font-display / --font-sans / --font-mono tokens to a '
+                    . 'family from availableFonts (quote multi-word names) with a generic fallback, e.g. '
+                    . "--font-display: \"'Bricolage Grotesque', sans-serif\". A family NOT in availableFonts "
+                    . 'silently falls back. The manifest `fonts` array is metadata only — it does NOT load fonts.',
+                'available' => self::AVAILABLE_FONTS,
+                'systemStacks' => [
+                    'sans' => 'ui-sans-serif, system-ui, sans-serif',
+                    'serif' => 'ui-serif, Georgia, serif',
+                    'mono' => 'ui-monospace, monospace',
+                ],
+            ],
         ];
     }
 

--- a/tests/Theme/ThemeAuthoringGuideTest.php
+++ b/tests/Theme/ThemeAuthoringGuideTest.php
@@ -114,6 +114,23 @@ final class ThemeAuthoringGuideTest extends TestCase
         self::assertSame([], array_values($missing), 'undocumented engine vars: ' . implode(', ', $missing));
     }
 
+    public function testAvailableFontsAreActuallyBundledInThePublicSite(): void
+    {
+        $fonts = ThemeAuthoringGuide::build()['renderModel']['fonts']['available'];
+        self::assertNotEmpty($fonts);
+
+        // Every advertised font must be imported by the public site, or the
+        // theme would set a family that silently falls back (#446).
+        $publicFonts = self::readFrontend('src/pages/consumer/public-fonts.ts');
+        foreach ($fonts as $font) {
+            self::assertStringContainsString(
+                "@fontsource/{$font['slug']}/",
+                $publicFonts,
+                "font {$font['family']} ({$font['slug']}) is not bundled in public-fonts.ts",
+            );
+        }
+    }
+
     private static function readFrontend(string $relative): string
     {
         $path = dirname(__DIR__, 2) . '/frontend/' . $relative;

--- a/tools/generate-mcp-tools.php
+++ b/tools/generate-mcp-tools.php
@@ -144,6 +144,16 @@ $themeManifestProps = [
         'type' => 'object',
         'description' => 'Optional structural style flags (enumerated; e.g. feedLayout, headerLayout).',
     ],
+    'fonts' => [
+        'type' => 'array',
+        'description' => 'Optional metadata list of {family, role, source} (source must be fontsource or system). Note: does NOT load fonts at runtime — the public site only renders families bundled in the authoring guide renderModel.fonts.available; set those via the font-* tokens.',
+        'items' => ['type' => 'object', 'additionalProperties' => true],
+    ],
+    'assets' => [
+        'type' => 'object',
+        'description' => 'Optional asset slots (preview/hero/background). Each value is a media id (positive integer, from listMedia) or a safe bundle-relative path. assets.preview drives the picker thumbnail.',
+        'additionalProperties' => true,
+    ],
 ];
 $themeManifestRequired = ['id', 'name', 'version', 'supportsModes', 'tokens'];
 


### PR DESCRIPTION
## 目的

ClaudeDesign の Ember 検証で、ライブに意図書体が出ない真因を特定。ClaudeDesign の診断（fonts 配列が無いせい）は誤りで、実際は (1) ランタイムの fonts 配列は描画に使われない、(2) 公開サイトは public-fonts.ts のバンドル固定セットしか描画できない、が原因。Ember は未バンドルの Public Sans / JetBrains Mono を選んでフォールバックしていた（Bricolage はバンドル済み）。

## 変更
- `getThemeAuthoringGuide` renderModel に **fonts.available**（public-fonts.ts がバンドルする18 family＝runtime が実際に使える書体、family/slug/kind）＋使い方注記（`--font-*` トークンで指定、配列はメタデータで描画不使用、未収載 family はフォールバック）＋ system スタック。
- `createTheme`/`updateTheme` ツールに **fonts(array) / assets(object)** パラメータを追加 → `additionalProperties` 経由で配列が非配列化し 422（`fonts must be an array`）になる問題を解消、`assets.preview`（サムネ）も送れる。

## drift 防止
- availableFonts の各 slug が `public-fonts.ts` に `@fontsource/<slug>` として import されていることをテスト。

## 検証
- `composer check` / `npm run check` グリーン（guide tests 10）。
- 公開フォント実 family 名は @fontsource 各パッケージの font-family から取得。

関連: #444 #442 #434

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)