### PR TITLE
feat(theme): デプロイ済み engine CSS を返す getThemeEngineCss を追加 (#448)

### DIFF
--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -1155,6 +1155,24 @@
             "responseSchemaRef": "#/components/schemas/MediaListResponse"
         },
         {
+            "name": "getThemeEngineCss",
+            "title": "Theme Engine CSS",
+            "description": "Returns the deployed public-site base engine CSS. Use it to copy exact flag implementations (e.g. the rules under [data-cards='framed'] / [data-media='duotone']) \u2014 radius, border, padding \u2014 instead of guessing. Runtime themes restyle this engine via tokens and flags.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "getThemeEngineCss",
+                "method": "GET",
+                "path": "/api/v1/themes/engine-css"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": [],
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/ThemeEngineCssResponse"
+        },
+        {
             "name": "getThemeAuthoringGuide",
             "title": "Theme Authoring Guide",
             "description": "Read this FIRST before creating or updating a runtime theme. Returns the manifest contract (required tokens, flag enums, token value rules, reserved ids), recipes, common mistakes and a minimal valid example manifest. Derived from the server validator so it matches exactly what createTheme/updateTheme enforce.",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2975,6 +2975,28 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/themes/engine-css:
+    get:
+      tags:
+        - Themes
+      summary: Public-site base engine CSS
+      description: >-
+        Returns the deployed public-site base engine CSS so an AI agent can copy
+        exact flag implementations (e.g. [data-cards='framed']) instead of
+        guessing radius/border/padding. Runtime themes restyle this engine via
+        tokens and flags; per-theme components.css is not included. See #448.
+      operationId: getThemeEngineCss
+      responses:
+        '200':
+          description: Engine CSS.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThemeEngineCssResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /api/v1/themes/{key}:
     get:
       tags:
@@ -6115,6 +6137,27 @@ components:
           type: object
           additionalProperties:
             type: string
+      additionalProperties: false
+    ThemeEngineCssResponse:
+      type: object
+      description: Deployed public-site base engine CSS (#448).
+      required:
+        - source
+        - bytes
+        - css
+        - note
+      properties:
+        source:
+          type: string
+          description: Repo-relative path of the engine CSS.
+        bytes:
+          type: integer
+          description: Length of the returned CSS in bytes.
+        css:
+          type: string
+          description: The full base engine stylesheet (includes flag implementations).
+        note:
+          type: string
       additionalProperties: false
 
 

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -1220,6 +1220,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/themes/engine-css": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Public-site base engine CSS
+         * @description Returns the deployed public-site base engine CSS so an AI agent can copy exact flag implementations (e.g. [data-cards='framed']) instead of guessing radius/border/padding. Runtime themes restyle this engine via tokens and flags; per-theme components.css is not included. See #448.
+         */
+        get: operations["getThemeEngineCss"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/themes/{key}": {
         parameters: {
             query?: never;
@@ -2441,6 +2461,16 @@ export interface components {
             relatedTools: {
                 [key: string]: string;
             };
+        };
+        /** @description Deployed public-site base engine CSS (#448). */
+        ThemeEngineCssResponse: {
+            /** @description Repo-relative path of the engine CSS. */
+            source: string;
+            /** @description Length of the returned CSS in bytes. */
+            bytes: number;
+            /** @description The full base engine stylesheet (includes flag implementations). */
+            css: string;
+            note: string;
         };
         WebhookResponse: {
             /** Format: int64 */
@@ -5636,6 +5666,28 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ThemeAuthoringGuideResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    getThemeEngineCss: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Engine CSS. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ThemeEngineCssResponse"];
                 };
             };
             401: components["responses"]["Unauthorized"];

--- a/src/Theme/ThemeAuthoringGuide.php
+++ b/src/Theme/ThemeAuthoringGuide.php
@@ -262,6 +262,9 @@ final class ThemeAuthoringGuide
                 . 'ship a *.components.css, but runtime themes cannot — you style by setting tokens and flags only.',
             'cssVarRule' => "Each token `foo` is emitted as `--foo` on `.nene-public[data-theme='<id>']` "
                 . '(and `<id>-dark` for the dark set); the engine consumes it via var(--foo).',
+            'engineCssTool' => 'Call getThemeEngineCss for the deployed base engine CSS, including the exact '
+                . "flag implementations (e.g. [data-cards='framed'] .card radius/border/padding) — copy those "
+                . 'values rather than guessing.',
             'tokenScope' => 'requiredTokens must be set in both light and dark. You MAY also override any '
                 . 'optionalTokens below (the engine reads them too); omit them to keep the engine defaults.',
             'requiredTokens' => $requiredTokens,

--- a/src/Theme/ThemeEngineCssHandler.php
+++ b/src/Theme/ThemeEngineCssHandler.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Returns the deployed public-site base engine CSS so ClaudeDesign can read the
+ * exact flag implementations (`[data-cards='framed']` etc.) over MCP instead of
+ * guessing border/radius/padding values (#448).
+ *
+ * Runtime themes restyle this fixed engine via tokens + flags; the per-built-in
+ * `*.components.css` is intentionally NOT included (runtime themes never get it).
+ */
+final readonly class ThemeEngineCssHandler
+{
+    private const DEFAULT_RELATIVE = 'frontend/src/pages/consumer/public-site.css';
+
+    public function __construct(
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $path = $this->resolvePath();
+        $css = is_file($path) ? (string) file_get_contents($path) : '';
+
+        $note = 'Deployed public-site base engine CSS. Runtime themes restyle this via tokens '
+            . '(var(--token)) and flags (data-* attributes); copy flag rules like '
+            . "[data-cards='framed'] .card for exact radius/border/padding. Per-theme "
+            . '*.components.css is NOT included — runtime themes cannot use it.';
+
+        if ($css === '') {
+            $note = 'Engine CSS not found on this deployment. Set NENE_ENGINE_CSS_PATH to the '
+                . 'public-site.css location. ' . $note;
+        }
+
+        return $this->response->create([
+            'source' => self::DEFAULT_RELATIVE,
+            'bytes' => strlen($css),
+            'css' => $css,
+            'note' => $note,
+        ]);
+    }
+
+    private function resolvePath(): string
+    {
+        $override = getenv('NENE_ENGINE_CSS_PATH');
+        if (is_string($override) && $override !== '') {
+            return $override;
+        }
+
+        return dirname(__DIR__, 2) . '/' . self::DEFAULT_RELATIVE;
+    }
+}

--- a/src/Theme/ThemeRouteRegistrar.php
+++ b/src/Theme/ThemeRouteRegistrar.php
@@ -18,6 +18,7 @@ final readonly class ThemeRouteRegistrar
         private ListPublicThemesHandler $listPublicHandler,
         private PreviewThemeHandler $previewHandler,
         private ThemeAuthoringGuideHandler $authoringGuideHandler,
+        private ThemeEngineCssHandler $engineCssHandler,
     ) {
     }
 
@@ -31,12 +32,18 @@ final readonly class ThemeRouteRegistrar
         $listPublic = $this->listPublicHandler;
         $preview = $this->previewHandler;
         $authoringGuide = $this->authoringGuideHandler;
+        $engineCss = $this->engineCssHandler;
 
         // In-band authoring guide for MCP agents (#440). The router prioritises
-        // this static path over /themes/{key} (fewer path params win).
+        // these static paths over /themes/{key} (fewer path params win).
         $router->get(
             '/api/v1/themes/authoring-guide',
             static fn (ServerRequestInterface $request) => $authoringGuide->handle($request),
+        );
+        // Deployed base engine CSS (flag implementations) for exact authoring (#448).
+        $router->get(
+            '/api/v1/themes/engine-css',
+            static fn (ServerRequestInterface $request) => $engineCss->handle($request),
         );
         $router->get(
             '/api/v1/themes',

--- a/src/Theme/ThemeServiceProvider.php
+++ b/src/Theme/ThemeServiceProvider.php
@@ -236,6 +236,17 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                ThemeEngineCssHandler::class,
+                static function (ContainerInterface $container): ThemeEngineCssHandler {
+                    $response = $container->get(JsonResponseFactory::class);
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ThemeEngineCssHandler($response);
+                },
+            )
+            ->set(
                 ThemeNotFoundExceptionHandler::class,
                 static function (ContainerInterface $container): ThemeNotFoundExceptionHandler {
                     $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
@@ -257,6 +268,7 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                     $listPublic = $container->get(ListPublicThemesHandler::class);
                     $preview = $container->get(PreviewThemeHandler::class);
                     $authoringGuide = $container->get(ThemeAuthoringGuideHandler::class);
+                    $engineCss = $container->get(ThemeEngineCssHandler::class);
 
                     if (!$list instanceof ListThemesHandler) {
                         throw new LogicException('ListThemes handler service is invalid.');
@@ -282,8 +294,11 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                     if (!$authoringGuide instanceof ThemeAuthoringGuideHandler) {
                         throw new LogicException('ThemeAuthoringGuide handler service is invalid.');
                     }
+                    if (!$engineCss instanceof ThemeEngineCssHandler) {
+                        throw new LogicException('ThemeEngineCss handler service is invalid.');
+                    }
 
-                    return new ThemeRouteRegistrar($list, $get, $create, $update, $delete, $listPublic, $preview, $authoringGuide);
+                    return new ThemeRouteRegistrar($list, $get, $create, $update, $delete, $listPublic, $preview, $authoringGuide, $engineCss);
                 },
             );
     }

--- a/tests/Theme/ThemeEngineCssHandlerTest.php
+++ b/tests/Theme/ThemeEngineCssHandlerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Theme;
+
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Theme\ThemeEngineCssHandler;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class ThemeEngineCssHandlerTest extends TestCase
+{
+    public function testReturnsTheEngineCssIncludingFlagImplementations(): void
+    {
+        $factory = new Psr17Factory();
+        $handler = new ThemeEngineCssHandler(new JsonResponseFactory($factory, $factory));
+        $response = $handler->handle($this->createStub(ServerRequestInterface::class));
+
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertGreaterThan(0, $payload['bytes']);
+        // The whole point is the deployed flag CSS — assert a known flag rule is present.
+        self::assertStringContainsString("[data-cards='framed']", $payload['css']);
+        self::assertStringContainsString("[data-media='duotone']", $payload['css']);
+        self::assertSame($payload['bytes'], strlen($payload['css']));
+    }
+}

--- a/tools/generate-mcp-tools.php
+++ b/tools/generate-mcp-tools.php
@@ -758,6 +758,16 @@ $tools = [
         '#/components/schemas/MediaListResponse',
     ),
     readTool(
+        'getThemeEngineCss',
+        'Theme Engine CSS',
+        'Returns the deployed public-site base engine CSS. Use it to copy exact flag implementations (e.g. the rules under [data-cards=\'framed\'] / [data-media=\'duotone\']) — radius, border, padding — instead of guessing. Runtime themes restyle this engine via tokens and flags.',
+        'getThemeEngineCss',
+        'GET',
+        '/api/v1/themes/engine-css',
+        [],
+        '#/components/schemas/ThemeEngineCssResponse',
+    ),
+    readTool(
         'getThemeAuthoringGuide',
         'Theme Authoring Guide',
         'Read this FIRST before creating or updating a runtime theme. Returns the manifest contract (required tokens, flag enums, token value rules, reserved ids), recipes, common mistakes and a minimal valid example manifest. Derived from the server validator so it matches exactly what createTheme/updateTheme enforce.',


### PR DESCRIPTION
## 目的
ClaudeDesign が framed カード等のフラグCSS（radius/border/padding）を推測してライブとズレていた（例：radius を radius-lg と推測したが実値は radius-sm、枠色も差異）。フラグ実装は `public-site.css` にしか無いため。生CSSを MCP で返し、写経でピクセル一致できるようにする（ClaudeDesign 最優先要望）。

## 変更
- `GET /api/v1/themes/engine-css` → `{ source, bytes, css, note }`（css = public-site.css 全文、`[data-cards='framed']` 等のフラグ実装を含む）。
- MCP tool **getThemeEngineCss**（read, themes スコープ）。
- パスは `NENE_ENGINE_CSS_PATH` で上書き可、既定はリポジトリ内 `frontend/src/pages/consumer/public-site.css`。未配置なら note 付きで空返却。
- renderModel に `engineCssTool` ポインタ。

## 検証
- `composer check` / `npm run check` グリーン。
- 実機：54KB の生CSSを取得、framed ブロック（`border-radius: var(--radius-sm)` / `border-top: 3px solid var(--color-accent)` / `border: 1px solid var(--color-border-strong)`）を確認。テストで framed/duotone ルールの存在を保証。

## 補足
- スクショ系（renderTheme→PNG）は headless が要るため別タスク。今回は精度の根本解決＝生CSS を優先。

関連: #444 #446

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)