### PR TITLE
feat(appearance): テーマサムネのミニレンダリングを具象化する (#452)

### DIFF
--- a/frontend/src/features/manage-appearance/ui/ThemeMiniPreview.tsx
+++ b/frontend/src/features/manage-appearance/ui/ThemeMiniPreview.tsx
@@ -6,59 +6,73 @@ const PILL: CSSProperties = { borderRadius: 9999, display: 'block' }
 
 /**
  * A tiny live mockup of a theme rendered straight from its swatch tokens
- * (surface · raised · accent) — far more recognisable than three flat stripes,
- * and generated from the theme itself so every runtime theme gets a thumbnail
- * with no image upload (#450). Ink/border colours are derived from the swatch
- * luminance, so it works for built-in and runtime themes alike. Dimensions are
- * inline styles (arbitrary Tailwind values are disallowed in features/).
+ * (surface · raised · accent) — generated from the theme itself so every runtime
+ * theme gets a recognisable thumbnail with no image upload (#450). Concretised
+ * into a mini "article site": header, hero/eyecatch, and a two-card grid (#452).
+ * Ink/border colours are derived from the swatch luminance, so it works for
+ * built-in and runtime themes alike. Dimensions are inline styles (arbitrary
+ * Tailwind values are disallowed in features/).
  */
 export function ThemeMiniPreview({ preview }: { preview: PublicThemeMeta['preview'] }) {
   const { surface, raised, accent } = preview
   const ink = inkOn(surface)
   const cardInk = inkOn(raised)
-  const onAccent = inkOn(accent)
+
+  // A neutral "image" placeholder reads as media without inventing a colour.
+  const media = cardInk === '#16181d' ? 'rgba(0, 0, 0, 0.12)' : 'rgba(255, 255, 255, 0.14)'
 
   return (
     <span
       aria-hidden
-      style={{ aspectRatio: '16 / 7', background: surface, color: ink, gap: '4%', padding: '5%' }}
+      style={{ aspectRatio: '16 / 7', background: surface, color: ink, gap: '5%', padding: '5%' }}
       className="flex w-full flex-col overflow-hidden rounded-sm border border-border"
     >
-      {/* Header row: brand mark + nav lines */}
+      {/* Header: brand mark + nav lines */}
       <span className="flex items-center" style={{ gap: '3%' }}>
-        <span style={{ ...PILL, background: accent, width: 10, height: 10, flexShrink: 0 }} />
-        <span style={{ ...PILL, background: ink, opacity: 0.4, width: '24%', height: 5 }} />
+        <span style={{ ...PILL, background: accent, width: 9, height: 9, flexShrink: 0 }} />
+        <span style={{ ...PILL, background: ink, opacity: 0.4, width: '22%', height: 4 }} />
         <span
           style={{
             ...PILL,
             background: ink,
             opacity: 0.22,
-            width: '16%',
-            height: 5,
+            width: '14%',
+            height: 4,
             marginLeft: 'auto',
           }}
         />
       </span>
 
-      {/* Body card: title, copy line, accent button */}
+      {/* Hero / eyecatch: media panel with an accent top rule + headline */}
       <span
-        className="flex flex-1 flex-col"
-        style={{ background: raised, gap: 7, padding: '6%', borderRadius: 3 }}
+        className="flex flex-col justify-end"
+        style={{
+          flex: '1.6',
+          background: media,
+          borderTop: `2px solid ${accent}`,
+          borderRadius: 3,
+          padding: '5%',
+          gap: 4,
+        }}
       >
-        <span style={{ ...PILL, background: cardInk, opacity: 0.9, width: '58%', height: 7 }} />
-        <span style={{ ...PILL, background: cardInk, opacity: 0.4, width: '88%', height: 5 }} />
-        <span
-          className="flex items-center justify-center"
-          style={{
-            background: accent,
-            width: '36%',
-            height: 13,
-            borderRadius: 9999,
-            marginTop: 'auto',
-          }}
-        >
-          <span style={{ ...PILL, background: onAccent, opacity: 0.85, width: '60%', height: 4 }} />
-        </span>
+        <span style={{ ...PILL, background: cardInk, opacity: 0.85, width: '62%', height: 6 }} />
+        <span style={{ ...PILL, background: cardInk, opacity: 0.4, width: '40%', height: 4 }} />
+      </span>
+
+      {/* Article grid: two mini cards (image + title line) */}
+      <span className="flex" style={{ flex: '1', gap: '5%' }}>
+        {[0, 1].map((i) => (
+          <span
+            key={i}
+            className="flex flex-1 flex-col"
+            style={{ background: raised, borderRadius: 3, padding: '6%', gap: 3, minWidth: 0 }}
+          >
+            <span style={{ background: media, borderRadius: 2, flex: '1', minHeight: 8 }} />
+            <span
+              style={{ ...PILL, background: cardInk, opacity: 0.55, width: '80%', height: 4 }}
+            />
+          </span>
+        ))}
       </span>
     </span>
   )


### PR DESCRIPTION
## 目的
#450 のミニレンダリングが抽象的だったので、「記事サイトのミニページ」へ具象化して一目で Web ページと分かるようにする。

## 変更
`ThemeMiniPreview`：ヘッダー（ブランド＋ナビ）＋ヒーロー/eyecatch（メディア面＋accent 上罫＋見出し）＋記事カード2枚グリッド（画像プレースホルダ＋タイトル線）。既存3色＋輝度導出 ink のみ、データ追加なし。`assets.preview` 画像の上書きは従来どおり。

## 非対象（将来 = #450 option 3）
フラグ（feedLayout/cardStyle 等）の構造忠実反映は別途。

## 検証
`npm run check`：tsc / eslint / prettier / 229 tests / validate:themes / knip / Storybook グリーン。

関連: #450

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)