### PR TITLE
feat(theme): manifest の description/author を MCP とガイドで露出する (#456)

### DIFF
--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -1251,6 +1251,16 @@
                         "type": "object",
                         "description": "Per-mode CSS tokens: {\"light\":{token:value,\u2026},\"dark\":{\u2026}}. Keys are contract tokens; values must be safe CSS (no ;{}<>, url(), @import)."
                     },
+                    "description": {
+                        "type": "string",
+                        "maxLength": 280,
+                        "description": "Optional short blurb shown under the theme name in the picker."
+                    },
+                    "author": {
+                        "type": "string",
+                        "maxLength": 80,
+                        "description": "Optional author/credit shown in the picker."
+                    },
                     "flags": {
                         "type": "object",
                         "description": "Optional structural style flags (enumerated; e.g. feedLayout, headerLayout)."
@@ -1322,6 +1332,16 @@
                     "tokens": {
                         "type": "object",
                         "description": "Per-mode CSS tokens: {\"light\":{token:value,\u2026},\"dark\":{\u2026}}. Keys are contract tokens; values must be safe CSS (no ;{}<>, url(), @import)."
+                    },
+                    "description": {
+                        "type": "string",
+                        "maxLength": 280,
+                        "description": "Optional short blurb shown under the theme name in the picker."
+                    },
+                    "author": {
+                        "type": "string",
+                        "maxLength": 80,
+                        "description": "Optional author/credit shown in the picker."
                     },
                     "flags": {
                         "type": "object",
@@ -1426,6 +1446,16 @@
                     "tokens": {
                         "type": "object",
                         "description": "Per-mode CSS tokens: {\"light\":{token:value,\u2026},\"dark\":{\u2026}}. Keys are contract tokens; values must be safe CSS (no ;{}<>, url(), @import)."
+                    },
+                    "description": {
+                        "type": "string",
+                        "maxLength": 280,
+                        "description": "Optional short blurb shown under the theme name in the picker."
+                    },
+                    "author": {
+                        "type": "string",
+                        "maxLength": 80,
+                        "description": "Optional author/credit shown in the picker."
                     },
                     "flags": {
                         "type": "object",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -5931,6 +5931,14 @@ components:
         version:
           type: string
           pattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
+        description:
+          type: string
+          maxLength: 280
+          description: Optional blurb shown under the theme name in the picker.
+        author:
+          type: string
+          maxLength: 80
+          description: Optional author/credit shown in the picker.
         supportsModes:
           type: array
           items:

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -2359,6 +2359,10 @@ export interface components {
             id: string;
             name: string;
             version: string;
+            /** @description Optional blurb shown under the theme name in the picker. */
+            description?: string;
+            /** @description Optional author/credit shown in the picker. */
+            author?: string;
             supportsModes: ("light" | "dark")[];
             tokens: {
                 light: components["schemas"]["ThemeTokenSet"];

--- a/src/Theme/ThemeAuthoringGuide.php
+++ b/src/Theme/ThemeAuthoringGuide.php
@@ -343,6 +343,8 @@ final class ThemeAuthoringGuide
             'id' => 'example-theme',
             'name' => 'Example Theme',
             'version' => '1.0.0',
+            'description' => 'A clean, accessible starting point — restyle the tokens to make it yours.',
+            'author' => 'ClaudeDesign',
             'supportsModes' => ['light', 'dark'],
             'tokens' => ['light' => $light, 'dark' => $dark],
             'flags' => [
@@ -362,6 +364,12 @@ final class ThemeAuthoringGuide
     private static function optionalFields(): array
     {
         return [
+            'metadata' => [
+                'note' => 'Top-level manifest strings shown in the admin theme picker. Set them so your '
+                    . 'themes are recognisable.',
+                'description' => 'Short blurb under the theme name (≤280 chars).',
+                'author' => 'Author/credit (≤80 chars).',
+            ],
             'fonts' => [
                 'shape' => '{ family, role, source, weights? }',
                 'roles' => ['display', 'body', 'chrome', 'mono'],

--- a/tests/Theme/ThemeAuthoringGuideTest.php
+++ b/tests/Theme/ThemeAuthoringGuideTest.php
@@ -64,6 +64,17 @@ final class ThemeAuthoringGuideTest extends TestCase
         self::assertArrayHasKey('preview', $optional['assets']['example']);
     }
 
+    public function testGuideAdvertisesDescriptionAndAuthorMetadata(): void
+    {
+        $guide = ThemeAuthoringGuide::build();
+
+        self::assertArrayHasKey('metadata', $guide['optionalFields']);
+        self::assertArrayHasKey('description', $guide['optionalFields']['metadata']);
+        self::assertArrayHasKey('author', $guide['optionalFields']['metadata']);
+        // The example should model it so ClaudeDesign copies the field.
+        self::assertNotSame('', $guide['exampleManifest']['description']);
+    }
+
     public function testGuideListsTheThemeToolsAndIsActionable(): void
     {
         $guide = ThemeAuthoringGuide::build();

--- a/tools/generate-mcp-tools.php
+++ b/tools/generate-mcp-tools.php
@@ -140,6 +140,16 @@ $themeManifestProps = [
         'type' => 'object',
         'description' => 'Per-mode CSS tokens: {"light":{token:value,…},"dark":{…}}. Keys are contract tokens; values must be safe CSS (no ;{}<>, url(), @import).',
     ],
+    'description' => [
+        'type' => 'string',
+        'maxLength' => 280,
+        'description' => 'Optional short blurb shown under the theme name in the picker.',
+    ],
+    'author' => [
+        'type' => 'string',
+        'maxLength' => 80,
+        'description' => 'Optional author/credit shown in the picker.',
+    ],
     'flags' => [
         'type' => 'object',
         'description' => 'Optional structural style flags (enumerated; e.g. feedLayout, headerLayout).',


### PR DESCRIPTION
## 目的
runtime manifest の `description`/`author` はサーバが保存・返却し、ピッカーも表示するが、MCP ツールスキーマと getThemeAuthoringGuide が露出していないため ClaudeDesign が設定できると気づけなかった。口を開けてガイドに載せる。

## 変更
- `createTheme`/`updateTheme` ツールに `description`(≤280)/`author`(≤80)。
- OpenAPI `ThemeManifest` に `description`/`author` を名前付きプロパティで追加。
- `getThemeAuthoringGuide`：exampleManifest に description/author、optionalFields に metadata 注記。
- フロント型再生成。

## 検証
- 実機：description 付き createTheme が保存・返却されるのを確認済み（元々サーバは受理）。
- `composer check`（PHPUnit/PHPStan/CS/OpenAPI/MCP）＋`npm run check`（tsc/lint/prettier/233 tests/knip/Storybook）グリーン。

関連: #440 #442 #454

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)