### PR TITLE
fix(theme): RESERVED_KEYS を全組み込みテーマidに同期する (#458)

### DIFF
--- a/src/Theme/ThemeManifestValidator.php
+++ b/src/Theme/ThemeManifestValidator.php
@@ -58,13 +58,15 @@ final class ThemeManifestValidator
 
     /**
      * Built-in (static) theme ids — runtime themes must not shadow them.
-     * Mirrors frontend/src/shared/lib/public-themes.ts PUBLIC_THEMES + the
-     * authoring bundles under themes/. Keep in sync when built-ins change.
+     * Must cover every `[data-theme='id']` defined under
+     * frontend/src/shared/ui/theme/themes/*.css; ThemeReservedKeysSyncTest
+     * fails if a built-in is added without updating this list.
      */
     private const RESERVED_KEYS = [
-        'consumer', 'aurora', 'reading', 'noir', 'botanical', 'pastel',
-        'newsprint', 'academia', 'coastal', 'funk',
-        'synthwave', 'terminal', 'western', 'y2k',
+        'academia', 'aurora', 'botanical', 'brutalist', 'coastal', 'comic',
+        'consumer', 'deco', 'funk', 'gothic', 'japandi', 'kraft', 'luxe',
+        'memphis', 'nebula', 'newsprint', 'noir', 'pastel', 'reading', 'riso',
+        'stadium', 'sumi', 'swiss', 'synthwave', 'terminal', 'western', 'y2k',
     ];
 
     private const MAX_TOKEN_VALUE_LEN = 200;

--- a/tests/Theme/ThemeReservedKeysSyncTest.php
+++ b/tests/Theme/ThemeReservedKeysSyncTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Theme;
+
+use NeNeRecords\Theme\ThemeManifestValidator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards that RESERVED_KEYS covers every built-in public theme, so a runtime
+ * theme created over MCP can never shadow a built-in id (#458). The source of
+ * truth is the set of `[data-theme='id']` blocks under the frontend theme CSS.
+ */
+final class ThemeReservedKeysSyncTest extends TestCase
+{
+    public function testReservedKeysMatchBuiltInThemeCss(): void
+    {
+        $reserved = ThemeManifestValidator::contract()['reservedIds'];
+        sort($reserved);
+
+        $builtIn = $this->builtInThemeIdsFromCss();
+        self::assertNotEmpty($builtIn, 'No built-in theme CSS found — check the path.');
+
+        self::assertSame(
+            $builtIn,
+            $reserved,
+            'RESERVED_KEYS is out of sync with the built-in theme CSS. '
+                . 'Update ThemeManifestValidator::RESERVED_KEYS to match.',
+        );
+    }
+
+    /** @return list<string> sorted, unique base ids (excludes the -dark variants) */
+    private function builtInThemeIdsFromCss(): array
+    {
+        $dir = dirname(__DIR__, 2) . '/frontend/src/shared/ui/theme/themes';
+        $ids = [];
+        foreach (glob($dir . '/*.css') ?: [] as $file) {
+            $name = basename($file);
+            if (str_ends_with($name, '.components.css') || $name === 'admin-themes.css') {
+                continue;
+            }
+            $css = (string) file_get_contents($file);
+            if (preg_match_all("/\\[data-theme='([a-z0-9-]+)'\\]\\s*\\{/", $css, $matches) === false) {
+                continue;
+            }
+            foreach ($matches[1] as $id) {
+                if (!str_ends_with($id, '-dark')) {
+                    $ids[$id] = true;
+                }
+            }
+        }
+        $list = array_keys($ids);
+        sort($list);
+
+        return $list;
+    }
+}


### PR DESCRIPTION
## 目的
`ThemeManifestValidator::RESERVED_KEYS` が14個で組み込み27種をカバーしておらず、MCP の createTheme で `id='swiss'` 等を作成して組み込みテーマを実質シャドウできた。

## 変更
- RESERVED_KEYS を全27組み込みidに更新（academia…y2k）。
- `ThemeReservedKeysSyncTest`：frontend テーマCSS の `[data-theme='id']`（-dark 除く）から組み込みidを抽出し、`contract().reservedIds` と一致を assert。新しい組み込みテーマ追加時に落ちて同期を促す。

## 検証
- `composer check`（PHPUnit/PHPStan/CS/OpenAPI/MCP）グリーン。
- 実機：`id='swiss'` の createTheme が 422（reserved）になることを確認。

関連: #423 #454 #456

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)