### PR TITLE
feat(appearance): テーマ選択を詳細モーダル＋明示適用にする (#460)

### DIFF
--- a/frontend/src/features/manage-appearance/ui/PublicThemeView.test.tsx
+++ b/frontend/src/features/manage-appearance/ui/PublicThemeView.test.tsx
@@ -35,12 +35,16 @@ describe('PublicThemeView', () => {
   it('renders a card per registered theme and marks the active one', () => {
     renderView()
     const active = screen.getByRole('button', { name: /Terracotta/ })
-    expect(active).toHaveAttribute('aria-pressed', 'true')
+    expect(active).toHaveAttribute('aria-current', 'true')
   })
 
-  it('calls selectTheme when a theme card is clicked', () => {
+  it('opens a details modal on card click and applies only on confirm', () => {
     const { selectTheme } = renderView({ activeThemeId: 'other' })
+    // A single card click opens details — it must NOT apply yet.
     fireEvent.click(screen.getByRole('button', { name: /Terracotta/ }))
+    expect(selectTheme).not.toHaveBeenCalled()
+    // Explicit apply in the modal applies it.
+    fireEvent.click(screen.getByRole('button', { name: /Apply this theme/ }))
     expect(selectTheme).toHaveBeenCalledWith('consumer')
   })
 
@@ -64,6 +68,7 @@ describe('PublicThemeView', () => {
       activeThemeId: 'consumer',
     })
     fireEvent.click(screen.getByRole('button', { name: /Midnight/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Apply this theme/ }))
     expect(selectTheme).toHaveBeenCalledWith('midnight')
   })
 

--- a/frontend/src/features/manage-appearance/ui/PublicThemeView.tsx
+++ b/frontend/src/features/manage-appearance/ui/PublicThemeView.tsx
@@ -56,10 +56,13 @@ export function PublicThemeView({
   isMutating,
 }: PublicThemePageState) {
   const { t, locale } = useTranslation()
+  const [detailsId, setDetailsId] = useState<string | null>(null)
   const [confirmKey, setConfirmKey] = useState<string | null>(null)
   const [editKey, setEditKey] = useState<string | null>(null)
   const [draft, setDraft] = useState('')
   const [editError, setEditError] = useState<string | null>(null)
+
+  const detailsTheme = themes.find((theme) => theme.id === detailsId)
 
   const openEdit = (key: string): void => {
     const theme = runtimeThemes.find((item) => item.theme_key === key)
@@ -108,10 +111,10 @@ export function PublicThemeView({
               <div key={theme.id} className="flex flex-col gap-stack-xs">
                 <button
                   type="button"
-                  aria-pressed={isSelected}
+                  aria-current={isSelected ? 'true' : undefined}
                   disabled={isLoading || isSaving}
                   onClick={() => {
-                    selectTheme(theme.id)
+                    setDetailsId(theme.id)
                   }}
                   className={[
                     'flex flex-col gap-stack-xs rounded-md border bg-surface p-stack-sm text-left transition-colors duration-fast',
@@ -216,6 +219,40 @@ export function PublicThemeView({
           mono
         />
       </ConfirmDialog>
+
+      {detailsTheme !== undefined ? (
+        <ConfirmDialog
+          open
+          title={detailsTheme.name}
+          confirmLabel={
+            detailsTheme.id === activeThemeId
+              ? t('admin.publicTheme.applied')
+              : t('admin.publicTheme.apply')
+          }
+          cancelLabel={t('common.actions.cancel')}
+          confirmDisabled={detailsTheme.id === activeThemeId}
+          isPending={pendingThemeId === detailsTheme.id}
+          onConfirm={() => {
+            selectTheme(detailsTheme.id)
+            setDetailsId(null)
+          }}
+          onCancel={() => {
+            setDetailsId(null)
+          }}
+        >
+          <Stack gap="sm">
+            <ThemeThumb theme={detailsTheme} />
+            <Text variant="caption">{detailsTheme.description}</Text>
+            <Text muted variant="caption">
+              {`v${detailsTheme.version} · ${detailsTheme.author}${
+                formatThemeDate(detailsTheme.createdAt, locale) !== ''
+                  ? ` · ${formatThemeDate(detailsTheme.createdAt, locale)}`
+                  : ''
+              }`}
+            </Text>
+          </Stack>
+        </ConfirmDialog>
+      ) : null}
     </Stack>
   )
 }

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -59,6 +59,8 @@ export const en = {
   'admin.publicTheme.intro': 'Pick the theme applied to every public page.',
   'admin.publicTheme.saving': 'Saving…',
   'admin.publicTheme.runtimeBadge': 'Runtime',
+  'admin.publicTheme.apply': 'Apply this theme',
+  'admin.publicTheme.applied': 'Currently applied',
   'admin.publicTheme.edit': 'Edit',
   'admin.publicTheme.delete': 'Delete',
   'admin.publicTheme.deleteTitle': 'Delete theme',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -52,6 +52,8 @@ export const ja: Partial<MessageCatalog> = {
   'admin.publicTheme.intro': 'すべての公開ページに適用するテーマを選びます。',
   'admin.publicTheme.saving': '保存中…',
   'admin.publicTheme.runtimeBadge': 'Runtime',
+  'admin.publicTheme.apply': 'このテーマを適用',
+  'admin.publicTheme.applied': '適用中',
   'admin.publicTheme.edit': '編集',
   'admin.publicTheme.delete': '削除',
   'admin.publicTheme.deleteTitle': 'テーマを削除',


### PR DESCRIPTION
## 目的
テーマカード1クリックで即 active_theme が切り替わり、誤クリックで公開サイトが変わるリスクがあった。WordPress（カード→詳細モーダル→明示「有効化」）に倣う。

## 変更
- カードクリック → **詳細モーダル**（プレビュー＋説明文全文＋version・author・date）。
- モーダル内 **「このテーマを適用」** で初めて適用。適用中はボタン無効＝「適用中」。
- active カードに `aria-current`。編集/削除リンクは現状維持。i18n（apply/applied）。

## 検証
- `npm run check`：tsc/eslint/prettier/**233 tests**/knip/Storybook グリーン。クリック=非適用→モーダルApply=適用 をテストで保証。

関連: #450 #452 #454

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)