### PR TITLE
feat(appearance): カスタマイザの未保存変更ガードを追加する (#462)

### DIFF
--- a/frontend/src/pages/appearance/AppearanceLayoutPage.tsx
+++ b/frontend/src/pages/appearance/AppearanceLayoutPage.tsx
@@ -19,7 +19,8 @@ import {
   useManageWidgetsPage,
 } from '@/features/manage-widgets'
 import { useTranslation } from '@/shared/i18n'
-import { Button, Stack, Text } from '@/shared/ui'
+import { useUnsavedChangesGuard } from '@/shared/lib/use-unsaved-changes-guard'
+import { Button, ConfirmDialog, Stack, Text } from '@/shared/ui'
 
 const TOUR_LS_KEY = 'nene_layout_tour_seen'
 
@@ -40,6 +41,8 @@ function ThemeTab() {
   const page = usePublicThemePage()
   const customize = useThemeCustomizePage()
   const headerContent = useHeaderConfigPage()
+  // Warn before leaving with unsaved customizer edits (route change + tab close).
+  const blocker = useUnsavedChangesGuard(customize.isDirty)
   return (
     <Stack gap="lg">
       <PublicThemeView {...page} />
@@ -56,6 +59,22 @@ function ThemeTab() {
         <HeaderPreview flags={customize.draft.flags} header={headerContent.draft} />
         <HeaderContentView {...headerContent} />
       </Stack>
+
+      {blocker.state === 'blocked' ? (
+        <ConfirmDialog
+          open
+          title={t('admin.themeCustomize.unsavedTitle')}
+          description={t('admin.themeCustomize.unsavedBody')}
+          confirmLabel={t('admin.themeCustomize.unsavedLeave')}
+          cancelLabel={t('admin.themeCustomize.unsavedStay')}
+          onConfirm={() => {
+            blocker.proceed()
+          }}
+          onCancel={() => {
+            blocker.reset()
+          }}
+        />
+      ) : null}
     </Stack>
   )
 }

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -134,6 +134,11 @@ export const en = {
   'admin.themeCustomize.savedAsTheme': 'Theme created',
   'admin.themeCustomize.saveAsError': 'Could not create theme',
   'admin.themeCustomize.saveAsUnavailable': 'This theme cannot be captured.',
+  'admin.themeCustomize.unsavedTitle': 'Unsaved changes',
+  'admin.themeCustomize.unsavedBody':
+    'You have unsaved customizer changes. Leave without saving? Use “Save” or “Save as theme” to keep them.',
+  'admin.themeCustomize.unsavedLeave': 'Leave without saving',
+  'admin.themeCustomize.unsavedStay': 'Stay',
   'admin.menus.listTitle': 'Menus',
   'admin.menus.new': '+ New',
   'admin.menus.newMenuName': 'New menu',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -127,6 +127,11 @@ export const ja: Partial<MessageCatalog> = {
   'admin.themeCustomize.savedAsTheme': 'テーマを作成しました',
   'admin.themeCustomize.saveAsError': 'テーマを作成できませんでした',
   'admin.themeCustomize.saveAsUnavailable': 'このテーマは保存できません。',
+  'admin.themeCustomize.unsavedTitle': '未保存の変更があります',
+  'admin.themeCustomize.unsavedBody':
+    'カスタマイザの変更が未保存です。保存せずに離れますか？「保存」または「テーマとして保存」で残せます。',
+  'admin.themeCustomize.unsavedLeave': '保存せずに離れる',
+  'admin.themeCustomize.unsavedStay': 'とどまる',
   'admin.menus.listTitle': 'メニュー一覧',
   'admin.menus.new': '＋ 新規',
   'admin.menus.newMenuName': '新しいメニュー',

--- a/frontend/src/shared/lib/use-unsaved-changes-guard.test.tsx
+++ b/frontend/src/shared/lib/use-unsaved-changes-guard.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { Link, RouterProvider, createMemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useUnsavedChangesGuard } from './use-unsaved-changes-guard'
+
+afterEach(cleanup)
+
+function Guarded({ when }: { when: boolean }) {
+  const blocker = useUnsavedChangesGuard(when)
+  return (
+    <div>
+      <Link to="/b">go</Link>
+      {blocker.state === 'blocked' ? (
+        <button
+          type="button"
+          onClick={() => {
+            blocker.proceed()
+          }}
+        >
+          proceed
+        </button>
+      ) : null}
+    </div>
+  )
+}
+
+function renderAt(when: boolean) {
+  const router = createMemoryRouter(
+    [
+      { path: '/', element: <Guarded when={when} /> },
+      { path: '/b', element: <div>PageB</div> },
+    ],
+    { initialEntries: ['/'] },
+  )
+  render(<RouterProvider router={router} />)
+}
+
+describe('useUnsavedChangesGuard', () => {
+  it('blocks in-app navigation when dirty, then proceeds on confirm', () => {
+    renderAt(true)
+    fireEvent.click(screen.getByText('go'))
+    expect(screen.queryByText('PageB')).toBeNull()
+    fireEvent.click(screen.getByText('proceed'))
+    expect(screen.getByText('PageB')).toBeTruthy()
+  })
+
+  it('does not block when clean', () => {
+    renderAt(false)
+    fireEvent.click(screen.getByText('go'))
+    expect(screen.getByText('PageB')).toBeTruthy()
+  })
+})

--- a/frontend/src/shared/lib/use-unsaved-changes-guard.ts
+++ b/frontend/src/shared/lib/use-unsaved-changes-guard.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react'
+import { type Blocker, useBlocker } from 'react-router-dom'
+
+/**
+ * Warn before losing unsaved work. While `when` is true it blocks in-app route
+ * changes (returns a Blocker the caller renders a confirm dialog for) and warns
+ * the browser on tab close / reload via `beforeunload` (#462).
+ */
+export function useUnsavedChangesGuard(when: boolean): Blocker {
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) =>
+      when && currentLocation.pathname !== nextLocation.pathname,
+  )
+
+  // If the changes get saved/discarded while a block is pending, release it.
+  useEffect(() => {
+    if (!when && blocker.state === 'blocked') {
+      blocker.reset()
+    }
+  }, [when, blocker])
+
+  useEffect(() => {
+    if (!when) {
+      return
+    }
+    // preventDefault() is the modern way to trigger the browser's leave prompt
+    // (the legacy event.returnValue is deprecated).
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault()
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => {
+      window.removeEventListener('beforeunload', handler)
+    }
+  }, [when])
+
+  return blocker
+}


### PR DESCRIPTION
## 目的
カスタマイザで knob/色/flag をいじって未保存のまま離脱・タブ移動・リロードすると変更が失われる。離脱前に警告する。

## 変更
- `useUnsavedChangesGuard(when)`：react-router v7 `useBlocker` で in-app ナビをブロック＋`beforeunload` でタブ閉じ/リロード警告。
- ThemeTab に `customize.isDirty` を渡し、ブロック時に確認ダイアログ（保存せず離れる/とどまる）。
- i18n（ja/en）。

## 検証
- `npm run check`：tsc/eslint/prettier/**235 tests**/knip/Storybook グリーン。dirty=ブロック→確認で遷移／clean=ブロックなし をテストで保証。

関連: #454 #460

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)