### PR TITLE
fix(webhook): 配信ワーカーを cron に配線し cron トリガー API を公開する (#466)

### DIFF
--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -1,3 +1,7 @@
 # NeNe Records scheduled publish processor
 # Runs every minute — transitions scheduled entities to published when scheduled_at has passed.
 * * * * * wget -q -O- --post-data="" http://app/api/v1/entities/process-scheduled
+
+# NeNe Records webhook delivery worker (#466)
+# Runs every minute — drains the webhook_deliveries queue (send with retry/backoff).
+* * * * * wget -q -O- --post-data="" http://app/api/v1/webhooks/process-deliveries

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2208,6 +2208,42 @@ paths:
                 $ref: '#/components/schemas/WebhookResponse'
         '422':
           $ref: '#/components/responses/ValidationFailed'
+  /api/v1/webhooks/process-deliveries:
+    post:
+      tags:
+        - Webhooks
+      summary: Process webhook deliveries
+      description: >-
+        Drains the webhook delivery queue — sends due deliveries with retry and
+        exponential backoff. Intended for cron job invocation. The delivery queue
+        is not organization-scoped, so a single call drains all tenants.
+      operationId: processWebhookDeliveries
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of due deliveries to process in this run.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 50
+      responses:
+        '200':
+          description: Summary of the queue drain.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProcessWebhookDeliveriesResponse'
+              examples:
+                ok:
+                  value:
+                    processed: 3
+                    delivered: 2
+                    retried: 1
+                    failed: 0
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /api/v1/webhooks/{id}:
     parameters:
       - name: id
@@ -4739,6 +4775,30 @@ components:
           items:
             type: integer
             format: int64
+    ProcessWebhookDeliveriesResponse:
+      type: object
+      required:
+        - processed
+        - delivered
+        - retried
+        - failed
+      properties:
+        processed:
+          type: integer
+          minimum: 0
+          description: Number of due deliveries claimed and attempted this run.
+        delivered:
+          type: integer
+          minimum: 0
+          description: Deliveries that succeeded.
+        retried:
+          type: integer
+          minimum: 0
+          description: Deliveries that failed but were rescheduled with backoff.
+        failed:
+          type: integer
+          minimum: 0
+          description: Deliveries that exhausted their attempt budget and were marked failed.
     EntityListResponse:
       type: object
       required:

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -805,6 +805,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/webhooks/process-deliveries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Process webhook deliveries
+         * @description Drains the webhook delivery queue — sends due deliveries with retry and exponential backoff. Intended for cron job invocation. The delivery queue is not organization-scoped, so a single call drains all tenants.
+         */
+        post: operations["processWebhookDeliveries"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/webhooks/{id}": {
         parameters: {
             query?: never;
@@ -1920,6 +1940,16 @@ export interface components {
         ProcessScheduledPublishResponse: {
             published_count: number;
             published_ids: number[];
+        };
+        ProcessWebhookDeliveriesResponse: {
+            /** @description Number of due deliveries claimed and attempted this run. */
+            processed: number;
+            /** @description Deliveries that succeeded. */
+            delivered: number;
+            /** @description Deliveries that failed but were rescheduled with backoff. */
+            retried: number;
+            /** @description Deliveries that exhausted their attempt budget and were marked failed. */
+            failed: number;
         };
         EntityListResponse: {
             items: components["schemas"]["EntityResponse"][];
@@ -4855,6 +4885,30 @@ export interface operations {
                 };
             };
             422: components["responses"]["ValidationFailed"];
+        };
+    };
+    processWebhookDeliveries: {
+        parameters: {
+            query?: {
+                /** @description Maximum number of due deliveries to process in this run. */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Summary of the queue drain. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProcessWebhookDeliveriesResponse"];
+                };
+            };
+            500: components["responses"]["InternalServerError"];
         };
     };
     getWebhookById: {

--- a/src/Auth/AdminApiAuthMiddleware.php
+++ b/src/Auth/AdminApiAuthMiddleware.php
@@ -16,18 +16,28 @@ use Psr\Http\Server\RequestHandlerInterface;
  * Method-aware API authentication middleware.
  *
  * Protection rules (first match wins):
- *  1. Always open: /health, /api/v1/auth/*, paths starting with /api/v1/public/
+ *  1. Always open: /health, /api/v1/auth/*, /api/v1/public/*, and the
+ *     cron-triggered batch endpoints (process-scheduled / process-deliveries)
  *  2. Always protected (all HTTP methods): paths starting with /api/v1/settings
  *  3. Protected for non-GET methods: all other /api/v1/ paths
  *  4. Everything else: open (static assets, public HTML pages)
  */
 final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
 {
-    /** @var list<string> */
+    /**
+     * Open prefixes. The two `process-*` entries are full paths (not true
+     * prefixes) for cron-triggered batch jobs: the cron container drains them
+     * over HTTP without credentials. They expose no data, are idempotent, and
+     * remain rate-limited by ThrottleMiddleware (#466).
+     *
+     * @var list<string>
+     */
     private const ALWAYS_OPEN_PREFIXES = [
         '/health',
         '/api/v1/auth/',
         '/api/v1/public/',
+        '/api/v1/entities/process-scheduled',
+        '/api/v1/webhooks/process-deliveries',
     ];
 
     /** @var list<string> */

--- a/src/Webhook/ProcessWebhookDeliveriesHandler.php
+++ b/src/Webhook/ProcessWebhookDeliveriesHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Webhook;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Cron-triggered entry point that drains the webhook delivery queue (#466).
+ *
+ * Mirrors the scheduled-publish processor: invoked by the cron container over
+ * HTTP (no auth — see AdminApiAuthMiddleware::ALWAYS_OPEN_PREFIXES). The queue
+ * is intentionally not organization-scoped, so a single call drains all tenants.
+ */
+final readonly class ProcessWebhookDeliveriesHandler
+{
+    private const DEFAULT_LIMIT = 50;
+    private const MAX_LIMIT = 1000;
+
+    public function __construct(
+        private WebhookDeliveryProcessor $processor,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $summary = $this->processor->process($this->resolveLimit($request));
+
+        return $this->response->create([
+            'processed' => $summary['processed'],
+            'delivered' => $summary['delivered'],
+            'retried' => $summary['retried'],
+            'failed' => $summary['failed'],
+        ]);
+    }
+
+    private function resolveLimit(ServerRequestInterface $request): int
+    {
+        $query = $request->getQueryParams();
+        $raw = $query['limit'] ?? null;
+
+        if (!is_scalar($raw)) {
+            return self::DEFAULT_LIMIT;
+        }
+
+        $limit = (int) $raw;
+
+        if ($limit < 1) {
+            return self::DEFAULT_LIMIT;
+        }
+
+        return min($limit, self::MAX_LIMIT);
+    }
+}

--- a/src/Webhook/WebhookRouteRegistrar.php
+++ b/src/Webhook/WebhookRouteRegistrar.php
@@ -15,6 +15,7 @@ final readonly class WebhookRouteRegistrar
         private CreateWebhookHandler $createHandler,
         private UpdateWebhookHandler $updateHandler,
         private DeleteWebhookHandler $deleteHandler,
+        private ProcessWebhookDeliveriesHandler $processDeliveriesHandler,
     ) {
     }
 
@@ -25,6 +26,7 @@ final readonly class WebhookRouteRegistrar
         $create = $this->createHandler;
         $update = $this->updateHandler;
         $delete = $this->deleteHandler;
+        $processDeliveries = $this->processDeliveriesHandler;
 
         $router->get(
             '/api/v1/webhooks',
@@ -33,6 +35,12 @@ final readonly class WebhookRouteRegistrar
         $router->post(
             '/api/v1/webhooks',
             static fn (ServerRequestInterface $request) => $create->handle($request),
+        );
+        // Cron-triggered queue drain — registered before the {id} routes so the
+        // literal path is never shadowed. Public (see AdminApiAuthMiddleware).
+        $router->post(
+            '/api/v1/webhooks/process-deliveries',
+            static fn (ServerRequestInterface $request) => $processDeliveries->handle($request),
         );
         $router->get(
             '/api/v1/webhooks/{id}',

--- a/src/Webhook/WebhookServiceProvider.php
+++ b/src/Webhook/WebhookServiceProvider.php
@@ -231,6 +231,23 @@ final readonly class WebhookServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                ProcessWebhookDeliveriesHandler::class,
+                static function (ContainerInterface $container): ProcessWebhookDeliveriesHandler {
+                    $processor = $container->get(WebhookDeliveryProcessor::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$processor instanceof WebhookDeliveryProcessor) {
+                        throw new LogicException('Webhook delivery processor service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ProcessWebhookDeliveriesHandler($processor, $response);
+                },
+            )
+            ->set(
                 WebhookNotFoundExceptionHandler::class,
                 static function (ContainerInterface $container): WebhookNotFoundExceptionHandler {
                     $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
@@ -250,6 +267,7 @@ final readonly class WebhookServiceProvider implements ServiceProviderInterface
                     $create = $container->get(CreateWebhookHandler::class);
                     $update = $container->get(UpdateWebhookHandler::class);
                     $delete = $container->get(DeleteWebhookHandler::class);
+                    $processDeliveries = $container->get(ProcessWebhookDeliveriesHandler::class);
 
                     if (!$list instanceof ListWebhooksHandler) {
                         throw new LogicException('ListWebhooks handler service is invalid.');
@@ -271,7 +289,11 @@ final readonly class WebhookServiceProvider implements ServiceProviderInterface
                         throw new LogicException('DeleteWebhook handler service is invalid.');
                     }
 
-                    return new WebhookRouteRegistrar($list, $getById, $create, $update, $delete);
+                    if (!$processDeliveries instanceof ProcessWebhookDeliveriesHandler) {
+                        throw new LogicException('ProcessWebhookDeliveries handler service is invalid.');
+                    }
+
+                    return new WebhookRouteRegistrar($list, $getById, $create, $update, $delete, $processDeliveries);
                 },
             );
     }

--- a/tests/Auth/AdminApiAuthMiddlewareTest.php
+++ b/tests/Auth/AdminApiAuthMiddlewareTest.php
@@ -90,6 +90,29 @@ final class AdminApiAuthMiddlewareTest extends TestCase
         self::assertSame(401, $this->middleware->process($request, $this->passThrough())->getStatusCode());
     }
 
+    public function testScheduledPublishCronEndpointIsOpenWithoutAuth(): void
+    {
+        // The cron container POSTs this without credentials — it must pass through.
+        $request = $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities/process-scheduled');
+
+        self::assertSame(204, $this->middleware->process($request, $this->passThrough())->getStatusCode());
+    }
+
+    public function testProcessWebhookDeliveriesCronEndpointIsOpenWithoutAuth(): void
+    {
+        $request = $this->factory->createServerRequest('POST', 'https://example.test/api/v1/webhooks/process-deliveries');
+
+        self::assertSame(204, $this->middleware->process($request, $this->passThrough())->getStatusCode());
+    }
+
+    public function testOtherWebhookWritesStillRequireAuth(): void
+    {
+        // Opening process-deliveries must not open the rest of /api/v1/webhooks.
+        $request = $this->factory->createServerRequest('POST', 'https://example.test/api/v1/webhooks');
+
+        self::assertSame(401, $this->middleware->process($request, $this->passThrough())->getStatusCode());
+    }
+
     public function testInvalidTokenReturns401(): void
     {
         $request = $this->factory

--- a/tests/Webhook/ProcessWebhookDeliveriesHandlerTest.php
+++ b/tests/Webhook/ProcessWebhookDeliveriesHandlerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Webhook;
+
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Webhook\ProcessWebhookDeliveriesHandler;
+use NeNeRecords\Webhook\WebhookDeliveryProcessor;
+use NeNeRecords\Webhook\WebhookSendResult;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class ProcessWebhookDeliveriesHandlerTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryWebhookDeliveryRepository $deliveries;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new Psr17Factory();
+        $this->deliveries = new InMemoryWebhookDeliveryRepository();
+    }
+
+    private function enqueueDue(): int
+    {
+        // nextAttemptAt in the distant past so it is due against the real clock.
+        return $this->deliveries->enqueue(
+            1,
+            'entity.created',
+            1,
+            42,
+            'https://example.test/hook',
+            'secret',
+            '{"event":"entity.created"}',
+            5,
+            1000,
+        );
+    }
+
+    private function handler(WebhookSendResult $result): ProcessWebhookDeliveriesHandler
+    {
+        return new ProcessWebhookDeliveriesHandler(
+            new WebhookDeliveryProcessor($this->deliveries, new FakeWebhookSender($result)),
+            new JsonResponseFactory($this->factory, $this->factory),
+        );
+    }
+
+    public function testDrainsDueDeliveriesAndReturnsSummary(): void
+    {
+        $this->enqueueDue();
+        $this->enqueueDue();
+
+        $request = $this->factory->createServerRequest('POST', 'https://example.test/api/v1/webhooks/process-deliveries');
+        $response = $this->handler(WebhookSendResult::ok(200))->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('application/json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertSame(
+            ['processed' => 2, 'delivered' => 2, 'retried' => 0, 'failed' => 0],
+            $payload,
+        );
+    }
+
+    public function testLimitQueryParamCapsProcessedDeliveries(): void
+    {
+        $this->enqueueDue();
+        $this->enqueueDue();
+        $this->enqueueDue();
+
+        $request = $this->factory
+            ->createServerRequest('POST', 'https://example.test/api/v1/webhooks/process-deliveries')
+            ->withQueryParams(['limit' => '2']);
+        $response = $this->handler(WebhookSendResult::ok(200))->handle($request);
+
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertSame(2, $payload['processed']);
+        self::assertSame(2, $payload['delivered']);
+    }
+
+    public function testNoDueDeliveriesReturnsZeroedSummary(): void
+    {
+        $request = $this->factory->createServerRequest('POST', 'https://example.test/api/v1/webhooks/process-deliveries');
+        $response = $this->handler(WebhookSendResult::ok(200))->handle($request);
+
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertSame(
+            ['processed' => 0, 'delivered' => 0, 'retried' => 0, 'failed' => 0],
+            $payload,
+        );
+    }
+}

--- a/tests/Webhook/WebhookHttpTest.php
+++ b/tests/Webhook/WebhookHttpTest.php
@@ -15,10 +15,13 @@ use NeNeRecords\Webhook\GetWebhookByIdHandler;
 use NeNeRecords\Webhook\GetWebhookByIdUseCase;
 use NeNeRecords\Webhook\ListWebhooksHandler;
 use NeNeRecords\Webhook\ListWebhooksUseCase;
+use NeNeRecords\Webhook\ProcessWebhookDeliveriesHandler;
 use NeNeRecords\Webhook\UpdateWebhookHandler;
 use NeNeRecords\Webhook\UpdateWebhookUseCase;
+use NeNeRecords\Webhook\WebhookDeliveryProcessor;
 use NeNeRecords\Webhook\WebhookNotFoundExceptionHandler;
 use NeNeRecords\Webhook\WebhookRouteRegistrar;
+use NeNeRecords\Webhook\WebhookSendResult;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -40,12 +43,16 @@ final class WebhookHttpTest extends TestCase
         $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
         $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
 
+        $deliveries = new InMemoryWebhookDeliveryRepository();
+        $processor = new WebhookDeliveryProcessor($deliveries, new FakeWebhookSender(WebhookSendResult::ok(200)));
+
         $registrar = new WebhookRouteRegistrar(
             new ListWebhooksHandler(new ListWebhooksUseCase($this->webhooks), $jsonResponse),
             new GetWebhookByIdHandler(new GetWebhookByIdUseCase($this->webhooks), $jsonResponse),
             new CreateWebhookHandler(new CreateWebhookUseCase($this->webhooks), $jsonResponse),
             new UpdateWebhookHandler(new UpdateWebhookUseCase($this->webhooks), $jsonResponse),
             new DeleteWebhookHandler(new DeleteWebhookUseCase($this->webhooks), $jsonResponse),
+            new ProcessWebhookDeliveriesHandler($processor, $jsonResponse),
         );
 
         $this->application = (new RuntimeApplicationFactory(


### PR DESCRIPTION
## 目的

Webhook 配信は非同期キュー設計（#285）だが、**キューを捌くワーカーが既定の docker スタックで自動実行されておらず、Webhook が事実上配信されていなかった**。さらに調査の過程で、**既存の scheduled-publish cron も認証に阻まれて機能していない**ことが判明した（#466）。

`AdminApiAuthMiddleware` は `/api/v1/*` の非GETをデフォルトで認証必須にするが、cron（PHP を持たない alpine）は認証ヘッダ無しの `wget` で叩くため、`POST /api/v1/entities/process-scheduled` は 401 になっていた（auth 強化 #314 時に ALWAYS_OPEN へ再登録され損ねた回帰）。

方針（事前合意）: **HTTP エンドポイント方式＋ALWAYS_OPEN 公開**で、既存 scheduled-publish の 401 も本PRで同時是正。

## 変更内容

**バックエンド**
- `ProcessWebhookDeliveriesHandler` 新設 — `WebhookDeliveryProcessor::process()` を呼び `{processed,delivered,retried,failed}` を返す。`?limit`（既定50・最大1000）対応。
- `POST /api/v1/webhooks/process-deliveries` を `WebhookRouteRegistrar`（`{id}` より前に登録）+ `WebhookServiceProvider` に配線。
- `AdminApiAuthMiddleware::ALWAYS_OPEN_PREFIXES` に `/api/v1/entities/process-scheduled` と `/api/v1/webhooks/process-deliveries` を追加（**既存 scheduled-publish の 401 を同時是正**）。

**インフラ**
- `docker/cron/crontab` に Webhook ワーカーの1分毎ジョブを追加。

**契約**
- OpenAPI に新エンドポイント + `ProcessWebhookDeliveriesResponse` を追記。`npm run codegen` で frontend 型を再生成。
- MCP ツールは手動キュレーション（process-scheduled 同様、この内部バッチ API はツール化しない）。

**テスト**
- `ProcessWebhookDeliveriesHandlerTest`: JSON サマリ / `limit` 上限 / due 無しの 0 件。
- `AdminApiAuthMiddlewareTest`: 両 cron エンドポイントが無認証で通過し、他の `/api/v1/webhooks` 書込は 401 のまま。
- `WebhookHttpTest`: 新コンストラクタ引数に追随。

## 設計メモ

配信キュー `PdoWebhookDeliveryRepository` は**意図的に非 org スコープ**（各行が target URL/secret をスナップショット済み）なので、HTTP 経由でも全テナントのキューを1回で捌ける。公開許可は冪等なバッチ処理・データ非露出・`ThrottleMiddleware` 有効のため低リスク。

## 検証

- `composer check` 全グリーン
  - PHPUnit: **770 tests / 2182 assertions** OK
  - PHPStan level 8: 0 errors
  - PHP-CS-Fixer / OpenAPI / MCP: valid
- frontend: `type-check` / `lint` / prettier（schema.gen.ts 含む）グリーン

## チェックリスト

- [x] Issue 駆動（#466）
- [x] `type/issue-number-summary` ブランチ
- [x] Conventional Commits（type/scope 英語・本文日本語・`(#466)`）
- [x] OpenAPI 更新 + `npm run codegen` 再生成
- [x] `composer check` 全グリーン

Closes #466