### PR TITLE
docs(todo): current.md のドキュメントドリフトを解消する (#468)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ NeNe Records does not yet follow Semantic Versioning — entries are grouped by 
 
 ---
 
+## [M11–M16 サマリー] — 2026-05-28 〜 2026-06-20
+
+> このまとめは CHANGELOG が M10 で停止していたドリフトの補填（#468）。各マイルストーンの
+> Issue/PR 内訳は `docs/todo/current.md` を正本とする。以降は同 file を都度更新すること。
+
+### Added
+- **M11 通知・運用** — 通知チャンネル（email/slack/discord/chatwork/webhook、#263/#267）、管理 GUI（#273/#280）、Webhook 非同期化（DB キュー＋ワーカー、#285/#295）、コメントスパム対策（#264/#292）。
+- **M12 メディアライブラリ強化** — ストレージ抽象化 Local/S3（#299/#300）、寸法/alt/storage_key（#301）、オンデマンド派生（WebP/AVIF＋キャッシュ、#302）、レスポンシブ srcset（#303）、使用箇所逆引き＋削除ガード（#304/#305）。
+- **M13 管理コンソール再設計** — Console 仕様への再設計・タイプ並び替え（#298）。
+- **M14 公開レイアウト & Custom Page** — 型付きレイアウトプリセット（#307/#308）、2/3カラム領域配置（#309/#310）、サニタイズ html フィールド（#312/#313）、bundle フィールド＋サンドボックス iframe（#316/#317）、iframe 自動高さ＋SEO テキスト（#318/#319）、セッションを httpOnly Cookie へ（#314/#315）。
+- **M15 ウィジェット（Epic #324）** — recent-posts/menu/toc/search/tag-cloud/popular-posts/calendar、公開ページ `/search`・`/tag/:slug`・`/archive/:y/:m(/:d)`（#325〜#342）。
+- **M16 公開サイトのテーマシステム（Epic #367・コア）** — runtime テーマ（DB manifest 駆動、#425/#428/#429）、ハイブリッドなスタイルフラグエンジン（#394/#401）、カスタマイザ（#399/#405）、MCP bridge（#438）、オーサリングガイド/描画モデル（#441/#444/#446/#448）、テーマ保存/詳細モーダル/未保存ガード（#454/#460/#462）。
+- 名前付きメニュー移行（Epic #347）とレイアウトビルダー（Epic #352）を完了。
+
+### Changed
+- 検証基準: PHPUnit 545 → **764 tests**、MCP **83 tools**、Playwright E2E 157 tests を維持。
+
+---
+
 ## [E2E テスト拡充 — 包括的ブラウザシナリオ] — 2026-05-27
 
 ### Added

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-06-14
+Last updated: 2026-06-21
 
 ## 状態サマリー
 
@@ -34,27 +34,68 @@ Last updated: 2026-06-14
 
 **M15 — ウィジェット（Epic #324・全フェーズ）: 完了（2026-06-13）**
 
-最新の検証基準: PHPUnit 691 tests / PHPStan level 8 / CS-Fixer / OpenAPI / MCP ＋
-`npm run check`（type-check / lint / prettier / test / knip / storybook）全グリーン。
+**M16 — 公開サイトのテーマシステム（Epic #367・コア）: 完了（2026-06-20）**
+
+最新の検証基準: PHPUnit 764 tests / 2172 assertions / PHPStan level 8（1114 files）/
+CS-Fixer / OpenAPI / MCP（83 tools）＋ Playwright E2E 157 tests ＋
+`npm run check`（type-check / lint / prettier / test / validate:themes / knip / storybook）全グリーン。
 
 ---
 
-## 進行中エピック
+## 進行中エピック（現在のフロンティア）
 
-### #347 名前付きメニュー移行（location → menus）
+> 直近の作業文脈は新しいハンドオフが正本:
+> `docs/todo/handoff-2026-06-17-public-theme-system.md`（テーマシステム）/
+> `docs/todo/handoff-2026-06-19-mcp-connector.md`（MCP コネクタ）。
 
-| Phase | PR | Summary |
+現在の主戦線は **公開サイトのテーマ作り込み（#362 / #367 系）**。コア（runtime テーマ・
+カスタマイザ・スタイルフラグエンジン・MCP bridge）は M16 で完了し、残りは以下の派生フェーズ。
+
+| Issue | 内容 | 状態 |
 | --- | --- | --- |
-| PR1 | #348 | feat: 名前付きメニューのバックエンド基盤（`menus` + `navigation_items.menu_id` + 移行） |
-| PR2a | #349 | feat: メニューウィジェットを名前付きメニュー選択へ |
-| PR3 | — | chore: `navigation_items.location` / `NavLocations` を撤去（#352 スライス5 と同一） |
+| #390 | テーマを「JSONプリセット＋汎用エンジン（スタイルフラグ）」へ — ハイブリッド | 進行中（全6フラグ base CSS・カスタマイザ UI・validator 実装済み。残: ClaudeCode による JSON テーマ量産） |
+| #372 | テーマ カスタマイザ（トークン上書きノブ）Phase 2 | 残: 画像ノブ（logo/hero・メディア #299 連携）、ライブプレビュー（iframe） |
+| #371 | モーション/インタラクション能力レイヤ Phase 1.5 | 未着手（hero バリアント / scroll-reveal / View Transitions） |
+| #373 | ClaudeDesign「MD→テーマ」量産パイプライン＋バリデータ Phase 3 | 未着手 |
+| #362 | 公開サイトのテーマ/見た目の作り込み（design-first / ダークモード対応）epic | 進行中（上記を束ねる） |
+| #311 | Custom Page（sandboxed iframe + 二重表現SEO + ClaudeDesign 連携）厳格契約 | 設計 issue（オープン） |
+| #402 | トップフィードの列数フラグ（feedColumns） | オープン（#403/#404 で初期実装済み・残点検あり） |
+| #435 | ClaudeDesign 向け MCP 実践ガイド（ドキュメント） | オープン（PR #436） |
 
-PR3 で旧 `location` バケツモデルを完全撤去。項目は `menu_id` で名前付きメニューに所属、
-ヘッダー/フッターは region ウィジェット（#350）で描画。`menus.location`（テーマ表示場所）は存置。
+### 完了済みエピック（旧「進行中」）
 
-### #352 外観 › レイアウトビルダー
+- **#347 名前付きメニュー移行（location → menus）: 完了** — PR1 #348 / PR2a #349 / region 一本化 #350・#351。
+  `navigation_items.location` は migration（`20260614000000_drop_location_from_navigation_items`）で撤去済み・`NavLocations` 参照ゼロ。
+  項目は `menu_id` で名前付きメニューに所属、ヘッダー/フッターは region ウィジェットで描画。
+  `menus.location`（テーマ表示場所）は方針どおり存置。
+- **#352 外観 › レイアウトビルダー: 完了** — スライス1〜5（#353〜#358）＋ページ別 cfg・公開接続（#360/#361/#408）まで全マージ。
+  `layout_config` 設定（`20260617000001_add_layout_config_setting`）で永続化済み。
 
-スライス1〜4（#353〜#358）実装済み。スライス5（後片付け）は #347 PR3 に統合。
+---
+
+## M16 — 公開サイトのテーマシステム（Epic #367・コア）: 完了（2026-06-20）
+
+公開サイト（consumer フロント）の WordPress 風テーマ機能。**色だけ → 版面ごと変わる
+＋管理者カスタマイズ＋ClaudeDesign で JSON 量産**まで到達。正本は
+`docs/todo/handoff-2026-06-17-public-theme-system.md` ＋ `docs/theming/`。
+
+| 領域 | PR（抜粋） | Summary |
+| --- | --- | --- |
+| ヘッダー設定 | #420 / #422 | feat: ヘッダー要素トグル・コンテンツ設定 |
+| runtime テーマ基盤 | #425 / #428 / #429 | feat: DB manifest 駆動の runtime テーマ（backend / 公開 / FOUC 回避） |
+| テーマサムネ | #430 | feat: テーマサムネのメディア指定 |
+| ハイブリッドエンジン | #394 / #401 | feat: スタイルフラグエンジン v2 ＋ ビルトインテーマ量産 |
+| feedColumns | #403 / #404 | feat: トップフィードの列数フラグ |
+| カスタマイザ | #399 / #405 | feat: chrome 設定 ＋ カスタマイズのトースト |
+| MCP bridge | #438 | feat: MCP bridge（OpenAPI 境界経由でテーマ操作を Claude.ai へ） |
+| オーサリングガイド | #441 / #443 | feat: getThemeAuthoringGuide（サーバ検証由来の manifest 契約） |
+| 描画モデル/フォント/CSS | #444 / #446 / #448 | feat: renderModel ＋ availableFonts ＋ getThemeEngineCss |
+| ミニプレビュー | #450 / #452 | feat: テーマピッカーの実物ミニレンダリング |
+| テーマ保存/詳細 | #454 / #460 / #462 | feat: 「テーマとして保存」/ 詳細モーダル＋明示適用 / 未保存変更ガード |
+| reserved keys 同期 | #458 | fix: RESERVED_KEYS を全ビルトイン id に同期 |
+
+**残（派生フェーズ・進行中）:** #390（JSON テーマ量産）/ #372（画像ノブ・ライブプレビュー）/
+#371（モーション層）/ #373（MD→テーマ パイプライン）。詳細は上記「進行中エピック」。
 
 ---
 

--- a/docs/todo/handoff-2026-06-14-layout-builder.md
+++ b/docs/todo/handoff-2026-06-14-layout-builder.md
@@ -1,5 +1,13 @@
 # Handoff: 外観 › レイアウト（レイアウトビルダー）実装中 (2026-06-14)
 
+> ✅ **完了 / SUPERSEDED（2026-06-21 追記）** — 本ハンドオフが扱うレイアウトビルダー
+> （Epic **#352**）と名前付きメニュー移行（Epic **#347**）は**いずれも完了・CLOSED 済み**。
+> スライス1〜5（PR #353〜#358）＋ページ別 cfg・公開接続（#360/#361/#408）まで全マージ、
+> `layout_config` 設定で永続化済み。`navigation_items.location`/`NavLocations` は撤去、
+> `menus.location` は方針どおり存置。**本書は歴史的経緯の記録として残置**。
+> 最新の現状は `docs/todo/current.md`、その後のテーマ作業は
+> `handoff-2026-06-17-public-theme-system.md` を参照。
+
 ClaudeDesign 仕様（`appearance-layout-handoff` / 配布名 `nene-records_008`）に基づく
 **レイアウトビルダー**を多スライスで実装中。本書は途中再開のための引き継ぎ。
 


### PR DESCRIPTION
## 目的

`docs/todo/current.md` が **2026-06-14 で更新停止**しており実コードと乖離していた（#468）。完了済みの **#347（名前付きメニュー移行）/ #352（レイアウトビルダー）** が「進行中」のまま残り、再着手調査で完了済み作業を誤認する原因になった。

## 検証で確定した実状態

- **#347 / #352 は GitHub 上で CLOSED・全 PR マージ済み**（#352 スライス3 DnD=#356 / 4=#357 / 5=#358 / ページ別cfg+公開接続=#360/#361/#408、#347 PR2a=#349）。`navigation_items.location` は migration で drop 済み・`NavLocations` 参照ゼロ。`menus.location` は方針どおり存置。
- 6/14 以降に **公開サイトのテーマシステム（Epic #367）** が一式出荷（runtime テーマ・カスタマイザ・スタイルフラグエンジン・MCP bridge #438 等）。
- 実測: **PHPUnit 764 tests / 2172 assertions**、Playwright E2E 157、MCP 83 tools（current.md は 691 のまま）。

## 変更内容

- **`current.md`**
  - `Last updated` を 2026-06-21 に更新。
  - 状態サマリーに **M16（テーマシステム #367・コア）完了** を追記、検証基準を実測値へ。
  - 「進行中エピック」を実状態へ書換: #347/#352 を「完了済みエピック」へ移動し、**現在のフロンティア**（テーマ系 #390/#372/#371/#373・#362・#311 ＋ #402・#435）の表に置換。新しい handoff（2026-06-17 / 2026-06-19）を参照として明示。
  - **M16 詳細セクション**を追加（テーマシステムの主要 PR 一覧）。
- **`handoff-2026-06-14-layout-builder.md`**: 冒頭に「完了 / SUPERSEDED」バナーを追記（歴史的記録として残置）。
- **`CHANGELOG.md`**: M10 で停止していたため **M11–M16 の高レベル要約エントリ**を追記（per-PR 詳細は current.md を正本とする旨を明記）。

## 検証

- ドキュメントのみ・コード変更なし。root の `docs/`・`CHANGELOG.md` は prettier 管理外（lint-staged はフロントのみ対象）の手書き Markdown で、既存規約に合わせて記述。
- いずれの品質ゲート（`composer check` / `npm run check`）も対象外ファイルのため影響なし。

## チェックリスト

- [x] Issue 駆動（#468）
- [x] `type/issue-number-summary` ブランチ
- [x] Conventional Commits（type/scope 英語・本文日本語・`(#468)`）

Closes #468