### PR TITLE
chore(field): フィールド型 Repository のコピペ引数/プロパティ名を正名化する (#470)

### DIFF
--- a/src/BoolField/BoolFieldRepositoryInterface.php
+++ b/src/BoolField/BoolFieldRepositoryInterface.php
@@ -22,9 +22,9 @@ interface BoolFieldRepositoryInterface
      */
     public function findByEntityId(int $entityId, int $limit, int $offset): array;
 
-    public function save(BoolField $intField): int;
+    public function save(BoolField $boolField): int;
 
-    public function update(BoolField $intField): void;
+    public function update(BoolField $boolField): void;
 
     /**
      * Soft delete: sets is_deleted and deleted_at.

--- a/src/BoolField/BoolFieldServiceProvider.php
+++ b/src/BoolField/BoolFieldServiceProvider.php
@@ -41,11 +41,11 @@ final readonly class BoolFieldServiceProvider implements ServiceProviderInterfac
             ->set(
                 CreateBoolFieldUseCaseInterface::class,
                 static function (ContainerInterface $container): CreateBoolFieldUseCaseInterface {
-                    $intFields = $container->get(BoolFieldRepositoryInterface::class);
+                    $boolFields = $container->get(BoolFieldRepositoryInterface::class);
                     $entities = $container->get(EntityRepositoryInterface::class);
                     $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
 
-                    if (!$intFields instanceof BoolFieldRepositoryInterface) {
+                    if (!$boolFields instanceof BoolFieldRepositoryInterface) {
                         throw new LogicException('bool field repository service is invalid.');
                     }
 
@@ -57,7 +57,7 @@ final readonly class BoolFieldServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('Field definition repository service is invalid.');
                     }
 
-                    return new CreateBoolFieldUseCase($intFields, $entities, $fieldDefs);
+                    return new CreateBoolFieldUseCase($boolFields, $entities, $fieldDefs);
                 },
             )
             ->set(
@@ -167,11 +167,11 @@ final readonly class BoolFieldServiceProvider implements ServiceProviderInterfac
             ->set(
                 UpdateBoolFieldUseCaseInterface::class,
                 static function (ContainerInterface $container): UpdateBoolFieldUseCaseInterface {
-                    $intFields = $container->get(BoolFieldRepositoryInterface::class);
+                    $boolFields = $container->get(BoolFieldRepositoryInterface::class);
                     $entities = $container->get(EntityRepositoryInterface::class);
                     $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
 
-                    if (!$intFields instanceof BoolFieldRepositoryInterface) {
+                    if (!$boolFields instanceof BoolFieldRepositoryInterface) {
                         throw new LogicException('bool field repository service is invalid.');
                     }
 
@@ -183,7 +183,7 @@ final readonly class BoolFieldServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('Field definition repository service is invalid.');
                     }
 
-                    return new UpdateBoolFieldUseCase($intFields, $entities, $fieldDefs);
+                    return new UpdateBoolFieldUseCase($boolFields, $entities, $fieldDefs);
                 },
             )
             ->set(

--- a/src/BoolField/CreateBoolFieldUseCase.php
+++ b/src/BoolField/CreateBoolFieldUseCase.php
@@ -15,7 +15,7 @@ final readonly class CreateBoolFieldUseCase implements CreateBoolFieldUseCaseInt
     private const BOOL_DATA_TYPE = 'bool';
 
     public function __construct(
-        private BoolFieldRepositoryInterface $intFields,
+        private BoolFieldRepositoryInterface $boolFields,
         private EntityRepositoryInterface $entities,
         private FieldDefRepositoryInterface $fieldDefs,
     ) {
@@ -31,7 +31,7 @@ final readonly class CreateBoolFieldUseCase implements CreateBoolFieldUseCaseInt
 
         $this->assertBoolFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
 
-        $id = $this->intFields->save(new BoolField(
+        $id = $this->boolFields->save(new BoolField(
             entityId: $input->entityId,
             fieldKey: $input->fieldKey,
             value: $input->value,

--- a/src/BoolField/DeleteBoolFieldUseCase.php
+++ b/src/BoolField/DeleteBoolFieldUseCase.php
@@ -7,18 +7,18 @@ namespace NeNeRecords\BoolField;
 final readonly class DeleteBoolFieldUseCase implements DeleteBoolFieldUseCaseInterface
 {
     public function __construct(
-        private BoolFieldRepositoryInterface $intFields,
+        private BoolFieldRepositoryInterface $boolFields,
     ) {
     }
 
     public function execute(DeleteBoolFieldByIdInput $input): void
     {
-        $intField = $this->intFields->findById($input->id);
+        $boolField = $this->boolFields->findById($input->id);
 
-        if ($intField === null) {
+        if ($boolField === null) {
             throw new BoolFieldNotFoundException($input->id);
         }
 
-        $this->intFields->delete($input->id);
+        $this->boolFields->delete($input->id);
     }
 }

--- a/src/BoolField/GetBoolFieldByIdUseCase.php
+++ b/src/BoolField/GetBoolFieldByIdUseCase.php
@@ -7,23 +7,23 @@ namespace NeNeRecords\BoolField;
 final readonly class GetBoolFieldByIdUseCase implements GetBoolFieldByIdUseCaseInterface
 {
     public function __construct(
-        private BoolFieldRepositoryInterface $intFields,
+        private BoolFieldRepositoryInterface $boolFields,
     ) {
     }
 
     public function execute(GetBoolFieldByIdInput $input): GetBoolFieldByIdOutput
     {
-        $intField = $this->intFields->findById($input->id);
+        $boolField = $this->boolFields->findById($input->id);
 
-        if ($intField === null) {
+        if ($boolField === null) {
             throw new BoolFieldNotFoundException($input->id);
         }
 
         return new GetBoolFieldByIdOutput(
-            id: (int) $intField->id,
-            entityId: $intField->entityId,
-            fieldKey: $intField->fieldKey,
-            value: $intField->value,
+            id: (int) $boolField->id,
+            entityId: $boolField->entityId,
+            fieldKey: $boolField->fieldKey,
+            value: $boolField->value,
         );
     }
 }

--- a/src/BoolField/ListBoolFieldsUseCase.php
+++ b/src/BoolField/ListBoolFieldsUseCase.php
@@ -7,15 +7,15 @@ namespace NeNeRecords\BoolField;
 final readonly class ListBoolFieldsUseCase implements ListBoolFieldsUseCaseInterface
 {
     public function __construct(
-        private BoolFieldRepositoryInterface $intFields,
+        private BoolFieldRepositoryInterface $boolFields,
     ) {
     }
 
     public function execute(ListBoolFieldsInput $input): ListBoolFieldsOutput
     {
         $rows = $input->entityId !== null
-            ? $this->intFields->findByEntityId($input->entityId, $input->limit, $input->offset)
-            : $this->intFields->findAll($input->limit, $input->offset);
+            ? $this->boolFields->findByEntityId($input->entityId, $input->limit, $input->offset)
+            : $this->boolFields->findAll($input->limit, $input->offset);
 
         $items = array_map(
             static fn (BoolField $field) => new ListBoolFieldItem(

--- a/src/BoolField/PdoBoolFieldRepository.php
+++ b/src/BoolField/PdoBoolFieldRepository.php
@@ -76,29 +76,29 @@ final readonly class PdoBoolFieldRepository implements BoolFieldRepositoryInterf
         );
     }
 
-    public function save(BoolField $intField): int
+    public function save(BoolField $boolField): int
     {
         $this->query->execute(
             'INSERT INTO bool_fields (organization_id, entity_id, field_key, value) VALUES (?, ?, ?, ?)',
-            [$this->orgId->get(), $intField->entityId, $intField->fieldKey, $intField->value],
+            [$this->orgId->get(), $boolField->entityId, $boolField->fieldKey, $boolField->value],
         );
 
         return $this->query->lastInsertId();
     }
 
-    public function update(BoolField $intField): void
+    public function update(BoolField $boolField): void
     {
-        if ($intField->id === null) {
+        if ($boolField->id === null) {
             throw new LogicException('BoolField id is required when updating.');
         }
 
         $affected = $this->query->execute(
             'UPDATE bool_fields SET field_key = ?, value = ? WHERE id = ? AND is_deleted = 0 AND organization_id = ?',
-            [$intField->fieldKey, $intField->value, $intField->id, $this->orgId->get()],
+            [$boolField->fieldKey, $boolField->value, $boolField->id, $this->orgId->get()],
         );
 
         if ($affected === 0) {
-            throw new BoolFieldNotFoundException($intField->id);
+            throw new BoolFieldNotFoundException($boolField->id);
         }
     }
 

--- a/src/BoolField/UpdateBoolFieldUseCase.php
+++ b/src/BoolField/UpdateBoolFieldUseCase.php
@@ -15,7 +15,7 @@ final readonly class UpdateBoolFieldUseCase implements UpdateBoolFieldUseCaseInt
     private const BOOL_DATA_TYPE = 'bool';
 
     public function __construct(
-        private BoolFieldRepositoryInterface $intFields,
+        private BoolFieldRepositoryInterface $boolFields,
         private EntityRepositoryInterface $entities,
         private FieldDefRepositoryInterface $fieldDefs,
     ) {
@@ -23,7 +23,7 @@ final readonly class UpdateBoolFieldUseCase implements UpdateBoolFieldUseCaseInt
 
     public function execute(UpdateBoolFieldInput $input): UpdateBoolFieldOutput
     {
-        $existing = $this->intFields->findById($input->id);
+        $existing = $this->boolFields->findById($input->id);
 
         if ($existing === null) {
             throw new BoolFieldNotFoundException($input->id);
@@ -43,7 +43,7 @@ final readonly class UpdateBoolFieldUseCase implements UpdateBoolFieldUseCaseInt
             value: $input->value,
             id: $input->id,
         );
-        $this->intFields->update($updated);
+        $this->boolFields->update($updated);
 
         return new UpdateBoolFieldOutput(
             id: $input->id,

--- a/src/DateTimeField/CreateDateTimeFieldUseCase.php
+++ b/src/DateTimeField/CreateDateTimeFieldUseCase.php
@@ -15,7 +15,7 @@ final readonly class CreateDateTimeFieldUseCase implements CreateDateTimeFieldUs
     private const DATETIME_DATA_TYPE = 'datetime';
 
     public function __construct(
-        private DateTimeFieldRepositoryInterface $intFields,
+        private DateTimeFieldRepositoryInterface $dateTimeFields,
         private EntityRepositoryInterface $entities,
         private FieldDefRepositoryInterface $fieldDefs,
     ) {
@@ -31,7 +31,7 @@ final readonly class CreateDateTimeFieldUseCase implements CreateDateTimeFieldUs
 
         $this->assertDateTimeFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
 
-        $id = $this->intFields->save(new DateTimeField(
+        $id = $this->dateTimeFields->save(new DateTimeField(
             entityId: $input->entityId,
             fieldKey: $input->fieldKey,
             value: $input->value,

--- a/src/DateTimeField/DateTimeFieldRepositoryInterface.php
+++ b/src/DateTimeField/DateTimeFieldRepositoryInterface.php
@@ -22,9 +22,9 @@ interface DateTimeFieldRepositoryInterface
      */
     public function findByEntityId(int $entityId, int $limit, int $offset): array;
 
-    public function save(DateTimeField $intField): int;
+    public function save(DateTimeField $dateTimeField): int;
 
-    public function update(DateTimeField $intField): void;
+    public function update(DateTimeField $dateTimeField): void;
 
     /**
      * Soft delete: sets is_deleted and deleted_at.

--- a/src/DateTimeField/DateTimeFieldServiceProvider.php
+++ b/src/DateTimeField/DateTimeFieldServiceProvider.php
@@ -41,11 +41,11 @@ final readonly class DateTimeFieldServiceProvider implements ServiceProviderInte
             ->set(
                 CreateDateTimeFieldUseCaseInterface::class,
                 static function (ContainerInterface $container): CreateDateTimeFieldUseCaseInterface {
-                    $intFields = $container->get(DateTimeFieldRepositoryInterface::class);
+                    $dateTimeFields = $container->get(DateTimeFieldRepositoryInterface::class);
                     $entities = $container->get(EntityRepositoryInterface::class);
                     $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
 
-                    if (!$intFields instanceof DateTimeFieldRepositoryInterface) {
+                    if (!$dateTimeFields instanceof DateTimeFieldRepositoryInterface) {
                         throw new LogicException('datetime field repository service is invalid.');
                     }
 
@@ -57,7 +57,7 @@ final readonly class DateTimeFieldServiceProvider implements ServiceProviderInte
                         throw new LogicException('Field definition repository service is invalid.');
                     }
 
-                    return new CreateDateTimeFieldUseCase($intFields, $entities, $fieldDefs);
+                    return new CreateDateTimeFieldUseCase($dateTimeFields, $entities, $fieldDefs);
                 },
             )
             ->set(
@@ -167,11 +167,11 @@ final readonly class DateTimeFieldServiceProvider implements ServiceProviderInte
             ->set(
                 UpdateDateTimeFieldUseCaseInterface::class,
                 static function (ContainerInterface $container): UpdateDateTimeFieldUseCaseInterface {
-                    $intFields = $container->get(DateTimeFieldRepositoryInterface::class);
+                    $dateTimeFields = $container->get(DateTimeFieldRepositoryInterface::class);
                     $entities = $container->get(EntityRepositoryInterface::class);
                     $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
 
-                    if (!$intFields instanceof DateTimeFieldRepositoryInterface) {
+                    if (!$dateTimeFields instanceof DateTimeFieldRepositoryInterface) {
                         throw new LogicException('datetime field repository service is invalid.');
                     }
 
@@ -183,7 +183,7 @@ final readonly class DateTimeFieldServiceProvider implements ServiceProviderInte
                         throw new LogicException('Field definition repository service is invalid.');
                     }
 
-                    return new UpdateDateTimeFieldUseCase($intFields, $entities, $fieldDefs);
+                    return new UpdateDateTimeFieldUseCase($dateTimeFields, $entities, $fieldDefs);
                 },
             )
             ->set(

--- a/src/DateTimeField/DeleteDateTimeFieldUseCase.php
+++ b/src/DateTimeField/DeleteDateTimeFieldUseCase.php
@@ -7,18 +7,18 @@ namespace NeNeRecords\DateTimeField;
 final readonly class DeleteDateTimeFieldUseCase implements DeleteDateTimeFieldUseCaseInterface
 {
     public function __construct(
-        private DateTimeFieldRepositoryInterface $intFields,
+        private DateTimeFieldRepositoryInterface $dateTimeFields,
     ) {
     }
 
     public function execute(DeleteDateTimeFieldByIdInput $input): void
     {
-        $intField = $this->intFields->findById($input->id);
+        $dateTimeField = $this->dateTimeFields->findById($input->id);
 
-        if ($intField === null) {
+        if ($dateTimeField === null) {
             throw new DateTimeFieldNotFoundException($input->id);
         }
 
-        $this->intFields->delete($input->id);
+        $this->dateTimeFields->delete($input->id);
     }
 }

--- a/src/DateTimeField/GetDateTimeFieldByIdUseCase.php
+++ b/src/DateTimeField/GetDateTimeFieldByIdUseCase.php
@@ -7,23 +7,23 @@ namespace NeNeRecords\DateTimeField;
 final readonly class GetDateTimeFieldByIdUseCase implements GetDateTimeFieldByIdUseCaseInterface
 {
     public function __construct(
-        private DateTimeFieldRepositoryInterface $intFields,
+        private DateTimeFieldRepositoryInterface $dateTimeFields,
     ) {
     }
 
     public function execute(GetDateTimeFieldByIdInput $input): GetDateTimeFieldByIdOutput
     {
-        $intField = $this->intFields->findById($input->id);
+        $dateTimeField = $this->dateTimeFields->findById($input->id);
 
-        if ($intField === null) {
+        if ($dateTimeField === null) {
             throw new DateTimeFieldNotFoundException($input->id);
         }
 
         return new GetDateTimeFieldByIdOutput(
-            id: (int) $intField->id,
-            entityId: $intField->entityId,
-            fieldKey: $intField->fieldKey,
-            value: $intField->value,
+            id: (int) $dateTimeField->id,
+            entityId: $dateTimeField->entityId,
+            fieldKey: $dateTimeField->fieldKey,
+            value: $dateTimeField->value,
         );
     }
 }

--- a/src/DateTimeField/ListDateTimeFieldsUseCase.php
+++ b/src/DateTimeField/ListDateTimeFieldsUseCase.php
@@ -7,15 +7,15 @@ namespace NeNeRecords\DateTimeField;
 final readonly class ListDateTimeFieldsUseCase implements ListDateTimeFieldsUseCaseInterface
 {
     public function __construct(
-        private DateTimeFieldRepositoryInterface $intFields,
+        private DateTimeFieldRepositoryInterface $dateTimeFields,
     ) {
     }
 
     public function execute(ListDateTimeFieldsInput $input): ListDateTimeFieldsOutput
     {
         $rows = $input->entityId !== null
-            ? $this->intFields->findByEntityId($input->entityId, $input->limit, $input->offset)
-            : $this->intFields->findAll($input->limit, $input->offset);
+            ? $this->dateTimeFields->findByEntityId($input->entityId, $input->limit, $input->offset)
+            : $this->dateTimeFields->findAll($input->limit, $input->offset);
 
         $items = array_map(
             static fn (DateTimeField $field) => new ListDateTimeFieldItem(

--- a/src/DateTimeField/PdoDateTimeFieldRepository.php
+++ b/src/DateTimeField/PdoDateTimeFieldRepository.php
@@ -76,29 +76,29 @@ final readonly class PdoDateTimeFieldRepository implements DateTimeFieldReposito
         );
     }
 
-    public function save(DateTimeField $intField): int
+    public function save(DateTimeField $dateTimeField): int
     {
         $this->query->execute(
             'INSERT INTO datetime_fields (organization_id, entity_id, field_key, value) VALUES (?, ?, ?, ?)',
-            [$this->orgId->get(), $intField->entityId, $intField->fieldKey, $intField->value],
+            [$this->orgId->get(), $dateTimeField->entityId, $dateTimeField->fieldKey, $dateTimeField->value],
         );
 
         return $this->query->lastInsertId();
     }
 
-    public function update(DateTimeField $intField): void
+    public function update(DateTimeField $dateTimeField): void
     {
-        if ($intField->id === null) {
+        if ($dateTimeField->id === null) {
             throw new LogicException('DateTimeField id is required when updating.');
         }
 
         $affected = $this->query->execute(
             'UPDATE datetime_fields SET field_key = ?, value = ? WHERE id = ? AND is_deleted = 0 AND organization_id = ?',
-            [$intField->fieldKey, $intField->value, $intField->id, $this->orgId->get()],
+            [$dateTimeField->fieldKey, $dateTimeField->value, $dateTimeField->id, $this->orgId->get()],
         );
 
         if ($affected === 0) {
-            throw new DateTimeFieldNotFoundException($intField->id);
+            throw new DateTimeFieldNotFoundException($dateTimeField->id);
         }
     }
 

--- a/src/DateTimeField/UpdateDateTimeFieldUseCase.php
+++ b/src/DateTimeField/UpdateDateTimeFieldUseCase.php
@@ -15,7 +15,7 @@ final readonly class UpdateDateTimeFieldUseCase implements UpdateDateTimeFieldUs
     private const DATETIME_DATA_TYPE = 'datetime';
 
     public function __construct(
-        private DateTimeFieldRepositoryInterface $intFields,
+        private DateTimeFieldRepositoryInterface $dateTimeFields,
         private EntityRepositoryInterface $entities,
         private FieldDefRepositoryInterface $fieldDefs,
     ) {
@@ -23,7 +23,7 @@ final readonly class UpdateDateTimeFieldUseCase implements UpdateDateTimeFieldUs
 
     public function execute(UpdateDateTimeFieldInput $input): UpdateDateTimeFieldOutput
     {
-        $existing = $this->intFields->findById($input->id);
+        $existing = $this->dateTimeFields->findById($input->id);
 
         if ($existing === null) {
             throw new DateTimeFieldNotFoundException($input->id);
@@ -43,7 +43,7 @@ final readonly class UpdateDateTimeFieldUseCase implements UpdateDateTimeFieldUs
             value: $input->value,
             id: $input->id,
         );
-        $this->intFields->update($updated);
+        $this->dateTimeFields->update($updated);
 
         return new UpdateDateTimeFieldOutput(
             id: $input->id,

--- a/src/EnumField/CreateEnumFieldUseCase.php
+++ b/src/EnumField/CreateEnumFieldUseCase.php
@@ -15,7 +15,7 @@ final readonly class CreateEnumFieldUseCase implements CreateEnumFieldUseCaseInt
     private const ENUM_DATA_TYPE = 'enum';
 
     public function __construct(
-        private EnumFieldRepositoryInterface $intFields,
+        private EnumFieldRepositoryInterface $enumFields,
         private EntityRepositoryInterface $entities,
         private FieldDefRepositoryInterface $fieldDefs,
     ) {
@@ -31,7 +31,7 @@ final readonly class CreateEnumFieldUseCase implements CreateEnumFieldUseCaseInt
 
         $this->assertEnumFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
 
-        $id = $this->intFields->save(new EnumField(
+        $id = $this->enumFields->save(new EnumField(
             entityId: $input->entityId,
             fieldKey: $input->fieldKey,
             value: $input->value,

--- a/src/EnumField/DeleteEnumFieldUseCase.php
+++ b/src/EnumField/DeleteEnumFieldUseCase.php
@@ -7,18 +7,18 @@ namespace NeNeRecords\EnumField;
 final readonly class DeleteEnumFieldUseCase implements DeleteEnumFieldUseCaseInterface
 {
     public function __construct(
-        private EnumFieldRepositoryInterface $intFields,
+        private EnumFieldRepositoryInterface $enumFields,
     ) {
     }
 
     public function execute(DeleteEnumFieldByIdInput $input): void
     {
-        $intField = $this->intFields->findById($input->id);
+        $enumField = $this->enumFields->findById($input->id);
 
-        if ($intField === null) {
+        if ($enumField === null) {
             throw new EnumFieldNotFoundException($input->id);
         }
 
-        $this->intFields->delete($input->id);
+        $this->enumFields->delete($input->id);
     }
 }

--- a/src/EnumField/EnumFieldRepositoryInterface.php
+++ b/src/EnumField/EnumFieldRepositoryInterface.php
@@ -22,9 +22,9 @@ interface EnumFieldRepositoryInterface
      */
     public function findByEntityId(int $entityId, int $limit, int $offset): array;
 
-    public function save(EnumField $intField): int;
+    public function save(EnumField $enumField): int;
 
-    public function update(EnumField $intField): void;
+    public function update(EnumField $enumField): void;
 
     /**
      * Soft delete: sets is_deleted and deleted_at.

--- a/src/EnumField/EnumFieldServiceProvider.php
+++ b/src/EnumField/EnumFieldServiceProvider.php
@@ -41,11 +41,11 @@ final readonly class EnumFieldServiceProvider implements ServiceProviderInterfac
             ->set(
                 CreateEnumFieldUseCaseInterface::class,
                 static function (ContainerInterface $container): CreateEnumFieldUseCaseInterface {
-                    $intFields = $container->get(EnumFieldRepositoryInterface::class);
+                    $enumFields = $container->get(EnumFieldRepositoryInterface::class);
                     $entities = $container->get(EntityRepositoryInterface::class);
                     $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
 
-                    if (!$intFields instanceof EnumFieldRepositoryInterface) {
+                    if (!$enumFields instanceof EnumFieldRepositoryInterface) {
                         throw new LogicException('enum field repository service is invalid.');
                     }
 
@@ -57,7 +57,7 @@ final readonly class EnumFieldServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('Field definition repository service is invalid.');
                     }
 
-                    return new CreateEnumFieldUseCase($intFields, $entities, $fieldDefs);
+                    return new CreateEnumFieldUseCase($enumFields, $entities, $fieldDefs);
                 },
             )
             ->set(
@@ -167,11 +167,11 @@ final readonly class EnumFieldServiceProvider implements ServiceProviderInterfac
             ->set(
                 UpdateEnumFieldUseCaseInterface::class,
                 static function (ContainerInterface $container): UpdateEnumFieldUseCaseInterface {
-                    $intFields = $container->get(EnumFieldRepositoryInterface::class);
+                    $enumFields = $container->get(EnumFieldRepositoryInterface::class);
                     $entities = $container->get(EntityRepositoryInterface::class);
                     $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
 
-                    if (!$intFields instanceof EnumFieldRepositoryInterface) {
+                    if (!$enumFields instanceof EnumFieldRepositoryInterface) {
                         throw new LogicException('enum field repository service is invalid.');
                     }
 
@@ -183,7 +183,7 @@ final readonly class EnumFieldServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('Field definition repository service is invalid.');
                     }
 
-                    return new UpdateEnumFieldUseCase($intFields, $entities, $fieldDefs);
+                    return new UpdateEnumFieldUseCase($enumFields, $entities, $fieldDefs);
                 },
             )
             ->set(

--- a/src/EnumField/GetEnumFieldByIdUseCase.php
+++ b/src/EnumField/GetEnumFieldByIdUseCase.php
@@ -7,23 +7,23 @@ namespace NeNeRecords\EnumField;
 final readonly class GetEnumFieldByIdUseCase implements GetEnumFieldByIdUseCaseInterface
 {
     public function __construct(
-        private EnumFieldRepositoryInterface $intFields,
+        private EnumFieldRepositoryInterface $enumFields,
     ) {
     }
 
     public function execute(GetEnumFieldByIdInput $input): GetEnumFieldByIdOutput
     {
-        $intField = $this->intFields->findById($input->id);
+        $enumField = $this->enumFields->findById($input->id);
 
-        if ($intField === null) {
+        if ($enumField === null) {
             throw new EnumFieldNotFoundException($input->id);
         }
 
         return new GetEnumFieldByIdOutput(
-            id: (int) $intField->id,
-            entityId: $intField->entityId,
-            fieldKey: $intField->fieldKey,
-            value: $intField->value,
+            id: (int) $enumField->id,
+            entityId: $enumField->entityId,
+            fieldKey: $enumField->fieldKey,
+            value: $enumField->value,
         );
     }
 }

--- a/src/EnumField/ListEnumFieldsUseCase.php
+++ b/src/EnumField/ListEnumFieldsUseCase.php
@@ -7,15 +7,15 @@ namespace NeNeRecords\EnumField;
 final readonly class ListEnumFieldsUseCase implements ListEnumFieldsUseCaseInterface
 {
     public function __construct(
-        private EnumFieldRepositoryInterface $intFields,
+        private EnumFieldRepositoryInterface $enumFields,
     ) {
     }
 
     public function execute(ListEnumFieldsInput $input): ListEnumFieldsOutput
     {
         $rows = $input->entityId !== null
-            ? $this->intFields->findByEntityId($input->entityId, $input->limit, $input->offset)
-            : $this->intFields->findAll($input->limit, $input->offset);
+            ? $this->enumFields->findByEntityId($input->entityId, $input->limit, $input->offset)
+            : $this->enumFields->findAll($input->limit, $input->offset);
 
         $items = array_map(
             static fn (EnumField $field) => new ListEnumFieldItem(

--- a/src/EnumField/PdoEnumFieldRepository.php
+++ b/src/EnumField/PdoEnumFieldRepository.php
@@ -76,29 +76,29 @@ final readonly class PdoEnumFieldRepository implements EnumFieldRepositoryInterf
         );
     }
 
-    public function save(EnumField $intField): int
+    public function save(EnumField $enumField): int
     {
         $this->query->execute(
             'INSERT INTO enum_fields (organization_id, entity_id, field_key, value) VALUES (?, ?, ?, ?)',
-            [$this->orgId->get(), $intField->entityId, $intField->fieldKey, $intField->value],
+            [$this->orgId->get(), $enumField->entityId, $enumField->fieldKey, $enumField->value],
         );
 
         return $this->query->lastInsertId();
     }
 
-    public function update(EnumField $intField): void
+    public function update(EnumField $enumField): void
     {
-        if ($intField->id === null) {
+        if ($enumField->id === null) {
             throw new LogicException('EnumField id is required when updating.');
         }
 
         $affected = $this->query->execute(
             'UPDATE enum_fields SET field_key = ?, value = ? WHERE id = ? AND is_deleted = 0 AND organization_id = ?',
-            [$intField->fieldKey, $intField->value, $intField->id, $this->orgId->get()],
+            [$enumField->fieldKey, $enumField->value, $enumField->id, $this->orgId->get()],
         );
 
         if ($affected === 0) {
-            throw new EnumFieldNotFoundException($intField->id);
+            throw new EnumFieldNotFoundException($enumField->id);
         }
     }
 

--- a/src/EnumField/UpdateEnumFieldUseCase.php
+++ b/src/EnumField/UpdateEnumFieldUseCase.php
@@ -15,7 +15,7 @@ final readonly class UpdateEnumFieldUseCase implements UpdateEnumFieldUseCaseInt
     private const ENUM_DATA_TYPE = 'enum';
 
     public function __construct(
-        private EnumFieldRepositoryInterface $intFields,
+        private EnumFieldRepositoryInterface $enumFields,
         private EntityRepositoryInterface $entities,
         private FieldDefRepositoryInterface $fieldDefs,
     ) {
@@ -23,7 +23,7 @@ final readonly class UpdateEnumFieldUseCase implements UpdateEnumFieldUseCaseInt
 
     public function execute(UpdateEnumFieldInput $input): UpdateEnumFieldOutput
     {
-        $existing = $this->intFields->findById($input->id);
+        $existing = $this->enumFields->findById($input->id);
 
         if ($existing === null) {
             throw new EnumFieldNotFoundException($input->id);
@@ -43,7 +43,7 @@ final readonly class UpdateEnumFieldUseCase implements UpdateEnumFieldUseCaseInt
             value: $input->value,
             id: $input->id,
         );
-        $this->intFields->update($updated);
+        $this->enumFields->update($updated);
 
         return new UpdateEnumFieldOutput(
             id: $input->id,

--- a/tests/BoolField/BoolFieldHttpTest.php
+++ b/tests/BoolField/BoolFieldHttpTest.php
@@ -91,7 +91,7 @@ final class BoolFieldHttpTest extends TestCase
             new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities), $jsonResponse),
         );
 
-        $intFieldRegistrar = new BoolFieldRouteRegistrar(
+        $boolFieldRegistrar = new BoolFieldRouteRegistrar(
             new ListBoolFieldsHandler(new ListBoolFieldsUseCase($this->boolFields), $jsonResponse),
             new GetBoolFieldByIdHandler(new GetBoolFieldByIdUseCase($this->boolFields), $jsonResponse),
             new CreateBoolFieldHandler(new CreateBoolFieldUseCase($this->boolFields, $this->entities, $this->fieldDefs), $jsonResponse),
@@ -109,7 +109,7 @@ final class BoolFieldHttpTest extends TestCase
                 new FieldKeyNotRegisteredExceptionHandler($problemDetails),
                 new FieldTypeMismatchExceptionHandler($problemDetails),
             ],
-            routeRegistrars: [$entityRegistrar, $intFieldRegistrar],
+            routeRegistrars: [$entityRegistrar, $boolFieldRegistrar],
         ))->create();
     }
 

--- a/tests/BoolField/InMemoryBoolFieldRepository.php
+++ b/tests/BoolField/InMemoryBoolFieldRepository.php
@@ -75,22 +75,22 @@ final class InMemoryBoolFieldRepository implements BoolFieldRepositoryInterface
         return array_slice($active, $offset, $limit);
     }
 
-    public function save(BoolField $intField): int
+    public function save(BoolField $boolField): int
     {
         $id = $this->nextId++;
         $this->fields[$id] = new BoolField(
-            entityId: $intField->entityId,
-            fieldKey: $intField->fieldKey,
-            value: $intField->value,
+            entityId: $boolField->entityId,
+            fieldKey: $boolField->fieldKey,
+            value: $boolField->value,
             id: $id,
         );
 
         return $id;
     }
 
-    public function update(BoolField $intField): void
+    public function update(BoolField $boolField): void
     {
-        $id = $intField->id;
+        $id = $boolField->id;
 
         if ($id === null) {
             return;
@@ -100,7 +100,7 @@ final class InMemoryBoolFieldRepository implements BoolFieldRepositoryInterface
             throw new BoolFieldNotFoundException($id);
         }
 
-        $this->fields[$id] = $intField;
+        $this->fields[$id] = $boolField;
     }
 
     public function delete(int $id): void

--- a/tests/DateTimeField/DateTimeFieldHttpTest.php
+++ b/tests/DateTimeField/DateTimeFieldHttpTest.php
@@ -91,7 +91,7 @@ final class DateTimeFieldHttpTest extends TestCase
             new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities), $jsonResponse),
         );
 
-        $intFieldRegistrar = new DateTimeFieldRouteRegistrar(
+        $dateTimeFieldRegistrar = new DateTimeFieldRouteRegistrar(
             new ListDateTimeFieldsHandler(new ListDateTimeFieldsUseCase($this->datetimeFields), $jsonResponse),
             new GetDateTimeFieldByIdHandler(new GetDateTimeFieldByIdUseCase($this->datetimeFields), $jsonResponse),
             new CreateDateTimeFieldHandler(new CreateDateTimeFieldUseCase($this->datetimeFields, $this->entities, $this->fieldDefs), $jsonResponse),
@@ -109,7 +109,7 @@ final class DateTimeFieldHttpTest extends TestCase
                 new FieldKeyNotRegisteredExceptionHandler($problemDetails),
                 new FieldTypeMismatchExceptionHandler($problemDetails),
             ],
-            routeRegistrars: [$entityRegistrar, $intFieldRegistrar],
+            routeRegistrars: [$entityRegistrar, $dateTimeFieldRegistrar],
         ))->create();
     }
 

--- a/tests/DateTimeField/InMemoryDateTimeFieldRepository.php
+++ b/tests/DateTimeField/InMemoryDateTimeFieldRepository.php
@@ -75,22 +75,22 @@ final class InMemoryDateTimeFieldRepository implements DateTimeFieldRepositoryIn
         return array_slice($active, $offset, $limit);
     }
 
-    public function save(DateTimeField $intField): int
+    public function save(DateTimeField $dateTimeField): int
     {
         $id = $this->nextId++;
         $this->fields[$id] = new DateTimeField(
-            entityId: $intField->entityId,
-            fieldKey: $intField->fieldKey,
-            value: $intField->value,
+            entityId: $dateTimeField->entityId,
+            fieldKey: $dateTimeField->fieldKey,
+            value: $dateTimeField->value,
             id: $id,
         );
 
         return $id;
     }
 
-    public function update(DateTimeField $intField): void
+    public function update(DateTimeField $dateTimeField): void
     {
-        $id = $intField->id;
+        $id = $dateTimeField->id;
 
         if ($id === null) {
             return;
@@ -100,7 +100,7 @@ final class InMemoryDateTimeFieldRepository implements DateTimeFieldRepositoryIn
             throw new DateTimeFieldNotFoundException($id);
         }
 
-        $this->fields[$id] = $intField;
+        $this->fields[$id] = $dateTimeField;
     }
 
     public function delete(int $id): void

--- a/tests/EnumField/EnumFieldHttpTest.php
+++ b/tests/EnumField/EnumFieldHttpTest.php
@@ -91,7 +91,7 @@ final class EnumFieldHttpTest extends TestCase
             new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities), $jsonResponse),
         );
 
-        $intFieldRegistrar = new EnumFieldRouteRegistrar(
+        $enumFieldRegistrar = new EnumFieldRouteRegistrar(
             new ListEnumFieldsHandler(new ListEnumFieldsUseCase($this->enumFields), $jsonResponse),
             new GetEnumFieldByIdHandler(new GetEnumFieldByIdUseCase($this->enumFields), $jsonResponse),
             new CreateEnumFieldHandler(new CreateEnumFieldUseCase($this->enumFields, $this->entities, $this->fieldDefs), $jsonResponse),
@@ -109,7 +109,7 @@ final class EnumFieldHttpTest extends TestCase
                 new FieldKeyNotRegisteredExceptionHandler($problemDetails),
                 new FieldTypeMismatchExceptionHandler($problemDetails),
             ],
-            routeRegistrars: [$entityRegistrar, $intFieldRegistrar],
+            routeRegistrars: [$entityRegistrar, $enumFieldRegistrar],
         ))->create();
     }
 

--- a/tests/EnumField/InMemoryEnumFieldRepository.php
+++ b/tests/EnumField/InMemoryEnumFieldRepository.php
@@ -75,22 +75,22 @@ final class InMemoryEnumFieldRepository implements EnumFieldRepositoryInterface
         return array_slice($active, $offset, $limit);
     }
 
-    public function save(EnumField $intField): int
+    public function save(EnumField $enumField): int
     {
         $id = $this->nextId++;
         $this->fields[$id] = new EnumField(
-            entityId: $intField->entityId,
-            fieldKey: $intField->fieldKey,
-            value: $intField->value,
+            entityId: $enumField->entityId,
+            fieldKey: $enumField->fieldKey,
+            value: $enumField->value,
             id: $id,
         );
 
         return $id;
     }
 
-    public function update(EnumField $intField): void
+    public function update(EnumField $enumField): void
     {
-        $id = $intField->id;
+        $id = $enumField->id;
 
         if ($id === null) {
             return;
@@ -100,7 +100,7 @@ final class InMemoryEnumFieldRepository implements EnumFieldRepositoryInterface
             throw new EnumFieldNotFoundException($id);
         }
 
-        $this->fields[$id] = $intField;
+        $this->fields[$id] = $enumField;
     }
 
     public function delete(int $id): void


### PR DESCRIPTION
## 目的

`EnumField` / `BoolField` / `DateTimeField` の各モジュールに、`IntField` からコピペした名前が残留していた（#470）。型ごとの最適化ではなく機械的複製の痕跡で、可読性・一貫性の品質バグ。

`save(BoolField $intField)` のような引数名残留が発端だったが、実装時に範囲がより広いと判明:
- 引数/ローカル変数 `$intField`
- リポジトリプロパティ宣言 `private XxxFieldRepositoryInterface $intFields` とその参照 `$this->intFields`
- テスト（InMemory リポジトリの引数、HttpTest の `$intFieldRegistrar` 等）

半端な修正は宣言と参照の不整合を生むため、スコープを拡大して 3 モジュール（src + tests）の `intField`/`intFields` 残留を各型名（`enumField`/`boolField`/`dateTimeField`）へ全て正名化した（#470 にコメントで経緯を記録）。

## 変更内容

- `src/{EnumField,BoolField,DateTimeField}/` の Repository / Interface / UseCase / ServiceProvider のコピペ名を正名化（**24ファイル**）。
- `tests/{EnumField,BoolField,DateTimeField}/` の InMemory リポジトリ・HttpTest の残留名を正名化（**6ファイル**）。
- `IntField` モジュールは正しい命名のため**無変更**。

## スコープ外（意図的に行わないこと）

フィールド型モジュールの**重複そのものは技術的負債ではなく NENE2 規約・思想への準拠**（明示性 > DRY、本体も abstract/trait 0 件、層分割禁止、起動時 instanceof fail-fast）。よって `AbstractFieldRepository`/Trait 等の抽象化は**行わない**。本 PR は純粋な命名一貫性の修正のみで、削減効果ゼロ・動作影響なし。

## 検証

- `composer check` 全グリーン
  - PHPUnit: **764 tests / 2172 assertions** OK
  - PHPStan level 8: 0 errors（宣言↔参照の一貫性も担保）
  - PHP-CS-Fixer / OpenAPI / MCP: valid
- 名前付き引数（`save(intField: ...)`）の呼び出しが無いことを確認済み（互換影響なし）。

## チェックリスト

- [x] Issue 駆動（#470）
- [x] `type/issue-number-summary` ブランチ
- [x] Conventional Commits（type/scope 英語・本文日本語・`(#470)`）
- [x] `composer check` 全グリーン

Closes #470