### PR TITLE
docs(field): フィールド型重複が NENE2 規約準拠（意図的）である旨を明記する (#472)

### DIFF
--- a/docs/development/backend-standards.md
+++ b/docs/development/backend-standards.md
@@ -234,6 +234,35 @@ List operations use `List{Entity}Item` inside `List{Entity}sOutput` — same as 
 - Shared kernel (future): `src/Shared/` with ADR — not a dumping ground for convenience helpers.
 - **ApplicationServiceProvider** aggregates domain providers and exposes route registrar list — it does not contain business logic.
 
+### Intentional per-type duplication (field-type modules) — NOT debt
+
+The five field-value modules — `src/{Text,Int,Enum,Bool,DateTime}Field/` — are
+**deliberately near-identical** (each ~32 classes following the canonical tree above).
+This is **NENE2 convention compliance, not technical debt.** Do **not** "DRY" it by
+introducing an `AbstractFieldRepository`, a shared trait, or a generic
+`FieldRepositoryInterface<T>`.
+
+Why this is the intended design:
+
+- **NENE2 prioritizes explicitness over DRY.** The framework itself ships **zero
+  `abstract class` and zero `trait`** and documents the trade-off
+  (`vendor/hideyukimori/nene2/docs/explanation/why-explicit-wiring.md`: "Verbose for
+  large class counts" is accepted on purpose; `domain-layer.md`: "Group by domain
+  concept, not by layer type"). Its Non-Goals exclude reflection/annotation DI and
+  Active-Record-style models.
+- **The zero-tolerance rules above already forbid the usual de-duplication tools**:
+  no layer-grouped roots, no generic `src/Util/`, shared kernel only via ADR.
+- **A shared base is technically a poor fit here anyway:** PHP has no generics; only
+  `TextField` carries a divergent signature (`?string $locale`, `findByEntityTypeId`,
+  `findByEntityIds`), so the interfaces cannot be unified; and the container's
+  start-up `instanceof` fail-fast guards assume one concrete interface per type.
+- **If the type count ever outgrows hand-written providers**, the NENE2-aligned
+  response is to re-evaluate the framework fit (per `why-explicit-wiring.md`), **not**
+  to bolt on autowiring or abstraction.
+
+Acceptable in-grain cleanups only: class-local `private`/`private static` helpers,
+fixing copy-paste naming residue. Anything that crosses the module boundary needs an ADR.
+
 ### Forbidden placements (automatic PR reject)
 
 - Business logic in handlers beyond format validation

--- a/src/BoolField/PdoBoolFieldRepository.php
+++ b/src/BoolField/PdoBoolFieldRepository.php
@@ -8,6 +8,14 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Http\RequestScopedHolder;
 
+/**
+ * Per-type field-value repository (text/int/enum/bool/datetime).
+ *
+ * The five *Field modules are intentionally near-duplicated: NENE2 convention
+ * (explicit wiring over DRY; the framework ships zero abstract classes/traits),
+ * NOT debt. Do NOT extract a shared AbstractFieldRepository / trait / generic.
+ * Rationale: docs/development/backend-standards.md → "Intentional per-type duplication".
+ */
 final readonly class PdoBoolFieldRepository implements BoolFieldRepositoryInterface
 {
     /**

--- a/src/DateTimeField/PdoDateTimeFieldRepository.php
+++ b/src/DateTimeField/PdoDateTimeFieldRepository.php
@@ -8,6 +8,14 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Http\RequestScopedHolder;
 
+/**
+ * Per-type field-value repository (text/int/enum/bool/datetime).
+ *
+ * The five *Field modules are intentionally near-duplicated: NENE2 convention
+ * (explicit wiring over DRY; the framework ships zero abstract classes/traits),
+ * NOT debt. Do NOT extract a shared AbstractFieldRepository / trait / generic.
+ * Rationale: docs/development/backend-standards.md → "Intentional per-type duplication".
+ */
 final readonly class PdoDateTimeFieldRepository implements DateTimeFieldRepositoryInterface
 {
     /**

--- a/src/EnumField/PdoEnumFieldRepository.php
+++ b/src/EnumField/PdoEnumFieldRepository.php
@@ -8,6 +8,14 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Http\RequestScopedHolder;
 
+/**
+ * Per-type field-value repository (text/int/enum/bool/datetime).
+ *
+ * The five *Field modules are intentionally near-duplicated: NENE2 convention
+ * (explicit wiring over DRY; the framework ships zero abstract classes/traits),
+ * NOT debt. Do NOT extract a shared AbstractFieldRepository / trait / generic.
+ * Rationale: docs/development/backend-standards.md → "Intentional per-type duplication".
+ */
 final readonly class PdoEnumFieldRepository implements EnumFieldRepositoryInterface
 {
     /**

--- a/src/IntField/PdoIntFieldRepository.php
+++ b/src/IntField/PdoIntFieldRepository.php
@@ -8,6 +8,14 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Http\RequestScopedHolder;
 
+/**
+ * Per-type field-value repository (text/int/enum/bool/datetime).
+ *
+ * The five *Field modules are intentionally near-duplicated: NENE2 convention
+ * (explicit wiring over DRY; the framework ships zero abstract classes/traits),
+ * NOT debt. Do NOT extract a shared AbstractFieldRepository / trait / generic.
+ * Rationale: docs/development/backend-standards.md → "Intentional per-type duplication".
+ */
 final readonly class PdoIntFieldRepository implements IntFieldRepositoryInterface
 {
     /**

--- a/src/TextField/PdoTextFieldRepository.php
+++ b/src/TextField/PdoTextFieldRepository.php
@@ -8,6 +8,14 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Http\RequestScopedHolder;
 
+/**
+ * Per-type field-value repository (text/int/enum/bool/datetime).
+ *
+ * The five *Field modules are intentionally near-duplicated: NENE2 convention
+ * (explicit wiring over DRY; the framework ships zero abstract classes/traits),
+ * NOT debt. Do NOT extract a shared AbstractFieldRepository / trait / generic.
+ * Rationale: docs/development/backend-standards.md → "Intentional per-type duplication".
+ */
 final readonly class PdoTextFieldRepository implements TextFieldRepositoryInterface
 {
     /**


### PR DESCRIPTION
## 目的

`src/{Text,Int,Enum,Bool,DateTime}Field/` の5モジュールはほぼ同型の重複（各32クラス）で、見た開発者/AIエージェントが「技術的負債」と誤認し `AbstractFieldRepository`/Trait で抽象化しようとする恐れがある（#472）。

NENE2 一次資料の調査結論では、この重複は**負債ではなく NENE2 規約・思想への準拠**。その根拠を**すぐ判断できる場所**（PHPDoc ＋ 規約文書）に明記し、将来の誤った「DRY 化」を予防する。

## 変更内容

- **正本**: `docs/development/backend-standards.md` の `Module placement` 節に「**Intentional per-type duplication (field-type modules) — NOT debt**」サブセクションを追加。
  - NENE2 は明示性 > DRY（本体に `abstract class`/`trait` 0件・`why-explicit-wiring.md`/`domain-layer.md` 引用）
  - zero-tolerance ルール（層分割禁止・Shared kernel は ADR 必須）が通常の脱重複手段を既に塞いでいる
  - 抽象化が技術的にも不適: PHP ジェネリクス無し / TextField のみ signature 非統一（`locale`・`findByEntityTypeId`・`findByEntityIds`）/ 起動時 `instanceof` fail-fast が型ごとの具象 interface 前提
  - 型数が増えて手書き provider を超えるなら、抽象化ではなく「NENE2 適合性の再評価」が NENE2 流
  - 許容される整理: クラス内 private ヘルパ・コピペ命名の修正のみ。境界を越えるなら ADR
- **コード**: 5つの `Pdo{Type}FieldRepository` にクラス PHPDoc を追加（意図的・抽象化しない・正本へのポインタ）。

挙動・公開APIへの影響なし（ドキュメント/コメントのみ）。

## 検証

- `composer check` 全グリーン（PHPUnit 764 / PHPStan level 8 / **CS-Fixer も新 docblock を許容** / OpenAPI / MCP）。

## チェックリスト

- [x] Issue 駆動（#472）
- [x] `type/issue-number-summary` ブランチ
- [x] Conventional Commits（type/scope 英語・本文日本語・`(#472)`）
- [x] `composer check` 全グリーン

Closes #472

---
関連: #470/#471（命名残留の正名化）。本 PR は「なぜ重複したままで正しいか」の明文化。