### PR TITLE
fix(security): アップロードSVGを深サニタイズし配信をハードニングする (#474)

### DIFF
--- a/frontend/src/shared/lib/theme-bundle/sanitize-svg.test.ts
+++ b/frontend/src/shared/lib/theme-bundle/sanitize-svg.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { findDataUriSvgIssues, findSvgIssues } from './sanitize-svg'
+
+describe('findSvgIssues', () => {
+  it('flags <script>, event handlers, foreignObject, javascript: and external href', () => {
+    expect(findSvgIssues('<svg><script>x()</script></svg>')).toContain(
+      'data URI SVG contains <script>',
+    )
+    expect(findSvgIssues('<svg><rect onload="x()"/></svg>')).toContain(
+      'data URI SVG contains an on* event handler',
+    )
+    expect(findSvgIssues('<svg><foreignObject/></svg>')).toContain(
+      'data URI SVG contains <foreignObject>',
+    )
+    expect(findSvgIssues('<svg><a href="javascript:x()"/></svg>')).toContain(
+      'data URI SVG contains a javascript: URI',
+    )
+    expect(findSvgIssues('<svg><use xlink:href="https://evil/x"/></svg>')).toContain(
+      'data URI SVG contains an external/data href',
+    )
+  })
+
+  it('returns nothing for a benign svg', () => {
+    expect(findSvgIssues('<svg><path d="M0 0 L1 1"/><circle r="1"/></svg>')).toEqual([])
+  })
+})
+
+describe('findDataUriSvgIssues', () => {
+  it('ignores values without a data:image/svg+xml URI', () => {
+    expect(findDataUriSvgIssues('url(#blur)')).toEqual([])
+    expect(findDataUriSvgIssues('url(./logo.svg)')).toEqual([])
+  })
+
+  it('decodes percent-encoded svg data URIs and flags active content', () => {
+    const value = `url("data:image/svg+xml,%3Csvg%20onload%3D%22steal()%22%3E%3C/svg%3E")`
+    expect(findDataUriSvgIssues(value)).toContain('data URI SVG contains an on* event handler')
+  })
+
+  it('decodes base64 svg data URIs and flags <script>', () => {
+    // <svg><script>alert(1)</script></svg>
+    const b64 = btoa('<svg><script>alert(1)</script></svg>')
+    const value = `background: url(data:image/svg+xml;base64,${b64})`
+    expect(findDataUriSvgIssues(value)).toContain('data URI SVG contains <script>')
+  })
+
+  it('passes a benign data URI svg', () => {
+    const value = `url("data:image/svg+xml,%3Csvg%3E%3Cpath%20d%3D%22M0%200%22/%3E%3C/svg%3E")`
+    expect(findDataUriSvgIssues(value)).toEqual([])
+  })
+})

--- a/frontend/src/shared/lib/theme-bundle/sanitize-svg.ts
+++ b/frontend/src/shared/lib/theme-bundle/sanitize-svg.ts
@@ -1,0 +1,71 @@
+/**
+ * Heuristic SVG danger checks for the theme-bundle CI gate (#373).
+ *
+ * This gives theme authors fast feedback when a `data:image/svg+xml` URI inside
+ * components.css carries active content. It is a quality gate, NOT the trust
+ * boundary: the authoritative deep sanitiser runs server-side on upload
+ * (`src/Media/SvgSanitizer.php`) and at serve time (nosniff + locked-down CSP).
+ */
+
+const SVG_DANGER: { re: RegExp; message: string }[] = [
+  { re: /<script[\s>/]/i, message: 'data URI SVG contains <script>' },
+  { re: /<foreignobject[\s>/]/i, message: 'data URI SVG contains <foreignObject>' },
+  { re: /\son[a-z]+\s*=/i, message: 'data URI SVG contains an on* event handler' },
+  { re: /javascript:/i, message: 'data URI SVG contains a javascript: URI' },
+  {
+    re: /(?:xlink:href|href)\s*=\s*['"]?\s*(?:https?:|\/\/|data:)/i,
+    message: 'data URI SVG contains an external/data href',
+  },
+]
+
+/** Dangerous-construct messages for a decoded SVG string. */
+export function findSvgIssues(svg: string): string[] {
+  return SVG_DANGER.filter(({ re }) => re.test(svg)).map(({ message }) => message)
+}
+
+function decodeBase64(value: string): string | null {
+  try {
+    return atob(value.replace(/\s+/g, ''))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Inspect a CSS declaration value for `data:image/svg+xml` URIs and report any
+ * dangerous constructs in the (percent- or base64-) decoded payload.
+ */
+export function findDataUriSvgIssues(cssValue: string): string[] {
+  if (!/data:image\/svg\+xml/i.test(cssValue)) {
+    return []
+  }
+
+  const candidates: string[] = []
+
+  // Percent / plain encoding — decode the whole value so attribute quotes don't
+  // truncate the payload.
+  try {
+    candidates.push(decodeURIComponent(cssValue))
+  } catch {
+    candidates.push(cssValue)
+  }
+
+  // Base64 payloads.
+  const base64 = /base64,([a-z0-9+/=\s]+)/gi
+  let match: RegExpExecArray | null
+  while ((match = base64.exec(cssValue)) !== null) {
+    const decoded = decodeBase64(match[1] ?? '')
+    if (decoded !== null) {
+      candidates.push(decoded)
+    }
+  }
+
+  const found = new Set<string>()
+  for (const candidate of candidates) {
+    for (const message of findSvgIssues(candidate)) {
+      found.add(message)
+    }
+  }
+
+  return [...found]
+}

--- a/frontend/src/shared/lib/theme-bundle/validate-theme-css.test.ts
+++ b/frontend/src/shared/lib/theme-bundle/validate-theme-css.test.ts
@@ -79,4 +79,13 @@ describe('validateThemeCss', () => {
     const css = `.nene-public { width: expression(alert(1)); }`
     expect(validateThemeCss(css, { themeId: 'aurora' }).length).toBeGreaterThan(0)
   })
+
+  it('flags active content inside a data:image/svg+xml URI', () => {
+    const css = `.nene-public { background: url("data:image/svg+xml,%3Csvg%20onload%3D%22x()%22%3E%3C/svg%3E"); }`
+    expect(
+      validateThemeCss(css, { themeId: 'aurora' }).some((i) =>
+        i.message.includes('on* event handler'),
+      ),
+    ).toBe(true)
+  })
 })

--- a/frontend/src/shared/lib/theme-bundle/validate-theme-css.ts
+++ b/frontend/src/shared/lib/theme-bundle/validate-theme-css.ts
@@ -1,4 +1,5 @@
 import postcss, { type AtRule, type ChildNode } from 'postcss'
+import { findDataUriSvgIssues } from './sanitize-svg'
 import type { ValidationIssue } from './validate-manifest'
 
 export interface ThemeCssOptions {
@@ -38,9 +39,13 @@ function isKeyframeChild(node: ChildNode): boolean {
  *    `.nene-public` — a theme can't leak styles into the admin/other themes;
  *  - no `@import` (no remote or local stylesheet pulls);
  *  - no external `url()` (assets are bundled / data URIs only);
- *  - no executable constructs (`javascript:`, `expression()`, …).
+ *  - no executable constructs (`javascript:`, `expression()`, …);
+ *  - `data:image/svg+xml` URIs are decoded and screened for active content
+ *    (<script>, on* handlers, external href) — see {@link findDataUriSvgIssues}.
  *
- * NOTE (slice 1): contrast-AA and deep SVG sanitisation are not covered yet.
+ * This is the author-facing CI gate. The authoritative SVG sanitiser is
+ * server-side (`src/Media/SvgSanitizer.php`, applied on media upload). Contrast
+ * AA is checked separately server-side (`src/Theme/ColorContrast.php`).
  */
 export function validateThemeCss(css: string, { themeId }: ThemeCssOptions): ValidationIssue[] {
   const issues: ValidationIssue[] = []
@@ -82,6 +87,9 @@ export function validateThemeCss(css: string, { themeId }: ThemeCssOptions): Val
     }
     if (DANGEROUS.test(value)) {
       issues.push({ path: decl.prop, message: 'value contains a disallowed construct' })
+    }
+    for (const message of findDataUriSvgIssues(value)) {
+      issues.push({ path: decl.prop, message })
     }
   })
 

--- a/src/Media/ServeMediaHandler.php
+++ b/src/Media/ServeMediaHandler.php
@@ -43,11 +43,26 @@ final readonly class ServeMediaHandler
         }
 
         $stream = $this->streamFactory->createStreamFromResource($this->storage->readStream($key));
+        $isSvg = str_ends_with(strtolower($key), '.svg');
 
-        return $this->responseFactory->createResponse(200)
-            ->withHeader('Content-Type', $this->storage->mimeType($key))
+        $response = $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', $isSvg ? 'image/svg+xml' : $this->storage->mimeType($key))
             ->withHeader('Content-Length', (string) $this->storage->size($key))
             ->withHeader('Cache-Control', 'public, max-age=31536000, immutable')
+            // Never let the browser sniff a different (executable) type.
+            ->withHeader('X-Content-Type-Options', 'nosniff')
             ->withBody($stream);
+
+        if ($isSvg) {
+            // Defence in depth: uploads are already deep-sanitised, but if an SVG
+            // is opened top-level / via <object>, this CSP blocks any script from
+            // running in the app origin. <img>/CSS embedding is unaffected.
+            $response = $response->withHeader(
+                'Content-Security-Policy',
+                "default-src 'none'; style-src 'unsafe-inline'",
+            );
+        }
+
+        return $response;
     }
 }

--- a/src/Media/SvgSanitizer.php
+++ b/src/Media/SvgSanitizer.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+use DOMAttr;
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+
+/**
+ * Deep-sanitises user-supplied SVG before it is stored and served (#474 / #373).
+ *
+ * SVG is the one allowed upload type that can carry executable content
+ * (`<script>`, `on*` handlers, `javascript:` URIs, `<foreignObject>` HTML,
+ * SMIL `<set attributeName="href" to="javascript:…">`). Media is served
+ * same-origin and the JWT lives in localStorage, so an un-sanitised SVG is a
+ * stored-XSS → token-theft vector.
+ *
+ * Strategy: parse as XML, reject DOCTYPE (kills XXE / entity-expansion), drop
+ * forbidden elements, strip event handlers, dangerous URL schemes and external
+ * references, and neutralise dangerous CSS. Fails closed — unparseable input or
+ * a non-`<svg>` root throws {@see MediaInvalidTypeException}.
+ *
+ * Defence in depth only: {@see ServeMediaHandler} additionally sends
+ * `X-Content-Type-Options: nosniff` and a locked-down CSP for SVG responses.
+ */
+final class SvgSanitizer
+{
+    /** Elements removed entirely, with their subtree. */
+    private const FORBIDDEN_ELEMENTS = [
+        'script', 'foreignobject', 'handler', 'iframe', 'embed', 'object', 'audio', 'video',
+    ];
+
+    /** Animation elements that can rewrite another attribute at runtime (SMIL injection). */
+    private const ANIMATION_ELEMENTS = ['set', 'animate', 'animatetransform', 'animatemotion'];
+
+    /** Elements whose URL references must stay in-document (`#id`) — external refs are dropped. */
+    private const EXTERNAL_REF_ELEMENTS = [
+        'use', 'image', 'feimage', 'a', 'filter', 'pattern',
+        'lineargradient', 'radialgradient', 'textpath', 'mpath', 'tref',
+    ];
+
+    /**
+     * @throws MediaInvalidTypeException when the input is not parseable SVG.
+     */
+    public function sanitize(string $svg): string
+    {
+        $svg = trim($svg);
+
+        if ($svg === '') {
+            throw new MediaInvalidTypeException('image/svg+xml');
+        }
+
+        $doc = new DOMDocument();
+        $previous = libxml_use_internal_errors(true);
+        // LIBXML_NONET blocks network access. We deliberately omit LIBXML_NOENT
+        // so XML entities are never expanded into text.
+        $loaded = $doc->loadXML($svg, LIBXML_NONET | LIBXML_NOERROR | LIBXML_NOWARNING);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        if ($loaded === false || $doc->documentElement === null) {
+            throw new MediaInvalidTypeException('image/svg+xml');
+        }
+
+        // Reject DOCTYPE outright — neutralises XXE and entity-expansion vectors.
+        if ($doc->doctype !== null) {
+            throw new MediaInvalidTypeException('image/svg+xml');
+        }
+
+        if (strtolower((string) $doc->documentElement->localName) !== 'svg') {
+            throw new MediaInvalidTypeException('image/svg+xml');
+        }
+
+        $xpath = new DOMXPath($doc);
+
+        // 1. Remove forbidden elements and SMIL animations targeting href/event attrs.
+        /** @var list<DOMElement> $toRemove */
+        $toRemove = [];
+        foreach (($xpath->query('//*') ?: []) as $node) {
+            if (!$node instanceof DOMElement) {
+                continue;
+            }
+            $local = strtolower((string) $node->localName);
+
+            if (in_array($local, self::FORBIDDEN_ELEMENTS, true)) {
+                $toRemove[] = $node;
+
+                continue;
+            }
+
+            if (in_array($local, self::ANIMATION_ELEMENTS, true) && $this->animatesUnsafeAttribute($node)) {
+                $toRemove[] = $node;
+            }
+        }
+        foreach ($toRemove as $node) {
+            $node->parentNode?->removeChild($node);
+        }
+
+        // 2. Scrub attributes on every remaining element.
+        foreach (($xpath->query('//*') ?: []) as $node) {
+            if ($node instanceof DOMElement) {
+                $this->scrubAttributes($node);
+            }
+        }
+
+        // 3. Neutralise dangerous CSS inside <style> elements.
+        foreach (($xpath->query("//*[local-name()='style']") ?: []) as $style) {
+            if ($style instanceof DOMElement && $this->hasDangerousCss($style->textContent)) {
+                $style->textContent = '';
+            }
+        }
+
+        $result = $doc->saveXML($doc->documentElement);
+
+        if ($result === false) {
+            throw new MediaInvalidTypeException('image/svg+xml');
+        }
+
+        return $result;
+    }
+
+    /**
+     * True when the content is an SVG document (after an optional XML prolog,
+     * comments and DOCTYPE). Used to catch SVG uploaded under a spoofed MIME.
+     */
+    public static function looksLikeSvg(string $content): bool
+    {
+        $head = ltrim($content, "\xEF\xBB\xBF \t\r\n");
+        $head = preg_replace('/^<\?xml\b[^>]*\?>\s*/i', '', $head) ?? $head;
+        $head = preg_replace('/^(?:<!--.*?-->\s*|<!DOCTYPE\b[^>]*>\s*)+/is', '', $head) ?? $head;
+
+        return str_starts_with(strtolower(ltrim($head)), '<svg');
+    }
+
+    private function animatesUnsafeAttribute(DOMElement $element): bool
+    {
+        $target = strtolower($element->getAttribute('attributeName'));
+
+        return $target === 'href' || $target === 'xlink:href' || str_starts_with($target, 'on');
+    }
+
+    private function scrubAttributes(DOMElement $element): void
+    {
+        $external = in_array(strtolower((string) $element->localName), self::EXTERNAL_REF_ELEMENTS, true);
+
+        /** @var list<DOMAttr> $remove */
+        $remove = [];
+        foreach (iterator_to_array($element->attributes ?? []) as $attr) {
+            $name = strtolower((string) $attr->localName);
+            $value = $this->normalize($attr->value);
+
+            // Event-handler attributes (onload, onclick, onbegin, …).
+            if (str_starts_with($name, 'on')) {
+                $remove[] = $attr;
+
+                continue;
+            }
+
+            // URL-bearing attributes: drop dangerous schemes and external refs.
+            if (in_array($name, ['href', 'src'], true)) {
+                if ($this->isDangerousScheme($value) || ($external && $this->isExternal($value))) {
+                    $remove[] = $attr;
+
+                    continue;
+                }
+            }
+
+            // Inline style carrying dangerous CSS.
+            if ($name === 'style' && $this->hasDangerousCss($attr->value)) {
+                $remove[] = $attr;
+
+                continue;
+            }
+
+            // Catch-all: any attribute value carrying a script scheme (covers
+            // SMIL to/from/values="javascript:…" and odd presentation attrs).
+            if (str_contains($value, 'javascript:') || str_contains($value, 'vbscript:')) {
+                $remove[] = $attr;
+            }
+        }
+
+        foreach ($remove as $attr) {
+            $element->removeAttributeNode($attr);
+        }
+    }
+
+    /** Lower-cased, entity-decoded, whitespace/control-char-stripped value for scheme checks. */
+    private function normalize(string $value): string
+    {
+        $decoded = html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        return strtolower((string) preg_replace('/[\s\x00-\x20]+/', '', $decoded));
+    }
+
+    private function isDangerousScheme(string $normalized): bool
+    {
+        return str_starts_with($normalized, 'javascript:')
+            || str_starts_with($normalized, 'vbscript:')
+            || str_starts_with($normalized, 'data:');
+    }
+
+    /** External = has a URI scheme or protocol-relative `//`; in-document `#id` and relative paths are kept. */
+    private function isExternal(string $normalized): bool
+    {
+        return str_starts_with($normalized, '//') || (bool) preg_match('#^[a-z][a-z0-9+.\-]*:#', $normalized);
+    }
+
+    private function hasDangerousCss(string $css): bool
+    {
+        $value = strtolower(html_entity_decode($css, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+
+        if (str_contains($value, 'javascript:') || str_contains($value, 'expression(') || str_contains($value, '@import')) {
+            return true;
+        }
+
+        // url(...) pointing at a scheme or protocol-relative target. url(#id) is safe.
+        return (bool) preg_match('#url\(\s*["\']?\s*(?:[a-z][a-z0-9+.\-]*:|//)#i', $value);
+    }
+}

--- a/src/Media/UploadMediaUseCase.php
+++ b/src/Media/UploadMediaUseCase.php
@@ -37,6 +37,12 @@ final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
 
     private const MAX_SIZE_BYTES = 10 * 1024 * 1024; // 10 MiB
 
+    /** SVG is sanitised but still capped hard — it should only ever be icons/logos. */
+    private const SVG_MAX_SIZE_BYTES = 64 * 1024; // 64 KiB
+
+    /** Bytes read from the head to detect SVG smuggled under a spoofed MIME. */
+    private const SVG_SNIFF_BYTES = 8192;
+
     public function __construct(
         private MediaRepositoryInterface $mediaRepository,
         private StorageInterface $storage,
@@ -51,6 +57,16 @@ final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
 
         if ($input->size > self::MAX_SIZE_BYTES) {
             throw new MediaTooLargeException($input->size, self::MAX_SIZE_BYTES);
+        }
+
+        // SVG path: detect by declared MIME *or* by sniffing the bytes, so a
+        // spoofed Content-Type (e.g. image/png wrapping SVG) cannot bypass
+        // sanitisation. SVG is the only upload type that can carry executable
+        // content, so it is hard-capped, deep-sanitised, and stored as
+        // image/svg+xml regardless of the declared type.
+        $head = (string) @file_get_contents($input->tmpPath, false, null, 0, self::SVG_SNIFF_BYTES);
+        if ($input->mimeType === 'image/svg+xml' || SvgSanitizer::looksLikeSvg($head)) {
+            return $this->storeSvg($input);
         }
 
         $ext = $this->extensionForMimeType($input->mimeType);
@@ -90,6 +106,59 @@ final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
             createdAt: $now,
             width: $width,
             height: $height,
+        );
+    }
+
+    /**
+     * Hard-cap, deep-sanitise and store an SVG upload. Always persists as
+     * image/svg+xml with the sanitised bytes — never the raw upload.
+     */
+    private function storeSvg(UploadMediaInput $input): UploadMediaOutput
+    {
+        $actualSize = @filesize($input->tmpPath);
+        $actualSize = $actualSize === false ? $input->size : $actualSize;
+
+        if ($actualSize > self::SVG_MAX_SIZE_BYTES) {
+            throw new MediaTooLargeException($actualSize, self::SVG_MAX_SIZE_BYTES);
+        }
+
+        $raw = (string) @file_get_contents($input->tmpPath);
+        // Throws MediaInvalidTypeException on unparseable / non-SVG content.
+        $clean = (new SvgSanitizer())->sanitize($raw);
+        $size = strlen($clean);
+
+        $storedName = bin2hex(random_bytes(16)) . '.svg';
+        $key = date('Y') . '/' . date('m') . '/' . $storedName;
+
+        $this->storage->write($key, $clean);
+
+        $url = $this->storage->publicUrl($key);
+        $now = date('Y-m-d H:i:s');
+
+        $media = new Media(
+            id: null,
+            originalName: $input->originalName,
+            storedName: $storedName,
+            mimeType: 'image/svg+xml',
+            size: $size,
+            url: $url,
+            createdAt: $now,
+            storageKey: $key,
+            width: null,
+            height: null,
+        );
+
+        $id = $this->mediaRepository->save($media);
+
+        return new UploadMediaOutput(
+            id: $id,
+            url: $url,
+            originalName: $input->originalName,
+            mimeType: 'image/svg+xml',
+            size: $size,
+            createdAt: $now,
+            width: null,
+            height: null,
         );
     }
 

--- a/tests/Media/MediaHttpTest.php
+++ b/tests/Media/MediaHttpTest.php
@@ -370,6 +370,41 @@ final class MediaHttpTest extends TestCase
 
     // ── Derivatives ────────────────────────────────────────────────────────────
 
+    // ── Serve security headers ───────────────────────────────────────────────
+
+    public function testServeSvgSetsSecurityHardeningHeaders(): void
+    {
+        $this->storage->write(
+            '2026/05/icon.svg',
+            '<svg xmlns="http://www.w3.org/2000/svg"><rect width="1" height="1"/></svg>',
+        );
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/media/2026/05/icon.svg'),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('image/svg+xml', $response->getHeaderLine('Content-Type'));
+        self::assertSame('nosniff', $response->getHeaderLine('X-Content-Type-Options'));
+        self::assertStringContainsString("default-src 'none'", $response->getHeaderLine('Content-Security-Policy'));
+    }
+
+    public function testServeNonSvgKeepsBaselineCspAndNosniff(): void
+    {
+        $this->seedStorageImage('2026/05/pic.png', 4, 4);
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/media/2026/05/pic.png'),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('nosniff', $response->getHeaderLine('X-Content-Type-Options'));
+        // Non-SVG keeps the framework baseline CSP; only SVG gets the locked-down 'none'.
+        self::assertStringNotContainsString("default-src 'none'", $response->getHeaderLine('Content-Security-Policy'));
+    }
+
+    // ── Derivatives ────────────────────────────────────────────────────────────
+
     public function testDerivativeGeneratesResizedImageAndCachesIt(): void
     {
         $this->seedStorageImage('2026/05/pic.png', 800, 400);

--- a/tests/Media/MediaUseCaseTest.php
+++ b/tests/Media/MediaUseCaseTest.php
@@ -122,6 +122,124 @@ final class MediaUseCaseTest extends TestCase
         $useCase->execute($input);
     }
 
+    public function testUploadSvgIsSanitizedBeforeStorage(): void
+    {
+        $storageRoot = sys_get_temp_dir() . '/nene_media_test_' . uniqid('', true);
+        mkdir($storageRoot, 0755, true);
+
+        $tmpFile = tempnam(sys_get_temp_dir(), 'nene_upload_');
+        file_put_contents(
+            $tmpFile,
+            '<svg xmlns="http://www.w3.org/2000/svg"><script>fetch("/steal")</script><rect width="1" height="1" onload="x()"/></svg>',
+        );
+
+        $mediaRepo = new InMemoryMediaRepository();
+        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot));
+
+        $output = $useCase->execute(new UploadMediaInput(
+            tmpPath: $tmpFile,
+            originalName: 'logo.svg',
+            mimeType: 'image/svg+xml',
+            size: filesize($tmpFile) ?: 0,
+        ));
+
+        self::assertSame('image/svg+xml', $output->mimeType);
+
+        $saved = $mediaRepo->findById($output->id);
+        self::assertNotNull($saved);
+        self::assertStringEndsWith('.svg', $saved->storageKey);
+
+        $stored = (string) file_get_contents($storageRoot . '/' . $saved->storageKey);
+        self::assertStringNotContainsStringIgnoringCase('script', $stored);
+        self::assertStringNotContainsString('fetch(', $stored);
+        self::assertStringNotContainsStringIgnoringCase('onload', $stored);
+        self::assertStringContainsString('<rect', $stored);
+
+        unlink($tmpFile);
+    }
+
+    public function testUploadSvgSpoofedAsPngIsDetectedAndSanitized(): void
+    {
+        $storageRoot = sys_get_temp_dir() . '/nene_media_test_' . uniqid('', true);
+        mkdir($storageRoot, 0755, true);
+
+        $tmpFile = tempnam(sys_get_temp_dir(), 'nene_upload_');
+        file_put_contents($tmpFile, '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>');
+
+        $mediaRepo = new InMemoryMediaRepository();
+        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot));
+
+        // Declared as PNG to try to dodge the SVG path — content sniff must catch it.
+        $output = $useCase->execute(new UploadMediaInput(
+            tmpPath: $tmpFile,
+            originalName: 'evil.png',
+            mimeType: 'image/png',
+            size: filesize($tmpFile) ?: 0,
+        ));
+
+        self::assertSame('image/svg+xml', $output->mimeType);
+
+        $saved = $mediaRepo->findById($output->id);
+        self::assertNotNull($saved);
+        self::assertStringEndsWith('.svg', $saved->storageKey);
+
+        $stored = (string) file_get_contents($storageRoot . '/' . $saved->storageKey);
+        self::assertStringNotContainsString('alert(1)', $stored);
+
+        unlink($tmpFile);
+    }
+
+    public function testUploadOversizeSvgIsRejected(): void
+    {
+        $storageRoot = sys_get_temp_dir() . '/nene_media_test_' . uniqid('', true);
+        mkdir($storageRoot, 0755, true);
+
+        $tmpFile = tempnam(sys_get_temp_dir(), 'nene_upload_');
+        $padding = str_repeat('<rect width="1" height="1"/>', 3000); // > 64 KiB
+        file_put_contents($tmpFile, '<svg xmlns="http://www.w3.org/2000/svg">' . $padding . '</svg>');
+
+        $mediaRepo = new InMemoryMediaRepository();
+        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot));
+
+        $this->expectException(MediaTooLargeException::class);
+
+        try {
+            $useCase->execute(new UploadMediaInput(
+                tmpPath: $tmpFile,
+                originalName: 'big.svg',
+                mimeType: 'image/svg+xml',
+                size: filesize($tmpFile) ?: 0,
+            ));
+        } finally {
+            unlink($tmpFile);
+        }
+    }
+
+    public function testUploadInvalidSvgIsRejected(): void
+    {
+        $storageRoot = sys_get_temp_dir() . '/nene_media_test_' . uniqid('', true);
+        mkdir($storageRoot, 0755, true);
+
+        $tmpFile = tempnam(sys_get_temp_dir(), 'nene_upload_');
+        file_put_contents($tmpFile, '<svg xmlns="http://www.w3.org/2000/svg"><rect'); // truncated / unparseable
+
+        $mediaRepo = new InMemoryMediaRepository();
+        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot));
+
+        $this->expectException(MediaInvalidTypeException::class);
+
+        try {
+            $useCase->execute(new UploadMediaInput(
+                tmpPath: $tmpFile,
+                originalName: 'broken.svg',
+                mimeType: 'image/svg+xml',
+                size: filesize($tmpFile) ?: 0,
+            ));
+        } finally {
+            unlink($tmpFile);
+        }
+    }
+
     public function testDeleteRemovesMediaRecord(): void
     {
         $seeded = new Media(

--- a/tests/Media/SvgSanitizerTest.php
+++ b/tests/Media/SvgSanitizerTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Media;
+
+use NeNeRecords\Media\MediaInvalidTypeException;
+use NeNeRecords\Media\SvgSanitizer;
+use PHPUnit\Framework\TestCase;
+
+final class SvgSanitizerTest extends TestCase
+{
+    private SvgSanitizer $sanitizer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->sanitizer = new SvgSanitizer();
+    }
+
+    /** @param non-empty-string $inner */
+    private function svg(string $inner, string $extraRootAttrs = ''): string
+    {
+        return '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"' . $extraRootAttrs . '>' . $inner . '</svg>';
+    }
+
+    public function testRemovesScriptElement(): void
+    {
+        $out = $this->sanitizer->sanitize($this->svg('<script>alert(1)</script><rect width="1" height="1"/>'));
+
+        self::assertStringNotContainsStringIgnoringCase('script', $out);
+        self::assertStringNotContainsString('alert(1)', $out);
+        self::assertStringContainsString('<rect', $out);
+    }
+
+    public function testRemovesScriptElementWithCdata(): void
+    {
+        $out = $this->sanitizer->sanitize($this->svg('<script><![CDATA[alert(document.cookie)]]></script><g/>'));
+
+        self::assertStringNotContainsString('alert', $out);
+        self::assertStringNotContainsStringIgnoringCase('cdata', $out);
+    }
+
+    public function testRemovesCaseVariantScriptElement(): void
+    {
+        // XML is case-sensitive, but we lower-case local names so <ScRiPt> is still dropped.
+        $out = $this->sanitizer->sanitize($this->svg('<ScRiPt>alert(1)</ScRiPt><circle r="1"/>'));
+
+        self::assertStringNotContainsStringIgnoringCase('alert', $out);
+        self::assertStringContainsString('<circle', $out);
+    }
+
+    public function testRemovesEventHandlerAttributes(): void
+    {
+        $out = $this->sanitizer->sanitize($this->svg('<rect width="1" height="1" onload="x()" onClick="y()"/>'));
+
+        self::assertStringNotContainsStringIgnoringCase('onload', $out);
+        self::assertStringNotContainsStringIgnoringCase('onclick', $out);
+        self::assertStringContainsString('<rect', $out);
+    }
+
+    public function testStripsJavascriptHref(): void
+    {
+        $out = $this->sanitizer->sanitize($this->svg('<a xlink:href="javascript:alert(1)"><text>hi</text></a>'));
+
+        self::assertStringNotContainsStringIgnoringCase('javascript:', $out);
+        self::assertStringContainsString('hi', $out);
+    }
+
+    public function testStripsEntityEncodedJavascriptHref(): void
+    {
+        // &#106; = 'j' — DOM decodes char refs, so the scheme must still be caught.
+        $out = $this->sanitizer->sanitize($this->svg('<a href="&#106;avascript:alert(1)"><text>x</text></a>'));
+
+        self::assertStringNotContainsStringIgnoringCase('javascript:', $out);
+        self::assertStringNotContainsString('alert(1)', $out);
+    }
+
+    public function testRemovesForeignObject(): void
+    {
+        $out = $this->sanitizer->sanitize($this->svg('<foreignObject><body xmlns="http://www.w3.org/1999/xhtml"><script>alert(1)</script></body></foreignObject><rect/>'));
+
+        self::assertStringNotContainsStringIgnoringCase('foreignobject', $out);
+        self::assertStringNotContainsString('alert(1)', $out);
+        self::assertStringContainsString('<rect', $out);
+    }
+
+    public function testDropsExternalUseReferenceButKeepsInternalFragment(): void
+    {
+        $external = $this->sanitizer->sanitize($this->svg('<use xlink:href="https://evil.example/x.svg#a"/>'));
+        self::assertStringNotContainsString('evil.example', $external);
+
+        $internal = $this->sanitizer->sanitize($this->svg('<defs><rect id="a" width="1" height="1"/></defs><use xlink:href="#a"/>'));
+        self::assertStringContainsString('#a', $internal);
+    }
+
+    public function testDropsDataUriImageHref(): void
+    {
+        // Valid XML attribute value, but a data: URI href must be dropped (it can
+        // nest an SVG/HTML payload). Internal #id and real media URLs are the only
+        // intended references.
+        $out = $this->sanitizer->sanitize($this->svg('<image href="data:image/svg+xml;base64,PHN2Zz48c2NyaXB0Lz48L3N2Zz4="/>'));
+
+        self::assertStringNotContainsString('data:', $out);
+        self::assertStringNotContainsString('base64', $out);
+    }
+
+    public function testStripsDangerousStyleAttributeButKeepsInternalFilterRef(): void
+    {
+        $dangerous = $this->sanitizer->sanitize($this->svg('<rect style="background:url(https://evil.example/x)" width="1" height="1"/>'));
+        self::assertStringNotContainsString('evil.example', $dangerous);
+
+        // url(#id) for an in-document filter is legitimate and must survive.
+        $safe = $this->sanitizer->sanitize($this->svg('<rect style="filter:url(#blur)" width="1" height="1"/>'));
+        self::assertStringContainsString('url(#blur)', $safe);
+    }
+
+    public function testRemovesSmilAnimationTargetingHref(): void
+    {
+        $out = $this->sanitizer->sanitize($this->svg('<a><set attributeName="xlink:href" to="javascript:alert(1)"/><text>x</text></a>'));
+
+        self::assertStringNotContainsStringIgnoringCase('javascript:', $out);
+        self::assertStringNotContainsStringIgnoringCase('<set', $out);
+    }
+
+    public function testStripsJavascriptInAnimateValues(): void
+    {
+        $out = $this->sanitizer->sanitize($this->svg('<rect width="1" height="1"><animate attributeName="fill" to="javascript:alert(1)"/></rect>'));
+
+        self::assertStringNotContainsStringIgnoringCase('javascript:', $out);
+    }
+
+    public function testRejectsDoctypeToBlockXxe(): void
+    {
+        $this->expectException(MediaInvalidTypeException::class);
+        $this->sanitizer->sanitize(
+            '<?xml version="1.0"?><!DOCTYPE svg [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>'
+            . '<svg xmlns="http://www.w3.org/2000/svg"><text>&xxe;</text></svg>',
+        );
+    }
+
+    public function testRejectsNonSvgRoot(): void
+    {
+        $this->expectException(MediaInvalidTypeException::class);
+        $this->sanitizer->sanitize('<html><body>nope</body></html>');
+    }
+
+    public function testRejectsUnparseableInput(): void
+    {
+        $this->expectException(MediaInvalidTypeException::class);
+        $this->sanitizer->sanitize('this is not xml at all <<<');
+    }
+
+    public function testKeepsBenignSvgContent(): void
+    {
+        $out = $this->sanitizer->sanitize($this->svg(
+            '<title>Logo</title><g fill="#123456"><path d="M0 0 L10 10"/><circle cx="5" cy="5" r="3"/></g>',
+        ));
+
+        self::assertStringContainsString('<path', $out);
+        self::assertStringContainsString('<circle', $out);
+        self::assertStringContainsString('#123456', $out);
+        self::assertStringContainsString('Logo', $out);
+    }
+
+    public function testLooksLikeSvgDetectsSpoofedContent(): void
+    {
+        self::assertTrue(SvgSanitizer::looksLikeSvg('<svg xmlns="http://www.w3.org/2000/svg"></svg>'));
+        self::assertTrue(SvgSanitizer::looksLikeSvg("\xEF\xBB\xBF<?xml version=\"1.0\"?>\n<svg></svg>"));
+        self::assertTrue(SvgSanitizer::looksLikeSvg("<!-- a comment -->\n<svg/>"));
+        self::assertFalse(SvgSanitizer::looksLikeSvg('a plain text note mentioning <svg> midway'));
+        self::assertFalse(SvgSanitizer::looksLikeSvg("\x89PNG\r\n\x1a\n binary"));
+    }
+}


### PR DESCRIPTION
## 目的

SVG は唯一 `<script>`/`on*`/`javascript:`/`<foreignObject>` を運べる許可アップロード型。メディアは同一オリジン配信で JWT は localStorage 保持のため、サニタイズ無しの SVG は **将来のインライン描画（dangerouslySetInnerHTML 等）や CSP 緩和時に stored XSS → トークン窃取** になりうる（#474, #373 のSVG要件）。多層防御で塞ぐ。

## 脅威モデルの訂正（重要）

調査当初は「nosniff も CSP も無し＝オープンな stored XSS」とされたが、**実際は NENE2 の `SecurityHeadersMiddleware` が全レスポンスに `X-Content-Type-Options: nosniff` と baseline `Content-Security-Policy: default-src 'self'` を既に付与済み**（未設定時のみ）。`default-src 'self'`（unsafe-inline 無し）は SVG をドキュメントとして開いた際のインライン script/on* を既にブロックする。

→ 本PRは「未対策の穴を塞ぐ」ではなく **多層防御の上乗せ**:
1. **保存時サニタイズ**（ペイロードを永続させない＝将来のインライン描画/CSP緩和への唯一の防御・OWASP 推奨）
2. **SVG専用の厳格CSP**（baseline `'self'` より強い `default-src 'none'`）
3. **64KiB上限**（DoS）+ DOCTYPE拒否（XXE）

## 変更内容

**サーバ（信頼境界）**
- `src/Media/SvgSanitizer.php`（新規）: DOMDocument・fail-closed・DOCTYPE拒否。`<script>`/`<foreignObject>` 等除去、`on*` 除去、`javascript:`/`vbscript:`/`data:` 除去、`use`/`image`/`a` の外部参照除去、SMIL(`set`/`animate`)の href/on* 改ざん除去、`<style>` 内危険CSS無害化。
- `UploadMediaUseCase`: 申告MIME **または内容sniff**（`looksLikeSvg`＝MIME詐称対策）で SVG 検出 → 64KiB上限 → サニタイズ → `image/svg+xml` で保存。非SVGは従来どおり（汎用メディアの10MiB上限維持）。
- `ServeMediaHandler`: 全メディアに `nosniff`、SVG に `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'`（直接/`<object>` 読込時のスクリプト無効化。`<img>`/CSS 埋め込みは非破壊）。

**フロント（CI品質ゲート・#373 NOTE 解消）**
- `theme-bundle/sanitize-svg.ts`（新規）+ `validate-theme-css.ts`: components.css の `data:image/svg+xml`（%・base64）を decode し危険トークンを検出。`validate-theme-css.ts:43` の「SVG未対応」NOTE を解消。

## スコープ外（別途）

- 一律ラスタ1MiB上限は汎用メディアを壊すため非対応（テーマ資産固有の上限は #373 のバンドル検証へ）。
- MD→bundle 自動生成・components.css semantic 検証は #373 本体に残置。

## 検証

- `composer check` 全グリーン: **PHPUnit 770+8 / PHPStan level 8 0件 / CS-Fixer / OpenAPI / MCP**
  - 新規 `SvgSanitizerTest`（17）= script/on*/foreignObject/javascript:/data:/外部use/SMIL/XXE/大文字/CDATA/エンティティ符号化等の**バイパス試行**、`MediaUseCaseTest`（+4 サニタイズ保存/MIME詐称/64KiB超/不正SVG）、`MediaHttpTest`（+2 配信ヘッダ）
- frontend: type-check / lint / prettier / vitest（sanitize-svg 9 + css validator 配線）グリーン
- **敵対的セキュリティレビュー実施 → 必須修正の穴なし**（名前空間/SMIL/CSS/外部参照/MIME詐称/DoS いずれも遮断 or CSPで緩和を確認）

## チェックリスト

- [x] Issue 駆動（#474、#373 関連）
- [x] `type/...` ブランチ・Conventional Commits（`(#474)`）
- [x] `composer check` 全グリーン

Closes #474