### PR TITLE
feat(appearance): カスタマイザに見出し/モノスペースフォントのノブを追加する (#372)

### DIFF
--- a/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
+++ b/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
@@ -2,10 +2,12 @@ import { type ReactNode, useState } from 'react'
 import { useTranslation } from '@/shared/i18n'
 import {
   DENSITY_OPTIONS,
+  DISPLAY_FONT_OPTIONS,
   FLAG_DEFS,
   FONT_OPTIONS,
   FONT_SIZE_OPTIONS,
   GUTTER_OPTIONS,
+  MONO_FONT_OPTIONS,
   RADIUS_OPTIONS,
   TYPE_SCALE_OPTIONS,
   WIDTH_OPTIONS,
@@ -181,6 +183,26 @@ export function ThemeCustomizeView({
               placeholder={themePlaceholder}
               onChange={(v) => {
                 setKnob('fontBody', v)
+              }}
+            />
+          </Field>
+          <Field label={t('admin.themeCustomize.fontDisplay')}>
+            <Select
+              value={draft.fontDisplay}
+              options={DISPLAY_FONT_OPTIONS}
+              placeholder={themePlaceholder}
+              onChange={(v) => {
+                setKnob('fontDisplay', v)
+              }}
+            />
+          </Field>
+          <Field label={t('admin.themeCustomize.fontMono')}>
+            <Select
+              value={draft.fontMono}
+              options={MONO_FONT_OPTIONS}
+              placeholder={themePlaceholder}
+              onChange={(v) => {
+                setKnob('fontMono', v)
               }}
             />
           </Field>

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -80,6 +80,8 @@ export const en = {
   'admin.themeCustomize.surface': 'Surface (light / dark)',
   'admin.themeCustomize.text': 'Text (light / dark)',
   'admin.themeCustomize.font': 'Body font',
+  'admin.themeCustomize.fontDisplay': 'Display font',
+  'admin.themeCustomize.fontMono': 'Mono font',
   'admin.themeCustomize.width': 'Content width',
   'admin.themeCustomize.gutter': 'Side margin',
   'admin.themeCustomize.radius': 'Corners',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -73,6 +73,8 @@ export const ja: Partial<MessageCatalog> = {
   'admin.themeCustomize.surface': '背景（light / dark）',
   'admin.themeCustomize.text': '文字（light / dark）',
   'admin.themeCustomize.font': '本文フォント',
+  'admin.themeCustomize.fontDisplay': '見出しフォント',
+  'admin.themeCustomize.fontMono': 'モノスペースフォント',
   'admin.themeCustomize.width': 'コンテンツ幅',
   'admin.themeCustomize.gutter': '左右余白',
   'admin.themeCustomize.radius': '角丸',

--- a/frontend/src/shared/lib/theme-customization.test.ts
+++ b/frontend/src/shared/lib/theme-customization.test.ts
@@ -25,6 +25,18 @@ describe('resolveOverrideStyle', () => {
     expect(style['--radius-md']).toBe('2px')
   })
 
+  it('emits display and mono font variables for valid keys', () => {
+    const style = resolveOverrideStyle({ fontDisplay: 'playfair', fontMono: 'space-mono' })
+    expect(style['--font-display']).toContain('Playfair Display')
+    expect(style['--font-mono']).toContain('Space Mono')
+  })
+
+  it('ignores unknown display / mono font keys', () => {
+    const style = resolveOverrideStyle({ fontDisplay: 'evil-font', fontMono: 'evil-font' })
+    expect(style['--font-display']).toBeUndefined()
+    expect(style['--font-mono']).toBeUndefined()
+  })
+
   it('ignores invalid / unknown values (no injection)', () => {
     const style = resolveOverrideStyle({
       accent: 'red; } body { display:none',

--- a/frontend/src/shared/lib/theme-customization.ts
+++ b/frontend/src/shared/lib/theme-customization.ts
@@ -7,8 +7,8 @@
  * override the active theme's tokens). Values are constrained/sanitised here —
  * we only ever emit known CSS variables with validated values, never raw input.
  *
- * Knobs: accent (色) / body font (フォント) / content width (幅) / gutter (余白)
- * / radius (角丸) / font size × type scale (→ `--text-*`) / density (→ `--space-*`).
+ * Knobs: accent (色) / body・display・mono font (フォント) / content width (幅)
+ * / gutter (余白) / radius (角丸) / font size × type scale (→ `--text-*`) / density (→ `--space-*`).
  * Derived tokens that reference these (e.g. `--color-accent-weak`) auto-follow.
  */
 
@@ -18,6 +18,10 @@ export interface ThemeOverrides {
   accent?: string
   /** Body font key (see FONT_OPTIONS). Maps to `--font-sans`. */
   fontBody?: string
+  /** Display/heading font key (see DISPLAY_FONT_OPTIONS). Maps to `--font-display`. */
+  fontDisplay?: string
+  /** Mono/eyebrow font key (see MONO_FONT_OPTIONS). Maps to `--font-mono`. */
+  fontMono?: string
   /** Content width preset key (see WIDTH_OPTIONS). Maps to `--content-w`. */
   contentWidth?: string
   /** Gutter preset key (see GUTTER_OPTIONS). Maps to `--gutter`. */
@@ -212,6 +216,36 @@ const FONT_STACKS: Record<string, string> = {
   system: 'ui-sans-serif, system-ui, sans-serif',
 }
 
+/** Display/heading font allowlist (→ `--font-display`). All self-hosted via @fontsource. */
+export const DISPLAY_FONT_OPTIONS: readonly KnobOption[] = [
+  { value: 'playfair', label: 'Playfair Display (serif)' },
+  { value: 'bricolage', label: 'Bricolage Grotesque' },
+  { value: 'archivo', label: 'Archivo' },
+  { value: 'oswald', label: 'Oswald' },
+  { value: 'source-serif', label: 'Source Serif 4 (serif)' },
+  { value: 'system', label: 'System sans' },
+]
+
+const DISPLAY_FONT_STACKS: Record<string, string> = {
+  playfair: "'Playfair Display', Georgia, 'Times New Roman', serif",
+  bricolage: "'Bricolage Grotesque', 'Noto Sans JP', system-ui, sans-serif",
+  archivo: "'Archivo', 'Arial Narrow', system-ui, sans-serif",
+  oswald: "'Oswald', 'Noto Sans JP', system-ui, sans-serif",
+  'source-serif': "'Source Serif 4', 'Noto Serif JP', Georgia, serif",
+  system: 'ui-sans-serif, system-ui, sans-serif',
+}
+
+/** Mono/eyebrow font allowlist (→ `--font-mono`). All self-hosted via @fontsource. */
+export const MONO_FONT_OPTIONS: readonly KnobOption[] = [
+  { value: 'space-mono', label: 'Space Mono' },
+  { value: 'system', label: 'System mono' },
+]
+
+const MONO_FONT_STACKS: Record<string, string> = {
+  'space-mono': "'Space Mono', ui-monospace, 'Cascadia Code', monospace",
+  system: "ui-monospace, 'Cascadia Code', 'Courier New', monospace",
+}
+
 export const WIDTH_OPTIONS: readonly KnobOption[] = [
   { value: 'narrow', label: 'Narrow' },
   { value: 'default', label: 'Default' },
@@ -311,6 +345,12 @@ export function resolveOverrideStyle(overrides: ThemeOverrides): Record<string, 
   }
   if (isOption(FONT_OPTIONS, overrides.fontBody)) {
     style['--font-sans'] = FONT_STACKS[overrides.fontBody]
+  }
+  if (isOption(DISPLAY_FONT_OPTIONS, overrides.fontDisplay)) {
+    style['--font-display'] = DISPLAY_FONT_STACKS[overrides.fontDisplay]
+  }
+  if (isOption(MONO_FONT_OPTIONS, overrides.fontMono)) {
+    style['--font-mono'] = MONO_FONT_STACKS[overrides.fontMono]
   }
   if (isOption(WIDTH_OPTIONS, overrides.contentWidth)) {
     style['--content-w'] = WIDTH_VALUES[overrides.contentWidth]


### PR DESCRIPTION
## 目的

テーマ カスタマイザは本文フォント（`fontBody` → `--font-sans`）のみ調整可能で、契約 §7 が求める **3フォント（本文 / 見出し / mono）** のうち **見出し・mono が未実装**だった（#372 の積み残し・状況確認で特定）。既存 `fontBody` と完全に同型で `fontDisplay` / `fontMono` を追加する。

## 変更内容

- `ThemeOverrides` に `fontDisplay`（→ `--font-display`）/ `fontMono`（→ `--font-mono`）を追加。
- `DISPLAY_FONT_OPTIONS` / `MONO_FONT_OPTIONS`（**バンドル済み @fontsource フォントのみ**の allowlist）＋スタックを追加。`resolveOverrideStyle` で **検証済みキーのみ** CSS 変数へ emit（不正値はインジェクト不可）。
- カスタマイザ UI（`ThemeCustomizeView`）に見出し/mono の Select を2つ追加。i18n キー `admin.themeCustomize.fontDisplay` / `fontMono` を en・ja に追加。
- テスト: 有効キーで `--font-display`/`--font-mono` を emit、未知キーは無視。

公開サイトのみスコープ（`.nene-public`）・外部JS不使用。`fontBody` の3つの touch point（interface / resolveOverrideStyle / UI）に厳密にミラー。

## スコープ（#372 の残りは別スライス）

本PRは「フォント3種化」の完了のみ。#372 の残り — **画像ノブ（logo / hero / background）＋メディアライブラリ連携、全体ライブプレビュー（iframe）** — は基盤（メディア連携・iframe）が必要なため別スライスとし、#372 は open 維持。

## 検証

- `npm run check` 全グリーン（type-check / lint / prettier / **test** / validate:themes / knip / **storybook build**）。
- バックエンド変更なし。

## チェックリスト

- [x] Issue 駆動（#372 部分対応）
- [x] `type/issue-number-summary` ブランチ・Conventional Commits（`(#372)`）
- [x] i18n キーを en（真実源）+ ja に追加
- [x] `npm run check` 全グリーン

Refs #372