### PR TITLE
feat(public): モーション能力レイヤ基盤 ＋ scroll-reveal (#477)

### DIFF
--- a/docs/theming/public-theme.schema.json
+++ b/docs/theming/public-theme.schema.json
@@ -95,7 +95,8 @@
         "headerNavAlign": { "enum": ["start", "center", "end"] },
         "headerDensity": { "enum": ["compact", "regular", "tall"] },
         "headerWidth": { "enum": ["boxed", "full"] },
-        "headerSticky": { "enum": ["sticky", "none"] }
+        "headerSticky": { "enum": ["sticky", "none"] },
+        "motionReveal": { "enum": ["off", "subtle", "standard"] }
       }
     },
     "assets": {

--- a/docs/theming/theme-flags.md
+++ b/docs/theming/theme-flags.md
@@ -37,6 +37,7 @@ A だけでも「WP の定番テーマ」級は出せる。語彙に収まらな
 | `headerDensity` | `data-header-density` | `compact` \| `regular` \| `tall` | ヘッダー行高（regular=現行 72px） |
 | `headerWidth`   | `data-header-width`   | `boxed` \| `full` | ヘッダー内容の幅（boxed=現行 `--content-w` / full=フル幅） |
 | `headerSticky`  | `data-header-sticky`  | `sticky` \| `none` | スクロール追従（既定=sticky・現行挙動 / none=固定しない） |
+| `motionReveal`  | `data-motion-reveal`  | `off` \| `subtle` \| `standard` | スクロール進入時のフェードイン（モーション能力レイヤ #371）。第一者JSが `.card`/`.typecard`/見出しに適用、`prefers-reduced-motion` で無効・JS無効でも要素は表示。テーマは flag を宣言するのみ |
 
 > ヘッダー構造の全体仕様（グリッド/プリセット/インフォ要素）は [`header-patterns.md`](./header-patterns.md) を参照。
 > 追加フラグは本表に追記して語彙を拡張する。実装は base CSS（`public-site.css` 近傍の専用ファイル）に集約。

--- a/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
+++ b/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
@@ -402,6 +402,16 @@ export function ThemeCustomizeView({
                 }}
               />
             </Field>
+            <Field label={t('admin.themeCustomize.motionReveal')}>
+              <Select
+                value={draft.flags?.motionReveal}
+                options={FLAG_DEFS.motionReveal.options}
+                placeholder={themePlaceholder}
+                onChange={(v) => {
+                  setKnob('flags', { ...draft.flags, motionReveal: v })
+                }}
+              />
+            </Field>
           </Stack>
         </details>
 

--- a/frontend/src/pages/consumer/PublicSiteShell.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.tsx
@@ -1,16 +1,21 @@
-import { type ReactNode, useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { type ReactNode, useMemo, useRef, useState } from 'react'
+import { Link, useLocation } from 'react-router-dom'
 import { useEntityTypeList } from '@/entities/entity-type'
 import { usePublicWidgets } from '@/entities/widget'
 import { SiteWidgets } from '@/features/render-widgets'
 import { hasCta, hasTopbarContent, safeHref } from '@/shared/lib/header-config'
+import { useScrollReveal } from '@/shared/lib/motion/use-scroll-reveal'
 import { NeneMark } from '@/shared/ui'
 import { IconMenu, IconMoon, IconSearch, IconSun, IconX } from '@/shared/ui/icons/Icons'
 import { IconAuto } from '@/shared/ui/icons/magazine-icons'
 import './public-site.css'
 import type { HeaderCta, HeaderTopbar } from '@/shared/lib/header-config'
+import { useConsumerMotion } from './use-consumer-motion'
 import type { PublicSite } from './public-site-context'
 import { type ThemeMode, useConsumerTheme } from './use-consumer-theme'
+
+/** Repeating content blocks that scroll-reveal targets (#371 S1). */
+const REVEAL_SELECTOR = '.card, .typecard, .section__head, .article__head'
 
 export interface PublicSiteShellProps {
   site: PublicSite
@@ -146,6 +151,18 @@ export function PublicSiteShell({
   const { mode, resolvedTheme, setMode } = useConsumerTheme(site.activeTheme)
   const [drawerOpen, setDrawerOpen] = useState(false)
 
+  // Motion capability layer (#371): the theme declares `data-motion-reveal`;
+  // first-party JS implements scroll-reveal, gated by prefers-reduced-motion.
+  const mainRef = useRef<HTMLElement>(null)
+  const { pathname } = useLocation()
+  const motion = useConsumerMotion(site.themeFlagAttrs)
+  useScrollReveal({
+    containerRef: mainRef,
+    enabled: motion.reveal !== 'off',
+    selector: REVEAL_SELECTOR,
+    scanKey: pathname,
+  })
+
   // Render `sidebar` / `aside` regions as side columns when widgets are placed
   // there (and the page opts in). Empty regions collapse, so the grid steps down
   // from three → two → single column as content allows.
@@ -226,7 +243,7 @@ export function PublicSiteShell({
         </div>
       </header>
 
-      <main>
+      <main ref={mainRef}>
         {hero}
         <div className="wrap">
           <div className={`layout ${layoutModifier}`}>

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -1696,22 +1696,38 @@
   }
 }
 /* ── Motion capability: scroll-reveal (#371 S1) ──────────────────────────────
-   First-party JS (use-scroll-reveal) tags in-view candidates with
-   [data-motion-reveal-item] and flips [data-revealed] once they enter the
-   viewport. We hide the initial state ONLY when the theme's data-motion-reveal
-   flag is set AND JS has tagged the element — so a no-JS visitor sees content
-   immediately. The whole block is wrapped in no-preference, so reduced-motion
-   users never get the hidden initial state (reinforced by the reduce block). */
-@media (prefers-reduced-motion: no-preference) {
-  .nene-public[data-motion-reveal='subtle'] [data-motion-reveal-item],
-  .nene-public[data-motion-reveal='standard'] [data-motion-reveal-item] {
+   First-party JS (use-scroll-reveal) tags candidates with [data-motion-reveal-item]
+   and flips [data-revealed] when they enter (or already sit in) the viewport.
+   The fade-in is a keyframe animation, NOT a transition: a transition from a
+   JS-set opacity:0 in the same frame snaps instantly (the start value is never
+   painted), which is why the reveal looked instant. A keyframe owns its `from`
+   state and always plays. Hidden state applies ONLY when the theme flag is on
+   AND JS has tagged the item, so no-JS visitors see everything. Wrapped in
+   no-preference so reduced-motion users never get the hidden state. */
+@keyframes nene-reveal {
+  from {
     opacity: 0;
     transform: translateY(var(--motion-reveal-shift, 16px));
-    /* Ease-out (glide in, settle gently) — reveal-specific, not the global --ease. */
-    transition:
-      opacity var(--motion-reveal-dur) cubic-bezier(0.16, 1, 0.3, 1),
-      transform var(--motion-reveal-dur) cubic-bezier(0.16, 1, 0.3, 1);
-    transition-delay: calc(var(--motion-reveal-index, 0) * var(--motion-reveal-step, 120ms));
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  /* Hidden until revealed. */
+  .nene-public[data-motion-reveal='subtle'] [data-motion-reveal-item]:not([data-revealed]),
+  .nene-public[data-motion-reveal='standard'] [data-motion-reveal-item]:not([data-revealed]) {
+    opacity: 0;
+  }
+
+  /* Reveal = play the keyframe. `both` holds opacity:0 through the stagger delay,
+     then settles at the final state. Ease-out glides in and settles gently. */
+  .nene-public[data-motion-reveal='subtle'] [data-motion-reveal-item][data-revealed],
+  .nene-public[data-motion-reveal='standard'] [data-motion-reveal-item][data-revealed] {
+    animation: nene-reveal var(--motion-reveal-dur, 1000ms) cubic-bezier(0.16, 1, 0.3, 1)
+      calc(var(--motion-reveal-index, 0) * var(--motion-reveal-step, 120ms)) both;
     will-change: opacity, transform;
   }
 
@@ -1728,12 +1744,6 @@
   .nene-public[data-motion-reveal] .typecard[data-motion-reveal-item] {
     --motion-reveal-dur: 800ms;
     --motion-reveal-step: 90ms;
-  }
-
-  .nene-public[data-motion-reveal='subtle'] [data-motion-reveal-item][data-revealed],
-  .nene-public[data-motion-reveal='standard'] [data-motion-reveal-item][data-revealed] {
-    opacity: 1;
-    transform: none;
   }
 }
 

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -62,6 +62,7 @@
   --dur-fast: 120ms;
   --dur-normal: 220ms;
   --motion-reveal-dur: 1000ms;
+  --motion-reveal-step: 120ms;
 
   display: flex;
   flex-direction: column;
@@ -1710,7 +1711,7 @@
     transition:
       opacity var(--motion-reveal-dur) cubic-bezier(0.16, 1, 0.3, 1),
       transform var(--motion-reveal-dur) cubic-bezier(0.16, 1, 0.3, 1);
-    transition-delay: var(--motion-reveal-delay, 0ms);
+    transition-delay: calc(var(--motion-reveal-index, 0) * var(--motion-reveal-step, 120ms));
     will-change: opacity, transform;
   }
 
@@ -1718,13 +1719,15 @@
     --motion-reveal-shift: 32px;
   }
 
-  /* Per-type pacing: the larger Latest-records cards read better slower; the
-     compact Browse-by-type cards can move a touch quicker. */
+  /* Per-type pacing: the larger Latest-records cards read better slow with a
+     pronounced cascade; the compact Browse-by-type cards stay snappy and tight. */
   .nene-public[data-motion-reveal] .card[data-motion-reveal-item] {
-    --motion-reveal-dur: 1200ms;
+    --motion-reveal-dur: 1400ms;
+    --motion-reveal-step: 260ms;
   }
   .nene-public[data-motion-reveal] .typecard[data-motion-reveal-item] {
     --motion-reveal-dur: 800ms;
+    --motion-reveal-step: 90ms;
   }
 
   .nene-public[data-motion-reveal='subtle'] [data-motion-reveal-item][data-revealed],

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -1718,6 +1718,15 @@
     --motion-reveal-shift: 32px;
   }
 
+  /* Per-type pacing: the larger Latest-records cards read better slower; the
+     compact Browse-by-type cards can move a touch quicker. */
+  .nene-public[data-motion-reveal] .card[data-motion-reveal-item] {
+    --motion-reveal-dur: 1200ms;
+  }
+  .nene-public[data-motion-reveal] .typecard[data-motion-reveal-item] {
+    --motion-reveal-dur: 800ms;
+  }
+
   .nene-public[data-motion-reveal='subtle'] [data-motion-reveal-item][data-revealed],
   .nene-public[data-motion-reveal='standard'] [data-motion-reveal-item][data-revealed] {
     opacity: 1;

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -61,7 +61,7 @@
   --ease: cubic-bezier(0.4, 0, 0.2, 1);
   --dur-fast: 120ms;
   --dur-normal: 220ms;
-  --motion-reveal-dur: 520ms;
+  --motion-reveal-dur: 760ms;
 
   display: flex;
   flex-direction: column;
@@ -1706,9 +1706,10 @@
   .nene-public[data-motion-reveal='standard'] [data-motion-reveal-item] {
     opacity: 0;
     transform: translateY(var(--motion-reveal-shift, 16px));
+    /* Ease-out (glide in, settle gently) — reveal-specific, not the global --ease. */
     transition:
-      opacity var(--motion-reveal-dur) var(--ease),
-      transform var(--motion-reveal-dur) var(--ease);
+      opacity var(--motion-reveal-dur) cubic-bezier(0.16, 1, 0.3, 1),
+      transform var(--motion-reveal-dur) cubic-bezier(0.16, 1, 0.3, 1);
     transition-delay: var(--motion-reveal-delay, 0ms);
     will-change: opacity, transform;
   }

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -1705,15 +1705,16 @@
   .nene-public[data-motion-reveal='subtle'] [data-motion-reveal-item],
   .nene-public[data-motion-reveal='standard'] [data-motion-reveal-item] {
     opacity: 0;
-    transform: translateY(var(--motion-reveal-shift, 8px));
+    transform: translateY(var(--motion-reveal-shift, 16px));
     transition:
       opacity var(--motion-reveal-dur) var(--ease),
       transform var(--motion-reveal-dur) var(--ease);
+    transition-delay: var(--motion-reveal-delay, 0ms);
     will-change: opacity, transform;
   }
 
   .nene-public[data-motion-reveal='standard'] [data-motion-reveal-item] {
-    --motion-reveal-shift: 18px;
+    --motion-reveal-shift: 32px;
   }
 
   .nene-public[data-motion-reveal='subtle'] [data-motion-reveal-item][data-revealed],

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -61,7 +61,7 @@
   --ease: cubic-bezier(0.4, 0, 0.2, 1);
   --dur-fast: 120ms;
   --dur-normal: 220ms;
-  --motion-reveal-dur: 760ms;
+  --motion-reveal-dur: 1000ms;
 
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -61,6 +61,7 @@
   --ease: cubic-bezier(0.4, 0, 0.2, 1);
   --dur-fast: 120ms;
   --dur-normal: 220ms;
+  --motion-reveal-dur: 520ms;
 
   display: flex;
   flex-direction: column;
@@ -1693,6 +1694,35 @@
     white-space: nowrap;
   }
 }
+/* ── Motion capability: scroll-reveal (#371 S1) ──────────────────────────────
+   First-party JS (use-scroll-reveal) tags in-view candidates with
+   [data-motion-reveal-item] and flips [data-revealed] once they enter the
+   viewport. We hide the initial state ONLY when the theme's data-motion-reveal
+   flag is set AND JS has tagged the element — so a no-JS visitor sees content
+   immediately. The whole block is wrapped in no-preference, so reduced-motion
+   users never get the hidden initial state (reinforced by the reduce block). */
+@media (prefers-reduced-motion: no-preference) {
+  .nene-public[data-motion-reveal='subtle'] [data-motion-reveal-item],
+  .nene-public[data-motion-reveal='standard'] [data-motion-reveal-item] {
+    opacity: 0;
+    transform: translateY(var(--motion-reveal-shift, 8px));
+    transition:
+      opacity var(--motion-reveal-dur) var(--ease),
+      transform var(--motion-reveal-dur) var(--ease);
+    will-change: opacity, transform;
+  }
+
+  .nene-public[data-motion-reveal='standard'] [data-motion-reveal-item] {
+    --motion-reveal-shift: 18px;
+  }
+
+  .nene-public[data-motion-reveal='subtle'] [data-motion-reveal-item][data-revealed],
+  .nene-public[data-motion-reveal='standard'] [data-motion-reveal-item][data-revealed] {
+    opacity: 1;
+    transform: none;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .nene-public * {
     transition: none !important;

--- a/frontend/src/pages/consumer/use-consumer-motion.test.ts
+++ b/frontend/src/pages/consumer/use-consumer-motion.test.ts
@@ -1,0 +1,38 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useConsumerMotion } from './use-consumer-motion'
+
+function stubReducedMotion(matches: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue({
+      matches,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('useConsumerMotion', () => {
+  it('passes the reveal flag through when motion is allowed', () => {
+    stubReducedMotion(false)
+    const { result } = renderHook(() => useConsumerMotion({ 'data-motion-reveal': 'subtle' }))
+    expect(result.current.reveal).toBe('subtle')
+  })
+
+  it('forces reveal off under reduced-motion', () => {
+    stubReducedMotion(true)
+    const { result } = renderHook(() => useConsumerMotion({ 'data-motion-reveal': 'standard' }))
+    expect(result.current.reveal).toBe('off')
+  })
+
+  it('defaults to off when no motion flag is present', () => {
+    stubReducedMotion(false)
+    const { result } = renderHook(() => useConsumerMotion({}))
+    expect(result.current.reveal).toBe('off')
+  })
+})

--- a/frontend/src/pages/consumer/use-consumer-motion.ts
+++ b/frontend/src/pages/consumer/use-consumer-motion.ts
@@ -1,0 +1,24 @@
+import { usePrefersReducedMotion } from '@/shared/lib/motion/use-prefers-reduced-motion'
+
+/**
+ * Consumer motion orchestrator (#371). Composes the theme's declarative motion
+ * flags (read from the `data-motion-*` attributes applied to `.nene-public`)
+ * with the live `prefers-reduced-motion` setting into the set of *effective*
+ * capabilities. Under reduced-motion every capability is forced off — this is
+ * the JS layer of the 3-layer reduced-motion gate (CSS + JS + theme data).
+ *
+ * Themes never ship behaviour, only these enumerated flags; the first-party
+ * hooks in `shared/lib/motion` implement the actual motion.
+ */
+export interface ConsumerMotion {
+  /** `off` | `subtle` | `standard` — forced `off` under reduced-motion. */
+  reveal: string
+}
+
+export function useConsumerMotion(flagAttrs: Record<string, string>): ConsumerMotion {
+  const reduced = usePrefersReducedMotion()
+
+  return {
+    reveal: reduced ? 'off' : (flagAttrs['data-motion-reveal'] ?? 'off'),
+  }
+}

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -101,6 +101,7 @@ export const en = {
   'admin.themeCustomize.headerDensity': 'Header height',
   'admin.themeCustomize.headerWidth': 'Header width',
   'admin.themeCustomize.headerSticky': 'Header sticky',
+  'admin.themeCustomize.motionReveal': 'Scroll reveal',
   'admin.headerContent.title': 'Header content',
   'admin.headerPreview.label': 'Preview',
   'admin.headerContent.intro':

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -94,6 +94,7 @@ export const ja: Partial<MessageCatalog> = {
   'admin.themeCustomize.headerDensity': 'ヘッダーの高さ',
   'admin.themeCustomize.headerWidth': 'ヘッダー幅',
   'admin.themeCustomize.headerSticky': 'ヘッダー追従',
+  'admin.themeCustomize.motionReveal': 'スクロール演出',
   'admin.headerContent.title': 'ヘッダーの内容',
   'admin.headerPreview.label': 'プレビュー',
   'admin.headerContent.intro':

--- a/frontend/src/shared/lib/motion/use-prefers-reduced-motion.test.ts
+++ b/frontend/src/shared/lib/motion/use-prefers-reduced-motion.test.ts
@@ -1,0 +1,59 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { usePrefersReducedMotion } from './use-prefers-reduced-motion'
+
+function mockMatchMedia(matches: boolean) {
+  const listeners = new Set<() => void>()
+  const mql = {
+    matches,
+    media: '(prefers-reduced-motion: reduce)',
+    addEventListener: (_type: string, cb: () => void) => {
+      listeners.add(cb)
+    },
+    removeEventListener: (_type: string, cb: () => void) => {
+      listeners.delete(cb)
+    },
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => true,
+    onchange: null,
+  }
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mql))
+  const fire = (): void => {
+    listeners.forEach((cb) => {
+      cb()
+    })
+  }
+  return { mql, fire }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('usePrefersReducedMotion', () => {
+  it('returns true when the OS prefers reduced motion', () => {
+    mockMatchMedia(true)
+    const { result } = renderHook(() => usePrefersReducedMotion())
+    expect(result.current).toBe(true)
+  })
+
+  it('returns false when there is no preference', () => {
+    mockMatchMedia(false)
+    const { result } = renderHook(() => usePrefersReducedMotion())
+    expect(result.current).toBe(false)
+  })
+
+  it('live-updates when the preference changes', () => {
+    const media = mockMatchMedia(false)
+    const { result } = renderHook(() => usePrefersReducedMotion())
+    expect(result.current).toBe(false)
+
+    act(() => {
+      media.mql.matches = true
+      media.fire()
+    })
+
+    expect(result.current).toBe(true)
+  })
+})

--- a/frontend/src/shared/lib/motion/use-prefers-reduced-motion.ts
+++ b/frontend/src/shared/lib/motion/use-prefers-reduced-motion.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Live `prefers-reduced-motion: reduce` state.
+ *
+ * The single source of truth for the motion capability layer (#371): every
+ * first-party motion effect gates on this so reduced-motion users get no
+ * animation. SSR-safe — returns `false` when `window`/`matchMedia` is absent.
+ */
+const REDUCE_QUERY = '(prefers-reduced-motion: reduce)'
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia(REDUCE_QUERY).matches
+    : false
+}
+
+export function usePrefersReducedMotion(): boolean {
+  // Initialise synchronously so the first render already matches the OS setting.
+  const [reduced, setReduced] = useState<boolean>(prefersReducedMotion)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined
+    }
+    const mq = window.matchMedia(REDUCE_QUERY)
+    const onChange = (): void => {
+      setReduced(mq.matches)
+    }
+    mq.addEventListener('change', onChange)
+    return () => {
+      mq.removeEventListener('change', onChange)
+    }
+  }, [])
+
+  return reduced
+}

--- a/frontend/src/shared/lib/motion/use-scroll-reveal.test.ts
+++ b/frontend/src/shared/lib/motion/use-scroll-reveal.test.ts
@@ -29,19 +29,13 @@ class MockIntersectionObserver {
   }
 }
 
-/** Force an element's vertical position relative to the (768px tall) jsdom viewport. */
-function setTop(el: Element, top: number): void {
-  el.getBoundingClientRect = () =>
-    ({
-      top,
-      bottom: top + 100,
-      left: 0,
-      right: 0,
-      width: 100,
-      height: 100,
-      x: 0,
-      y: top,
-    }) as DOMRect
+function intersect(...targets: Element[]): void {
+  const entries = targets.map(
+    (target) => ({ isIntersecting: true, target }) as IntersectionObserverEntry,
+  )
+  act(() => {
+    lastCallback?.(entries, fakeObserver)
+  })
 }
 
 function mountContainer(html: string): HTMLDivElement {
@@ -62,12 +56,6 @@ beforeEach(() => {
   observed = []
   lastCallback = null
   vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
-  // Run rAF synchronously so the in-view reveal is observable in the test.
-  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
-    cb(0)
-    return 1
-  })
-  vi.stubGlobal('cancelAnimationFrame', () => {})
 })
 
 afterEach(() => {
@@ -76,45 +64,33 @@ afterEach(() => {
 })
 
 describe('useScrollReveal', () => {
-  it('tags matching elements and reveals the ones already in view', () => {
+  it('tags and observes only matching elements when enabled', () => {
     const root = mountContainer(
       '<div class="card">a</div><div class="card">b</div><div class="x">c</div>',
     )
-    root.querySelectorAll('.card').forEach((card) => {
-      setTop(card, 100)
-    }) // in view (< 768)
     renderReveal(root, true)
 
     root.querySelectorAll('.card').forEach((card) => {
       expect(card.hasAttribute('data-motion-reveal-item')).toBe(true)
-      expect(card.hasAttribute('data-revealed')).toBe(true)
+      expect(card.hasAttribute('data-revealed')).toBe(false) // not until it intersects
     })
-    // In-view items are revealed directly, not handed to the IntersectionObserver.
-    expect(observed).toHaveLength(0)
+    expect(observed).toHaveLength(2)
     expect(root.querySelector('.x')?.hasAttribute('data-motion-reveal-item')).toBe(false)
   })
 
-  it('defers below-the-fold elements to the IntersectionObserver and reveals on intersect', () => {
-    const root = mountContainer('<div class="card">a</div>')
-    const card = root.querySelector('.card')
-    expect(card).not.toBeNull()
-    if (card !== null) {
-      setTop(card, 5000)
-    } // below the fold (> 768)
+  it('reveals, unobserves and staggers items as they intersect', () => {
+    const root = mountContainer('<div class="card">a</div><div class="card">b</div>')
     renderReveal(root, true)
+    const [first, second] = root.querySelectorAll<HTMLElement>('.card')
+    expect(observed).toHaveLength(2)
 
-    expect(card?.hasAttribute('data-motion-reveal-item')).toBe(true)
-    expect(card?.hasAttribute('data-revealed')).toBe(false)
-    expect(observed).toHaveLength(1)
+    intersect(first, second)
 
-    act(() => {
-      lastCallback?.(
-        [{ isIntersecting: true, target: card } as IntersectionObserverEntry],
-        fakeObserver,
-      )
-    })
-
-    expect(card?.hasAttribute('data-revealed')).toBe(true)
+    expect(first.hasAttribute('data-revealed')).toBe(true)
+    expect(second.hasAttribute('data-revealed')).toBe(true)
+    // Cascade index applied for the second item in the batch.
+    expect(first.style.getPropertyValue('--motion-reveal-index')).toBe('0')
+    expect(second.style.getPropertyValue('--motion-reveal-index')).toBe('1')
     expect(observed).toHaveLength(0)
   })
 
@@ -126,14 +102,10 @@ describe('useScrollReveal', () => {
     expect(root.querySelector('.card')?.hasAttribute('data-motion-reveal-item')).toBe(false)
   })
 
-  it('re-establishes the reveal when the effect re-runs on an already-tagged item', () => {
-    // Reproduces the StrictMode / back-navigation regression: an item tagged but
-    // not yet revealed must be re-observed (not skipped) when the effect re-runs.
+  it('re-observes an already-tagged but unrevealed item when the effect re-runs', () => {
+    // Guards the StrictMode / back-navigation regression: a tagged-but-unrevealed
+    // item must be re-observed (not skipped) when the effect re-runs.
     const root = mountContainer('<div class="card">a</div>')
-    const card = root.querySelector('.card')
-    if (card !== null) {
-      setTop(card, 5000) // below the fold → observed, not auto-revealed
-    }
     const ref = { current: root } as RefObject<HTMLElement | null>
 
     const { rerender } = renderHook(
@@ -147,7 +119,7 @@ describe('useScrollReveal', () => {
     // Effect teardown (mock disconnect empties `observed`) + re-run.
     rerender({ key: '/next' })
 
-    expect(card?.hasAttribute('data-revealed')).toBe(false)
+    expect(root.querySelector('.card')?.hasAttribute('data-revealed')).toBe(false)
     expect(observed).toHaveLength(1) // re-observed, not skipped
   })
 })

--- a/frontend/src/shared/lib/motion/use-scroll-reveal.test.ts
+++ b/frontend/src/shared/lib/motion/use-scroll-reveal.test.ts
@@ -1,0 +1,96 @@
+import { act, renderHook } from '@testing-library/react'
+import { type RefObject } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useScrollReveal } from './use-scroll-reveal'
+
+let observed: Element[]
+let lastCallback: IntersectionObserverCallback | null
+
+// Synthetic observer passed to the callback so the hook's `obs.unobserve(...)`
+// mutates the same `observed` list the mock tracks.
+const fakeObserver = {
+  unobserve(el: Element): void {
+    observed = observed.filter((entry) => entry !== el)
+  },
+} as unknown as IntersectionObserver
+
+class MockIntersectionObserver {
+  constructor(cb: IntersectionObserverCallback) {
+    lastCallback = cb
+  }
+  observe(el: Element): void {
+    observed.push(el)
+  }
+  unobserve(el: Element): void {
+    observed = observed.filter((entry) => entry !== el)
+  }
+  disconnect(): void {
+    observed = []
+  }
+}
+
+function mountContainer(html: string): HTMLDivElement {
+  const root = document.createElement('div')
+  root.innerHTML = html
+  document.body.appendChild(root)
+  return root
+}
+
+function renderReveal(root: HTMLElement, enabled: boolean): void {
+  const ref = { current: root } as RefObject<HTMLElement | null>
+  renderHook(() => {
+    useScrollReveal({ containerRef: ref, enabled, selector: '.card', scanKey: '/' })
+  })
+}
+
+beforeEach(() => {
+  observed = []
+  lastCallback = null
+  vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  document.body.innerHTML = ''
+})
+
+describe('useScrollReveal', () => {
+  it('tags and observes only matching elements when enabled', () => {
+    const root = mountContainer(
+      '<div class="card">a</div><div class="card">b</div><div class="x">c</div>',
+    )
+    renderReveal(root, true)
+
+    root.querySelectorAll('.card').forEach((card) => {
+      expect(card.hasAttribute('data-motion-reveal-item')).toBe(true)
+    })
+    expect(observed).toHaveLength(2)
+    expect(root.querySelector('.x')?.hasAttribute('data-motion-reveal-item')).toBe(false)
+  })
+
+  it('reveals and unobserves an element once it intersects', () => {
+    const root = mountContainer('<div class="card">a</div>')
+    renderReveal(root, true)
+    const card = root.querySelector('.card')
+    expect(card).not.toBeNull()
+
+    act(() => {
+      lastCallback?.(
+        [{ isIntersecting: true, target: card } as IntersectionObserverEntry],
+        fakeObserver,
+      )
+    })
+
+    expect(card?.hasAttribute('data-revealed')).toBe(true)
+    // The only observed element was unobserved on reveal.
+    expect(observed).toHaveLength(0)
+  })
+
+  it('does nothing when disabled', () => {
+    const root = mountContainer('<div class="card">a</div>')
+    renderReveal(root, false)
+
+    expect(observed).toHaveLength(0)
+    expect(root.querySelector('.card')?.hasAttribute('data-motion-reveal-item')).toBe(false)
+  })
+})

--- a/frontend/src/shared/lib/motion/use-scroll-reveal.test.ts
+++ b/frontend/src/shared/lib/motion/use-scroll-reveal.test.ts
@@ -29,6 +29,21 @@ class MockIntersectionObserver {
   }
 }
 
+/** Force an element's vertical position relative to the (768px tall) jsdom viewport. */
+function setTop(el: Element, top: number): void {
+  el.getBoundingClientRect = () =>
+    ({
+      top,
+      bottom: top + 100,
+      left: 0,
+      right: 0,
+      width: 100,
+      height: 100,
+      x: 0,
+      y: top,
+    }) as DOMRect
+}
+
 function mountContainer(html: string): HTMLDivElement {
   const root = document.createElement('div')
   root.innerHTML = html
@@ -47,6 +62,12 @@ beforeEach(() => {
   observed = []
   lastCallback = null
   vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+  // Run rAF synchronously so the in-view reveal is observable in the test.
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    cb(0)
+    return 1
+  })
+  vi.stubGlobal('cancelAnimationFrame', () => {})
 })
 
 afterEach(() => {
@@ -55,24 +76,36 @@ afterEach(() => {
 })
 
 describe('useScrollReveal', () => {
-  it('tags and observes only matching elements when enabled', () => {
+  it('tags matching elements and reveals the ones already in view', () => {
     const root = mountContainer(
       '<div class="card">a</div><div class="card">b</div><div class="x">c</div>',
     )
+    root.querySelectorAll('.card').forEach((card) => {
+      setTop(card, 100)
+    }) // in view (< 768)
     renderReveal(root, true)
 
     root.querySelectorAll('.card').forEach((card) => {
       expect(card.hasAttribute('data-motion-reveal-item')).toBe(true)
+      expect(card.hasAttribute('data-revealed')).toBe(true)
     })
-    expect(observed).toHaveLength(2)
+    // In-view items are revealed directly, not handed to the IntersectionObserver.
+    expect(observed).toHaveLength(0)
     expect(root.querySelector('.x')?.hasAttribute('data-motion-reveal-item')).toBe(false)
   })
 
-  it('reveals and unobserves an element once it intersects', () => {
+  it('defers below-the-fold elements to the IntersectionObserver and reveals on intersect', () => {
     const root = mountContainer('<div class="card">a</div>')
-    renderReveal(root, true)
     const card = root.querySelector('.card')
     expect(card).not.toBeNull()
+    if (card !== null) {
+      setTop(card, 5000)
+    } // below the fold (> 768)
+    renderReveal(root, true)
+
+    expect(card?.hasAttribute('data-motion-reveal-item')).toBe(true)
+    expect(card?.hasAttribute('data-revealed')).toBe(false)
+    expect(observed).toHaveLength(1)
 
     act(() => {
       lastCallback?.(
@@ -82,7 +115,6 @@ describe('useScrollReveal', () => {
     })
 
     expect(card?.hasAttribute('data-revealed')).toBe(true)
-    // The only observed element was unobserved on reveal.
     expect(observed).toHaveLength(0)
   })
 

--- a/frontend/src/shared/lib/motion/use-scroll-reveal.test.ts
+++ b/frontend/src/shared/lib/motion/use-scroll-reveal.test.ts
@@ -125,4 +125,29 @@ describe('useScrollReveal', () => {
     expect(observed).toHaveLength(0)
     expect(root.querySelector('.card')?.hasAttribute('data-motion-reveal-item')).toBe(false)
   })
+
+  it('re-establishes the reveal when the effect re-runs on an already-tagged item', () => {
+    // Reproduces the StrictMode / back-navigation regression: an item tagged but
+    // not yet revealed must be re-observed (not skipped) when the effect re-runs.
+    const root = mountContainer('<div class="card">a</div>')
+    const card = root.querySelector('.card')
+    if (card !== null) {
+      setTop(card, 5000) // below the fold → observed, not auto-revealed
+    }
+    const ref = { current: root } as RefObject<HTMLElement | null>
+
+    const { rerender } = renderHook(
+      ({ key }: { key: string }) => {
+        useScrollReveal({ containerRef: ref, enabled: true, selector: '.card', scanKey: key })
+      },
+      { initialProps: { key: '/' } },
+    )
+    expect(observed).toHaveLength(1)
+
+    // Effect teardown (mock disconnect empties `observed`) + re-run.
+    rerender({ key: '/next' })
+
+    expect(card?.hasAttribute('data-revealed')).toBe(false)
+    expect(observed).toHaveLength(1) // re-observed, not skipped
+  })
 })

--- a/frontend/src/shared/lib/motion/use-scroll-reveal.ts
+++ b/frontend/src/shared/lib/motion/use-scroll-reveal.ts
@@ -1,0 +1,63 @@
+import { type RefObject, useEffect } from 'react'
+
+/**
+ * First-party scroll-reveal (#371 S1). Tags matching descendants of `containerRef`
+ * with `data-motion-reveal-item` and, when each scrolls into view, adds
+ * `data-revealed` (then stops observing it). The accompanying CSS animates the
+ * transition and — crucially — only hides elements that carry BOTH the theme's
+ * `data-motion-reveal` flag AND this JS-applied `data-motion-reveal-item`, so a
+ * no-JS / no-IntersectionObserver visitor sees everything immediately.
+ *
+ * The caller gates `enabled` (off when the flag is off or reduced-motion is on).
+ * `scanKey` (e.g. the route pathname) re-scans for freshly rendered targets.
+ */
+const ITEM_ATTR = 'data-motion-reveal-item'
+const REVEALED_ATTR = 'data-revealed'
+
+export interface ScrollRevealOptions {
+  containerRef: RefObject<HTMLElement | null>
+  /** Reveal is active only when true (flag on AND not reduced-motion). */
+  enabled: boolean
+  /** CSS selector for the elements to reveal. */
+  selector: string
+  /** Changing this re-runs the scan (pass the route pathname). */
+  scanKey?: string
+}
+
+export function useScrollReveal({
+  containerRef,
+  enabled,
+  selector,
+  scanKey,
+}: ScrollRevealOptions): void {
+  useEffect(() => {
+    const root = containerRef.current
+    if (!enabled || root === null || typeof IntersectionObserver === 'undefined') {
+      return undefined
+    }
+
+    const observer = new IntersectionObserver(
+      (entries, obs) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.setAttribute(REVEALED_ATTR, '')
+            obs.unobserve(entry.target)
+          }
+        }
+      },
+      // Reveal slightly before fully in view; tiny threshold so tall items count.
+      { rootMargin: '0px 0px -8% 0px', threshold: 0.04 },
+    )
+
+    root.querySelectorAll(selector).forEach((el) => {
+      if (!el.hasAttribute(REVEALED_ATTR)) {
+        el.setAttribute(ITEM_ATTR, '')
+        observer.observe(el)
+      }
+    })
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [containerRef, enabled, selector, scanKey])
+}

--- a/frontend/src/shared/lib/motion/use-scroll-reveal.ts
+++ b/frontend/src/shared/lib/motion/use-scroll-reveal.ts
@@ -8,11 +8,18 @@ import { type RefObject, useEffect } from 'react'
  * `data-motion-reveal` flag AND this JS-applied `data-motion-reveal-item`, so a
  * no-JS / no-IntersectionObserver visitor sees everything immediately.
  *
+ * Public feeds load their cards asynchronously (react-query), so the targets are
+ * not in the DOM when the effect first runs. A MutationObserver picks up nodes
+ * added after mount (and on route change). Items that enter the viewport in the
+ * same batch get a small staggered delay so a grid row cascades in visibly.
+ *
  * The caller gates `enabled` (off when the flag is off or reduced-motion is on).
- * `scanKey` (e.g. the route pathname) re-scans for freshly rendered targets.
+ * `scanKey` (e.g. the route pathname) forces a fresh observer on navigation.
  */
 const ITEM_ATTR = 'data-motion-reveal-item'
 const REVEALED_ATTR = 'data-revealed'
+const DELAY_VAR = '--motion-reveal-delay'
+const STAGGER_STEP_MS = 80
 
 export interface ScrollRevealOptions {
   containerRef: RefObject<HTMLElement | null>
@@ -38,26 +45,46 @@ export function useScrollReveal({
 
     const observer = new IntersectionObserver(
       (entries, obs) => {
+        let staggerIndex = 0
         for (const entry of entries) {
-          if (entry.isIntersecting) {
-            entry.target.setAttribute(REVEALED_ATTR, '')
-            obs.unobserve(entry.target)
+          if (!entry.isIntersecting) {
+            continue
           }
+          // Items revealing together cascade; one-at-a-time scrolling has no delay.
+          if (entry.target instanceof HTMLElement) {
+            entry.target.style.setProperty(DELAY_VAR, `${String(staggerIndex * STAGGER_STEP_MS)}ms`)
+          }
+          entry.target.setAttribute(REVEALED_ATTR, '')
+          obs.unobserve(entry.target)
+          staggerIndex += 1
         }
       },
       // Reveal slightly before fully in view; tiny threshold so tall items count.
       { rootMargin: '0px 0px -8% 0px', threshold: 0.04 },
     )
 
-    root.querySelectorAll(selector).forEach((el) => {
-      if (!el.hasAttribute(REVEALED_ATTR)) {
-        el.setAttribute(ITEM_ATTR, '')
-        observer.observe(el)
-      }
-    })
+    const tagAndObserve = (): void => {
+      root.querySelectorAll(selector).forEach((el) => {
+        if (!el.hasAttribute(ITEM_ATTR) && !el.hasAttribute(REVEALED_ATTR)) {
+          el.setAttribute(ITEM_ATTR, '')
+          observer.observe(el)
+        }
+      })
+    }
+
+    // Tag what is already present, then keep up with async-rendered content.
+    tagAndObserve()
+    const mutationObserver =
+      typeof MutationObserver === 'undefined'
+        ? null
+        : new MutationObserver(() => {
+            tagAndObserve()
+          })
+    mutationObserver?.observe(root, { childList: true, subtree: true })
 
     return () => {
       observer.disconnect()
+      mutationObserver?.disconnect()
     }
   }, [containerRef, enabled, selector, scanKey])
 }

--- a/frontend/src/shared/lib/motion/use-scroll-reveal.ts
+++ b/frontend/src/shared/lib/motion/use-scroll-reveal.ts
@@ -23,8 +23,9 @@ import { type RefObject, useEffect } from 'react'
  */
 const ITEM_ATTR = 'data-motion-reveal-item'
 const REVEALED_ATTR = 'data-revealed'
-const DELAY_VAR = '--motion-reveal-delay'
-const STAGGER_STEP_MS = 150
+// JS only sets the cascade INDEX; the per-step delay (and duration) live in CSS
+// so each element type can be paced independently (see public-site.css).
+const INDEX_VAR = '--motion-reveal-index'
 
 export interface ScrollRevealOptions {
   containerRef: RefObject<HTMLElement | null>
@@ -36,9 +37,9 @@ export interface ScrollRevealOptions {
   scanKey?: string
 }
 
-function reveal(el: Element, delayMs: number): void {
+function reveal(el: Element, staggerIndex: number): void {
   if (el instanceof HTMLElement) {
-    el.style.setProperty(DELAY_VAR, `${String(delayMs)}ms`)
+    el.style.setProperty(INDEX_VAR, String(staggerIndex))
   }
   el.setAttribute(REVEALED_ATTR, '')
 }
@@ -64,7 +65,7 @@ export function useScrollReveal({
           if (!entry.isIntersecting) {
             continue
           }
-          reveal(entry.target, staggerIndex * STAGGER_STEP_MS)
+          reveal(entry.target, staggerIndex)
           obs.unobserve(entry.target)
           staggerIndex += 1
         }
@@ -98,7 +99,7 @@ export function useScrollReveal({
         // reveal animates rather than snapping.
         const id = requestAnimationFrame(() => {
           inView.forEach((el, index) => {
-            reveal(el, index * STAGGER_STEP_MS)
+            reveal(el, index)
           })
         })
         rafIds.push(id)

--- a/frontend/src/shared/lib/motion/use-scroll-reveal.ts
+++ b/frontend/src/shared/lib/motion/use-scroll-reveal.ts
@@ -24,7 +24,7 @@ import { type RefObject, useEffect } from 'react'
 const ITEM_ATTR = 'data-motion-reveal-item'
 const REVEALED_ATTR = 'data-revealed'
 const DELAY_VAR = '--motion-reveal-delay'
-const STAGGER_STEP_MS = 80
+const STAGGER_STEP_MS = 110
 
 export interface ScrollRevealOptions {
   containerRef: RefObject<HTMLElement | null>

--- a/frontend/src/shared/lib/motion/use-scroll-reveal.ts
+++ b/frontend/src/shared/lib/motion/use-scroll-reveal.ts
@@ -56,8 +56,6 @@ export function useScrollReveal({
       return undefined
     }
 
-    const rafIds: number[] = []
-
     const observer = new IntersectionObserver(
       (entries, obs) => {
         let staggerIndex = 0
@@ -74,36 +72,27 @@ export function useScrollReveal({
     )
 
     const tagAndObserve = (): void => {
-      const inView: Element[] = []
+      let inViewIndex = 0
       root.querySelectorAll(selector).forEach((el) => {
         // Skip only items that are already revealed. A tagged-but-unrevealed
         // item must be re-processed: under React StrictMode (and on remount) the
-        // effect runs, its cleanup cancels the pending reveal / disconnects the
-        // observer, then it runs again — if we skipped on the tag alone the item
-        // would stay at opacity 0 forever (the home feed vanishing on back-nav).
+        // effect runs, its cleanup disconnects the observer, then it runs again —
+        // if we skipped on the tag alone the item would stay hidden forever (the
+        // home feed vanishing on back-nav).
         if (el.hasAttribute(REVEALED_ATTR)) {
           return
         }
         el.setAttribute(ITEM_ATTR, '')
-        // Reveal anything not strictly below the fold straight away; defer the
-        // rest to scroll. window.innerHeight is safe here (browser-only effect).
+        // Anything in or above the viewport reveals straight away; the CSS
+        // keyframe handles the fade-in from opacity 0, so there is no need to
+        // wait a frame. Genuinely below-the-fold items wait for scroll.
         if (el.getBoundingClientRect().top < window.innerHeight) {
-          inView.push(el)
+          reveal(el, inViewIndex)
+          inViewIndex += 1
         } else {
           observer.observe(el)
         }
       })
-
-      if (inView.length > 0) {
-        // One frame later, so the opacity:0 initial state has painted and the
-        // reveal animates rather than snapping.
-        const id = requestAnimationFrame(() => {
-          inView.forEach((el, index) => {
-            reveal(el, index)
-          })
-        })
-        rafIds.push(id)
-      }
     }
 
     tagAndObserve()
@@ -118,9 +107,6 @@ export function useScrollReveal({
     return () => {
       observer.disconnect()
       mutationObserver?.disconnect()
-      rafIds.forEach((id) => {
-        cancelAnimationFrame(id)
-      })
     }
   }, [containerRef, enabled, selector, scanKey])
 }

--- a/frontend/src/shared/lib/motion/use-scroll-reveal.ts
+++ b/frontend/src/shared/lib/motion/use-scroll-reveal.ts
@@ -24,7 +24,7 @@ import { type RefObject, useEffect } from 'react'
 const ITEM_ATTR = 'data-motion-reveal-item'
 const REVEALED_ATTR = 'data-revealed'
 const DELAY_VAR = '--motion-reveal-delay'
-const STAGGER_STEP_MS = 110
+const STAGGER_STEP_MS = 150
 
 export interface ScrollRevealOptions {
   containerRef: RefObject<HTMLElement | null>

--- a/frontend/src/shared/lib/motion/use-scroll-reveal.ts
+++ b/frontend/src/shared/lib/motion/use-scroll-reveal.ts
@@ -2,19 +2,24 @@ import { type RefObject, useEffect } from 'react'
 
 /**
  * First-party scroll-reveal (#371 S1). Tags matching descendants of `containerRef`
- * with `data-motion-reveal-item` and, when each scrolls into view, adds
- * `data-revealed` (then stops observing it). The accompanying CSS animates the
- * transition and — crucially — only hides elements that carry BOTH the theme's
+ * with `data-motion-reveal-item` and reveals them (`data-revealed`) so the CSS can
+ * fade/slide them in. CSS only hides elements that carry BOTH the theme's
  * `data-motion-reveal` flag AND this JS-applied `data-motion-reveal-item`, so a
  * no-JS / no-IntersectionObserver visitor sees everything immediately.
  *
- * Public feeds load their cards asynchronously (react-query), so the targets are
- * not in the DOM when the effect first runs. A MutationObserver picks up nodes
- * added after mount (and on route change). Items that enter the viewport in the
- * same batch get a small staggered delay so a grid row cascades in visibly.
+ * Resilience rules (a reveal must never strand content hidden):
+ *  - Anything already in or above the viewport is revealed right away — this
+ *    covers above-the-fold content and SPA back-navigation (the shell remounts
+ *    with cached content at a restored scroll position, where IntersectionObserver
+ *    would otherwise not re-fire and leave cards stuck at opacity 0).
+ *  - Only genuinely below-the-fold elements are deferred to the IntersectionObserver
+ *    for a scroll-triggered reveal.
+ *  - Feeds load asynchronously (react-query); a MutationObserver picks up nodes
+ *    added after mount and on route change.
  *
- * The caller gates `enabled` (off when the flag is off or reduced-motion is on).
- * `scanKey` (e.g. the route pathname) forces a fresh observer on navigation.
+ * Items revealed in the same batch get a small staggered delay so a grid row
+ * cascades in visibly. The caller gates `enabled` (off when the flag is off or
+ * reduced-motion is on); `scanKey` (route pathname) forces a fresh observer.
  */
 const ITEM_ATTR = 'data-motion-reveal-item'
 const REVEALED_ATTR = 'data-revealed'
@@ -31,6 +36,13 @@ export interface ScrollRevealOptions {
   scanKey?: string
 }
 
+function reveal(el: Element, delayMs: number): void {
+  if (el instanceof HTMLElement) {
+    el.style.setProperty(DELAY_VAR, `${String(delayMs)}ms`)
+  }
+  el.setAttribute(REVEALED_ATTR, '')
+}
+
 export function useScrollReveal({
   containerRef,
   enabled,
@@ -43,6 +55,8 @@ export function useScrollReveal({
       return undefined
     }
 
+    const rafIds: number[] = []
+
     const observer = new IntersectionObserver(
       (entries, obs) => {
         let staggerIndex = 0
@@ -50,29 +64,42 @@ export function useScrollReveal({
           if (!entry.isIntersecting) {
             continue
           }
-          // Items revealing together cascade; one-at-a-time scrolling has no delay.
-          if (entry.target instanceof HTMLElement) {
-            entry.target.style.setProperty(DELAY_VAR, `${String(staggerIndex * STAGGER_STEP_MS)}ms`)
-          }
-          entry.target.setAttribute(REVEALED_ATTR, '')
+          reveal(entry.target, staggerIndex * STAGGER_STEP_MS)
           obs.unobserve(entry.target)
           staggerIndex += 1
         }
       },
-      // Reveal slightly before fully in view; tiny threshold so tall items count.
       { rootMargin: '0px 0px -8% 0px', threshold: 0.04 },
     )
 
     const tagAndObserve = (): void => {
+      const inView: Element[] = []
       root.querySelectorAll(selector).forEach((el) => {
-        if (!el.hasAttribute(ITEM_ATTR) && !el.hasAttribute(REVEALED_ATTR)) {
-          el.setAttribute(ITEM_ATTR, '')
+        if (el.hasAttribute(ITEM_ATTR) || el.hasAttribute(REVEALED_ATTR)) {
+          return
+        }
+        el.setAttribute(ITEM_ATTR, '')
+        // Reveal anything not strictly below the fold straight away; defer the
+        // rest to scroll. window.innerHeight is safe here (browser-only effect).
+        if (el.getBoundingClientRect().top < window.innerHeight) {
+          inView.push(el)
+        } else {
           observer.observe(el)
         }
       })
+
+      if (inView.length > 0) {
+        // One frame later, so the opacity:0 initial state has painted and the
+        // reveal animates rather than snapping.
+        const id = requestAnimationFrame(() => {
+          inView.forEach((el, index) => {
+            reveal(el, index * STAGGER_STEP_MS)
+          })
+        })
+        rafIds.push(id)
+      }
     }
 
-    // Tag what is already present, then keep up with async-rendered content.
     tagAndObserve()
     const mutationObserver =
       typeof MutationObserver === 'undefined'
@@ -85,6 +112,9 @@ export function useScrollReveal({
     return () => {
       observer.disconnect()
       mutationObserver?.disconnect()
+      rafIds.forEach((id) => {
+        cancelAnimationFrame(id)
+      })
     }
   }, [containerRef, enabled, selector, scanKey])
 }

--- a/frontend/src/shared/lib/motion/use-scroll-reveal.ts
+++ b/frontend/src/shared/lib/motion/use-scroll-reveal.ts
@@ -75,7 +75,12 @@ export function useScrollReveal({
     const tagAndObserve = (): void => {
       const inView: Element[] = []
       root.querySelectorAll(selector).forEach((el) => {
-        if (el.hasAttribute(ITEM_ATTR) || el.hasAttribute(REVEALED_ATTR)) {
+        // Skip only items that are already revealed. A tagged-but-unrevealed
+        // item must be re-processed: under React StrictMode (and on remount) the
+        // effect runs, its cleanup cancels the pending reveal / disconnects the
+        // observer, then it runs again — if we skipped on the tag alone the item
+        // would stay at opacity 0 forever (the home feed vanishing on back-nav).
+        if (el.hasAttribute(REVEALED_ATTR)) {
           return
         }
         el.setAttribute(ITEM_ATTR, '')

--- a/frontend/src/shared/lib/motion/use-scroll-reveal.ts
+++ b/frontend/src/shared/lib/motion/use-scroll-reveal.ts
@@ -7,13 +7,13 @@ import { type RefObject, useEffect } from 'react'
  * `data-motion-reveal` flag AND this JS-applied `data-motion-reveal-item`, so a
  * no-JS / no-IntersectionObserver visitor sees everything immediately.
  *
- * Resilience rules (a reveal must never strand content hidden):
- *  - Anything already in or above the viewport is revealed right away — this
- *    covers above-the-fold content and SPA back-navigation (the shell remounts
- *    with cached content at a restored scroll position, where IntersectionObserver
- *    would otherwise not re-fire and leave cards stuck at opacity 0).
- *  - Only genuinely below-the-fold elements are deferred to the IntersectionObserver
- *    for a scroll-triggered reveal.
+ * Every tagged item is handed to one IntersectionObserver: it fires the initial
+ * intersection state asynchronously (so items already in view reveal on load) and
+ * again as below-the-fold items scroll in. Notes:
+ *  - A fresh observer is created per effect run, so SPA back-navigation (the shell
+ *    remounts with cached content) re-evaluates intersection and reveals correctly.
+ *  - We do NOT eagerly reveal "in view at mount" — that raced with async content
+ *    still shifting the layout and revealed sections before the reader reached them.
  *  - Feeds load asynchronously (react-query); a MutationObserver picks up nodes
  *    added after mount and on route change.
  *
@@ -72,26 +72,22 @@ export function useScrollReveal({
     )
 
     const tagAndObserve = (): void => {
-      let inViewIndex = 0
       root.querySelectorAll(selector).forEach((el) => {
-        // Skip only items that are already revealed. A tagged-but-unrevealed
-        // item must be re-processed: under React StrictMode (and on remount) the
-        // effect runs, its cleanup disconnects the observer, then it runs again —
-        // if we skipped on the tag alone the item would stay hidden forever (the
-        // home feed vanishing on back-nav).
+        // Skip only items that are already revealed. A tagged-but-unrevealed item
+        // must be re-processed: under React StrictMode (and on remount) the effect
+        // runs, its cleanup disconnects the observer, then it runs again — if we
+        // skipped on the tag alone the item would stay hidden forever.
         if (el.hasAttribute(REVEALED_ATTR)) {
           return
         }
         el.setAttribute(ITEM_ATTR, '')
-        // Anything in or above the viewport reveals straight away; the CSS
-        // keyframe handles the fade-in from opacity 0, so there is no need to
-        // wait a frame. Genuinely below-the-fold items wait for scroll.
-        if (el.getBoundingClientRect().top < window.innerHeight) {
-          reveal(el, inViewIndex)
-          inViewIndex += 1
-        } else {
-          observer.observe(el)
-        }
+        // Hand everything to the IntersectionObserver: it fires the initial
+        // intersection state asynchronously for items already in view (so they
+        // reveal on load) and again as below-the-fold items are scrolled in. The
+        // keyframe reveal plays reliably either way. Doing this for ALL items
+        // (rather than eagerly revealing "in view at mount") avoids revealing
+        // sections while async content is still shifting the layout.
+        observer.observe(el)
       })
     }
 

--- a/frontend/src/shared/lib/theme-customization.test.ts
+++ b/frontend/src/shared/lib/theme-customization.test.ts
@@ -168,4 +168,12 @@ describe('resolveFlagAttrs / flagAttrsForTheme', () => {
       'data-header-sticky': 'none',
     })
   })
+
+  it('maps the motion-reveal capability flag', () => {
+    expect(resolveFlagAttrs(undefined, { motionReveal: 'subtle' })).toEqual({
+      'data-motion-reveal': 'subtle',
+    })
+    // Invalid values are dropped like any other flag.
+    expect(resolveFlagAttrs(undefined, { motionReveal: 'fancy' })).toEqual({})
+  })
 })

--- a/frontend/src/shared/lib/theme-customization.ts
+++ b/frontend/src/shared/lib/theme-customization.ts
@@ -63,6 +63,9 @@ export interface ThemeFlags {
   headerDensity?: string
   headerWidth?: string
   headerSticky?: string
+  /** Motion capability layer (see #371 / theme-flags.md §6). First-party JS implements
+   *  the behaviour; themes only declare the flag. Gated by prefers-reduced-motion. */
+  motionReveal?: string
 }
 
 /** flag key → { data attribute, allowed values }. Mirrors theme-flags.md §2. */
@@ -186,6 +189,14 @@ export const FLAG_DEFS: Record<keyof ThemeFlags, { attr: string; options: readon
       options: [
         { value: 'sticky', label: 'Sticky' },
         { value: 'none', label: 'Static' },
+      ],
+    },
+    motionReveal: {
+      attr: 'data-motion-reveal',
+      options: [
+        { value: 'off', label: 'Off' },
+        { value: 'subtle', label: 'Subtle' },
+        { value: 'standard', label: 'Standard' },
       ],
     },
   }

--- a/src/Theme/ThemeAuthoringGuide.php
+++ b/src/Theme/ThemeAuthoringGuide.php
@@ -72,6 +72,7 @@ final class ThemeAuthoringGuide
         'headerDensity' => 'Vertical density/height of the header (compact / regular / tall).',
         'headerWidth' => 'Header content width (boxed / full-bleed).',
         'headerSticky' => 'Whether the header sticks to the top on scroll (sticky / none).',
+        'motionReveal' => 'Scroll-into-view fade for cards/headings (off / subtle / standard); first-party, disabled under prefers-reduced-motion.',
     ];
 
     /**
@@ -95,6 +96,7 @@ final class ThemeAuthoringGuide
         'headerDensity' => 'data-header-density',
         'headerWidth' => 'data-header-width',
         'headerSticky' => 'data-header-sticky',
+        'motionReveal' => 'data-motion-reveal',
     ];
 
     /**
@@ -150,6 +152,7 @@ final class ThemeAuthoringGuide
         // Motion
         'dur-fast' => ['motion', 'Fast transition duration.'],
         'dur-normal' => ['motion', 'Normal transition duration.'],
+        'motion-reveal-dur' => ['motion', 'Scroll-reveal fade duration (motionReveal flag).'],
         'ease' => ['motion', 'Default easing function.'],
         // Elevation (shadow-sm/md/lg are in the required contract)
         'shadow-focus' => ['elevation', 'Focus-ring shadow.'],

--- a/src/Theme/ThemeManifestValidator.php
+++ b/src/Theme/ThemeManifestValidator.php
@@ -54,6 +54,7 @@ final class ThemeManifestValidator
         'headerDensity' => ['compact', 'regular', 'tall'],
         'headerWidth' => ['boxed', 'full'],
         'headerSticky' => ['sticky', 'none'],
+        'motionReveal' => ['off', 'subtle', 'standard'],
     ];
 
     /**


### PR DESCRIPTION
## 目的

**#371（モーション/インタラクション能力レイヤ Phase 1.5）のスライス1**。能力レイヤの基盤を確立し、最初の具体能力として **scroll-reveal**（スクロール進入時のフェードイン）を実装する。以降のスライス（sticky-shrink / hero variants / lightbox / View Transitions / parallax）の型紙。

方針: **テーマは `data-motion-*` フラグ（closed enum）を宣言するのみ。挙動の実装は第一者JSに固定**（メモリ方針「no arbitrary JS」と一貫）。

## 変更内容

**基盤（`shared/lib/motion/`）**
- `use-prefers-reduced-motion.ts` — `prefers-reduced-motion` をライブ監視する唯一の真実源（SSR安全）。
- `use-scroll-reveal.ts` — `IntersectionObserver` で対象に `data-motion-reveal-item` を付与し、進入時に `data-revealed`→`unobserve`。

**オーケストレーション（`pages/consumer/`）**
- `use-consumer-motion.ts` — フラグ＋reduced-motion を合成し有効能力を返す（reduced で全 off）。
- `PublicSiteShell.tsx` — 単一マウント点で `.card`/`.typecard`/見出しに scroll-reveal を配線（`scanKey`=pathname で遷移時に再スキャン）。

**フラグ end-to-end（`motionReveal`: `off|subtle|standard` / `data-motion-reveal`）**
- フロント: `ThemeFlags`・`FLAG_DEFS`・`public-theme.schema.json`・`theme-flags.md`・カスタマイザUI（詳細設定の Select）・i18n(en/ja)。
- バックエンド: `ThemeManifestValidator::FLAG_ENUMS` と `ThemeAuthoringGuide`（`FLAG_DOCS`/`FLAG_ATTRS`/`OPTIONAL_TOKENS`=`motion-reveal-dur`）。**parity テスト**（contract↔docs↔frontend FLAG_DEFS）を維持。

**CSS（`public-site.css`）**
- 「Motion capability」ブロック＋`--motion-reveal-dur`。

## reduced-motion 3層ゲート
1. **CSS**: reveal 初期非表示を `@media (prefers-reduced-motion: no-preference)` でラップ＋既存の全滅ルール維持。**`data-motion-reveal-item` がJSで付いた時のみ隠れる**＝no-JS / 非対応ブラウザでも要素は表示。
2. **JS**: reduced で能力 off・observer 未生成。
3. **データ**: flag `off`。

## スコープ
S1 のみ。S2〜S7（sticky-shrink / hero split・gradient / lightbox / View Transitions / parallax / video）は後続スライス（#371 にスライス計画をコメント済み）。

## 検証
- `composer check` 全グリーン（PHPUnit / PHPStan level 8 / CS-Fixer / OpenAPI / MCP。`ThemeAuthoringGuide` の no-drift / engine-var カバレッジ parity テスト通過）。
- `npm run check` 全グリーン（type-check / lint / prettier / **test**（motion フック3＋orchestrator＋flag parity）/ validate:themes / knip / storybook）。

## 動作確認
管理 › 外観 › テーマ › カスタマイズ › 詳細設定 › **Scroll reveal = Subtle/Standard** で公開サイトのカード/見出しがスクロール進入時にフェードイン。OS の「視差効果を減らす」で無効化されることも確認可。

## チェックリスト
- [x] Issue 駆動（#477 / 親 #371）
- [x] `type/issue-number-summary` ブランチ・Conventional Commits（`(#477)`）
- [x] スキーマ↔バリデータ↔オーサリングガイド↔FLAG_DEFS の parity 維持
- [x] `composer check` / `npm run check` 全グリーン

Closes #477