### PR TITLE
feat(public): ヘッダー sticky-shrink モーション (#479)

### DIFF
--- a/docs/theming/public-theme.schema.json
+++ b/docs/theming/public-theme.schema.json
@@ -96,7 +96,8 @@
         "headerDensity": { "enum": ["compact", "regular", "tall"] },
         "headerWidth": { "enum": ["boxed", "full"] },
         "headerSticky": { "enum": ["sticky", "none"] },
-        "motionReveal": { "enum": ["off", "subtle", "standard"] }
+        "motionReveal": { "enum": ["off", "subtle", "standard"] },
+        "motionHeader": { "enum": ["static", "shrink"] }
       }
     },
     "assets": {

--- a/docs/theming/theme-flags.md
+++ b/docs/theming/theme-flags.md
@@ -38,6 +38,7 @@ A だけでも「WP の定番テーマ」級は出せる。語彙に収まらな
 | `headerWidth`   | `data-header-width`   | `boxed` \| `full` | ヘッダー内容の幅（boxed=現行 `--content-w` / full=フル幅） |
 | `headerSticky`  | `data-header-sticky`  | `sticky` \| `none` | スクロール追従（既定=sticky・現行挙動 / none=固定しない） |
 | `motionReveal`  | `data-motion-reveal`  | `off` \| `subtle` \| `standard` | スクロール進入時のフェードイン（モーション能力レイヤ #371）。第一者JSが `.card`/`.typecard`/見出しに適用、`prefers-reduced-motion` で無効・JS無効でも要素は表示。テーマは flag を宣言するのみ |
+| `motionHeader`  | `data-motion-header`  | `static` \| `shrink` | スクロールで sticky ヘッダーをコンパクトに縮小（#371 S2）。第一者JSが sentinel + IntersectionObserver で検出し `data-shrunk` を付与、`prefers-reduced-motion` で無効。`headerSticky=sticky`（既定）前提 |
 
 > ヘッダー構造の全体仕様（グリッド/プリセット/インフォ要素）は [`header-patterns.md`](./header-patterns.md) を参照。
 > 追加フラグは本表に追記して語彙を拡張する。実装は base CSS（`public-site.css` 近傍の専用ファイル）に集約。

--- a/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
+++ b/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
@@ -412,6 +412,16 @@ export function ThemeCustomizeView({
                 }}
               />
             </Field>
+            <Field label={t('admin.themeCustomize.motionHeader')}>
+              <Select
+                value={draft.flags?.motionHeader}
+                options={FLAG_DEFS.motionHeader.options}
+                placeholder={themePlaceholder}
+                onChange={(v) => {
+                  setKnob('flags', { ...draft.flags, motionHeader: v })
+                }}
+              />
+            </Field>
           </Stack>
         </details>
 

--- a/frontend/src/pages/consumer/PublicSiteShell.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.tsx
@@ -4,6 +4,7 @@ import { useEntityTypeList } from '@/entities/entity-type'
 import { usePublicWidgets } from '@/entities/widget'
 import { SiteWidgets } from '@/features/render-widgets'
 import { hasCta, hasTopbarContent, safeHref } from '@/shared/lib/header-config'
+import { useHeaderShrink } from '@/shared/lib/motion/use-header-shrink'
 import { useScrollReveal } from '@/shared/lib/motion/use-scroll-reveal'
 import { NeneMark } from '@/shared/ui'
 import { IconMenu, IconMoon, IconSearch, IconSun, IconX } from '@/shared/ui/icons/Icons'
@@ -154,6 +155,7 @@ export function PublicSiteShell({
   // Motion capability layer (#371): the theme declares `data-motion-reveal`;
   // first-party JS implements scroll-reveal, gated by prefers-reduced-motion.
   const mainRef = useRef<HTMLElement>(null)
+  const sentinelRef = useRef<HTMLDivElement>(null)
   const { pathname } = useLocation()
   const motion = useConsumerMotion(site.themeFlagAttrs)
   useScrollReveal({
@@ -161,6 +163,10 @@ export function PublicSiteShell({
     enabled: motion.reveal !== 'off',
     selector: REVEAL_SELECTOR,
     scanKey: pathname,
+  })
+  const headerShrunk = useHeaderShrink({
+    enabled: motion.header === 'shrink',
+    sentinelRef,
   })
 
   // Render `sidebar` / `aside` regions as side columns when widgets are placed
@@ -202,7 +208,11 @@ export function PublicSiteShell({
       data-theme={resolvedTheme}
       data-theme-mode={mode}
       {...site.themeFlagAttrs}
+      data-shrunk={headerShrunk ? '' : undefined}
     >
+      {/* Zero-height marker at the page top; when it scrolls away the sticky
+          header compacts (motionHeader='shrink'). See use-header-shrink. */}
+      <div ref={sentinelRef} className="motion-sentinel" aria-hidden="true" />
       {site.runtimeThemeCss !== '' ? <style>{site.runtimeThemeCss}</style> : null}
       {site.themeOverrideCss !== '' ? <style>{site.themeOverrideCss}</style> : null}
       {hasTopbarContent(site.headerConfig.topbar) ? (

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -1754,6 +1754,33 @@
   }
 }
 
+/* ── Motion capability: header sticky-shrink (#371 S2) ───────────────────────
+   First-party JS (use-header-shrink) sets data-shrunk on the root once the page
+   scrolls past the top sentinel. data-shrunk is only ever set when the flag is
+   on AND not reduced-motion (JS gate), so reduced-motion users never shrink. */
+.nene-public .motion-sentinel {
+  height: 0;
+}
+
+.nene-public[data-motion-header='shrink'] .hd__in,
+.nene-public[data-motion-header='shrink'] .brand__mark {
+  transition:
+    height var(--dur-normal) var(--ease),
+    width var(--dur-normal) var(--ease),
+    box-shadow var(--dur-normal) var(--ease);
+}
+
+.nene-public[data-motion-header='shrink'][data-shrunk] .hd__in {
+  height: 56px;
+}
+.nene-public[data-motion-header='shrink'][data-shrunk] .brand__mark {
+  width: 28px;
+  height: 28px;
+}
+.nene-public[data-motion-header='shrink'][data-shrunk] .hd {
+  box-shadow: 0 2px 14px color-mix(in oklch, var(--color-text-primary) 12%, transparent);
+}
+
 /* ── Style flags (preset engine) ──────────────────────────────────────────
    Structural variations selected by theme/customizer flags and applied as
    data-* attributes on .nene-public (see docs/theming/theme-flags.md).

--- a/frontend/src/pages/consumer/use-consumer-motion.test.ts
+++ b/frontend/src/pages/consumer/use-consumer-motion.test.ts
@@ -35,4 +35,18 @@ describe('useConsumerMotion', () => {
     const { result } = renderHook(() => useConsumerMotion({}))
     expect(result.current.reveal).toBe('off')
   })
+
+  it('passes the header flag through and defaults to static', () => {
+    stubReducedMotion(false)
+    expect(
+      renderHook(() => useConsumerMotion({ 'data-motion-header': 'shrink' })).result.current.header,
+    ).toBe('shrink')
+    expect(renderHook(() => useConsumerMotion({})).result.current.header).toBe('static')
+  })
+
+  it('forces the header static under reduced-motion', () => {
+    stubReducedMotion(true)
+    const { result } = renderHook(() => useConsumerMotion({ 'data-motion-header': 'shrink' }))
+    expect(result.current.header).toBe('static')
+  })
 })

--- a/frontend/src/pages/consumer/use-consumer-motion.ts
+++ b/frontend/src/pages/consumer/use-consumer-motion.ts
@@ -13,6 +13,8 @@ import { usePrefersReducedMotion } from '@/shared/lib/motion/use-prefers-reduced
 export interface ConsumerMotion {
   /** `off` | `subtle` | `standard` — forced `off` under reduced-motion. */
   reveal: string
+  /** `static` | `shrink` — forced `static` under reduced-motion. */
+  header: string
 }
 
 export function useConsumerMotion(flagAttrs: Record<string, string>): ConsumerMotion {
@@ -20,5 +22,6 @@ export function useConsumerMotion(flagAttrs: Record<string, string>): ConsumerMo
 
   return {
     reveal: reduced ? 'off' : (flagAttrs['data-motion-reveal'] ?? 'off'),
+    header: reduced ? 'static' : (flagAttrs['data-motion-header'] ?? 'static'),
   }
 }

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -102,6 +102,7 @@ export const en = {
   'admin.themeCustomize.headerWidth': 'Header width',
   'admin.themeCustomize.headerSticky': 'Header sticky',
   'admin.themeCustomize.motionReveal': 'Scroll reveal',
+  'admin.themeCustomize.motionHeader': 'Header shrink',
   'admin.headerContent.title': 'Header content',
   'admin.headerPreview.label': 'Preview',
   'admin.headerContent.intro':

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -95,6 +95,7 @@ export const ja: Partial<MessageCatalog> = {
   'admin.themeCustomize.headerWidth': 'ヘッダー幅',
   'admin.themeCustomize.headerSticky': 'ヘッダー追従',
   'admin.themeCustomize.motionReveal': 'スクロール演出',
+  'admin.themeCustomize.motionHeader': 'ヘッダー縮小',
   'admin.headerContent.title': 'ヘッダーの内容',
   'admin.headerPreview.label': 'プレビュー',
   'admin.headerContent.intro':

--- a/frontend/src/shared/lib/motion/use-header-shrink.test.ts
+++ b/frontend/src/shared/lib/motion/use-header-shrink.test.ts
@@ -1,0 +1,66 @@
+import { act, renderHook } from '@testing-library/react'
+import { type RefObject } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useHeaderShrink } from './use-header-shrink'
+
+let lastCallback: IntersectionObserverCallback | null
+let observedEl: Element | null
+
+class MockIntersectionObserver {
+  constructor(cb: IntersectionObserverCallback) {
+    lastCallback = cb
+  }
+  observe(el: Element): void {
+    observedEl = el
+  }
+  unobserve(): void {}
+  disconnect(): void {
+    observedEl = null
+  }
+}
+
+function fire(isIntersecting: boolean): void {
+  act(() => {
+    lastCallback?.([{ isIntersecting } as IntersectionObserverEntry], {} as IntersectionObserver)
+  })
+}
+
+function render(enabled: boolean) {
+  const sentinel = document.createElement('div')
+  const sentinelRef = { current: sentinel } as RefObject<Element | null>
+  return renderHook(() => useHeaderShrink({ enabled, sentinelRef }))
+}
+
+beforeEach(() => {
+  lastCallback = null
+  observedEl = null
+  vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('useHeaderShrink', () => {
+  it('observes the sentinel and stays unshrunk while it is in view', () => {
+    const { result } = render(true)
+    expect(observedEl).not.toBeNull()
+
+    fire(true)
+    expect(result.current).toBe(false)
+  })
+
+  it('shrinks once the sentinel scrolls out of view', () => {
+    const { result } = render(true)
+
+    fire(false)
+    expect(result.current).toBe(true)
+  })
+
+  it('does nothing and stays unshrunk when disabled', () => {
+    const { result } = render(false)
+
+    expect(observedEl).toBeNull()
+    expect(result.current).toBe(false)
+  })
+})

--- a/frontend/src/shared/lib/motion/use-header-shrink.ts
+++ b/frontend/src/shared/lib/motion/use-header-shrink.ts
@@ -1,0 +1,49 @@
+import { type RefObject, useEffect, useState } from 'react'
+
+/**
+ * First-party sticky-header shrink (#371 S2). Observes a zero-height sentinel at
+ * the very top of the page; once the reader scrolls past a small threshold the
+ * sentinel leaves the (margin-expanded) root and we report `shrunk = true`, which
+ * the shell reflects as `data-shrunk` so CSS can compact the sticky header.
+ *
+ * Sentinel + IntersectionObserver rather than a scroll listener (no per-frame
+ * work). The caller gates `enabled` (off when the flag is off or reduced-motion
+ * is on). SSR-safe — returns `false` when IntersectionObserver is unavailable.
+ */
+// Positive top margin grows the root upward, so the top sentinel keeps
+// intersecting until the page is scrolled past this threshold.
+const THRESHOLD_PX = 72
+
+export interface HeaderShrinkOptions {
+  enabled: boolean
+  sentinelRef: RefObject<Element | null>
+}
+
+export function useHeaderShrink({ enabled, sentinelRef }: HeaderShrinkOptions): boolean {
+  const [shrunk, setShrunk] = useState(false)
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current
+    if (!enabled || sentinel === null || typeof IntersectionObserver === 'undefined') {
+      setShrunk(false)
+      return undefined
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0]
+        if (entry !== undefined) {
+          setShrunk(!entry.isIntersecting)
+        }
+      },
+      { rootMargin: `${String(THRESHOLD_PX)}px 0px 0px 0px`, threshold: 0 },
+    )
+    observer.observe(sentinel)
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [enabled, sentinelRef])
+
+  return shrunk
+}

--- a/frontend/src/shared/lib/theme-customization.test.ts
+++ b/frontend/src/shared/lib/theme-customization.test.ts
@@ -176,4 +176,11 @@ describe('resolveFlagAttrs / flagAttrsForTheme', () => {
     // Invalid values are dropped like any other flag.
     expect(resolveFlagAttrs(undefined, { motionReveal: 'fancy' })).toEqual({})
   })
+
+  it('maps the motion-header capability flag', () => {
+    expect(resolveFlagAttrs(undefined, { motionHeader: 'shrink' })).toEqual({
+      'data-motion-header': 'shrink',
+    })
+    expect(resolveFlagAttrs(undefined, { motionHeader: 'wobble' })).toEqual({})
+  })
 })

--- a/frontend/src/shared/lib/theme-customization.ts
+++ b/frontend/src/shared/lib/theme-customization.ts
@@ -66,6 +66,7 @@ export interface ThemeFlags {
   /** Motion capability layer (see #371 / theme-flags.md §6). First-party JS implements
    *  the behaviour; themes only declare the flag. Gated by prefers-reduced-motion. */
   motionReveal?: string
+  motionHeader?: string
 }
 
 /** flag key → { data attribute, allowed values }. Mirrors theme-flags.md §2. */
@@ -197,6 +198,13 @@ export const FLAG_DEFS: Record<keyof ThemeFlags, { attr: string; options: readon
         { value: 'off', label: 'Off' },
         { value: 'subtle', label: 'Subtle' },
         { value: 'standard', label: 'Standard' },
+      ],
+    },
+    motionHeader: {
+      attr: 'data-motion-header',
+      options: [
+        { value: 'static', label: 'Static' },
+        { value: 'shrink', label: 'Shrink on scroll' },
       ],
     },
   }

--- a/src/Theme/ThemeAuthoringGuide.php
+++ b/src/Theme/ThemeAuthoringGuide.php
@@ -73,6 +73,7 @@ final class ThemeAuthoringGuide
         'headerWidth' => 'Header content width (boxed / full-bleed).',
         'headerSticky' => 'Whether the header sticks to the top on scroll (sticky / none).',
         'motionReveal' => 'Scroll-into-view fade for cards/headings (off / subtle / standard); first-party, disabled under prefers-reduced-motion.',
+        'motionHeader' => 'Sticky header compaction on scroll (static / shrink); first-party, disabled under prefers-reduced-motion.',
     ];
 
     /**
@@ -97,6 +98,7 @@ final class ThemeAuthoringGuide
         'headerWidth' => 'data-header-width',
         'headerSticky' => 'data-header-sticky',
         'motionReveal' => 'data-motion-reveal',
+        'motionHeader' => 'data-motion-header',
     ];
 
     /**

--- a/src/Theme/ThemeManifestValidator.php
+++ b/src/Theme/ThemeManifestValidator.php
@@ -55,6 +55,7 @@ final class ThemeManifestValidator
         'headerWidth' => ['boxed', 'full'],
         'headerSticky' => ['sticky', 'none'],
         'motionReveal' => ['off', 'subtle', 'standard'],
+        'motionHeader' => ['static', 'shrink'],
     ];
 
     /**


### PR DESCRIPTION
## 目的

**#371（モーション能力レイヤ）のスライス2**。S1 で確立した基盤（`use-consumer-motion`・reduced-motion 3層ゲート・フラグ機構・parity）を再利用し、スクロールで sticky ヘッダーをコンパクトに縮める **sticky-shrink** を第一者JSで実装。テーマは flag を宣言するのみ。

## 変更内容

- **`shared/lib/motion/use-header-shrink.ts`**（新）: ページ先頭の 0px sentinel を `IntersectionObserver`（`rootMargin: 72px` の閾値）で監視し、超えたら `shrunk` を返す。**scroll listener 不使用**。
- **`use-consumer-motion`**: `header`（`static|shrink`）を合成、reduced-motion で `static` 強制（3層ゲートの JS 層）。
- **`PublicSiteShell`**: 先頭に sentinel を置き、`data-shrunk` を root に付与（`data-motion-header` は flag spread 由来）。
- **`public-site.css`**: `[data-motion-header='shrink'][data-shrunk]` で `.hd__in` 高さ（72→56px）・brand mark・影をコンパクト化（`transition` で滑らか）。`data-shrunk` は JS gate により reduced/flag-off では付かないため安全。
- **`motionHeader` フラグ end-to-end**: ThemeFlags / FLAG_DEFS / `public-theme.schema.json` / `theme-flags.md` / カスタマイザUI / i18n(en,ja) / backend `FLAG_ENUMS` / `ThemeAuthoringGuide`(FLAG_DOCS/FLAG_ATTRS)。parity テスト維持。
- **テスト**: `use-header-shrink`（sentinel in/out → shrunk）/ `use-consumer-motion`（header flag・reduced 強制）/ `resolveFlagAttrs`（motionHeader）。

## reduced-motion / no-JS
- reduced-motion: `useConsumerMotion` が `header='static'` を強制 → hook 無効 → `data-shrunk` 不発 → 縮小しない。
- no-JS: `data-shrunk` が付かないので常にフルサイズ（破綻なし）。

## スコープ
S2 のみ。残り S3（hero split/gradient・CSS-only・並行可）/ S4 lightbox / S5 View Transitions / S6 parallax は後続。

## 検証
- `npm run check`（type/lint/prettier/test/validate:themes/knip/storybook）全グリーン。
- `composer check`（PHPUnit / PHPStan8 / CS / OpenAPI / MCP・**FLAG parity & engine-var 検証**）全グリーン。

## 動作確認
管理 › 外観 › テーマ › カスタマイズ › 詳細設定 › **Header shrink = Shrink on scroll** → 公開サイトをスクロールするとヘッダーが縮む。OS の reduce motion で無効化。

Closes #479