### PR TITLE
feat(public): hero バリアント split / gradient (#481)

### DIFF
--- a/docs/theming/public-theme.schema.json
+++ b/docs/theming/public-theme.schema.json
@@ -85,7 +85,7 @@
         "feedColumns": { "enum": ["auto", "1", "2", "3", "4"] },
         "cardStyle": { "enum": ["flat", "bordered", "shadowed", "framed"] },
         "media": { "enum": ["plain", "duotone", "grayscale", "framed"] },
-        "hero": { "enum": ["standard", "fullbleed", "minimal"] },
+        "hero": { "enum": ["standard", "fullbleed", "minimal", "split", "gradient"] },
         "sectionRule": { "enum": ["none", "hairline", "heavy"] },
         "eyebrow": { "enum": ["plain", "caps", "barred"] },
         "headerSearch": { "enum": ["show", "hide"] },

--- a/docs/theming/theme-flags.md
+++ b/docs/theming/theme-flags.md
@@ -26,7 +26,7 @@ A だけでも「WP の定番テーマ」級は出せる。語彙に収まらな
 | `feedColumns` | `data-feed-cols` | `auto` \| `1` \| `2` \| `3` \| `4`            | グリッドフィードの列数。auto=幅に応じた auto-fill（現行）/ 1〜4=固定列（デスクトップ/タブレットは尊重、スマホ幅 ≤430px で 1 列に畳む。4 は ≤620px で 2 列）。`feedLayout=list` 時は無効 |
 | `cardStyle`   | `data-cards`   | `flat` \| `bordered` \| `shadowed` \| `framed`  | `.card` の意匠（枠/影/額装）                                                                                                       |
 | `media`       | `data-media`   | `plain` \| `duotone` \| `grayscale` \| `framed` | `.card__media` / `.featured__media` / `.article__hero` の見せ方（`filter`/枠）                                                     |
-| `hero`        | `data-hero`    | `standard` \| `fullbleed` \| `minimal`          | `.hero` 構図（minimal=アート省略・タイポ主体 / fullbleed=幅広）                                                                    |
+| `hero`        | `data-hero`    | `standard` \| `fullbleed` \| `minimal` \| `split` \| `gradient` | `.hero` 構図（minimal=アート省略・タイポ主体 / fullbleed=幅広帯 / split=均等2カラム＋アート全高 / gradient=アクセント色のグラデ帯）。CSS-only・DOM不変 |
 | `sectionRule` | `data-rule`    | `none` \| `hairline` \| `heavy`                 | `.section__head` の区切り罫                                                                                                        |
 | `eyebrow`     | `data-eyebrow` | `plain` \| `caps` \| `barred`                   | `.eyebrow` の表情（小型キャップス/バー）                                                                                           |
 | `headerSearch`  | `data-header-search`  | `show` \| `hide` | ヘッダー検索アイコン（`.hd__search`）の表示。詳細は [`header-patterns.md`](./header-patterns.md) |

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -1948,6 +1948,48 @@
   z-index: -1;
 }
 
+/* split — balanced 50/50 columns with a full-height art panel. */
+.nene-public[data-hero='split'] .hero {
+  padding-block: clamp(3rem, 1.5rem + 5vw, 5.5rem);
+}
+.nene-public[data-hero='split'] .hero__grid {
+  grid-template-columns: 1fr 1fr;
+  align-items: stretch;
+}
+.nene-public[data-hero='split'] .hero__copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.nene-public[data-hero='split'] .hero__art,
+.nene-public[data-hero='split'] .hero__art-frame {
+  height: 100%;
+}
+.nene-public[data-hero='split'] .hero__art-frame img {
+  height: 100%;
+  object-fit: cover;
+}
+
+/* gradient — a full-width accent-tinted gradient band behind the hero. */
+.nene-public[data-hero='gradient'] .hero {
+  position: relative;
+  padding-block: clamp(3rem, 1.5rem + 6vw, 6rem);
+}
+.nene-public[data-hero='gradient'] .hero::before {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: 50%;
+  width: 100vw;
+  transform: translateX(-50%);
+  background: linear-gradient(
+    135deg,
+    color-mix(in oklch, var(--color-accent) 20%, var(--color-surface)),
+    var(--color-surface) 62%
+  );
+  z-index: -1;
+}
+
 /* sectionRule — the rule under a section heading. */
 .nene-public[data-rule='none'] .section__head {
   border-bottom: none;

--- a/frontend/src/shared/lib/theme-customization.test.ts
+++ b/frontend/src/shared/lib/theme-customization.test.ts
@@ -183,4 +183,9 @@ describe('resolveFlagAttrs / flagAttrsForTheme', () => {
     })
     expect(resolveFlagAttrs(undefined, { motionHeader: 'wobble' })).toEqual({})
   })
+
+  it('maps the new hero variants (split / gradient)', () => {
+    expect(resolveFlagAttrs(undefined, { hero: 'split' })).toEqual({ 'data-hero': 'split' })
+    expect(resolveFlagAttrs(undefined, { hero: 'gradient' })).toEqual({ 'data-hero': 'gradient' })
+  })
 })

--- a/frontend/src/shared/lib/theme-customization.ts
+++ b/frontend/src/shared/lib/theme-customization.ts
@@ -114,6 +114,8 @@ export const FLAG_DEFS: Record<keyof ThemeFlags, { attr: string; options: readon
         { value: 'standard', label: 'Standard' },
         { value: 'fullbleed', label: 'Full bleed' },
         { value: 'minimal', label: 'Minimal' },
+        { value: 'split', label: 'Split' },
+        { value: 'gradient', label: 'Gradient' },
       ],
     },
     sectionRule: {

--- a/src/Theme/ThemeAuthoringGuide.php
+++ b/src/Theme/ThemeAuthoringGuide.php
@@ -61,7 +61,7 @@ final class ThemeAuthoringGuide
         'feedColumns' => 'Column count of the feed grid; auto = responsive.',
         'cardStyle' => 'Visual treatment of cards (flat / bordered / shadowed / framed).',
         'media' => 'Image/thumbnail rendering treatment (plain / duotone / grayscale / framed).',
-        'hero' => 'Top hero/banner layout (standard / fullbleed / minimal).',
+        'hero' => 'Top hero/banner layout (standard / fullbleed / minimal / split / gradient).',
         'sectionRule' => 'Divider style between sections (none / hairline / heavy).',
         'eyebrow' => 'Style of the small kicker label above titles (plain / caps / barred).',
         'headerSearch' => 'Show or hide the header search control.',

--- a/src/Theme/ThemeManifestValidator.php
+++ b/src/Theme/ThemeManifestValidator.php
@@ -43,7 +43,7 @@ final class ThemeManifestValidator
         'feedColumns' => ['auto', '1', '2', '3', '4'],
         'cardStyle' => ['flat', 'bordered', 'shadowed', 'framed'],
         'media' => ['plain', 'duotone', 'grayscale', 'framed'],
-        'hero' => ['standard', 'fullbleed', 'minimal'],
+        'hero' => ['standard', 'fullbleed', 'minimal', 'split', 'gradient'],
         'sectionRule' => ['none', 'hairline', 'heavy'],
         'eyebrow' => ['plain', 'caps', 'barred'],
         'headerSearch' => ['show', 'hide'],


### PR DESCRIPTION
## 目的

**#371（モーション能力レイヤ）のスライス3**。**CSS-only・DOM不変**で、既存 `hero` フラグ（`standard | fullbleed | minimal`）に **`split`** と **`gradient`** を追加。motion JS とは独立なので並行マージ可。

## 変更内容

- **`split`**: `.hero__grid` を均等2カラム（1fr 1fr）にし、アートを全高パネル化。編集的な左右分割ヒーロー。
- **`gradient`**: アクセント色のフルブリードなグラデーション帯を hero 背景に（既存 fullbleed と同じ `::before` + 100vw 帯。`color-mix(--color-accent, --color-surface)` で light/dark に追従）。
- `hero` enum 拡張を end-to-end: frontend `FLAG_DEFS` / `public-theme.schema.json` / `theme-flags.md` / backend `FLAG_ENUMS` / `ThemeAuthoringGuide`（FLAG_DOCS）。カスタマイザ UI は `FLAG_DEFS` 駆動のため**自動でオプション追加**。
- テスト: `resolveFlagAttrs(hero='split'/'gradient')`。

## 検証
- `npm run check`（type/lint/prettier/test/validate:themes/knip/storybook）全グリーン。
- `composer check`（PHPUnit/PHPStan8/CS/OpenAPI/MCP・**FLAG parity** 含む）全グリーン。

## 動作確認
管理 › 外観 › テーマ › カスタマイズ › 詳細設定 › **Hero = Split / Gradient** → 公開トップのヒーローが切り替わる。

Closes #481