### PR TITLE
fix(appearance): カスタマイザのラベルとセレクトを隣接配置にする (#483)

### DIFF
--- a/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
+++ b/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
@@ -15,9 +15,14 @@ import { Button, Card, ConfirmDialog, Input, Stack, Text, Textarea } from '@/sha
 import type { ThemeCustomizePageState } from '../hooks/useThemeCustomizePage'
 
 function Field({ label, children }: { label: string; children: ReactNode }) {
+  // Fixed-width label column + left-grouped control: keeps each control right
+  // next to its label (no wide spread on large screens) while controls still
+  // line up in a tidy column.
   return (
-    <label className="flex items-center justify-between gap-inline-md">
-      <span className="font-chrome text-caption font-semibold text-text-primary">{label}</span>
+    <label className="flex items-center gap-inline-md">
+      <span className="w-44 shrink-0 font-chrome text-caption font-semibold text-text-primary">
+        {label}
+      </span>
       {children}
     </label>
   )


### PR DESCRIPTION
## 目的

テーマ カスタマイザの各行（`ThemeCustomizeView` の `Field`）が `flex justify-between` でラベルを左端・コントロールを右端に突き放しており、**ブラウザ幅が広いと両者が大きく離れて、どのセレクトがどのラベルか分かりにくかった**（#483）。

## 変更内容

- `Field` を `justify-between` から **固定幅ラベル列（`w-44` = 11rem, `shrink-0`）＋左寄せ**に変更。各コントロールがラベルのすぐ隣に整列し、画面幅に関係なく対応が一目で分かる。
- UI のみ・挙動/ロジック変更なし。基本ノブも詳細フラグも同じ `Field` を使うため全行に一貫適用。

## 検証
- `npm run check`（type/lint/prettier/test/validate:themes/knip/storybook）全グリーン。

Closes #483