### PR TITLE
feat(blocks): blocks フィールド型のバックエンド基盤 (#486 S1a)

### DIFF
--- a/database/migrations/20260621000000_create_blocks_fields_table.php
+++ b/database/migrations/20260621000000_create_blocks_fields_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Db\Adapter\MysqlAdapter;
+use Phinx\Migration\AbstractMigration;
+
+final class CreateBlocksFieldsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        // Mirrors text_fields (incl. the later organization_id + locale additions),
+        // but `value` holds a JSON document ([{id,type,data}]); LONGTEXT so large
+        // block lists are not truncated. Document shape is validated in the app
+        // layer (BlocksDocumentValidator), not the DB.
+        $this->table('blocks_fields')
+            ->addColumn('organization_id', 'integer', ['null' => false, 'signed' => false, 'default' => 0])
+            ->addColumn('entity_id', 'integer', ['null' => false, 'signed' => false])
+            ->addColumn('field_key', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('locale', 'string', ['limit' => 35, 'null' => true, 'default' => null])
+            ->addColumn('value', 'text', ['null' => false, 'limit' => MysqlAdapter::TEXT_LONG])
+            ->addColumn('is_deleted', 'boolean', ['default' => false, 'null' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true, 'default' => null])
+            ->addIndex(['organization_id'])
+            ->addIndex(['entity_id'])
+            ->addForeignKey('entity_id', 'entities', 'id', ['delete' => 'RESTRICT', 'update' => 'NO_ACTION'])
+            ->create();
+    }
+}

--- a/docs/blocks/blocks.schema.json
+++ b/docs/blocks/blocks.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nene-records.dev/schemas/blocks.schema.json",
+  "title": "Post Blocks Document",
+  "description": "Canonical shape of a `blocks` field value (epic #486): an ordered list of curated, typed blocks. Server validation lives in src/BlocksField/BlocksDocumentValidator.php (the trust boundary); this schema is the contract source for the frontend (Ajv) and codegen. Curated typed blocks, NOT a free-form page builder.",
+  "type": "array",
+  "maxItems": 200,
+  "items": { "$ref": "#/$defs/block" },
+  "$defs": {
+    "block": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "data"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Client-generated stable key (React key / future anchor). Opaque.",
+          "minLength": 1,
+          "maxLength": 64
+        },
+        "type": { "enum": ["text", "callout"] },
+        "data": { "type": "object" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "text" } } },
+          "then": { "properties": { "data": { "$ref": "#/$defs/textData" } } }
+        },
+        {
+          "if": { "properties": { "type": { "const": "callout" } } },
+          "then": { "properties": { "data": { "$ref": "#/$defs/calloutData" } } }
+        }
+      ]
+    },
+    "textData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["markdown"],
+      "properties": {
+        "markdown": { "type": "string", "minLength": 1, "maxLength": 50000 }
+      }
+    },
+    "calloutData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "body"],
+      "properties": {
+        "kind": { "enum": ["info", "warn", "ok", "danger"] },
+        "title": { "type": "string", "maxLength": 200 },
+        "body": { "type": "string", "minLength": 1, "maxLength": 50000 }
+      }
+    }
+  }
+}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -20,6 +20,8 @@ tags:
     description: Registered field definitions per entity type.
   - name: TextFields
     description: Typed text field values on entities.
+  - name: BlocksFields
+    description: Typed post-block document values on entities (epic #486).
   - name: IntFields
     description: Typed integer field values on entities.
   - name: EnumFields
@@ -1111,6 +1113,173 @@ paths:
       responses:
         '204':
           description: Text field soft-deleted.
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/blocks-fields:
+    get:
+      tags:
+        - BlocksFields
+      summary: List blocks fields
+      description: Returns non-deleted blocks fields.
+      operationId: listBlocksFields
+      parameters:
+        - $ref: '#/components/parameters/LimitQuery'
+        - $ref: '#/components/parameters/OffsetQuery'
+        - $ref: '#/components/parameters/EntityIdQuery'
+        - $ref: '#/components/parameters/EntityTypeIdQuery'
+        - name: locale
+          in: query
+          required: false
+          description: Filter by locale code (e.g. "ja", "en"). When omitted, rows of all locales are returned.
+          schema:
+            type: string
+            maxLength: 10
+      responses:
+        '200':
+          description: Paginated blocks field list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlocksFieldListResponse'
+              examples:
+                ok:
+                  summary: Empty list
+                  value:
+                    items: []
+                    limit: 20
+                    offset: 0
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - BlocksFields
+      summary: Create blocks field
+      operationId: createBlocksField
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateBlocksFieldRequest'
+            examples:
+              ok:
+                value:
+                  entity_id: 1
+                  field_key: body
+                  value: '[{"id":"b1","type":"text","data":{"markdown":"Hello world"}}]'
+      responses:
+        '201':
+          description: Blocks field created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlocksFieldResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_id: 1
+                    field_key: body
+                    value: '[{"id":"b1","type":"text","data":{"markdown":"Hello world"}}]'
+                    locale: null
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: Validation failed (malformed blocks document, unknown block type, unregistered field key, or field type mismatch).
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ValidationProblemDetails'
+                  - $ref: '#/components/schemas/ProblemDetails'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/blocks-fields/{id}:
+    get:
+      tags:
+        - BlocksFields
+      summary: Get blocks field by id
+      operationId: getBlocksFieldById
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      responses:
+        '200':
+          description: Blocks field found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlocksFieldResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_id: 1
+                    field_key: body
+                    value: '[{"id":"b1","type":"text","data":{"markdown":"Hello world"}}]'
+                    locale: null
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      tags:
+        - BlocksFields
+      summary: Update blocks field
+      operationId: updateBlocksField
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateBlocksFieldRequest'
+            examples:
+              ok:
+                value:
+                  field_key: body
+                  value: '[{"id":"b1","type":"callout","data":{"kind":"info","body":"Note"}}]'
+      responses:
+        '200':
+          description: Blocks field updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlocksFieldResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    entity_id: 1
+                    field_key: body
+                    value: '[{"id":"b1","type":"callout","data":{"kind":"info","body":"Note"}}]'
+                    locale: null
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: Validation failed (malformed blocks document, unknown block type, unregistered field key, or field type mismatch).
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ValidationProblemDetails'
+                  - $ref: '#/components/schemas/ProblemDetails'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - BlocksFields
+      summary: Soft delete blocks field
+      operationId: deleteBlocksField
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      responses:
+        '204':
+          description: Blocks field soft-deleted.
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -5043,6 +5212,86 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TextFieldResponse'
+        limit:
+          type: integer
+        offset:
+          type: integer
+    BlocksFieldResponse:
+      type: object
+      required:
+        - id
+        - entity_id
+        - field_key
+        - value
+        - locale
+      properties:
+        id:
+          type: integer
+          format: int64
+        entity_id:
+          type: integer
+          format: int64
+        field_key:
+          type: string
+        value:
+          type: string
+          description: 'JSON document (string): an ordered array of blocks `[{id,type,data}]`. See docs/blocks/blocks.schema.json. Server-validated by BlocksDocumentValidator.'
+        locale:
+          type: string
+          nullable: true
+          description: BCP-47 locale code (e.g. "ja", "en-US"). Null indicates the default/global value.
+    CreateBlocksFieldRequest:
+      type: object
+      required:
+        - entity_id
+        - field_key
+        - value
+      properties:
+        entity_id:
+          type: integer
+          format: int64
+          minimum: 1
+        field_key:
+          type: string
+          minLength: 1
+        value:
+          type: string
+          description: 'JSON document (string): an ordered array of blocks `[{id,type,data}]`.'
+        locale:
+          type: string
+          nullable: true
+          maxLength: 10
+          description: BCP-47 locale code. Omit for the default/global value.
+      additionalProperties: false
+    UpdateBlocksFieldRequest:
+      type: object
+      required:
+        - field_key
+        - value
+      properties:
+        field_key:
+          type: string
+          minLength: 1
+        value:
+          type: string
+          description: 'JSON document (string): an ordered array of blocks `[{id,type,data}]`.'
+        locale:
+          type: string
+          nullable: true
+          maxLength: 10
+          description: BCP-47 locale code. Omit to keep as the default/global value.
+      additionalProperties: false
+    BlocksFieldListResponse:
+      type: object
+      required:
+        - items
+        - limit
+        - offset
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/BlocksFieldResponse'
         limit:
           type: integer
         offset:

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -407,6 +407,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/blocks-fields": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List blocks fields
+         * @description Returns non-deleted blocks fields.
+         */
+        get: operations["listBlocksFields"];
+        put?: never;
+        /** Create blocks field */
+        post: operations["createBlocksField"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/blocks-fields/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get blocks field by id */
+        get: operations["getBlocksFieldById"];
+        /** Update blocks field */
+        put: operations["updateBlocksField"];
+        post?: never;
+        /** Soft delete blocks field */
+        delete: operations["deleteBlocksField"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/int-fields": {
         parameters: {
             query?: never;
@@ -2033,6 +2073,38 @@ export interface components {
         };
         TextFieldListResponse: {
             items: components["schemas"]["TextFieldResponse"][];
+            limit: number;
+            offset: number;
+        };
+        BlocksFieldResponse: {
+            /** Format: int64 */
+            id: number;
+            /** Format: int64 */
+            entity_id: number;
+            field_key: string;
+            /** @description JSON document (string): an ordered array of blocks `[{id,type,data}]`. See docs/blocks/blocks.schema.json. Server-validated by BlocksDocumentValidator. */
+            value: string;
+            /** @description BCP-47 locale code (e.g. "ja", "en-US"). Null indicates the default/global value. */
+            locale: string | null;
+        };
+        CreateBlocksFieldRequest: {
+            /** Format: int64 */
+            entity_id: number;
+            field_key: string;
+            /** @description JSON document (string): an ordered array of blocks `[{id,type,data}]`. */
+            value: string;
+            /** @description BCP-47 locale code. Omit for the default/global value. */
+            locale?: string | null;
+        };
+        UpdateBlocksFieldRequest: {
+            field_key: string;
+            /** @description JSON document (string): an ordered array of blocks `[{id,type,data}]`. */
+            value: string;
+            /** @description BCP-47 locale code. Omit to keep as the default/global value. */
+            locale?: string | null;
+        };
+        BlocksFieldListResponse: {
+            items: components["schemas"]["BlocksFieldResponse"][];
             limit: number;
             offset: number;
         };
@@ -3779,6 +3851,160 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description Text field soft-deleted. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    listBlocksFields: {
+        parameters: {
+            query?: {
+                /** @example 20 */
+                limit?: components["parameters"]["LimitQuery"];
+                /** @example 0 */
+                offset?: components["parameters"]["OffsetQuery"];
+                /** @example 1 */
+                entity_id?: components["parameters"]["EntityIdQuery"];
+                /** @example 1 */
+                entity_type_id?: components["parameters"]["EntityTypeIdQuery"];
+                /** @description Filter by locale code (e.g. "ja", "en"). When omitted, rows of all locales are returned. */
+                locale?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated blocks field list. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BlocksFieldListResponse"];
+                };
+            };
+            422: components["responses"]["ValidationFailed"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    createBlocksField: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateBlocksFieldRequest"];
+            };
+        };
+        responses: {
+            /** @description Blocks field created. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BlocksFieldResponse"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            /** @description Validation failed (malformed blocks document, unknown block type, unregistered field key, or field type mismatch). */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ValidationProblemDetails"] | components["schemas"]["ProblemDetails"];
+                };
+            };
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    getBlocksFieldById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @example 1 */
+                id: components["parameters"]["IdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Blocks field found. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BlocksFieldResponse"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    updateBlocksField: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @example 1 */
+                id: components["parameters"]["IdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateBlocksFieldRequest"];
+            };
+        };
+        responses: {
+            /** @description Blocks field updated. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BlocksFieldResponse"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            /** @description Validation failed (malformed blocks document, unknown block type, unregistered field key, or field type mismatch). */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ValidationProblemDetails"] | components["schemas"]["ProblemDetails"];
+                };
+            };
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    deleteBlocksField: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @example 1 */
+                id: components["parameters"]["IdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Blocks field soft-deleted. */
             204: {
                 headers: {
                     [name: string]: unknown;

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -13,6 +13,9 @@ use NeNeRecords\Analytics\AnalyticsRouteRegistrar;
 use NeNeRecords\Analytics\AnalyticsServiceProvider;
 use NeNeRecords\Auth\AuthRouteRegistrar;
 use NeNeRecords\Auth\InvalidCredentialsExceptionHandler;
+use NeNeRecords\BlocksField\BlocksFieldNotFoundExceptionHandler;
+use NeNeRecords\BlocksField\BlocksFieldRouteRegistrar;
+use NeNeRecords\BlocksField\BlocksFieldServiceProvider;
 use NeNeRecords\BoolField\BoolFieldNotFoundExceptionHandler;
 use NeNeRecords\BoolField\BoolFieldRouteRegistrar;
 use NeNeRecords\BoolField\BoolFieldServiceProvider;
@@ -148,6 +151,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new FieldDefServiceProvider())
             ->addProvider(new EntityServiceProvider())
             ->addProvider(new TextFieldServiceProvider())
+            ->addProvider(new BlocksFieldServiceProvider())
             ->addProvider(new IntFieldServiceProvider())
             ->addProvider(new EnumFieldServiceProvider())
             ->addProvider(new BoolFieldServiceProvider())
@@ -184,6 +188,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $fieldDef = $container->get('nene-records.route_registrar.field_def');
                     $entity = $container->get('nene-records.route_registrar.entity');
                     $textField = $container->get('nene-records.route_registrar.text_field');
+                    $blocksField = $container->get('nene-records.route_registrar.blocks_field');
                     $intField = $container->get('nene-records.route_registrar.int_field');
                     $enumField = $container->get('nene-records.route_registrar.enum_field');
                     $boolField = $container->get('nene-records.route_registrar.bool_field');
@@ -218,6 +223,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !$fieldDef instanceof FieldDefRouteRegistrar
                         || !$entity instanceof EntityRouteRegistrar
                         || !$textField instanceof TextFieldRouteRegistrar
+                        || !$blocksField instanceof BlocksFieldRouteRegistrar
                         || !$intField instanceof IntFieldRouteRegistrar
                         || !$enumField instanceof EnumFieldRouteRegistrar
                         || !$boolField instanceof BoolFieldRouteRegistrar
@@ -256,6 +262,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $fieldDef,
                         $entity,
                         $textField,
+                        $blocksField,
                         $intField,
                         $enumField,
                         $boolField,
@@ -296,6 +303,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $entityNotFound = $container->get(EntityNotFoundExceptionHandler::class);
                     $duplicateEntitySlug = $container->get(DuplicateEntitySlugExceptionHandler::class);
                     $textFieldNotFound = $container->get(TextFieldNotFoundExceptionHandler::class);
+                    $blocksFieldNotFound = $container->get(BlocksFieldNotFoundExceptionHandler::class);
                     $intFieldNotFound = $container->get(IntFieldNotFoundExceptionHandler::class);
                     $enumFieldNotFound = $container->get(EnumFieldNotFoundExceptionHandler::class);
                     $boolFieldNotFound = $container->get(BoolFieldNotFoundExceptionHandler::class);
@@ -346,6 +354,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $entityNotFound,
                         $duplicateEntitySlug,
                         $textFieldNotFound,
+                        $blocksFieldNotFound,
                         $intFieldNotFound,
                         $enumFieldNotFound,
                         $boolFieldNotFound,
@@ -401,6 +410,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $entityNotFound,
                         $duplicateEntitySlug,
                         $textFieldNotFound,
+                        $blocksFieldNotFound,
                         $intFieldNotFound,
                         $enumFieldNotFound,
                         $boolFieldNotFound,

--- a/src/BlocksField/BlockTypes.php
+++ b/src/BlocksField/BlockTypes.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+/**
+ * Whitelist of post-block types (#486). Each type has a known consumer renderer,
+ * an admin inspector form, and a `data` shape validated by
+ * {@see BlocksDocumentValidator}. Curated typed blocks (Gutenberg-style column),
+ * NOT a free-form page builder. S1 ships `text` and `callout`; later slices add
+ * `hero`, `gallery`/`carousel`, and `chart`.
+ */
+final class BlockTypes
+{
+    /** @var list<string> */
+    private const TYPES = [
+        'text',
+        'callout',
+    ];
+
+    public static function isValid(string $type): bool
+    {
+        return in_array($type, self::TYPES, true);
+    }
+
+    /** @return list<string> */
+    public static function all(): array
+    {
+        return self::TYPES;
+    }
+}

--- a/src/BlocksField/BlocksDocumentValidator.php
+++ b/src/BlocksField/BlocksDocumentValidator.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+
+/**
+ * Server-side validator for a blocks document — the value of a `blocks` field
+ * (#486). This is the trust boundary: the admin editor and MCP write tools are
+ * convenience, but only this guarantees a stored document is a well-formed list
+ * of curated, typed blocks. Mirrors the hand-written style of
+ * {@see \NeNeRecords\Theme\ThemeManifestValidator}; the canonical shape lives in
+ * docs/blocks/blocks.schema.json (frontend Ajv source).
+ *
+ * A document is `[{ id, type, data }]`. Each `type` must be whitelisted
+ * ({@see BlockTypes}) and its `data` must match that type's shape.
+ */
+final class BlocksDocumentValidator
+{
+    public const MAX_BLOCKS = 200;
+    private const MAX_ID_LEN = 64;
+    private const MAX_TITLE_LEN = 200;
+    private const MAX_TEXT_LEN = 50000;
+
+    /** @var list<string> */
+    private const CALLOUT_KINDS = ['info', 'warn', 'ok', 'danger'];
+
+    /**
+     * @throws ValidationException when the document is malformed or a block is invalid
+     */
+    public function validate(string $json): void
+    {
+        $decoded = json_decode($json, true);
+
+        if (!is_array($decoded) || !array_is_list($decoded)) {
+            throw new ValidationException([
+                new ValidationError('value', 'Blocks document must be a JSON array of blocks.', 'invalid'),
+            ]);
+        }
+
+        if (count($decoded) > self::MAX_BLOCKS) {
+            throw new ValidationException([
+                new ValidationError('value', 'A blocks document may contain at most ' . self::MAX_BLOCKS . ' blocks.', 'invalid'),
+            ]);
+        }
+
+        $errors = [];
+
+        foreach ($decoded as $index => $block) {
+            $this->validateBlock($index, $block, $errors);
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+    }
+
+    /**
+     * @param list<ValidationError> $errors
+     */
+    private function validateBlock(int $index, mixed $block, array &$errors): void
+    {
+        $path = "value[{$index}]";
+
+        if (!is_array($block)) {
+            $errors[] = new ValidationError($path, 'Each block must be an object.', 'invalid');
+
+            return;
+        }
+
+        $id = $block['id'] ?? null;
+        if (!is_string($id) || $id === '' || strlen($id) > self::MAX_ID_LEN) {
+            $errors[] = new ValidationError("{$path}.id", 'Block id must be a non-empty string (max ' . self::MAX_ID_LEN . ' chars).', 'invalid');
+        }
+
+        $type = $block['type'] ?? null;
+        if (!is_string($type) || !BlockTypes::isValid($type)) {
+            $errors[] = new ValidationError("{$path}.type", 'Block type must be one of: ' . implode(', ', BlockTypes::all()) . '.', 'invalid');
+
+            return;
+        }
+
+        $data = $block['data'] ?? null;
+        if (!is_array($data)) {
+            $errors[] = new ValidationError("{$path}.data", 'Block data must be an object.', 'invalid');
+
+            return;
+        }
+
+        match ($type) {
+            'text' => $this->validateTextData($path, $data, $errors),
+            'callout' => $this->validateCalloutData($path, $data, $errors),
+            default => null,
+        };
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     * @param list<ValidationError> $errors
+     */
+    private function validateTextData(string $path, array $data, array &$errors): void
+    {
+        $markdown = $data['markdown'] ?? null;
+        if (!is_string($markdown) || $markdown === '' || strlen($markdown) > self::MAX_TEXT_LEN) {
+            $errors[] = new ValidationError("{$path}.data.markdown", 'Text block requires non-empty markdown (max ' . self::MAX_TEXT_LEN . ' chars).', 'invalid');
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     * @param list<ValidationError> $errors
+     */
+    private function validateCalloutData(string $path, array $data, array &$errors): void
+    {
+        $kind = $data['kind'] ?? null;
+        if (!is_string($kind) || !in_array($kind, self::CALLOUT_KINDS, true)) {
+            $errors[] = new ValidationError("{$path}.data.kind", 'Callout kind must be one of: ' . implode(', ', self::CALLOUT_KINDS) . '.', 'invalid');
+        }
+
+        $body = $data['body'] ?? null;
+        if (!is_string($body) || $body === '' || strlen($body) > self::MAX_TEXT_LEN) {
+            $errors[] = new ValidationError("{$path}.data.body", 'Callout block requires a non-empty body (max ' . self::MAX_TEXT_LEN . ' chars).', 'invalid');
+        }
+
+        $title = $data['title'] ?? null;
+        if ($title !== null && (!is_string($title) || strlen($title) > self::MAX_TITLE_LEN)) {
+            $errors[] = new ValidationError("{$path}.data.title", 'Callout title must be a string (max ' . self::MAX_TITLE_LEN . ' chars).', 'invalid');
+        }
+    }
+}

--- a/src/BlocksField/BlocksField.php
+++ b/src/BlocksField/BlocksField.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+final readonly class BlocksField
+{
+    public function __construct(
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+        public ?int $id = null,
+        public ?string $locale = null,
+    ) {
+    }
+}

--- a/src/BlocksField/BlocksFieldNotFoundException.php
+++ b/src/BlocksField/BlocksFieldNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+use RuntimeException;
+
+final class BlocksFieldNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("Blocks field with id {$id} was not found.");
+    }
+}

--- a/src/BlocksField/BlocksFieldNotFoundExceptionHandler.php
+++ b/src/BlocksField/BlocksFieldNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class BlocksFieldNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof BlocksFieldNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'not-found',
+            'Not Found',
+            404,
+            'The requested blocks field was not found.',
+        );
+    }
+}

--- a/src/BlocksField/BlocksFieldRepositoryInterface.php
+++ b/src/BlocksField/BlocksFieldRepositoryInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+interface BlocksFieldRepositoryInterface
+{
+    public function findById(int $id): ?BlocksField;
+
+    /**
+     * Active (non-soft-deleted) rows only.
+     * When $locale is given, only rows with that locale are returned.
+     *
+     * @return list<BlocksField>
+     */
+    public function findAll(int $limit, int $offset, ?string $locale = null): array;
+
+    /**
+     * Active (non-soft-deleted) rows for the given entity only.
+     * When $locale is given, only rows with that locale are returned.
+     *
+     * @return list<BlocksField>
+     */
+    public function findByEntityId(int $entityId, int $limit, int $offset, ?string $locale = null): array;
+
+    /**
+     * Active (non-soft-deleted) rows for entities belonging to the given entity type.
+     * When $locale is given, only rows with that locale are returned.
+     *
+     * @return list<BlocksField>
+     */
+    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset, ?string $locale = null): array;
+
+    /**
+     * Active (non-soft-deleted) rows for a batch of entity ids (no limit).
+     *
+     * @param list<int> $entityIds
+     * @return list<BlocksField>
+     */
+    public function findByEntityIds(array $entityIds): array;
+
+    public function save(BlocksField $blocksField): int;
+
+    public function update(BlocksField $blocksField): void;
+
+    /**
+     * Soft delete: sets is_deleted and deleted_at.
+     *
+     * @throws BlocksFieldNotFoundException When the id does not refer to an active row.
+     */
+    public function delete(int $id): void;
+}

--- a/src/BlocksField/BlocksFieldRouteRegistrar.php
+++ b/src/BlocksField/BlocksFieldRouteRegistrar.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class BlocksFieldRouteRegistrar
+{
+    public function __construct(
+        private ListBlocksFieldsHandler $listHandler,
+        private GetBlocksFieldByIdHandler $getHandler,
+        private CreateBlocksFieldHandler $createHandler,
+        private UpdateBlocksFieldHandler $updateHandler,
+        private DeleteBlocksFieldHandler $deleteHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $listHandler = $this->listHandler;
+        $getHandler = $this->getHandler;
+        $createHandler = $this->createHandler;
+        $updateHandler = $this->updateHandler;
+        $deleteHandler = $this->deleteHandler;
+
+        $router->get('/api/v1/blocks-fields', static fn (ServerRequestInterface $request) => $listHandler->handle($request));
+        $router->get('/api/v1/blocks-fields/{id}', static fn (ServerRequestInterface $request) => $getHandler->handle($request));
+        $router->post('/api/v1/blocks-fields', static fn (ServerRequestInterface $request) => $createHandler->handle($request));
+        $router->put('/api/v1/blocks-fields/{id}', static fn (ServerRequestInterface $request) => $updateHandler->handle($request));
+        $router->delete('/api/v1/blocks-fields/{id}', static fn (ServerRequestInterface $request) => $deleteHandler->handle($request));
+    }
+}

--- a/src/BlocksField/BlocksFieldServiceProvider.php
+++ b/src/BlocksField/BlocksFieldServiceProvider.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class BlocksFieldServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                BlocksFieldRepositoryInterface::class,
+                static function (ContainerInterface $container): BlocksFieldRepositoryInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    $orgId = $container->get('nene-records.org_id_holder');
+                    if (!$orgId instanceof RequestScopedHolder) {
+                        throw new LogicException('Org ID holder service is invalid.');
+                    }
+
+                    return new PdoBlocksFieldRepository($query, $orgId);
+                },
+            )
+            ->set(
+                CreateBlocksFieldUseCaseInterface::class,
+                static function (ContainerInterface $container): CreateBlocksFieldUseCaseInterface {
+                    $blocksFields = $container->get(BlocksFieldRepositoryInterface::class);
+                    $entities = $container->get(EntityRepositoryInterface::class);
+                    $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
+
+                    if (!$blocksFields instanceof BlocksFieldRepositoryInterface) {
+                        throw new LogicException('Blocks field repository service is invalid.');
+                    }
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field definition repository service is invalid.');
+                    }
+
+                    return new CreateBlocksFieldUseCase($blocksFields, $entities, $fieldDefs, new BlocksDocumentValidator());
+                },
+            )
+            ->set(
+                CreateBlocksFieldHandler::class,
+                static function (ContainerInterface $container): CreateBlocksFieldHandler {
+                    $useCase = $container->get(CreateBlocksFieldUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof CreateBlocksFieldUseCaseInterface) {
+                        throw new LogicException('CreateBlocksField use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new CreateBlocksFieldHandler($useCase, $response);
+                },
+            )
+            ->set(
+                DeleteBlocksFieldUseCaseInterface::class,
+                static function (ContainerInterface $container): DeleteBlocksFieldUseCaseInterface {
+                    $repository = $container->get(BlocksFieldRepositoryInterface::class);
+
+                    if (!$repository instanceof BlocksFieldRepositoryInterface) {
+                        throw new LogicException('Blocks field repository service is invalid.');
+                    }
+
+                    return new DeleteBlocksFieldUseCase($repository);
+                },
+            )
+            ->set(
+                DeleteBlocksFieldHandler::class,
+                static function (ContainerInterface $container): DeleteBlocksFieldHandler {
+                    $useCase = $container->get(DeleteBlocksFieldUseCaseInterface::class);
+                    $responseFactory = $container->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof DeleteBlocksFieldUseCaseInterface) {
+                        throw new LogicException('DeleteBlocksField use case service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    return new DeleteBlocksFieldHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
+                GetBlocksFieldByIdUseCaseInterface::class,
+                static function (ContainerInterface $container): GetBlocksFieldByIdUseCaseInterface {
+                    $repository = $container->get(BlocksFieldRepositoryInterface::class);
+
+                    if (!$repository instanceof BlocksFieldRepositoryInterface) {
+                        throw new LogicException('Blocks field repository service is invalid.');
+                    }
+
+                    return new GetBlocksFieldByIdUseCase($repository);
+                },
+            )
+            ->set(
+                GetBlocksFieldByIdHandler::class,
+                static function (ContainerInterface $container): GetBlocksFieldByIdHandler {
+                    $useCase = $container->get(GetBlocksFieldByIdUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof GetBlocksFieldByIdUseCaseInterface) {
+                        throw new LogicException('GetBlocksFieldById use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new GetBlocksFieldByIdHandler($useCase, $response);
+                },
+            )
+            ->set(
+                ListBlocksFieldsUseCaseInterface::class,
+                static function (ContainerInterface $container): ListBlocksFieldsUseCaseInterface {
+                    $repository = $container->get(BlocksFieldRepositoryInterface::class);
+
+                    if (!$repository instanceof BlocksFieldRepositoryInterface) {
+                        throw new LogicException('Blocks field repository service is invalid.');
+                    }
+
+                    return new ListBlocksFieldsUseCase($repository);
+                },
+            )
+            ->set(
+                ListBlocksFieldsHandler::class,
+                static function (ContainerInterface $container): ListBlocksFieldsHandler {
+                    $useCase = $container->get(ListBlocksFieldsUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListBlocksFieldsUseCaseInterface) {
+                        throw new LogicException('ListBlocksFields use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListBlocksFieldsHandler($useCase, $response);
+                },
+            )
+            ->set(
+                UpdateBlocksFieldUseCaseInterface::class,
+                static function (ContainerInterface $container): UpdateBlocksFieldUseCaseInterface {
+                    $blocksFields = $container->get(BlocksFieldRepositoryInterface::class);
+                    $entities = $container->get(EntityRepositoryInterface::class);
+                    $fieldDefs = $container->get(FieldDefRepositoryInterface::class);
+
+                    if (!$blocksFields instanceof BlocksFieldRepositoryInterface) {
+                        throw new LogicException('Blocks field repository service is invalid.');
+                    }
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field definition repository service is invalid.');
+                    }
+
+                    return new UpdateBlocksFieldUseCase($blocksFields, $entities, $fieldDefs, new BlocksDocumentValidator());
+                },
+            )
+            ->set(
+                UpdateBlocksFieldHandler::class,
+                static function (ContainerInterface $container): UpdateBlocksFieldHandler {
+                    $useCase = $container->get(UpdateBlocksFieldUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof UpdateBlocksFieldUseCaseInterface) {
+                        throw new LogicException('UpdateBlocksField use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new UpdateBlocksFieldHandler($useCase, $response);
+                },
+            )
+            ->set(
+                BlocksFieldNotFoundExceptionHandler::class,
+                static function (ContainerInterface $container): BlocksFieldNotFoundExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new BlocksFieldNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.blocks_field',
+                static function (ContainerInterface $container): BlocksFieldRouteRegistrar {
+                    $list = $container->get(ListBlocksFieldsHandler::class);
+                    $get = $container->get(GetBlocksFieldByIdHandler::class);
+                    $create = $container->get(CreateBlocksFieldHandler::class);
+                    $update = $container->get(UpdateBlocksFieldHandler::class);
+                    $delete = $container->get(DeleteBlocksFieldHandler::class);
+
+                    if (!$list instanceof ListBlocksFieldsHandler) {
+                        throw new LogicException('ListBlocksFields handler service is invalid.');
+                    }
+
+                    if (!$get instanceof GetBlocksFieldByIdHandler) {
+                        throw new LogicException('GetBlocksFieldById handler service is invalid.');
+                    }
+
+                    if (!$create instanceof CreateBlocksFieldHandler) {
+                        throw new LogicException('CreateBlocksField handler service is invalid.');
+                    }
+
+                    if (!$update instanceof UpdateBlocksFieldHandler) {
+                        throw new LogicException('UpdateBlocksField handler service is invalid.');
+                    }
+
+                    if (!$delete instanceof DeleteBlocksFieldHandler) {
+                        throw new LogicException('DeleteBlocksField handler service is invalid.');
+                    }
+
+                    return new BlocksFieldRouteRegistrar($list, $get, $create, $update, $delete);
+                },
+            );
+    }
+}

--- a/src/BlocksField/CreateBlocksFieldHandler.php
+++ b/src/BlocksField/CreateBlocksFieldHandler.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateBlocksFieldHandler
+{
+    public function __construct(
+        private CreateBlocksFieldUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+
+        $entityId = (int) ($body['entity_id'] ?? 0);
+        $fieldKey = trim((string) ($body['field_key'] ?? ''));
+
+        if ($entityId <= 0) {
+            $errors[] = new ValidationError('entity_id', 'Entity id must be a positive integer.', 'invalid');
+        }
+
+        if ($fieldKey === '') {
+            $errors[] = new ValidationError('field_key', 'Field key is required.', 'required');
+        }
+
+        if (!array_key_exists('value', $body)) {
+            $errors[] = new ValidationError('value', 'Value is required.', 'required');
+        }
+
+        $valueRaw = array_key_exists('value', $body) ? trim((string) $body['value']) : '';
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $localeRaw = isset($body['locale']) && is_string($body['locale']) && $body['locale'] !== ''
+            ? $body['locale']
+            : null;
+
+        $output = $this->useCase->execute(new CreateBlocksFieldInput(
+            entityId: $entityId,
+            fieldKey: $fieldKey,
+            value: $valueRaw,
+            locale: $localeRaw,
+        ));
+
+        return $this->response->create(
+            [
+                'id'         => $output->id,
+                'entity_id'  => $output->entityId,
+                'field_key'  => $output->fieldKey,
+                'value'      => $output->value,
+                'locale'     => $output->locale,
+            ],
+            201,
+            ['Location' => '/api/v1/blocks-fields/' . $output->id],
+        );
+    }
+}

--- a/src/BlocksField/CreateBlocksFieldInput.php
+++ b/src/BlocksField/CreateBlocksFieldInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+final readonly class CreateBlocksFieldInput
+{
+    public function __construct(
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+        public ?string $locale = null,
+    ) {
+    }
+}

--- a/src/BlocksField/CreateBlocksFieldOutput.php
+++ b/src/BlocksField/CreateBlocksFieldOutput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+final readonly class CreateBlocksFieldOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+        public ?string $locale = null,
+    ) {
+    }
+}

--- a/src/BlocksField/CreateBlocksFieldUseCase.php
+++ b/src/BlocksField/CreateBlocksFieldUseCase.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+use NeNeRecords\FieldDef\FieldKeyNotRegisteredException;
+use NeNeRecords\FieldDef\FieldTypeMismatchException;
+
+final readonly class CreateBlocksFieldUseCase implements CreateBlocksFieldUseCaseInterface
+{
+    /** Data types whose values are stored in blocks_fields. */
+    private const BLOCKS_BACKED_DATA_TYPES = ['blocks'];
+
+    public function __construct(
+        private BlocksFieldRepositoryInterface $blocksFields,
+        private EntityRepositoryInterface $entities,
+        private FieldDefRepositoryInterface $fieldDefs,
+        private BlocksDocumentValidator $documentValidator,
+    ) {
+    }
+
+    public function execute(CreateBlocksFieldInput $input): CreateBlocksFieldOutput
+    {
+        $entity = $this->entities->findById($input->entityId);
+
+        if ($entity === null) {
+            throw new EntityNotFoundException($input->entityId);
+        }
+
+        $this->assertBlocksFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
+
+        // The trust boundary: reject malformed/unknown blocks regardless of client.
+        $this->documentValidator->validate($input->value);
+
+        $id = $this->blocksFields->save(new BlocksField(
+            entityId: $input->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+            locale: $input->locale,
+        ));
+
+        return new CreateBlocksFieldOutput(
+            id: $id,
+            entityId: $input->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+            locale: $input->locale,
+        );
+    }
+
+    private function assertBlocksFieldKeyRegistered(int $entityTypeId, string $fieldKey): void
+    {
+        $fieldDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($entityTypeId, $fieldKey);
+
+        if ($fieldDef === null) {
+            throw new FieldKeyNotRegisteredException($fieldKey, $entityTypeId);
+        }
+
+        if (!in_array($fieldDef->dataType, self::BLOCKS_BACKED_DATA_TYPES, true)) {
+            throw new FieldTypeMismatchException($fieldKey, 'blocks', $fieldDef->dataType);
+        }
+    }
+}

--- a/src/BlocksField/CreateBlocksFieldUseCaseInterface.php
+++ b/src/BlocksField/CreateBlocksFieldUseCaseInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+
+interface CreateBlocksFieldUseCaseInterface
+{
+    /**
+     * @throws EntityNotFoundException When {@see CreateBlocksFieldInput::$entityId} does not exist.
+     */
+    public function execute(CreateBlocksFieldInput $input): CreateBlocksFieldOutput;
+}

--- a/src/BlocksField/DeleteBlocksFieldByIdInput.php
+++ b/src/BlocksField/DeleteBlocksFieldByIdInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+final readonly class DeleteBlocksFieldByIdInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/BlocksField/DeleteBlocksFieldHandler.php
+++ b/src/BlocksField/DeleteBlocksFieldHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteBlocksFieldHandler
+{
+    public function __construct(
+        private DeleteBlocksFieldUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new BlocksFieldNotFoundException($id);
+        }
+
+        $this->useCase->execute(new DeleteBlocksFieldByIdInput($id));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/BlocksField/DeleteBlocksFieldUseCase.php
+++ b/src/BlocksField/DeleteBlocksFieldUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+final readonly class DeleteBlocksFieldUseCase implements DeleteBlocksFieldUseCaseInterface
+{
+    public function __construct(
+        private BlocksFieldRepositoryInterface $blocksFields,
+    ) {
+    }
+
+    public function execute(DeleteBlocksFieldByIdInput $input): void
+    {
+        $blocksField = $this->blocksFields->findById($input->id);
+
+        if ($blocksField === null) {
+            throw new BlocksFieldNotFoundException($input->id);
+        }
+
+        $this->blocksFields->delete($input->id);
+    }
+}

--- a/src/BlocksField/DeleteBlocksFieldUseCaseInterface.php
+++ b/src/BlocksField/DeleteBlocksFieldUseCaseInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+interface DeleteBlocksFieldUseCaseInterface
+{
+    /**
+     * Soft-deletes the blocks field.
+     *
+     * @throws BlocksFieldNotFoundException when no blocks field matches the given id.
+     */
+    public function execute(DeleteBlocksFieldByIdInput $input): void;
+}

--- a/src/BlocksField/GetBlocksFieldByIdHandler.php
+++ b/src/BlocksField/GetBlocksFieldByIdHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetBlocksFieldByIdHandler
+{
+    public function __construct(
+        private GetBlocksFieldByIdUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new BlocksFieldNotFoundException($id);
+        }
+
+        $output = $this->useCase->execute(new GetBlocksFieldByIdInput($id));
+
+        return $this->response->create([
+            'id'        => $output->id,
+            'entity_id' => $output->entityId,
+            'field_key' => $output->fieldKey,
+            'value'     => $output->value,
+            'locale'    => $output->locale,
+        ]);
+    }
+}

--- a/src/BlocksField/GetBlocksFieldByIdInput.php
+++ b/src/BlocksField/GetBlocksFieldByIdInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+final readonly class GetBlocksFieldByIdInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/BlocksField/GetBlocksFieldByIdOutput.php
+++ b/src/BlocksField/GetBlocksFieldByIdOutput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+final readonly class GetBlocksFieldByIdOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+        public ?string $locale = null,
+    ) {
+    }
+}

--- a/src/BlocksField/GetBlocksFieldByIdUseCase.php
+++ b/src/BlocksField/GetBlocksFieldByIdUseCase.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+final readonly class GetBlocksFieldByIdUseCase implements GetBlocksFieldByIdUseCaseInterface
+{
+    public function __construct(
+        private BlocksFieldRepositoryInterface $blocksFields,
+    ) {
+    }
+
+    public function execute(GetBlocksFieldByIdInput $input): GetBlocksFieldByIdOutput
+    {
+        $blocksField = $this->blocksFields->findById($input->id);
+
+        if ($blocksField === null) {
+            throw new BlocksFieldNotFoundException($input->id);
+        }
+
+        return new GetBlocksFieldByIdOutput(
+            id: (int) $blocksField->id,
+            entityId: $blocksField->entityId,
+            fieldKey: $blocksField->fieldKey,
+            value: $blocksField->value,
+            locale: $blocksField->locale,
+        );
+    }
+}

--- a/src/BlocksField/GetBlocksFieldByIdUseCaseInterface.php
+++ b/src/BlocksField/GetBlocksFieldByIdUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+interface GetBlocksFieldByIdUseCaseInterface
+{
+    /**
+     * @throws BlocksFieldNotFoundException when no blocks field matches the given id.
+     */
+    public function execute(GetBlocksFieldByIdInput $input): GetBlocksFieldByIdOutput;
+}

--- a/src/BlocksField/ListBlocksFieldItem.php
+++ b/src/BlocksField/ListBlocksFieldItem.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+final readonly class ListBlocksFieldItem
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+        public ?string $locale = null,
+    ) {
+    }
+}

--- a/src/BlocksField/ListBlocksFieldsHandler.php
+++ b/src/BlocksField/ListBlocksFieldsHandler.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListBlocksFieldsHandler
+{
+    public function __construct(
+        private ListBlocksFieldsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $pagination = PaginationQueryParser::parse($request);
+        $query = $request->getQueryParams();
+
+        $entityId = null;
+        if (isset($query['entity_id'])) {
+            $raw = (int) $query['entity_id'];
+            if ($raw > 0) {
+                $entityId = $raw;
+            }
+        }
+
+        $entityTypeId = null;
+        if ($entityId === null && isset($query['entity_type_id'])) {
+            $raw = (int) $query['entity_type_id'];
+            if ($raw > 0) {
+                $entityTypeId = $raw;
+            }
+        }
+
+        $locale = null;
+        if (isset($query['locale']) && is_string($query['locale']) && $query['locale'] !== '') {
+            $locale = $query['locale'];
+        }
+
+        $output = $this->useCase->execute(new ListBlocksFieldsInput(
+            entityId: $entityId,
+            entityTypeId: $entityTypeId,
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+            locale: $locale,
+        ));
+
+        return $this->response->create(
+            (new PaginationResponse(
+                items: array_map(
+                    static fn (ListBlocksFieldItem $item) => [
+                        'id'        => $item->id,
+                        'entity_id' => $item->entityId,
+                        'field_key' => $item->fieldKey,
+                        'value'     => $item->value,
+                        'locale'    => $item->locale,
+                    ],
+                    $output->items,
+                ),
+                limit:  $output->limit,
+                offset: $output->offset,
+            ))->toArray(),
+        );
+    }
+}

--- a/src/BlocksField/ListBlocksFieldsInput.php
+++ b/src/BlocksField/ListBlocksFieldsInput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+final readonly class ListBlocksFieldsInput
+{
+    public function __construct(
+        public ?int $entityId = null,
+        public ?int $entityTypeId = null,
+        public int $limit = 20,
+        public int $offset = 0,
+        public ?string $locale = null,
+    ) {
+    }
+}

--- a/src/BlocksField/ListBlocksFieldsOutput.php
+++ b/src/BlocksField/ListBlocksFieldsOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+final readonly class ListBlocksFieldsOutput
+{
+    /** @param list<ListBlocksFieldItem> $items */
+    public function __construct(
+        public array $items,
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/BlocksField/ListBlocksFieldsUseCase.php
+++ b/src/BlocksField/ListBlocksFieldsUseCase.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+final readonly class ListBlocksFieldsUseCase implements ListBlocksFieldsUseCaseInterface
+{
+    public function __construct(
+        private BlocksFieldRepositoryInterface $blocksFields,
+    ) {
+    }
+
+    public function execute(ListBlocksFieldsInput $input): ListBlocksFieldsOutput
+    {
+        $rows = match (true) {
+            $input->entityId !== null => $this->blocksFields->findByEntityId(
+                $input->entityId,
+                $input->limit,
+                $input->offset,
+                $input->locale,
+            ),
+            $input->entityTypeId !== null => $this->blocksFields->findByEntityTypeId(
+                $input->entityTypeId,
+                $input->limit,
+                $input->offset,
+                $input->locale,
+            ),
+            default => $this->blocksFields->findAll($input->limit, $input->offset, $input->locale),
+        };
+
+        $items = array_map(
+            static fn (BlocksField $blocksField) => new ListBlocksFieldItem(
+                id: (int) $blocksField->id,
+                entityId: $blocksField->entityId,
+                fieldKey: $blocksField->fieldKey,
+                value: $blocksField->value,
+                locale: $blocksField->locale,
+            ),
+            $rows,
+        );
+
+        return new ListBlocksFieldsOutput(
+            items: $items,
+            limit: $input->limit,
+            offset: $input->offset,
+        );
+    }
+}

--- a/src/BlocksField/ListBlocksFieldsUseCaseInterface.php
+++ b/src/BlocksField/ListBlocksFieldsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+interface ListBlocksFieldsUseCaseInterface
+{
+    public function execute(ListBlocksFieldsInput $input): ListBlocksFieldsOutput;
+}

--- a/src/BlocksField/PdoBlocksFieldRepository.php
+++ b/src/BlocksField/PdoBlocksFieldRepository.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
+
+final readonly class PdoBlocksFieldRepository implements BlocksFieldRepositoryInterface
+{
+    /**
+     * @param RequestScopedHolder<int> $orgId
+     */
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private readonly RequestScopedHolder $orgId,
+    ) {
+    }
+
+    public function findById(int $id): ?BlocksField
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, entity_id, field_key, locale, value FROM blocks_fields WHERE id = ? AND is_deleted = 0 AND organization_id = ?',
+            [$id, $this->orgId->get()],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return $this->mapRow($row);
+    }
+
+    /** @return list<BlocksField> */
+    public function findAll(int $limit, int $offset, ?string $locale = null): array
+    {
+        if ($locale !== null) {
+            $rows = $this->query->fetchAll(
+                'SELECT id, entity_id, field_key, locale, value FROM blocks_fields WHERE is_deleted = 0 AND locale = ? AND organization_id = ? ORDER BY id ASC LIMIT ? OFFSET ?',
+                [$locale, $this->orgId->get(), $limit, $offset],
+            );
+        } else {
+            $rows = $this->query->fetchAll(
+                'SELECT id, entity_id, field_key, locale, value FROM blocks_fields WHERE is_deleted = 0 AND organization_id = ? ORDER BY id ASC LIMIT ? OFFSET ?',
+                [$this->orgId->get(), $limit, $offset],
+            );
+        }
+
+        return array_map(fn (array $row) => $this->mapRow($row), $rows);
+    }
+
+    /** @return list<BlocksField> */
+    public function findByEntityId(int $entityId, int $limit, int $offset, ?string $locale = null): array
+    {
+        if ($locale !== null) {
+            $rows = $this->query->fetchAll(
+                'SELECT id, entity_id, field_key, locale, value FROM blocks_fields WHERE entity_id = ? AND locale = ? AND is_deleted = 0 AND organization_id = ? ORDER BY id ASC LIMIT ? OFFSET ?',
+                [$entityId, $locale, $this->orgId->get(), $limit, $offset],
+            );
+        } else {
+            $rows = $this->query->fetchAll(
+                'SELECT id, entity_id, field_key, locale, value FROM blocks_fields WHERE entity_id = ? AND is_deleted = 0 AND organization_id = ? ORDER BY id ASC LIMIT ? OFFSET ?',
+                [$entityId, $this->orgId->get(), $limit, $offset],
+            );
+        }
+
+        return array_map(fn (array $row) => $this->mapRow($row), $rows);
+    }
+
+    /** @return list<BlocksField> */
+    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset, ?string $locale = null): array
+    {
+        if ($locale !== null) {
+            $rows = $this->query->fetchAll(
+                <<<'SQL'
+                SELECT bf.id, bf.entity_id, bf.field_key, bf.locale, bf.value
+                FROM blocks_fields bf
+                INNER JOIN entities e ON e.id = bf.entity_id
+                WHERE bf.is_deleted = 0
+                  AND e.is_deleted = 0
+                  AND e.entity_type_id = ?
+                  AND bf.locale = ?
+                  AND bf.organization_id = ?
+                ORDER BY bf.id ASC
+                LIMIT ? OFFSET ?
+                SQL,
+                [$entityTypeId, $locale, $this->orgId->get(), $limit, $offset],
+            );
+        } else {
+            $rows = $this->query->fetchAll(
+                <<<'SQL'
+                SELECT bf.id, bf.entity_id, bf.field_key, bf.locale, bf.value
+                FROM blocks_fields bf
+                INNER JOIN entities e ON e.id = bf.entity_id
+                WHERE bf.is_deleted = 0
+                  AND e.is_deleted = 0
+                  AND e.entity_type_id = ?
+                  AND bf.organization_id = ?
+                ORDER BY bf.id ASC
+                LIMIT ? OFFSET ?
+                SQL,
+                [$entityTypeId, $this->orgId->get(), $limit, $offset],
+            );
+        }
+
+        return array_map(fn (array $row) => $this->mapRow($row), $rows);
+    }
+
+    /** @param list<int> $entityIds @return list<BlocksField> */
+    public function findByEntityIds(array $entityIds): array
+    {
+        if ($entityIds === []) {
+            return [];
+        }
+
+        $placeholders = implode(', ', array_fill(0, count($entityIds), '?'));
+        $rows = $this->query->fetchAll(
+            "SELECT id, entity_id, field_key, locale, value FROM blocks_fields WHERE entity_id IN ({$placeholders}) AND is_deleted = 0 AND organization_id = ? ORDER BY entity_id ASC, id ASC",
+            [...$entityIds, $this->orgId->get()],
+        );
+
+        return array_map(fn (array $row) => $this->mapRow($row), $rows);
+    }
+
+    public function save(BlocksField $blocksField): int
+    {
+        $this->query->execute(
+            'INSERT INTO blocks_fields (organization_id, entity_id, field_key, locale, value) VALUES (?, ?, ?, ?, ?)',
+            [$this->orgId->get(), $blocksField->entityId, $blocksField->fieldKey, $blocksField->locale, $blocksField->value],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function update(BlocksField $blocksField): void
+    {
+        if ($blocksField->id === null) {
+            throw new LogicException('BlocksField id is required when updating.');
+        }
+
+        $affected = $this->query->execute(
+            'UPDATE blocks_fields SET field_key = ?, locale = ?, value = ? WHERE id = ? AND is_deleted = 0 AND organization_id = ?',
+            [$blocksField->fieldKey, $blocksField->locale, $blocksField->value, $blocksField->id, $this->orgId->get()],
+        );
+
+        if ($affected === 0) {
+            throw new BlocksFieldNotFoundException($blocksField->id);
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        $affected = $this->query->execute(
+            'UPDATE blocks_fields SET is_deleted = 1, deleted_at = CURRENT_TIMESTAMP WHERE id = ? AND is_deleted = 0 AND organization_id = ?',
+            [$id, $this->orgId->get()],
+        );
+
+        if ($affected === 0) {
+            throw new BlocksFieldNotFoundException($id);
+        }
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): BlocksField
+    {
+        $localeRaw = $row['locale'] ?? null;
+
+        return new BlocksField(
+            entityId: (int) $row['entity_id'],
+            fieldKey: (string) $row['field_key'],
+            value: (string) $row['value'],
+            id: (int) $row['id'],
+            locale: ($localeRaw !== null && $localeRaw !== '') ? (string) $localeRaw : null,
+        );
+    }
+}

--- a/src/BlocksField/UpdateBlocksFieldHandler.php
+++ b/src/BlocksField/UpdateBlocksFieldHandler.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateBlocksFieldHandler
+{
+    public function __construct(
+        private UpdateBlocksFieldUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new BlocksFieldNotFoundException($id);
+        }
+
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+
+        $fieldKey = trim((string) ($body['field_key'] ?? ''));
+
+        if ($fieldKey === '') {
+            $errors[] = new ValidationError('field_key', 'Field key is required.', 'required');
+        }
+
+        if (!array_key_exists('value', $body)) {
+            $errors[] = new ValidationError('value', 'Value is required.', 'required');
+        }
+
+        $valueRaw = array_key_exists('value', $body) ? trim((string) $body['value']) : '';
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $localeRaw = isset($body['locale']) && is_string($body['locale']) && $body['locale'] !== ''
+            ? $body['locale']
+            : null;
+
+        $output = $this->useCase->execute(new UpdateBlocksFieldInput(
+            id: $id,
+            fieldKey: $fieldKey,
+            value: $valueRaw,
+            locale: $localeRaw,
+        ));
+
+        return $this->response->create([
+            'id'        => $output->id,
+            'entity_id' => $output->entityId,
+            'field_key' => $output->fieldKey,
+            'value'     => $output->value,
+            'locale'    => $output->locale,
+        ]);
+    }
+}

--- a/src/BlocksField/UpdateBlocksFieldInput.php
+++ b/src/BlocksField/UpdateBlocksFieldInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+final readonly class UpdateBlocksFieldInput
+{
+    public function __construct(
+        public int $id,
+        public string $fieldKey,
+        public string $value,
+        public ?string $locale = null,
+    ) {
+    }
+}

--- a/src/BlocksField/UpdateBlocksFieldOutput.php
+++ b/src/BlocksField/UpdateBlocksFieldOutput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+final readonly class UpdateBlocksFieldOutput
+{
+    public function __construct(
+        public int $id,
+        public int $entityId,
+        public string $fieldKey,
+        public string $value,
+        public ?string $locale = null,
+    ) {
+    }
+}

--- a/src/BlocksField/UpdateBlocksFieldUseCase.php
+++ b/src/BlocksField/UpdateBlocksFieldUseCase.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+use NeNeRecords\FieldDef\FieldKeyNotRegisteredException;
+use NeNeRecords\FieldDef\FieldTypeMismatchException;
+
+final readonly class UpdateBlocksFieldUseCase implements UpdateBlocksFieldUseCaseInterface
+{
+    /** Data types whose values are stored in blocks_fields. */
+    private const BLOCKS_BACKED_DATA_TYPES = ['blocks'];
+
+    public function __construct(
+        private BlocksFieldRepositoryInterface $blocksFields,
+        private EntityRepositoryInterface $entities,
+        private FieldDefRepositoryInterface $fieldDefs,
+        private BlocksDocumentValidator $documentValidator,
+    ) {
+    }
+
+    public function execute(UpdateBlocksFieldInput $input): UpdateBlocksFieldOutput
+    {
+        $existing = $this->blocksFields->findById($input->id);
+
+        if ($existing === null) {
+            throw new BlocksFieldNotFoundException($input->id);
+        }
+
+        $entity = $this->entities->findById($existing->entityId);
+
+        if ($entity === null) {
+            throw new EntityNotFoundException($existing->entityId);
+        }
+
+        $this->assertBlocksFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
+
+        // The trust boundary: reject malformed/unknown blocks regardless of client.
+        $this->documentValidator->validate($input->value);
+
+        $updated = new BlocksField(
+            entityId: $existing->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+            id: $input->id,
+            locale: $input->locale,
+        );
+        $this->blocksFields->update($updated);
+
+        return new UpdateBlocksFieldOutput(
+            id: $input->id,
+            entityId: $existing->entityId,
+            fieldKey: $input->fieldKey,
+            value: $input->value,
+            locale: $input->locale,
+        );
+    }
+
+    private function assertBlocksFieldKeyRegistered(int $entityTypeId, string $fieldKey): void
+    {
+        $fieldDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($entityTypeId, $fieldKey);
+
+        if ($fieldDef === null) {
+            throw new FieldKeyNotRegisteredException($fieldKey, $entityTypeId);
+        }
+
+        if (!in_array($fieldDef->dataType, self::BLOCKS_BACKED_DATA_TYPES, true)) {
+            throw new FieldTypeMismatchException($fieldKey, 'blocks', $fieldDef->dataType);
+        }
+    }
+}

--- a/src/BlocksField/UpdateBlocksFieldUseCaseInterface.php
+++ b/src/BlocksField/UpdateBlocksFieldUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BlocksField;
+
+interface UpdateBlocksFieldUseCaseInterface
+{
+    /**
+     * @throws BlocksFieldNotFoundException when no blocks field matches the given id.
+     */
+    public function execute(UpdateBlocksFieldInput $input): UpdateBlocksFieldOutput;
+}

--- a/src/FieldDef/FieldDefWriteValidator.php
+++ b/src/FieldDef/FieldDefWriteValidator.php
@@ -10,7 +10,7 @@ use NeNeRecords\Layout\ContentRegions;
 final readonly class FieldDefWriteValidator
 {
     /** @var list<string> */
-    public const ALLOWED_DATA_TYPES = ['text', 'markdown', 'html', 'bundle', 'int', 'enum', 'bool', 'datetime', 'image', 'file', 'relation'];
+    public const ALLOWED_DATA_TYPES = ['text', 'markdown', 'html', 'bundle', 'int', 'enum', 'bool', 'datetime', 'image', 'file', 'relation', 'blocks'];
 
     /** @var list<string> */
     public const ALLOWED_CARDINALITIES = ['one', 'many'];
@@ -42,7 +42,7 @@ final readonly class FieldDefWriteValidator
         } elseif (!in_array($dataType, self::ALLOWED_DATA_TYPES, true)) {
             $errors[] = new ValidationError(
                 'data_type',
-                'Data type must be one of: text, markdown, html, bundle, int, enum, bool, datetime, image, file, relation.',
+                'Data type must be one of: text, markdown, html, bundle, int, enum, bool, datetime, image, file, relation, blocks.',
                 'invalid',
             );
         }

--- a/tests/BlocksField/BlocksDocumentValidatorTest.php
+++ b/tests/BlocksField/BlocksDocumentValidatorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\BlocksField;
+
+use Nene2\Validation\ValidationException;
+use NeNeRecords\BlocksField\BlocksDocumentValidator;
+use PHPUnit\Framework\TestCase;
+
+final class BlocksDocumentValidatorTest extends TestCase
+{
+    private BlocksDocumentValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new BlocksDocumentValidator();
+    }
+
+    public function testAcceptsEmptyDocument(): void
+    {
+        $this->validator->validate('[]');
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAcceptsValidTextAndCalloutBlocks(): void
+    {
+        $json = json_encode([
+            ['id' => 'b1', 'type' => 'text', 'data' => ['markdown' => '# Hello']],
+            ['id' => 'b2', 'type' => 'callout', 'data' => ['kind' => 'info', 'title' => 'Note', 'body' => 'Body text']],
+            ['id' => 'b3', 'type' => 'callout', 'data' => ['kind' => 'danger', 'body' => 'No title is fine']],
+        ], JSON_THROW_ON_ERROR);
+
+        $this->validator->validate($json);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testRejectsNonJson(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('not json');
+    }
+
+    public function testRejectsNonArrayDocument(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('{"id":"b1","type":"text"}');
+    }
+
+    public function testRejectsUnknownBlockType(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('[{"id":"b1","type":"spaceship","data":{}}]');
+    }
+
+    public function testRejectsBlockMissingId(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('[{"type":"text","data":{"markdown":"hi"}}]');
+    }
+
+    public function testRejectsBlockWithNonObjectData(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('[{"id":"b1","type":"text","data":"nope"}]');
+    }
+
+    public function testRejectsTextBlockWithoutMarkdown(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('[{"id":"b1","type":"text","data":{}}]');
+    }
+
+    public function testRejectsCalloutWithInvalidKind(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('[{"id":"b1","type":"callout","data":{"kind":"chaos","body":"x"}}]');
+    }
+
+    public function testRejectsCalloutWithoutBody(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('[{"id":"b1","type":"callout","data":{"kind":"info"}}]');
+    }
+
+    public function testRejectsTooManyBlocks(): void
+    {
+        $blocks = [];
+        for ($i = 0; $i <= BlocksDocumentValidator::MAX_BLOCKS; $i++) {
+            $blocks[] = ['id' => 'b' . $i, 'type' => 'text', 'data' => ['markdown' => 'x']];
+        }
+
+        $this->expectException(ValidationException::class);
+        $this->validator->validate(json_encode($blocks, JSON_THROW_ON_ERROR));
+    }
+}

--- a/tests/BlocksField/CreateBlocksFieldUseCaseTest.php
+++ b/tests/BlocksField/CreateBlocksFieldUseCaseTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\BlocksField;
+
+use Nene2\Validation\ValidationException;
+use NeNeRecords\BlocksField\BlocksDocumentValidator;
+use NeNeRecords\BlocksField\BlocksField;
+use NeNeRecords\BlocksField\CreateBlocksFieldInput;
+use NeNeRecords\BlocksField\CreateBlocksFieldUseCase;
+use NeNeRecords\BlocksField\UpdateBlocksFieldInput;
+use NeNeRecords\BlocksField\UpdateBlocksFieldUseCase;
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\FieldDef\FieldKeyNotRegisteredException;
+use NeNeRecords\FieldDef\FieldTypeMismatchException;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use PHPUnit\Framework\TestCase;
+
+final class CreateBlocksFieldUseCaseTest extends TestCase
+{
+    private const VALID_DOC = '[{"id":"b1","type":"text","data":{"markdown":"Hello"}}]';
+
+    public function testReturnsOutputWithNewId(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 99));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 99, fieldKey: 'body', dataType: 'blocks', id: 1),
+        ]);
+
+        $useCase = $this->useCase($entities, $fieldDefs);
+
+        $output = $useCase->execute(new CreateBlocksFieldInput(entityId: $entityId, fieldKey: 'body', value: self::VALID_DOC));
+
+        self::assertSame(1, $output->id);
+        self::assertSame($entityId, $output->entityId);
+        self::assertSame('body', $output->fieldKey);
+        self::assertSame(self::VALID_DOC, $output->value);
+    }
+
+    public function testThrowsFieldKeyNotRegisteredExceptionWhenFieldDefAbsent(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $useCase = $this->useCase($entities, new InMemoryFieldDefRepository([]));
+
+        $this->expectException(FieldKeyNotRegisteredException::class);
+
+        $useCase->execute(new CreateBlocksFieldInput(entityId: $entityId, fieldKey: 'body', value: self::VALID_DOC));
+    }
+
+    public function testThrowsFieldTypeMismatchExceptionWhenDataTypeIsNotBlocks(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'body', dataType: 'text', id: 1),
+        ]);
+
+        $useCase = $this->useCase($entities, $fieldDefs);
+
+        $this->expectException(FieldTypeMismatchException::class);
+
+        $useCase->execute(new CreateBlocksFieldInput(entityId: $entityId, fieldKey: 'body', value: self::VALID_DOC));
+    }
+
+    public function testRejectsInvalidBlocksDocument(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'body', dataType: 'blocks', id: 1),
+        ]);
+
+        $useCase = $this->useCase($entities, $fieldDefs);
+
+        // The use case is the trust boundary: a registered blocks field still
+        // rejects a malformed document.
+        $this->expectException(ValidationException::class);
+
+        $useCase->execute(new CreateBlocksFieldInput(
+            entityId: $entityId,
+            fieldKey: 'body',
+            value: '[{"id":"b1","type":"spaceship","data":{}}]',
+        ));
+    }
+
+    private function useCase(
+        InMemoryEntityRepository $entities,
+        InMemoryFieldDefRepository $fieldDefs,
+    ): CreateBlocksFieldUseCase {
+        return new CreateBlocksFieldUseCase(
+            new InMemoryBlocksFieldRepository([]),
+            $entities,
+            $fieldDefs,
+            new BlocksDocumentValidator(),
+        );
+    }
+}
+
+final class UpdateBlocksFieldUseCaseTest extends TestCase
+{
+    public function testThrowsFieldKeyNotRegisteredExceptionWhenUpdatedKeyIsUnregistered(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
+
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'body', dataType: 'blocks', id: 1),
+        ]);
+
+        $blocksFields = new InMemoryBlocksFieldRepository([]);
+        $blocksFields->save(new BlocksField(entityId: $entityId, fieldKey: 'body', value: '[]', id: null));
+
+        $useCase = new UpdateBlocksFieldUseCase($blocksFields, $entities, $fieldDefs, new BlocksDocumentValidator());
+
+        $this->expectException(FieldKeyNotRegisteredException::class);
+
+        $useCase->execute(new UpdateBlocksFieldInput(id: 1, fieldKey: 'missing', value: '[]'));
+    }
+}

--- a/tests/BlocksField/InMemoryBlocksFieldRepository.php
+++ b/tests/BlocksField/InMemoryBlocksFieldRepository.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\BlocksField;
+
+use NeNeRecords\BlocksField\BlocksField;
+use NeNeRecords\BlocksField\BlocksFieldNotFoundException;
+use NeNeRecords\BlocksField\BlocksFieldRepositoryInterface;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+
+final class InMemoryBlocksFieldRepository implements BlocksFieldRepositoryInterface
+{
+    /** @var array<int, BlocksField> */
+    private array $fields;
+
+    /** @var array<int, true> */
+    private array $deletedIds;
+
+    private int $nextId;
+
+    /**
+     * @param list<BlocksField> $seed
+     */
+    public function __construct(
+        array $seed = [],
+        private ?EntityRepositoryInterface $entities = null,
+    ) {
+        $this->fields = [];
+        $this->deletedIds = [];
+        $this->nextId = 1;
+
+        foreach ($seed as $blocksField) {
+            $id = $blocksField->id;
+            if ($id !== null) {
+                $this->fields[$id] = $blocksField;
+                $this->nextId = max($this->nextId, $id + 1);
+            }
+        }
+    }
+
+    public function findById(int $id): ?BlocksField
+    {
+        if (isset($this->deletedIds[$id])) {
+            return null;
+        }
+
+        return $this->fields[$id] ?? null;
+    }
+
+    /** @return list<BlocksField> */
+    public function findAll(int $limit, int $offset, ?string $locale = null): array
+    {
+        $active = [];
+
+        foreach ($this->fields as $id => $blocksField) {
+            if (!isset($this->deletedIds[$id])) {
+                if ($locale !== null && $blocksField->locale !== $locale) {
+                    continue;
+                }
+
+                $active[] = $blocksField;
+            }
+        }
+
+        usort($active, static fn (BlocksField $a, BlocksField $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
+
+        return array_slice($active, $offset, $limit);
+    }
+
+    /** @return list<BlocksField> */
+    public function findByEntityId(int $entityId, int $limit, int $offset, ?string $locale = null): array
+    {
+        $active = [];
+
+        foreach ($this->fields as $id => $blocksField) {
+            if (!isset($this->deletedIds[$id]) && $blocksField->entityId === $entityId) {
+                if ($locale !== null && $blocksField->locale !== $locale) {
+                    continue;
+                }
+
+                $active[] = $blocksField;
+            }
+        }
+
+        usort($active, static fn (BlocksField $a, BlocksField $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
+
+        return array_slice($active, $offset, $limit);
+    }
+
+    /** @return list<BlocksField> */
+    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset, ?string $locale = null): array
+    {
+        $active = [];
+
+        foreach ($this->fields as $id => $blocksField) {
+            if (isset($this->deletedIds[$id])) {
+                continue;
+            }
+
+            if ($this->entities === null) {
+                continue;
+            }
+
+            $entity = $this->entities->findById($blocksField->entityId);
+
+            if ($entity !== null && $entity->entityTypeId === $entityTypeId) {
+                if ($locale !== null && $blocksField->locale !== $locale) {
+                    continue;
+                }
+
+                $active[] = $blocksField;
+            }
+        }
+
+        usort($active, static fn (BlocksField $a, BlocksField $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
+
+        return array_slice($active, $offset, $limit);
+    }
+
+    /**
+     * @param list<int> $entityIds
+     * @return list<BlocksField>
+     */
+    public function findByEntityIds(array $entityIds): array
+    {
+        if ($entityIds === []) {
+            return [];
+        }
+
+        $active = [];
+
+        foreach ($this->fields as $id => $blocksField) {
+            if (!isset($this->deletedIds[$id]) && in_array($blocksField->entityId, $entityIds, true)) {
+                $active[] = $blocksField;
+            }
+        }
+
+        usort($active, static fn (BlocksField $a, BlocksField $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
+
+        return $active;
+    }
+
+    public function save(BlocksField $blocksField): int
+    {
+        $id = $this->nextId++;
+        $this->fields[$id] = new BlocksField(
+            entityId: $blocksField->entityId,
+            fieldKey: $blocksField->fieldKey,
+            value: $blocksField->value,
+            id: $id,
+            locale: $blocksField->locale,
+        );
+
+        return $id;
+    }
+
+    public function update(BlocksField $blocksField): void
+    {
+        $id = $blocksField->id;
+
+        if ($id === null) {
+            return;
+        }
+
+        if ($this->findById($id) === null) {
+            throw new BlocksFieldNotFoundException($id);
+        }
+
+        $this->fields[$id] = $blocksField;
+    }
+
+    public function delete(int $id): void
+    {
+        if (!isset($this->fields[$id]) || isset($this->deletedIds[$id])) {
+            throw new BlocksFieldNotFoundException($id);
+        }
+
+        unset($this->fields[$id]);
+        $this->deletedIds[$id] = true;
+    }
+}


### PR DESCRIPTION
## 目的

型付き投稿ブロックシステム **#486** の **S1a＝契約/バックエンド層**。GUI は ClaudeDesign 合意ゲート(G2)後の **S1b** で実装するため、本PRは **GUI を含まない**（設計合意と独立に進められる層）。

## 変更内容

- **新フィールド型 `blocks`**: `src/BlocksField/`（`TextField` を NENE2 規約どおりコピーした CRUD モジュール32ファイル）。値は JSON 文書 `[{id,type,data}]` の文字列。
- **マイグレーション** `blocks_fields`（organization_id / locale / value LONGTEXT）。
- **信頼境界の検証**（本設計の肝）: `BlocksDocumentValidator`（手書きPHP・`ThemeManifestValidator` 流）が **文書形・ブロック型 whitelist・型別 data・ブロック数上限(200)** を検証し、Create/Update UseCase で実行。`BlockTypes`（whitelist: `text` / `callout`）、`docs/blocks/blocks.schema.json`（Ajv 契約源）。
  > 既存 widget の `settings` が型別未検証（opaque JSON）の轍を踏まないよう、`data` を schema 駆動でサーバ検証。
- `FieldDefWriteValidator::ALLOWED_DATA_TYPES` に `blocks` を追加。
- **OpenAPI** に `/api/v1/blocks-fields` の CRUD を追記、`npm run codegen` で TS 型生成。
- **テスト**: 検証器の単体（不正文書を全パターン 422 拒否）＋ UseCase（検証が呼ばれる／field 型整合）。

## スコープ外（後続）
- 管理エディタ GUI・consumer 描画（**S1b**, G2 合意後）。
- HERO ブロック（S2）、メディアピッカー（S3）、carousel/gallery（S4）、chart（S5）。

## 検証
- `composer check`（**779 tests** / PHPStan L8 / CS-Fixer / OpenAPI / MCP）全グリーン。
- `npm run check`（type/lint/prettier/test/knip/storybook）全グリーン。

Part of #486