### PR TITLE
feat(entity-types): コンテンツタイプ作成にスターター項目（Rich page=blocks本文）(#491 WS1-S1)

### DIFF
--- a/frontend/src/features/manage-entity-types/hooks/use-create-entity-type-form.ts
+++ b/frontend/src/features/manage-entity-types/hooks/use-create-entity-type-form.ts
@@ -2,6 +2,14 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 
+/**
+ * Starter field presets provisioned right after a content type is created
+ * (#491 WS1): `rich_page` gives a blocks body so authors compose the page with
+ * the block editor without an admin adding fields manually.
+ */
+export const ENTITY_TYPE_STARTERS = ['blank', 'article', 'rich_page'] as const
+export type EntityTypeStarter = (typeof ENTITY_TYPE_STARTERS)[number]
+
 export const createEntityTypeFormSchema = z.object({
   name: z.string().trim().min(1, 'Name is required'),
   slug: z
@@ -9,6 +17,7 @@ export const createEntityTypeFormSchema = z.object({
     .trim()
     .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Use lowercase letters, numbers, and hyphens'),
   isPinned: z.boolean().default(false),
+  starter: z.enum(['blank', 'article', 'rich_page']).default('blank'),
 })
 
 export type CreateEntityTypeFormValues = z.infer<typeof createEntityTypeFormSchema>
@@ -58,6 +67,7 @@ export function useCreateEntityTypeForm() {
       name: '',
       slug: '',
       isPinned: false,
+      starter: 'blank',
     },
   })
 }

--- a/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.test.ts
+++ b/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { act, waitFor } from '@testing-library/react'
 import { useManageEntityTypesPage } from './use-manage-entity-types-page'
 import { resetEntityTypeStore, seedEntityTypes } from '@tests/msw/handlers/entity-type'
+import { fieldDefStoreSnapshot, resetFieldDefStore } from '@tests/msw/handlers/field-def'
 import { mswServer } from '@tests/msw/server'
 import { renderHookWithProviders } from '@tests/render/render-with-providers'
 
@@ -12,6 +13,7 @@ describe('useManageEntityTypesPage', () => {
   afterEach(() => {
     mswServer.resetHandlers()
     resetEntityTypeStore()
+    resetFieldDefStore()
   })
   afterAll(() => {
     mswServer.close()
@@ -37,12 +39,44 @@ describe('useManageEntityTypesPage', () => {
     })
 
     await act(async () => {
-      await result.current.createEntityType({ name: 'Page', slug: 'page', isPinned: false })
+      await result.current.createEntityType({
+        name: 'Page',
+        slug: 'page',
+        isPinned: false,
+        starter: 'blank',
+      })
     })
 
     await waitFor(() => {
       expect(result.current.items.map((t) => t.slug)).toContain('page')
     })
+  })
+
+  it('provisions a title + blocks body when the rich_page starter is chosen', async () => {
+    seedEntityTypes([])
+
+    const { result } = renderHookWithProviders(() => useManageEntityTypesPage())
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(0)
+    })
+
+    await act(async () => {
+      await result.current.createEntityType({
+        name: 'Landing',
+        slug: 'landing',
+        isPinned: false,
+        starter: 'rich_page',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current.items.map((t) => t.slug)).toContain('landing')
+    })
+
+    const created = result.current.items.find((t) => t.slug === 'landing')
+    const fields = fieldDefStoreSnapshot().filter((f) => f.entity_type_id === created?.id)
+    expect(fields.map((f) => f.field_key)).toEqual(['title', 'content'])
+    expect(fields.find((f) => f.field_key === 'content')?.data_type).toBe('blocks')
   })
 
   it('deletes the targeted entity type', async () => {

--- a/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.ts
+++ b/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.ts
@@ -8,15 +8,34 @@ import {
   type EntityType,
   type EntityTypeId,
 } from '@/entities/entity-type'
+import { useCreateFieldDef, type FieldDataType } from '@/entities/field-def'
 import {
   formValuesToLabels,
   type CreateEntityTypeFormValues,
   type EditEntityTypeFormValues,
+  type EntityTypeStarter,
 } from './use-create-entity-type-form'
+
+/** Fields auto-provisioned per starter when a content type is created (#491 WS1). */
+const STARTER_FIELDS: Record<
+  EntityTypeStarter,
+  readonly { fieldKey: string; dataType: FieldDataType }[]
+> = {
+  blank: [],
+  article: [
+    { fieldKey: 'title', dataType: 'text' },
+    { fieldKey: 'body', dataType: 'markdown' },
+  ],
+  rich_page: [
+    { fieldKey: 'title', dataType: 'text' },
+    { fieldKey: 'content', dataType: 'blocks' },
+  ],
+}
 
 export function useManageEntityTypesPage() {
   const listQuery = useEntityTypeList()
   const createMutation = useCreateEntityType()
+  const createFieldDefMutation = useCreateFieldDef()
   const updateMutation = useUpdateEntityType()
   const deleteMutation = useDeleteEntityType()
   const reorderMutation = useReorderEntityTypes()
@@ -25,9 +44,20 @@ export function useManageEntityTypesPage() {
 
   const createEntityType = useCallback(
     async (values: CreateEntityTypeFormValues) => {
-      await createMutation.mutateAsync(values)
+      const { starter, ...typeInput } = values
+      const created = await createMutation.mutateAsync(typeInput)
+      // Provision the starter's fields (e.g. rich_page → title + blocks body).
+      for (const [index, field] of STARTER_FIELDS[starter].entries()) {
+        await createFieldDefMutation.mutateAsync({
+          entityTypeId: created.id,
+          fieldKey: field.fieldKey,
+          dataType: field.dataType,
+          region: null,
+          displayOrder: index,
+        })
+      }
     },
-    [createMutation],
+    [createMutation, createFieldDefMutation],
   )
 
   const requestEdit = useCallback((entityType: EntityType) => {
@@ -119,8 +149,8 @@ export function useManageEntityTypesPage() {
     errorTitle: listQuery.error?.title ?? null,
     refetch: listQuery.refetch,
     createEntityType,
-    isCreating: createMutation.isPending,
-    createErrorTitle: createMutation.error?.title ?? null,
+    isCreating: createMutation.isPending || createFieldDefMutation.isPending,
+    createErrorTitle: createMutation.error?.title ?? createFieldDefMutation.error?.title ?? null,
     editTarget,
     requestEdit,
     cancelEdit,

--- a/frontend/src/features/manage-entity-types/ui/EntityTypeCreateForm.tsx
+++ b/frontend/src/features/manage-entity-types/ui/EntityTypeCreateForm.tsx
@@ -1,8 +1,17 @@
 import { Controller } from 'react-hook-form'
-import { useTranslation } from '@/shared/i18n'
-import { Button, Card, Input, Stack, Text } from '@/shared/ui'
-import type { CreateEntityTypeFormValues } from '../hooks/use-create-entity-type-form'
-import { useCreateEntityTypeForm } from '../hooks/use-create-entity-type-form'
+import { type MessageKey, useTranslation } from '@/shared/i18n'
+import { Button, Card, Input, Select, Stack, Text } from '@/shared/ui'
+import type {
+  CreateEntityTypeFormValues,
+  EntityTypeStarter,
+} from '../hooks/use-create-entity-type-form'
+import { ENTITY_TYPE_STARTERS, useCreateEntityTypeForm } from '../hooks/use-create-entity-type-form'
+
+const STARTER_LABEL_KEY: Record<EntityTypeStarter, MessageKey> = {
+  blank: 'admin.entityTypes.starter.blank',
+  article: 'admin.entityTypes.starter.article',
+  rich_page: 'admin.entityTypes.starter.richPage',
+}
 
 export interface EntityTypeCreateFormProps {
   isSubmitting: boolean
@@ -69,6 +78,29 @@ export function EntityTypeCreateForm({
             />
           )}
         />
+        <Controller
+          name="starter"
+          control={control}
+          render={({ field }) => (
+            <Select
+              id="entity-type-starter"
+              label={t('admin.entityTypes.createForm.starterLabel')}
+              disabled={isSubmitting}
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+            >
+              {ENTITY_TYPE_STARTERS.map((starter) => (
+                <option key={starter} value={starter}>
+                  {t(STARTER_LABEL_KEY[starter])}
+                </option>
+              ))}
+            </Select>
+          )}
+        />
+        <Text muted variant="caption">
+          {t('admin.entityTypes.createForm.starterHelp')}
+        </Text>
         {serverErrorTitle !== null ? <Text muted>{serverErrorTitle}</Text> : null}
         <Button
           type="submit"

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -382,6 +382,12 @@ export const en = {
   'admin.entityTypes.createForm.title': 'Create content type',
   'admin.entityTypes.createForm.submit': 'Create content type',
   'admin.entityTypes.createForm.submitting': 'Creating…',
+  'admin.entityTypes.createForm.starterLabel': 'Starter fields',
+  'admin.entityTypes.createForm.starterHelp':
+    'Provisions fields right after creation. Rich page adds a blocks body so you compose the page with the block editor.',
+  'admin.entityTypes.starter.blank': 'Blank (no fields)',
+  'admin.entityTypes.starter.article': 'Article (title + Markdown body)',
+  'admin.entityTypes.starter.richPage': 'Rich page (title + blocks body)',
   'admin.entityTypes.editForm.title': 'Edit content type',
   'admin.entityTypes.editForm.save': 'Save changes',
   'admin.entityTypes.editForm.saving': 'Saving…',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -376,6 +376,12 @@ export const ja: Partial<MessageCatalog> = {
   'admin.entityTypes.createForm.title': 'コンテンツタイプを作成',
   'admin.entityTypes.createForm.submit': 'コンテンツタイプを作成',
   'admin.entityTypes.createForm.submitting': '作成中…',
+  'admin.entityTypes.createForm.starterLabel': 'スターター項目',
+  'admin.entityTypes.createForm.starterHelp':
+    '作成直後に項目を自動追加します。リッチページはブロック本文を追加し、ブロックエディタでページを組めます。',
+  'admin.entityTypes.starter.blank': '空（項目なし）',
+  'admin.entityTypes.starter.article': '記事（タイトル＋Markdown本文）',
+  'admin.entityTypes.starter.richPage': 'リッチページ（タイトル＋ブロック本文）',
   'admin.entityTypes.editForm.title': 'コンテンツタイプを編集',
   'admin.entityTypes.editForm.save': '変更を保存',
   'admin.entityTypes.editForm.saving': '保存中…',

--- a/frontend/tests/msw/handlers/field-def.ts
+++ b/frontend/tests/msw/handlers/field-def.ts
@@ -1,9 +1,35 @@
 import { http, HttpResponse } from 'msw'
 
-type FieldDataType = 'text' | 'int' | 'enum' | 'bool' | 'datetime' | 'relation'
+type FieldDataType =
+  | 'text'
+  | 'markdown'
+  | 'html'
+  | 'bundle'
+  | 'int'
+  | 'enum'
+  | 'bool'
+  | 'datetime'
+  | 'image'
+  | 'file'
+  | 'relation'
+  | 'blocks'
 type RelationCardinality = 'one' | 'many'
 
-const FIELD_DATA_TYPES: FieldDataType[] = ['text', 'int', 'enum', 'bool', 'datetime', 'relation']
+// Mirrors entities/field-def/enum FIELD_DATA_TYPES — keep in sync.
+const FIELD_DATA_TYPES: FieldDataType[] = [
+  'text',
+  'markdown',
+  'html',
+  'bundle',
+  'int',
+  'enum',
+  'bool',
+  'datetime',
+  'image',
+  'file',
+  'relation',
+  'blocks',
+]
 
 function isFieldDataType(value: string): value is FieldDataType {
   return (FIELD_DATA_TYPES as string[]).includes(value)
@@ -29,6 +55,11 @@ export function resetFieldDefStore(): void {
 export function seedFieldDefs(seed: FieldDefRecord[]): void {
   items = [...seed]
   nextId = Math.max(0, ...seed.map((item) => item.id)) + 1
+}
+
+/** Test peek into the created field-def records (e.g. to assert starter provisioning). */
+export function fieldDefStoreSnapshot(): readonly FieldDefRecord[] {
+  return [...items]
 }
 
 export function findFieldDefForEntityType(


### PR DESCRIPTION
EPIC #491「リッチページ化」の **WS1-S1**。

## 目的
「投稿＝リッチページ」を、管理者が手でフィールドを足さずに始められるように。コンテンツタイプ作成時に **スターター項目** を選べるようにする。

## 変更
- 作成フォームに **スターター** セレクト: `Blank（項目なし）` / `Article（title + Markdown本文）` / `Rich page（title + blocks本文）`
- 作成直後に該当フィールドを自動 provision（**フロント主導**：`createEntityType` → 返却 id に対し `useCreateFieldDef` で順次作成。**API 契約変更なし**、既存エンドポイント利用）
- `Rich page` を選ぶと `content`(blocks) が付き、著者は投稿を開いてブロックエディタで組める
- i18n(en/ja)、フックテスト（rich_page → `title` + `content(blocks)` を provision）
- 付随修正: field-def の MSW ハンドラの `FIELD_DATA_TYPES` が古く `blocks`/`markdown`/`image` 等を欠いていたため実 enum に同期

## 設計メモ
- 非破壊（既存 posts/pages 不変、新規作成タイプにのみ作用）。既定 starter は `blank`（現状維持）。
- 原子性: 型作成成功後にフィールド作成が失敗した場合は型のみ残る（管理者が後から追加可）。`createErrorTitle` に field-def エラーも反映。将来バックエンドで atomic 化する余地あり。

## 検証
`npm run check` 全緑（**289 tests** / type-check 0 / lint / prettier / themes / knip / storybook）。

## 次（#491）
WS2（レイアウトブロック: ネスト対応＋group→columns）→ WS2 仕上げ → WS3（bundle discovery）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)