### PR TITLE
feat(blocks): レイアウト用 group ブロック（ネスト対応の第一歩）(#491 WS2-S2a)

### DIFF
--- a/docs/blocks/blocks.schema.json
+++ b/docs/blocks/blocks.schema.json
@@ -18,7 +18,7 @@
           "minLength": 1,
           "maxLength": 64
         },
-        "type": { "enum": ["text", "callout", "hero", "gallery", "chart"] },
+        "type": { "enum": ["text", "callout", "hero", "gallery", "chart", "group"] },
         "data": { "type": "object" }
       },
       "allOf": [
@@ -41,8 +41,22 @@
         {
           "if": { "properties": { "type": { "const": "chart" } } },
           "then": { "properties": { "data": { "$ref": "#/$defs/chartData" } } }
+        },
+        {
+          "if": { "properties": { "type": { "const": "group" } } },
+          "then": { "properties": { "data": { "$ref": "#/$defs/groupData" } } }
         }
       ]
+    },
+    "groupData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tone", "children"],
+      "description": "Layout container holding child blocks (#491 WS2). The server validator further restricts children to leaf blocks (no container nesting; depth 2).",
+      "properties": {
+        "tone": { "enum": ["plain", "muted", "card"] },
+        "children": { "type": "array", "maxItems": 30, "items": { "$ref": "#/$defs/block" } }
+      }
     },
     "textData": {
       "type": "object",

--- a/frontend/src/features/edit-entity-text-fields/ui/BlockInspector.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/BlockInspector.tsx
@@ -7,8 +7,12 @@ import {
   CALLOUT_KINDS,
   CHART_TYPES,
   GALLERY_LAYOUTS,
+  GROUP_TONES,
   HERO_VARIANTS,
+  createBlock,
+  validateBlock,
   type Block,
+  type BlockType,
   type BlockValidationCode,
   type CalloutBlockData,
   type CalloutKind,
@@ -17,12 +21,16 @@ import {
   type GalleryBlockData,
   type GalleryItem,
   type GalleryLayout,
+  type GroupBlockData,
+  type GroupTone,
   type HeroBlockData,
   type HeroMedia,
   type HeroVariant,
+  type LeafBlock,
   type SeriesPoint,
   type TextBlockData,
 } from '@/shared/lib/blocks-document'
+import { BLOCK_CATALOG, blockCatalogEntry } from './block-catalog'
 import { BlockMarkdownInput } from './BlockMarkdownInput'
 import { MediaSelectorModal } from './MediaSelectorModal'
 
@@ -32,6 +40,10 @@ type BlockDataChange =
   | HeroBlockData
   | GalleryBlockData
   | ChartBlockData
+  | GroupBlockData
+
+/** Leaf block types a group may contain (no container-in-container; depth 2). */
+const GROUP_CHILD_CATALOG = BLOCK_CATALOG.filter((entry) => entry.type !== 'group')
 
 interface BlockInspectorProps {
   block: Block
@@ -62,6 +74,12 @@ const LAYOUT_LABEL_KEY: Record<GalleryLayout, MessageKey> = {
 const CHART_TYPE_LABEL_KEY: Record<ChartType, MessageKey> = {
   bar: 'admin.blocks.chartType.bar',
   line: 'admin.blocks.chartType.line',
+}
+
+const GROUP_TONE_LABEL_KEY: Record<GroupTone, MessageKey> = {
+  plain: 'admin.blocks.groupTone.plain',
+  muted: 'admin.blocks.groupTone.muted',
+  card: 'admin.blocks.groupTone.card',
 }
 
 /** Settings form for the selected block (text / callout / hero / gallery). */
@@ -215,6 +233,40 @@ export function BlockInspector({
           }
           onChange={(event) => {
             onChange({ ...data, summary: event.target.value })
+          }}
+        />
+      </Stack>
+    )
+  }
+
+  if (block.type === 'group') {
+    const data = block.data
+    return (
+      <Stack gap="sm">
+        <Select
+          id={`${idPrefix}-group-tone`}
+          label={t('admin.blocks.field.tone')}
+          value={data.tone}
+          disabled={disabled}
+          onChange={(event) => {
+            onChange({ ...data, tone: event.target.value as GroupTone })
+          }}
+        >
+          {GROUP_TONES.map((tone) => (
+            <option key={tone} value={tone}>
+              {t(GROUP_TONE_LABEL_KEY[tone])}
+            </option>
+          ))}
+        </Select>
+        <GroupChildrenField
+          idPrefix={idPrefix}
+          items={data.children}
+          disabled={disabled}
+          error={
+            errorCode === 'children-required' ? t('admin.blocks.error.childrenRequired') : undefined
+          }
+          onChange={(children) => {
+            onChange({ ...data, children })
           }}
         />
       </Stack>
@@ -691,6 +743,155 @@ function SeriesField({ idPrefix, series, disabled, error, onChange }: SeriesFiel
           {t('admin.blocks.series.add')}
         </Button>
       </div>
+    </div>
+  )
+}
+
+interface GroupChildrenFieldProps {
+  idPrefix: string
+  items: LeafBlock[]
+  disabled: boolean
+  error?: string | undefined
+  onChange: (items: LeafBlock[]) => void
+}
+
+/**
+ * Sub-editor for a group's child blocks (#491 WS2): a leaf-only palette + a
+ * reorderable list where each child expands to its own BlockInspector. Children
+ * are leaf blocks, so the recursion terminates at one level (depth 2).
+ */
+function GroupChildrenField({
+  idPrefix,
+  items,
+  disabled,
+  error,
+  onChange,
+}: GroupChildrenFieldProps) {
+  const { t } = useTranslation()
+  const [openIndex, setOpenIndex] = useState<number | null>(null)
+
+  const add = (type: BlockType) => {
+    onChange([...items, createBlock(type) as LeafBlock])
+    setOpenIndex(items.length)
+  }
+  const update = (index: number, data: BlockDataChange) => {
+    onChange(items.map((item, i) => (i === index ? ({ ...item, data } as LeafBlock) : item)))
+  }
+  const move = (index: number, direction: -1 | 1) => {
+    const target = index + direction
+    if (target < 0 || target >= items.length) {
+      return
+    }
+    const next = items.slice()
+    const [moved] = next.splice(index, 1)
+    if (moved === undefined) {
+      return
+    }
+    next.splice(target, 0, moved)
+    onChange(next)
+    setOpenIndex(null)
+  }
+  const remove = (index: number) => {
+    onChange(items.filter((_, i) => i !== index))
+    setOpenIndex(null)
+  }
+
+  return (
+    <div className="flex flex-col gap-stack-sm">
+      <span className="font-sans text-caption font-medium text-text-primary">
+        {t('admin.blocks.field.children')}
+      </span>
+      {error !== undefined ? (
+        <span role="alert" className="font-sans text-caption text-danger">
+          {error}
+        </span>
+      ) : null}
+      <div className="flex flex-wrap gap-inline-sm">
+        {GROUP_CHILD_CATALOG.map((entry) => (
+          <Button
+            key={entry.type}
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={disabled}
+            onClick={() => {
+              add(entry.type)
+            }}
+          >
+            {t('admin.blocks.add', { type: t(entry.labelKey) })}
+          </Button>
+        ))}
+      </div>
+      {items.map((item, index) => (
+        <div
+          key={item.id}
+          className="flex flex-col gap-stack-xs rounded-md border border-border p-inline-sm"
+        >
+          <div className="flex items-center gap-inline-sm">
+            <span className="flex-1 font-sans text-caption font-medium text-text-primary">
+              {t(blockCatalogEntry(item.type).labelKey)}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={disabled || index === 0}
+              title={t('admin.blocks.moveUp')}
+              onClick={() => {
+                move(index, -1)
+              }}
+            >
+              <IconChevronUp size={15} />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={disabled || index === items.length - 1}
+              title={t('admin.blocks.moveDown')}
+              onClick={() => {
+                move(index, 1)
+              }}
+            >
+              <IconChevronDown size={15} />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={disabled}
+              onClick={() => {
+                setOpenIndex(openIndex === index ? null : index)
+              }}
+            >
+              {openIndex === index ? t('admin.blocks.childCollapse') : t('admin.blocks.childEdit')}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={disabled}
+              title={t('common.actions.remove')}
+              onClick={() => {
+                remove(index)
+              }}
+            >
+              <IconX size={15} />
+            </Button>
+          </div>
+          {openIndex === index ? (
+            <BlockInspector
+              block={item}
+              errorCode={validateBlock(item)}
+              disabled={disabled}
+              idPrefix={`${idPrefix}-c${String(index)}`}
+              onChange={(data) => {
+                update(index, data)
+              }}
+            />
+          ) : null}
+        </div>
+      ))}
     </div>
   )
 }

--- a/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.tsx
@@ -4,6 +4,7 @@ import { Button, Card, EmptyState, Stack, Text } from '@/shared/ui'
 import {
   IconChevronDown,
   IconChevronUp,
+  IconCopy,
   IconFileText,
   IconImage,
   IconLayers,
@@ -22,6 +23,7 @@ import {
   type CalloutBlockData,
   type ChartBlockData,
   type GalleryBlockData,
+  type GroupBlockData,
   type HeroBlockData,
   type TextBlockData,
 } from '@/shared/lib/blocks-document'
@@ -57,6 +59,8 @@ function blockTypeIcon(type: BlockType) {
       return IconImage
     case 'chart':
       return IconLayers
+    case 'group':
+      return IconCopy
   }
 }
 
@@ -76,6 +80,8 @@ function rawSummary(block: Block): string {
       return block.data.title !== undefined && block.data.title.trim() !== ''
         ? block.data.title
         : block.data.summary
+    case 'group':
+      return block.data.children.map((child) => rawSummary(child)).join(' · ')
   }
 }
 
@@ -160,7 +166,13 @@ export function BlocksFieldEditor({
 
   const updateData = (
     blockId: string,
-    data: TextBlockData | CalloutBlockData | HeroBlockData | GalleryBlockData | ChartBlockData,
+    data:
+      | TextBlockData
+      | CalloutBlockData
+      | HeroBlockData
+      | GalleryBlockData
+      | ChartBlockData
+      | GroupBlockData,
   ) => {
     emit(
       blocks.map((block): Block => {
@@ -178,6 +190,8 @@ export function BlocksFieldEditor({
             return { ...block, data: data as GalleryBlockData }
           case 'chart':
             return { ...block, data: data as ChartBlockData }
+          case 'group':
+            return { ...block, data: data as GroupBlockData }
         }
       }),
     )

--- a/frontend/src/features/edit-entity-text-fields/ui/block-catalog.ts
+++ b/frontend/src/features/edit-entity-text-fields/ui/block-catalog.ts
@@ -22,6 +22,7 @@ export const BLOCK_CATALOG: readonly BlockCatalogEntry[] = [
     descKey: 'admin.blocks.type.gallery.desc',
   },
   { type: 'chart', labelKey: 'admin.blocks.type.chart', descKey: 'admin.blocks.type.chart.desc' },
+  { type: 'group', labelKey: 'admin.blocks.type.group', descKey: 'admin.blocks.type.group.desc' },
 ]
 
 const CATALOG_BY_TYPE = Object.fromEntries(

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -2296,3 +2296,21 @@
   color: var(--color-text-muted);
   text-align: center;
 }
+/* group block (#491 WS2) — layout container with a tone (plain / muted band / card). */
+.nene-public .group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  margin-block: var(--space-xl);
+}
+.nene-public .group[data-group-tone='muted'] {
+  background: var(--color-surface-sunken);
+  padding: var(--space-lg);
+  border-radius: var(--radius-md);
+}
+.nene-public .group[data-group-tone='card'] {
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border);
+  padding: var(--space-lg);
+  border-radius: var(--radius-md);
+}

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -584,6 +584,17 @@ export const en = {
   'admin.blocks.error.itemsRequired': 'Add at least one image.',
   'admin.blocks.error.seriesRequired': 'Add at least two data points.',
   'admin.blocks.error.labelRequired': 'Label is required.',
+  // group (#491 WS2)
+  'admin.blocks.type.group': 'Group',
+  'admin.blocks.type.group.desc': 'A container that lays out other blocks',
+  'admin.blocks.field.tone': 'Tone',
+  'admin.blocks.field.children': 'Blocks in this group',
+  'admin.blocks.groupTone.plain': 'Plain',
+  'admin.blocks.groupTone.muted': 'Muted band',
+  'admin.blocks.groupTone.card': 'Card',
+  'admin.blocks.childEdit': 'Edit',
+  'admin.blocks.childCollapse': 'Done',
+  'admin.blocks.error.childrenRequired': 'Add at least one block.',
 
   // ── Home hero (#486) ──────────────────────────────────────────────────────
   'admin.homeHero.title': 'Home hero',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -581,6 +581,17 @@ export const ja: Partial<MessageCatalog> = {
   'admin.blocks.error.itemsRequired': '画像を1枚以上追加してください。',
   'admin.blocks.error.seriesRequired': 'データ点を2つ以上追加してください。',
   'admin.blocks.error.labelRequired': 'ラベルは必須です。',
+  // group (#491 WS2)
+  'admin.blocks.type.group': 'グループ',
+  'admin.blocks.type.group.desc': '他のブロックをまとめて配置する入れ物',
+  'admin.blocks.field.tone': 'トーン',
+  'admin.blocks.field.children': 'グループ内のブロック',
+  'admin.blocks.groupTone.plain': '標準',
+  'admin.blocks.groupTone.muted': '帯（淡色）',
+  'admin.blocks.groupTone.card': 'カード',
+  'admin.blocks.childEdit': '編集',
+  'admin.blocks.childCollapse': '閉じる',
+  'admin.blocks.error.childrenRequired': 'ブロックを1つ以上追加してください。',
 
   // ── Home hero (#486) ──────────────────────────────────────────────────────
   'admin.homeHero.title': 'ホームヒーロー',

--- a/frontend/src/shared/lib/blocks-document.test.ts
+++ b/frontend/src/shared/lib/blocks-document.test.ts
@@ -284,4 +284,35 @@ describe('blocks-document', () => {
       expect(chart.data.series).toHaveLength(1)
     }
   })
+
+  it('parses/validates a group and drops nested containers (leaf-only, depth 2)', () => {
+    const doc = JSON.stringify([
+      {
+        id: 'g1',
+        type: 'group',
+        data: {
+          tone: 'card',
+          children: [
+            { id: 'c1', type: 'text', data: { markdown: 'inside' } },
+            { id: 'c2', type: 'group', data: { tone: 'plain', children: [] } },
+          ],
+        },
+      },
+    ])
+    const blocks = parseBlocksDocument(doc)
+    expect(blocks).toHaveLength(1)
+    const group = blocks[0]
+    expect(group?.type).toBe('group')
+    if (group?.type === 'group') {
+      expect(group.data.tone).toBe('card')
+      // the nested group child is dropped on parse (containers can't nest)
+      expect(group.data.children.map((child) => child.type)).toEqual(['text'])
+      expect(validateBlock(group)).toBeNull()
+      expect(parseBlocksDocument(serializeBlocksDocument(blocks))).toEqual(blocks)
+    }
+  })
+
+  it('flags an empty group as children-required', () => {
+    expect(validateBlock(createBlock('group'))).toBe('children-required')
+  })
 })

--- a/frontend/src/shared/lib/blocks-document.ts
+++ b/frontend/src/shared/lib/blocks-document.ts
@@ -12,7 +12,7 @@
  * shared/ui) can import it.
  */
 
-const BLOCK_TYPES = ['text', 'callout', 'hero', 'gallery', 'chart'] as const
+const BLOCK_TYPES = ['text', 'callout', 'hero', 'gallery', 'chart', 'group'] as const
 export type BlockType = (typeof BLOCK_TYPES)[number]
 
 export const CALLOUT_KINDS = ['info', 'warn', 'ok', 'danger'] as const
@@ -26,6 +26,9 @@ export type GalleryLayout = (typeof GALLERY_LAYOUTS)[number]
 
 export const CHART_TYPES = ['bar', 'line'] as const
 export type ChartType = (typeof CHART_TYPES)[number]
+
+export const GROUP_TONES = ['plain', 'muted', 'card'] as const
+export type GroupTone = (typeof GROUP_TONES)[number]
 
 export interface TextBlockData {
   markdown: string
@@ -86,12 +89,21 @@ export interface ChartBlockData {
   summary: string
 }
 
-export type Block =
+/** Leaf (non-container) blocks. A group's children are leaf blocks only (depth 2). */
+export type LeafBlock =
   | { id: string; type: 'text'; data: TextBlockData }
   | { id: string; type: 'callout'; data: CalloutBlockData }
   | { id: string; type: 'hero'; data: HeroBlockData }
   | { id: string; type: 'gallery'; data: GalleryBlockData }
   | { id: string; type: 'chart'; data: ChartBlockData }
+
+/** Layout container holding leaf child blocks (#491 WS2); not nestable in another container. */
+export interface GroupBlockData {
+  tone: GroupTone
+  children: LeafBlock[]
+}
+
+export type Block = LeafBlock | { id: string; type: 'group'; data: GroupBlockData }
 
 export type BlockValidationCode =
   | 'markdown-required'
@@ -103,6 +115,7 @@ export type BlockValidationCode =
   | 'series-required'
   | 'series-label-required'
   | 'summary-required'
+  | 'children-required'
 
 function isBlockType(value: string): value is BlockType {
   return (BLOCK_TYPES as readonly string[]).includes(value)
@@ -114,6 +127,10 @@ function isCalloutKind(value: unknown): value is CalloutKind {
 
 function isHeroVariant(value: unknown): value is HeroVariant {
   return typeof value === 'string' && (HERO_VARIANTS as readonly string[]).includes(value)
+}
+
+function isGroupTone(value: unknown): value is GroupTone {
+  return typeof value === 'string' && (GROUP_TONES as readonly string[]).includes(value)
 }
 
 function isGalleryLayout(value: unknown): value is GalleryLayout {
@@ -223,6 +240,8 @@ export function createBlock(type: BlockType): Block {
         type,
         data: { chartType: 'bar', title: '', series: [], summary: '' },
       }
+    case 'group':
+      return { id: newBlockId(), type, data: { tone: 'plain', children: [] } }
   }
 }
 
@@ -249,7 +268,7 @@ export function parseBlocksDocument(json: string): Block[] {
 
   const blocks: Block[] = []
   for (const [index, raw] of decoded.entries()) {
-    const block = coerceBlock(raw, index)
+    const block = coerceBlock(raw, index, true)
     if (block !== null) {
       blocks.push(block)
     }
@@ -257,7 +276,7 @@ export function parseBlocksDocument(json: string): Block[] {
   return blocks
 }
 
-function coerceBlock(raw: unknown, index: number): Block | null {
+function coerceBlock(raw: unknown, index: number, allowContainers: boolean): Block | null {
   if (typeof raw !== 'object' || raw === null) {
     return null
   }
@@ -265,6 +284,11 @@ function coerceBlock(raw: unknown, index: number): Block | null {
   const candidate = raw as Record<string, unknown>
   const type = candidate.type
   if (typeof type !== 'string' || !isBlockType(type)) {
+    return null
+  }
+
+  // Container blocks are not nestable inside another container (depth 2).
+  if (!allowContainers && type === 'group') {
     return null
   }
 
@@ -332,72 +356,94 @@ function coerceBlock(raw: unknown, index: number): Block | null {
           summary: typeof record.summary === 'string' ? record.summary : '',
         },
       }
+    case 'group': {
+      const rawChildren = Array.isArray(record.children) ? record.children : []
+      const children = rawChildren
+        .map((child, childIndex) => coerceBlock(child, childIndex, false))
+        .filter((child): child is LeafBlock => child !== null && child.type !== 'group')
+      return {
+        id,
+        type,
+        data: { tone: isGroupTone(record.tone) ? record.tone : 'plain', children },
+      }
+    }
   }
 }
 
 /** Serialize the editor's blocks to the stored JSON string, dropping empty optionals. */
 export function serializeBlocksDocument(blocks: Block[]): string {
-  const normalized = blocks.map((block): Block => {
-    if (block.type === 'callout') {
-      const { kind, body, title } = block.data
-      return {
-        id: block.id,
-        type: 'callout',
-        data: { kind, body, ...optional({ title }) },
-      }
+  return JSON.stringify(blocks.map(normalizeBlock))
+}
+
+function normalizeBlock(block: Block): Block {
+  if (block.type === 'callout') {
+    const { kind, body, title } = block.data
+    return {
+      id: block.id,
+      type: 'callout',
+      data: { kind, body, ...optional({ title }) },
     }
-    if (block.type === 'hero') {
-      const { variant, heading } = block.data
-      return {
-        id: block.id,
-        type: 'hero',
-        data: {
-          variant,
-          heading,
-          ...optional({
-            kicker: block.data.kicker,
-            lead: block.data.lead,
-            ctaLabel: block.data.ctaLabel,
-            ctaUrl: block.data.ctaUrl,
-            ghostLabel: block.data.ghostLabel,
-            ghostUrl: block.data.ghostUrl,
-          }),
-          ...(block.data.media !== undefined ? { media: block.data.media } : {}),
-        },
-      }
+  }
+  if (block.type === 'hero') {
+    const { variant, heading } = block.data
+    return {
+      id: block.id,
+      type: 'hero',
+      data: {
+        variant,
+        heading,
+        ...optional({
+          kicker: block.data.kicker,
+          lead: block.data.lead,
+          ctaLabel: block.data.ctaLabel,
+          ctaUrl: block.data.ctaUrl,
+          ghostLabel: block.data.ghostLabel,
+          ghostUrl: block.data.ghostUrl,
+        }),
+        ...(block.data.media !== undefined ? { media: block.data.media } : {}),
+      },
     }
-    if (block.type === 'gallery') {
-      return {
-        id: block.id,
-        type: 'gallery',
-        data: {
-          layout: block.data.layout,
-          items: block.data.items.map((item) => ({
-            mediaId: item.mediaId,
-            url: item.url,
-            alt: item.alt,
-            ...(item.caption !== undefined && item.caption.trim() !== ''
-              ? { caption: item.caption }
-              : {}),
-          })),
-        },
-      }
+  }
+  if (block.type === 'gallery') {
+    return {
+      id: block.id,
+      type: 'gallery',
+      data: {
+        layout: block.data.layout,
+        items: block.data.items.map((item) => ({
+          mediaId: item.mediaId,
+          url: item.url,
+          alt: item.alt,
+          ...(item.caption !== undefined && item.caption.trim() !== ''
+            ? { caption: item.caption }
+            : {}),
+        })),
+      },
     }
-    if (block.type === 'chart') {
-      return {
-        id: block.id,
-        type: 'chart',
-        data: {
-          chartType: block.data.chartType,
-          ...optional({ title: block.data.title }),
-          series: block.data.series,
-          summary: block.data.summary,
-        },
-      }
+  }
+  if (block.type === 'chart') {
+    return {
+      id: block.id,
+      type: 'chart',
+      data: {
+        chartType: block.data.chartType,
+        ...optional({ title: block.data.title }),
+        series: block.data.series,
+        summary: block.data.summary,
+      },
     }
-    return block
-  })
-  return JSON.stringify(normalized)
+  }
+  if (block.type === 'group') {
+    return {
+      id: block.id,
+      type: 'group',
+      data: {
+        tone: block.data.tone,
+        children: block.data.children.map(normalizeBlock) as LeafBlock[],
+      },
+    }
+  }
+  return block
 }
 
 /** Keep only fields whose value is defined, preserving empty strings. */
@@ -447,6 +493,8 @@ export function validateBlock(block: Block): BlockValidationCode | null {
         return 'series-label-required'
       }
       return block.data.summary.trim() === '' ? 'summary-required' : null
+    case 'group':
+      return block.data.children.length === 0 ? 'children-required' : null
   }
 }
 

--- a/frontend/src/shared/ui/blocks/BlocksRenderer.test.tsx
+++ b/frontend/src/shared/ui/blocks/BlocksRenderer.test.tsx
@@ -126,4 +126,24 @@ describe('BlocksRenderer', () => {
     expect(screen.getByText('Up from Jan to Feb.')).toBeInTheDocument()
     expect(container.querySelectorAll('.chart__table tbody tr')).toHaveLength(2)
   })
+
+  it('renders a group container with its leaf children and tone', () => {
+    const doc = JSON.stringify([
+      {
+        id: 'g1',
+        type: 'group',
+        data: {
+          tone: 'card',
+          children: [{ id: 'c1', type: 'callout', data: { kind: 'info', body: 'Grouped note' } }],
+        },
+      },
+    ])
+
+    const { container } = renderWithProviders(<BlocksRenderer documentJson={doc} />)
+
+    const group = container.querySelector('.group')
+    expect(group?.getAttribute('data-group-tone')).toBe('card')
+    expect(group?.querySelector('.callout')).not.toBeNull()
+    expect(screen.getByText('Grouped note')).toBeInTheDocument()
+  })
 })

--- a/frontend/src/shared/ui/blocks/BlocksRenderer.tsx
+++ b/frontend/src/shared/ui/blocks/BlocksRenderer.tsx
@@ -5,6 +5,7 @@ import {
   type CalloutKind,
   type ChartBlockData,
   type GalleryBlockData,
+  type GroupBlockData,
   type HeroBlockData,
 } from '@/shared/lib/blocks-document'
 import { PublicMarkdownContent } from '@/shared/ui/markdown'
@@ -71,7 +72,27 @@ function ConsumerBlock({ block }: { block: Block }) {
       return <ConsumerGallery data={block.data} />
     case 'chart':
       return <ConsumerChart data={block.data} />
+    case 'group':
+      return <ConsumerGroup data={block.data} />
   }
+}
+
+/**
+ * Group block (#491 WS2): a layout container that renders its leaf children with
+ * a tone (plain / muted band / bordered card). Children are leaf blocks only
+ * (depth 2), so this never recurses into another group.
+ */
+function ConsumerGroup({ data }: { data: GroupBlockData }) {
+  if (data.children.length === 0) {
+    return null
+  }
+  return (
+    <div className="group" data-group-tone={data.tone}>
+      {data.children.map((child) => (
+        <ConsumerBlock key={child.id} block={child} />
+      ))}
+    </div>
+  )
 }
 
 /**

--- a/src/BlocksField/BlockTypes.php
+++ b/src/BlocksField/BlockTypes.php
@@ -20,6 +20,7 @@ final class BlockTypes
         'hero',
         'gallery',
         'chart',
+        'group',
     ];
 
     public static function isValid(string $type): bool

--- a/src/BlocksField/BlocksDocumentValidator.php
+++ b/src/BlocksField/BlocksDocumentValidator.php
@@ -37,6 +37,13 @@ final class BlocksDocumentValidator
     /** @var list<string> */
     private const CHART_TYPES = ['bar', 'line'];
 
+    /** Layout/container blocks that hold child blocks; cannot be nested in each other (depth 2). */
+    private const CONTAINER_TYPES = ['group'];
+
+    private const GROUP_TONES = ['plain', 'muted', 'card'];
+
+    private const MAX_GROUP_CHILDREN = 30;
+
     private const MAX_GALLERY_ITEMS = 50;
     private const MAX_SERIES_POINTS = 60;
     private const MAX_SERIES_LABEL_LEN = 120;
@@ -65,9 +72,10 @@ final class BlocksDocumentValidator
         }
 
         $errors = [];
+        $count = 0;
 
         foreach ($decoded as $index => $block) {
-            $this->validateBlock($index, $block, $errors);
+            $this->validateBlock("value[{$index}]", $block, true, $count, $errors);
         }
 
         if ($errors !== []) {
@@ -78,9 +86,16 @@ final class BlocksDocumentValidator
     /**
      * @param list<ValidationError> $errors
      */
-    private function validateBlock(int $index, mixed $block, array &$errors): void
+    private function validateBlock(string $path, mixed $block, bool $allowContainers, int &$count, array &$errors): void
     {
-        $path = "value[{$index}]";
+        // Cap total nodes including nested children; add the overflow error once.
+        if (++$count > self::MAX_BLOCKS) {
+            if ($count === self::MAX_BLOCKS + 1) {
+                $errors[] = new ValidationError('value', 'A blocks document may contain at most ' . self::MAX_BLOCKS . ' blocks (including nested).', 'invalid');
+            }
+
+            return;
+        }
 
         if (!is_array($block)) {
             $errors[] = new ValidationError($path, 'Each block must be an object.', 'invalid');
@@ -100,6 +115,12 @@ final class BlocksDocumentValidator
             return;
         }
 
+        if (!$allowContainers && in_array($type, self::CONTAINER_TYPES, true)) {
+            $errors[] = new ValidationError("{$path}.type", 'Container blocks cannot be nested inside another container.', 'invalid');
+
+            return;
+        }
+
         $data = $block['data'] ?? null;
         if (!is_array($data)) {
             $errors[] = new ValidationError("{$path}.data", 'Block data must be an object.', 'invalid');
@@ -113,8 +134,39 @@ final class BlocksDocumentValidator
             'hero' => $this->validateHeroData($path, $data, $errors),
             'gallery' => $this->validateGalleryData($path, $data, $errors),
             'chart' => $this->validateChartData($path, $data, $errors),
+            'group' => $this->validateGroupData($path, $data, $count, $errors),
             default => null,
         };
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     * @param list<ValidationError> $errors
+     */
+    private function validateGroupData(string $path, array $data, int &$count, array &$errors): void
+    {
+        $tone = $data['tone'] ?? null;
+        if (!is_string($tone) || !in_array($tone, self::GROUP_TONES, true)) {
+            $errors[] = new ValidationError("{$path}.data.tone", 'Group tone must be one of: ' . implode(', ', self::GROUP_TONES) . '.', 'invalid');
+        }
+
+        $children = $data['children'] ?? null;
+        if (!is_array($children) || !array_is_list($children)) {
+            $errors[] = new ValidationError("{$path}.data.children", 'Group children must be an array of blocks.', 'invalid');
+
+            return;
+        }
+
+        if (count($children) > self::MAX_GROUP_CHILDREN) {
+            $errors[] = new ValidationError("{$path}.data.children", 'A group may contain at most ' . self::MAX_GROUP_CHILDREN . ' blocks.', 'invalid');
+
+            return;
+        }
+
+        foreach ($children as $i => $child) {
+            // Children are leaf blocks only (no container-in-container) → depth capped at 2.
+            $this->validateBlock("{$path}.data.children[{$i}]", $child, false, $count, $errors);
+        }
     }
 
     /**

--- a/tests/BlocksField/BlocksDocumentValidatorTest.php
+++ b/tests/BlocksField/BlocksDocumentValidatorTest.php
@@ -251,4 +251,49 @@ final class BlocksDocumentValidatorTest extends TestCase
             '[{"id":"k1","type":"chart","data":{"chartType":"bar","summary":"x","series":[{"label":"A","value":"NaN"},{"label":"B","value":2}]}}]',
         );
     }
+
+    public function testAcceptsValidGroupBlockWithLeafChildren(): void
+    {
+        $json = json_encode([
+            ['id' => 'g1', 'type' => 'group', 'data' => [
+                'tone' => 'card',
+                'children' => [
+                    ['id' => 'c1', 'type' => 'text', 'data' => ['markdown' => 'Inside']],
+                    ['id' => 'c2', 'type' => 'callout', 'data' => ['kind' => 'info', 'body' => 'Note']],
+                ],
+            ]],
+        ], JSON_THROW_ON_ERROR);
+
+        $this->validator->validate($json);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAcceptsEmptyGroup(): void
+    {
+        $this->validator->validate('[{"id":"g1","type":"group","data":{"tone":"plain","children":[]}}]');
+        $this->addToAssertionCount(1);
+    }
+
+    public function testRejectsGroupWithInvalidTone(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('[{"id":"g1","type":"group","data":{"tone":"wild","children":[]}}]');
+    }
+
+    public function testRejectsContainerNestedInsideContainer(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate(
+            '[{"id":"g1","type":"group","data":{"tone":"plain","children":[{"id":"g2","type":"group","data":{"tone":"plain","children":[]}}]}}]',
+        );
+    }
+
+    public function testRejectsGroupChildWithInvalidData(): void
+    {
+        // A leaf child with invalid data propagates an error from the nested path.
+        $this->expectException(ValidationException::class);
+        $this->validator->validate(
+            '[{"id":"g1","type":"group","data":{"tone":"plain","children":[{"id":"c1","type":"text","data":{}}]}}]',
+        );
+    }
 }


### PR DESCRIPTION
EPIC #491「リッチページ化」**WS2-S2a**。ブロックの**ネスト対応**を導入し、子ブロックをまとめてトーン付きで配置する `group` コンテナを追加（“自由にデザイン”の核・Gutenberg 流・Elementor なし）。

## ネスト基盤
- サーバ検証器を `path` ＋ `allowContainers` ＋総ノード数(`MAX_BLOCKS`) で**再帰化**。
- `group.children` は **leaf ブロックのみ**（container-in-container 禁止 ＝ **深さ2**）、子数上限 **30**、`tone` allowlist（plain/muted/card）。

## backend
- `BlockTypes` に `group`、`validateGroupData`、`blocks.schema.json` に `groupData`、PHPUnit（valid / 空 / 不正 tone / ネスト拒否 / 子の不正データ伝播）。

## frontend
- **model**: `GroupBlockData`/`LeafBlock`。parse は子を leaf-only に coerce（ネスト group を破棄）、serialize は子も再帰正規化、`validateBlock` は `children-required`。
- **consumer**: `ConsumerGroup` が `.group[data-group-tone]` で子を再帰描画。`public-site.css` にトーン（plain/帯/カード）。
- **editor**: パレットに group、`BlockInspector` に tone Select ＋ `GroupChildrenField`（leaf-only パレット＋並べ替え＋子ごとに `BlockInspector` を展開して編集）。
- i18n(en/ja)、テスト（model: parse/validate/round-trip・ネスト破棄、renderer: tone＋子描画）。

## 検証
`composer check`（**831 tests** / PHPStan / OpenAPI / MCP）＋ `npm run check`（**292 tests** / type-check 0 / lint / storybook）緑。実機: group+leaf **201** / group ネスト **422**（`value[0].data.children[0].type`）/ 不正 tone **422**。

## 次（#491）
WS2-S2b（`columns` 多段組み）→ WS2-S2c（`spacer`/`divider`）→ WS3（bundle discovery）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)