### PR TITLE
feat(blocks): 多段組み columns ブロック（#491 WS2-S2b）

### DIFF
--- a/docs/blocks/blocks.schema.json
+++ b/docs/blocks/blocks.schema.json
@@ -18,7 +18,7 @@
           "minLength": 1,
           "maxLength": 64
         },
-        "type": { "enum": ["text", "callout", "hero", "gallery", "chart", "group"] },
+        "type": { "enum": ["text", "callout", "hero", "gallery", "chart", "group", "columns"] },
         "data": { "type": "object" }
       },
       "allOf": [
@@ -45,8 +45,33 @@
         {
           "if": { "properties": { "type": { "const": "group" } } },
           "then": { "properties": { "data": { "$ref": "#/$defs/groupData" } } }
+        },
+        {
+          "if": { "properties": { "type": { "const": "columns" } } },
+          "then": { "properties": { "data": { "$ref": "#/$defs/columnsData" } } }
         }
       ]
+    },
+    "columnsData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["columns"],
+      "description": "Multi-column layout container (#491 WS2). 2-4 columns, each holding leaf child blocks (no container nesting; depth 2, server-enforced).",
+      "properties": {
+        "columns": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 4,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["children"],
+            "properties": {
+              "children": { "type": "array", "maxItems": 20, "items": { "$ref": "#/$defs/block" } }
+            }
+          }
+        }
+      }
     },
     "groupData": {
       "type": "object",

--- a/frontend/src/features/edit-entity-text-fields/ui/BlockInspector.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/BlockInspector.tsx
@@ -18,6 +18,7 @@ import {
   type CalloutKind,
   type ChartBlockData,
   type ChartType,
+  type ColumnsBlockData,
   type GalleryBlockData,
   type GalleryItem,
   type GalleryLayout,
@@ -41,9 +42,12 @@ type BlockDataChange =
   | GalleryBlockData
   | ChartBlockData
   | GroupBlockData
+  | ColumnsBlockData
 
-/** Leaf block types a group may contain (no container-in-container; depth 2). */
-const GROUP_CHILD_CATALOG = BLOCK_CATALOG.filter((entry) => entry.type !== 'group')
+/** Leaf block types a container (group / columns) may hold (no nesting; depth 2). */
+const GROUP_CHILD_CATALOG = BLOCK_CATALOG.filter(
+  (entry) => entry.type !== 'group' && entry.type !== 'columns',
+)
 
 interface BlockInspectorProps {
   block: Block
@@ -269,6 +273,62 @@ export function BlockInspector({
             onChange({ ...data, children })
           }}
         />
+      </Stack>
+    )
+  }
+
+  if (block.type === 'columns') {
+    const data = block.data
+    const setColumns = (columns: ColumnsBlockData['columns']) => {
+      onChange({ ...data, columns })
+    }
+    return (
+      <Stack gap="sm">
+        <div className="flex items-center gap-inline-sm">
+          <span className="flex-1 font-sans text-caption font-medium text-text-primary">
+            {t('admin.blocks.columns.count', { count: String(data.columns.length) })}
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={disabled || data.columns.length <= 2}
+            onClick={() => {
+              setColumns(data.columns.slice(0, -1))
+            }}
+          >
+            {t('admin.blocks.columns.remove')}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={disabled || data.columns.length >= 4}
+            onClick={() => {
+              setColumns([...data.columns, { children: [] }])
+            }}
+          >
+            {t('admin.blocks.columns.add')}
+          </Button>
+        </div>
+        {data.columns.map((column, columnIndex) => (
+          <div
+            key={columnIndex}
+            className="flex flex-col gap-stack-xs rounded-md border border-border p-inline-sm"
+          >
+            <span className="font-sans text-caption font-medium text-text-muted">
+              {t('admin.blocks.columns.label', { n: String(columnIndex + 1) })}
+            </span>
+            <GroupChildrenField
+              idPrefix={`${idPrefix}-col${String(columnIndex)}`}
+              items={column.children}
+              disabled={disabled}
+              onChange={(children) => {
+                setColumns(data.columns.map((col, i) => (i === columnIndex ? { children } : col)))
+              }}
+            />
+          </div>
+        ))}
       </Stack>
     )
   }

--- a/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.tsx
@@ -22,6 +22,7 @@ import {
   type BlockType,
   type CalloutBlockData,
   type ChartBlockData,
+  type ColumnsBlockData,
   type GalleryBlockData,
   type GroupBlockData,
   type HeroBlockData,
@@ -61,6 +62,8 @@ function blockTypeIcon(type: BlockType) {
       return IconLayers
     case 'group':
       return IconCopy
+    case 'columns':
+      return IconLayout
   }
 }
 
@@ -82,6 +85,10 @@ function rawSummary(block: Block): string {
         : block.data.summary
     case 'group':
       return block.data.children.map((child) => rawSummary(child)).join(' · ')
+    case 'columns':
+      return block.data.columns
+        .flatMap((column) => column.children.map((child) => rawSummary(child)))
+        .join(' · ')
   }
 }
 
@@ -172,7 +179,8 @@ export function BlocksFieldEditor({
       | HeroBlockData
       | GalleryBlockData
       | ChartBlockData
-      | GroupBlockData,
+      | GroupBlockData
+      | ColumnsBlockData,
   ) => {
     emit(
       blocks.map((block): Block => {
@@ -192,6 +200,8 @@ export function BlocksFieldEditor({
             return { ...block, data: data as ChartBlockData }
           case 'group':
             return { ...block, data: data as GroupBlockData }
+          case 'columns':
+            return { ...block, data: data as ColumnsBlockData }
         }
       }),
     )

--- a/frontend/src/features/edit-entity-text-fields/ui/block-catalog.ts
+++ b/frontend/src/features/edit-entity-text-fields/ui/block-catalog.ts
@@ -23,6 +23,11 @@ export const BLOCK_CATALOG: readonly BlockCatalogEntry[] = [
   },
   { type: 'chart', labelKey: 'admin.blocks.type.chart', descKey: 'admin.blocks.type.chart.desc' },
   { type: 'group', labelKey: 'admin.blocks.type.group', descKey: 'admin.blocks.type.group.desc' },
+  {
+    type: 'columns',
+    labelKey: 'admin.blocks.type.columns',
+    descKey: 'admin.blocks.type.columns.desc',
+  },
 ]
 
 const CATALOG_BY_TYPE = Object.fromEntries(

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -2314,3 +2314,27 @@
   padding: var(--space-lg);
   border-radius: var(--radius-md);
 }
+/* columns block (#491 WS2) — responsive multi-column layout; stacks on narrow viewports. */
+.nene-public .columns {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-lg);
+  margin-block: var(--space-xl);
+}
+.nene-public .columns__col {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  min-width: 0;
+}
+@media (min-width: 768px) {
+  .nene-public .columns[data-columns='2'] {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .nene-public .columns[data-columns='3'] {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .nene-public .columns[data-columns='4'] {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -595,6 +595,13 @@ export const en = {
   'admin.blocks.childEdit': 'Edit',
   'admin.blocks.childCollapse': 'Done',
   'admin.blocks.error.childrenRequired': 'Add at least one block.',
+  // columns (#491 WS2)
+  'admin.blocks.type.columns': 'Columns',
+  'admin.blocks.type.columns.desc': 'A responsive multi-column layout',
+  'admin.blocks.columns.count': '{{count}} columns',
+  'admin.blocks.columns.add': 'Add column',
+  'admin.blocks.columns.remove': 'Remove column',
+  'admin.blocks.columns.label': 'Column {{n}}',
 
   // ── Home hero (#486) ──────────────────────────────────────────────────────
   'admin.homeHero.title': 'Home hero',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -592,6 +592,13 @@ export const ja: Partial<MessageCatalog> = {
   'admin.blocks.childEdit': '編集',
   'admin.blocks.childCollapse': '閉じる',
   'admin.blocks.error.childrenRequired': 'ブロックを1つ以上追加してください。',
+  // columns (#491 WS2)
+  'admin.blocks.type.columns': 'カラム',
+  'admin.blocks.type.columns.desc': 'レスポンシブな多段組みレイアウト',
+  'admin.blocks.columns.count': '{{count}} カラム',
+  'admin.blocks.columns.add': 'カラムを追加',
+  'admin.blocks.columns.remove': 'カラムを削除',
+  'admin.blocks.columns.label': 'カラム {{n}}',
 
   // ── Home hero (#486) ──────────────────────────────────────────────────────
   'admin.homeHero.title': 'ホームヒーロー',

--- a/frontend/src/shared/lib/blocks-document.test.ts
+++ b/frontend/src/shared/lib/blocks-document.test.ts
@@ -315,4 +315,38 @@ describe('blocks-document', () => {
   it('flags an empty group as children-required', () => {
     expect(validateBlock(createBlock('group'))).toBe('children-required')
   })
+
+  it('parses/validates a columns block (2-4 columns, leaf-only children)', () => {
+    const doc = JSON.stringify([
+      {
+        id: 'cols',
+        type: 'columns',
+        data: {
+          columns: [
+            {
+              children: [
+                { id: 'a', type: 'text', data: { markdown: 'Left' } },
+                { id: 'nested', type: 'group', data: { tone: 'plain', children: [] } },
+              ],
+            },
+            { children: [{ id: 'b', type: 'callout', data: { kind: 'info', body: 'Right' } }] },
+          ],
+        },
+      },
+    ])
+    const blocks = parseBlocksDocument(doc)
+    const cols = blocks[0]
+    expect(cols?.type).toBe('columns')
+    if (cols?.type === 'columns') {
+      expect(cols.data.columns).toHaveLength(2)
+      // the nested container child is dropped (leaf-only, depth 2)
+      expect(cols.data.columns[0]?.children.map((c) => c.type)).toEqual(['text'])
+      expect(validateBlock(cols)).toBeNull()
+      expect(parseBlocksDocument(serializeBlocksDocument(blocks))).toEqual(blocks)
+    }
+  })
+
+  it('flags an all-empty columns block as children-required', () => {
+    expect(validateBlock(createBlock('columns'))).toBe('children-required')
+  })
 })

--- a/frontend/src/shared/lib/blocks-document.ts
+++ b/frontend/src/shared/lib/blocks-document.ts
@@ -12,7 +12,7 @@
  * shared/ui) can import it.
  */
 
-const BLOCK_TYPES = ['text', 'callout', 'hero', 'gallery', 'chart', 'group'] as const
+const BLOCK_TYPES = ['text', 'callout', 'hero', 'gallery', 'chart', 'group', 'columns'] as const
 export type BlockType = (typeof BLOCK_TYPES)[number]
 
 export const CALLOUT_KINDS = ['info', 'warn', 'ok', 'danger'] as const
@@ -103,7 +103,20 @@ export interface GroupBlockData {
   children: LeafBlock[]
 }
 
-export type Block = LeafBlock | { id: string; type: 'group'; data: GroupBlockData }
+/** One column of a columns block; holds leaf children. */
+export interface ColumnsColumn {
+  children: LeafBlock[]
+}
+
+/** Multi-column layout container (#491 WS2); 2-4 columns of leaf blocks. */
+export interface ColumnsBlockData {
+  columns: ColumnsColumn[]
+}
+
+export type Block =
+  | LeafBlock
+  | { id: string; type: 'group'; data: GroupBlockData }
+  | { id: string; type: 'columns'; data: ColumnsBlockData }
 
 export type BlockValidationCode =
   | 'markdown-required'
@@ -131,6 +144,11 @@ function isHeroVariant(value: unknown): value is HeroVariant {
 
 function isGroupTone(value: unknown): value is GroupTone {
   return typeof value === 'string' && (GROUP_TONES as readonly string[]).includes(value)
+}
+
+/** True for non-container blocks (a container's children are leaf-only; depth 2). */
+function isLeafBlock(block: Block): block is LeafBlock {
+  return block.type !== 'group' && block.type !== 'columns'
 }
 
 function isGalleryLayout(value: unknown): value is GalleryLayout {
@@ -242,6 +260,8 @@ export function createBlock(type: BlockType): Block {
       }
     case 'group':
       return { id: newBlockId(), type, data: { tone: 'plain', children: [] } }
+    case 'columns':
+      return { id: newBlockId(), type, data: { columns: [{ children: [] }, { children: [] }] } }
   }
 }
 
@@ -288,7 +308,7 @@ function coerceBlock(raw: unknown, index: number, allowContainers: boolean): Blo
   }
 
   // Container blocks are not nestable inside another container (depth 2).
-  if (!allowContainers && type === 'group') {
+  if (!allowContainers && (type === 'group' || type === 'columns')) {
     return null
   }
 
@@ -360,12 +380,26 @@ function coerceBlock(raw: unknown, index: number, allowContainers: boolean): Blo
       const rawChildren = Array.isArray(record.children) ? record.children : []
       const children = rawChildren
         .map((child, childIndex) => coerceBlock(child, childIndex, false))
-        .filter((child): child is LeafBlock => child !== null && child.type !== 'group')
+        .filter((child): child is LeafBlock => child !== null && isLeafBlock(child))
       return {
         id,
         type,
         data: { tone: isGroupTone(record.tone) ? record.tone : 'plain', children },
       }
+    }
+    case 'columns': {
+      const rawColumns = Array.isArray(record.columns) ? record.columns : []
+      const columns = rawColumns.map((col) => {
+        const colRecord =
+          typeof col === 'object' && col !== null ? (col as Record<string, unknown>) : {}
+        const rawChildren = Array.isArray(colRecord.children) ? colRecord.children : []
+        return {
+          children: rawChildren
+            .map((child, childIndex) => coerceBlock(child, childIndex, false))
+            .filter((child): child is LeafBlock => child !== null && isLeafBlock(child)),
+        }
+      })
+      return { id, type, data: { columns } }
     }
   }
 }
@@ -443,6 +477,17 @@ function normalizeBlock(block: Block): Block {
       },
     }
   }
+  if (block.type === 'columns') {
+    return {
+      id: block.id,
+      type: 'columns',
+      data: {
+        columns: block.data.columns.map((col) => ({
+          children: col.children.map(normalizeBlock) as LeafBlock[],
+        })),
+      },
+    }
+  }
   return block
 }
 
@@ -495,6 +540,10 @@ export function validateBlock(block: Block): BlockValidationCode | null {
       return block.data.summary.trim() === '' ? 'summary-required' : null
     case 'group':
       return block.data.children.length === 0 ? 'children-required' : null
+    case 'columns':
+      return block.data.columns.every((col) => col.children.length === 0)
+        ? 'children-required'
+        : null
   }
 }
 

--- a/frontend/src/shared/ui/blocks/BlocksRenderer.test.tsx
+++ b/frontend/src/shared/ui/blocks/BlocksRenderer.test.tsx
@@ -146,4 +146,27 @@ describe('BlocksRenderer', () => {
     expect(group?.querySelector('.callout')).not.toBeNull()
     expect(screen.getByText('Grouped note')).toBeInTheDocument()
   })
+
+  it('renders a columns block with one rendered column per data column', () => {
+    const doc = JSON.stringify([
+      {
+        id: 'cols',
+        type: 'columns',
+        data: {
+          columns: [
+            { children: [{ id: 'a', type: 'text', data: { markdown: 'Left col' } }] },
+            { children: [{ id: 'b', type: 'text', data: { markdown: 'Right col' } }] },
+          ],
+        },
+      },
+    ])
+
+    const { container } = renderWithProviders(<BlocksRenderer documentJson={doc} />)
+
+    const columns = container.querySelector('.columns')
+    expect(columns?.getAttribute('data-columns')).toBe('2')
+    expect(container.querySelectorAll('.columns__col')).toHaveLength(2)
+    expect(screen.getByText('Left col')).toBeInTheDocument()
+    expect(screen.getByText('Right col')).toBeInTheDocument()
+  })
 })

--- a/frontend/src/shared/ui/blocks/BlocksRenderer.tsx
+++ b/frontend/src/shared/ui/blocks/BlocksRenderer.tsx
@@ -4,6 +4,7 @@ import {
   type Block,
   type CalloutKind,
   type ChartBlockData,
+  type ColumnsBlockData,
   type GalleryBlockData,
   type GroupBlockData,
   type HeroBlockData,
@@ -74,7 +75,31 @@ function ConsumerBlock({ block }: { block: Block }) {
       return <ConsumerChart data={block.data} />
     case 'group':
       return <ConsumerGroup data={block.data} />
+    case 'columns':
+      return <ConsumerColumns data={block.data} />
   }
+}
+
+/**
+ * Columns block (#491 WS2): a responsive multi-column layout (2-4 columns of leaf
+ * blocks). Stacks to one column on narrow viewports (see `.columns` in
+ * public-site.css). Children are leaf blocks only (depth 2).
+ */
+function ConsumerColumns({ data }: { data: ColumnsBlockData }) {
+  if (data.columns.length === 0) {
+    return null
+  }
+  return (
+    <div className="columns" data-columns={data.columns.length}>
+      {data.columns.map((column, index) => (
+        <div key={index} className="columns__col">
+          {column.children.map((child) => (
+            <ConsumerBlock key={child.id} block={child} />
+          ))}
+        </div>
+      ))}
+    </div>
+  )
 }
 
 /**

--- a/src/BlocksField/BlockTypes.php
+++ b/src/BlocksField/BlockTypes.php
@@ -21,6 +21,7 @@ final class BlockTypes
         'gallery',
         'chart',
         'group',
+        'columns',
     ];
 
     public static function isValid(string $type): bool

--- a/src/BlocksField/BlocksDocumentValidator.php
+++ b/src/BlocksField/BlocksDocumentValidator.php
@@ -38,11 +38,17 @@ final class BlocksDocumentValidator
     private const CHART_TYPES = ['bar', 'line'];
 
     /** Layout/container blocks that hold child blocks; cannot be nested in each other (depth 2). */
-    private const CONTAINER_TYPES = ['group'];
+    private const CONTAINER_TYPES = ['group', 'columns'];
 
     private const GROUP_TONES = ['plain', 'muted', 'card'];
 
     private const MAX_GROUP_CHILDREN = 30;
+
+    private const MIN_COLUMNS = 2;
+
+    private const MAX_COLUMNS = 4;
+
+    private const MAX_COLUMN_CHILDREN = 20;
 
     private const MAX_GALLERY_ITEMS = 50;
     private const MAX_SERIES_POINTS = 60;
@@ -135,6 +141,7 @@ final class BlocksDocumentValidator
             'gallery' => $this->validateGalleryData($path, $data, $errors),
             'chart' => $this->validateChartData($path, $data, $errors),
             'group' => $this->validateGroupData($path, $data, $count, $errors),
+            'columns' => $this->validateColumnsData($path, $data, $count, $errors),
             default => null,
         };
     }
@@ -166,6 +173,52 @@ final class BlocksDocumentValidator
         foreach ($children as $i => $child) {
             // Children are leaf blocks only (no container-in-container) → depth capped at 2.
             $this->validateBlock("{$path}.data.children[{$i}]", $child, false, $count, $errors);
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     * @param list<ValidationError> $errors
+     */
+    private function validateColumnsData(string $path, array $data, int &$count, array &$errors): void
+    {
+        $columns = $data['columns'] ?? null;
+        if (!is_array($columns) || !array_is_list($columns)) {
+            $errors[] = new ValidationError("{$path}.data.columns", 'Columns must be an array of column objects.', 'invalid');
+
+            return;
+        }
+
+        if (count($columns) < self::MIN_COLUMNS || count($columns) > self::MAX_COLUMNS) {
+            $errors[] = new ValidationError("{$path}.data.columns", 'A columns block must have between ' . self::MIN_COLUMNS . ' and ' . self::MAX_COLUMNS . ' columns.', 'invalid');
+
+            return;
+        }
+
+        foreach ($columns as $c => $column) {
+            if (!is_array($column)) {
+                $errors[] = new ValidationError("{$path}.data.columns[{$c}]", 'Each column must be an object.', 'invalid');
+
+                continue;
+            }
+
+            $children = $column['children'] ?? null;
+            if (!is_array($children) || !array_is_list($children)) {
+                $errors[] = new ValidationError("{$path}.data.columns[{$c}].children", 'Column children must be an array of blocks.', 'invalid');
+
+                continue;
+            }
+
+            if (count($children) > self::MAX_COLUMN_CHILDREN) {
+                $errors[] = new ValidationError("{$path}.data.columns[{$c}].children", 'A column may contain at most ' . self::MAX_COLUMN_CHILDREN . ' blocks.', 'invalid');
+
+                continue;
+            }
+
+            foreach ($children as $i => $child) {
+                // Column children are leaf blocks only (no container-in-container) → depth 2.
+                $this->validateBlock("{$path}.data.columns[{$c}].children[{$i}]", $child, false, $count, $errors);
+            }
         }
     }
 

--- a/tests/BlocksField/BlocksDocumentValidatorTest.php
+++ b/tests/BlocksField/BlocksDocumentValidatorTest.php
@@ -296,4 +296,44 @@ final class BlocksDocumentValidatorTest extends TestCase
             '[{"id":"g1","type":"group","data":{"tone":"plain","children":[{"id":"c1","type":"text","data":{}}]}}]',
         );
     }
+
+    public function testAcceptsValidColumnsBlock(): void
+    {
+        $json = json_encode([
+            ['id' => 'cols', 'type' => 'columns', 'data' => [
+                'columns' => [
+                    ['children' => [['id' => 'a', 'type' => 'text', 'data' => ['markdown' => 'Left']]]],
+                    ['children' => [['id' => 'b', 'type' => 'callout', 'data' => ['kind' => 'info', 'body' => 'Right']]]],
+                ],
+            ]],
+        ], JSON_THROW_ON_ERROR);
+
+        $this->validator->validate($json);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testRejectsColumnsWithTooFewColumns(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate(
+            '[{"id":"cols","type":"columns","data":{"columns":[{"children":[]}]}}]',
+        );
+    }
+
+    public function testRejectsColumnsWithTooManyColumns(): void
+    {
+        $cols = array_fill(0, 5, ['children' => []]);
+        $this->expectException(ValidationException::class);
+        $this->validator->validate(
+            json_encode([['id' => 'cols', 'type' => 'columns', 'data' => ['columns' => $cols]]], JSON_THROW_ON_ERROR),
+        );
+    }
+
+    public function testRejectsContainerNestedInsideColumn(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate(
+            '[{"id":"cols","type":"columns","data":{"columns":[{"children":[{"id":"g","type":"group","data":{"tone":"plain","children":[]}}]},{"children":[]}]}}]',
+        );
+    }
 }


### PR DESCRIPTION
EPIC #491「リッチページ化」**WS2-S2b**（“自由にデザイン”の本命）。S2a の group ネスト基盤に乗せて、横並びレイアウトの `columns` コンテナを追加。

## 仕様
- **2〜4カラム**、各カラムは leaf ブロックを保持（カラム内コンテナ禁止＝深さ2、各カラム children ≤ 20）。
- **レスポンシブ**: mobile-first（既定1列、768px↑で N 列）。

## backend
- `BlockTypes` に `columns`、`CONTAINER_TYPES` に追加（columns 自身もネスト不可）、`validateColumnsData`、`blocks.schema.json` に `columnsData`、PHPUnit（valid / カラム少なすぎ / 多すぎ / カラム内コンテナ拒否）。

## frontend
- **model**: `ColumnsBlockData`/`ColumnsColumn`、`isLeafBlock`（group/columns 共通の leaf 判定）、parse はカラム子を leaf-only に coerce、serialize 再帰正規化、`validateBlock` は全カラム空で `children-required`。
- **consumer**: `ConsumerColumns` が `.columns[data-columns=N]` でグリッド描画、`public-site.css` は mobile-first。
- **editor**: パレットに columns、`BlockInspector` でカラム数増減（2-4）＋各カラムを `GroupChildrenField`（S2a の子エディタ）で編集。
- i18n(en/ja)、テスト（model: parse/validate/round-trip・ネスト破棄、renderer: data-columns＋各カラム描画）。

## 検証
`composer check`（**835 tests** / PHPStan / OpenAPI / MCP）＋ `npm run check`（**295 tests** / type-check 0 / lint / storybook）緑。実機: 2カラム+leaf **201** / 1カラム **422** / カラム内コンテナ **422**。

## 次（#491）
WS2-S2c（`spacer` / `divider`・仕上げ）→ WS3（bundle discovery）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)