### PR TITLE
feat(blocks): spacer / divider ブロック＋WS2 レイアウト堅牢化 (#491 WS2-S2c)

### DIFF
--- a/docs/blocks/blocks.schema.json
+++ b/docs/blocks/blocks.schema.json
@@ -18,7 +18,19 @@
           "minLength": 1,
           "maxLength": 64
         },
-        "type": { "enum": ["text", "callout", "hero", "gallery", "chart", "group", "columns"] },
+        "type": {
+          "enum": [
+            "text",
+            "callout",
+            "hero",
+            "gallery",
+            "chart",
+            "group",
+            "columns",
+            "spacer",
+            "divider"
+          ]
+        },
         "data": { "type": "object" }
       },
       "allOf": [
@@ -49,6 +61,39 @@
         {
           "if": { "properties": { "type": { "const": "columns" } } },
           "then": { "properties": { "data": { "$ref": "#/$defs/columnsData" } } }
+        },
+        {
+          "if": { "properties": { "type": { "const": "spacer" } } },
+          "then": { "properties": { "data": { "$ref": "#/$defs/spacerData" } } }
+        },
+        {
+          "if": { "properties": { "type": { "const": "divider" } } },
+          "then": { "properties": { "data": { "$ref": "#/$defs/dividerData" } } }
+        }
+      ]
+    },
+    "spacerData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["size"],
+      "description": "Vertical whitespace block (#491 WS2).",
+      "properties": { "size": { "enum": ["sm", "md", "lg"] } }
+    },
+    "dividerData": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Horizontal rule block (#491 WS2). No options.",
+      "properties": {}
+    },
+    "leafBlock": {
+      "description": "A non-container (leaf) block — what a group/columns child may be (no nesting; depth 2). Mirrors the server validator, which rejects containers nested in containers.",
+      "allOf": [
+        { "$ref": "#/$defs/block" },
+        {
+          "not": {
+            "required": ["type"],
+            "properties": { "type": { "enum": ["group", "columns"] } }
+          }
         }
       ]
     },
@@ -67,7 +112,11 @@
             "additionalProperties": false,
             "required": ["children"],
             "properties": {
-              "children": { "type": "array", "maxItems": 20, "items": { "$ref": "#/$defs/block" } }
+              "children": {
+                "type": "array",
+                "maxItems": 20,
+                "items": { "$ref": "#/$defs/leafBlock" }
+              }
             }
           }
         }
@@ -80,7 +129,7 @@
       "description": "Layout container holding child blocks (#491 WS2). The server validator further restricts children to leaf blocks (no container nesting; depth 2).",
       "properties": {
         "tone": { "enum": ["plain", "muted", "card"] },
-        "children": { "type": "array", "maxItems": 30, "items": { "$ref": "#/$defs/block" } }
+        "children": { "type": "array", "maxItems": 30, "items": { "$ref": "#/$defs/leafBlock" } }
       }
     },
     "textData": {

--- a/frontend/src/features/edit-entity-text-fields/ui/BlockInspector.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/BlockInspector.tsx
@@ -9,6 +9,9 @@ import {
   GALLERY_LAYOUTS,
   GROUP_TONES,
   HERO_VARIANTS,
+  MAX_COLUMN_CHILDREN,
+  MAX_GROUP_CHILDREN,
+  SPACER_SIZES,
   createBlock,
   validateBlock,
   type Block,
@@ -19,6 +22,7 @@ import {
   type ChartBlockData,
   type ChartType,
   type ColumnsBlockData,
+  type DividerBlockData,
   type GalleryBlockData,
   type GalleryItem,
   type GalleryLayout,
@@ -29,6 +33,8 @@ import {
   type HeroVariant,
   type LeafBlock,
   type SeriesPoint,
+  type SpacerBlockData,
+  type SpacerSize,
   type TextBlockData,
 } from '@/shared/lib/blocks-document'
 import { BLOCK_CATALOG, blockCatalogEntry } from './block-catalog'
@@ -43,6 +49,8 @@ type BlockDataChange =
   | ChartBlockData
   | GroupBlockData
   | ColumnsBlockData
+  | SpacerBlockData
+  | DividerBlockData
 
 /** Leaf block types a container (group / columns) may hold (no nesting; depth 2). */
 const GROUP_CHILD_CATALOG = BLOCK_CATALOG.filter(
@@ -84,6 +92,12 @@ const GROUP_TONE_LABEL_KEY: Record<GroupTone, MessageKey> = {
   plain: 'admin.blocks.groupTone.plain',
   muted: 'admin.blocks.groupTone.muted',
   card: 'admin.blocks.groupTone.card',
+}
+
+const SPACER_SIZE_LABEL_KEY: Record<SpacerSize, MessageKey> = {
+  sm: 'admin.blocks.spacerSize.sm',
+  md: 'admin.blocks.spacerSize.md',
+  lg: 'admin.blocks.spacerSize.lg',
 }
 
 /** Settings form for the selected block (text / callout / hero / gallery). */
@@ -266,8 +280,13 @@ export function BlockInspector({
           idPrefix={idPrefix}
           items={data.children}
           disabled={disabled}
+          maxItems={MAX_GROUP_CHILDREN}
           error={
-            errorCode === 'children-required' ? t('admin.blocks.error.childrenRequired') : undefined
+            errorCode === 'children-required'
+              ? t('admin.blocks.error.childrenRequired')
+              : errorCode === 'children-invalid'
+                ? t('admin.blocks.error.childrenInvalid')
+                : undefined
           }
           onChange={(children) => {
             onChange({ ...data, children })
@@ -311,6 +330,13 @@ export function BlockInspector({
             {t('admin.blocks.columns.add')}
           </Button>
         </div>
+        {errorCode === 'children-required' || errorCode === 'children-invalid' ? (
+          <span role="alert" className="font-sans text-caption text-danger">
+            {errorCode === 'children-required'
+              ? t('admin.blocks.error.childrenRequired')
+              : t('admin.blocks.error.childrenInvalid')}
+          </span>
+        ) : null}
         {data.columns.map((column, columnIndex) => (
           <div
             key={columnIndex}
@@ -323,6 +349,7 @@ export function BlockInspector({
               idPrefix={`${idPrefix}-col${String(columnIndex)}`}
               items={column.children}
               disabled={disabled}
+              maxItems={MAX_COLUMN_CHILDREN}
               onChange={(children) => {
                 setColumns(data.columns.map((col, i) => (i === columnIndex ? { children } : col)))
               }}
@@ -330,6 +357,35 @@ export function BlockInspector({
           </div>
         ))}
       </Stack>
+    )
+  }
+
+  if (block.type === 'spacer') {
+    const data = block.data
+    return (
+      <Select
+        id={`${idPrefix}-spacer-size`}
+        label={t('admin.blocks.field.spacerSize')}
+        value={data.size}
+        disabled={disabled}
+        onChange={(event) => {
+          onChange({ size: event.target.value as SpacerSize })
+        }}
+      >
+        {SPACER_SIZES.map((size) => (
+          <option key={size} value={size}>
+            {t(SPACER_SIZE_LABEL_KEY[size])}
+          </option>
+        ))}
+      </Select>
+    )
+  }
+
+  if (block.type === 'divider') {
+    return (
+      <span className="font-sans text-caption text-text-muted">
+        {t('admin.blocks.divider.hint')}
+      </span>
     )
   }
 
@@ -812,6 +868,8 @@ interface GroupChildrenFieldProps {
   items: LeafBlock[]
   disabled: boolean
   error?: string | undefined
+  /** Max children (mirrors the server cap); the add palette disables at the limit. */
+  maxItems: number
   onChange: (items: LeafBlock[]) => void
 }
 
@@ -825,10 +883,12 @@ function GroupChildrenField({
   items,
   disabled,
   error,
+  maxItems,
   onChange,
 }: GroupChildrenFieldProps) {
   const { t } = useTranslation()
   const [openIndex, setOpenIndex] = useState<number | null>(null)
+  const atCapacity = items.length >= maxItems
 
   const add = (type: BlockType) => {
     onChange([...items, createBlock(type) as LeafBlock])
@@ -873,7 +933,7 @@ function GroupChildrenField({
             type="button"
             variant="ghost"
             size="sm"
-            disabled={disabled}
+            disabled={disabled || atCapacity}
             onClick={() => {
               add(entry.type)
             }}

--- a/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.tsx
@@ -14,6 +14,7 @@ import {
   IconX,
 } from '@/shared/ui/icons/Icons'
 import {
+  MAX_BLOCKS_PER_DOCUMENT,
   createBlock,
   parseBlocksDocument,
   serializeBlocksDocument,
@@ -23,9 +24,11 @@ import {
   type CalloutBlockData,
   type ChartBlockData,
   type ColumnsBlockData,
+  type DividerBlockData,
   type GalleryBlockData,
   type GroupBlockData,
   type HeroBlockData,
+  type SpacerBlockData,
   type TextBlockData,
 } from '@/shared/lib/blocks-document'
 import { BLOCK_CATALOG, blockCatalogEntry } from './block-catalog'
@@ -64,6 +67,10 @@ function blockTypeIcon(type: BlockType) {
       return IconCopy
     case 'columns':
       return IconLayout
+    case 'spacer':
+      return IconChevronDown
+    case 'divider':
+      return IconMenu
   }
 }
 
@@ -89,6 +96,9 @@ function rawSummary(block: Block): string {
       return block.data.columns
         .flatMap((column) => column.children.map((child) => rawSummary(child)))
         .join(' · ')
+    case 'spacer':
+    case 'divider':
+      return ''
   }
 }
 
@@ -180,7 +190,9 @@ export function BlocksFieldEditor({
       | GalleryBlockData
       | ChartBlockData
       | GroupBlockData
-      | ColumnsBlockData,
+      | ColumnsBlockData
+      | SpacerBlockData
+      | DividerBlockData,
   ) => {
     emit(
       blocks.map((block): Block => {
@@ -202,6 +214,10 @@ export function BlocksFieldEditor({
             return { ...block, data: data as GroupBlockData }
           case 'columns':
             return { ...block, data: data as ColumnsBlockData }
+          case 'spacer':
+            return { ...block, data: data as SpacerBlockData }
+          case 'divider':
+            return { ...block, data: data as DividerBlockData }
         }
       }),
     )
@@ -248,7 +264,7 @@ export function BlocksFieldEditor({
             key={entry.type}
             variant="secondary"
             size="sm"
-            disabled={disabled}
+            disabled={disabled || blocks.length >= MAX_BLOCKS_PER_DOCUMENT}
             onClick={() => {
               addBlock(entry.type)
             }}

--- a/frontend/src/features/edit-entity-text-fields/ui/block-catalog.ts
+++ b/frontend/src/features/edit-entity-text-fields/ui/block-catalog.ts
@@ -28,6 +28,16 @@ export const BLOCK_CATALOG: readonly BlockCatalogEntry[] = [
     labelKey: 'admin.blocks.type.columns',
     descKey: 'admin.blocks.type.columns.desc',
   },
+  {
+    type: 'spacer',
+    labelKey: 'admin.blocks.type.spacer',
+    descKey: 'admin.blocks.type.spacer.desc',
+  },
+  {
+    type: 'divider',
+    labelKey: 'admin.blocks.type.divider',
+    descKey: 'admin.blocks.type.divider.desc',
+  },
 ]
 
 const CATALOG_BY_TYPE = Object.fromEntries(

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -2338,3 +2338,18 @@
     grid-template-columns: repeat(4, 1fr);
   }
 }
+/* spacer / divider blocks (#491 WS2). */
+.nene-public .spacer[data-spacer-size='sm'] {
+  height: var(--space-md);
+}
+.nene-public .spacer[data-spacer-size='md'] {
+  height: var(--space-xl);
+}
+.nene-public .spacer[data-spacer-size='lg'] {
+  height: var(--space-2xl);
+}
+.nene-public .divider {
+  border: 0;
+  border-top: 1px solid var(--color-border);
+  margin-block: var(--space-xl);
+}

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -595,6 +595,7 @@ export const en = {
   'admin.blocks.childEdit': 'Edit',
   'admin.blocks.childCollapse': 'Done',
   'admin.blocks.error.childrenRequired': 'Add at least one block.',
+  'admin.blocks.error.childrenInvalid': 'One or more blocks inside need attention.',
   // columns (#491 WS2)
   'admin.blocks.type.columns': 'Columns',
   'admin.blocks.type.columns.desc': 'A responsive multi-column layout',
@@ -602,6 +603,16 @@ export const en = {
   'admin.blocks.columns.add': 'Add column',
   'admin.blocks.columns.remove': 'Remove column',
   'admin.blocks.columns.label': 'Column {{n}}',
+  // spacer / divider (#491 WS2)
+  'admin.blocks.type.spacer': 'Spacer',
+  'admin.blocks.type.spacer.desc': 'Vertical whitespace',
+  'admin.blocks.type.divider': 'Divider',
+  'admin.blocks.type.divider.desc': 'A horizontal rule',
+  'admin.blocks.field.spacerSize': 'Height',
+  'admin.blocks.spacerSize.sm': 'Small',
+  'admin.blocks.spacerSize.md': 'Medium',
+  'admin.blocks.spacerSize.lg': 'Large',
+  'admin.blocks.divider.hint': 'A horizontal rule — no settings.',
 
   // ── Home hero (#486) ──────────────────────────────────────────────────────
   'admin.homeHero.title': 'Home hero',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -592,6 +592,7 @@ export const ja: Partial<MessageCatalog> = {
   'admin.blocks.childEdit': '編集',
   'admin.blocks.childCollapse': '閉じる',
   'admin.blocks.error.childrenRequired': 'ブロックを1つ以上追加してください。',
+  'admin.blocks.error.childrenInvalid': '内側のブロックに未入力/不備があります。',
   // columns (#491 WS2)
   'admin.blocks.type.columns': 'カラム',
   'admin.blocks.type.columns.desc': 'レスポンシブな多段組みレイアウト',
@@ -599,6 +600,16 @@ export const ja: Partial<MessageCatalog> = {
   'admin.blocks.columns.add': 'カラムを追加',
   'admin.blocks.columns.remove': 'カラムを削除',
   'admin.blocks.columns.label': 'カラム {{n}}',
+  // spacer / divider (#491 WS2)
+  'admin.blocks.type.spacer': 'スペーサー',
+  'admin.blocks.type.spacer.desc': '縦方向の余白',
+  'admin.blocks.type.divider': '区切り線',
+  'admin.blocks.type.divider.desc': '水平の罫線',
+  'admin.blocks.field.spacerSize': '高さ',
+  'admin.blocks.spacerSize.sm': '小',
+  'admin.blocks.spacerSize.md': '中',
+  'admin.blocks.spacerSize.lg': '大',
+  'admin.blocks.divider.hint': '水平の罫線です（設定なし）。',
 
   // ── Home hero (#486) ──────────────────────────────────────────────────────
   'admin.homeHero.title': 'ホームヒーロー',

--- a/frontend/src/shared/lib/blocks-document.test.ts
+++ b/frontend/src/shared/lib/blocks-document.test.ts
@@ -316,6 +316,19 @@ describe('blocks-document', () => {
     expect(validateBlock(createBlock('group'))).toBe('children-required')
   })
 
+  it('flags a container whose child is invalid as children-invalid (mirrors server recursion)', () => {
+    const group = parseBlocksDocument(
+      JSON.stringify([
+        {
+          id: 'g',
+          type: 'group',
+          data: { tone: 'plain', children: [{ id: 't', type: 'text', data: { markdown: '' } }] },
+        },
+      ]),
+    )[0]
+    expect(group && validateBlock(group)).toBe('children-invalid')
+  })
+
   it('parses/validates a columns block (2-4 columns, leaf-only children)', () => {
     const doc = JSON.stringify([
       {
@@ -348,5 +361,25 @@ describe('blocks-document', () => {
 
   it('flags an all-empty columns block as children-required', () => {
     expect(validateBlock(createBlock('columns'))).toBe('children-required')
+  })
+
+  it('parses/validates spacer and divider leaf blocks', () => {
+    const blocks = parseBlocksDocument(
+      JSON.stringify([
+        { id: 's', type: 'spacer', data: { size: 'lg' } },
+        { id: 'd', type: 'divider', data: {} },
+        { id: 's2', type: 'spacer', data: { size: 'bogus' } },
+      ]),
+    )
+    expect(blocks.map((b) => b.type)).toEqual(['spacer', 'divider', 'spacer'])
+    const spacer = blocks[0]
+    if (spacer?.type === 'spacer') {
+      expect(spacer.data.size).toBe('lg')
+    }
+    const fallback = blocks[2]
+    if (fallback?.type === 'spacer') {
+      expect(fallback.data.size).toBe('md') // invalid size coerced to default
+    }
+    expect(blocks.every((b) => validateBlock(b) === null)).toBe(true)
   })
 })

--- a/frontend/src/shared/lib/blocks-document.ts
+++ b/frontend/src/shared/lib/blocks-document.ts
@@ -12,7 +12,17 @@
  * shared/ui) can import it.
  */
 
-const BLOCK_TYPES = ['text', 'callout', 'hero', 'gallery', 'chart', 'group', 'columns'] as const
+const BLOCK_TYPES = [
+  'text',
+  'callout',
+  'hero',
+  'gallery',
+  'chart',
+  'group',
+  'columns',
+  'spacer',
+  'divider',
+] as const
 export type BlockType = (typeof BLOCK_TYPES)[number]
 
 export const CALLOUT_KINDS = ['info', 'warn', 'ok', 'danger'] as const
@@ -29,6 +39,14 @@ export type ChartType = (typeof CHART_TYPES)[number]
 
 export const GROUP_TONES = ['plain', 'muted', 'card'] as const
 export type GroupTone = (typeof GROUP_TONES)[number]
+
+export const SPACER_SIZES = ['sm', 'md', 'lg'] as const
+export type SpacerSize = (typeof SPACER_SIZES)[number]
+
+/** Block caps — mirror the server validator (`BlocksDocumentValidator`); enforced in the editor. */
+export const MAX_BLOCKS_PER_DOCUMENT = 200
+export const MAX_GROUP_CHILDREN = 30
+export const MAX_COLUMN_CHILDREN = 20
 
 export interface TextBlockData {
   markdown: string
@@ -89,6 +107,14 @@ export interface ChartBlockData {
   summary: string
 }
 
+/** Vertical whitespace block (#491 WS2). */
+export interface SpacerBlockData {
+  size: SpacerSize
+}
+
+/** Horizontal rule block (#491 WS2); no options. */
+export type DividerBlockData = Record<string, never>
+
 /** Leaf (non-container) blocks. A group's children are leaf blocks only (depth 2). */
 export type LeafBlock =
   | { id: string; type: 'text'; data: TextBlockData }
@@ -96,6 +122,8 @@ export type LeafBlock =
   | { id: string; type: 'hero'; data: HeroBlockData }
   | { id: string; type: 'gallery'; data: GalleryBlockData }
   | { id: string; type: 'chart'; data: ChartBlockData }
+  | { id: string; type: 'spacer'; data: SpacerBlockData }
+  | { id: string; type: 'divider'; data: DividerBlockData }
 
 /** Layout container holding leaf child blocks (#491 WS2); not nestable in another container. */
 export interface GroupBlockData {
@@ -129,6 +157,7 @@ export type BlockValidationCode =
   | 'series-label-required'
   | 'summary-required'
   | 'children-required'
+  | 'children-invalid'
 
 function isBlockType(value: string): value is BlockType {
   return (BLOCK_TYPES as readonly string[]).includes(value)
@@ -149,6 +178,10 @@ function isGroupTone(value: unknown): value is GroupTone {
 /** True for non-container blocks (a container's children are leaf-only; depth 2). */
 function isLeafBlock(block: Block): block is LeafBlock {
   return block.type !== 'group' && block.type !== 'columns'
+}
+
+function isSpacerSize(value: unknown): value is SpacerSize {
+  return typeof value === 'string' && (SPACER_SIZES as readonly string[]).includes(value)
 }
 
 function isGalleryLayout(value: unknown): value is GalleryLayout {
@@ -262,6 +295,10 @@ export function createBlock(type: BlockType): Block {
       return { id: newBlockId(), type, data: { tone: 'plain', children: [] } }
     case 'columns':
       return { id: newBlockId(), type, data: { columns: [{ children: [] }, { children: [] }] } }
+    case 'spacer':
+      return { id: newBlockId(), type, data: { size: 'md' } }
+    case 'divider':
+      return { id: newBlockId(), type, data: {} }
   }
 }
 
@@ -401,6 +438,10 @@ function coerceBlock(raw: unknown, index: number, allowContainers: boolean): Blo
       })
       return { id, type, data: { columns } }
     }
+    case 'spacer':
+      return { id, type, data: { size: isSpacerSize(record.size) ? record.size : 'md' } }
+    case 'divider':
+      return { id, type, data: {} }
   }
 }
 
@@ -539,11 +580,26 @@ export function validateBlock(block: Block): BlockValidationCode | null {
       }
       return block.data.summary.trim() === '' ? 'summary-required' : null
     case 'group':
-      return block.data.children.length === 0 ? 'children-required' : null
-    case 'columns':
-      return block.data.columns.every((col) => col.children.length === 0)
-        ? 'children-required'
+      if (block.data.children.length === 0) {
+        return 'children-required'
+      }
+      // Recurse: the server validates children too, so flag a container whose
+      // child is invalid (else the user hits a silent 422 on save).
+      return block.data.children.some((child) => validateBlock(child) !== null)
+        ? 'children-invalid'
         : null
+    case 'columns':
+      if (block.data.columns.every((col) => col.children.length === 0)) {
+        return 'children-required'
+      }
+      return block.data.columns.some((col) =>
+        col.children.some((child) => validateBlock(child) !== null),
+      )
+        ? 'children-invalid'
+        : null
+    case 'spacer':
+    case 'divider':
+      return null
   }
 }
 

--- a/frontend/src/shared/ui/blocks/BlocksRenderer.test.tsx
+++ b/frontend/src/shared/ui/blocks/BlocksRenderer.test.tsx
@@ -169,4 +169,16 @@ describe('BlocksRenderer', () => {
     expect(screen.getByText('Left col')).toBeInTheDocument()
     expect(screen.getByText('Right col')).toBeInTheDocument()
   })
+
+  it('renders spacer (with size) and divider blocks', () => {
+    const doc = JSON.stringify([
+      { id: 's', type: 'spacer', data: { size: 'lg' } },
+      { id: 'd', type: 'divider', data: {} },
+    ])
+
+    const { container } = renderWithProviders(<BlocksRenderer documentJson={doc} />)
+
+    expect(container.querySelector('.spacer')?.getAttribute('data-spacer-size')).toBe('lg')
+    expect(container.querySelector('hr.divider')).not.toBeNull()
+  })
 })

--- a/frontend/src/shared/ui/blocks/BlocksRenderer.tsx
+++ b/frontend/src/shared/ui/blocks/BlocksRenderer.tsx
@@ -77,6 +77,10 @@ function ConsumerBlock({ block }: { block: Block }) {
       return <ConsumerGroup data={block.data} />
     case 'columns':
       return <ConsumerColumns data={block.data} />
+    case 'spacer':
+      return <div className="spacer" data-spacer-size={block.data.size} aria-hidden="true" />
+    case 'divider':
+      return <hr className="divider" />
   }
 }
 

--- a/src/BlocksField/BlockTypes.php
+++ b/src/BlocksField/BlockTypes.php
@@ -22,6 +22,8 @@ final class BlockTypes
         'chart',
         'group',
         'columns',
+        'spacer',
+        'divider',
     ];
 
     public static function isValid(string $type): bool

--- a/src/BlocksField/BlocksDocumentValidator.php
+++ b/src/BlocksField/BlocksDocumentValidator.php
@@ -50,6 +50,8 @@ final class BlocksDocumentValidator
 
     private const MAX_COLUMN_CHILDREN = 20;
 
+    private const SPACER_SIZES = ['sm', 'md', 'lg'];
+
     private const MAX_GALLERY_ITEMS = 50;
     private const MAX_SERIES_POINTS = 60;
     private const MAX_SERIES_LABEL_LEN = 120;
@@ -142,6 +144,7 @@ final class BlocksDocumentValidator
             'chart' => $this->validateChartData($path, $data, $errors),
             'group' => $this->validateGroupData($path, $data, $count, $errors),
             'columns' => $this->validateColumnsData($path, $data, $count, $errors),
+            'spacer' => $this->validateSpacerData($path, $data, $errors),
             default => null,
         };
     }
@@ -219,6 +222,18 @@ final class BlocksDocumentValidator
                 // Column children are leaf blocks only (no container-in-container) → depth 2.
                 $this->validateBlock("{$path}.data.columns[{$c}].children[{$i}]", $child, false, $count, $errors);
             }
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     * @param list<ValidationError> $errors
+     */
+    private function validateSpacerData(string $path, array $data, array &$errors): void
+    {
+        $size = $data['size'] ?? null;
+        if (!is_string($size) || !in_array($size, self::SPACER_SIZES, true)) {
+            $errors[] = new ValidationError("{$path}.data.size", 'Spacer size must be one of: ' . implode(', ', self::SPACER_SIZES) . '.', 'invalid');
         }
     }
 

--- a/tests/BlocksField/BlocksDocumentValidatorTest.php
+++ b/tests/BlocksField/BlocksDocumentValidatorTest.php
@@ -336,4 +336,18 @@ final class BlocksDocumentValidatorTest extends TestCase
             '[{"id":"cols","type":"columns","data":{"columns":[{"children":[{"id":"g","type":"group","data":{"tone":"plain","children":[]}}]},{"children":[]}]}}]',
         );
     }
+
+    public function testAcceptsSpacerAndDivider(): void
+    {
+        $this->validator->validate(
+            '[{"id":"s","type":"spacer","data":{"size":"md"}},{"id":"d","type":"divider","data":{}}]',
+        );
+        $this->addToAssertionCount(1);
+    }
+
+    public function testRejectsSpacerWithInvalidSize(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('[{"id":"s","type":"spacer","data":{"size":"huge"}}]');
+    }
 }


### PR DESCRIPTION
EPIC #491「リッチページ化」**WS2-S2c**（仕上げ）。軽量な leaf ブロック **spacer**（縦余白 sm/md/lg）/ **divider**（区切り線）を追加し、あわせて**多視点アドバーサリアルレビュー**で確定した WS2 レイアウトシステムの不具合を修正。

## S2c（spacer / divider）
- backend: `BlockTypes` に追加、`validateSpacerData`、`blocks.schema.json` に `spacerData`/`dividerData`、PHPUnit。
- frontend: model（`SpacerBlockData`/`DividerBlockData`）、consumer（`.spacer[data-spacer-size]` / `<hr class=divider>`＋CSS）、editor（パレット＋size Select / 設定なしヒント）、i18n、テスト。

## レビュー修正（confirmed 3件）
- 🔴 **[high] 子の無効が client 検証をすり抜け silent 422**: `validateBlock` がコンテナの子妥当性を再帰検証していなかった（PHP は再帰検証）。例: group に空 markdown の text 子 → client は有効扱い → 保存で 422。→ `validateBlock` を再帰化（子が無効なら **`children-invalid`**）し、**盤面カードのバッジ＋インスペクタ**で保存前に気づけるように。
- 🟡 **[med] schema が容器ネストを許容**（PHP は深さ2で拒否）: `groupData/columnsData` の子が `#/$defs/block`（容器含む）を参照 → 新 `$def leafBlock`（容器を除外）参照に変更。**Ajv で nested 容器=invalid / leaf 子=valid を確認**。
- 🟡 **[med] エディタが上限未強制 → 生 422**: `MAX_BLOCKS(200)` / `MAX_GROUP_CHILDREN(30)` / `MAX_COLUMN_CHILDREN(20)` を `blocks-document` から公開し、上限到達で追加ボタンを無効化。

（low: divider data の厳密検証・全空 columns の空描画 は forward-compat / 軽微のため見送り、レビューに記録）

## 検証
`composer check`（**837 tests** / PHPStan / OpenAPI / MCP）＋ `npm run check`（**298 tests** / type-check 0 / lint / storybook）緑。Ajv で schema 契約一致を確認。実機: spacer/divider **201** / 不正 size **422** / group 子 **201**。

## これで EPIC #491 WS2 完了
group（囲み）/ columns（多段）/ spacer / divider が揃い、**Elementor なしの Gutenberg 流レイアウト**が型安全・サーバ検証・深さ2 で実現。残り: WS3（bundle discovery）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)