### PR TITLE
feat(bundle): bundle に dual-SEO（クローラブルテキスト）(#311 / #491 WS3-S3a)

### DIFF
--- a/frontend/src/features/edit-entity-text-fields/ui/BundleFieldEditor.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/BundleFieldEditor.tsx
@@ -1,0 +1,75 @@
+import { useTranslation } from '@/shared/i18n'
+import { parseBundleDocument, serializeBundleDocument } from '@/shared/lib/bundle-document'
+
+const TEXTAREA_CLASS =
+  'rounded-sm border border-border bg-surface-raised px-inline-sm py-stack-xs text-caption text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent'
+
+export interface BundleFieldEditorProps {
+  id: string
+  label: string
+  /** The stored field value: a JSON envelope { html, seoText }. */
+  value: string
+  disabled: boolean
+  onChange: (value: string) => void
+}
+
+/**
+ * Editor for a `bundle` field (#311 / #491 WS3-S3a): a raw HTML/JS/CSS document
+ * (rendered only inside a sandboxed iframe on the public site) plus a REQUIRED
+ * crawlable `seoText` markdown twin (dual representation — no cloaking; it is
+ * also the no-JS / a11y fallback). Admin never executes the HTML.
+ */
+export function BundleFieldEditor({
+  id,
+  label,
+  value,
+  disabled,
+  onChange,
+}: BundleFieldEditorProps) {
+  const { t } = useTranslation()
+  const doc = parseBundleDocument(value)
+  const patch = (next: Partial<{ html: string; seoText: string }>) => {
+    onChange(serializeBundleDocument({ ...doc, ...next }))
+  }
+
+  return (
+    <div className="flex flex-col gap-stack-sm">
+      <span className="font-sans text-body font-medium text-text-primary">{label}</span>
+      <span className="font-sans text-caption text-text-muted">
+        {t('admin.fieldDefs.bundle.hint')}
+      </span>
+
+      <label
+        htmlFor={`${id}-html`}
+        className="font-sans text-caption font-medium text-text-primary"
+      >
+        {t('admin.bundle.htmlLabel')}
+      </label>
+      <textarea
+        id={`${id}-html`}
+        rows={16}
+        disabled={disabled}
+        value={doc.html}
+        onChange={(event) => {
+          patch({ html: event.target.value })
+        }}
+        className={`${TEXTAREA_CLASS} font-mono`}
+      />
+
+      <label htmlFor={`${id}-seo`} className="font-sans text-caption font-medium text-text-primary">
+        {t('admin.bundle.seoLabel')}
+      </label>
+      <textarea
+        id={`${id}-seo`}
+        rows={6}
+        disabled={disabled}
+        value={doc.seoText}
+        onChange={(event) => {
+          patch({ seoText: event.target.value })
+        }}
+        className={`${TEXTAREA_CLASS} font-sans`}
+      />
+      <span className="font-sans text-caption text-text-muted">{t('admin.bundle.seoHint')}</span>
+    </div>
+  )
+}

--- a/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
@@ -3,6 +3,7 @@ import type { FieldDataType, FieldDef } from '@/entities/field-def'
 import { useTranslation } from '@/shared/i18n'
 import { Button, Card, EmptyState, Input, Stack, Text } from '@/shared/ui'
 import { BlocksFieldEditor } from './BlocksFieldEditor'
+import { BundleFieldEditor } from './BundleFieldEditor'
 import { FileFieldInput } from './FileFieldInput'
 import { ImageFieldInput } from './ImageFieldInput'
 import { MarkdownFieldInput } from './MarkdownFieldInput'
@@ -121,7 +122,22 @@ export function EntityTextFieldsForm({
             )
           }
 
-          if (fieldDef.dataType === 'html' || fieldDef.dataType === 'bundle') {
+          if (fieldDef.dataType === 'bundle') {
+            return (
+              <BundleFieldEditor
+                key={fieldDef.fieldKey}
+                id={fieldId}
+                label={label}
+                value={values[fieldDef.fieldKey] ?? ''}
+                disabled={isSubmitting}
+                onChange={(val) => {
+                  setValues((current) => ({ ...current, [fieldDef.fieldKey]: val }))
+                }}
+              />
+            )
+          }
+
+          if (fieldDef.dataType === 'html') {
             return (
               <div key={fieldDef.fieldKey} className="flex flex-col gap-stack-xs">
                 <label
@@ -132,7 +148,7 @@ export function EntityTextFieldsForm({
                 </label>
                 <textarea
                   id={fieldId}
-                  rows={fieldDef.dataType === 'bundle' ? 16 : 10}
+                  rows={10}
                   disabled={isSubmitting}
                   value={values[fieldDef.fieldKey] ?? ''}
                   onChange={(event) => {
@@ -144,11 +160,7 @@ export function EntityTextFieldsForm({
                   className="rounded-sm border border-border bg-surface-raised px-inline-sm py-stack-xs font-mono text-caption text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
                 />
                 <span className="font-sans text-caption text-text-muted">
-                  {t(
-                    fieldDef.dataType === 'bundle'
-                      ? 'admin.fieldDefs.bundle.hint'
-                      : 'admin.fieldDefs.html.hint',
-                  )}
+                  {t('admin.fieldDefs.html.hint')}
                 </span>
               </div>
             )

--- a/frontend/src/features/public-view-entity-record/ui/PublicRecordFieldList.tsx
+++ b/frontend/src/features/public-view-entity-record/ui/PublicRecordFieldList.tsx
@@ -1,4 +1,5 @@
 import type { Entity } from '@/entities/entity'
+import { parseBundleDocument } from '@/shared/lib/bundle-document'
 import { isMarkdownBodyField } from '@/shared/lib/is-markdown-body-field'
 import { SandboxedBundle, SanitizedHtml, Text } from '@/shared/ui'
 import { BlocksRenderer } from '@/shared/ui/blocks'
@@ -62,16 +63,30 @@ export function PublicRecordFieldList({
           )
         }
 
+        // Custom-page bundle (#311 / WS3): the sandboxed iframe IS the page (no
+        // field-key label). Its crawlable seoText twin is projected sr-only for
+        // assistive tech + JS crawlers; the SSR document carries the same text
+        // server-rendered for no-JS / basic crawlers.
+        if (row.dataType === 'bundle') {
+          const bundle = parseBundleDocument(row.displayValue === '—' ? '' : row.displayValue)
+          return (
+            <div key={row.fieldKey}>
+              {bundle.seoText.trim() !== '' ? (
+                <div className="sr-only">
+                  <PublicMarkdownContent markdown={bundle.seoText} />
+                </div>
+              ) : null}
+              <SandboxedBundle html={bundle.html} />
+            </div>
+          )
+        }
+
         return (
           <div key={row.fieldKey} className="flex flex-col gap-stack-xs">
             <Text as="dt" variant="heading-sm">
               {row.fieldKey}
             </Text>
-            {row.dataType === 'bundle' ? (
-              <dd>
-                <SandboxedBundle html={row.displayValue === '—' ? '' : row.displayValue} />
-              </dd>
-            ) : row.dataType === 'html' ? (
+            {row.dataType === 'html' ? (
               <dd>
                 <SanitizedHtml html={row.displayValue === '—' ? '' : row.displayValue} />
               </dd>

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -489,6 +489,10 @@ export const en = {
   'admin.fieldDefs.html.hint': 'HTML with CSS is allowed; scripts are removed on display.',
   'admin.fieldDefs.bundle.hint':
     'A full HTML document (JS/CSS allowed). Runs isolated in a sandboxed iframe on the public page.',
+  'admin.bundle.htmlLabel': 'Bundle HTML (sandboxed)',
+  'admin.bundle.seoLabel': 'Crawlable text (required)',
+  'admin.bundle.seoHint':
+    'Markdown that faithfully represents the bundle’s visible content. Server-rendered for crawlers and used as the no-JS / screen-reader fallback.',
   'admin.fieldDefs.dataType.int': 'Integer',
   'admin.fieldDefs.dataType.enum': 'Enum',
   'admin.fieldDefs.dataType.bool': 'Boolean',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -486,6 +486,10 @@ export const ja: Partial<MessageCatalog> = {
   'admin.fieldDefs.html.hint': 'CSS込みのHTMLを使えます。表示時にスクリプトは除去されます。',
   'admin.fieldDefs.bundle.hint':
     'HTMLドキュメント一式（JS/CSS可）。公開ページではサンドボックスiframe内で隔離実行されます。',
+  'admin.bundle.htmlLabel': 'バンドルHTML（サンドボックス）',
+  'admin.bundle.seoLabel': 'クロール用テキスト（必須）',
+  'admin.bundle.seoHint':
+    'バンドルの可視内容を忠実に表す Markdown。クローラ向けにサーバ描画され、no-JS / スクリーンリーダーのフォールバックにも使われます。',
   'admin.fieldDefs.dataType.int': '整数',
   'admin.fieldDefs.dataType.enum': '列挙型',
   'admin.fieldDefs.dataType.bool': 'ブール値',

--- a/frontend/src/shared/lib/bundle-document.test.ts
+++ b/frontend/src/shared/lib/bundle-document.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { parseBundleDocument, serializeBundleDocument } from './bundle-document'
+
+describe('bundle-document', () => {
+  it('parses an envelope and round-trips', () => {
+    const json = serializeBundleDocument({ html: '<h1>x</h1>', seoText: '# x' })
+    expect(parseBundleDocument(json)).toEqual({ html: '<h1>x</h1>', seoText: '# x' })
+  })
+
+  it('treats a legacy raw-HTML value as html with empty seoText', () => {
+    expect(parseBundleDocument('<h1>legacy</h1>')).toEqual({ html: '<h1>legacy</h1>', seoText: '' })
+  })
+
+  it('returns empty for empty input', () => {
+    expect(parseBundleDocument('')).toEqual({ html: '', seoText: '' })
+  })
+})

--- a/frontend/src/shared/lib/bundle-document.ts
+++ b/frontend/src/shared/lib/bundle-document.ts
@@ -1,0 +1,40 @@
+/**
+ * Bundle field model (#311 / #491 WS3-S3a).
+ *
+ * A `bundle` field is the "fully custom page" escape hatch: a self-contained
+ * HTML/JS/CSS document rendered ONLY inside a sandboxed iframe. Because iframe
+ * content is invisible to crawlers and assistive tech, the value is a small
+ * envelope carrying a crawlable text twin (`seoText`, markdown) — the dual-
+ * representation contract. The server (`BundleField/BundleDocumentValidator.php`)
+ * is the trust boundary; this mirrors it for the editor + consumer.
+ *
+ * Lenient parse: a legacy raw-HTML string (pre-envelope) is read as
+ * `{ html, seoText: '' }` so old values still render.
+ */
+export interface BundleDocument {
+  html: string
+  seoText: string
+}
+
+export function parseBundleDocument(raw: string): BundleDocument {
+  if (raw.trim() === '') {
+    return { html: '', seoText: '' }
+  }
+  try {
+    const decoded: unknown = JSON.parse(raw)
+    if (typeof decoded === 'object' && decoded !== null && !Array.isArray(decoded)) {
+      const record = decoded as Record<string, unknown>
+      return {
+        html: typeof record.html === 'string' ? record.html : '',
+        seoText: typeof record.seoText === 'string' ? record.seoText : '',
+      }
+    }
+  } catch {
+    // Not JSON → a legacy raw-HTML bundle.
+  }
+  return { html: raw, seoText: '' }
+}
+
+export function serializeBundleDocument(doc: BundleDocument): string {
+  return JSON.stringify({ html: doc.html, seoText: doc.seoText })
+}

--- a/src/BundleField/BundleDocumentValidator.php
+++ b/src/BundleField/BundleDocumentValidator.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\BundleField;
+
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+
+/**
+ * Server-side validator for a `bundle` field value (#311 / #491 WS3-S3a).
+ *
+ * A bundle is the "fully custom page" escape hatch: a self-contained HTML/JS/CSS
+ * document rendered ONLY inside a sandboxed iframe on the public site. Because
+ * iframe content is invisible to crawlers and assistive tech, the dual-
+ * representation contract requires a crawlable text twin. So the stored value is
+ * a small JSON envelope:
+ *
+ *   { "html": "<…sandboxed document…>", "seoText": "# markdown crawlable text" }
+ *
+ * `seoText` is REQUIRED (no cloaking; it doubles as the noscript / a11y
+ * fallback). This is the trust boundary; the admin editor is convenience only.
+ */
+final class BundleDocumentValidator
+{
+    public const MAX_HTML_LEN = 50000;
+    public const MAX_SEO_TEXT_LEN = 10000;
+
+    public function validate(string $json): void
+    {
+        $decoded = json_decode($json, true);
+
+        if (!is_array($decoded) || array_is_list($decoded)) {
+            throw new ValidationException([
+                new ValidationError('value', 'Bundle must be a JSON object { html, seoText }.', 'invalid'),
+            ]);
+        }
+
+        $errors = [];
+
+        $html = $decoded['html'] ?? null;
+        if (!is_string($html) || strlen($html) > self::MAX_HTML_LEN) {
+            $errors[] = new ValidationError('value.html', 'Bundle html must be a string (max ' . self::MAX_HTML_LEN . ' chars).', 'invalid');
+        }
+
+        $seoText = $decoded['seoText'] ?? null;
+        if (!is_string($seoText) || trim($seoText) === '' || strlen($seoText) > self::MAX_SEO_TEXT_LEN) {
+            $errors[] = new ValidationError('value.seoText', 'Bundle requires non-empty crawlable seoText (max ' . self::MAX_SEO_TEXT_LEN . ' chars).', 'invalid');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+    }
+
+    /** Extract the crawlable seoText (markdown) from a stored bundle value; '' if malformed. */
+    public static function seoTextOf(string $json): string
+    {
+        $decoded = json_decode($json, true);
+        if (is_array($decoded) && isset($decoded['seoText']) && is_string($decoded['seoText'])) {
+            return $decoded['seoText'];
+        }
+
+        return '';
+    }
+}

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\PublicRecord;
 use Nene2\Config\AppConfig;
 use Nene2\Routing\Router;
 use Nene2\View\HtmlResponseFactory;
+use NeNeRecords\BundleField\BundleDocumentValidator;
 use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -60,6 +61,9 @@ final readonly class RenderPublicRecordViewHandler
             'includeViteClient' => $this->config->debug,
             'viteUrl' => rtrim($viteUrl, '/'),
             'renderMarkdown' => static fn (string $markdown): string => PublicMarkdownRenderer::toSafeHtml($markdown),
+            // A bundle's crawlable twin (#311): render its seoText markdown server-side
+            // (the sandboxed iframe itself is SPA-only / invisible to crawlers).
+            'renderBundleSeo' => static fn (string $raw): string => PublicMarkdownRenderer::toSafeHtml(BundleDocumentValidator::seoTextOf($raw)),
         ]);
     }
 

--- a/src/TextField/CreateTextFieldUseCase.php
+++ b/src/TextField/CreateTextFieldUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\TextField;
 
+use NeNeRecords\BundleField\BundleDocumentValidator;
 use NeNeRecords\Entity\EntityNotFoundException;
 use NeNeRecords\Entity\EntityRepositoryInterface;
 use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
@@ -30,7 +31,13 @@ final readonly class CreateTextFieldUseCase implements CreateTextFieldUseCaseInt
             throw new EntityNotFoundException($input->entityId);
         }
 
-        $this->assertTextFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
+        $dataType = $this->assertTextFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
+
+        // Bundle is a typed envelope { html, seoText } (dual-representation, #311) —
+        // validate it; everything else text-backed is opaque text.
+        if ($dataType === 'bundle') {
+            (new BundleDocumentValidator())->validate($input->value);
+        }
 
         $id = $this->textFields->save(new TextField(
             entityId: $input->entityId,
@@ -48,7 +55,7 @@ final readonly class CreateTextFieldUseCase implements CreateTextFieldUseCaseInt
         );
     }
 
-    private function assertTextFieldKeyRegistered(int $entityTypeId, string $fieldKey): void
+    private function assertTextFieldKeyRegistered(int $entityTypeId, string $fieldKey): string
     {
         $fieldDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($entityTypeId, $fieldKey);
 
@@ -59,5 +66,7 @@ final readonly class CreateTextFieldUseCase implements CreateTextFieldUseCaseInt
         if (!in_array($fieldDef->dataType, self::TEXT_BACKED_DATA_TYPES, true)) {
             throw new FieldTypeMismatchException($fieldKey, 'text', $fieldDef->dataType);
         }
+
+        return $fieldDef->dataType;
     }
 }

--- a/src/TextField/UpdateTextFieldUseCase.php
+++ b/src/TextField/UpdateTextFieldUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\TextField;
 
+use NeNeRecords\BundleField\BundleDocumentValidator;
 use NeNeRecords\Entity\EntityNotFoundException;
 use NeNeRecords\Entity\EntityRepositoryInterface;
 use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
@@ -36,7 +37,11 @@ final readonly class UpdateTextFieldUseCase implements UpdateTextFieldUseCaseInt
             throw new EntityNotFoundException($existing->entityId);
         }
 
-        $this->assertTextFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
+        $dataType = $this->assertTextFieldKeyRegistered($entity->entityTypeId, $input->fieldKey);
+
+        if ($dataType === 'bundle') {
+            (new BundleDocumentValidator())->validate($input->value);
+        }
 
         $updated = new TextField(
             entityId: $existing->entityId,
@@ -56,7 +61,7 @@ final readonly class UpdateTextFieldUseCase implements UpdateTextFieldUseCaseInt
         );
     }
 
-    private function assertTextFieldKeyRegistered(int $entityTypeId, string $fieldKey): void
+    private function assertTextFieldKeyRegistered(int $entityTypeId, string $fieldKey): string
     {
         $fieldDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($entityTypeId, $fieldKey);
 
@@ -67,5 +72,7 @@ final readonly class UpdateTextFieldUseCase implements UpdateTextFieldUseCaseInt
         if (!in_array($fieldDef->dataType, self::TEXT_BACKED_DATA_TYPES, true)) {
             throw new FieldTypeMismatchException($fieldKey, 'text', $fieldDef->dataType);
         }
+
+        return $fieldDef->dataType;
     }
 }

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -45,6 +45,10 @@
             <h2><?= $e($field->fieldKey) ?></h2>
             <div class="markdown-body"><?= $renderMarkdown($field->displayValue) ?></div>
           </section>
+        <?php elseif ($field->dataType === 'bundle'): ?>
+          <section class="bundle-seo">
+            <div class="markdown-body"><?= $renderBundleSeo($field->displayValue) ?></div>
+          </section>
         <?php else: ?>
           <section>
             <h2><?= $e($field->fieldKey) ?></h2>

--- a/tests/BundleField/BundleDocumentValidatorTest.php
+++ b/tests/BundleField/BundleDocumentValidatorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\BundleField;
+
+use Nene2\Validation\ValidationException;
+use NeNeRecords\BundleField\BundleDocumentValidator;
+use PHPUnit\Framework\TestCase;
+
+final class BundleDocumentValidatorTest extends TestCase
+{
+    private BundleDocumentValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new BundleDocumentValidator();
+    }
+
+    public function testAcceptsValidBundle(): void
+    {
+        $this->validator->validate('{"html":"<h1>Hi</h1>","seoText":"# Hi\n\nWelcome."}');
+        $this->addToAssertionCount(1);
+    }
+
+    public function testRejectsBundleWithoutSeoText(): void
+    {
+        // seoText is REQUIRED (dual-representation / no-cloaking contract).
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('{"html":"<h1>Hi</h1>","seoText":"   "}');
+    }
+
+    public function testRejectsMissingSeoText(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('{"html":"<h1>Hi</h1>"}');
+    }
+
+    public function testRejectsNonObject(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('[1,2,3]');
+    }
+
+    public function testRejectsNonJson(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('not json');
+    }
+
+    public function testSeoTextOfExtractsOrEmpty(): void
+    {
+        self::assertSame('# Hi', BundleDocumentValidator::seoTextOf('{"html":"x","seoText":"# Hi"}'));
+        self::assertSame('', BundleDocumentValidator::seoTextOf('legacy raw html'));
+    }
+}


### PR DESCRIPTION
EPIC #491 **WS3-S3a**、#311 の二重表現契約のうち **クローラブルテキスト** を実装。bundle（サンドボックス iframe で隔離実行される完全カスタムページ）の中身は検索/スクリーンリーダーから不可視という **blocker** を解消する。

## 設計
bundle 値を自己完結のエンベロープ **`{ html, seoText }`** に（`seoText` = クローラブルな markdown 双子）。サンドボックス（`allow-scripts` / no `allow-same-origin`）は従来どおり。

## backend
- **`BundleField/BundleDocumentValidator`**: envelope を検証、**`seoText` 必須（＝クローキング禁止）**、html/seoText サイズ上限。`Create`/`UpdateTextFieldUseCase` の bundle 書込に注入（信頼境界）。
- **SSR**: `record-detail.php` / `RenderPublicRecordViewHandler` が bundle の**生ソース投棄をやめ**、`seoText` を markdown でサーバ描画し主ドキュメントに出力（クローラ / no-JS / 基本クローラ向け）。
- PHPUnit（envelope / seoText 必須 / 非オブジェクト / seoTextOf 抽出）。

## frontend
- **`shared/lib/bundle-document`**: parse/serialize、legacy 生HTML を後方互換で読む。
- **consumer**: bundle を **chrome-less** 化（iframe＝ページ本体、`seoText` を **sr-only** でクローラブル / AT 投影；SSR が no-JS 用の二重表現）。
- **`BundleFieldEditor`**: HTML テキストエリア＋**必須 SEO markdown** に分離（html とは別 UI；admin は実行しない）。
- i18n(en/ja)、テスト。

## 検証
`composer check`（**843 tests** / PHPStan / OpenAPI / MCP）＋ `npm run check`（**301 tests** / type-check 0 / lint / storybook）緑。実機: envelope **201** / seoText 欠落 **422** / 旧生HTML **422**。

## #311 の残り（後続スライス）
- S3b: ストレージ拡張（TEXT→MEDIUMTEXT/LONGTEXT）＋サイズ検証強化
- S3c: `custom` レイアウトを consumer で full-bleed 化
- S3d: 専用 `page` エンティティ型プリセット
- S3e: ClaudeDesign パイプライン＋スコープ資格情報＋JSON-LD

🤖 Generated with [Claude Code](https://claude.com/claude-code)