### PR TITLE
feat(public): custom レイアウトを full-width・chrome-less な page ホストに (#311 / #491 WS3-S3c)

### DIFF
--- a/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
@@ -272,6 +272,32 @@ function PublicRecordDetailContent({
     )
   }
 
+  // `custom` (#311 / WS3-S3c): the record IS a custom page — keep the site
+  // header/footer chrome, but drop the article chrome (backlink / title / byline /
+  // comments / related) so a sandboxed-bundle body fills the content host.
+  if (variant === 'custom') {
+    return (
+      <PageContentContext.Provider value={pageMarkdown}>
+        <PublicSiteShell site={site} activeTypeSlug={entityTypeSlug} withSidebar={false}>
+          <div className="custom-page">
+            <PublicRecordDetailView
+              entity={entity}
+              fieldRows={fieldRows}
+              entityTypeSlugById={entityTypeSlugById}
+              entityTypePatternById={entityTypePatternById}
+              isLoading={isLoading}
+              isError={isError}
+              errorTitle={errorTitle}
+              onRetry={() => {
+                void refetch()
+              }}
+            />
+          </div>
+        </PublicSiteShell>
+      </PageContentContext.Provider>
+    )
+  }
+
   // Multi-column layouts surface the global widget sidebar as the second column
   // of the shell's top-level `.layout` grid — a sibling of the article, not a
   // region nested inside it. `align-items: start` then aligns the sidebar's top

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -2353,3 +2353,9 @@
   border-top: 1px solid var(--color-border);
   margin-block: var(--space-xl);
 }
+/* custom-layout page host (#311 / WS3-S3c): full content-width, chrome-less body. */
+.nene-public .custom-page {
+  display: block;
+  width: 100%;
+  margin-block: var(--space-lg);
+}


### PR DESCRIPTION
EPIC #491 **WS3-S3c**（#311）。これまで **inert**（標準レイアウトにフォールバック）だった `custom` レイアウトを実装し、「1枚のカスタムページ」の見た目を完成させる。

## 変更
- `PublicRecordDetailPage` に `variant === 'custom'` 分岐を追加: サイトの**ヘッダ/フッタ chrome は保つ**が、**記事 chrome（戻るリンク / タイトル / 著者 / コメント / 関連）を落とす**。`PublicSiteShell` ＋ `.custom-page` ＋ `PublicRecordDetailView`（withSidebar=false）。
- `public-site.css` に `.custom-page`（full content-width・chrome-less body）。

S3a で bundle は既に chrome-less 描画＋クローラブルテキスト化済みなので、`custom` レイアウトの bundle ページが**綺麗な独立ページ**として表示される（従来は記事 chrome に埋もれていた）。

## 設計メモ
- `bare`（サイト chrome も無し・完全スタンドアロン）と `custom`（サイト chrome 内の full-width ページ）を明確に区別。
- full-bleed 100vw はスクロールバー由来の横溢れ回避のため見送り、content-width（`.wrap`）で安全側。必要なら後続で 100vw breakout 可。
- entity の MSW seed が `layout` を持たないため専用 RTL テストは省略（tested な `PublicSiteShell`/`PublicRecordDetailView` を再利用する単純分岐）。

## 検証
`npm run check`（**301 tests** / type-check 0 / lint / storybook）緑。backend 変更なし。

## #311 残り
S3b（ストレージ TEXT→LONGTEXT）/ S3d（`page` 型プリセット）/ S3e（ClaudeDesign＋JSON-LD）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)