### PR TITLE
feat(bundle): text_fields.value を LONGTEXT に拡張 ＋ bundle サイズ上限引き上げ (#311 / #491 WS3-S3b)

### DIFF
--- a/database/migrations/20260707000000_widen_text_fields_value_to_longtext.php
+++ b/database/migrations/20260707000000_widen_text_fields_value_to_longtext.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Db\Adapter\MysqlAdapter;
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Widen `text_fields.value` from MySQL TEXT (~64KB) to LONGTEXT (#311 / #491 WS3-S3b).
+ *
+ * `bundle` fields (self-contained HTML/JS/CSS custom pages) share this column and
+ * a real bundle easily exceeds 64KB; the old TEXT ceiling silently truncated/
+ * rejected large values. LONGTEXT matches `blocks_fields.value`. Non-destructive
+ * widening (existing values are preserved). The per-field size limit is enforced
+ * by the application (e.g. {@see \NeNeRecords\BundleField\BundleDocumentValidator}).
+ */
+final class WidenTextFieldsValueToLongtext extends AbstractMigration
+{
+    public function up(): void
+    {
+        if (!$this->hasTable('text_fields')) {
+            return;
+        }
+
+        $this->table('text_fields')
+            ->changeColumn('value', 'text', ['null' => false, 'limit' => MysqlAdapter::TEXT_LONG])
+            ->update();
+    }
+
+    public function down(): void
+    {
+        if (!$this->hasTable('text_fields')) {
+            return;
+        }
+
+        $this->table('text_fields')
+            ->changeColumn('value', 'text', ['null' => false])
+            ->update();
+    }
+}

--- a/src/BundleField/BundleDocumentValidator.php
+++ b/src/BundleField/BundleDocumentValidator.php
@@ -23,8 +23,9 @@ use Nene2\Validation\ValidationException;
  */
 final class BundleDocumentValidator
 {
-    public const MAX_HTML_LEN = 50000;
-    public const MAX_SEO_TEXT_LEN = 10000;
+    // text_fields.value is LONGTEXT (#491 WS3-S3b), so a real self-contained bundle fits.
+    public const MAX_HTML_LEN = 1000000;
+    public const MAX_SEO_TEXT_LEN = 50000;
 
     public function validate(string $json): void
     {

--- a/tests/BundleField/BundleDocumentValidatorTest.php
+++ b/tests/BundleField/BundleDocumentValidatorTest.php
@@ -53,4 +53,19 @@ final class BundleDocumentValidatorTest extends TestCase
         self::assertSame('# Hi', BundleDocumentValidator::seoTextOf('{"html":"x","seoText":"# Hi"}'));
         self::assertSame('', BundleDocumentValidator::seoTextOf('legacy raw html'));
     }
+
+    public function testAcceptsLargeBundleUnderNewCap(): void
+    {
+        // ~200KB html — exceeds the old TEXT/50KB ceiling, fits LONGTEXT (#491 WS3-S3b).
+        $html = str_repeat('a', 200000);
+        $this->validator->validate(json_encode(['html' => $html, 'seoText' => '# Big'], JSON_THROW_ON_ERROR));
+        $this->addToAssertionCount(1);
+    }
+
+    public function testRejectsBundleOverHtmlCap(): void
+    {
+        $html = str_repeat('a', BundleDocumentValidator::MAX_HTML_LEN + 1);
+        $this->expectException(ValidationException::class);
+        $this->validator->validate(json_encode(['html' => $html, 'seoText' => '# x'], JSON_THROW_ON_ERROR));
+    }
 }


### PR DESCRIPTION
EPIC #491 **WS3-S3b**（#311）。bundle は共有の `text_fields` に保存されており、列が MySQL **TEXT(~64KB)** だったため**実寸の HTML/JS/CSS バンドルが頭打ち**（silent truncation/422）になる問題を解消。

## 変更
- **migration `20260707000000`**: `text_fields.value` を **TEXT → LONGTEXT**（`blocks_fields.value` と同じ・非破壊な widening・既存値保持）。
- **`BundleDocumentValidator`**: `MAX_HTML_LEN` 50KB→**1MB**、`MAX_SEO_TEXT_LEN` 10KB→**50KB**。アプリ側が実上限の番人。
- PHPUnit: 旧上限超(~200KB)は許可・新上限超は 422。

## 検証
`composer check`（**845 tests** / PHPStan / OpenAPI / MCP）緑。マイグレーションは dev DB（実 MySQL）に適用済み。実機 E2E: **~200KB の bundle が 201 で保存**され、read-back で html 全長（200011 chars）を保持（旧 TEXT では不可能だった）。

## #311 残り
S3d（`page` 型プリセット）/ S3e（ClaudeDesign＋scoped creds＋JSON-LD）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)