### PR TITLE
feat(entity-types): 「Custom page」スターターでカスタムページ作成をターンキー化 (#311 / #491 WS3-S3d)

### DIFF
--- a/frontend/src/features/manage-entity-types/hooks/use-create-entity-type-form.ts
+++ b/frontend/src/features/manage-entity-types/hooks/use-create-entity-type-form.ts
@@ -7,7 +7,7 @@ import { z } from 'zod'
  * (#491 WS1): `rich_page` gives a blocks body so authors compose the page with
  * the block editor without an admin adding fields manually.
  */
-export const ENTITY_TYPE_STARTERS = ['blank', 'article', 'rich_page'] as const
+export const ENTITY_TYPE_STARTERS = ['blank', 'article', 'rich_page', 'custom_page'] as const
 export type EntityTypeStarter = (typeof ENTITY_TYPE_STARTERS)[number]
 
 export const createEntityTypeFormSchema = z.object({
@@ -17,7 +17,7 @@ export const createEntityTypeFormSchema = z.object({
     .trim()
     .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Use lowercase letters, numbers, and hyphens'),
   isPinned: z.boolean().default(false),
-  starter: z.enum(['blank', 'article', 'rich_page']).default('blank'),
+  starter: z.enum(['blank', 'article', 'rich_page', 'custom_page']).default('blank'),
 })
 
 export type CreateEntityTypeFormValues = z.infer<typeof createEntityTypeFormSchema>

--- a/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.test.ts
+++ b/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.test.ts
@@ -79,6 +79,34 @@ describe('useManageEntityTypesPage', () => {
     expect(fields.find((f) => f.field_key === 'content')?.data_type).toBe('blocks')
   })
 
+  it('provisions title + a bundle body for the custom_page starter (and sets custom layout)', async () => {
+    seedEntityTypes([])
+
+    const { result } = renderHookWithProviders(() => useManageEntityTypesPage())
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(0)
+    })
+
+    await act(async () => {
+      // Resolves only if the post-create default_layout=custom update also succeeds.
+      await result.current.createEntityType({
+        name: 'Promo',
+        slug: 'promo',
+        isPinned: false,
+        starter: 'custom_page',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current.items.map((t) => t.slug)).toContain('promo')
+    })
+
+    const created = result.current.items.find((t) => t.slug === 'promo')
+    const fields = fieldDefStoreSnapshot().filter((f) => f.entity_type_id === created?.id)
+    expect(fields.map((f) => f.field_key)).toEqual(['title', 'content'])
+    expect(fields.find((f) => f.field_key === 'content')?.data_type).toBe('bundle')
+  })
+
   it('deletes the targeted entity type', async () => {
     seedEntityTypes([
       { id: 1, name: 'Article', slug: 'article' },

--- a/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.ts
+++ b/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.ts
@@ -30,6 +30,12 @@ const STARTER_FIELDS: Record<
     { fieldKey: 'title', dataType: 'text' },
     { fieldKey: 'content', dataType: 'blocks' },
   ],
+  // Custom page (#311 / WS3-S3d): title + a sandboxed bundle body; the type also
+  // defaults to the `custom` full-bleed layout (set after creation below).
+  custom_page: [
+    { fieldKey: 'title', dataType: 'text' },
+    { fieldKey: 'content', dataType: 'bundle' },
+  ],
 }
 
 export function useManageEntityTypesPage() {
@@ -56,8 +62,21 @@ export function useManageEntityTypesPage() {
           displayOrder: index,
         })
       }
+      // A custom page defaults its records to the full-bleed `custom` layout.
+      if (starter === 'custom_page') {
+        await updateMutation.mutateAsync({
+          id: created.id,
+          input: {
+            name: created.name,
+            slug: created.slug,
+            isPinned: created.isPinned,
+            permalinkPattern: null,
+            defaultLayout: 'custom',
+          },
+        })
+      }
     },
-    [createMutation, createFieldDefMutation],
+    [createMutation, createFieldDefMutation, updateMutation],
   )
 
   const requestEdit = useCallback((entityType: EntityType) => {

--- a/frontend/src/features/manage-entity-types/ui/EntityTypeCreateForm.tsx
+++ b/frontend/src/features/manage-entity-types/ui/EntityTypeCreateForm.tsx
@@ -11,6 +11,7 @@ const STARTER_LABEL_KEY: Record<EntityTypeStarter, MessageKey> = {
   blank: 'admin.entityTypes.starter.blank',
   article: 'admin.entityTypes.starter.article',
   rich_page: 'admin.entityTypes.starter.richPage',
+  custom_page: 'admin.entityTypes.starter.customPage',
 }
 
 export interface EntityTypeCreateFormProps {

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -388,6 +388,7 @@ export const en = {
   'admin.entityTypes.starter.blank': 'Blank (no fields)',
   'admin.entityTypes.starter.article': 'Article (title + Markdown body)',
   'admin.entityTypes.starter.richPage': 'Rich page (title + blocks body)',
+  'admin.entityTypes.starter.customPage': 'Custom page (title + sandboxed bundle, custom layout)',
   'admin.entityTypes.editForm.title': 'Edit content type',
   'admin.entityTypes.editForm.save': 'Save changes',
   'admin.entityTypes.editForm.saving': 'Saving…',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -382,6 +382,8 @@ export const ja: Partial<MessageCatalog> = {
   'admin.entityTypes.starter.blank': '空（項目なし）',
   'admin.entityTypes.starter.article': '記事（タイトル＋Markdown本文）',
   'admin.entityTypes.starter.richPage': 'リッチページ（タイトル＋ブロック本文）',
+  'admin.entityTypes.starter.customPage':
+    'カスタムページ（タイトル＋サンドボックスbundle・custom レイアウト）',
   'admin.entityTypes.editForm.title': 'コンテンツタイプを編集',
   'admin.entityTypes.editForm.save': '変更を保存',
   'admin.entityTypes.editForm.saving': '保存中…',


### PR DESCRIPTION
EPIC #491 **WS3-S3d**（#311）。WS1 のコンテンツタイプ作成スターター機構に **「Custom page」** を追加し、**作成 1 クリック**でカスタムページ型を用意できるようにする（従来は型作成→bundle 項目追加→default_layout を custom に手で設定、が必要だった）。

## 変更
- `use-create-entity-type-form`: starter に **`custom_page`** を追加。
- `use-manage-entity-types-page`: `STARTER_FIELDS['custom_page']` = **`title`(text) + `content`(bundle)**、作成直後に **`default_layout` を `custom`**（full-bleed）へ update。
- `EntityTypeCreateForm`: スターターラベル、i18n(en/ja)、テスト（フィールド provision ＋ update 経路）。

S3a–S3c と合わせ、**「Custom page 型を作る → bundle 本文（HTML＋必須 SEO テキスト）を書く → サンドボックス隔離＋クローラブルに full-bleed 公開」** が手作業セットアップ無しで一通り回る。

## 検証
`npm run check`（**302 tests** / type-check 0 / lint / storybook）緑。実機 E2E（page セットアップ列）: 型作成 → `title`/`content(bundle)` 項目 **201** → `default_layout=custom` **200**（反映確認）。backend 変更なし。

## #311 残り
S3e（ClaudeDesign パイプライン＋スコープ資格情報＋JSON-LD）— AI 著作側の大物。

🤖 Generated with [Claude Code](https://claude.com/claude-code)