### PR TITLE
refactor(blocks): #501 基盤 — 安全網テスト＋DATA-1修正＋dedup (WS1-4)

### DIFF
--- a/frontend/src/features/edit-entity-text-fields/hooks/use-edit-entity-text-fields-page.test.tsx
+++ b/frontend/src/features/edit-entity-text-fields/hooks/use-edit-entity-text-fields-page.test.tsx
@@ -1,0 +1,138 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { act, waitFor } from '@testing-library/react'
+import { useEditEntityTextFieldsPage } from './use-edit-entity-text-fields-page'
+import {
+  blocksFieldStoreSnapshot,
+  resetBlocksFieldStore,
+  seedBlocksFields,
+} from '@tests/msw/handlers/blocks-field'
+import { resetEntityStore, seedEntities } from '@tests/msw/handlers/entity'
+import { resetFieldDefStore, seedFieldDefs } from '@tests/msw/handlers/field-def'
+import { mswServer } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+
+const ENTITY_TYPE_ID = 1
+const ENTITY_ID = 100
+const FIELD_KEY = 'body'
+
+const SAMPLE_DOC = '[{"id":"b1","type":"text","data":{"markdown":"hello"}}]'
+
+function seedFixtures(): void {
+  seedEntities([
+    { id: ENTITY_ID, entity_type_id: ENTITY_TYPE_ID, is_deleted: false, deleted_at: null },
+  ])
+  seedFieldDefs([
+    { id: 1, entity_type_id: ENTITY_TYPE_ID, field_key: FIELD_KEY, data_type: 'blocks' },
+  ])
+}
+
+function renderPage() {
+  return renderHookWithProviders(() => useEditEntityTextFieldsPage(ENTITY_TYPE_ID, ENTITY_ID))
+}
+
+describe('useEditEntityTextFieldsPage — blocks field', () => {
+  beforeAll(() => {
+    mswServer.listen()
+  })
+  afterEach(() => {
+    mswServer.resetHandlers()
+    resetEntityStore()
+    resetFieldDefStore()
+    resetBlocksFieldStore()
+  })
+  afterAll(() => {
+    mswServer.close()
+  })
+
+  it('loads the blocks field definition and its stored value into initialValues', async () => {
+    seedFixtures()
+    seedBlocksFields([
+      { id: 10, entity_id: ENTITY_ID, field_key: FIELD_KEY, value: SAMPLE_DOC, locale: null },
+    ])
+
+    const { result } = renderPage()
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+    expect(result.current.textFieldDefs.some((def) => def.fieldKey === FIELD_KEY)).toBe(true)
+    expect(result.current.initialValues[FIELD_KEY]).toBe(SAMPLE_DOC)
+  })
+
+  it('updates the existing blocks row on save (no new row created)', async () => {
+    seedFixtures()
+    seedBlocksFields([
+      { id: 10, entity_id: ENTITY_ID, field_key: FIELD_KEY, value: '[]', locale: null },
+    ])
+
+    const { result } = renderPage()
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    await act(async () => {
+      await result.current.saveTextFields({ [FIELD_KEY]: SAMPLE_DOC })
+    })
+
+    const rows = blocksFieldStoreSnapshot()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.id).toBe(10)
+    expect(rows[0]?.value).toBe(SAMPLE_DOC)
+  })
+
+  it('creates a blocks row when a non-empty document is saved for a new field', async () => {
+    seedFixtures()
+
+    const { result } = renderPage()
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    await act(async () => {
+      await result.current.saveTextFields({ [FIELD_KEY]: SAMPLE_DOC })
+    })
+
+    const rows = blocksFieldStoreSnapshot()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.field_key).toBe(FIELD_KEY)
+    expect(rows[0]?.value).toBe(SAMPLE_DOC)
+  })
+
+  it('skips create when an empty document is saved for a new field', async () => {
+    seedFixtures()
+
+    const { result } = renderPage()
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    await act(async () => {
+      await result.current.saveTextFields({ [FIELD_KEY]: '' })
+    })
+
+    expect(blocksFieldStoreSnapshot()).toHaveLength(0)
+  })
+
+  it('filters the blocks value by the selected locale', async () => {
+    seedFixtures()
+    seedBlocksFields([
+      { id: 10, entity_id: ENTITY_ID, field_key: FIELD_KEY, value: '[]', locale: null },
+      { id: 11, entity_id: ENTITY_ID, field_key: FIELD_KEY, value: SAMPLE_DOC, locale: 'ja' },
+    ])
+
+    const { result } = renderPage()
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+    // Default locale (null) → the language-neutral row.
+    expect(result.current.initialValues[FIELD_KEY]).toBe('[]')
+
+    act(() => {
+      result.current.setLocale('ja')
+    })
+
+    await waitFor(() => {
+      expect(result.current.initialValues[FIELD_KEY]).toBe(SAMPLE_DOC)
+    })
+  })
+})

--- a/frontend/src/features/edit-entity-text-fields/ui/BlockInspector.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/BlockInspector.tsx
@@ -15,42 +15,25 @@ import {
   createBlock,
   validateBlock,
   type Block,
+  type BlockData,
   type BlockType,
   type BlockValidationCode,
-  type CalloutBlockData,
   type CalloutKind,
-  type ChartBlockData,
   type ChartType,
   type ColumnsBlockData,
-  type DividerBlockData,
-  type GalleryBlockData,
   type GalleryItem,
   type GalleryLayout,
-  type GroupBlockData,
   type GroupTone,
-  type HeroBlockData,
   type HeroMedia,
   type HeroVariant,
   type LeafBlock,
   type SeriesPoint,
-  type SpacerBlockData,
   type SpacerSize,
-  type TextBlockData,
 } from '@/shared/lib/blocks-document'
+import { moveItem } from '@/shared/lib/move-item'
 import { BLOCK_CATALOG, blockCatalogEntry } from './block-catalog'
 import { BlockMarkdownInput } from './BlockMarkdownInput'
 import { MediaSelectorModal } from './MediaSelectorModal'
-
-type BlockDataChange =
-  | TextBlockData
-  | CalloutBlockData
-  | HeroBlockData
-  | GalleryBlockData
-  | ChartBlockData
-  | GroupBlockData
-  | ColumnsBlockData
-  | SpacerBlockData
-  | DividerBlockData
 
 /** Leaf block types a container (group / columns) may hold (no nesting; depth 2). */
 const GROUP_CHILD_CATALOG = BLOCK_CATALOG.filter(
@@ -62,7 +45,7 @@ interface BlockInspectorProps {
   errorCode: BlockValidationCode | null
   disabled: boolean
   idPrefix: string
-  onChange: (data: BlockDataChange) => void
+  onChange: (data: BlockData) => void
 }
 
 const KIND_LABEL_KEY: Record<CalloutKind, MessageKey> = {
@@ -603,17 +586,10 @@ function GalleryItemsField({ idPrefix, items, disabled, error, onChange }: Galle
     onChange(items.map((item, i) => (i === index ? { ...item, ...patch } : item)))
   }
   const move = (index: number, direction: -1 | 1) => {
-    const target = index + direction
-    if (target < 0 || target >= items.length) {
-      return
+    const next = moveItem(items, index, direction)
+    if (next !== null) {
+      onChange(next)
     }
-    const next = items.slice()
-    const [moved] = next.splice(index, 1)
-    if (moved === undefined) {
-      return
-    }
-    next.splice(target, 0, moved)
-    onChange(next)
   }
   const remove = (index: number) => {
     onChange(items.filter((_, i) => i !== index))
@@ -758,17 +734,10 @@ function SeriesField({ idPrefix, series, disabled, error, onChange }: SeriesFiel
     onChange(series.map((point, i) => (i === index ? { ...point, ...patch } : point)))
   }
   const move = (index: number, direction: -1 | 1) => {
-    const target = index + direction
-    if (target < 0 || target >= series.length) {
-      return
+    const next = moveItem(series, index, direction)
+    if (next !== null) {
+      onChange(next)
     }
-    const next = series.slice()
-    const [moved] = next.splice(index, 1)
-    if (moved === undefined) {
-      return
-    }
-    next.splice(target, 0, moved)
-    onChange(next)
   }
   const remove = (index: number) => {
     onChange(series.filter((_, i) => i !== index))
@@ -894,22 +863,15 @@ function GroupChildrenField({
     onChange([...items, createBlock(type) as LeafBlock])
     setOpenIndex(items.length)
   }
-  const update = (index: number, data: BlockDataChange) => {
+  const update = (index: number, data: BlockData) => {
     onChange(items.map((item, i) => (i === index ? ({ ...item, data } as LeafBlock) : item)))
   }
   const move = (index: number, direction: -1 | 1) => {
-    const target = index + direction
-    if (target < 0 || target >= items.length) {
-      return
+    const next = moveItem(items, index, direction)
+    if (next !== null) {
+      onChange(next)
+      setOpenIndex(null)
     }
-    const next = items.slice()
-    const [moved] = next.splice(index, 1)
-    if (moved === undefined) {
-      return
-    }
-    next.splice(target, 0, moved)
-    onChange(next)
-    setOpenIndex(null)
   }
   const remove = (index: number) => {
     onChange(items.filter((_, i) => i !== index))

--- a/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.tsx
@@ -20,17 +20,10 @@ import {
   serializeBlocksDocument,
   validateBlock,
   type Block,
+  type BlockData,
   type BlockType,
-  type CalloutBlockData,
-  type ChartBlockData,
-  type ColumnsBlockData,
-  type DividerBlockData,
-  type GalleryBlockData,
-  type GroupBlockData,
-  type HeroBlockData,
-  type SpacerBlockData,
-  type TextBlockData,
 } from '@/shared/lib/blocks-document'
+import { moveItem, reorderItem } from '@/shared/lib/move-item'
 import { BLOCK_CATALOG, blockCatalogEntry } from './block-catalog'
 import {
   clearBlockDragPayload,
@@ -153,74 +146,28 @@ export function BlocksFieldEditor({
   }
 
   const moveBlock = (index: number, direction: -1 | 1) => {
-    const target = index + direction
-    if (target < 0 || target >= blocks.length) {
-      return
+    const next = moveItem(blocks, index, direction)
+    if (next !== null) {
+      emit(next)
     }
-    const next = blocks.slice()
-    const [moved] = next.splice(index, 1)
-    if (moved === undefined) {
-      return
-    }
-    next.splice(target, 0, moved)
-    emit(next)
   }
 
   const reorder = (fromId: string, toIndex: number) => {
-    const fromIndex = blocks.findIndex((block) => block.id === fromId)
-    if (fromIndex === -1) {
-      return
+    const next = reorderItem(
+      blocks,
+      blocks.findIndex((block) => block.id === fromId),
+      toIndex,
+    )
+    if (next !== null) {
+      emit(next)
     }
-    const next = blocks.slice()
-    const [moved] = next.splice(fromIndex, 1)
-    if (moved === undefined) {
-      return
-    }
-    const adjusted = toIndex > fromIndex ? toIndex - 1 : toIndex
-    next.splice(adjusted, 0, moved)
-    emit(next)
   }
 
-  const updateData = (
-    blockId: string,
-    data:
-      | TextBlockData
-      | CalloutBlockData
-      | HeroBlockData
-      | GalleryBlockData
-      | ChartBlockData
-      | GroupBlockData
-      | ColumnsBlockData
-      | SpacerBlockData
-      | DividerBlockData,
-  ) => {
-    emit(
-      blocks.map((block): Block => {
-        if (block.id !== blockId) {
-          return block
-        }
-        switch (block.type) {
-          case 'text':
-            return { ...block, data: data as TextBlockData }
-          case 'callout':
-            return { ...block, data: data as CalloutBlockData }
-          case 'hero':
-            return { ...block, data: data as HeroBlockData }
-          case 'gallery':
-            return { ...block, data: data as GalleryBlockData }
-          case 'chart':
-            return { ...block, data: data as ChartBlockData }
-          case 'group':
-            return { ...block, data: data as GroupBlockData }
-          case 'columns':
-            return { ...block, data: data as ColumnsBlockData }
-          case 'spacer':
-            return { ...block, data: data as SpacerBlockData }
-          case 'divider':
-            return { ...block, data: data as DividerBlockData }
-        }
-      }),
-    )
+  const updateData = (blockId: string, data: BlockData) => {
+    // `data` is the inspector's matching variant for this block; narrowing the
+    // pair per type would just re-cast, so apply it directly (the inspector only
+    // emits the data shape for the block it was given).
+    emit(blocks.map((block) => (block.id === blockId ? ({ ...block, data } as Block) : block)))
   }
 
   const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {

--- a/frontend/src/features/edit-entity-text-fields/ui/EditEntityTextFieldsView.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/EditEntityTextFieldsView.tsx
@@ -145,10 +145,16 @@ export function EditEntityTextFieldsView({
         )}
       </Stack>
 
+      {/*
+        Stable key per entity + locale: switching locale remounts the form (discarding
+        that locale's unsaved draft, as before). Within a locale, React Hook Form's
+        `values` + `keepDirtyValues` syncs server data without remounting, so a background
+        refetch no longer wipes in-progress edits (the old JSON.stringify key did).
+      */}
       <EntityTextFieldsForm
-        key={`${selectedLocale ?? 'default'}-${JSON.stringify(initialValues)}`}
+        key={`${String(entity.id)}-${selectedLocale ?? 'default'}`}
         fieldDefs={textFieldDefs}
-        defaultValues={initialValues}
+        values={initialValues}
         isSubmitting={isSaving}
         serverErrorTitle={saveErrorTitle}
         onSubmit={handleSave}

--- a/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.test.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.test.tsx
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { EntityTextFieldsForm } from './EntityTextFieldsForm'
+import { type FieldDef, toFieldDefId } from '@/entities/field-def'
+import { renderWithProviders } from '@tests/render/render-with-providers'
+
+function textField(fieldKey: string, order: number): FieldDef {
+  return {
+    id: toFieldDefId(order),
+    entityTypeId: 1,
+    fieldKey,
+    dataType: 'text',
+    region: null,
+    displayOrder: order,
+  }
+}
+
+const FIELD_DEFS: FieldDef[] = [textField('title', 1), textField('subtitle', 2)]
+
+afterEach(cleanup)
+
+describe('EntityTextFieldsForm', () => {
+  it('renders the server values into the fields', () => {
+    renderWithProviders(
+      <EntityTextFieldsForm
+        fieldDefs={FIELD_DEFS}
+        values={{ title: 'Hello', subtitle: 'World' }}
+        isSubmitting={false}
+        serverErrorTitle={null}
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByLabelText('title (text)')).toHaveValue('Hello')
+    expect(screen.getByLabelText('subtitle (text)')).toHaveValue('World')
+  })
+
+  it('submits the current edited values', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    renderWithProviders(
+      <EntityTextFieldsForm
+        fieldDefs={FIELD_DEFS}
+        values={{ title: 'Hello', subtitle: 'World' }}
+        isSubmitting={false}
+        serverErrorTitle={null}
+        onSubmit={onSubmit}
+      />,
+    )
+
+    const title = screen.getByLabelText('title (text)')
+    await user.clear(title)
+    await user.type(title, 'Edited')
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({ title: 'Edited', subtitle: 'World' })
+  })
+
+  it('preserves an in-progress edit when server data refetches (keepDirtyValues)', async () => {
+    const user = userEvent.setup()
+    const { rerender } = renderWithProviders(
+      <EntityTextFieldsForm
+        fieldDefs={FIELD_DEFS}
+        values={{ title: 'Hello', subtitle: 'World' }}
+        isSubmitting={false}
+        serverErrorTitle={null}
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    // User starts editing `title` (now dirty), leaves `subtitle` untouched.
+    const title = screen.getByLabelText('title (text)')
+    await user.clear(title)
+    await user.type(title, 'Draft in progress')
+
+    // A background refetch delivers NEW server values for both fields.
+    rerender(
+      <EntityTextFieldsForm
+        fieldDefs={FIELD_DEFS}
+        values={{ title: 'Server Title', subtitle: 'Server Subtitle' }}
+        isSubmitting={false}
+        serverErrorTitle={null}
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    // Dirty field keeps the user's draft; untouched field adopts the new server value.
+    await waitFor(() => {
+      expect(screen.getByLabelText('subtitle (text)')).toHaveValue('Server Subtitle')
+    })
+    expect(screen.getByLabelText('title (text)')).toHaveValue('Draft in progress')
+  })
+})

--- a/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/EntityTextFieldsForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { Controller, useForm, type ControllerRenderProps } from 'react-hook-form'
 import type { FieldDataType, FieldDef } from '@/entities/field-def'
 import { useTranslation } from '@/shared/i18n'
 import { Button, Card, EmptyState, Input, Stack, Text } from '@/shared/ui'
@@ -8,12 +8,16 @@ import { FileFieldInput } from './FileFieldInput'
 import { ImageFieldInput } from './ImageFieldInput'
 import { MarkdownFieldInput } from './MarkdownFieldInput'
 
+type RecordFormValues = Record<string, string>
+type FieldRenderProps = ControllerRenderProps<RecordFormValues, string>
+
 export interface EntityTextFieldsFormProps {
   fieldDefs: FieldDef[]
-  defaultValues: Record<string, string>
+  /** Server-derived values; React Hook Form syncs to these while preserving dirty edits. */
+  values: RecordFormValues
   isSubmitting: boolean
   serverErrorTitle: string | null
-  onSubmit: (values: Record<string, string>) => Promise<void>
+  onSubmit: (values: RecordFormValues) => Promise<void>
 }
 
 function getInputType(dataType: FieldDataType): 'text' | 'number' | 'datetime-local' {
@@ -29,13 +33,18 @@ function getInputType(dataType: FieldDataType): 'text' | 'number' | 'datetime-lo
 
 export function EntityTextFieldsForm({
   fieldDefs,
-  defaultValues,
+  values,
   isSubmitting,
   serverErrorTitle,
   onSubmit,
 }: EntityTextFieldsFormProps) {
   const { t } = useTranslation()
-  const [values, setValues] = useState(defaultValues)
+  // Controlled by server data via `values`; `keepDirtyValues` preserves in-progress
+  // edits when a background refetch updates the server snapshot (no remount, no data loss).
+  const { control, handleSubmit } = useForm<RecordFormValues>({
+    values,
+    resetOptions: { keepDirtyValues: true },
+  })
 
   if (fieldDefs.length === 0) {
     return (
@@ -46,167 +55,139 @@ export function EntityTextFieldsForm({
     )
   }
 
+  const renderField = (fieldDef: FieldDef, field: FieldRenderProps) => {
+    const fieldId = `record-field-${fieldDef.fieldKey}`
+    const label = `${fieldDef.fieldKey} (${fieldDef.dataType})`
+    const value = field.value
+
+    switch (fieldDef.dataType) {
+      case 'image':
+        return (
+          <ImageFieldInput
+            id={fieldId}
+            label={label}
+            value={value}
+            disabled={isSubmitting}
+            onChange={field.onChange}
+          />
+        )
+      case 'file':
+        return (
+          <FileFieldInput
+            id={fieldId}
+            label={label}
+            value={value}
+            disabled={isSubmitting}
+            onChange={field.onChange}
+          />
+        )
+      case 'markdown':
+        return (
+          <MarkdownFieldInput
+            id={fieldId}
+            label={label}
+            value={value}
+            disabled={isSubmitting}
+            onChange={field.onChange}
+          />
+        )
+      case 'blocks':
+        return (
+          <BlocksFieldEditor
+            id={fieldId}
+            label={label}
+            value={value}
+            disabled={isSubmitting}
+            onChange={field.onChange}
+          />
+        )
+      case 'bundle':
+        return (
+          <BundleFieldEditor
+            id={fieldId}
+            label={label}
+            value={value}
+            disabled={isSubmitting}
+            onChange={field.onChange}
+          />
+        )
+      case 'html':
+        return (
+          <div className="flex flex-col gap-stack-xs">
+            <label htmlFor={fieldId} className="font-sans text-body font-medium text-text-primary">
+              {label}
+            </label>
+            <textarea
+              id={fieldId}
+              rows={10}
+              disabled={isSubmitting}
+              value={value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              className="rounded-sm border border-border bg-surface-raised px-inline-sm py-stack-xs font-mono text-caption text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+            />
+            <span className="font-sans text-caption text-text-muted">
+              {t('admin.fieldDefs.html.hint')}
+            </span>
+          </div>
+        )
+      case 'bool':
+        return (
+          <div className="flex flex-col gap-stack-xs">
+            <label
+              htmlFor={fieldId}
+              className="flex items-center gap-inline-sm font-sans text-body font-medium text-text-primary"
+            >
+              <input
+                id={fieldId}
+                type="checkbox"
+                disabled={isSubmitting}
+                checked={value === 'true'}
+                onChange={(event) => {
+                  field.onChange(event.target.checked ? 'true' : 'false')
+                }}
+                onBlur={field.onBlur}
+                className="size-4 rounded border border-border"
+              />
+              {label}
+            </label>
+          </div>
+        )
+      default:
+        return (
+          <Input
+            id={fieldId}
+            label={label}
+            type={getInputType(fieldDef.dataType)}
+            autoComplete="off"
+            disabled={isSubmitting}
+            value={value}
+            onChange={field.onChange}
+            onBlur={field.onBlur}
+          />
+        )
+    }
+  }
+
   return (
     <Card
       as="form"
       onSubmit={(event) => {
-        event.preventDefault()
-        void onSubmit(values)
+        void handleSubmit(onSubmit)(event)
       }}
     >
       <Stack gap="md">
         <Text as="h2" variant="heading-sm">
           {t('admin.entityRecord.textFields.title')}
         </Text>
-        {fieldDefs.map((fieldDef) => {
-          const fieldId = `record-field-${fieldDef.fieldKey}`
-          const label = `${fieldDef.fieldKey} (${fieldDef.dataType})`
-
-          if (fieldDef.dataType === 'image') {
-            return (
-              <ImageFieldInput
-                key={fieldDef.fieldKey}
-                id={fieldId}
-                label={label}
-                value={values[fieldDef.fieldKey] ?? ''}
-                disabled={isSubmitting}
-                onChange={(url) => {
-                  setValues((current) => ({ ...current, [fieldDef.fieldKey]: url }))
-                }}
-              />
-            )
-          }
-
-          if (fieldDef.dataType === 'file') {
-            return (
-              <FileFieldInput
-                key={fieldDef.fieldKey}
-                id={fieldId}
-                label={label}
-                value={values[fieldDef.fieldKey] ?? ''}
-                disabled={isSubmitting}
-                onChange={(url) => {
-                  setValues((current) => ({ ...current, [fieldDef.fieldKey]: url }))
-                }}
-              />
-            )
-          }
-
-          if (fieldDef.dataType === 'markdown') {
-            return (
-              <MarkdownFieldInput
-                key={fieldDef.fieldKey}
-                id={fieldId}
-                label={label}
-                value={values[fieldDef.fieldKey] ?? ''}
-                disabled={isSubmitting}
-                onChange={(val) => {
-                  setValues((current) => ({ ...current, [fieldDef.fieldKey]: val }))
-                }}
-              />
-            )
-          }
-
-          if (fieldDef.dataType === 'blocks') {
-            return (
-              <BlocksFieldEditor
-                key={fieldDef.fieldKey}
-                id={fieldId}
-                label={label}
-                value={values[fieldDef.fieldKey] ?? ''}
-                disabled={isSubmitting}
-                onChange={(json) => {
-                  setValues((current) => ({ ...current, [fieldDef.fieldKey]: json }))
-                }}
-              />
-            )
-          }
-
-          if (fieldDef.dataType === 'bundle') {
-            return (
-              <BundleFieldEditor
-                key={fieldDef.fieldKey}
-                id={fieldId}
-                label={label}
-                value={values[fieldDef.fieldKey] ?? ''}
-                disabled={isSubmitting}
-                onChange={(val) => {
-                  setValues((current) => ({ ...current, [fieldDef.fieldKey]: val }))
-                }}
-              />
-            )
-          }
-
-          if (fieldDef.dataType === 'html') {
-            return (
-              <div key={fieldDef.fieldKey} className="flex flex-col gap-stack-xs">
-                <label
-                  htmlFor={fieldId}
-                  className="font-sans text-body font-medium text-text-primary"
-                >
-                  {label}
-                </label>
-                <textarea
-                  id={fieldId}
-                  rows={10}
-                  disabled={isSubmitting}
-                  value={values[fieldDef.fieldKey] ?? ''}
-                  onChange={(event) => {
-                    setValues((current) => ({
-                      ...current,
-                      [fieldDef.fieldKey]: event.target.value,
-                    }))
-                  }}
-                  className="rounded-sm border border-border bg-surface-raised px-inline-sm py-stack-xs font-mono text-caption text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
-                />
-                <span className="font-sans text-caption text-text-muted">
-                  {t('admin.fieldDefs.html.hint')}
-                </span>
-              </div>
-            )
-          }
-
-          if (fieldDef.dataType === 'bool') {
-            return (
-              <div key={fieldDef.fieldKey} className="flex flex-col gap-stack-xs">
-                <label
-                  htmlFor={fieldId}
-                  className="flex items-center gap-inline-sm font-sans text-body font-medium text-text-primary"
-                >
-                  <input
-                    id={fieldId}
-                    type="checkbox"
-                    disabled={isSubmitting}
-                    checked={values[fieldDef.fieldKey] === 'true'}
-                    onChange={(event) => {
-                      setValues((current) => ({
-                        ...current,
-                        [fieldDef.fieldKey]: event.target.checked ? 'true' : 'false',
-                      }))
-                    }}
-                    className="size-4 rounded border border-border"
-                  />
-                  {label}
-                </label>
-              </div>
-            )
-          }
-
-          return (
-            <Input
-              key={fieldDef.fieldKey}
-              id={fieldId}
-              label={label}
-              type={getInputType(fieldDef.dataType)}
-              autoComplete="off"
-              disabled={isSubmitting}
-              value={values[fieldDef.fieldKey] ?? ''}
-              onChange={(event) => {
-                setValues((current) => ({ ...current, [fieldDef.fieldKey]: event.target.value }))
-              }}
-            />
-          )
-        })}
+        {fieldDefs.map((fieldDef) => (
+          <Controller
+            key={fieldDef.fieldKey}
+            name={fieldDef.fieldKey}
+            control={control}
+            render={({ field }) => renderField(fieldDef, field)}
+          />
+        ))}
         {serverErrorTitle !== null ? <Text muted>{serverErrorTitle}</Text> : null}
         <div className="flex items-center gap-inline-md">
           <Button type="submit" disabled={isSubmitting}>

--- a/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.ts
+++ b/frontend/src/features/manage-entity-types/hooks/use-manage-entity-types-page.ts
@@ -9,6 +9,7 @@ import {
   type EntityTypeId,
 } from '@/entities/entity-type'
 import { useCreateFieldDef, type FieldDataType } from '@/entities/field-def'
+import { moveItem } from '@/shared/lib/move-item'
 import {
   formValuesToLabels,
   type CreateEntityTypeFormValues,
@@ -132,20 +133,10 @@ export function useManageEntityTypesPage() {
   const moveEntityType = useCallback(
     async (id: EntityTypeId, direction: 'up' | 'down') => {
       const ids = (listQuery.data?.items ?? []).map((item) => item.id)
-      const from = ids.indexOf(id)
-      if (from === -1) {
+      const next = moveItem(ids, ids.indexOf(id), direction === 'up' ? -1 : 1)
+      if (next === null) {
         return
       }
-      const to = direction === 'up' ? from - 1 : from + 1
-      if (to < 0 || to >= ids.length) {
-        return
-      }
-      const next = [...ids]
-      const [removed] = next.splice(from, 1)
-      if (removed === undefined) {
-        return
-      }
-      next.splice(to, 0, removed)
       await reorderMutation.mutateAsync(next)
     },
     [listQuery.data, reorderMutation],

--- a/frontend/src/shared/lib/blocks-document.ts
+++ b/frontend/src/shared/lib/blocks-document.ts
@@ -146,6 +146,13 @@ export type Block =
   | { id: string; type: 'group'; data: GroupBlockData }
   | { id: string; type: 'columns'; data: ColumnsBlockData }
 
+/**
+ * The `data` payload of any block — the union of every block's data shape.
+ * Derived from {@link Block} so adding a block type updates this automatically;
+ * the editor uses it for the inspector's `onChange` and the board's update.
+ */
+export type BlockData = Block['data']
+
 export type BlockValidationCode =
   | 'markdown-required'
   | 'body-required'

--- a/frontend/src/shared/lib/move-item.test.ts
+++ b/frontend/src/shared/lib/move-item.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { moveItem, reorderItem } from './move-item'
+
+describe('moveItem', () => {
+  it('moves an item up', () => {
+    expect(moveItem(['a', 'b', 'c'], 1, -1)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('moves an item down', () => {
+    expect(moveItem(['a', 'b', 'c'], 1, 1)).toEqual(['a', 'c', 'b'])
+  })
+
+  it('returns null at the top edge', () => {
+    expect(moveItem(['a', 'b', 'c'], 0, -1)).toBeNull()
+  })
+
+  it('returns null at the bottom edge', () => {
+    expect(moveItem(['a', 'b', 'c'], 2, 1)).toBeNull()
+  })
+
+  it('returns null for an out-of-range source index (e.g. failed indexOf)', () => {
+    expect(moveItem(['a', 'b', 'c'], -1, 1)).toBeNull()
+    expect(moveItem(['a', 'b', 'c'], 5, -1)).toBeNull()
+  })
+
+  it('does not mutate the input', () => {
+    const input = ['a', 'b', 'c']
+    moveItem(input, 1, -1)
+    expect(input).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('reorderItem', () => {
+  it('moves an earlier item to a later drop index', () => {
+    // drop index measured against original array: move 'a' to before the 4th slot
+    expect(reorderItem(['a', 'b', 'c'], 0, 2)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('moves a later item to an earlier drop index', () => {
+    expect(reorderItem(['a', 'b', 'c'], 2, 0)).toEqual(['c', 'a', 'b'])
+  })
+
+  it('moving to the end appends', () => {
+    expect(reorderItem(['a', 'b', 'c'], 0, 3)).toEqual(['b', 'c', 'a'])
+  })
+
+  it('returns null when fromIndex is out of range', () => {
+    expect(reorderItem(['a', 'b'], -1, 0)).toBeNull()
+  })
+
+  it('does not mutate the input', () => {
+    const input = ['a', 'b', 'c']
+    reorderItem(input, 0, 2)
+    expect(input).toEqual(['a', 'b', 'c'])
+  })
+})

--- a/frontend/src/shared/lib/move-item.ts
+++ b/frontend/src/shared/lib/move-item.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure array reordering helpers shared by the block editor's reorderable lists
+ * (board, gallery slides, chart series, group/column children) and drag-and-drop.
+ * Each returns a new array (immutable) or `null` when the move is a no-op /
+ * out of range, so callers `if (next === null) return`.
+ */
+
+/** Move the item at `index` one step in `direction` (-1 up / +1 down). */
+export function moveItem<T>(items: readonly T[], index: number, direction: -1 | 1): T[] | null {
+  const target = index + direction
+  // Guard both source and target so an out-of-range `index` (e.g. from a failed
+  // `indexOf`) can't splice the wrong (negative-index) element.
+  if (index < 0 || index >= items.length || target < 0 || target >= items.length) {
+    return null
+  }
+  const next = items.slice()
+  const [moved] = next.splice(index, 1)
+  if (moved === undefined) {
+    return null
+  }
+  next.splice(target, 0, moved)
+  return next
+}
+
+/**
+ * Move the item at `fromIndex` to land at `toIndex`, where `toIndex` is measured
+ * against the original array (the drop-line index). Returns `null` when
+ * `fromIndex` is out of range.
+ */
+export function reorderItem<T>(
+  items: readonly T[],
+  fromIndex: number,
+  toIndex: number,
+): T[] | null {
+  if (fromIndex < 0 || fromIndex >= items.length) {
+    return null
+  }
+  const next = items.slice()
+  const [moved] = next.splice(fromIndex, 1)
+  if (moved === undefined) {
+    return null
+  }
+  // Removing the source shifts later indices left by one.
+  const adjusted = toIndex > fromIndex ? toIndex - 1 : toIndex
+  next.splice(adjusted, 0, moved)
+  return next
+}

--- a/frontend/tests/msw/handlers/blocks-field.ts
+++ b/frontend/tests/msw/handlers/blocks-field.ts
@@ -12,6 +12,21 @@ interface BlocksFieldRecord {
 let nextId = 1
 let items: BlocksFieldRecord[] = []
 
+export function resetBlocksFieldStore(): void {
+  nextId = 1
+  items = []
+}
+
+export function seedBlocksFields(seed: Omit<BlocksFieldRecord, 'is_deleted'>[]): void {
+  items = seed.map((item) => ({ ...item, is_deleted: false }))
+  nextId = Math.max(0, ...seed.map((item) => item.id)) + 1
+}
+
+/** Test peek into the blocks-field records (assert create vs update outcomes). */
+export function blocksFieldStoreSnapshot(): readonly BlocksFieldRecord[] {
+  return [...items]
+}
+
 export const blocksFieldHandlers = [
   http.get('/api/v1/blocks-fields', ({ request }) => {
     const url = new URL(request.url)


### PR DESCRIPTION
## 目的

Issue #501（ブロック関連フロントエンドの構造リファクタ）の基盤 PR。安全網テスト＋最重要のデータロス修正＋低リスクな重複排除をまとめる。stacked PR の最下段。

## 変更（WS2 / WS1 / WS3 / WS4）

- **WS2** `use-edit-entity-text-fields-page` に feature-hook テストを新設（blocks の create/update/空スキップ・locale フィルタ）。blocks-field MSW ハンドラに seed/reset/snapshot を追加。
- **WS1** 🔴 **DATA-1 修正**: `EntityTextFieldsForm` が server 由来 `initialValues` を `useState` に複製し、`key` に `JSON.stringify(initialValues)` を埋めて remount 同期していたため、本番の背景 refetch（`refetchOnWindowFocus`）で編集中フォームが再マウントされ未保存編集が消えうる規約違反だった。`useForm({ values, resetOptions: { keepDirtyValues: true } })` へ移行し、dirty な編集を保持しつつ非 dirty 項目のみ server 値へ追従。RTL テスト3本で実証。
- **WS3** `BlockData = Block['data']` を単一ソース化し、`BlockInspector`/`BlocksFieldEditor` の手書き重複 union と `updateData` の no-op 9分岐 switch を解消。
- **WS4** 隣接 move/reorder の逐語コピー（editor＋inspector 4箇所＋manage-entity-types）を `shared/lib/move-item.ts` の純関数へ集約（12テスト）。`indexOf===-1` で末尾を誤 splice する潜在バグも解消。

## 検証

`npm run check --prefix frontend` 全緑（type-check / lint / prettier / test / themes / knip / build-storybook）。

Part of #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)
