### PR TITLE
fix(entity): ステータス/スラッグ更新で SEO メタが消失するバグを修正 (#507)

### DIFF
--- a/frontend/src/features/manage-entity-status/hooks/useEntityStatusPanel.test.ts
+++ b/frontend/src/features/manage-entity-status/hooks/useEntityStatusPanel.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { act, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { useEntityStatusPanel } from './useEntityStatusPanel'
+import { toEntityId, type Entity } from '@/entities/entity'
+import { mswServer } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+
+function makeEntity(overrides: Partial<Entity> = {}): Entity {
+  return {
+    id: toEntityId(7),
+    entityTypeId: 1,
+    slug: 'hello',
+    layout: null,
+    status: 'draft',
+    publishedAt: null,
+    scheduledAt: null,
+    isDeleted: false,
+    deletedAt: null,
+    metaTitle: 'SEO Title',
+    metaDescription: 'SEO Description',
+    createdAt: null,
+    updatedAt: null,
+    ...overrides,
+  }
+}
+
+/** Install a PUT handler that records each update body and echoes a valid EntityDto. */
+function captureUpdates(): Array<Record<string, unknown>> {
+  const bodies: Array<Record<string, unknown>> = []
+  mswServer.use(
+    http.put('/api/v1/entities/:id', async ({ request, params }) => {
+      const body = (await request.json()) as Record<string, unknown>
+      bodies.push(body)
+      return HttpResponse.json({
+        id: Number(params.id),
+        entity_type_id: body.entity_type_id ?? 1,
+        slug: body.slug ?? null,
+        layout: body.layout ?? null,
+        status: body.status ?? 'draft',
+        published_at: null,
+        scheduled_at: null,
+        is_deleted: false,
+        deleted_at: null,
+        meta_title: body.meta_title ?? null,
+        meta_description: body.meta_description ?? null,
+        created_at: null,
+        updated_at: null,
+      })
+    }),
+  )
+  return bodies
+}
+
+describe('useEntityStatusPanel — preserves SEO meta on full-replace update', () => {
+  beforeAll(() => {
+    mswServer.listen()
+  })
+  afterEach(() => {
+    mswServer.resetHandlers()
+  })
+  afterAll(() => {
+    mswServer.close()
+  })
+
+  it('onChangeStatus echoes the existing meta_title / meta_description', async () => {
+    const bodies = captureUpdates()
+    const { result } = renderHookWithProviders(() => useEntityStatusPanel(makeEntity()))
+
+    act(() => {
+      result.current.onChangeStatus('published')
+    })
+
+    await waitFor(() => {
+      expect(bodies).toHaveLength(1)
+    })
+    expect(bodies[0]).toMatchObject({
+      status: 'published',
+      meta_title: 'SEO Title',
+      meta_description: 'SEO Description',
+    })
+  })
+
+  it('onSaveSlug echoes the existing meta_title / meta_description', async () => {
+    const bodies = captureUpdates()
+    const { result } = renderHookWithProviders(() => useEntityStatusPanel(makeEntity()))
+
+    act(() => {
+      result.current.onSaveSlug()
+    })
+
+    await waitFor(() => {
+      expect(bodies).toHaveLength(1)
+    })
+    expect(bodies[0]).toMatchObject({
+      meta_title: 'SEO Title',
+      meta_description: 'SEO Description',
+    })
+  })
+})

--- a/frontend/src/features/manage-entity-status/hooks/useEntityStatusPanel.ts
+++ b/frontend/src/features/manage-entity-status/hooks/useEntityStatusPanel.ts
@@ -79,7 +79,10 @@ export function useEntityStatusPanel(
         entityTypeId: entity.entityTypeId,
         slug: slugInput !== '' ? slugInput : null,
         status: nextStatus,
-        // Preserve layout: the update endpoint is full-replace.
+        // The update endpoint is full-replace: omitted fields are nulled, so
+        // every call must echo back the fields it does not intend to change.
+        metaTitle: entity.metaTitle,
+        metaDescription: entity.metaDescription,
         layout: entity.layout,
       })
     } catch (e) {
@@ -94,6 +97,9 @@ export function useEntityStatusPanel(
         entityTypeId: entity.entityTypeId,
         slug: slugInput !== '' ? slugInput : null,
         status: entity.status,
+        // Full-replace endpoint: preserve SEO meta and layout we are not editing.
+        metaTitle: entity.metaTitle,
+        metaDescription: entity.metaDescription,
         layout: entity.layout,
       })
       showToast(t('admin.entityStatus.slugSaved'), 'success')


### PR DESCRIPTION
## 目的
フロント全体監査（epic #507）の唯一の high severity = **データ消失バグ**を修正。

## バグ
記録更新エンドポイントは full-replace（省略フィールドは null 化）。`useEntityStatusPanel` の `onChangeStatus` / `onSaveSlug` が `metaTitle` / `metaDescription` を送らないため、**ステータス変更・スラッグ保存のたびに既存 SEO メタが null 上書き**されていた（`onChangeLayout` は正しく保持しており局所逸脱）。

## 変更
- 両ハンドラで現在の meta 値をエコーバック。
- PUT body にメタが含まれることを検証する回帰テストを新設（feature は従来テスト皆無）。

## 検証
`npm run type-check` / 新規テスト2本 緑。

Part of #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)
