### PR TITLE
fix(security): クロステナント cache 残留 / SanitizedHtml 明示ポリシー (#507)

### DIFF
--- a/frontend/src/entities/auth/mutations.test.tsx
+++ b/frontend/src/entities/auth/mutations.test.tsx
@@ -1,0 +1,61 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import type { ReactNode } from 'react'
+import { useLogin, useLogout } from './mutations'
+import { mswServer } from '@tests/msw/server'
+
+function makeWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+function freshClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+}
+
+describe('auth mutations clear the org-scoped query cache', () => {
+  beforeAll(() => {
+    mswServer.listen()
+  })
+  afterEach(() => {
+    mswServer.resetHandlers()
+  })
+  afterAll(() => {
+    mswServer.close()
+  })
+
+  it('useLogout wipes cached data so the next session cannot read it', async () => {
+    mswServer.use(http.post('/api/v1/auth/logout', () => new HttpResponse(null, { status: 204 })))
+    const queryClient = freshClient()
+    queryClient.setQueryData(['entities', 'list'], { items: [{ id: 1 }] })
+
+    const { result } = renderHook(() => useLogout(), { wrapper: makeWrapper(queryClient) })
+    await result.current.mutateAsync()
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(['entities', 'list'])).toBeUndefined()
+    })
+  })
+
+  it('useLogin wipes any data cached before the session starts', async () => {
+    mswServer.use(
+      http.post('/api/v1/auth/login', () =>
+        HttpResponse.json({ expires_at: null, email: 'a@b.co', role: 'admin' }),
+      ),
+    )
+    const queryClient = freshClient()
+    queryClient.setQueryData(['entities', 'list'], { items: [{ id: 1 }] })
+
+    const { result } = renderHook(() => useLogin(), { wrapper: makeWrapper(queryClient) })
+    await result.current.mutateAsync({ email: 'a@b.co', password: 'pw' })
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(['entities', 'list'])).toBeUndefined()
+    })
+  })
+})

--- a/frontend/src/entities/auth/mutations.ts
+++ b/frontend/src/entities/auth/mutations.ts
@@ -1,9 +1,10 @@
-import { useMutation, type UseMutationResult } from '@tanstack/react-query'
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
 import { apiClient, AppError } from '@/shared/api/client'
 import type { LoginRequestDto, LoginResponseDto } from './api-types'
 import { authStore, type AuthSession } from './model'
 
 export function useLogin(): UseMutationResult<AuthSession, AppError, LoginRequestDto> {
+  const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (input) => {
       // The API sets the session token as an HttpOnly cookie; we only keep the
@@ -17,10 +18,16 @@ export function useLogin(): UseMutationResult<AuthSession, AppError, LoginReques
       authStore.setSession(session)
       return session
     },
+    // Drop any org-scoped data cached before this session (e.g. a different
+    // user/org on a shared terminal) so the new session never reads it.
+    onSuccess: () => {
+      queryClient.clear()
+    },
   })
 }
 
 export function useLogout(): UseMutationResult<void, AppError, void> {
+  const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async () => {
       try {
@@ -29,6 +36,11 @@ export function useLogout(): UseMutationResult<void, AppError, void> {
         // Always clear the local profile, even if the network call fails.
         authStore.clearSession()
       }
+    },
+    // Wipe the org-scoped query cache on logout so the next user cannot read the
+    // previous session's data from cache (cross-tenant residue).
+    onSettled: () => {
+      queryClient.clear()
     },
   })
 }

--- a/frontend/src/shared/ui/html/SanitizedHtml.test.tsx
+++ b/frontend/src/shared/ui/html/SanitizedHtml.test.tsx
@@ -33,4 +33,26 @@ describe('SanitizedHtml', () => {
     const { container } = render(<SanitizedHtml html="   " />)
     expect(container).toBeEmptyDOMElement()
   })
+
+  it('strips javascript: URLs from links', () => {
+    const { container } = render(<SanitizedHtml html={'<a href="javascript:alert(1)">x</a>'} />)
+    expect(container.innerHTML.toLowerCase()).not.toContain('javascript:')
+  })
+
+  it('forbids global <style> blocks while keeping the rest', () => {
+    const { container } = render(
+      <SanitizedHtml html={'<style>body{color:red}</style><p>kept</p>'} />,
+    )
+    expect(container.querySelector('style')).toBeNull()
+    expect(container.querySelector('p')?.textContent).toBe('kept')
+  })
+
+  it('strips new-tab target from author links (no reverse-tabnabbing surface)', () => {
+    const { container } = render(
+      <SanitizedHtml html={'<a href="https://example.com" target="_blank">x</a>'} />,
+    )
+    const a = container.querySelector('a')
+    expect(a?.getAttribute('href')).toBe('https://example.com')
+    expect(a?.getAttribute('target')).toBeNull()
+  })
 })

--- a/frontend/src/shared/ui/html/SanitizedHtml.tsx
+++ b/frontend/src/shared/ui/html/SanitizedHtml.tsx
@@ -7,17 +7,25 @@ export interface SanitizedHtmlProps {
 }
 
 /**
+ * Explicit policy — do not lean on shifting library defaults. DOMPurify core
+ * strips scripts / `on*` handlers / `javascript:` URLs and the `target`
+ * attribute; we additionally forbid global `<style>` blocks (the default keeps
+ * them) to enforce the documented contract below. Inline `style` attributes
+ * (scoped CSS) are kept.
+ */
+const SANITIZE_CONFIG = { FORBID_TAGS: ['style'] }
+
+/**
  * Renders author-supplied HTML after sanitizing it. Safe markup and inline
- * `style` attributes (scoped CSS) are kept, but scripts, event handlers (`on*`)
- * and `javascript:` URLs are stripped — so an `html` field can carry rich,
- * styled markup without becoming an XSS vector. Global `<style>` blocks and JS
- * are intentionally not supported here; full custom pages that need those use
- * the sandboxed-iframe path (a separate feature), not this component.
+ * `style` attributes (scoped CSS) are kept, but scripts, event handlers (`on*`),
+ * `javascript:` URLs and new-tab `target`s are stripped — so an `html` field can
+ * carry rich, styled markup without becoming an XSS vector. Global `<style>`
+ * blocks and JS are intentionally not supported here; full custom pages that
+ * need those use the sandboxed-iframe path (a separate feature), not this
+ * component.
  */
 export function SanitizedHtml({ html, className }: SanitizedHtmlProps) {
-  // DOMPurify defaults keep safe tags + inline style attributes and strip
-  // scripts / on* handlers / javascript: URLs.
-  const clean = useMemo(() => DOMPurify.sanitize(html), [html])
+  const clean = useMemo(() => DOMPurify.sanitize(html, SANITIZE_CONFIG), [html])
 
   if (clean.trim() === '') {
     return null


### PR DESCRIPTION
## 目的
フロント全体監査（#507）のセキュリティ2件。クリティックがいずれも格上げ。

## 変更
- **SEC-1 クロステナント cache 残留**: `useLogin`/`useLogout` が TanStack Query キャッシュを未クリアで、共有端末でアカウント/組織を切り替えると前セッションの org_id スコープ済みデータがキャッシュから読めた。login `onSuccess` / logout `onSettled` で `queryClient.clear()`。
- **SEC-2 SanitizedHtml 明示ポリシー**: DOMPurify をデフォルトのまま使用し、ドキュメント上『global `<style>` 非対応』としながら実際は default が `<style>` を保持していた。`FORBID_TAGS:['style']` で契約を強制。script/on*/javascript:/target ストリップと `<style>` 排除・inline style 保持を回帰テスト化。

## 検証
`npm run type-check` / 新規テスト（auth 2本 + SanitizedHtml 7本）緑。

Part of #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)
