### PR TITLE
fix(shared): ProblemDetails 形状ガード / bootstrap seed 堅牢化 (#507)

### DIFF
--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -22,7 +22,16 @@ function createAppQueryClient(): QueryClient {
     },
   })
 
-  seedPublicRecordViewCache(queryClient)
+  // Runs in a useState initializer, outside RootErrorBoundary — a malformed
+  // server-injected bootstrap must not white-screen the app; skip seeding and
+  // let the queries fetch normally instead.
+  try {
+    seedPublicRecordViewCache(queryClient)
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error('Failed to seed public record view cache:', error)
+    }
+  }
 
   return queryClient
 }

--- a/frontend/src/shared/api/errors.test.ts
+++ b/frontend/src/shared/api/errors.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { AppError, parseProblemDetails } from './errors'
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('parseProblemDetails', () => {
+  it('maps a valid Problem Details document', async () => {
+    const error = await parseProblemDetails(
+      jsonResponse(
+        {
+          type: 'https://nene-records.dev/problems/validation',
+          title: 'Validation failed',
+          status: 422,
+          instance: '/api/v1/entities',
+        },
+        422,
+      ),
+    )
+    expect(error).toBeInstanceOf(AppError)
+    expect(error.status).toBe(422)
+    expect(error.title).toBe('Validation failed')
+    expect(error.isRetryable).toBe(false)
+  })
+
+  it('falls back to the HTTP status for a valid but non-Problem-Details body', async () => {
+    // A 503 with a non-conforming JSON body must NOT become status=undefined,
+    // which would make isRetryable() false and skip the retry.
+    const error = await parseProblemDetails(jsonResponse({ message: 'boom' }, 503))
+    expect(error.status).toBe(503)
+    expect(error.isRetryable).toBe(true)
+  })
+
+  it('falls back for a non-JSON body', async () => {
+    const error = await parseProblemDetails(new Response('upstream down', { status: 502 }))
+    expect(error.status).toBe(502)
+    expect(error.isRetryable).toBe(true)
+  })
+})

--- a/frontend/src/shared/api/errors.ts
+++ b/frontend/src/shared/api/errors.ts
@@ -41,20 +41,31 @@ export class AppError extends Error {
   }
 }
 
+function isProblemDetails(value: unknown): value is ProblemDetails {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as ProblemDetails).status === 'number' &&
+    typeof (value as ProblemDetails).title === 'string'
+  )
+}
+
 export async function parseProblemDetails(response: Response): Promise<AppError> {
   try {
-    const body = (await response.json()) as ProblemDetails
-    return new AppError({
-      ...body,
-      status: body.status,
-      instance: body.instance,
-    })
+    const body: unknown = await response.json()
+    // Only trust a body that is actually a Problem Details document. A valid but
+    // non-conforming JSON (e.g. {}, [], {message}) would otherwise yield
+    // status=undefined, breaking AppError.isRetryable (5xx treated as final).
+    if (isProblemDetails(body)) {
+      return new AppError({ ...body, instance: body.instance || response.url })
+    }
   } catch {
-    return new AppError({
-      type: 'about:blank',
-      title: response.statusText || 'Request failed',
-      status: response.status,
-      instance: response.url,
-    })
+    // Non-JSON body — fall through to the synthetic error below.
   }
+  return new AppError({
+    type: 'about:blank',
+    title: response.statusText || 'Request failed',
+    status: response.status,
+    instance: response.url,
+  })
 }


### PR DESCRIPTION
## 目的
フロント全体監査（#507）の shared 層 P1 バグ2件。

## 変更
- **WS-02 ProblemDetails 形状ガード**: `parseProblemDetails` が `response.json()` を ProblemDetails に unsafe cast していたため、有効だが非準拠な JSON（`{}` / `[]` / `{message}`）で `status=undefined` となり `AppError.isRetryable`（status>=500）が常に false 化、5xx が非リトライ扱いになっていた。形状ガード（status:number ∧ title:string）を追加し非準拠 body は HTTP status へフォールバック。
- **WS-06 bootstrap seed 堅牢化**: `seedPublicRecordViewCache` が `createAppQueryClient`（useState 初期化子＝RootErrorBoundary の外）で同期実行され、壊れた bootstrap が mapper で throw するとホワイトスクリーン化しうるため try/catch で包み、seed 失敗時は通常 fetch にフォールバック。

## 検証
`npm run type-check` / 新規テスト3本 緑。

Part of #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)
