### PR TITLE
fix(ui): mutation 失敗時のユーザー通知を追加（fail-closed）(#507)

### DIFF
--- a/frontend/src/features/manage-comments/hooks/useManageCommentsPage.ts
+++ b/frontend/src/features/manage-comments/hooks/useManageCommentsPage.ts
@@ -32,6 +32,9 @@ export function useManageCommentsPage(): ManageCommentsPageState {
       onSuccess: () => {
         showToast(t('admin.comments.approveSuccess'), 'success')
       },
+      onError: () => {
+        showToast(t('admin.comments.approveError'), 'error')
+      },
     })
   }
 
@@ -42,6 +45,9 @@ export function useManageCommentsPage(): ManageCommentsPageState {
     deleteComment.mutate(id, {
       onSuccess: () => {
         showToast(t('admin.comments.deleteSuccess'), 'success')
+      },
+      onError: () => {
+        showToast(t('admin.comments.deleteError'), 'error')
       },
     })
   }

--- a/frontend/src/features/manage-menus/hooks/use-manage-menus-page.ts
+++ b/frontend/src/features/manage-menus/hooks/use-manage-menus-page.ts
@@ -17,6 +17,19 @@ import { useCreateWidget, useWidgetList } from '@/entities/widget'
 import { useTranslation } from '@/shared/i18n'
 import { useToast } from '@/shared/ui'
 
+/** Prefer the server's validation message over the generic fallback. */
+function serverMessage(error: unknown, fallback: string): string {
+  if (typeof error === 'object' && error !== null) {
+    const e = error as {
+      errors?: ReadonlyArray<{ message?: string }>
+      detail?: string
+      title?: string
+    }
+    return e.errors?.[0]?.message ?? e.detail ?? e.title ?? fallback
+  }
+  return fallback
+}
+
 /**
  * Menu management (master–detail): named menus on the left, the selected menu's
  * link items on the right. Items belong to a menu via `menuId`. A menu is shown
@@ -40,6 +53,13 @@ export function useManageMenusPage() {
 
   const [selectedId, setSelectedId] = useState<number | null>(null)
 
+  const reportError = useCallback(
+    (error: unknown) => {
+      showToast(serverMessage(error, t('admin.menus.toast.error')), 'error')
+    },
+    [showToast, t],
+  )
+
   const menus = useMemo(() => menusQuery.data?.items ?? [], [menusQuery.data?.items])
   const allItems = useMemo(() => itemsQuery.data?.items ?? [], [itemsQuery.data?.items])
   const widgets = useMemo(() => widgetsQuery.data?.items ?? [], [widgetsQuery.data?.items])
@@ -62,63 +82,87 @@ export function useManageMenusPage() {
 
   const addMenu = useCallback(
     async (name: string) => {
-      const menu = await createMenu.mutateAsync({ name })
-      setSelectedId(menu.id)
-      showToast(t('admin.menus.toast.created'))
+      try {
+        const menu = await createMenu.mutateAsync({ name })
+        setSelectedId(menu.id)
+        showToast(t('admin.menus.toast.created'))
+      } catch (error) {
+        reportError(error)
+      }
     },
-    [createMenu, showToast, t],
+    [createMenu, showToast, t, reportError],
   )
 
   const renameMenu = useCallback(
     async (name: string) => {
       if (activeMenu === null) return
-      await updateMenu.mutateAsync({ id: activeMenu.id, input: { name } })
+      try {
+        await updateMenu.mutateAsync({ id: activeMenu.id, input: { name } })
+      } catch (error) {
+        reportError(error)
+      }
     },
-    [activeMenu, updateMenu],
+    [activeMenu, updateMenu, reportError],
   )
 
   const removeMenu = useCallback(async () => {
     if (activeMenu === null) return
-    await deleteMenu.mutateAsync(activeMenu.id)
-    setSelectedId(null)
-    showToast(t('admin.menus.toast.deleted'))
-  }, [activeMenu, deleteMenu, showToast, t])
+    try {
+      await deleteMenu.mutateAsync(activeMenu.id)
+      setSelectedId(null)
+      showToast(t('admin.menus.toast.deleted'))
+    } catch (error) {
+      reportError(error)
+    }
+  }, [activeMenu, deleteMenu, showToast, t, reportError])
 
   const addItem = useCallback(
     async (label: string, url: string) => {
       if (activeMenu === null) return
       const last = activeItems[activeItems.length - 1]
       const nextOrder = last !== undefined ? last.displayOrder + 1 : 0
-      await createItem.mutateAsync({
-        label,
-        url: url.trim() === '' ? '/' : url,
-        menuId: activeMenu.id,
-        displayOrder: nextOrder,
-      })
+      try {
+        await createItem.mutateAsync({
+          label,
+          url: url.trim() === '' ? '/' : url,
+          menuId: activeMenu.id,
+          displayOrder: nextOrder,
+        })
+      } catch (error) {
+        reportError(error)
+      }
     },
-    [activeMenu, activeItems, createItem],
+    [activeMenu, activeItems, createItem, reportError],
   )
 
   const editItem = useCallback(
     async (item: NavigationItem, label: string, url: string) => {
-      await updateItem.mutateAsync({
-        id: item.id,
-        input: {
-          label,
-          url,
-          menuId: item.menuId,
-          displayOrder: item.displayOrder,
-        },
-      })
+      try {
+        await updateItem.mutateAsync({
+          id: item.id,
+          input: {
+            label,
+            url,
+            menuId: item.menuId,
+            displayOrder: item.displayOrder,
+          },
+        })
+      } catch (error) {
+        reportError(error)
+      }
     },
-    [updateItem],
+    [updateItem, reportError],
   )
 
   const removeItem = useCallback(
     async (id: number) => {
-      await deleteItem.mutateAsync(id)
+      try {
+        await deleteItem.mutateAsync(id)
+      } catch (error) {
+        reportError(error)
+      }
     },
-    [deleteItem],
+    [deleteItem, reportError],
   )
 
   // Reorder by swapping display_order with the adjacent item.
@@ -129,42 +173,50 @@ export function useManageMenusPage() {
       const a = activeItems[index]
       const b = activeItems[target]
       if (a === undefined || b === undefined) return
-      await Promise.all([
-        updateItem.mutateAsync({
-          id: a.id,
-          input: {
-            label: a.label,
-            url: a.url,
-            menuId: a.menuId,
-            displayOrder: b.displayOrder,
-          },
-        }),
-        updateItem.mutateAsync({
-          id: b.id,
-          input: {
-            label: b.label,
-            url: b.url,
-            menuId: b.menuId,
-            displayOrder: a.displayOrder,
-          },
-        }),
-      ])
+      try {
+        await Promise.all([
+          updateItem.mutateAsync({
+            id: a.id,
+            input: {
+              label: a.label,
+              url: a.url,
+              menuId: a.menuId,
+              displayOrder: b.displayOrder,
+            },
+          }),
+          updateItem.mutateAsync({
+            id: b.id,
+            input: {
+              label: b.label,
+              url: b.url,
+              menuId: b.menuId,
+              displayOrder: a.displayOrder,
+            },
+          }),
+        ])
+      } catch (error) {
+        reportError(error)
+      }
     },
-    [activeItems, updateItem],
+    [activeItems, updateItem, reportError],
   )
 
   // Create a sidebar menu widget for this menu (the "place in a region" action).
   const placeMenu = useCallback(
     async (menuId: number) => {
-      await createWidget.mutateAsync({
-        widgetType: 'menu',
-        region: 'sidebar',
-        displayOrder: 0,
-        title: null,
-        settings: { menuId },
-      })
+      try {
+        await createWidget.mutateAsync({
+          widgetType: 'menu',
+          region: 'sidebar',
+          displayOrder: 0,
+          title: null,
+          settings: { menuId },
+        })
+      } catch (error) {
+        reportError(error)
+      }
     },
-    [createWidget],
+    [createWidget, reportError],
   )
 
   return {

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -220,6 +220,7 @@ export const en = {
     'Build a named menu on the Menus tab, then place it here as a Menu widget.',
   'admin.menus.toast.created': 'Menu created.',
   'admin.menus.toast.deleted': 'Menu deleted.',
+  'admin.menus.toast.error': 'Could not save the menu change.',
   'admin.layout.cond.sidebar': 'Shows on 2/3-column pages',
   'admin.layout.cond.aside': 'Shows on 3-column pages',
   'admin.widgets.board.deleteWidget': 'Delete this widget',
@@ -995,7 +996,9 @@ export const en = {
   'admin.comments.approve': 'Approve',
   'admin.comments.delete': 'Delete',
   'admin.comments.approveSuccess': 'Comment approved.',
+  'admin.comments.approveError': 'Could not approve the comment.',
   'admin.comments.deleteSuccess': 'Comment deleted.',
+  'admin.comments.deleteError': 'Could not delete the comment.',
   'admin.comments.deleteConfirmTitle': 'Delete comment?',
   'admin.comments.deleteConfirmDescription': 'Delete comment by {{name}}? This cannot be undone.',
 


### PR DESCRIPTION
## 目的
フロント全体監査（#507）の fail-closed フィードバック欠落（WS-03）。

## 変更
- **manage-menus**: 8 mutation（add/rename/remove menu, add/edit/remove/move item, placeMenu）が try/catch も onError も無くサイレント失敗していたため、`serverMessage` 抽出＋`reportError` で各アクションを try/catch 包み、失敗時に toast 表示。
- **manage-comments**: approve/delete の `mutate` に `onError` を追加（従来は成功 toast のみ）。
- `en.ts` に `admin.menus.toast.error` / `admin.comments.approveError` / `admin.comments.deleteError` を追加。確立済みパターン（serverMessage→showToast）に整合。

## 検証
`npm run type-check` / lint 緑。

Part of #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)
