### PR TITLE
fix(entity): 書込み後に公開フィードを invalidate（パブリック一覧の stale 解消）(#507)

### DIFF
--- a/frontend/src/entities/entity/mutations.test.tsx
+++ b/frontend/src/entities/entity/mutations.test.tsx
@@ -1,0 +1,52 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { useUpdateEntity } from './mutations'
+import { toEntityId } from './ids'
+import { entityKeys } from './query-keys'
+import { resetEntityStore, seedEntities } from '@tests/msw/handlers/entity'
+import { mswServer } from '@tests/msw/server'
+
+function freshClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+}
+
+describe('entity mutations invalidate the public feeds', () => {
+  beforeAll(() => {
+    mswServer.listen()
+  })
+  afterEach(() => {
+    mswServer.resetHandlers()
+    resetEntityStore()
+  })
+  afterAll(() => {
+    mswServer.close()
+  })
+
+  it('useUpdateEntity invalidates latest / search / by-tag / by-date-range feeds', async () => {
+    seedEntities([{ id: 5, entity_type_id: 1, is_deleted: false, deleted_at: null }])
+    const queryClient = freshClient()
+    // Public feeds live under entityKeys.all but outside lists().
+    queryClient.setQueryData(entityKeys.latest(10), [])
+    queryClient.setQueryData(entityKeys.search('q', 10), [])
+    queryClient.setQueryData(entityKeys.byTag('news', 10), [])
+    queryClient.setQueryData(entityKeys.byDateRange('2026-01-01', '2026-01-31', 10), [])
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    const { result } = renderHook(() => useUpdateEntity(), { wrapper })
+    await result.current.mutateAsync({ id: toEntityId(5), entityTypeId: 1, status: 'published' })
+
+    expect(queryClient.getQueryState(entityKeys.latest(10))?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(entityKeys.search('q', 10))?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(entityKeys.byTag('news', 10))?.isInvalidated).toBe(true)
+    expect(
+      queryClient.getQueryState(entityKeys.byDateRange('2026-01-01', '2026-01-31', 10))
+        ?.isInvalidated,
+    ).toBe(true)
+  })
+})

--- a/frontend/src/entities/entity/mutations.ts
+++ b/frontend/src/entities/entity/mutations.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
+import {
+  useMutation,
+  useQueryClient,
+  type QueryClient,
+  type UseMutationResult,
+} from '@tanstack/react-query'
 import { apiClient, AppError } from '@/shared/api/client'
 import type {
   EntityDto,
@@ -25,6 +30,19 @@ import type {
 } from './model'
 import { entityKeys } from './query-keys'
 
+// The cross-type public feeds (latest / search / by-tag / by-date-range) live
+// under entityKeys.all but OUTSIDE lists(), so the type-scoped list invalidation
+// never touches them. Any entity write must refresh them too, or public previews
+// (latest list, search, tag/date archives) stay stale until staleTime elapses.
+const PUBLIC_FEED_SEGMENTS = new Set(['latest', 'search', 'by-tag', 'by-date-range'])
+
+function invalidatePublicFeeds(queryClient: QueryClient): Promise<void> {
+  return queryClient.invalidateQueries({
+    queryKey: entityKeys.all,
+    predicate: (query) => PUBLIC_FEED_SEGMENTS.has(query.queryKey[1] as string),
+  })
+}
+
 export function useCreateEntity(): UseMutationResult<Entity, AppError, CreateEntityInput> {
   const queryClient = useQueryClient()
 
@@ -34,18 +52,21 @@ export function useCreateEntity(): UseMutationResult<Entity, AppError, CreateEnt
       return mapEntityDtoToModel(dto)
     },
     onSuccess: async (_data, variables) => {
-      await queryClient.invalidateQueries({
-        queryKey: entityKeys.lists(),
-        predicate: (query) => {
-          const params = query.queryKey[2]
-          return (
-            typeof params === 'object' &&
-            params !== null &&
-            'entityTypeId' in params &&
-            params.entityTypeId === variables.entityTypeId
-          )
-        },
-      })
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: entityKeys.lists(),
+          predicate: (query) => {
+            const params = query.queryKey[2]
+            return (
+              typeof params === 'object' &&
+              params !== null &&
+              'entityTypeId' in params &&
+              params.entityTypeId === variables.entityTypeId
+            )
+          },
+        }),
+        invalidatePublicFeeds(queryClient),
+      ])
     },
   })
 }
@@ -63,7 +84,10 @@ export function useUpdateEntity(): UseMutationResult<Entity, AppError, UpdateEnt
     },
     onSuccess: async (data) => {
       queryClient.setQueryData(entityKeys.detail(data.id), data)
-      await queryClient.invalidateQueries({ queryKey: entityKeys.lists() })
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: entityKeys.lists() }),
+        invalidatePublicFeeds(queryClient),
+      ])
     },
   })
 }
@@ -80,18 +104,21 @@ export function useDeleteEntity(): UseMutationResult<
       await apiClient.delete(`/api/v1/entities/${String(id)}`)
     },
     onSuccess: async (_data, variables) => {
-      await queryClient.invalidateQueries({
-        queryKey: entityKeys.lists(),
-        predicate: (query) => {
-          const params = query.queryKey[2]
-          return (
-            typeof params === 'object' &&
-            params !== null &&
-            'entityTypeId' in params &&
-            params.entityTypeId === variables.entityTypeId
-          )
-        },
-      })
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: entityKeys.lists(),
+          predicate: (query) => {
+            const params = query.queryKey[2]
+            return (
+              typeof params === 'object' &&
+              params !== null &&
+              'entityTypeId' in params &&
+              params.entityTypeId === variables.entityTypeId
+            )
+          },
+        }),
+        invalidatePublicFeeds(queryClient),
+      ])
     },
   })
 }
@@ -113,7 +140,10 @@ export function useScheduleEntity(): UseMutationResult<
     },
     onSuccess: async (_data, variables) => {
       queryClient.removeQueries({ queryKey: entityKeys.detail(toEntityId(variables.id)) })
-      await queryClient.invalidateQueries({ queryKey: entityKeys.lists() })
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: entityKeys.lists() }),
+        invalidatePublicFeeds(queryClient),
+      ])
     },
   })
 }
@@ -127,7 +157,10 @@ export function useUnscheduleEntity(): UseMutationResult<void, AppError, { id: E
     },
     onSuccess: async (_data, variables) => {
       queryClient.removeQueries({ queryKey: entityKeys.detail(variables.id) })
-      await queryClient.invalidateQueries({ queryKey: entityKeys.lists() })
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: entityKeys.lists() }),
+        invalidatePublicFeeds(queryClient),
+      ])
     },
   })
 }


### PR DESCRIPTION
公開フィード（latest/search/by-tag/by-date-range）が entityKeys.all 配下だが lists() 外のため、entity write 後に invalidate されず管理編集後もパブリックが stale だった。invalidatePublicFeeds を全5 mutation に追加。回帰テスト付き・全332テスト緑。Part of #507