### PR TITLE
fix(ui): ConfirmDialog useId 化 + SEO メタ入力を Input primitive へ (#507)

### DIFF
--- a/frontend/src/features/manage-entity-status/ui/EntitySeoPanel.tsx
+++ b/frontend/src/features/manage-entity-status/ui/EntitySeoPanel.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@/shared/i18n'
-import { Button, Stack, Text, Textarea } from '@/shared/ui'
+import { Button, Input, Stack, Text, Textarea } from '@/shared/ui'
 
 interface EntitySeoPanelProps {
   metaTitle: string
@@ -27,22 +27,16 @@ export function EntitySeoPanel({
           {t('admin.entitySeo.title')}
         </Text>
 
-        <Stack gap="xs">
-          <label htmlFor="entity-meta-title" className="text-sm font-medium text-text-primary">
-            {t('admin.entitySeo.metaTitle')}
-          </label>
-          <input
-            id="entity-meta-title"
-            type="text"
-            value={metaTitle}
-            onChange={(e) => {
-              onMetaTitleChange(e.target.value)
-            }}
-            placeholder={t('admin.entitySeo.metaTitle.placeholder')}
-            maxLength={255}
-            className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
-          />
-        </Stack>
+        <Input
+          id="entity-meta-title"
+          label={t('admin.entitySeo.metaTitle')}
+          value={metaTitle}
+          onChange={(e) => {
+            onMetaTitleChange(e.target.value)
+          }}
+          placeholder={t('admin.entitySeo.metaTitle.placeholder')}
+          maxLength={255}
+        />
 
         <Stack gap="xs">
           <Textarea

--- a/frontend/src/shared/ui/components/ConfirmDialog.tsx
+++ b/frontend/src/shared/ui/components/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useId, type ReactNode } from 'react'
 import { Button } from '@/shared/ui/primitives/Button'
 import { Stack } from '@/shared/ui/primitives/Stack'
 import { Text } from '@/shared/ui/primitives/Text'
@@ -40,6 +40,10 @@ export function ConfirmDialog({
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
+  // Unique per instance so simultaneously-open dialogs don't share an
+  // aria-labelledby target (screen-reader label resolution would break).
+  const titleId = useId()
+
   if (!open) {
     return null
   }
@@ -48,12 +52,12 @@ export function ConfirmDialog({
     <Modal
       onClose={onCancel}
       closeLabel="Close dialog"
-      labelledBy="confirm-dialog-title"
+      labelledBy={titleId}
       panelClassName="max-w-md shadow-md"
     >
       <Stack gap="md">
         <Stack gap="xs">
-          <Text as="h2" id="confirm-dialog-title" variant="heading-sm">
+          <Text as="h2" id={titleId} variant="heading-sm">
             {title}
           </Text>
           {description !== undefined ? <Text muted>{description}</Text> : null}


### PR DESCRIPTION
WS-13: ConfirmDialog の固定 aria-labelledby id を useId() で一意化（多重表示の SR ラベル衝突解消）。WS-09: EntitySeoPanel metaTitle を生 input → Input primitive。全332テスト緑。datetime-local/MediaGrid は別途（layout/uncontrolled 要対応）。Part of #507