### PR TITLE
fix(i18n): 残存する JA ハードコードを i18n 化/正規化する (#507)

### DIFF
--- a/frontend/src/features/edit-entity-text-fields/ui/MarkdownFieldInput.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/MarkdownFieldInput.tsx
@@ -20,7 +20,7 @@ const TOOLBAR_ACTIONS: ToolbarAction[] = [
     label: 'Bold',
     icon: 'B',
     action: (v, s, e) => {
-      const sel = v.slice(s, e) || 'テキスト'
+      const sel = v.slice(s, e) || 'text'
       return { text: v.slice(0, s) + `**${sel}**` + v.slice(e), cursor: s + sel.length + 4 }
     },
   },
@@ -28,7 +28,7 @@ const TOOLBAR_ACTIONS: ToolbarAction[] = [
     label: 'Italic',
     icon: 'I',
     action: (v, s, e) => {
-      const sel = v.slice(s, e) || 'テキスト'
+      const sel = v.slice(s, e) || 'text'
       return { text: v.slice(0, s) + `*${sel}*` + v.slice(e), cursor: s + sel.length + 2 }
     },
   },
@@ -84,7 +84,7 @@ const TOOLBAR_ACTIONS: ToolbarAction[] = [
     label: 'Link',
     icon: '🔗',
     action: (v, s, e) => {
-      const sel = v.slice(s, e) || 'リンクテキスト'
+      const sel = v.slice(s, e) || 'link text'
       const snippet = `[${sel}](url)`
       return { text: v.slice(0, s) + snippet + v.slice(e), cursor: s + sel.length + 3 }
     },

--- a/frontend/src/features/manage-widgets/ui/LayoutPreview.tsx
+++ b/frontend/src/features/manage-widgets/ui/LayoutPreview.tsx
@@ -18,6 +18,7 @@ const SAMPLE_POSTS = ['Midnight Drift EP', 'Glass Harbor', 'Neon Tide', 'Slow St
 const SAMPLE_TAGS = ['House', 'Techno', 'Ambient', 'Dub', 'Lo-fi']
 
 function MiniWidget({ w, menus, horizontal }: { w: Widget; menus: Menu[]; horizontal: boolean }) {
+  const { t } = useTranslation()
   const inner = (): ReactNode => {
     switch (w.widgetType) {
       case 'menu': {
@@ -50,7 +51,7 @@ function MiniWidget({ w, menus, horizontal }: { w: Widget; menus: Menu[]; horizo
           <div className="rounded-sm border border-border px-inline-sm py-stack-xs text-caption text-text-muted">
             {typeof w.settings['placeholder'] === 'string' && w.settings['placeholder'] !== ''
               ? w.settings['placeholder']
-              : '検索…'}
+              : t('public.search.placeholder')}
           </div>
         )
       case 'tag-cloud':
@@ -80,7 +81,7 @@ function MiniWidget({ w, menus, horizontal }: { w: Widget; menus: Menu[]; horizo
       case 'toc':
         return (
           <ul className="flex flex-col gap-stack-xs">
-            {['概要', 'トラックリスト', 'クレジット'].map((tg) => (
+            {['Overview', 'Tracklist', 'Credits'].map((tg) => (
               <li key={tg} className="text-caption text-accent">
                 {tg}
               </li>

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -38,6 +38,9 @@ export const en = {
 
   'common.dialog.close': 'Close dialog',
 
+  'common.toast.dismiss': 'Dismiss',
+  'common.toast.region': 'Notifications',
+
   // ── Admin nav ────────────────────────────────────────────────────────────
   'admin.nav.home': 'Home',
   'admin.nav.entityTypes': 'Content types',
@@ -1021,6 +1024,12 @@ export const en = {
   'public.comments.form.submitting': 'Submitting…',
   'public.comments.form.success': 'Your comment has been submitted and is awaiting moderation.',
   'public.comments.form.error': 'Could not submit comment. Please try again.',
+  'public.blocks.callout.info': 'Info: ',
+  'public.blocks.callout.warn': 'Warning: ',
+  'public.blocks.callout.ok': 'Success: ',
+  'public.blocks.callout.danger': 'Error: ',
+  'public.blocks.chart.label': 'Label',
+  'public.blocks.chart.value': 'Value',
 
   // ── Superadmin · System settings ──
   'admin.superSettings.pageTitle': 'System settings',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -31,6 +31,9 @@ export const ja: Partial<MessageCatalog> = {
 
   'common.dialog.close': 'ダイアログを閉じる',
 
+  'common.toast.dismiss': '閉じる',
+  'common.toast.region': '通知',
+
   // ── Admin nav ────────────────────────────────────────────────────────────
   'admin.nav.home': 'ホーム',
   'admin.nav.entityTypes': 'コンテンツタイプ',
@@ -1026,6 +1029,12 @@ export const ja: Partial<MessageCatalog> = {
   'public.comments.form.submitting': '送信中…',
   'public.comments.form.success': 'コメントを送信しました。承認後に表示されます。',
   'public.comments.form.error': 'コメントを送信できませんでした。もう一度お試しください。',
+  'public.blocks.callout.info': '情報: ',
+  'public.blocks.callout.warn': '警告: ',
+  'public.blocks.callout.ok': '成功: ',
+  'public.blocks.callout.danger': 'エラー: ',
+  'public.blocks.chart.label': 'ラベル',
+  'public.blocks.chart.value': '値',
 
   // ── Superadmin · System settings ──
   'admin.superSettings.pageTitle': 'システム設定',

--- a/frontend/src/shared/ui/blocks/BlocksRenderer.test.tsx
+++ b/frontend/src/shared/ui/blocks/BlocksRenderer.test.tsx
@@ -4,6 +4,9 @@ import { renderWithProviders } from '@tests/render/render-with-providers'
 import { BlocksRenderer } from './BlocksRenderer'
 
 afterEach(cleanup)
+afterEach(() => {
+  localStorage.removeItem('nene-locale')
+})
 
 describe('BlocksRenderer', () => {
   it('renders text and callout blocks', () => {
@@ -180,5 +183,43 @@ describe('BlocksRenderer', () => {
 
     expect(container.querySelector('.spacer')?.getAttribute('data-spacer-size')).toBe('lg')
     expect(container.querySelector('hr.divider')).not.toBeNull()
+  })
+
+  it('localizes the callout screen-reader prefix by locale', () => {
+    const doc = JSON.stringify([{ id: 'c', type: 'callout', data: { kind: 'danger', body: 'x' } }])
+
+    localStorage.setItem('nene-locale', 'ja')
+    const { container: ja } = renderWithProviders(<BlocksRenderer documentJson={doc} />)
+    expect(ja.querySelector('.callout .sr-only')?.textContent).toBe('エラー: ')
+    cleanup()
+
+    localStorage.setItem('nene-locale', 'en')
+    const { container: en } = renderWithProviders(<BlocksRenderer documentJson={doc} />)
+    expect(en.querySelector('.callout .sr-only')?.textContent).toBe('Error: ')
+  })
+
+  it('localizes the chart data-table headers (ja)', () => {
+    localStorage.setItem('nene-locale', 'ja')
+    const doc = JSON.stringify([
+      {
+        id: 'k',
+        type: 'chart',
+        data: {
+          chartType: 'bar',
+          title: 'M',
+          series: [
+            { label: 'a', value: 1 },
+            { label: 'b', value: 2 },
+          ],
+          summary: 's',
+        },
+      },
+    ])
+
+    const { container } = renderWithProviders(<BlocksRenderer documentJson={doc} />)
+    const headers = Array.from(container.querySelectorAll('.chart__table thead th')).map(
+      (th) => th.textContent,
+    )
+    expect(headers).toEqual(['ラベル', '値'])
   })
 })

--- a/frontend/src/shared/ui/blocks/BlocksRenderer.tsx
+++ b/frontend/src/shared/ui/blocks/BlocksRenderer.tsx
@@ -1,8 +1,8 @@
+import { useTranslation } from '@/shared/i18n'
 import {
   isSafeHref,
   parseBlocksDocument,
   type Block,
-  type CalloutKind,
   type ChartBlockData,
   type ColumnsBlockData,
   type GalleryBlockData,
@@ -40,6 +40,7 @@ export function BlocksRenderer({ documentJson }: BlocksRendererProps) {
 }
 
 function ConsumerBlock({ block }: { block: Block }) {
+  const { t } = useTranslation()
   switch (block.type) {
     case 'text':
       if (block.data.markdown.trim() === '') {
@@ -58,7 +59,7 @@ function ConsumerBlock({ block }: { block: Block }) {
       return (
         <aside className="callout" data-callout-kind={block.data.kind} role="note">
           <div className="callout__body">
-            <span className="sr-only">{CALLOUT_SR_PREFIX[block.data.kind]}</span>
+            <span className="sr-only">{t(`public.blocks.callout.${block.data.kind}`)}</span>
             {title !== undefined && title.trim() !== '' ? (
               <p className="callout__title">{title}</p>
             ) : null}
@@ -129,6 +130,7 @@ function ConsumerGroup({ data }: { data: GroupBlockData }) {
  * library, no JS) with the data also projected as an sr-only summary + table (C4).
  */
 function ConsumerChart({ data }: { data: ChartBlockData }) {
+  const { t } = useTranslation()
   const series = data.series
   if (series.length < 2) {
     return null
@@ -236,8 +238,8 @@ function ConsumerChart({ data }: { data: ChartBlockData }) {
         <caption>{title ?? ''}</caption>
         <thead>
           <tr>
-            <th scope="col">ラベル</th>
-            <th scope="col">値</th>
+            <th scope="col">{t('public.blocks.chart.label')}</th>
+            <th scope="col">{t('public.blocks.chart.value')}</th>
           </tr>
         </thead>
         <tbody>
@@ -357,15 +359,4 @@ function renderEmphasis(text: string) {
   return text
     .split('*')
     .map((part, index) => (index % 2 === 1 ? <em key={index}>{part}</em> : part))
-}
-
-/**
- * Screen-reader-only kind prefix (C4 SEO/a11y projection). Japanese to match the
- * current single-locale consumer site; consumer i18n is a separate effort.
- */
-const CALLOUT_SR_PREFIX: Record<CalloutKind, string> = {
-  info: '情報: ',
-  warn: '警告: ',
-  ok: '成功: ',
-  danger: 'エラー: ',
 }

--- a/frontend/src/shared/ui/toast/ToastProvider.tsx
+++ b/frontend/src/shared/ui/toast/ToastProvider.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from 'react'
+import { useTranslation } from '@/shared/i18n'
 import { ToastContext } from './toast-context'
 import type { Toast, ToastType } from './toast-context'
 
@@ -62,6 +63,7 @@ const TYPE_STYLES: Record<
 }
 
 function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: (id: number) => void }) {
+  const { t } = useTranslation()
   const styles = TYPE_STYLES[toast.type]
   return (
     <div
@@ -80,7 +82,7 @@ function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: (id: number)
         onClick={() => {
           onDismiss(toast.id)
         }}
-        aria-label="閉じる"
+        aria-label={t('common.toast.dismiss')}
         className="ml-1 shrink-0 text-text-muted transition-colors hover:text-text-primary"
       >
         <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
@@ -104,6 +106,7 @@ const FADE_MS = 300
 let nextId = 1
 
 export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const { t } = useTranslation()
   const [toasts, setToasts] = useState<Toast[]>([])
   const timersRef = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map())
 
@@ -132,7 +135,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
       {children}
       {/* ── Toast container (top-right) ── */}
       <div
-        aria-label="通知"
+        aria-label={t('common.toast.region')}
         className="pointer-events-none fixed right-4 top-4 z-50 flex flex-col gap-2"
         style={{ minWidth: '18rem', maxWidth: '22rem' }}
       >


### PR DESCRIPTION
## 目的 (WS-11 残 / epic #507)

admin/shared/app の i18n 移行は既に大半が完了済み（features 83 / pages 22 ファイルが `useTranslation` 使用）で、WS-11 として残っていたのは**点在する JA ハードコード 4 ファイル**のみだった（他は日本語コメントで対象外）。これを解消する。

> scope 補正: 監査時の WS-11「大移行」想定に反し、実残量は小。SettingsPage（#520）以降に既に進んでいた。

## 変更

genuine i18n（locale 駆動の chrome / 公開コンテンツ）と consistency 正規化（demo/挿入既定）を切り分けた。

- **`shared/ui/blocks/BlocksRenderer`**（公開コンテンツ）: callout のスクリーンリーダ接頭辞（`情報:/警告:/成功:/エラー:`）と chart データ表ヘッダ（`ラベル`/`値`）を `public.blocks.*` で i18n。
  - 作者コメントが「Japanese to match the current single-locale consumer site; **consumer i18n is a separate effort**」と明記していた箇所。**WS-10 で consumer i18n が入った**ため、ここで解消できる。
  - callout は `t(\`public.blocks.callout.${kind}\`)`（既存 `admin.region.${c}` と同型の template-literal キー）。
- **`shared/ui/toast/ToastProvider`**: `通知`/`閉じる` の `aria-label` を `common.toast.*` で i18n（I18nProvider 内に配置済みを確認）。
- **`manage-widgets/LayoutPreview`**（プレビュー mock）: 検索プレースホルダを実キー `public.search.placeholder` に配線（実表示と一致）、TOC サンプルは周囲の英語モック（`Midnight Drift EP`/`House`/`Home` 等）に合わせ `Overview/Tracklist/Credits` へ英語化。
- **`edit-entity-text-fields/MarkdownFieldInput`**: MD 挿入の既定文字（`テキスト`/`リンクテキスト`）を、同ファイル既存の英語既定（`Heading`/`code`/`url`）に合わせ `text`/`link text` へ正規化。

## 検証

- `npm run check --prefix frontend` 緑（type-check / eslint / prettier / **test 334** / validate:themes / knip / build-storybook）
- `BlocksRenderer.test.tsx` に **callout 接頭辞のロケール切替（ja=エラー: / en=Error:）と chart ヘッダ（ラベル/値）** の回帰テストを追加。既存テストは `renderWithProviders`（I18nProvider 内包）で描画のため useTranslation 追加でも不変
- 非コメント JA リテラル grep 監査クリア

## チェックリスト

- [x] `npm run check` 緑
- [x] 公開側 i18n 配線に回帰テスト追加
- [x] 表示のリグレッションなし

Refs #507（epic は WS-09/13残・WS-08 等が残るためクローズしない）

> 補足: #521(WS-10) と en.ts/ja.ts を別領域で編集（本PR=common.* と public.comments 末尾 / #521=public.dateArchive〜tagArchive 周辺）。マージ順は不問で自動マージ可能の想定。