### PR TITLE
fix(a11y): フォームの固定idを useId 化し datetime にラベルを付与する (#507)

### DIFF
--- a/frontend/src/features/manage-entity-status/ui/EntityStatusPanel.tsx
+++ b/frontend/src/features/manage-entity-status/ui/EntityStatusPanel.tsx
@@ -157,6 +157,7 @@ export function EntityStatusPanel({
         <div className="flex items-center gap-inline-sm rounded-md border border-border bg-surface p-3">
           <input
             type="datetime-local"
+            aria-label={t('admin.entityStatus.scheduledAtLabel')}
             value={scheduledAtInput}
             onChange={(e) => {
               onScheduledAtChange(e.target.value)

--- a/frontend/src/features/manage-notification-channels/ui/NotificationChannelForm.test.tsx
+++ b/frontend/src/features/manage-notification-channels/ui/NotificationChannelForm.test.tsx
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, screen } from '@testing-library/react'
+import { renderWithProviders } from '@tests/render/render-with-providers'
+import { NotificationChannelForm } from './NotificationChannelForm'
+
+afterEach(cleanup)
+
+const baseProps = {
+  isSubmitting: false,
+  serverErrorTitle: null,
+  submitLabel: 'Save',
+  onSubmit: vi.fn(() => Promise.resolve()),
+  onCancel: vi.fn(),
+}
+
+describe('NotificationChannelForm', () => {
+  it('associates the enabled checkbox with its label (useId)', () => {
+    renderWithProviders(<NotificationChannelForm {...baseProps} />)
+    const checkbox = screen.getByLabelText('Enabled')
+    expect(checkbox).toHaveProperty('type', 'checkbox')
+  })
+
+  it('generates a unique enabled-checkbox id per instance', () => {
+    renderWithProviders(
+      <>
+        <NotificationChannelForm {...baseProps} />
+        <NotificationChannelForm {...baseProps} />
+      </>,
+    )
+    const boxes = screen.getAllByLabelText('Enabled')
+    expect(boxes).toHaveLength(2)
+    expect(boxes[0]?.id).toBeTruthy()
+    expect(boxes[0]?.id).not.toBe(boxes[1]?.id)
+  })
+})

--- a/frontend/src/features/manage-notification-channels/ui/NotificationChannelForm.tsx
+++ b/frontend/src/features/manage-notification-channels/ui/NotificationChannelForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useId, useState } from 'react'
 import type {
   CreateNotificationChannelInput,
   NotificationChannel,
@@ -95,6 +95,7 @@ export function NotificationChannelForm({
   onCancel,
 }: NotificationChannelFormProps) {
   const { t } = useTranslation()
+  const enabledId = useId()
   const isEdit = defaultValues !== undefined
 
   const [channelType, setChannelType] = useState<NotificationChannelType>(
@@ -251,7 +252,7 @@ export function NotificationChannelForm({
 
         <div className="flex items-center gap-2">
           <input
-            id="is-enabled"
+            id={enabledId}
             type="checkbox"
             checked={isEnabled}
             onChange={(e) => {
@@ -259,7 +260,7 @@ export function NotificationChannelForm({
             }}
             className="h-4 w-4 rounded border-border text-accent"
           />
-          <label htmlFor="is-enabled" className="font-sans text-sm text-text">
+          <label htmlFor={enabledId} className="font-sans text-sm text-text">
             {t('admin.notifications.form.isEnabledLabel')}
           </label>
         </div>

--- a/frontend/src/features/manage-webhooks/ui/WebhookForm.test.tsx
+++ b/frontend/src/features/manage-webhooks/ui/WebhookForm.test.tsx
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, screen } from '@testing-library/react'
+import { renderWithProviders } from '@tests/render/render-with-providers'
+import { WebhookForm } from './WebhookForm'
+
+afterEach(cleanup)
+
+const baseProps = {
+  isSubmitting: false,
+  serverErrorTitle: null,
+  submitLabel: 'Save',
+  onSubmit: vi.fn(() => Promise.resolve()),
+}
+
+describe('WebhookForm', () => {
+  it('associates each label with its input (htmlFor/id wired via useId)', () => {
+    renderWithProviders(<WebhookForm {...baseProps} />)
+    expect(screen.getByLabelText('Endpoint URL').tagName).toBe('INPUT')
+    expect(screen.getByLabelText('Entity type ID (optional)').tagName).toBe('INPUT')
+    expect(screen.getByLabelText('Signing secret (optional)').tagName).toBe('INPUT')
+  })
+
+  it('generates unique field ids per instance (no fixed-id collision)', () => {
+    renderWithProviders(
+      <>
+        <WebhookForm {...baseProps} />
+        <WebhookForm {...baseProps} />
+      </>,
+    )
+    const urls = screen.getAllByLabelText('Endpoint URL')
+    expect(urls).toHaveLength(2)
+    expect(urls[0]?.id).toBeTruthy()
+    expect(urls[0]?.id).not.toBe(urls[1]?.id)
+  })
+})

--- a/frontend/src/features/manage-webhooks/ui/WebhookForm.tsx
+++ b/frontend/src/features/manage-webhooks/ui/WebhookForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useId, useState } from 'react'
 import type { CreateWebhookInput, WebhookEvent } from '@/entities/webhook'
 import { WEBHOOK_EVENTS } from '@/entities/webhook'
 import { useTranslation } from '@/shared/i18n'
@@ -22,6 +22,7 @@ export function WebhookForm({
   onCancel,
 }: WebhookFormProps) {
   const { t } = useTranslation()
+  const fieldId = useId()
   const [url, setUrl] = useState(defaultValues?.url ?? '')
   const [events, setEvents] = useState<WebhookEvent[]>(defaultValues?.events ?? ['entity.created'])
   const [entityTypeId, setEntityTypeId] = useState<string>(
@@ -50,11 +51,14 @@ export function WebhookForm({
       <Stack gap="md">
         {/* URL */}
         <div className="flex flex-col gap-stack-xs">
-          <label htmlFor="wh-url" className="font-sans text-body font-medium text-text-primary">
+          <label
+            htmlFor={`${fieldId}-url`}
+            className="font-sans text-body font-medium text-text-primary"
+          >
             {t('admin.webhooks.form.urlLabel')}
           </label>
           <input
-            id="wh-url"
+            id={`${fieldId}-url`}
             type="url"
             value={url}
             disabled={isSubmitting}
@@ -96,13 +100,13 @@ export function WebhookForm({
         {/* Entity type ID (optional) */}
         <div className="flex flex-col gap-stack-xs">
           <label
-            htmlFor="wh-entity-type"
+            htmlFor={`${fieldId}-entity-type`}
             className="font-sans text-body font-medium text-text-primary"
           >
             {t('admin.webhooks.form.entityTypeIdLabel')}
           </label>
           <input
-            id="wh-entity-type"
+            id={`${fieldId}-entity-type`}
             type="number"
             value={entityTypeId}
             disabled={isSubmitting}
@@ -117,11 +121,14 @@ export function WebhookForm({
 
         {/* Secret (optional) */}
         <div className="flex flex-col gap-stack-xs">
-          <label htmlFor="wh-secret" className="font-sans text-body font-medium text-text-primary">
+          <label
+            htmlFor={`${fieldId}-secret`}
+            className="font-sans text-body font-medium text-text-primary"
+          >
             {t('admin.webhooks.form.secretLabel')}
           </label>
           <input
-            id="wh-secret"
+            id={`${fieldId}-secret`}
             type="text"
             value={secret}
             disabled={isSubmitting}

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -683,6 +683,7 @@ export const en = {
 
   // ── Entity status panel ───────────────────────────────────────────────────
   'admin.entityStatus.panelTitle': 'Publish status',
+  'admin.entityStatus.scheduledAtLabel': 'Scheduled publish date and time',
   'admin.entityStatus.slugLabel': 'Slug',
   'admin.entityStatus.slugPlaceholder': 'e.g. hello-world',
   'admin.entityStatus.saveSlug': 'Save slug',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -682,6 +682,7 @@ export const ja: Partial<MessageCatalog> = {
 
   // ── Entity status panel ───────────────────────────────────────────────────
   'admin.entityStatus.panelTitle': '公開ステータス',
+  'admin.entityStatus.scheduledAtLabel': '公開予約日時',
   'admin.entityStatus.slugLabel': 'スラッグ',
   'admin.entityStatus.slugPlaceholder': '例: hello-world',
   'admin.entityStatus.saveSlug': 'スラッグを保存',


### PR DESCRIPTION
## 目的 (WS-09 残 / WS-13 残 / epic #507)

フォーム周りの a11y 残件を解消する。

## 変更

### WS-13 — 固定 id を `useId()` 化
複数同時描画時に id が衝突し `label`⇔`input` の紐付けが壊れるのを防ぐ。
- `NotificationChannelForm`: `is-enabled` → `useId()` 由来
- `WebhookForm`: `wh-url` / `wh-entity-type` / `wh-secret` → 単一 `useId()` ベース + サフィックス

### WS-09 — datetime にアクセシブル名を付与
- `EntityStatusPanel` の `datetime-local` 入力が**ラベル無し**（アクセシブル名なし）だったため `aria-label`（`admin.entityStatus.scheduledAtLabel`）を付与。

### WS-09 スコープ判断（primitive 化はしない）
監査は「raw input → Input primitive（uncontrolled 拡張含む）」を想定していたが、実装時に検証した結果:
- `Input` primitive は**フルサイズ field 用**（必須の `flex flex-col` wrapper + `px-inline-md py-stack-sm` の大きめ padding）。
- `EntityStatusPanel` の datetime は**ボタン行内のインライン控え**、`MediaGrid` の alt 入力は**カード内のコンパクト入力**（`text-caption`・`onBlur` 保存の uncontrolled）。
- これらを primitive へ migrate すると wrapper/サイズで**視覚的に崩れる**。2件のためにコア primitive へ `bare`/uncontrolled モードを足すのは API を汚し全 consumer にリスク。
- → **raw input のまま据置し a11y のみ担保**（MediaGrid は既に `aria-label` 済）。primitive は拡張しない。

## 検証

- `npm run check --prefix frontend` 緑（type-check / eslint / prettier / **test 336** / themes / knip / storybook）
- `WebhookForm` / `NotificationChannelForm` に **useId の一意性（2インスタンスで id 重複なし）＋ `getByLabelText` による label⇔input 紐付け** の回帰テストを追加

## チェックリスト

- [x] `npm run check` 緑
- [x] a11y 改善（useId / aria-label）に回帰テスト追加
- [x] 視覚リグレッションなし（primitive 化を避け raw input 据置）

Refs #507（WS-08/WS-14-18 等が残るためクローズしない）