### PR TITLE
fix(ui): 状態色を生パレットからセマンティックトークンへ移行する (#507)

### DIFF
--- a/frontend/src/features/manage-data-migration/ui/DataMigrationView.tsx
+++ b/frontend/src/features/manage-data-migration/ui/DataMigrationView.tsx
@@ -37,7 +37,7 @@ export function DataMigrationView({
           </Text>
         )}
         {isStatusError && (
-          <Text muted className="mt-3 text-red-500">
+          <Text muted className="mt-3 text-danger">
             Failed to load migration status.
           </Text>
         )}
@@ -46,15 +46,15 @@ export function DataMigrationView({
           <>
             <div className="mt-3 mb-4">
               {hasUnassigned ? (
-                <div className="rounded-md bg-amber-50 border border-amber-200 px-4 py-3 dark:bg-amber-950/20 dark:border-amber-900/40">
-                  <Text className="font-semibold text-amber-800 dark:text-amber-300">
+                <div className="rounded-md bg-warning-weak border border-warning px-4 py-3">
+                  <Text className="font-semibold text-warning">
                     {migrationStatus.total.toLocaleString()} unassigned record
                     {migrationStatus.total !== 1 ? 's' : ''} found
                   </Text>
                 </div>
               ) : (
-                <div className="rounded-md bg-green-50 border border-green-200 px-4 py-3 dark:bg-green-950/20 dark:border-green-900/40">
-                  <Text className="font-semibold text-green-800 dark:text-green-300">
+                <div className="rounded-md bg-success-weak border border-success px-4 py-3">
+                  <Text className="font-semibold text-success">
                     All records are assigned to an organization. ✓
                   </Text>
                 </div>

--- a/frontend/src/features/manage-notification-channels/ui/ManageNotificationChannelsView.tsx
+++ b/frontend/src/features/manage-notification-channels/ui/ManageNotificationChannelsView.tsx
@@ -140,7 +140,7 @@ export function ManageNotificationChannelsView({
                   <span
                     className={`inline-block rounded px-1.5 py-0.5 font-sans text-caption ${
                       channel.isEnabled
-                        ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                        ? 'bg-success/15 text-success'
                         : 'bg-surface text-text-muted'
                     }`}
                   >
@@ -149,12 +149,12 @@ export function ManageNotificationChannelsView({
                       : t('admin.notifications.status.disabled')}
                   </span>
                   {testSuccess === channel.id && (
-                    <span className="font-sans text-caption text-green-600 dark:text-green-400">
+                    <span className="font-sans text-caption text-success">
                       {t('admin.notifications.testSent')}
                     </span>
                   )}
                   {testError === channel.id && (
-                    <span className="font-sans text-caption text-error">
+                    <span className="font-sans text-caption text-danger">
                       {t('admin.notifications.testFailed')}
                     </span>
                   )}

--- a/frontend/src/features/manage-notification-channels/ui/NotificationChannelForm.tsx
+++ b/frontend/src/features/manage-notification-channels/ui/NotificationChannelForm.tsx
@@ -173,7 +173,7 @@ export function NotificationChannelForm({
     >
       <Stack gap="sm">
         {serverErrorTitle !== null && (
-          <Text className="text-error text-sm">{serverErrorTitle}</Text>
+          <Text className="text-danger text-sm">{serverErrorTitle}</Text>
         )}
 
         {!isEdit && (
@@ -213,7 +213,7 @@ export function NotificationChannelForm({
             className="w-full rounded-md border border-border bg-surface px-3 py-2 font-sans text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-accent"
           />
           {errors['label'] !== undefined && (
-            <p className="mt-1 font-sans text-xs text-error">{errors['label']}</p>
+            <p className="mt-1 font-sans text-xs text-danger">{errors['label']}</p>
           )}
         </div>
 
@@ -221,7 +221,7 @@ export function NotificationChannelForm({
           <div key={field.key}>
             <label className="mb-1 block font-sans text-sm font-medium text-text">
               {field.label}
-              {field.required && <span className="ml-1 text-error">*</span>}
+              {field.required && <span className="ml-1 text-danger">*</span>}
             </label>
             {field.multiline === true ? (
               <textarea
@@ -245,7 +245,7 @@ export function NotificationChannelForm({
               />
             )}
             {errors[field.key] !== undefined && (
-              <p className="mt-1 font-sans text-xs text-error">{errors[field.key]}</p>
+              <p className="mt-1 font-sans text-xs text-danger">{errors[field.key]}</p>
             )}
           </div>
         ))}

--- a/frontend/src/features/manage-organizations/ui/ManageOrganizationDetailView.tsx
+++ b/frontend/src/features/manage-organizations/ui/ManageOrganizationDetailView.tsx
@@ -232,7 +232,7 @@ export function ManageOrganizationDetailView({
       </Card>
 
       {/* Danger zone */}
-      <div className="rounded-lg border border-red-200 bg-red-50 p-6 dark:border-red-900/40 dark:bg-red-950/20">
+      <div className="rounded-lg border border-danger bg-danger-weak p-6">
         <Text as="h2" variant="heading-sm">
           Danger Zone
         </Text>

--- a/frontend/src/features/manage-organizations/ui/ManageOrganizationsView.tsx
+++ b/frontend/src/features/manage-organizations/ui/ManageOrganizationsView.tsx
@@ -213,7 +213,7 @@ export function ManageOrganizationsView({
                   </td>
                   <td className="px-4 py-3">
                     {org.isActive ? (
-                      <span className="text-xs text-green-600 dark:text-green-400">Active</span>
+                      <span className="text-xs text-success">Active</span>
                     ) : (
                       <span className="text-xs text-text-muted">Inactive</span>
                     )}
@@ -231,7 +231,7 @@ export function ManageOrganizationsView({
                         onClick={() => {
                           onSetDeleteTarget(org)
                         }}
-                        className="text-xs text-red-500 hover:text-red-700"
+                        className="text-xs text-danger hover:text-danger-hover"
                       >
                         Delete
                       </button>

--- a/frontend/src/features/manage-users/ui/UserInviteForm.tsx
+++ b/frontend/src/features/manage-users/ui/UserInviteForm.tsx
@@ -67,7 +67,7 @@ export function UserInviteForm({
           <option value="admin">{t('admin.users.role.admin')}</option>
         </Select>
         {serverErrorTitle !== null ? (
-          <Text muted className="text-red-500">
+          <Text muted className="text-danger">
             {serverErrorTitle}
           </Text>
         ) : null}

--- a/frontend/src/features/manage-webhooks/ui/ManageWebhooksView.tsx
+++ b/frontend/src/features/manage-webhooks/ui/ManageWebhooksView.tsx
@@ -116,7 +116,7 @@ export function ManageWebhooksView({
                     <span
                       className={`inline-block rounded px-1.5 py-0.5 font-sans text-caption font-medium ${
                         webhook.isActive
-                          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                          ? 'bg-success/15 text-success'
                           : 'bg-surface text-text-muted'
                       }`}
                     >

--- a/frontend/src/features/media-library/ui/MediaDropzone.tsx
+++ b/frontend/src/features/media-library/ui/MediaDropzone.tsx
@@ -78,7 +78,7 @@ export function MediaDropzone({ isUploading, uploadErrorTitle, onUpload }: Media
         onChange={handleFileChange}
       />
       {uploadErrorTitle !== null ? (
-        <Text muted className="mt-2 text-red-500">
+        <Text muted className="mt-2 text-danger">
           {uploadErrorTitle}
         </Text>
       ) : null}

--- a/frontend/src/features/media-library/ui/MediaUsageList.tsx
+++ b/frontend/src/features/media-library/ui/MediaUsageList.tsx
@@ -28,17 +28,17 @@ export function MediaUsageList({ usages, isLoading }: MediaUsageListProps) {
   return (
     <div
       role="alert"
-      className="rounded-md border border-amber-200 bg-amber-50 px-inline-sm py-stack-xs"
+      className="rounded-md border border-warning bg-warning-weak px-inline-sm py-stack-xs"
     >
       <Stack gap="xs">
-        <Text variant="caption" className="font-medium text-amber-800">
+        <Text variant="caption" className="font-medium text-warning">
           {t('admin.media.usages.blocked', { count: usages.length })}
         </Text>
         <ul className="flex flex-col gap-stack-xs">
           {usages.map((usage) => (
             <li
               key={`${String(usage.entityId)}-${usage.fieldKey}`}
-              className="text-caption leading-body text-amber-800"
+              className="text-caption leading-body text-warning"
             >
               <Link
                 to={`/admin/${usage.entityTypeSlug}/${String(usage.entityId)}`}

--- a/frontend/src/pages/accept-invite/AcceptInvitePage.tsx
+++ b/frontend/src/pages/accept-invite/AcceptInvitePage.tsx
@@ -56,7 +56,7 @@ export function AcceptInvitePage() {
             <Stack gap="md">
               <div
                 role="status"
-                className="rounded-md border border-green-200 bg-green-50 px-inline-sm py-stack-xs text-sm text-green-700 dark:border-green-800 dark:bg-green-950/30 dark:text-green-300"
+                className="rounded-md border border-success bg-success-weak px-inline-sm py-stack-xs text-sm text-success"
               >
                 {t('admin.acceptInvite.success')}
               </div>
@@ -78,7 +78,7 @@ export function AcceptInvitePage() {
                 {acceptInvite.isError ? (
                   <div
                     role="alert"
-                    className="rounded-md border border-red-200 bg-red-50 px-inline-sm py-stack-xs text-sm text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-300"
+                    className="rounded-md border border-danger bg-danger-weak px-inline-sm py-stack-xs text-sm text-danger"
                   >
                     {t('admin.acceptInvite.invalidToken')}
                   </div>

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -164,7 +164,7 @@ export function AppShell() {
         {/* ── Overlay backdrop (mobile only) ──────────────────────────────── */}
         {sidebarOpen ? (
           <div
-            className="fixed inset-0 z-20 bg-black/50 lg:hidden"
+            className="fixed inset-0 z-20 bg-scrim lg:hidden"
             aria-hidden="true"
             onClick={closeSidebar}
           />

--- a/frontend/src/pages/reset-password/ResetPasswordPage.tsx
+++ b/frontend/src/pages/reset-password/ResetPasswordPage.tsx
@@ -56,7 +56,7 @@ export function ResetPasswordPage() {
             <Stack gap="md">
               <div
                 role="status"
-                className="rounded-md border border-green-200 bg-green-50 px-inline-sm py-stack-xs text-sm text-green-700 dark:border-green-800 dark:bg-green-950/30 dark:text-green-300"
+                className="rounded-md border border-success bg-success-weak px-inline-sm py-stack-xs text-sm text-success"
               >
                 {t('admin.resetPassword.success')}
               </div>
@@ -78,7 +78,7 @@ export function ResetPasswordPage() {
                 {confirmReset.isError ? (
                   <div
                     role="alert"
-                    className="rounded-md border border-red-200 bg-red-50 px-inline-sm py-stack-xs text-sm text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-300"
+                    className="rounded-md border border-danger bg-danger-weak px-inline-sm py-stack-xs text-sm text-danger"
                   >
                     {t('admin.resetPassword.invalidToken')}
                   </div>

--- a/frontend/src/pages/verify-email/VerifyEmailPage.tsx
+++ b/frontend/src/pages/verify-email/VerifyEmailPage.tsx
@@ -48,7 +48,7 @@ export function VerifyEmailPage() {
           {token === '' || verify.isError ? (
             <div
               role="alert"
-              className="rounded-md border border-red-200 bg-red-50 px-inline-sm py-stack-xs text-sm text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-300"
+              className="rounded-md border border-danger bg-danger-weak px-inline-sm py-stack-xs text-sm text-danger"
             >
               {token === '' ? t('admin.verifyEmail.invalid') : errorMessage()}
             </div>
@@ -56,7 +56,7 @@ export function VerifyEmailPage() {
             <Stack gap="md">
               <div
                 role="status"
-                className="rounded-md border border-green-200 bg-green-50 px-inline-sm py-stack-xs text-sm text-green-700 dark:border-green-800 dark:bg-green-950/30 dark:text-green-300"
+                className="rounded-md border border-success bg-success-weak px-inline-sm py-stack-xs text-sm text-success"
               >
                 {t('admin.verifyEmail.success')}
               </div>

--- a/frontend/src/shared/ui/components/ConfirmDialog.tsx
+++ b/frontend/src/shared/ui/components/ConfirmDialog.tsx
@@ -66,7 +66,7 @@ export function ConfirmDialog({
         {errorDetail !== null ? (
           <div
             role="alert"
-            className="rounded-md border border-red-200 bg-red-50 px-inline-sm py-stack-xs text-sm text-red-700"
+            className="rounded-md border border-danger bg-danger-weak px-inline-sm py-stack-xs text-sm text-danger"
           >
             {errorDetail}
           </div>

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -45,6 +45,21 @@
   --color-warn: oklch(70% 0.15 75);
   --color-info: oklch(58% 0.14 250);
 
+  /* ── Feedback (status messages / alerts) ─────────────────────────────────
+     success/warning alias the badge status hues so they track each theme + its
+     dark variant automatically (ok/warn are overridden per [data-theme]).
+     *-weak = a tinted surface for alert boxes, derived via color-mix like
+     --color-accent-weak, so it re-resolves against the active theme's hue +
+     surface at the use site (no per-theme/dark duplication needed). */
+  --color-success: var(--color-ok);
+  --color-warning: var(--color-warn);
+  --color-success-weak: color-mix(in oklch, var(--color-ok) 10%, var(--color-surface-raised));
+  --color-warning-weak: color-mix(in oklch, var(--color-warn) 10%, var(--color-surface-raised));
+  --color-danger-weak: color-mix(in oklch, var(--color-danger) 10%, var(--color-surface-raised));
+
+  /* ── Scrim (modal / drawer / mobile-nav backdrop veil) ───────────────── */
+  --color-scrim: oklch(0% 0 0 / 0.5);
+
   /* ── Focus ring ─────────────────────────────────────────────────────── */
   --color-focus-ring: oklch(70% 0.14 72);
 

--- a/frontend/src/shared/ui/toast/ToastProvider.tsx
+++ b/frontend/src/shared/ui/toast/ToastProvider.tsx
@@ -47,12 +47,12 @@ const TYPE_STYLES: Record<
 > = {
   success: {
     container: 'bg-surface-raised border border-border text-text-primary shadow-lg',
-    icon: 'text-green-500',
+    icon: 'text-success',
     iconNode: <IconCheck />,
   },
   error: {
-    container: 'bg-surface-raised border border-red-500/40 text-text-primary shadow-lg',
-    icon: 'text-red-400',
+    container: 'bg-surface-raised border border-danger/40 text-text-primary shadow-lg',
+    icon: 'text-danger',
     iconNode: <IconAlertCircle />,
   },
   info: {


### PR DESCRIPTION
## 目的 (WS-08 / epic #507)

success / error / warning の色が**生 Tailwind パレット直書き**でテーマ・light/dark を追従しない問題と、**未定義トークン**（`text-success`/`text-warning`/`text-error` = 色が出ていない）を解消し、状態色をセマンティックトークンに乗せる。

## 変更

### トークン定義（`default.css` の `@theme` 1箇所＝全テーマ追従）
- `--color-success: var(--color-ok)` / `--color-warning: var(--color-warn)` … 既存のバッジ用 status 色に **alias**。`ok`/`warn` は各テーマ＋dark で個別チューニング済みなので、success/warning も自動でテーマ追従（新規デザイン値ゼロ）。
- `--color-{danger,success,warning}-weak` … `color-mix(... 10%, surface-raised)` で**淡い背景**を派生（既存 `--color-accent-weak` と同方式）。alert箱用。use 時に各テーマの hue＋surface で再解決されるため per-theme/dark 重複が不要。
- `--color-scrim: oklch(0% 0 0 / .5)` … modal/drawer/モバイルnav の backdrop veil。

### 移行（生パレット約26箇所 / 13ファイル）
- `text-red-*`→`text-danger`、`text-green-*`→`text-success`、`text-amber-*`→`text-warning`
- alert箱: `bg-red-50`→`bg-danger-weak` 等、`border-*-200`→`border-{danger,success,warning}`
- pill/badge: `bg-green-100`→`bg-success/15` 等
- **redundant な `dark:` パレット変種を削除**（トークンが light/dark を吸収）
- 未定義 `text-error` 5箇所 → `text-danger`
- `AppShell` モバイル backdrop `bg-black/50` → `bg-scrim`

> 既存の `bg-success/10`・`bg-success/15`（CommentSection / ManageComments の pill）はトークン未定義で**今まで無色**だったが、本 PR の `--color-success` 定義により有効化される。

## 検証
- `npm run check --prefix frontend` 緑（type-check / eslint / prettier / **test 355** / **validate:themes** / knip / build-storybook）
- 生 status パレット残ゼロ・className アーティファクト無しを grep 監査
- **アプリビルド CSS で新 utility 生成を実確認**: `.bg-danger-weak{background-color:var(--color-danger-weak)}`、`.bg-scrim`、`.text-success`、`.bg-success/15{…color-mix(in oklab, var(--color-success) 15%, transparent)}`（hex フォールバック付き）、`--color-success-weak` の `@supports color-mix` 段階的フォールバックも出力を確認

## チェックリスト
- [x] `npm run check` 緑
- [x] ビルド CSS で新トークン utility の生成を確認（視覚回帰の構造的担保）
- [x] 表示意図の保持（success=緑 / warning=琥珀 / danger=赤、light/dark 追従）

Refs #507（残: WS-14/15/16/17/ENT-7・WS-18 — 要 API/製品判断）