### PR TITLE
chore(lint): 生パレット色と features/pages の JA 直書きを禁止する (#507)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -77,6 +77,28 @@ const importZones = [
   },
 ]
 
+const noArbitraryTailwindValues = {
+  selector: 'JSXAttribute[name.name="className"] Literal[value=/\\[.*\\]/]',
+  message: 'Tailwind arbitrary values are forbidden outside shared/ui/theme.',
+}
+
+// Recurrence guards from the #507 audit remediation. Both currently have zero
+// violations; they stop the migrated patterns from creeping back.
+//  - WS-08: raw Tailwind palette colours must be semantic theme tokens.
+//  - WS-10/WS-11: user-facing Japanese must go through i18n (features/pages only).
+const noRawTailwindPalette = {
+  selector:
+    'Literal[value=/\\b(?:bg|text|border|ring|fill|stroke|from|via|to|divide|outline|decoration|shadow|caret|accent)-(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|slate|gray|zinc|neutral|stone)-\\d{2,3}\\b/]',
+  message:
+    'Raw Tailwind palette colours are forbidden — use semantic theme tokens (text-danger, bg-success-weak, text-warning, bg-scrim, …) from src/shared/ui/theme/themes/default.css @theme.',
+}
+
+const noHardcodedJapanese = {
+  selector: 'Literal[value=/[\\u3040-\\u30FF\\u3400-\\u9FFF]/]',
+  message:
+    'Hardcoded Japanese string in a feature/page — route user-facing text through useTranslation()/t(). Non-translatable native endonyms may use an inline eslint-disable with a reason.',
+}
+
 export default tseslint.config(
   {
     ignores: [
@@ -117,12 +139,20 @@ export default tseslint.config(
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
       ...jsxA11y.configs.recommended.rules,
       'import/no-restricted-paths': ['error', { zones: importZones }],
+      'no-restricted-syntax': ['error', noArbitraryTailwindValues, noRawTailwindPalette],
+    },
+  },
+  {
+    // Feature/page components must use semantic tokens + i18n (audit #507 recurrence
+    // guards). Tests and stories are exempt: JA assertions / demo content are fine.
+    files: ['src/features/**/*.{ts,tsx}', 'src/pages/**/*.{ts,tsx}'],
+    ignores: ['**/*.test.{ts,tsx}', '**/*.stories.{ts,tsx}'],
+    rules: {
       'no-restricted-syntax': [
         'error',
-        {
-          selector: 'JSXAttribute[name.name="className"] Literal[value=/\\[.*\\]/]',
-          message: 'Tailwind arbitrary values are forbidden outside shared/ui/theme.',
-        },
+        noArbitraryTailwindValues,
+        noRawTailwindPalette,
+        noHardcodedJapanese,
       ],
     },
   },

--- a/frontend/src/features/manage-entity-types/hooks/use-create-entity-type-form.ts
+++ b/frontend/src/features/manage-entity-types/hooks/use-create-entity-type-form.ts
@@ -53,8 +53,10 @@ export function formValuesToLabels(values: EditEntityTypeFormValues): Record<str
 
 /** Locale-field mapping used to render label inputs in the edit form. */
 export const EDIT_LABEL_FIELDS = [
+  // eslint-disable-next-line no-restricted-syntax -- native language endonym, never translated
   { fieldName: 'labelJa' as const, localeId: 'ja', nativeLabel: '日本語 (ja)' },
   { fieldName: 'labelFr' as const, localeId: 'fr', nativeLabel: 'Français (fr)' },
+  // eslint-disable-next-line no-restricted-syntax -- native language endonym, never translated
   { fieldName: 'labelZhHans' as const, localeId: 'zh-Hans', nativeLabel: '中文（简体）(zh-Hans)' },
   { fieldName: 'labelPtBr' as const, localeId: 'pt-BR', nativeLabel: 'Português (Brasil) (pt-BR)' },
   { fieldName: 'labelDe' as const, localeId: 'de', nativeLabel: 'Deutsch (de)' },

--- a/frontend/src/features/manage-widgets/ui/ManageWidgetsView.tsx
+++ b/frontend/src/features/manage-widgets/ui/ManageWidgetsView.tsx
@@ -144,7 +144,9 @@ export function ManageWidgetsView({ page }: ManageWidgetsViewProps) {
           <Text as="span" variant="caption">
             {t('admin.layoutCfg.hiddenWarning', {
               count: String(hiddenCount),
-              regions: hiddenRegions.map((r) => t(`admin.region.${r}`)).join('・'),
+              regions: hiddenRegions
+                .map((r) => t(`admin.region.${r}`))
+                .join(t('common.listSeparator')),
             })}
           </Text>
           <Button

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -37,6 +37,7 @@ export const en = {
   'common.error.serverError': 'A server error occurred. Please try again later.',
 
   'common.dialog.close': 'Close dialog',
+  'common.listSeparator': ', ',
 
   'common.toast.dismiss': 'Dismiss',
   'common.toast.region': 'Notifications',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -30,6 +30,7 @@ export const ja: Partial<MessageCatalog> = {
   'common.error.serverError': 'サーバーエラーが発生しました。後でもう一度お試しください。',
 
   'common.dialog.close': 'ダイアログを閉じる',
+  'common.listSeparator': '・',
 
   'common.toast.dismiss': '閉じる',
   'common.toast.region': '通知',


### PR DESCRIPTION
## 目的 (audit 横断トラック「lint/CI 強化」/ epic #507)

監査クリティックの所見「境界/規約違反の多くが lint の穴をすり抜ける」に対し、本セッションで解消した **WS-08（生パレット色）** と **WS-10/WS-11（ハードコード i18n）** の**再発を ESLint で防ぐ**。

## 変更

`eslint.config.js` の `no-restricted-syntax` に2セレクタ追加（**追加時点で違反ゼロ**）:

1. **生 Tailwind パレット named color 禁止**（全 src）
   `bg-red-500` / `text-green-600` 等を禁止 → セマンティックトークン（`text-danger` / `bg-success-weak` / `text-warning` / `bg-scrim` …）を強制。
2. **features/pages の文字列リテラル内 日本語 禁止**
   ハードコード JA を禁止し `useTranslation()`/`t()` を強制。**tests / stories / i18n カタログ（src/shared/i18n）は除外**（JA アサーション・demo・翻訳辞書は正当）。

### 副産物（新ルールの実証）
- 新 JA ルールが **WS-11 のスキャンが見逃していた JA 直書きを1件検出**: `ManageWidgetsView` のリージョン名区切り `'・'`（katakana 中点）。→ locale 対応の **`common.listSeparator`**（en `', '` / ja `'・'`）に修正（JA 表示は不変・EN が改善）。
- ネイティブ言語 endonym 2件（`'日本語 (ja)'` / `'中文（简体）(zh-Hans)'`）は**翻訳不可**のため理由付き inline-disable。

## 保留（依存）
- **importZones の `shared→entities` 拡張（WS-04/05）** は、`shared/api`・`shared/lib` の load-bearing な entity 依存（API client の auth store / public-record ドメインヘルパ）の**再配置が前提**のため、別 refactor として保留（`eslint.config.js` のコメントに明記済み）。本 PR では対象外。

## 検証
- `npm run check --prefix frontend` 緑（type-check / **eslint（新ルール適用）** / prettier / 355 test / validate:themes / knip / storybook）
- 新ルールが実際に違反を検出することを確認（上記 `・` を検出 → 修正で解消）

## チェックリスト
- [x] `npm run check` 緑
- [x] 新ルールの実効性を確認（誤検出は endonym のみ・理由付き disable）

Refs #507