### PR TITLE
refactor(shared): 公開フォーマッタを shared/lib へ集約する (#507)

### DIFF
--- a/frontend/src/features/edit-entity-text-fields/ui/FileFieldInput.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/FileFieldInput.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react'
 import { useUploadMedia } from '@/entities/media'
 import { useTranslation } from '@/shared/i18n'
+import { formatBytes } from '@/shared/lib/format-bytes'
 import { Button, Stack, Text } from '@/shared/ui'
 
 interface FileFieldInputProps {
@@ -9,12 +10,6 @@ interface FileFieldInputProps {
   value: string
   disabled: boolean
   onChange: (value: string) => void
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${String(bytes)} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
 function FileIcon({ mimeType }: { mimeType: string }) {

--- a/frontend/src/features/media-library/ui/MediaGrid.tsx
+++ b/frontend/src/features/media-library/ui/MediaGrid.tsx
@@ -1,5 +1,6 @@
 import type { Media } from '@/entities/media'
 import { useTranslation } from '@/shared/i18n'
+import { formatBytes } from '@/shared/lib/format-bytes'
 import { Button, Card, EmptyState, ErrorState, LoadingState, ResponsiveImage } from '@/shared/ui'
 import { IconCopy, IconImage } from '@/shared/ui/icons/Icons'
 
@@ -13,12 +14,6 @@ export interface MediaGridProps {
   onCopy: (media: Media) => void
   onUpdateAlt: (media: Media, altText: string) => void
   onDelete: (media: Media) => void
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${String(bytes)} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
 function isImageMime(mimeType: string): boolean {

--- a/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.ts
+++ b/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.ts
@@ -3,6 +3,7 @@ import { defaultEntityListParams, useEntityList } from '@/entities/entity'
 import { useEntityTypeList } from '@/entities/entity-type'
 import { defaultTextFieldListParamsForEntityType, useTextFieldList } from '@/entities/text-field'
 import { findEntityTypeBySlug } from '@/shared/lib/find-entity-type-by-slug'
+import { formatPublishedDate } from '@/shared/lib/format-published-date'
 import { getRecordDisplayLabel } from '@/shared/lib/get-record-display-label'
 import { resolvePermalink } from '@/shared/lib/resolve-permalink'
 import { PUBLIC_BROWSE_PAGE_SIZE } from '../lib/public-browse-pagination'
@@ -21,17 +22,6 @@ export interface PublicBrowseType {
   slug: string
   name: string
   href: string
-}
-
-function formatPublishedDate(iso: string | null): string {
-  if (iso === null || iso === '') {
-    return ''
-  }
-  const date = new Date(iso)
-  if (Number.isNaN(date.getTime())) {
-    return ''
-  }
-  return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
 }
 
 export function usePublicBrowseEntityRecordsPage(entityTypeSlug: string, offset: number) {

--- a/frontend/src/features/public-home/hooks/use-public-home-page.ts
+++ b/frontend/src/features/public-home/hooks/use-public-home-page.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { usePublicLatestEntities } from '@/entities/entity'
 import { useEntityTypeList } from '@/entities/entity-type'
+import { formatPublishedDate } from '@/shared/lib/format-published-date'
 import { resolvePermalink } from '@/shared/lib/resolve-permalink'
 
 /** A single article in the "Latest records" feed. */
@@ -44,17 +45,6 @@ function humanizeSlug(slug: string | null): string {
     .filter((part) => part !== '')
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ')
-}
-
-function formatPublishedDate(iso: string | null): string {
-  if (iso === null || iso === '') {
-    return ''
-  }
-  const date = new Date(iso)
-  if (Number.isNaN(date.getTime())) {
-    return ''
-  }
-  return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
 }
 
 /**

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
@@ -12,6 +12,7 @@ import {
 import { PageContentContext } from '@/features/render-widgets'
 import { useTranslation } from '@/shared/i18n'
 import { findEntityTypeBySlug } from '@/shared/lib/find-entity-type-by-slug'
+import { formatPublishedDate } from '@/shared/lib/format-published-date'
 import { isMarkdownBodyField } from '@/shared/lib/is-markdown-body-field'
 import { type PublicLayoutKey, resolveLayout } from '@/shared/lib/resolve-layout'
 import {
@@ -31,17 +32,6 @@ import { PublicSiteShell } from './PublicSiteShell'
 import { usePublicSite, type PublicSite } from './public-site-context'
 
 // ── Presentation helpers ──────────────────────────────────────────────────────
-
-function formatPublishedDate(iso: string | null): string {
-  if (iso === null || iso === '') {
-    return ''
-  }
-  const date = new Date(iso)
-  if (Number.isNaN(date.getTime())) {
-    return ''
-  }
-  return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
-}
 
 function humanizeSlug(slug: string | null | undefined): string {
   if (slug == null || slug.trim() === '') {

--- a/frontend/src/shared/lib/format-bytes.test.ts
+++ b/frontend/src/shared/lib/format-bytes.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { formatBytes } from './format-bytes'
+
+describe('formatBytes', () => {
+  it('formats at the B / KB / MB thresholds', () => {
+    expect(formatBytes(0)).toBe('0 B')
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(1024)).toBe('1.0 KB')
+    expect(formatBytes(1536)).toBe('1.5 KB')
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB')
+    expect(formatBytes(5 * 1024 * 1024)).toBe('5.0 MB')
+  })
+})

--- a/frontend/src/shared/lib/format-bytes.ts
+++ b/frontend/src/shared/lib/format-bytes.ts
@@ -1,0 +1,6 @@
+/** Formats a byte count as a compact human-readable size (B / KB / MB). */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${String(bytes)} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}

--- a/frontend/src/shared/lib/format-published-date.test.ts
+++ b/frontend/src/shared/lib/format-published-date.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { formatPublishedDate } from './format-published-date'
+
+describe('formatPublishedDate', () => {
+  it('formats a valid ISO timestamp as a long date', () => {
+    const result = formatPublishedDate('2026-06-23T12:00:00Z')
+    // Timezone-robust assertion (noon UTC stays on the same calendar day worldwide).
+    expect(result).toContain('June')
+    expect(result).toContain('2026')
+  })
+
+  it('returns an empty string for null / empty / unparseable input', () => {
+    expect(formatPublishedDate(null)).toBe('')
+    expect(formatPublishedDate('')).toBe('')
+    expect(formatPublishedDate('not-a-date')).toBe('')
+  })
+})

--- a/frontend/src/shared/lib/format-published-date.ts
+++ b/frontend/src/shared/lib/format-published-date.ts
@@ -1,0 +1,17 @@
+/**
+ * Formats an ISO timestamp as a human-readable published date
+ * (e.g. "June 23, 2026"). Returns '' for null / empty / unparseable input.
+ *
+ * Shared by the public home / browse / record-detail views (WS-17): a single
+ * source of truth instead of three identical local copies.
+ */
+export function formatPublishedDate(iso: string | null): string {
+  if (iso === null || iso === '') {
+    return ''
+  }
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+  return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+}


### PR DESCRIPTION
## 目的 (WS-17 / epic #507)

複数ファイルに**バイト同一で重複**していた public 系フォーマッタを `shared/lib` の単一ソースへ集約する（DRY・ドリフト防止）。

## 変更
- **`formatPublishedDate`**（3重複: public-home / public-browse / PublicRecordDetailPage）→ `src/shared/lib/format-published-date.ts`
- **`formatBytes`**（2重複: MediaGrid / FileFieldInput）→ `src/shared/lib/format-bytes.ts`
- 各 consumer の local 定義を撤去し import へ差し替え（**挙動不変**・既存の `get-record-display-label.ts` と同じ「1関数1ファイル・直 import」規約）
- 集約した純関数に**回帰テストを追加**（従来は component 内 inline で未テスト・3ケース）

## スコープ外
- WS-17 の残り「**menu location の製品判断**」は機能をどう扱うかの判断が要るため本 PR に含めない（要相談）。

## 検証
- `npm run check --prefix frontend` 緑（type-check / eslint / prettier / **test 358** / validate:themes / knip / storybook）
- 撤去後に `function formatPublishedDate|formatBytes` の local 定義が残っていないことを grep 確認

Refs #507