### PR TITLE
refactor(entity): theme entity の query-key を factory 化する (#507)

### DIFF
--- a/frontend/src/entities/theme/mutations.ts
+++ b/frontend/src/entities/theme/mutations.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
 import { apiClient, type AppError } from '@/shared/api/client'
 import type { ThemeDto, ThemeManifestDto } from './api-types'
+import { themeKeys } from './query-keys'
 
 /** Register a new runtime theme from a full manifest. The server validates and may 422. */
 export function useCreateTheme(): UseMutationResult<ThemeDto, AppError, ThemeManifestDto> {
@@ -9,7 +10,7 @@ export function useCreateTheme(): UseMutationResult<ThemeDto, AppError, ThemeMan
     mutationFn: (manifest: ThemeManifestDto) =>
       apiClient.post<ThemeDto>('/api/v1/themes', manifest),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['themes'] })
+      void queryClient.invalidateQueries({ queryKey: themeKeys.all })
     },
   })
 }
@@ -21,7 +22,7 @@ export function useDeleteTheme(): UseMutationResult<undefined, AppError, string>
     mutationFn: (themeKey: string) =>
       apiClient.delete(`/api/v1/themes/${encodeURIComponent(themeKey)}`),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['themes'] })
+      void queryClient.invalidateQueries({ queryKey: themeKeys.all })
     },
   })
 }
@@ -37,7 +38,7 @@ export function useUpdateTheme(): UseMutationResult<
     mutationFn: ({ key, manifest }) =>
       apiClient.put<ThemeDto>(`/api/v1/themes/${encodeURIComponent(key)}`, manifest),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['themes'] })
+      void queryClient.invalidateQueries({ queryKey: themeKeys.all })
     },
   })
 }

--- a/frontend/src/entities/theme/queries.ts
+++ b/frontend/src/entities/theme/queries.ts
@@ -1,6 +1,7 @@
 import { useQuery, type UseQueryResult } from '@tanstack/react-query'
 import { apiClient, type AppError } from '@/shared/api/client'
 import type { ThemeListDto } from './api-types'
+import { themeKeys } from './query-keys'
 
 /**
  * Public list of runtime (data-driven) themes. The public site applies the
@@ -8,7 +9,7 @@ import type { ThemeListDto } from './api-types'
  */
 export function usePublicThemes(): UseQueryResult<ThemeListDto, AppError> {
   return useQuery({
-    queryKey: ['themes', 'public'],
+    queryKey: themeKeys.publicList(),
     queryFn: async ({ signal }) => apiClient.get<ThemeListDto>('/api/v1/public/themes', signal),
   })
 }
@@ -16,7 +17,7 @@ export function usePublicThemes(): UseQueryResult<ThemeListDto, AppError> {
 /** Admin list of runtime themes (auth) — for the theme picker / management. */
 export function useThemes(): UseQueryResult<ThemeListDto, AppError> {
   return useQuery({
-    queryKey: ['themes', 'admin'],
+    queryKey: themeKeys.adminList(),
     queryFn: async ({ signal }) => apiClient.get<ThemeListDto>('/api/v1/themes', signal),
   })
 }

--- a/frontend/src/entities/theme/query-keys.ts
+++ b/frontend/src/entities/theme/query-keys.ts
@@ -1,0 +1,11 @@
+/**
+ * Query-key factory for the theme entity. Matches the `xKeys` convention used by
+ * every other entity module (settingKeys / widgetKeys / …): a shared `all`
+ * prefix so a mutation can invalidate both the public and admin theme lists in
+ * one call, and named sub-keys so the lists never drift apart by hand.
+ */
+export const themeKeys = {
+  all: ['themes'] as const,
+  publicList: () => [...themeKeys.all, 'public'] as const,
+  adminList: () => [...themeKeys.all, 'admin'] as const,
+}


### PR DESCRIPTION
## 目的 (WS-16 / epic #507)

`theme` は**全 entity 中ただ一つ** query-key をインライン（`['themes', ...]`）で持つ outlier だった（他 27 entity は `xKeys` factory を保有）。これを規約に揃える。

## 変更
- `src/entities/theme/query-keys.ts` を追加（`themeKeys`: `all` / `publicList()` / `adminList()`）— `settingKeys` 等と同形。
- `queries.ts` / `mutations.ts` をインラインキーから `themeKeys` へ差し替え。
  - **キー配列は不変**（`['themes','public']` 等そのまま）＝**挙動不変・consumer 変更なし**。
  - mutation の invalidation は `themeKeys.all` で public/admin 両リストを一括無効化（従来と同じ）。

## `model.ts` / `mapper.ts` を追加しない判断
他 entity は DTO→ドメイン変換のため model/mapper を持つが、**`theme` は DTO がそのままドメイン契約のパススルー** entity（変換なし・consumer も DTO を直接利用）。恒等 mapper を入れるとランタイム theming 経路の consumer 3本（`PublicShell` / `useThemeCustomizePage` / `usePublicThemePage`）の型移行を伴う ceremony になり、振る舞い・型安全の利得が無い。**query-key の集約が実質的な正規化ギャップ**だったため、そこに絞った。フル model/mapper 化が必要なら別途相談。

## 検証
- `npm run check --prefix frontend` 緑（type-check / eslint / prettier / 355 test / validate:themes / knip / storybook）

Refs #507