### PR TITLE
fix(server): bypass ルートで orgId を 0 にし access-log の例外を解消する (#528)

### DIFF
--- a/src/Organization/Resolution/OrgResolverMiddleware.php
+++ b/src/Organization/Resolution/OrgResolverMiddleware.php
@@ -16,9 +16,10 @@ use Psr\Http\Server\RequestHandlerInterface;
  * Resolves the current organization from the request and stores its ID
  * in a RequestScopedHolder for downstream repositories to read.
  *
- * Bypass paths (superadmin org management, health, auth) skip resolution
- * and pass through with org ID unset. Repositories on those routes must
- * not call $orgId->get().
+ * Bypass paths (superadmin org management, health, auth) skip resolution but
+ * still seed the holder with 0 — the no-org sentinel (access_logs.organization_id
+ * is NOT NULL DEFAULT 0) — so downstream request-scoped readers such as the
+ * access-log writer don't fault on these org-agnostic routes.
  *
  * Resolution order:
  *  1. strategy->resolve() → slug or custom domain identifier
@@ -56,9 +57,13 @@ final readonly class OrgResolverMiddleware implements MiddlewareInterface
     {
         $path = $request->getUri()->getPath();
 
-        // Bypass: superadmin / health / auth routes don't need org context
+        // Bypass: superadmin / health / auth routes don't need org context, but
+        // downstream request-scoped readers (e.g. the access-log writer) still read
+        // the holder — seed it with 0 (the no-org sentinel) so they don't fault.
         foreach (self::BYPASS_PREFIXES as $prefix) {
             if (str_starts_with($path, $prefix)) {
+                $this->orgId->set(0);
+
                 return $handler->handle($request);
             }
         }

--- a/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
+++ b/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Organization\Resolution;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Organization\Resolution\OrgResolutionStrategyInterface;
+use NeNeRecords\Organization\Resolution\OrgResolverMiddleware;
+use NeNeRecords\Tests\Organization\InMemoryOrganizationRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class OrgResolverMiddlewareTest extends TestCase
+{
+    /**
+     * Bypass routes (auth / superadmin / org management / health) carry no tenant,
+     * but the holder must still be seeded with 0 (the no-org sentinel) so that
+     * downstream request-scoped readers — notably the access-log writer — don't
+     * fault with "RequestScopedHolder::get() called before set()". Regression for #528.
+     */
+    public function testBypassRouteSeedsOrgIdWithZero(): void
+    {
+        $factory = new Psr17Factory();
+        /** @var RequestScopedHolder<int> $orgId */
+        $orgId = new RequestScopedHolder();
+
+        $middleware = new OrgResolverMiddleware(
+            $orgId,
+            new InMemoryOrganizationRepository(),
+            new ProblemDetailsResponseFactory($factory, $factory),
+            new class () implements OrgResolutionStrategyInterface {
+                public function resolve(ServerRequestInterface $request): ?string
+                {
+                    return null;
+                }
+            },
+        );
+
+        $response = $middleware->process(
+            $factory->createServerRequest('POST', 'https://example.test/api/v1/auth/login'),
+            new readonly class ($factory) implements RequestHandlerInterface {
+                public function __construct(private Psr17Factory $factory)
+                {
+                }
+
+                public function handle(ServerRequestInterface $request): ResponseInterface
+                {
+                    return $this->factory->createResponse(200);
+                }
+            },
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(0, $orgId->get());
+    }
+}


### PR DESCRIPTION
## 目的
`Closes #528`。`docker compose logs app` に再発していた非致命 ERROR を解消する:

```
level=ERROR "Failed to persist access log entry."
exception: Nene2\Http\RequestScopedHolder::get() called before set()
path: /api/v1/auth/login
```

## 原因
`OrgResolverMiddleware` は bypass プレフィックス（`/health`, `/api/v1/organizations`, `/api/v1/superadmin/`, `/api/v1/auth/`）を早期 return で通す際 **`$this->orgId->set()` を呼ばない**。一方 `AccessLogMiddleware` はハンドラ後に毎リクエスト insert し、`PdoAccessLogRepository::insert()` が org スコープの `$this->orgId->get()` を呼ぶため、bypass ルートで未 set → 例外（catch して ERROR ログ・access-log 行は欠落）。リクエスト本体は 200 成功する非致命。

## 変更
- `OrgResolverMiddleware` の bypass 分岐に **`$this->orgId->set(0)`** を追加。
  - `0` は `access_logs.organization_id NOT NULL DEFAULT 0`（migration 20260628000001）の **no-org sentinel** と整合。
  - 同 middleware の非 bypass 分岐 `$org->id ?? 0` とも一貫（0 = org なし）。
  - これで auth / superadmin の access-log も **org_id=0 で保持**され（監査ログ維持）、例外が解消。bypass ルートで他の org スコープ repo は呼ばれないため副作用なし。
- クラス docstring を新挙動（「0 を seed」）に更新。
- **回帰テスト** `OrgResolverMiddlewareTest`：bypass パス（`/api/v1/auth/login`）の process 後に `orgId->get() === 0` かつハンドラ 200 を検証。

## 検証
- `composer check` 緑（**PHPUnit 846 / 2305 assertions**・**PHPStan level 8 エラー0**・CS-Fixer clean・OpenAPI valid・MCP valid）。

## 備考
フロント epic #507 とは無関係の別件バックエンド修正（#507 の作業中に発見）。