### PR TITLE
feat(seo): 公開レコードの SSR head に OGP/Twitter/canonical/JSON-LD を付与する (#537)

### DIFF
--- a/src/PreviewToken/GetPreviewRecordViewUseCase.php
+++ b/src/PreviewToken/GetPreviewRecordViewUseCase.php
@@ -21,6 +21,7 @@ use NeNeRecords\IntField\IntField;
 use NeNeRecords\IntField\IntFieldRepositoryInterface;
 use NeNeRecords\PublicRecord\GetPublicRecordViewOutput;
 use NeNeRecords\PublicRecord\PublicFieldDisplayFormatter;
+use NeNeRecords\PublicRecord\PublicPermalinkResolver;
 use NeNeRecords\PublicRecord\PublicRecordViewDisplayField;
 use NeNeRecords\PublicRecord\PublicRecordViewHttpMapper;
 use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
@@ -170,12 +171,24 @@ final readonly class GetPreviewRecordViewUseCase implements GetPreviewRecordView
             ),
         ];
 
+        $canonicalPath = PublicPermalinkResolver::resolve(
+            $entityType->permalinkPattern,
+            $entityTypeSlug,
+            $entity->slug,
+            $entityId,
+            $entity->publishedAt,
+        );
+
         return new GetPublicRecordViewOutput(
             entityTypeSlug: $entityTypeSlug,
             entityTypeName: $entityType->name,
             entityId: $entityId,
             entitySlug: $entitySlug,
             pageTitle: $pageTitle,
+            metaDescription: $entity->metaDescription ?? '',
+            canonicalPath: $canonicalPath,
+            publishedAtIso: $entity->publishedAt?->format(\DateTimeInterface::ATOM),
+            updatedAtIso: $entity->updatedAt?->format(\DateTimeInterface::ATOM),
             bootstrap: $bootstrap,
             displayFields: $displayFields,
         );

--- a/src/PublicRecord/GetPublicRecordViewOutput.php
+++ b/src/PublicRecord/GetPublicRecordViewOutput.php
@@ -16,6 +16,10 @@ final readonly class GetPublicRecordViewOutput
         public int $entityId,
         public string $entitySlug,
         public string $pageTitle,
+        public string $metaDescription,
+        public string $canonicalPath,
+        public ?string $publishedAtIso,
+        public ?string $updatedAtIso,
         public array $bootstrap,
         public array $displayFields,
     ) {

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -162,12 +162,24 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             ),
         ];
 
+        $canonicalPath = PublicPermalinkResolver::resolve(
+            $entityType->permalinkPattern,
+            $input->entityTypeSlug,
+            $entity->slug,
+            $entityId,
+            $entity->publishedAt,
+        );
+
         return new GetPublicRecordViewOutput(
             entityTypeSlug: $input->entityTypeSlug,
             entityTypeName: $entityType->name,
             entityId: $entityId,
             entitySlug: $input->entitySlug,
             pageTitle: $pageTitle,
+            metaDescription: $entity->metaDescription ?? '',
+            canonicalPath: $canonicalPath,
+            publishedAtIso: $entity->publishedAt?->format(\DateTimeInterface::ATOM),
+            updatedAtIso: $entity->updatedAt?->format(\DateTimeInterface::ATOM),
             bootstrap: $bootstrap,
             displayFields: $displayFields,
         );

--- a/src/PublicRecord/PublicPermalinkResolver.php
+++ b/src/PublicRecord/PublicPermalinkResolver.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use DateTimeImmutable;
+use DateTimeZone;
+
+/**
+ * Resolves a public record permalink from an entity type's pattern.
+ *
+ * Mirrors the frontend resolver (`frontend/src/shared/lib/resolve-permalink.ts`)
+ * so server-rendered canonical/og:url values match the SPA's user-facing URLs.
+ *
+ * Supported tokens: {type} {slug} {id} {year} {month} {day}
+ * ({year}/{month}/{day} come from publishedAt in UTC, else "0000"/"00"/"00").
+ */
+final readonly class PublicPermalinkResolver
+{
+    public const DEFAULT_PATTERN = '/{type}/{id}';
+
+    public static function resolve(
+        ?string $pattern,
+        string $typeSlug,
+        ?string $entitySlug,
+        int $entityId,
+        ?DateTimeImmutable $publishedAt,
+    ): string {
+        $pat = ($pattern === null || $pattern === '') ? self::DEFAULT_PATTERN : $pattern;
+
+        if ($publishedAt !== null) {
+            $utc = $publishedAt->setTimezone(new DateTimeZone('UTC'));
+            $year = $utc->format('Y');
+            $month = $utc->format('m');
+            $day = $utc->format('d');
+        } else {
+            $year = '0000';
+            $month = '00';
+            $day = '00';
+        }
+
+        $slug = ($entitySlug === null || $entitySlug === '') ? (string) $entityId : $entitySlug;
+
+        return strtr($pat, [
+            '{type}' => $typeSlug,
+            '{slug}' => $slug,
+            '{id}' => (string) $entityId,
+            '{year}' => $year,
+            '{month}' => $month,
+            '{day}' => $day,
+        ]);
+    }
+}

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -38,6 +38,15 @@ final readonly class RenderPublicRecordViewHandler
         $output = $this->useCase->execute(new GetPublicRecordViewInput($typeSlug, $entitySlug));
         $siteSettings = $this->resolveSiteSettings();
 
+        // Canonical / og:url point at the user-facing permalink (not this /view/ twin).
+        $uri = $request->getUri();
+        $canonicalUrl = $uri->getScheme() . '://' . $uri->getAuthority() . $output->canonicalPath;
+
+        // Prefer the per-entity meta description, falling back to the site default.
+        $metaDescription = $output->metaDescription !== ''
+            ? $output->metaDescription
+            : $siteSettings['default_meta_description'];
+
         $bootstrapJson = json_encode(
             $output->bootstrap,
             JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE,
@@ -56,7 +65,10 @@ final readonly class RenderPublicRecordViewHandler
             'entityId' => $output->entityId,
             'displayFields' => $output->displayFields,
             'siteName' => $siteSettings['site_name'],
-            'metaDescription' => $siteSettings['default_meta_description'],
+            'metaDescription' => $metaDescription,
+            'canonicalUrl' => $canonicalUrl,
+            'publishedAtIso' => $output->publishedAtIso,
+            'updatedAtIso' => $output->updatedAtIso,
             'bootstrapJson' => $bootstrapJson,
             'includeViteClient' => $this->config->debug,
             'viteUrl' => rtrim($viteUrl, '/'),

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -7,6 +7,42 @@
       <meta name="description" content="<?= $e($metaDescription) ?>" />
     <?php endif; ?>
     <title><?= $e($pageTitle) ?> — <?= $e($siteName) ?></title>
+    <link rel="canonical" href="<?= $e($canonicalUrl) ?>" />
+
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="<?= $e($pageTitle) ?>" />
+    <?php if ($metaDescription !== ''): ?>
+      <meta property="og:description" content="<?= $e($metaDescription) ?>" />
+    <?php endif; ?>
+    <meta property="og:site_name" content="<?= $e($siteName) ?>" />
+    <meta property="og:url" content="<?= $e($canonicalUrl) ?>" />
+
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="<?= $e($pageTitle) ?>" />
+    <?php if ($metaDescription !== ''): ?>
+      <meta name="twitter:description" content="<?= $e($metaDescription) ?>" />
+    <?php endif; ?>
+
+    <?php
+      $jsonLd = [
+          '@context' => 'https://schema.org',
+          '@type' => 'BlogPosting',
+          'headline' => $pageTitle,
+          'url' => $canonicalUrl,
+          'mainEntityOfPage' => $canonicalUrl,
+          'publisher' => ['@type' => 'Organization', 'name' => $siteName],
+      ];
+      if ($metaDescription !== '') {
+          $jsonLd['description'] = $metaDescription;
+      }
+      if ($publishedAtIso !== null) {
+          $jsonLd['datePublished'] = $publishedAtIso;
+      }
+      if ($updatedAtIso !== null) {
+          $jsonLd['dateModified'] = $updatedAtIso;
+      }
+    ?>
+    <script type="application/ld+json"><?= json_encode($jsonLd, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?></script>
     <style>
       .markdown-body { display: flex; flex-direction: column; gap: 0.75rem; line-height: 1.6; }
       .markdown-body :is(h1, h2, h3, h4) { font-weight: 600; line-height: 1.3; }

--- a/tests/PublicRecord/PublicPermalinkResolverTest.php
+++ b/tests/PublicRecord/PublicPermalinkResolverTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use DateTimeImmutable;
+use NeNeRecords\PublicRecord\PublicPermalinkResolver;
+use PHPUnit\Framework\TestCase;
+
+final class PublicPermalinkResolverTest extends TestCase
+{
+    public function testNullPatternFallsBackToDefaultTypeId(): void
+    {
+        self::assertSame(
+            '/posts/42',
+            PublicPermalinkResolver::resolve(null, 'posts', 'my-article', 42, null),
+        );
+    }
+
+    public function testPostNamePatternUsesSlug(): void
+    {
+        self::assertSame(
+            '/posts/my-article',
+            PublicPermalinkResolver::resolve('/{type}/{slug}', 'posts', 'my-article', 42, null),
+        );
+    }
+
+    public function testSlugFallsBackToIdWhenMissing(): void
+    {
+        self::assertSame(
+            '/posts/42',
+            PublicPermalinkResolver::resolve('/{type}/{slug}', 'posts', null, 42, null),
+        );
+    }
+
+    public function testDatePatternUsesUtcPublishedAt(): void
+    {
+        self::assertSame(
+            '/posts/2026/01/15/my-article',
+            PublicPermalinkResolver::resolve(
+                '/{type}/{year}/{month}/{day}/{slug}',
+                'posts',
+                'my-article',
+                42,
+                new DateTimeImmutable('2026-01-15T10:00:00+09:00'),
+            ),
+        );
+    }
+
+    public function testDateTokensAreZeroedWithoutPublishedAt(): void
+    {
+        self::assertSame(
+            '/posts/0000/00/00/my-article',
+            PublicPermalinkResolver::resolve(
+                '/{type}/{year}/{month}/{day}/{slug}',
+                'posts',
+                'my-article',
+                42,
+                null,
+            ),
+        );
+    }
+}

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Tests\PublicRecord;
 
+use DateTimeImmutable;
 use Nene2\Config\AppConfig;
 use Nene2\Config\AppEnvironment;
 use Nene2\Config\DatabaseConfig;
@@ -57,7 +58,15 @@ final class PublicRecordHttpTest extends TestCase
             new EntityType(name: 'Article', slug: 'article', id: 1),
         ]);
         $entities = new InMemoryEntityRepository([
-            new Entity(id: 10, entityTypeId: 1, slug: 'hello-world', status: EntityStatus::Published),
+            new Entity(
+                id: 10,
+                entityTypeId: 1,
+                slug: 'hello-world',
+                status: EntityStatus::Published,
+                publishedAt: new DateTimeImmutable('2026-01-15T00:00:00+00:00'),
+                updatedAt: new DateTimeImmutable('2026-02-20T00:00:00+00:00'),
+                metaDescription: 'A short summary.',
+            ),
         ]);
         $fieldDefs = new InMemoryFieldDefRepository([
             new FieldDef(entityTypeId: 1, fieldKey: 'title', dataType: 'text', id: 1),
@@ -166,6 +175,38 @@ final class PublicRecordHttpTest extends TestCase
         self::assertStringContainsString('"entityTypeSlug":"article"', $html);
         self::assertStringContainsString('<h2>Sample</h2>', $html);
         self::assertStringContainsString('<strong>bold</strong>', $html);
+    }
+
+    public function testRenderPublicRecordViewIncludesSeoHeadTags(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest(
+                'GET',
+                'https://example.test/view/article/hello-world',
+            ),
+        );
+        $html = (string) $response->getBody();
+
+        self::assertSame(200, $response->getStatusCode());
+        // Canonical / og:url point at the user-facing permalink (default /{type}/{id}), not /view/.
+        self::assertStringContainsString('<link rel="canonical" href="https://example.test/article/10" />', $html);
+        self::assertStringContainsString('content="https://example.test/article/10"', $html);
+        // Open Graph
+        self::assertStringContainsString('property="og:type" content="article"', $html);
+        self::assertStringContainsString('property="og:title" content="Hello world"', $html);
+        self::assertStringContainsString('property="og:description" content="A short summary."', $html);
+        self::assertStringContainsString('property="og:site_name" content="NeNe Records"', $html);
+        // Twitter Card
+        self::assertStringContainsString('name="twitter:card" content="summary"', $html);
+        self::assertStringContainsString('name="twitter:title" content="Hello world"', $html);
+        // Per-entity meta description (not the site default)
+        self::assertStringContainsString('<meta name="description" content="A short summary." />', $html);
+        // JSON-LD structured data
+        self::assertStringContainsString('application/ld+json', $html);
+        self::assertStringContainsString('"@type":"BlogPosting"', $html);
+        self::assertStringContainsString('"headline":"Hello world"', $html);
+        self::assertStringContainsString('"datePublished":"2026-01-15T00:00:00+00:00"', $html);
+        self::assertStringContainsString('"dateModified":"2026-02-20T00:00:00+00:00"', $html);
     }
 
     /** @return array<string, mixed> */


### PR DESCRIPTION
## 目的
`#537` S1（エピック #536 / レポート #534 由来）。**全6ペルソナが最大の採用障害に挙げた公開サイト SEO** の第一スライス。サーバ描画される公開レコードビュー `/view/{type}/{entitySlug}` の `<head>` を SEO/ソーシャル対応にする。

## 変更
- `PublicPermalinkResolver`（新規）— フロント `resolve-permalink.ts` をミラー。canonical/og:url を `/view/` ツインではなく**ユーザー向け permalink**（既定 `/{type}/{id}` 等）に揃える。
- `record-detail.php` の `<head>` に追加: **per-entity meta description**（サイト既定フォールバック）/ `<link rel=canonical>` / **Open Graph**（og:type=article, title, description, site_name, url）/ **Twitter Card**(summary) / **JSON-LD `BlogPosting`**（headline/url/description/datePublished/dateModified/publisher）。
- `GetPublicRecordViewOutput` に `metaDescription` / `canonicalPath` / `publishedAtIso` / `updatedAtIso` を追加。公開・プレビュー両 UseCase が供給（プレビューの構築 500 退行も解消）。

## 検証
- `composer check` 緑（**PHPUnit 852 / 2325 assertions**・PHPStan lvl8 0 error・CS-Fixer・OpenAPI・MCP）。
- 追加テスト: `PublicRecordHttpTest::testRenderPublicRecordViewIncludesSeoHeadTags`（head タグ）/ `PublicPermalinkResolverTest`（トークン解決 5 ケース）。
- 実機: `GET /view/posts/blocks-showcase` で per-entity description・canonical `/posts/246`・OGP・Twitter・JSON-LD(datePublished/dateModified) を目視確認。

## 後続スライス（本PRには含めない）
- S2: ユーザー向け permalink でクローラブル HTML を配信（SPA ルートと SSR 統合／プリレンダ／ボット配信・要アーキ判断）。
- S3: sitemap.xml / RSS、og:image、NewsArticle 等。

Part of #537 / #536