### PR TITLE
feat(seo): OG画像を派生画像エンジンで自動生成し og:image を自動充填する (#547)

### DIFF
--- a/src/Media/MediaDerivativeUrl.php
+++ b/src/Media/MediaDerivativeUrl.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Media;
+
+/**
+ * Resolves the on-demand derivative URL for a media-library image URL.
+ *
+ * Mirrors the frontend resolver (`frontend/src/shared/lib/media-derivatives.ts`):
+ * given the public URL of a media image (`.../media/{year}/{month}/{file}`),
+ * returns the derivative URL for a preset (`.../media/{preset}/{year}/{month}/{file}`).
+ * Returns null for non-media URLs, non-image extensions, or unknown presets so
+ * callers can fall back (e.g. omit og:image).
+ */
+final readonly class MediaDerivativeUrl
+{
+    private const MEDIA_PATH = '~^(.*/media/)(\d{4})/(\d{2})/([^/?#]+)$~';
+    private const IMAGE_EXTENSIONS = '/\.(png|jpe?g|webp|gif|avif)$/i';
+
+    public static function forPreset(string $url, string $preset): ?string
+    {
+        if (!MediaImagePresets::isValid($preset)) {
+            return null;
+        }
+
+        if (preg_match(self::MEDIA_PATH, $url, $m) !== 1) {
+            return null;
+        }
+
+        [, $prefix, $year, $month, $filename] = $m;
+
+        if (preg_match(self::IMAGE_EXTENSIONS, $filename) !== 1) {
+            return null;
+        }
+
+        return $prefix . $preset . '/' . $year . '/' . $month . '/' . $filename;
+    }
+}

--- a/src/Media/MediaImagePresets.php
+++ b/src/Media/MediaImagePresets.php
@@ -17,6 +17,9 @@ final class MediaImagePresets
         'sm' => 320,
         'md' => 640,
         'lg' => 1280,
+        // Social card width (og:image / twitter:image). Aspect is preserved
+        // (width-constrained), which social platforms crop/letterbox as needed.
+        'og' => 1200,
     ];
 
     public static function isValid(string $name): bool

--- a/src/PreviewToken/GetPreviewRecordViewUseCase.php
+++ b/src/PreviewToken/GetPreviewRecordViewUseCase.php
@@ -19,6 +19,7 @@ use NeNeRecords\FieldDef\FieldDef;
 use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
 use NeNeRecords\IntField\IntField;
 use NeNeRecords\IntField\IntFieldRepositoryInterface;
+use NeNeRecords\Media\MediaDerivativeUrl;
 use NeNeRecords\PublicRecord\GetPublicRecordViewOutput;
 use NeNeRecords\PublicRecord\PublicFieldDisplayFormatter;
 use NeNeRecords\PublicRecord\PublicPermalinkResolver;
@@ -179,6 +180,18 @@ final readonly class GetPreviewRecordViewUseCase implements GetPreviewRecordView
             $entity->publishedAt,
         );
 
+        $ogImagePath = null;
+        foreach ($displayFields as $field) {
+            if ($field->dataType !== 'image') {
+                continue;
+            }
+            $candidate = MediaDerivativeUrl::forPreset($field->displayValue, 'og');
+            if ($candidate !== null) {
+                $ogImagePath = $candidate;
+                break;
+            }
+        }
+
         return new GetPublicRecordViewOutput(
             entityTypeSlug: $entityTypeSlug,
             entityTypeName: $entityType->name,
@@ -187,6 +200,7 @@ final readonly class GetPreviewRecordViewUseCase implements GetPreviewRecordView
             pageTitle: $pageTitle,
             metaDescription: $entity->metaDescription ?? '',
             canonicalPath: $canonicalPath,
+            ogImagePath: $ogImagePath,
             publishedAtIso: $entity->publishedAt?->format(\DateTimeInterface::ATOM),
             updatedAtIso: $entity->updatedAt?->format(\DateTimeInterface::ATOM),
             bootstrap: $bootstrap,

--- a/src/PublicRecord/GetPublicRecordViewOutput.php
+++ b/src/PublicRecord/GetPublicRecordViewOutput.php
@@ -18,6 +18,7 @@ final readonly class GetPublicRecordViewOutput
         public string $pageTitle,
         public string $metaDescription,
         public string $canonicalPath,
+        public ?string $ogImagePath,
         public ?string $publishedAtIso,
         public ?string $updatedAtIso,
         public array $bootstrap,

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -19,6 +19,7 @@ use NeNeRecords\FieldDef\FieldDef;
 use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
 use NeNeRecords\IntField\IntField;
 use NeNeRecords\IntField\IntFieldRepositoryInterface;
+use NeNeRecords\Media\MediaDerivativeUrl;
 use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
 use NeNeRecords\Setting\SettingEntry;
 use NeNeRecords\Setting\SettingHttpMapper;
@@ -170,6 +171,8 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             $entity->publishedAt,
         );
 
+        $ogImagePath = $this->resolveOgImagePath($displayFields);
+
         return new GetPublicRecordViewOutput(
             entityTypeSlug: $input->entityTypeSlug,
             entityTypeName: $entityType->name,
@@ -178,11 +181,35 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             pageTitle: $pageTitle,
             metaDescription: $entity->metaDescription ?? '',
             canonicalPath: $canonicalPath,
+            ogImagePath: $ogImagePath,
             publishedAtIso: $entity->publishedAt?->format(\DateTimeInterface::ATOM),
             updatedAtIso: $entity->updatedAt?->format(\DateTimeInterface::ATOM),
             bootstrap: $bootstrap,
             displayFields: $displayFields,
         );
+    }
+
+    /**
+     * Pick the first image field whose value resolves to a media derivative,
+     * for use as the og:image / twitter:image social card. Null if none.
+     *
+     * @param list<PublicRecordViewDisplayField> $displayFields
+     */
+    private function resolveOgImagePath(array $displayFields): ?string
+    {
+        foreach ($displayFields as $field) {
+            if ($field->dataType !== 'image') {
+                continue;
+            }
+
+            $candidate = MediaDerivativeUrl::forPreset($field->displayValue, 'og');
+
+            if ($candidate !== null) {
+                return $candidate;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -40,7 +40,16 @@ final readonly class RenderPublicRecordViewHandler
 
         // Canonical / og:url point at the user-facing permalink (not this /view/ twin).
         $uri = $request->getUri();
-        $canonicalUrl = $uri->getScheme() . '://' . $uri->getAuthority() . $output->canonicalPath;
+        $baseUrl = $uri->getScheme() . '://' . $uri->getAuthority();
+        $canonicalUrl = $baseUrl . $output->canonicalPath;
+
+        // og:image / twitter:image — absolutize the entity's social-card derivative.
+        $ogImageUrl = null;
+        if ($output->ogImagePath !== null) {
+            $ogImageUrl = str_starts_with($output->ogImagePath, 'http')
+                ? $output->ogImagePath
+                : $baseUrl . $output->ogImagePath;
+        }
 
         // Prefer the per-entity meta description, falling back to the site default.
         $metaDescription = $output->metaDescription !== ''
@@ -67,6 +76,7 @@ final readonly class RenderPublicRecordViewHandler
             'siteName' => $siteSettings['site_name'],
             'metaDescription' => $metaDescription,
             'canonicalUrl' => $canonicalUrl,
+            'ogImageUrl' => $ogImageUrl,
             'publishedAtIso' => $output->publishedAtIso,
             'updatedAtIso' => $output->updatedAtIso,
             'bootstrapJson' => $bootstrapJson,

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -16,11 +16,17 @@
     <?php endif; ?>
     <meta property="og:site_name" content="<?= $e($siteName) ?>" />
     <meta property="og:url" content="<?= $e($canonicalUrl) ?>" />
+    <?php if ($ogImageUrl !== null): ?>
+      <meta property="og:image" content="<?= $e($ogImageUrl) ?>" />
+    <?php endif; ?>
 
-    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:card" content="<?= $ogImageUrl !== null ? 'summary_large_image' : 'summary' ?>" />
     <meta name="twitter:title" content="<?= $e($pageTitle) ?>" />
     <?php if ($metaDescription !== ''): ?>
       <meta name="twitter:description" content="<?= $e($metaDescription) ?>" />
+    <?php endif; ?>
+    <?php if ($ogImageUrl !== null): ?>
+      <meta name="twitter:image" content="<?= $e($ogImageUrl) ?>" />
     <?php endif; ?>
 
     <?php
@@ -40,6 +46,9 @@
       }
       if ($updatedAtIso !== null) {
           $jsonLd['dateModified'] = $updatedAtIso;
+      }
+      if ($ogImageUrl !== null) {
+          $jsonLd['image'] = $ogImageUrl;
       }
     ?>
     <script type="application/ld+json"><?= json_encode($jsonLd, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?></script>

--- a/tests/Media/MediaDerivativeUrlTest.php
+++ b/tests/Media/MediaDerivativeUrlTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Media;
+
+use NeNeRecords\Media\MediaDerivativeUrl;
+use PHPUnit\Framework\TestCase;
+
+final class MediaDerivativeUrlTest extends TestCase
+{
+    public function testResolvesOgDerivativeForRelativeMediaImage(): void
+    {
+        self::assertSame(
+            '/media/og/2026/06/hero.png',
+            MediaDerivativeUrl::forPreset('/media/2026/06/hero.png', 'og'),
+        );
+    }
+
+    public function testPreservesAbsolutePrefix(): void
+    {
+        self::assertSame(
+            'https://cdn.example.test/media/og/2026/06/hero.jpg',
+            MediaDerivativeUrl::forPreset('https://cdn.example.test/media/2026/06/hero.jpg', 'og'),
+        );
+    }
+
+    public function testReturnsNullForUnknownPreset(): void
+    {
+        self::assertNull(MediaDerivativeUrl::forPreset('/media/2026/06/hero.png', 'bogus'));
+    }
+
+    public function testReturnsNullForNonImageExtension(): void
+    {
+        self::assertNull(MediaDerivativeUrl::forPreset('/media/2026/06/doc.pdf', 'og'));
+    }
+
+    public function testReturnsNullForNonMediaUrl(): void
+    {
+        self::assertNull(MediaDerivativeUrl::forPreset('https://example.test/posts/42', 'og'));
+        self::assertNull(MediaDerivativeUrl::forPreset('', 'og'));
+    }
+}

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -71,10 +71,12 @@ final class PublicRecordHttpTest extends TestCase
         $fieldDefs = new InMemoryFieldDefRepository([
             new FieldDef(entityTypeId: 1, fieldKey: 'title', dataType: 'text', id: 1),
             new FieldDef(entityTypeId: 1, fieldKey: 'body', dataType: 'text', id: 2),
+            new FieldDef(entityTypeId: 1, fieldKey: 'hero', dataType: 'image', id: 3),
         ]);
         $textFields = new InMemoryTextFieldRepository([
             new TextField(entityId: 10, fieldKey: 'title', value: 'Hello world', id: 1),
             new TextField(entityId: 10, fieldKey: 'body', value: "## Sample\n\n**bold** line", id: 2),
+            new TextField(entityId: 10, fieldKey: 'hero', value: '/media/2026/06/hero.png', id: 3),
         ], $entities);
 
         $publicSettings = new ListPublicSettingsUseCase(new InMemorySettingRepository(), new InMemoryMediaRepository());
@@ -196,9 +198,12 @@ final class PublicRecordHttpTest extends TestCase
         self::assertStringContainsString('property="og:title" content="Hello world"', $html);
         self::assertStringContainsString('property="og:description" content="A short summary."', $html);
         self::assertStringContainsString('property="og:site_name" content="NeNe Records"', $html);
-        // Twitter Card
-        self::assertStringContainsString('name="twitter:card" content="summary"', $html);
+        // Twitter Card — large image because the record has an image field
+        self::assertStringContainsString('name="twitter:card" content="summary_large_image"', $html);
         self::assertStringContainsString('name="twitter:title" content="Hello world"', $html);
+        // og:image / twitter:image resolve the image field to the `og` derivative (absolute)
+        self::assertStringContainsString('property="og:image" content="https://example.test/media/og/2026/06/hero.png"', $html);
+        self::assertStringContainsString('name="twitter:image" content="https://example.test/media/og/2026/06/hero.png"', $html);
         // Per-entity meta description (not the site default)
         self::assertStringContainsString('<meta name="description" content="A short summary." />', $html);
         // JSON-LD structured data
@@ -207,6 +212,7 @@ final class PublicRecordHttpTest extends TestCase
         self::assertStringContainsString('"headline":"Hello world"', $html);
         self::assertStringContainsString('"datePublished":"2026-01-15T00:00:00+00:00"', $html);
         self::assertStringContainsString('"dateModified":"2026-02-20T00:00:00+00:00"', $html);
+        self::assertStringContainsString('"image":"https://example.test/media/og/2026/06/hero.png"', $html);
     }
 
     /** @return array<string, mixed> */


### PR DESCRIPTION
## 目的
`Closes #547`。市場ディスカッション #545 が「グロースループの起点」と名指しした施策。既存の派生画像エンジンを活かし、公開レコードのソーシャルカード画像（og:image / twitter:image）を**設定不要で自動充填**する。

## 変更
- `MediaImagePresets` に **`og`（幅1200）** プリセットを追加。
- `MediaDerivativeUrl`（新規）— フロント `media-derivatives.ts` をミラー。メディアURL(`/media/{y}/{m}/{file}`)→preset派生URL(`/media/{preset}/...`)を解決（非メディア/非画像/不明presetは null）。
- 公開レコード SSR head（#537 S1 の延長）に、エンティティ先頭の画像フィールド→`og`派生URLを **og:image / twitter:image** として自動充填。画像有り時は `twitter:card=summary_large_image`＋JSON-LD `image`、無ければ従来どおり `summary`。
- `GetPublicRecordViewOutput` に `ogImagePath` を追加、公開・プレビュー両 UseCase が供給。

## 検証
- `composer check` 緑（PHPUnit 856 相当・PHPStan lvl8 0 error・CS-Fixer・OpenAPI・MCP）。
- 追加テスト: `PublicRecordHttpTest`（og:image/twitter:image/summary_large_image/JSON-LD image を絶対URLで検証）／`MediaDerivativeUrlTest`（happy/null 5ケース）。
- 実機 `/view/posts/blocks-showcase`（画像フィールド無し）で `twitter:card=summary`・og:image 非出力を確認（仕様どおり）。

## 後続（任意）
- テーマトークンからのブランドOGカード自動生成（タイトル/ダーク・ライト/ロゴ合成）。

Part of #536 / #537