### PR TITLE
feat(seo): 実 permalink でクローラブル SSR を配信する（単一オリジン）(#537 S2)

### DIFF
--- a/src/PublicRecord/GetPublicRecordViewInput.php
+++ b/src/PublicRecord/GetPublicRecordViewInput.php
@@ -8,7 +8,8 @@ final readonly class GetPublicRecordViewInput
 {
     public function __construct(
         public string $entityTypeSlug,
-        public string $entitySlug,
+        public ?string $entitySlug = null,
+        public ?int $entityId = null,
     ) {
     }
 }

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -54,15 +54,25 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             throw new PublicEntityTypeNotFoundException($input->entityTypeSlug);
         }
 
-        $entity = $this->entities->findBySlug($input->entitySlug, $entityType->id);
+        // Resolve by numeric id (id-style permalinks) or by slug. findBySlug already
+        // scopes to the type; for findById we verify the type explicitly below.
+        $entity = $input->entityId !== null
+            ? $this->entities->findById($input->entityId)
+            : ($input->entitySlug !== null
+                ? $this->entities->findBySlug($input->entitySlug, $entityType->id)
+                : null);
 
         if (
             $entity === null
             || $entity->id === null
+            || $entity->entityTypeId !== $entityType->id
             || $entity->isDeleted
             || $entity->status !== EntityStatus::Published
         ) {
-            throw new PublicRecordNotFoundException($input->entityTypeSlug, $input->entitySlug);
+            throw new PublicRecordNotFoundException(
+                $input->entityTypeSlug,
+                $input->entitySlug ?? (string) ($input->entityId ?? 'unknown'),
+            );
         }
 
         $entityTypeId = $entityType->id;
@@ -177,7 +187,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             entityTypeSlug: $input->entityTypeSlug,
             entityTypeName: $entityType->name,
             entityId: $entityId,
-            entitySlug: $input->entitySlug,
+            entitySlug: $entity->slug ?? (string) $entityId,
             pageTitle: $pageTitle,
             metaDescription: $entity->metaDescription ?? '',
             canonicalPath: $canonicalPath,

--- a/src/PublicRecord/PublicPermalinkResolver.php
+++ b/src/PublicRecord/PublicPermalinkResolver.php
@@ -51,4 +51,29 @@ final readonly class PublicPermalinkResolver
             '{day}' => $day,
         ]);
     }
+
+    /**
+     * Reverse-resolve a permalink's trailing path (everything after the type slug)
+     * into the entity lookup key. Mirrors the frontend `extractEntityKeyFromSplat`:
+     * an id pattern (`{id}` without `{slug}`) resolves the last numeric segment as
+     * an id; otherwise the last path segment is the slug.
+     *
+     * @return array{entityId: int|null, entitySlug: string|null}
+     */
+    public static function extractEntityKey(?string $pattern, string $splat): array
+    {
+        $pat = ($pattern === null || $pattern === '') ? self::DEFAULT_PATTERN : $pattern;
+
+        $segments = array_values(array_filter(
+            explode('/', $splat),
+            static fn (string $segment): bool => $segment !== '',
+        ));
+        $last = $segments === [] ? $splat : $segments[count($segments) - 1];
+
+        if (str_contains($pat, '{id}') && !str_contains($pat, '{slug}') && ctype_digit($last)) {
+            return ['entityId' => (int) $last, 'entitySlug' => null];
+        }
+
+        return ['entityId' => null, 'entitySlug' => $last];
+    }
 }

--- a/src/PublicRecord/PublicRecordRouteRegistrar.php
+++ b/src/PublicRecord/PublicRecordRouteRegistrar.php
@@ -12,6 +12,7 @@ final readonly class PublicRecordRouteRegistrar
     public function __construct(
         private GetPublicRecordViewHandler $getPublicRecordViewHandler,
         private RenderPublicRecordViewHandler $renderPublicRecordViewHandler,
+        private RenderPublicPermalinkHandler $renderPublicPermalinkHandler,
     ) {
     }
 
@@ -19,6 +20,7 @@ final readonly class PublicRecordRouteRegistrar
     {
         $getPublicRecordViewHandler = $this->getPublicRecordViewHandler;
         $renderPublicRecordViewHandler = $this->renderPublicRecordViewHandler;
+        $renderPublicPermalinkHandler = $this->renderPublicPermalinkHandler;
 
         $router->get(
             '/api/v1/public/entity-types/{slug}/records/{entitySlug}',
@@ -29,5 +31,14 @@ final readonly class PublicRecordRouteRegistrar
             '/view/{slug}/{entitySlug}',
             static fn (ServerRequestInterface $request) => $renderPublicRecordViewHandler->handle($request),
         );
+
+        // Real-permalink crawlable HTML (single-origin). These max-param patterns
+        // cover the built-in permalink presets ({type}/{id}, {type}/{slug},
+        // {type}/{y}/{m}/{slug}, {type}/{y}/{m}/{d}/{slug}); the router's
+        // param-count sort guarantees any more-specific route (api/media/view) wins.
+        $permalink = static fn (ServerRequestInterface $request) => $renderPublicPermalinkHandler->handle($request);
+        $router->get('/{p0}/{p1}', $permalink);
+        $router->get('/{p0}/{p1}/{p2}/{p3}', $permalink);
+        $router->get('/{p0}/{p1}/{p2}/{p3}/{p4}', $permalink);
     }
 }

--- a/src/PublicRecord/PublicRecordServiceProvider.php
+++ b/src/PublicRecord/PublicRecordServiceProvider.php
@@ -184,6 +184,23 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                 },
             )
             ->set(
+                RenderPublicPermalinkHandler::class,
+                static function (ContainerInterface $container): RenderPublicPermalinkHandler {
+                    $entityTypes = $container->get(EntityTypeRepositoryInterface::class);
+                    $viewRenderer = $container->get(RenderPublicRecordViewHandler::class);
+
+                    if (!$entityTypes instanceof EntityTypeRepositoryInterface) {
+                        throw new LogicException('Entity type repository service is invalid.');
+                    }
+
+                    if (!$viewRenderer instanceof RenderPublicRecordViewHandler) {
+                        throw new LogicException('RenderPublicRecordView handler service is invalid.');
+                    }
+
+                    return new RenderPublicPermalinkHandler($entityTypes, $viewRenderer);
+                },
+            )
+            ->set(
                 PublicEntityTypeNotFoundExceptionHandler::class,
                 static function (ContainerInterface $container): PublicEntityTypeNotFoundExceptionHandler {
                     $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
@@ -212,6 +229,7 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                 static function (ContainerInterface $container): PublicRecordRouteRegistrar {
                     $getHandler = $container->get(GetPublicRecordViewHandler::class);
                     $renderHandler = $container->get(RenderPublicRecordViewHandler::class);
+                    $permalinkHandler = $container->get(RenderPublicPermalinkHandler::class);
 
                     if (!$getHandler instanceof GetPublicRecordViewHandler) {
                         throw new LogicException('GetPublicRecordView handler service is invalid.');
@@ -221,7 +239,11 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                         throw new LogicException('RenderPublicRecordView handler service is invalid.');
                     }
 
-                    return new PublicRecordRouteRegistrar($getHandler, $renderHandler);
+                    if (!$permalinkHandler instanceof RenderPublicPermalinkHandler) {
+                        throw new LogicException('RenderPublicPermalink handler service is invalid.');
+                    }
+
+                    return new PublicRecordRouteRegistrar($getHandler, $renderHandler, $permalinkHandler);
                 },
             );
     }

--- a/src/PublicRecord/RenderPublicPermalinkHandler.php
+++ b/src/PublicRecord/RenderPublicPermalinkHandler.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use Nene2\Routing\Router;
+use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Serves crawlable server-rendered HTML at the user-facing permalink
+ * (e.g. `/posts/42`, `/posts/2026/06/my-article`) — the single-origin model
+ * where the PHP app fronts public content URLs and the SPA hydrates on top.
+ *
+ * The route patterns capture the path as `p0..pN` (max-param so any more-specific
+ * route always wins the router's param-count sort). `p0` is the entity-type slug;
+ * the remaining segments are reverse-resolved against the type's permalink pattern.
+ */
+final readonly class RenderPublicPermalinkHandler
+{
+    private const SEGMENT_KEYS = ['p0', 'p1', 'p2', 'p3', 'p4'];
+
+    public function __construct(
+        private EntityTypeRepositoryInterface $entityTypes,
+        private RenderPublicRecordViewHandler $viewRenderer,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $parameters = is_array($parameters) ? $parameters : [];
+
+        $segments = [];
+        foreach (self::SEGMENT_KEYS as $key) {
+            $value = trim((string) ($parameters[$key] ?? ''));
+            if ($value !== '') {
+                $segments[] = $value;
+            }
+        }
+
+        $typeSlug = $segments[0] ?? '';
+        $splat = implode('/', array_slice($segments, 1));
+
+        if ($typeSlug === '') {
+            throw new PublicRecordNotFoundException('unknown', $splat !== '' ? $splat : 'unknown');
+        }
+
+        $entityType = $this->entityTypes->findBySlug($typeSlug);
+
+        if ($entityType === null) {
+            // Not a known content type → not a record permalink.
+            throw new PublicRecordNotFoundException($typeSlug, $splat !== '' ? $splat : 'unknown');
+        }
+
+        $key = PublicPermalinkResolver::extractEntityKey($entityType->permalinkPattern, $splat);
+
+        return $this->viewRenderer->renderEntity(
+            $typeSlug,
+            $key['entitySlug'],
+            $key['entityId'],
+            $request,
+        );
+    }
+}

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -35,7 +35,20 @@ final readonly class RenderPublicRecordViewHandler
             );
         }
 
-        $output = $this->useCase->execute(new GetPublicRecordViewInput($typeSlug, $entitySlug));
+        return $this->renderEntity($typeSlug, $entitySlug, null, $request);
+    }
+
+    /**
+     * Render the crawlable record HTML for a resolved entity (by slug or id).
+     * Shared by the `/view/` route and the real-permalink route.
+     */
+    public function renderEntity(
+        string $typeSlug,
+        ?string $entitySlug,
+        ?int $entityId,
+        ServerRequestInterface $request,
+    ): ResponseInterface {
+        $output = $this->useCase->execute(new GetPublicRecordViewInput($typeSlug, $entitySlug, $entityId));
         $siteSettings = $this->resolveSiteSettings();
 
         // Canonical / og:url point at the user-facing permalink (not this /view/ twin).

--- a/tests/PublicRecord/PublicCacheHttpTest.php
+++ b/tests/PublicRecord/PublicCacheHttpTest.php
@@ -90,21 +90,24 @@ final class PublicCacheHttpTest extends TestCase
         $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
         $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
 
+        // RenderPublicRecordViewHandler is not exercised by these cache tests, but is
+        // needed to wire the registrar (and the permalink handler delegates to it).
+        $renderHandler = new \NeNeRecords\PublicRecord\RenderPublicRecordViewHandler(
+            $useCase,
+            $publicSettings,
+            new \Nene2\View\HtmlResponseFactory($this->factory, $this->factory, new \Nene2\View\NativePhpViewRenderer(dirname(__DIR__, 2) . '/templates')),
+            new \Nene2\Config\AppConfig(
+                environment: \Nene2\Config\AppEnvironment::Test,
+                debug: true,
+                name: 'Test',
+                database: new \Nene2\Config\DatabaseConfig(null, 'test', 'sqlite', '', 1, ':memory:', '', '', ''),
+                machineApiKey: null,
+            ),
+        );
         $publicRecordRegistrar = new PublicRecordRouteRegistrar(
             new GetPublicRecordViewHandler($useCase, $jsonResponse, $this->factory),
-            // RenderPublicRecordViewHandler is not needed for these tests; use a no-op placeholder via the JSON handler
-            new \NeNeRecords\PublicRecord\RenderPublicRecordViewHandler(
-                $useCase,
-                $publicSettings,
-                new \Nene2\View\HtmlResponseFactory($this->factory, $this->factory, new \Nene2\View\NativePhpViewRenderer(dirname(__DIR__, 2) . '/templates')),
-                new \Nene2\Config\AppConfig(
-                    environment: \Nene2\Config\AppEnvironment::Test,
-                    debug: true,
-                    name: 'Test',
-                    database: new \Nene2\Config\DatabaseConfig(null, 'test', 'sqlite', '', 1, ':memory:', '', '', ''),
-                    machineApiKey: null,
-                ),
-            ),
+            $renderHandler,
+            new \NeNeRecords\PublicRecord\RenderPublicPermalinkHandler($entityTypes, $renderHandler),
         );
 
         $settingRegistrar = new SettingRouteRegistrar(

--- a/tests/PublicRecord/PublicPermalinkResolverTest.php
+++ b/tests/PublicRecord/PublicPermalinkResolverTest.php
@@ -61,4 +61,39 @@ final class PublicPermalinkResolverTest extends TestCase
             ),
         );
     }
+
+    public function testExtractEntityKeyResolvesIdForDefaultPattern(): void
+    {
+        self::assertSame(
+            ['entityId' => 42, 'entitySlug' => null],
+            PublicPermalinkResolver::extractEntityKey('/{type}/{id}', '42'),
+        );
+        // null pattern falls back to the default (id) pattern.
+        self::assertSame(
+            ['entityId' => 42, 'entitySlug' => null],
+            PublicPermalinkResolver::extractEntityKey(null, '42'),
+        );
+    }
+
+    public function testExtractEntityKeyResolvesSlugForSlugPatterns(): void
+    {
+        self::assertSame(
+            ['entityId' => null, 'entitySlug' => 'my-article'],
+            PublicPermalinkResolver::extractEntityKey('/{type}/{slug}', 'my-article'),
+        );
+        // Date pattern → last segment is the slug.
+        self::assertSame(
+            ['entityId' => null, 'entitySlug' => 'my-article'],
+            PublicPermalinkResolver::extractEntityKey('/{type}/{year}/{month}/{slug}', '2026/06/my-article'),
+        );
+    }
+
+    public function testExtractEntityKeyFallsBackToSlugForNonNumericIdPattern(): void
+    {
+        // Pattern expects an id but the segment isn't numeric → treat as slug.
+        self::assertSame(
+            ['entityId' => null, 'entitySlug' => 'not-a-number'],
+            PublicPermalinkResolver::extractEntityKey('/{type}/{id}', 'not-a-number'),
+        );
+    }
 }

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -22,6 +22,7 @@ use NeNeRecords\PublicRecord\GetPublicRecordViewUseCase;
 use NeNeRecords\PublicRecord\PublicEntityTypeNotFoundExceptionHandler;
 use NeNeRecords\PublicRecord\PublicRecordNotFoundExceptionHandler;
 use NeNeRecords\PublicRecord\PublicRecordRouteRegistrar;
+use NeNeRecords\PublicRecord\RenderPublicPermalinkHandler;
 use NeNeRecords\PublicRecord\RenderPublicRecordViewHandler;
 use NeNeRecords\Setting\ListPublicSettingsUseCase;
 use NeNeRecords\Tests\BoolField\InMemoryBoolFieldRepository;
@@ -116,9 +117,11 @@ final class PublicRecordHttpTest extends TestCase
             machineApiKey: null,
         );
 
+        $renderHandler = new RenderPublicRecordViewHandler($useCase, $publicSettings, $htmlResponse, $config);
         $registrar = new PublicRecordRouteRegistrar(
             new GetPublicRecordViewHandler($useCase, $jsonResponse, $this->factory),
-            new RenderPublicRecordViewHandler($useCase, $publicSettings, $htmlResponse, $config),
+            $renderHandler,
+            new RenderPublicPermalinkHandler($entityTypes, $renderHandler),
         );
 
         $this->application = (new RuntimeApplicationFactory(
@@ -213,6 +216,40 @@ final class PublicRecordHttpTest extends TestCase
         self::assertStringContainsString('"datePublished":"2026-01-15T00:00:00+00:00"', $html);
         self::assertStringContainsString('"dateModified":"2026-02-20T00:00:00+00:00"', $html);
         self::assertStringContainsString('"image":"https://example.test/media/og/2026/06/hero.png"', $html);
+    }
+
+    public function testRealPermalinkServesCrawlableHtmlByIdPattern(): void
+    {
+        // The "article" type uses the default pattern /{type}/{id}, so /article/10 is the permalink.
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        );
+        $html = (string) $response->getBody();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
+        self::assertStringContainsString('<h1>Hello world</h1>', $html);
+        // Canonical/og still point at the same real permalink.
+        self::assertStringContainsString('<link rel="canonical" href="https://example.test/article/10" />', $html);
+        self::assertStringContainsString('id="nene-records-public-record-bootstrap"', $html);
+    }
+
+    public function testRealPermalinkReturns404ForUnknownId(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/999'),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testRealPermalinkReturns404ForUnknownType(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/missing/10'),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
     }
 
     /** @return array<string, mixed> */


### PR DESCRIPTION
## 目的
`#537` S2（エピック #536・市場討論 #545 で確定した **PHP前段+SPAシェル単一オリジン**方針の中核）。S1 は SSR head を整えたが `/view/` ツインにしか無く、ユーザー/クローラが踏む実 permalink は SPA のままだった。本 PR で**実 permalink をサーバ描画**し、クローラブル HTML を返す。

## 変更
- `PublicPermalinkResolver::extractEntityKey` — フロント `resolve-permalink.ts` の逆解決をミラー（`{id}`パターンは末尾数値→id、その他→末尾 slug）。
- `GetPublicRecordViewInput`/`UseCase` を **id 解決**対応（slug が null の公開記事も `/{type}/{id}` で配信可）。findById は type 一致を明示検証。
- `RenderPublicRecordViewHandler` に **`renderEntity`** を抽出し `/view/` と permalink で共用。
- `RenderPublicPermalinkHandler`（新規）＋ ルート `/{p0}/{p1}` `/{p0}/{p1}/{p2}/{p3}` `/{p0}/{p1}/{p2}/{p3}/{p4}`（4つの組込パーマリンクプリセットを網羅）。**全て最大 param 数**なので NENE2 Router の param 数ソートで api/media/view 等の具体ルートが必ず優先＝**非シャドウ**。未知 type / 記事は 404。

## 検証
- `composer check` 緑（PHPUnit/PHPStan lvl8/CS-Fixer/OpenAPI/MCP）。
- 追加テスト: 実URL（id パターン）SSR 200 / 未知 id・未知 type 404（`PublicRecordHttpTest`）、`extractEntityKey`（`PublicPermalinkResolverTest`）。
- 実機: `/posts/246`・`/posts/blocks-showcase` → 200 SSR（title/canonical/OGP/JSON-LD/本文）、`/health`・`/view/...`・`/api/...`・`/media/...` → 非シャドウを確認。

## 残（後続スライス・本番完全化）
- 本番で **SPA ビルド資産を PHP/Apache 配信＋SSRページに SPA マウント**（prod でも完全な SPA 体験。dev は既存 Vite トグルで mount）。
- `/view/{type}/{slug}` → 301 → canonical permalink（ツイン統合）。

Part of #537 / #536