### PR TITLE
feat(seo): 単一オリジンで公開ページに本番SPAをマウントする (#537 S3)

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
     && docker-php-ext-install pdo_mysql pdo_sqlite intl gd \
     && rm -rf /var/lib/apt/lists/* \
     && a2enmod rewrite headers \
-    && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n' > /etc/apache2/conf-available/nene-records.conf \
+    && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n\n# Single-origin: serve the built SPA assets (Vite /assets/*) directly from the\n# frontend build so the PHP-rendered pages can mount the production SPA.\nAlias /assets /var/www/html/frontend/dist/assets\n<Directory /var/www/html/frontend/dist/assets>\n    Require all granted\n</Directory>\n' > /etc/apache2/conf-available/nene-records.conf \
     && a2enconf nene-records \
     && sed -ri -e 's!/var/www/html!/var/www/html/public_html!g' /etc/apache2/sites-available/*.conf \
     && sed -ri -e 's!/var/www/!/var/www/html/public_html!g' /etc/apache2/apache2.conf

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -19,6 +19,9 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [react(), tailwindcss()],
     build: {
+      // Emit dist/.vite/manifest.json so the PHP single-origin SSR can resolve
+      // the hashed entry JS/CSS and mount the built SPA on server-rendered pages.
+      manifest: true,
       rollupOptions: {
         output: {
           // Split long-lived vendor code out of the app entry so the initial

--- a/src/PublicRecord/PublicRecordServiceProvider.php
+++ b/src/PublicRecord/PublicRecordServiceProvider.php
@@ -163,6 +163,7 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                     $publicSettings = $container->get(ListPublicSettingsUseCaseInterface::class);
                     $html = $container->get(HtmlResponseFactory::class);
                     $config = $container->get(AppConfig::class);
+                    $projectRoot = $container->get(RuntimeServiceProvider::PROJECT_ROOT);
 
                     if (!$useCase instanceof GetPublicRecordViewUseCaseInterface) {
                         throw new LogicException('GetPublicRecordView use case service is invalid.');
@@ -180,7 +181,11 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                         throw new LogicException('Application config service is invalid.');
                     }
 
-                    return new RenderPublicRecordViewHandler($useCase, $publicSettings, $html, $config);
+                    if (!is_string($projectRoot)) {
+                        throw new LogicException('Project root service is invalid.');
+                    }
+
+                    return new RenderPublicRecordViewHandler($useCase, $publicSettings, $html, $config, $projectRoot);
                 },
             )
             ->set(

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -19,6 +19,7 @@ final readonly class RenderPublicRecordViewHandler
         private ListPublicSettingsUseCaseInterface $publicSettings,
         private HtmlResponseFactory $html,
         private AppConfig $config,
+        private string $projectRoot,
     ) {
     }
 
@@ -80,6 +81,26 @@ final readonly class RenderPublicRecordViewHandler
             $viteUrl = 'http://localhost:5173';
         }
 
+        // Single-origin SPA mount: in dev, load the Vite dev client; in prod,
+        // resolve the built entry assets so the SSR shell hydrates into the SPA.
+        // Falls back to crawlable-SSR-only when no build is present.
+        $spaMode = 'none';
+        $spaJs = null;
+        $spaCss = [];
+        $spaPreload = [];
+
+        if ($this->config->debug) {
+            $spaMode = 'dev';
+        } else {
+            $entry = ViteManifest::resolveEntry($this->projectRoot . '/frontend/dist/.vite/manifest.json');
+            if ($entry !== null) {
+                $spaMode = 'prod';
+                $spaJs = $entry['js'];
+                $spaCss = $entry['css'];
+                $spaPreload = $entry['preload'];
+            }
+        }
+
         return $this->html->create('public/record-detail.php', [
             'pageTitle' => $output->pageTitle,
             'entityTypeSlug' => $output->entityTypeSlug,
@@ -93,8 +114,11 @@ final readonly class RenderPublicRecordViewHandler
             'publishedAtIso' => $output->publishedAtIso,
             'updatedAtIso' => $output->updatedAtIso,
             'bootstrapJson' => $bootstrapJson,
-            'includeViteClient' => $this->config->debug,
+            'spaMode' => $spaMode,
             'viteUrl' => rtrim($viteUrl, '/'),
+            'spaJs' => $spaJs,
+            'spaCss' => $spaCss,
+            'spaPreload' => $spaPreload,
             'renderMarkdown' => static fn (string $markdown): string => PublicMarkdownRenderer::toSafeHtml($markdown),
             // A bundle's crawlable twin (#311): render its seoText markdown server-side
             // (the sandboxed iframe itself is SPA-only / invisible to crawlers).

--- a/src/PublicRecord/ViteManifest.php
+++ b/src/PublicRecord/ViteManifest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+/**
+ * Resolves the built SPA entry assets from a Vite manifest
+ * (`frontend/dist/.vite/manifest.json`) so the single-origin SSR pages can
+ * mount the production SPA. Walks the entry's import graph to collect every
+ * stylesheet and module-preload, mirroring what Vite injects into its own
+ * `index.html`. Returns null when no manifest is available (e.g. unbuilt),
+ * letting callers degrade to crawlable-SSR-only.
+ *
+ * @phpstan-type ViteEntry array{js: string, css: list<string>, preload: list<string>}
+ */
+final class ViteManifest
+{
+    /** @var array<string, ViteEntry|null> path => resolved entry (request-lifetime memo) */
+    private static array $memo = [];
+
+    /** @return ViteEntry|null */
+    public static function resolveEntry(string $manifestPath, string $base = '/'): ?array
+    {
+        $cacheKey = $manifestPath . '|' . $base;
+
+        if (array_key_exists($cacheKey, self::$memo)) {
+            return self::$memo[$cacheKey];
+        }
+
+        $resolved = self::load($manifestPath, $base);
+        self::$memo[$cacheKey] = $resolved;
+
+        return $resolved;
+    }
+
+    /** @return ViteEntry|null */
+    private static function load(string $manifestPath, string $base): ?array
+    {
+        if (!is_file($manifestPath)) {
+            return null;
+        }
+
+        $raw = file_get_contents($manifestPath);
+
+        if ($raw === false) {
+            return null;
+        }
+
+        try {
+            /** @var array<string, array<string, mixed>> $manifest */
+            $manifest = json_decode($raw, true, 32, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return null;
+        }
+
+        $entryKey = null;
+        foreach ($manifest as $key => $chunk) {
+            if (($chunk['isEntry'] ?? false) === true) {
+                $entryKey = $key;
+                break;
+            }
+        }
+
+        if ($entryKey === null || !isset($manifest[$entryKey]['file']) || !is_string($manifest[$entryKey]['file'])) {
+            return null;
+        }
+
+        $css = [];
+        $preload = [];
+        $seen = [];
+
+        $collect = static function (string $key) use (&$collect, $manifest, &$css, &$preload, &$seen): void {
+            if (isset($seen[$key])) {
+                return;
+            }
+            $seen[$key] = true;
+
+            $chunk = $manifest[$key] ?? null;
+            if (!is_array($chunk)) {
+                return;
+            }
+
+            foreach (($chunk['css'] ?? []) as $cssFile) {
+                if (is_string($cssFile)) {
+                    $css[] = $cssFile;
+                }
+            }
+
+            foreach (($chunk['imports'] ?? []) as $import) {
+                if (!is_string($import)) {
+                    continue;
+                }
+                if (isset($manifest[$import]['file']) && is_string($manifest[$import]['file'])) {
+                    $preload[] = $manifest[$import]['file'];
+                }
+                $collect($import);
+            }
+        };
+
+        $collect($entryKey);
+
+        $prefix = static fn (string $path): string => rtrim($base, '/') . '/' . ltrim($path, '/');
+
+        return [
+            'js' => $prefix((string) $manifest[$entryKey]['file']),
+            'css' => array_values(array_unique(array_map($prefix, $css))),
+            'preload' => array_values(array_unique(array_map($prefix, $preload))),
+        ];
+    }
+}

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -61,11 +61,18 @@
       .markdown-body ul, .markdown-body ol { margin: 0; padding-left: 1.25rem; }
       .markdown-body blockquote { margin: 0; padding-left: 0.75rem; border-left: 3px solid #d1d5db; color: #6b7280; }
     </style>
-    <?php if ($includeViteClient): ?>
+    <?php if ($spaMode === 'prod'): ?>
+      <?php foreach ($spaCss as $href): ?>
+      <link rel="stylesheet" crossorigin href="<?= $e($href) ?>" />
+      <?php endforeach; ?>
+    <?php elseif ($spaMode === 'dev'): ?>
       <script type="module" src="<?= $e($viteUrl) ?>/@vite/client"></script>
     <?php endif; ?>
   </head>
   <body>
+    <!-- SSR content lives inside #root: crawlers / no-JS read it; the SPA
+         (createRoot().render) replaces it with the interactive app on mount. -->
+    <div id="root">
     <header>
       <p><a href="/view/<?= $e($entityTypeSlug) ?>">← <?= $e($entityTypeName) ?></a></p>
       <h1><?= $e($pageTitle) ?></h1>
@@ -102,13 +109,18 @@
         <?php endif; ?>
       <?php endforeach; ?>
     </article>
+    </div>
     <script
       id="nene-records-public-record-bootstrap"
       type="application/json"
     ><?= $bootstrapJson ?></script>
-    <?php if ($includeViteClient): ?>
-      <div id="root"></div>
+    <?php if ($spaMode === 'dev'): ?>
       <script type="module" src="<?= $e($viteUrl) ?>/src/main.tsx"></script>
+    <?php elseif ($spaMode === 'prod' && $spaJs !== null): ?>
+      <?php foreach ($spaPreload as $href): ?>
+      <link rel="modulepreload" crossorigin href="<?= $e($href) ?>" />
+      <?php endforeach; ?>
+      <script type="module" crossorigin src="<?= $e($spaJs) ?>"></script>
     <?php endif; ?>
   </body>
 </html>

--- a/tests/PublicRecord/PublicCacheHttpTest.php
+++ b/tests/PublicRecord/PublicCacheHttpTest.php
@@ -103,6 +103,7 @@ final class PublicCacheHttpTest extends TestCase
                 database: new \Nene2\Config\DatabaseConfig(null, 'test', 'sqlite', '', 1, ':memory:', '', '', ''),
                 machineApiKey: null,
             ),
+            dirname(__DIR__, 2),
         );
         $publicRecordRegistrar = new PublicRecordRouteRegistrar(
             new GetPublicRecordViewHandler($useCase, $jsonResponse, $this->factory),

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -54,7 +54,11 @@ final class PublicRecordHttpTest extends TestCase
 
         $this->factory = new Psr17Factory();
         $this->projectRoot = dirname(__DIR__, 2);
+        $this->application = $this->buildApplication(true, $this->projectRoot);
+    }
 
+    private function buildApplication(bool $debug, string $projectRoot): RequestHandlerInterface
+    {
         $entityTypes = new InMemoryEntityTypeRepository([
             new EntityType(name: 'Article', slug: 'article', id: 1),
         ]);
@@ -97,11 +101,11 @@ final class PublicRecordHttpTest extends TestCase
 
         $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
         $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
-        $renderer = new NativePhpViewRenderer($this->projectRoot . '/templates');
+        $renderer = new NativePhpViewRenderer(dirname(__DIR__, 2) . '/templates');
         $htmlResponse = new HtmlResponseFactory($this->factory, $this->factory, $renderer);
         $config = new AppConfig(
             environment: AppEnvironment::Test,
-            debug: true,
+            debug: $debug,
             name: 'NeNe Records',
             database: new DatabaseConfig(
                 url: null,
@@ -117,14 +121,14 @@ final class PublicRecordHttpTest extends TestCase
             machineApiKey: null,
         );
 
-        $renderHandler = new RenderPublicRecordViewHandler($useCase, $publicSettings, $htmlResponse, $config);
+        $renderHandler = new RenderPublicRecordViewHandler($useCase, $publicSettings, $htmlResponse, $config, $projectRoot);
         $registrar = new PublicRecordRouteRegistrar(
             new GetPublicRecordViewHandler($useCase, $jsonResponse, $this->factory),
             $renderHandler,
             new RenderPublicPermalinkHandler($entityTypes, $renderHandler),
         );
 
-        $this->application = (new RuntimeApplicationFactory(
+        return (new RuntimeApplicationFactory(
             $this->factory,
             $this->factory,
             domainExceptionHandlers: [
@@ -250,6 +254,44 @@ final class PublicRecordHttpTest extends TestCase
         );
 
         self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testDevModeWrapsSsrContentInRootAndLoadsViteClient(): void
+    {
+        // Default app is debug=true → SSR content lives inside #root and the SPA
+        // mounts via the Vite dev client (createRoot replaces the SSR fallback).
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        );
+        $html = (string) $response->getBody();
+
+        self::assertStringContainsString('<div id="root">', $html);
+        self::assertStringContainsString('<h1>Hello world</h1>', $html);
+        self::assertStringContainsString('/@vite/client', $html);
+        self::assertStringContainsString('/src/main.tsx', $html);
+    }
+
+    public function testProdModeMountsBuiltSpaFromManifest(): void
+    {
+        // Prod build (debug=false) with a fixture Vite manifest → SSR shell + built
+        // SPA entry/css/modulepreload; no Vite dev client.
+        $app = $this->buildApplication(false, __DIR__ . '/fixtures/spa-build');
+        $response = $app->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        );
+        $html = (string) $response->getBody();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('<div id="root">', $html);
+        self::assertStringContainsString('<h1>Hello world</h1>', $html);
+        // Built entry + stylesheets + preload resolved from the manifest graph.
+        self::assertStringContainsString('<script type="module" crossorigin src="/assets/index-ABC.js">', $html);
+        self::assertStringContainsString('<link rel="stylesheet" crossorigin href="/assets/index-ABC.css" />', $html);
+        self::assertStringContainsString('<link rel="stylesheet" crossorigin href="/assets/vendor-XYZ.css" />', $html);
+        self::assertStringContainsString('<link rel="modulepreload" crossorigin href="/assets/vendor-XYZ.js" />', $html);
+        // No dev client in prod.
+        self::assertStringNotContainsString('/@vite/client', $html);
+        self::assertStringNotContainsString('/src/main.tsx', $html);
     }
 
     /** @return array<string, mixed> */

--- a/tests/PublicRecord/ViteManifestTest.php
+++ b/tests/PublicRecord/ViteManifestTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use NeNeRecords\PublicRecord\ViteManifest;
+use PHPUnit\Framework\TestCase;
+
+final class ViteManifestTest extends TestCase
+{
+    private string $manifest;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->manifest = __DIR__ . '/fixtures/spa-build/frontend/dist/.vite/manifest.json';
+    }
+
+    public function testResolvesEntryJsCssAndPreloadFromImportGraph(): void
+    {
+        $entry = ViteManifest::resolveEntry($this->manifest);
+
+        self::assertNotNull($entry);
+        self::assertSame('/assets/index-ABC.js', $entry['js']);
+        // CSS comes from the entry AND its imported chunks.
+        self::assertContains('/assets/index-ABC.css', $entry['css']);
+        self::assertContains('/assets/vendor-XYZ.css', $entry['css']);
+        // Imported chunk files become module preloads.
+        self::assertContains('/assets/vendor-XYZ.js', $entry['preload']);
+    }
+
+    public function testReturnsNullWhenManifestMissing(): void
+    {
+        self::assertNull(ViteManifest::resolveEntry(__DIR__ . '/fixtures/does-not-exist.json'));
+    }
+
+    public function testRespectsCustomBasePath(): void
+    {
+        $entry = ViteManifest::resolveEntry($this->manifest, '/app/');
+
+        self::assertNotNull($entry);
+        self::assertSame('/app/assets/index-ABC.js', $entry['js']);
+        self::assertContains('/app/assets/vendor-XYZ.css', $entry['css']);
+    }
+}

--- a/tests/PublicRecord/fixtures/spa-build/frontend/dist/.vite/manifest.json
+++ b/tests/PublicRecord/fixtures/spa-build/frontend/dist/.vite/manifest.json
@@ -1,0 +1,12 @@
+{
+  "_vendor-XYZ.js": {
+    "file": "assets/vendor-XYZ.js",
+    "css": ["assets/vendor-XYZ.css"]
+  },
+  "index.html": {
+    "file": "assets/index-ABC.js",
+    "isEntry": true,
+    "css": ["assets/index-ABC.css"],
+    "imports": ["_vendor-XYZ.js"]
+  }
+}


### PR DESCRIPTION
## 目的
`#537` S3（エピック #536・**市場再討論 #551 が「次の最大ブロッカー・全層共通の前提1位」と判定**した本番完全化）。S2 で実 permalink のクローラブル SSR は配信できたが、prod では静的 SSR のみだった。本 PR で**本番ビルドの SPA を SSR ページにマウント**し、クローラブル HTML ＋ 対話的 SPA を実 permalink で同時提供できるようにする（単一オリジン）。

## 変更
- **`ViteManifest`（新規）** — `dist/.vite/manifest.json` の entry を解決し、import グラフを辿って全 stylesheet / modulepreload を収集（Vite が自前 index.html に注入するのと同等）。未ビルド時は null を返し、クローラブル SSR のみへ degrade。
- **`record-detail.php` 再構成** — SSR 本文を **`#root` の中**に配置（`createRoot().render` が置換＝クローラ/no-JS は本文・ユーザーは SPA）。`dev`=Vite クライアント / `prod`=manifest 由来の entry js＋css＋modulepreload を出し分け。
- `RenderPublicRecordViewHandler` に `projectRoot` を注入し dev/prod の SPA アセットを解決。
- `vite.config.ts`: `build.manifest = true`。
- **`docker/php/Dockerfile`**: `Alias /assets → frontend/dist/assets`（単一オリジンで built 資産を配信。**デプロイ/コンテナ再ビルドで有効**）。

## 検証
- `composer check` 緑（PHPUnit/PHPStan lvl8/CS/OpenAPI/MCP）。`npm run check`（type-check/eslint/prettier 緑、test 369 緑※）。
- 追加テスト: `ViteManifestTest`（import グラフ/css/preload 収集・未ビルド null・custom base）、`PublicRecordHttpTest` に prod モード描画（fixture manifest → entry/css/preload 出力・dev client 不在）＋ dev モード（#root 内包＋Vite マウント）。
- ※ `npm run check` 中に `EntityRecordsPage.test.tsx` が一度フレーク（既知の vitest 無 auto-cleanup・順序汚染／本 PR は frontend/src 無改変）。単独・フル再実行とも 369/369 緑で再現せず。

## 後続スライス（本番完全化の残り）
- `/admin` 等 SPA ルートの shell フォールバック配信（dist/index.html）。
- `/view/{type}/{slug}` → 301 → canonical permalink。

Part of #537 / #536