### PR TITLE
feat(seo): /view を canonical へ301し SPAシェルフォールバックを配信する (#537 S4)

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Nene2\Http\ResponseEmitter;
 use NeNeRecords\Http\RuntimeContainerFactory;
+use NeNeRecords\Http\SpaShellFallback;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7Server\ServerRequestCreator;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -24,6 +25,14 @@ $request = $serverRequestCreator->fromGlobals();
 $application = $container->get(RequestHandlerInterface::class);
 assert($application instanceof RequestHandlerInterface);
 $response = $application->handle($request);
+
+// Single-origin: serve the built SPA shell for unmatched GET HTML navigations
+// (admin/login/search/tag/browse, etc.) so the client router takes over.
+$response = (new SpaShellFallback(
+    dirname(__DIR__) . '/frontend/dist/index.html',
+    $psr17Factory,
+    $psr17Factory,
+))->apply($request, $response);
 
 $emitter = $container->get(ResponseEmitter::class);
 assert($emitter instanceof ResponseEmitter);

--- a/src/Http/SpaShellFallback.php
+++ b/src/Http/SpaShellFallback.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Http;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+/**
+ * Single-origin SPA fallback: when the router 404s a GET HTML navigation to a
+ * non-API path, serve the built SPA shell (`frontend/dist/index.html`) so the
+ * client router can handle `/admin`, `/login`, `/search`, `/tag/:slug`, browse
+ * pages, etc. API / media / view / asset paths keep their genuine 404, and the
+ * fallback is a no-op when no build is present (dev / unbuilt).
+ */
+final readonly class SpaShellFallback
+{
+    private const PASSTHROUGH = '#^/(api|media|view|assets)(/|$)#';
+
+    public function __construct(
+        private string $shellPath,
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+    ) {
+    }
+
+    public function apply(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        if ($response->getStatusCode() !== 404) {
+            return $response;
+        }
+
+        if (strtoupper($request->getMethod()) !== 'GET') {
+            return $response;
+        }
+
+        if (!str_contains($request->getHeaderLine('Accept'), 'text/html')) {
+            return $response;
+        }
+
+        if (preg_match(self::PASSTHROUGH, $request->getUri()->getPath()) === 1) {
+            return $response;
+        }
+
+        if (!is_file($this->shellPath)) {
+            return $response;
+        }
+
+        $html = file_get_contents($this->shellPath);
+
+        if ($html === false) {
+            return $response;
+        }
+
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'text/html; charset=utf-8')
+            ->withBody($this->streamFactory->createStream($html));
+    }
+}

--- a/src/PublicRecord/PublicRecordServiceProvider.php
+++ b/src/PublicRecord/PublicRecordServiceProvider.php
@@ -164,6 +164,7 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                     $html = $container->get(HtmlResponseFactory::class);
                     $config = $container->get(AppConfig::class);
                     $projectRoot = $container->get(RuntimeServiceProvider::PROJECT_ROOT);
+                    $responseFactory = $container->get(ResponseFactoryInterface::class);
 
                     if (!$useCase instanceof GetPublicRecordViewUseCaseInterface) {
                         throw new LogicException('GetPublicRecordView use case service is invalid.');
@@ -185,7 +186,11 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                         throw new LogicException('Project root service is invalid.');
                     }
 
-                    return new RenderPublicRecordViewHandler($useCase, $publicSettings, $html, $config, $projectRoot);
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    return new RenderPublicRecordViewHandler($useCase, $publicSettings, $html, $config, $projectRoot, $responseFactory);
                 },
             )
             ->set(

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -9,6 +9,7 @@ use Nene2\Routing\Router;
 use Nene2\View\HtmlResponseFactory;
 use NeNeRecords\BundleField\BundleDocumentValidator;
 use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -20,9 +21,15 @@ final readonly class RenderPublicRecordViewHandler
         private HtmlResponseFactory $html,
         private AppConfig $config,
         private string $projectRoot,
+        private ResponseFactoryInterface $responseFactory,
     ) {
     }
 
+    /**
+     * Legacy `/view/{type}/{entitySlug}` twin → 301 to the canonical permalink.
+     * The crawlable SSR now lives at the real permalink; this keeps one canonical
+     * URL and avoids a duplicate-content twin.
+     */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
@@ -36,7 +43,12 @@ final readonly class RenderPublicRecordViewHandler
             );
         }
 
-        return $this->renderEntity($typeSlug, $entitySlug, null, $request);
+        // Resolve to the canonical permalink (also 404s via the use case if missing).
+        $output = $this->useCase->execute(new GetPublicRecordViewInput($typeSlug, $entitySlug));
+        $uri = $request->getUri();
+        $location = $uri->getScheme() . '://' . $uri->getAuthority() . $output->canonicalPath;
+
+        return $this->responseFactory->createResponse(301)->withHeader('Location', $location);
     }
 
     /**

--- a/tests/Http/SpaShellFallbackTest.php
+++ b/tests/Http/SpaShellFallbackTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Http;
+
+use NeNeRecords\Http\SpaShellFallback;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class SpaShellFallbackTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private SpaShellFallback $fallback;
+    private string $shellPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new Psr17Factory();
+        $this->shellPath = __DIR__ . '/fixtures/spa-index.html';
+        $this->fallback = new SpaShellFallback($this->shellPath, $this->factory, $this->factory);
+    }
+
+    private function request(string $method, string $path, string $accept = 'text/html'): ServerRequestInterface
+    {
+        return $this->factory
+            ->createServerRequest($method, 'https://example.test' . $path)
+            ->withHeader('Accept', $accept);
+    }
+
+    private function notFound(): ResponseInterface
+    {
+        return $this->factory->createResponse(404);
+    }
+
+    public function testServesShellForUnmatchedGetHtmlNavigation(): void
+    {
+        $result = $this->fallback->apply($this->request('GET', '/admin/users'), $this->notFound());
+
+        self::assertSame(200, $result->getStatusCode());
+        self::assertStringContainsString('text/html', $result->getHeaderLine('Content-Type'));
+        self::assertStringContainsString('<div id="root">', (string) $result->getBody());
+    }
+
+    public function testServesShellForBrowsePath(): void
+    {
+        // 1-segment browse path (e.g. /posts) is not a record permalink → SPA shell.
+        $result = $this->fallback->apply($this->request('GET', '/posts'), $this->notFound());
+
+        self::assertSame(200, $result->getStatusCode());
+    }
+
+    public function testPassesThroughApiMediaViewAssetPaths(): void
+    {
+        foreach (['/api/v1/things', '/media/2026/06/x.png', '/view/posts/x', '/assets/index.js'] as $path) {
+            $result = $this->fallback->apply($this->request('GET', $path), $this->notFound());
+            self::assertSame(404, $result->getStatusCode(), $path . ' must keep its genuine 404');
+        }
+    }
+
+    public function testIgnoresNonGetRequests(): void
+    {
+        $result = $this->fallback->apply($this->request('POST', '/admin/users'), $this->notFound());
+
+        self::assertSame(404, $result->getStatusCode());
+    }
+
+    public function testIgnoresNonHtmlRequests(): void
+    {
+        $result = $this->fallback->apply(
+            $this->request('GET', '/admin/users', 'application/json'),
+            $this->notFound(),
+        );
+
+        self::assertSame(404, $result->getStatusCode());
+    }
+
+    public function testLeavesNon404ResponsesUntouched(): void
+    {
+        $ok = $this->factory->createResponse(200);
+        $result = $this->fallback->apply($this->request('GET', '/admin/users'), $ok);
+
+        self::assertSame(200, $result->getStatusCode());
+        self::assertSame('', (string) $result->getBody());
+    }
+
+    public function testNoOpWhenShellMissing(): void
+    {
+        $fallback = new SpaShellFallback(__DIR__ . '/fixtures/does-not-exist.html', $this->factory, $this->factory);
+        $result = $fallback->apply($this->request('GET', '/admin/users'), $this->notFound());
+
+        self::assertSame(404, $result->getStatusCode());
+    }
+}

--- a/tests/Http/fixtures/spa-index.html
+++ b/tests/Http/fixtures/spa-index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+  <head><title>NeNe Records</title></head>
+  <body><div id="root"></div></body>
+</html>

--- a/tests/PublicRecord/PublicCacheHttpTest.php
+++ b/tests/PublicRecord/PublicCacheHttpTest.php
@@ -104,6 +104,7 @@ final class PublicCacheHttpTest extends TestCase
                 machineApiKey: null,
             ),
             dirname(__DIR__, 2),
+            $this->factory,
         );
         $publicRecordRegistrar = new PublicRecordRouteRegistrar(
             new GetPublicRecordViewHandler($useCase, $jsonResponse, $this->factory),

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -121,7 +121,7 @@ final class PublicRecordHttpTest extends TestCase
             machineApiKey: null,
         );
 
-        $renderHandler = new RenderPublicRecordViewHandler($useCase, $publicSettings, $htmlResponse, $config, $projectRoot);
+        $renderHandler = new RenderPublicRecordViewHandler($useCase, $publicSettings, $htmlResponse, $config, $projectRoot, $this->factory);
         $registrar = new PublicRecordRouteRegistrar(
             new GetPublicRecordViewHandler($useCase, $jsonResponse, $this->factory),
             $renderHandler,
@@ -172,7 +172,7 @@ final class PublicRecordHttpTest extends TestCase
         $response = $this->application->handle(
             $this->factory->createServerRequest(
                 'GET',
-                'https://example.test/view/article/hello-world',
+                'https://example.test/article/10',
             ),
         );
         $html = (string) $response->getBody();
@@ -191,7 +191,7 @@ final class PublicRecordHttpTest extends TestCase
         $response = $this->application->handle(
             $this->factory->createServerRequest(
                 'GET',
-                'https://example.test/view/article/hello-world',
+                'https://example.test/article/10',
             ),
         );
         $html = (string) $response->getBody();
@@ -220,6 +220,16 @@ final class PublicRecordHttpTest extends TestCase
         self::assertStringContainsString('"datePublished":"2026-01-15T00:00:00+00:00"', $html);
         self::assertStringContainsString('"dateModified":"2026-02-20T00:00:00+00:00"', $html);
         self::assertStringContainsString('"image":"https://example.test/media/og/2026/06/hero.png"', $html);
+    }
+
+    public function testViewUrlRedirectsToCanonicalPermalink(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/view/article/hello-world'),
+        );
+
+        self::assertSame(301, $response->getStatusCode());
+        self::assertSame('https://example.test/article/10', $response->getHeaderLine('Location'));
     }
 
     public function testRealPermalinkServesCrawlableHtmlByIdPattern(): void


### PR DESCRIPTION
## 目的
`#537` S4（単一オリジン仕上げ）。実URLクローラブルSSR(S2 #549)＋本番SPAマウント(S3 #553)に続き、配信モデルを完成させる2点。

## 変更
1. **`/view/{type}/{slug}` → 301 → canonical permalink**。`RenderPublicRecordViewHandler::handle` を 301 リダイレクトに変更（重複コンテンツ二重URL解消／クローラブルSSRは実URLに一本化）。`renderEntity` は permalink ハンドラ用に存置。
2. **SPA シェルフォールバック `SpaShellFallback`**: 未マッチの GET/HTML ナビ（`/admin`・`/login`・`/search`・`/tag/:slug`・`/posts` 等の browse）を `frontend/dist/index.html` で応答し SPA ルータへ委譲。`/api`・`/media`・`/view`・`/assets` は **genuine 404 を維持**。`public_html/index.php` で配線、未ビルド時は no-op。

## 検証
- `composer check` 緑（PHPUnit/PHPStan lvl8/CS/OpenAPI/MCP）。
- 追加テスト: `SpaShellFallbackTest`（shell配信・browse・passthrough・非GET/非HTML・非404・未ビルド の7ケース）＋ `/view→301` テスト。既存SSRレンダリングテストは実URL(`/article/10`)へ振替。
- 実機: `/view/posts/blocks-showcase`→**301→/posts/246**、`/admin`・`/posts`→**200 SPAシェル**、`/api/v1/nonexistent`→**404維持**、`/posts/246`→**200 SSR**。

## #537 の状態
これで **#537 のコードは完成**（実URLクローラブルSSR＋本番SPAマウント＋/view 301＋SPAシェルフォールバック）。残るは**実デプロイ**（公開ドメインを PHP 前段に＋`npm run build`）＝環境次第のオーナー作業のみ。

Closes #537