### PR TITLE
fix(security): 公開HTMLレスポンスのCSPをSPA対応に緩和する (#557)

### DIFF
--- a/src/Http/PublicHtmlCsp.php
+++ b/src/Http/PublicHtmlCsp.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Http;
+
+/**
+ * Content-Security-Policy for public SPA-bearing HTML responses (server-rendered
+ * record pages and the SPA shell fallback).
+ *
+ * The framework default `default-src 'self'` is too strict for the single-origin
+ * SPA: it injects inline `<style>` (runtime theme tokens) and loads `data:` fonts,
+ * which `default-src 'self'` blocks. This relaxes only `style-src` / `font-src` /
+ * `img-src` — scripts stay `'self'` (no `script-src 'unsafe-inline'`), and API
+ * responses keep the strict framework default.
+ */
+final class PublicHtmlCsp
+{
+    public const POLICY = "default-src 'self'; "
+        . "style-src 'self' 'unsafe-inline'; "
+        . "font-src 'self' data:; "
+        . "img-src 'self' data:";
+
+    private function __construct()
+    {
+    }
+}

--- a/src/Http/SpaShellFallback.php
+++ b/src/Http/SpaShellFallback.php
@@ -57,6 +57,7 @@ final readonly class SpaShellFallback
 
         return $this->responseFactory->createResponse(200)
             ->withHeader('Content-Type', 'text/html; charset=utf-8')
+            ->withHeader('Content-Security-Policy', PublicHtmlCsp::POLICY)
             ->withBody($this->streamFactory->createStream($html));
     }
 }

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -8,6 +8,7 @@ use Nene2\Config\AppConfig;
 use Nene2\Routing\Router;
 use Nene2\View\HtmlResponseFactory;
 use NeNeRecords\BundleField\BundleDocumentValidator;
+use NeNeRecords\Http\PublicHtmlCsp;
 use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -135,7 +136,7 @@ final readonly class RenderPublicRecordViewHandler
             // A bundle's crawlable twin (#311): render its seoText markdown server-side
             // (the sandboxed iframe itself is SPA-only / invisible to crawlers).
             'renderBundleSeo' => static fn (string $raw): string => PublicMarkdownRenderer::toSafeHtml(BundleDocumentValidator::seoTextOf($raw)),
-        ]);
+        ])->withHeader('Content-Security-Policy', PublicHtmlCsp::POLICY);
     }
 
     /** @return array{site_name: string, default_meta_description: string} */

--- a/tests/Http/SpaShellFallbackTest.php
+++ b/tests/Http/SpaShellFallbackTest.php
@@ -43,6 +43,10 @@ final class SpaShellFallbackTest extends TestCase
         self::assertSame(200, $result->getStatusCode());
         self::assertStringContainsString('text/html', $result->getHeaderLine('Content-Type'));
         self::assertStringContainsString('<div id="root">', (string) $result->getBody());
+        // SPA-aware CSP so the shell's inline styles / data: fonts are not blocked.
+        $csp = $result->getHeaderLine('Content-Security-Policy');
+        self::assertStringContainsString("style-src 'self' 'unsafe-inline'", $csp);
+        self::assertStringContainsString("font-src 'self' data:", $csp);
     }
 
     public function testServesShellForBrowsePath(): void

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -246,6 +246,10 @@ final class PublicRecordHttpTest extends TestCase
         // Canonical/og still point at the same real permalink.
         self::assertStringContainsString('<link rel="canonical" href="https://example.test/article/10" />', $html);
         self::assertStringContainsString('id="nene-records-public-record-bootstrap"', $html);
+        // SPA-aware CSP: inline styles (runtime theme) + data: fonts are allowed.
+        $csp = $response->getHeaderLine('Content-Security-Policy');
+        self::assertStringContainsString("style-src 'self' 'unsafe-inline'", $csp);
+        self::assertStringContainsString("font-src 'self' data:", $csp);
     }
 
     public function testRealPermalinkReturns404ForUnknownId(): void


### PR DESCRIPTION
## 目的
`Closes #557`。単一オリジン実機検証（#555）で判明した本番限定の課題: NENE2 既定 CSP `default-src 'self'` が公開SPAページの **inline style（runtimeテーマ注入）と data: フォント**をブロック（56違反）。

## 変更
- **`PublicHtmlCsp::POLICY`**（新規）: `default-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:`。
- **SSRレコードページ**（`RenderPublicRecordViewHandler`）と **SPAシェルフォールバック**（`SpaShellFallback`）の応答にだけ付与。`SecurityHeadersMiddleware` は `hasHeader` チェック付きで上書きしない。
- **script-src は 'self' 維持**（script の unsafe-inline は付けない）。**API レスポンスは `default-src 'self'` のまま厳格維持**。

## 検証
- `composer check` 緑（PHPUnit/PHPStan lvl8/CS/OpenAPI/MCP）。
- 実機(:18082): `/posts/246`・`/admin` = 緩和CSP、`/api/v1/entities` = `default-src 'self'` 厳格維持を確認。
- テスト: SSRレコード／SPAシェルの CSP ヘッダ assertion を追加。

Closes #557 / Part of #536