### PR TITLE
feat(migration): WXR パーサ＋インポート計画プレビューを追加する (#539 S1)

### DIFF
--- a/src/WxrImport/WxrDocument.php
+++ b/src/WxrImport/WxrDocument.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+/**
+ * A parsed WordPress WXR export: channel metadata, content items, and the
+ * category/tag definitions declared in the channel header.
+ */
+final readonly class WxrDocument
+{
+    /**
+     * @param list<WxrItem> $items
+     * @param list<WxrTerm> $terms
+     */
+    public function __construct(
+        public string $siteTitle,
+        public string $baseUrl,
+        public array $items,
+        public array $terms,
+    ) {
+    }
+}

--- a/src/WxrImport/WxrImportPlan.php
+++ b/src/WxrImport/WxrImportPlan.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+/**
+ * A dry-run preview of a WXR import: what would be created, what is skipped, the
+ * distinct tags, and warnings — surfaced before any write so the operator can
+ * confirm. The execute step (a later slice) consumes the same mapping.
+ */
+final readonly class WxrImportPlan
+{
+    /**
+     * @param list<WxrImportPlannedItem> $plannedItems
+     * @param list<WxrImportSkippedItem> $skippedItems
+     * @param list<string>               $tagSlugs distinct tags to be ensured
+     * @param list<string>               $warnings
+     * @param array<string, int>         $countsByEntityType posts/pages → count
+     * @param array<string, int>         $countsByStatus     published/draft/scheduled → count
+     */
+    public function __construct(
+        public array $plannedItems,
+        public array $skippedItems,
+        public array $tagSlugs,
+        public array $warnings,
+        public array $countsByEntityType,
+        public array $countsByStatus,
+    ) {
+    }
+}

--- a/src/WxrImport/WxrImportPlannedItem.php
+++ b/src/WxrImport/WxrImportPlannedItem.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+/** An item that would be imported, with its resolved NeNe mapping. */
+final readonly class WxrImportPlannedItem
+{
+    /** @param list<string> $tagSlugs */
+    public function __construct(
+        public string $title,
+        public string $slug,
+        public string $entityTypeSlug, // 'posts' | 'pages'
+        public string $status,         // 'published' | 'draft' | 'scheduled'
+        public array $tagSlugs,
+    ) {
+    }
+}

--- a/src/WxrImport/WxrImportPlanner.php
+++ b/src/WxrImport/WxrImportPlanner.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+/**
+ * Builds a dry-run {@see WxrImportPlan} from a parsed {@see WxrDocument}, applying
+ * the WordPress → NeNe Records mapping:
+ *   - post_type: post → `posts`, page → `pages` (others skipped)
+ *   - status:    publish → published, draft/pending/private → draft, future → scheduled
+ *                (trash / auto-draft / inherit etc. skipped)
+ *   - categories + post_tags → NeNe tags (merged)
+ *   - missing slug → derived from the title (warned)
+ */
+final class WxrImportPlanner
+{
+    private const POST_TYPE_MAP = [
+        'post' => 'posts',
+        'page' => 'pages',
+    ];
+
+    private const STATUS_MAP = [
+        'publish' => 'published',
+        'draft' => 'draft',
+        'pending' => 'draft',
+        'private' => 'draft',
+        'future' => 'scheduled',
+    ];
+
+    public function plan(WxrDocument $document): WxrImportPlan
+    {
+        $planned = [];
+        $skipped = [];
+        $warnings = [];
+        $tagSet = [];
+        $countsByType = [];
+        $countsByStatus = [];
+
+        foreach ($document->items as $item) {
+            $label = $item->title !== '' ? $item->title : ($item->slug ?? '(無題)');
+
+            $entityType = self::POST_TYPE_MAP[$item->postType] ?? null;
+            if ($entityType === null) {
+                $skipped[] = new WxrImportSkippedItem($label, "未対応の post_type: {$item->postType}");
+                continue;
+            }
+
+            $status = self::STATUS_MAP[$item->status] ?? null;
+            if ($status === null) {
+                $skipped[] = new WxrImportSkippedItem($label, "未対応の status: {$item->status}");
+                continue;
+            }
+
+            $slug = $item->slug ?? self::slugify($item->title);
+            if ($item->slug === null) {
+                $warnings[] = "「{$label}」は slug が無いためタイトルから生成します: {$slug}";
+            }
+            if ($slug === '') {
+                $skipped[] = new WxrImportSkippedItem($label, 'slug を決定できません（タイトルも空）');
+                continue;
+            }
+
+            $tags = array_values(array_unique([...$item->categorySlugs, ...$item->tagSlugs]));
+            foreach ($tags as $tag) {
+                $tagSet[$tag] = true;
+            }
+
+            $planned[] = new WxrImportPlannedItem($item->title, $slug, $entityType, $status, $tags);
+            $countsByType[$entityType] = ($countsByType[$entityType] ?? 0) + 1;
+            $countsByStatus[$status] = ($countsByStatus[$status] ?? 0) + 1;
+        }
+
+        return new WxrImportPlan(
+            plannedItems: $planned,
+            skippedItems: $skipped,
+            tagSlugs: array_keys($tagSet),
+            warnings: $warnings,
+            countsByEntityType: $countsByType,
+            countsByStatus: $countsByStatus,
+        );
+    }
+
+    private static function slugify(string $title): string
+    {
+        $slug = strtolower(trim($title));
+        $slug = preg_replace('/[^\p{L}\p{N}]+/u', '-', $slug) ?? '';
+
+        return trim($slug, '-');
+    }
+}

--- a/src/WxrImport/WxrImportSkippedItem.php
+++ b/src/WxrImport/WxrImportSkippedItem.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+/** An item that would be skipped (unsupported post_type / status). */
+final readonly class WxrImportSkippedItem
+{
+    public function __construct(
+        public string $title,
+        public string $reason,
+    ) {
+    }
+}

--- a/src/WxrImport/WxrItem.php
+++ b/src/WxrImport/WxrItem.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+/**
+ * A single parsed `<item>` from a WordPress WXR export. Content is kept as the
+ * raw `content:encoded` HTML for the downstream importer to map; status/type are
+ * the raw WordPress values (mapping to NeNe entity types/statuses happens later).
+ */
+final readonly class WxrItem
+{
+    /**
+     * @param list<string> $categorySlugs WP category nicenames assigned to this item
+     * @param list<string> $tagSlugs      WP post_tag slugs assigned to this item
+     */
+    public function __construct(
+        public ?int $wpPostId,
+        public string $postType,
+        public string $status,
+        public string $title,
+        public ?string $slug,
+        public string $contentHtml,
+        public string $excerptHtml,
+        public ?string $publishedAtIso,
+        public ?string $originalLink,
+        public array $categorySlugs,
+        public array $tagSlugs,
+    ) {
+    }
+}

--- a/src/WxrImport/WxrParseException.php
+++ b/src/WxrImport/WxrParseException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+use RuntimeException;
+
+/** Thrown when a WXR payload is not well-formed XML or not a recognizable export. */
+final class WxrParseException extends RuntimeException
+{
+}

--- a/src/WxrImport/WxrParser.php
+++ b/src/WxrImport/WxrParser.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+use SimpleXMLElement;
+
+/**
+ * Parses a WordPress WXR (eXtended RSS) export into a {@see WxrDocument}.
+ * Namespace prefixes (`wp:`, `content:`, `excerpt:`) are resolved via SimpleXML's
+ * prefixed-children lookup so any WXR version (1.0–1.2) works.
+ */
+final class WxrParser
+{
+    public function parse(string $xml): WxrDocument
+    {
+        if (trim($xml) === '') {
+            throw new WxrParseException('Empty WXR payload.');
+        }
+
+        $previous = libxml_use_internal_errors(true);
+        libxml_clear_errors();
+
+        try {
+            $root = simplexml_load_string($xml, SimpleXMLElement::class, LIBXML_NOCDATA);
+        } finally {
+            libxml_use_internal_errors($previous);
+        }
+
+        if ($root === false) {
+            throw new WxrParseException('WXR payload is not well-formed XML.');
+        }
+
+        $channel = $root->channel;
+
+        if (!$channel instanceof SimpleXMLElement) {
+            throw new WxrParseException('WXR payload has no <channel> (not a WordPress export?).');
+        }
+
+        $siteTitle = trim((string) $channel->title);
+        $baseUrl = trim((string) $channel->children('wp', true)->base_site_url);
+        if ($baseUrl === '') {
+            $baseUrl = trim((string) $channel->link);
+        }
+
+        $terms = [];
+        foreach ($channel->children('wp', true)->category as $category) {
+            $terms[] = new WxrTerm(
+                'category',
+                trim((string) $category->children('wp', true)->category_nicename),
+                trim((string) $category->children('wp', true)->cat_name),
+            );
+        }
+        foreach ($channel->children('wp', true)->tag as $tag) {
+            $terms[] = new WxrTerm(
+                'tag',
+                trim((string) $tag->children('wp', true)->tag_slug),
+                trim((string) $tag->children('wp', true)->tag_name),
+            );
+        }
+
+        $items = [];
+        foreach ($channel->item as $item) {
+            $items[] = $this->parseItem($item);
+        }
+
+        return new WxrDocument($siteTitle, $baseUrl, $items, $terms);
+    }
+
+    private function parseItem(SimpleXMLElement $item): WxrItem
+    {
+        $wp = $item->children('wp', true);
+
+        $postIdRaw = trim((string) $wp->post_id);
+        $slug = trim((string) $wp->post_name);
+        $publishedAt = $this->normalizeDate(trim((string) $wp->post_date));
+
+        $categorySlugs = [];
+        $tagSlugs = [];
+        foreach ($item->category as $category) {
+            $domain = (string) ($category['domain'] ?? '');
+            $nicename = trim((string) ($category['nicename'] ?? ''));
+            $value = $nicename !== '' ? $nicename : trim((string) $category);
+            if ($value === '') {
+                continue;
+            }
+            if ($domain === 'post_tag') {
+                $tagSlugs[] = $value;
+            } elseif ($domain === 'category') {
+                $categorySlugs[] = $value;
+            }
+        }
+
+        return new WxrItem(
+            wpPostId: $postIdRaw === '' ? null : (int) $postIdRaw,
+            postType: trim((string) $wp->post_type),
+            status: trim((string) $wp->status),
+            title: trim((string) $item->title),
+            slug: $slug === '' ? null : $slug,
+            contentHtml: (string) $item->children('content', true)->encoded,
+            excerptHtml: (string) $item->children('excerpt', true)->encoded,
+            publishedAtIso: $publishedAt,
+            originalLink: trim((string) $item->link) ?: null,
+            categorySlugs: array_values(array_unique($categorySlugs)),
+            tagSlugs: array_values(array_unique($tagSlugs)),
+        );
+    }
+
+    /** WP `post_date` is `Y-m-d H:i:s` (site-local); normalize to ISO-8601, else null. */
+    private function normalizeDate(string $raw): ?string
+    {
+        if ($raw === '' || $raw === '0000-00-00 00:00:00') {
+            return null;
+        }
+
+        $parsed = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $raw);
+
+        return $parsed === false ? null : $parsed->format('Y-m-d\TH:i:sP');
+    }
+}

--- a/src/WxrImport/WxrTerm.php
+++ b/src/WxrImport/WxrTerm.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+/**
+ * A category/tag definition from the WXR channel header
+ * (`<wp:category>` / `<wp:tag>`), used to resolve slug → display name.
+ */
+final readonly class WxrTerm
+{
+    public function __construct(
+        public string $kind, // 'category' | 'tag'
+        public string $slug,
+        public string $name,
+    ) {
+    }
+}

--- a/tests/WxrImport/WxrImportPlannerTest.php
+++ b/tests/WxrImport/WxrImportPlannerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\WxrImport;
+
+use NeNeRecords\WxrImport\WxrImportPlanner;
+use NeNeRecords\WxrImport\WxrParser;
+use PHPUnit\Framework\TestCase;
+
+final class WxrImportPlannerTest extends TestCase
+{
+    private function plan(): \NeNeRecords\WxrImport\WxrImportPlan
+    {
+        $xml = file_get_contents(__DIR__ . '/fixtures/sample.wxr.xml');
+        self::assertNotFalse($xml);
+        $doc = (new WxrParser())->parse($xml);
+
+        return (new WxrImportPlanner())->plan($doc);
+    }
+
+    public function testPlansPostsAndPagesAndSkipsAttachments(): void
+    {
+        $plan = $this->plan();
+
+        // hello-world(post), about(page), draft-post(post), no-slug(post) = 4 planned.
+        self::assertCount(4, $plan->plannedItems);
+        // attachment skipped.
+        self::assertCount(1, $plan->skippedItems);
+        self::assertSame('image.jpg', $plan->skippedItems[0]->title);
+        self::assertStringContainsString('attachment', $plan->skippedItems[0]->reason);
+
+        self::assertSame(['posts' => 3, 'pages' => 1], $plan->countsByEntityType);
+        self::assertSame(['published' => 3, 'draft' => 1], $plan->countsByStatus);
+    }
+
+    public function testMapsTypesStatusesAndTags(): void
+    {
+        $plan = $this->plan();
+        $bySlug = [];
+        foreach ($plan->plannedItems as $item) {
+            $bySlug[$item->slug] = $item;
+        }
+
+        self::assertSame('posts', $bySlug['hello-world']->entityTypeSlug);
+        self::assertSame('published', $bySlug['hello-world']->status);
+        self::assertSame(['news', 'php'], $bySlug['hello-world']->tagSlugs);
+
+        self::assertSame('pages', $bySlug['about']->entityTypeSlug);
+        self::assertSame('draft', $bySlug['draft-post']->status);
+
+        // Categories + post_tags are merged into NeNe tags.
+        self::assertContains('news', $plan->tagSlugs);
+        self::assertContains('php', $plan->tagSlugs);
+    }
+
+    public function testDerivesSlugFromTitleWithWarning(): void
+    {
+        $plan = $this->plan();
+        $bySlug = [];
+        foreach ($plan->plannedItems as $item) {
+            $bySlug[$item->slug] = $item;
+        }
+
+        // "No Slug Here" → derived slug + a warning.
+        self::assertArrayHasKey('no-slug-here', $bySlug);
+        self::assertNotEmpty($plan->warnings);
+        self::assertStringContainsString('No Slug Here', implode("\n", $plan->warnings));
+    }
+}

--- a/tests/WxrImport/WxrParserTest.php
+++ b/tests/WxrImport/WxrParserTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\WxrImport;
+
+use NeNeRecords\WxrImport\WxrParseException;
+use NeNeRecords\WxrImport\WxrParser;
+use PHPUnit\Framework\TestCase;
+
+final class WxrParserTest extends TestCase
+{
+    private function parseFixture(): \NeNeRecords\WxrImport\WxrDocument
+    {
+        $xml = file_get_contents(__DIR__ . '/fixtures/sample.wxr.xml');
+        self::assertNotFalse($xml);
+
+        return (new WxrParser())->parse($xml);
+    }
+
+    public function testParsesChannelMetadataAndTerms(): void
+    {
+        $doc = $this->parseFixture();
+
+        self::assertSame('My Old Blog', $doc->siteTitle);
+        self::assertSame('https://old.example.com', $doc->baseUrl);
+        self::assertCount(5, $doc->items);
+        self::assertCount(2, $doc->terms);
+        self::assertSame('category', $doc->terms[0]->kind);
+        self::assertSame('news', $doc->terms[0]->slug);
+        self::assertSame('News', $doc->terms[0]->name);
+        self::assertSame('tag', $doc->terms[1]->kind);
+        self::assertSame('php', $doc->terms[1]->slug);
+    }
+
+    public function testParsesPostItemFieldsCategoriesAndDate(): void
+    {
+        $hello = $this->parseFixture()->items[0];
+
+        self::assertSame(10, $hello->wpPostId);
+        self::assertSame('post', $hello->postType);
+        self::assertSame('publish', $hello->status);
+        self::assertSame('Hello World', $hello->title);
+        self::assertSame('hello-world', $hello->slug);
+        self::assertStringContainsString('<strong>world</strong>', $hello->contentHtml);
+        self::assertSame('A greeting.', $hello->excerptHtml);
+        self::assertSame('https://old.example.com/2024/01/hello-world/', $hello->originalLink);
+        self::assertSame(['news'], $hello->categorySlugs);
+        self::assertSame(['php'], $hello->tagSlugs);
+        // WP local date → ISO-8601.
+        self::assertNotNull($hello->publishedAtIso);
+        self::assertStringStartsWith('2024-01-15T10:00:00', $hello->publishedAtIso);
+    }
+
+    public function testItemWithoutSlugYieldsNull(): void
+    {
+        $noSlug = $this->parseFixture()->items[4];
+
+        self::assertSame('No Slug Here', $noSlug->title);
+        self::assertNull($noSlug->slug);
+        self::assertSame('post', $noSlug->postType);
+    }
+
+    public function testThrowsOnMalformedXml(): void
+    {
+        $this->expectException(WxrParseException::class);
+        (new WxrParser())->parse('<rss><channel><item></broken>');
+    }
+
+    public function testThrowsOnEmptyPayload(): void
+    {
+        $this->expectException(WxrParseException::class);
+        (new WxrParser())->parse('   ');
+    }
+}

--- a/tests/WxrImport/fixtures/sample.wxr.xml
+++ b/tests/WxrImport/fixtures/sample.wxr.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+  xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:wp="http://wordpress.org/export/1.2/">
+  <channel>
+    <title>My Old Blog</title>
+    <link>https://old.example.com</link>
+    <wp:wxr_version>1.2</wp:wxr_version>
+    <wp:base_site_url>https://old.example.com</wp:base_site_url>
+    <wp:category>
+      <wp:term_id>1</wp:term_id>
+      <wp:category_nicename>news</wp:category_nicename>
+      <wp:cat_name><![CDATA[News]]></wp:cat_name>
+    </wp:category>
+    <wp:tag>
+      <wp:term_id>5</wp:term_id>
+      <wp:tag_slug>php</wp:tag_slug>
+      <wp:tag_name><![CDATA[PHP]]></wp:tag_name>
+    </wp:tag>
+    <item>
+      <title>Hello World</title>
+      <link>https://old.example.com/2024/01/hello-world/</link>
+      <dc:creator><![CDATA[admin]]></dc:creator>
+      <content:encoded><![CDATA[<p>Hello <strong>world</strong>.</p>]]></content:encoded>
+      <excerpt:encoded><![CDATA[A greeting.]]></excerpt:encoded>
+      <wp:post_id>10</wp:post_id>
+      <wp:post_date><![CDATA[2024-01-15 10:00:00]]></wp:post_date>
+      <wp:post_name><![CDATA[hello-world]]></wp:post_name>
+      <wp:status><![CDATA[publish]]></wp:status>
+      <wp:post_type><![CDATA[post]]></wp:post_type>
+      <category domain="category" nicename="news"><![CDATA[News]]></category>
+      <category domain="post_tag" nicename="php"><![CDATA[PHP]]></category>
+    </item>
+    <item>
+      <title>About</title>
+      <link>https://old.example.com/about/</link>
+      <content:encoded><![CDATA[<p>About this site.</p>]]></content:encoded>
+      <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+      <wp:post_id>2</wp:post_id>
+      <wp:post_date><![CDATA[2023-06-01 09:00:00]]></wp:post_date>
+      <wp:post_name><![CDATA[about]]></wp:post_name>
+      <wp:status><![CDATA[publish]]></wp:status>
+      <wp:post_type><![CDATA[page]]></wp:post_type>
+    </item>
+    <item>
+      <title>Draft Post</title>
+      <content:encoded><![CDATA[<p>Work in progress.</p>]]></content:encoded>
+      <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+      <wp:post_id>11</wp:post_id>
+      <wp:post_date><![CDATA[2024-02-01 12:00:00]]></wp:post_date>
+      <wp:post_name><![CDATA[draft-post]]></wp:post_name>
+      <wp:status><![CDATA[draft]]></wp:status>
+      <wp:post_type><![CDATA[post]]></wp:post_type>
+    </item>
+    <item>
+      <title>image.jpg</title>
+      <content:encoded><![CDATA[]]></content:encoded>
+      <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+      <wp:post_id>99</wp:post_id>
+      <wp:post_date><![CDATA[2024-01-20 08:00:00]]></wp:post_date>
+      <wp:post_name><![CDATA[image-jpg]]></wp:post_name>
+      <wp:status><![CDATA[inherit]]></wp:status>
+      <wp:post_type><![CDATA[attachment]]></wp:post_type>
+    </item>
+    <item>
+      <title>No Slug Here</title>
+      <content:encoded><![CDATA[<p>Slugless.</p>]]></content:encoded>
+      <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+      <wp:post_id>12</wp:post_id>
+      <wp:post_date><![CDATA[2024-03-01 00:00:00]]></wp:post_date>
+      <wp:post_name><![CDATA[]]></wp:post_name>
+      <wp:status><![CDATA[publish]]></wp:status>
+      <wp:post_type><![CDATA[post]]></wp:post_type>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
## 目的
`#539`（**市場討論3回で「受託WPリプレース層の単一最大ゲート」「次に採用を動かす唯一の機能」と判定**）の第1スライス。設計から段階的に進めるため、まず最も基盤的で安全な **パース＋ドライラン計画**（純ドメイン・**DB書込なし**）を実装する。

## 変更（src/WxrImport）
- **`WxrParser`** — WordPress WXR(eXtended RSS) を SimpleXML で解析。`wp:`/`content:`/`excerpt:` 名前空間をプレフィックス解決し WXR 1.0–1.2 に対応。CDATA・日付(`Y-m-d H:i:s`→ISO-8601)・`<category domain="category|post_tag">` を処理。不正XML/空は `WxrParseException`。DTO: `WxrDocument`/`WxrItem`/`WxrTerm`。
- **`WxrImportPlanner`** — WordPress→NeNe マッピングのドライラン計画:
  - post_type: `post→posts` / `page→pages`（他は skip）
  - status: `publish→published` / `draft,pending,private→draft` / `future→scheduled`（trash/inherit 等 skip）
  - categories + post_tags → **NeNe タグ（統合）**
  - slug 欠如 → タイトルから生成（警告）
  - 計画は `plannedItems`/`skippedItems`/`tagSlugs`/`warnings`/件数集計 を返し**書込前に確認可能**。

## 段階計画（staged）
- **S1（本PR）**: パース＋計画プレビュー。
- S2: 実行インポート（エンティティ＋タグ＋text_fields 作成・冪等・org スコープ）。`content:encoded`(HTML) のフィールドマッピングは S2 で確定。
- S3: メディア添付・**301 リダイレクトマップ**（旧WP URL→新permalink）・postmeta。

## 検証
- `composer check` 緑（PHPUnit/PHPStan lvl8/CS/OpenAPI/MCP）。
- 追加テスト: `WxrParserTest`（チャネル/term/item/日付/不正XML）＋ `WxrImportPlannerTest`（型/status/タグ/skip/slug生成・計8）を**実WXRフィクスチャ**で検証。

Part of #539