### PR TITLE
feat(migration): WXR 実行インポートを追加する（エンティティ/タグ生成・冪等）(#539 S2)

### DIFF
--- a/src/WxrImport/WxrImportExecutor.php
+++ b/src/WxrImport/WxrImportExecutor.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+use DateTimeImmutable;
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\Entity\EntityStatus;
+use NeNeRecords\EntityTag\EntityTagRepositoryInterface;
+use NeNeRecords\EntityType\EntityType;
+use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+use NeNeRecords\Tag\Tag;
+use NeNeRecords\Tag\TagRepositoryInterface;
+use NeNeRecords\TextField\TextField;
+use NeNeRecords\TextField\TextFieldRepositoryInterface;
+
+/**
+ * Executes a parsed WXR import (S2): creates entities (posts/pages), their
+ * title/body text fields, and tags + entity-tag links, scoped to the active
+ * organization via the repositories' org-aware writes.
+ *
+ * - Idempotent: an item whose slug already exists for its type is skipped, so
+ *   re-running the same import does not duplicate.
+ * - Target type/fields are ensured (created if missing); `title` is text, `body`
+ *   is html so imported WordPress content renders sanitized. A pre-existing
+ *   markdown `body` is reused as-is (HTML stored verbatim; renders via the
+ *   markdown HTML passthrough).
+ *
+ * Out of scope (later slices): media attachments, 301 redirect map, postmeta.
+ */
+final class WxrImportExecutor
+{
+    public function __construct(
+        private EntityTypeRepositoryInterface $entityTypes,
+        private FieldDefRepositoryInterface $fieldDefs,
+        private EntityRepositoryInterface $entities,
+        private TextFieldRepositoryInterface $textFields,
+        private TagRepositoryInterface $tags,
+        private EntityTagRepositoryInterface $entityTags,
+    ) {
+    }
+
+    public function execute(WxrDocument $document): WxrImportResult
+    {
+        $plan = (new WxrImportPlanner())->plan($document);
+        $tagNames = $this->termNameMap($document);
+
+        /** @var array<string, int> $typeIdBySlug */
+        $typeIdBySlug = [];
+        /** @var array<string, int> $tagIdBySlug */
+        $tagIdBySlug = [];
+
+        $created = 0;
+        $skippedExisting = 0;
+        $tagLinks = 0;
+
+        foreach ($plan->plannedItems as $item) {
+            $typeId = $typeIdBySlug[$item->entityTypeSlug] ??= $this->resolveType($item->entityTypeSlug);
+
+            if ($this->entities->findBySlug($item->slug, $typeId) !== null) {
+                ++$skippedExisting;
+                continue;
+            }
+
+            $entityId = $this->entities->save(new Entity(
+                id: null,
+                entityTypeId: $typeId,
+                slug: $item->slug,
+                status: EntityStatus::from($item->status),
+                publishedAt: $item->publishedAtIso !== null ? new DateTimeImmutable($item->publishedAtIso) : null,
+            ));
+
+            $this->textFields->save(new TextField(entityId: $entityId, fieldKey: 'title', value: $item->title));
+            $this->textFields->save(new TextField(entityId: $entityId, fieldKey: 'body', value: $item->contentHtml));
+
+            foreach ($item->tagSlugs as $tagSlug) {
+                $tagId = $tagIdBySlug[$tagSlug] ??= $this->ensureTag($tagSlug, $tagNames[$tagSlug] ?? $tagSlug);
+                if (!$this->entityTags->isAttached($entityId, $tagId)) {
+                    $this->entityTags->attach($entityId, $tagId);
+                    ++$tagLinks;
+                }
+            }
+
+            ++$created;
+        }
+
+        return new WxrImportResult(
+            createdEntities: $created,
+            skippedExisting: $skippedExisting,
+            tagsEnsured: count($tagIdBySlug),
+            tagLinks: $tagLinks,
+            skippedItems: $plan->skippedItems,
+            warnings: $plan->warnings,
+        );
+    }
+
+    private function resolveType(string $slug): int
+    {
+        $existing = $this->entityTypes->findBySlug($slug);
+
+        if ($existing !== null && $existing->id !== null) {
+            $typeId = $existing->id;
+        } else {
+            $typeId = $this->entityTypes->save(new EntityType(name: ucfirst($slug), slug: $slug));
+        }
+
+        $this->ensureFieldDef($typeId, 'title', 'text');
+        $this->ensureFieldDef($typeId, 'body', 'html');
+
+        return $typeId;
+    }
+
+    private function ensureFieldDef(int $typeId, string $fieldKey, string $dataType): void
+    {
+        if ($this->fieldDefs->findByEntityTypeIdAndFieldKey($typeId, $fieldKey) === null) {
+            $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: $fieldKey, dataType: $dataType));
+        }
+    }
+
+    private function ensureTag(string $slug, string $name): int
+    {
+        $existing = $this->tags->findBySlug($slug);
+
+        if ($existing !== null && $existing->id !== null) {
+            return $existing->id;
+        }
+
+        return $this->tags->save(new Tag(slug: $slug, name: $name));
+    }
+
+    /** @return array<string, string> slug → display name from the WXR term definitions */
+    private function termNameMap(WxrDocument $document): array
+    {
+        $map = [];
+        foreach ($document->terms as $term) {
+            if ($term->slug !== '' && $term->name !== '') {
+                $map[$term->slug] = $term->name;
+            }
+        }
+
+        return $map;
+    }
+}

--- a/src/WxrImport/WxrImportPlannedItem.php
+++ b/src/WxrImport/WxrImportPlannedItem.php
@@ -14,6 +14,8 @@ final readonly class WxrImportPlannedItem
         public string $entityTypeSlug, // 'posts' | 'pages'
         public string $status,         // 'published' | 'draft' | 'scheduled'
         public array $tagSlugs,
+        public string $contentHtml = '',
+        public ?string $publishedAtIso = null,
     ) {
     }
 }

--- a/src/WxrImport/WxrImportPlanner.php
+++ b/src/WxrImport/WxrImportPlanner.php
@@ -66,7 +66,15 @@ final class WxrImportPlanner
                 $tagSet[$tag] = true;
             }
 
-            $planned[] = new WxrImportPlannedItem($item->title, $slug, $entityType, $status, $tags);
+            $planned[] = new WxrImportPlannedItem(
+                $item->title,
+                $slug,
+                $entityType,
+                $status,
+                $tags,
+                $item->contentHtml,
+                $item->publishedAtIso,
+            );
             $countsByType[$entityType] = ($countsByType[$entityType] ?? 0) + 1;
             $countsByStatus[$status] = ($countsByStatus[$status] ?? 0) + 1;
         }

--- a/src/WxrImport/WxrImportResult.php
+++ b/src/WxrImport/WxrImportResult.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+/** Outcome of executing a WXR import (S2). */
+final readonly class WxrImportResult
+{
+    /**
+     * @param list<WxrImportSkippedItem> $skippedItems unsupported post_type/status (from the plan)
+     * @param list<string>               $warnings
+     */
+    public function __construct(
+        public int $createdEntities,
+        public int $skippedExisting, // already present (idempotent re-import)
+        public int $tagsEnsured,     // distinct tags found-or-created
+        public int $tagLinks,
+        public array $skippedItems,
+        public array $warnings,
+    ) {
+    }
+}

--- a/tests/WxrImport/WxrImportExecutorTest.php
+++ b/tests/WxrImport/WxrImportExecutorTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\WxrImport;
+
+use NeNeRecords\Entity\EntityStatus;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\EntityTag\InMemoryEntityTagRepository;
+use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use NeNeRecords\Tests\Tag\InMemoryTagRepository;
+use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
+use NeNeRecords\WxrImport\WxrDocument;
+use NeNeRecords\WxrImport\WxrImportExecutor;
+use NeNeRecords\WxrImport\WxrImportResult;
+use NeNeRecords\WxrImport\WxrParser;
+use PHPUnit\Framework\TestCase;
+
+final class WxrImportExecutorTest extends TestCase
+{
+    private InMemoryEntityTypeRepository $entityTypes;
+    private InMemoryFieldDefRepository $fieldDefs;
+    private InMemoryEntityRepository $entities;
+    private InMemoryTextFieldRepository $textFields;
+    private InMemoryTagRepository $tags;
+    private InMemoryEntityTagRepository $entityTags;
+    private WxrImportExecutor $executor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->entityTypes = new InMemoryEntityTypeRepository([]);
+        $this->fieldDefs = new InMemoryFieldDefRepository([]);
+        $this->entities = new InMemoryEntityRepository([]);
+        $this->textFields = new InMemoryTextFieldRepository([], $this->entities);
+        $this->tags = new InMemoryTagRepository([]);
+        $this->entityTags = new InMemoryEntityTagRepository();
+        $this->executor = new WxrImportExecutor(
+            $this->entityTypes,
+            $this->fieldDefs,
+            $this->entities,
+            $this->textFields,
+            $this->tags,
+            $this->entityTags,
+        );
+    }
+
+    private function document(): WxrDocument
+    {
+        $xml = file_get_contents(__DIR__ . '/fixtures/sample.wxr.xml');
+        self::assertNotFalse($xml);
+
+        return (new WxrParser())->parse($xml);
+    }
+
+    public function testImportsPostsPagesFieldsAndTags(): void
+    {
+        $result = $this->executor->execute($this->document());
+
+        self::assertInstanceOf(WxrImportResult::class, $result);
+        self::assertSame(4, $result->createdEntities); // hello, about, draft, no-slug
+        self::assertSame(0, $result->skippedExisting);
+        self::assertCount(1, $result->skippedItems); // attachment
+        self::assertSame(2, $result->tagsEnsured);    // news, php
+        self::assertSame(2, $result->tagLinks);       // hello-world ← news, php
+
+        // Entity types were created on demand.
+        $posts = $this->entityTypes->findBySlug('posts');
+        $pages = $this->entityTypes->findBySlug('pages');
+        self::assertNotNull($posts);
+        self::assertNotNull($pages);
+        self::assertNotNull($posts->id);
+
+        // Field defs ensured: title=text, body=html.
+        $titleDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($posts->id, 'title');
+        $bodyDef = $this->fieldDefs->findByEntityTypeIdAndFieldKey($posts->id, 'body');
+        self::assertNotNull($titleDef);
+        self::assertSame('text', $titleDef->dataType);
+        self::assertNotNull($bodyDef);
+        self::assertSame('html', $bodyDef->dataType);
+
+        // hello-world: published, title + body content stored.
+        $hello = $this->entities->findBySlug('hello-world', $posts->id);
+        self::assertNotNull($hello);
+        self::assertNotNull($hello->id);
+        self::assertSame(EntityStatus::Published, $hello->status);
+
+        $values = [];
+        foreach ($this->textFields->findByEntityId($hello->id, 100, 0) as $tf) {
+            $values[$tf->fieldKey] = $tf->value;
+        }
+        self::assertSame('Hello World', $values['title'] ?? null);
+        self::assertStringContainsString('<strong>world</strong>', $values['body'] ?? '');
+
+        // Tags linked.
+        $news = $this->tags->findBySlug('news');
+        self::assertNotNull($news);
+        self::assertNotNull($news->id);
+        self::assertSame('News', $news->name); // resolved from <wp:category> definition
+        self::assertTrue($this->entityTags->isAttached($hello->id, $news->id));
+    }
+
+    public function testDraftStatusMappedAndPageImportedIntoPagesType(): void
+    {
+        $this->executor->execute($this->document());
+
+        $posts = $this->entityTypes->findBySlug('posts');
+        $pages = $this->entityTypes->findBySlug('pages');
+        self::assertNotNull($posts?->id);
+        self::assertNotNull($pages?->id);
+
+        $draft = $this->entities->findBySlug('draft-post', $posts->id);
+        self::assertNotNull($draft);
+        self::assertSame(EntityStatus::Draft, $draft->status);
+
+        $about = $this->entities->findBySlug('about', $pages->id);
+        self::assertNotNull($about);
+        self::assertSame(EntityStatus::Published, $about->status);
+    }
+
+    public function testIsIdempotentOnReRun(): void
+    {
+        $doc = $this->document();
+        $this->executor->execute($doc);
+        $second = $this->executor->execute($doc);
+
+        self::assertSame(0, $second->createdEntities);
+        self::assertSame(4, $second->skippedExisting);
+        self::assertSame(0, $second->tagLinks); // already attached
+    }
+}


### PR DESCRIPTION
## 目的
`#539` S2。S1(#561) のパーサ/計画に続き、計画を実際に DB へ反映する `WxrImportExecutor` を実装する（純ドメイン・既存リポジトリ経由で org スコープ）。

## 変更（src/WxrImport）
- **`WxrImportExecutor`** — 計画済みアイテムごとに:
  - 対象エンティティタイプ(`posts`/`pages`)を **find-or-create**、`title`(text)/`body`(html) のフィールド定義を ensure
  - エンティティ作成（slug / status / publishedAt）
  - `title`・`body`(=`content:encoded` HTML) の text_fields 作成
  - categories + tags を **find-or-create** し `entity_tags` を attach（タグ名は WXR の `<wp:category>`/`<wp:tag>` 定義から解決）
- **冪等**: slug が既存のアイテムは skip（再実行で重複しない）。
- **content マッピング**: `body` を find-or-create（無ければ `html` 型）し WP HTML を格納。既存 markdown `body` はそのまま再利用（HTML は markdown パススルーで描画）。
- `WxrImportPlannedItem` に `contentHtml`/`publishedAtIso` を追加。
- 結果 `WxrImportResult`（created/skippedExisting/tagsEnsured/tagLinks/skipped/warnings）。

## 検証
- `composer check` 緑（PHPUnit/PHPStan lvl8/CS/OpenAPI/MCP）。
- `WxrImportExecutorTest`（取込：posts3/pages1・title/body・タグ news/php 紐付け／status マッピング／**冪等再実行**で created 0・skippedExisting 4）。WxrImport 計 **11 テスト**。

## 残（後続）
- S3: メディア添付・**301 リダイレクトマップ**・postmeta。
- HTTP アップロード→プレビュー/実行エンドポイント＋管理UI（executor は実装済みなので配線中心）。

Part of #539