### PR TITLE
feat(migration): WXR インポートの HTTP エンドポイントを配線する (#539)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -3977,6 +3977,48 @@ paths:
           $ref: '#/components/responses/Gone'
         '422':
           $ref: '#/components/responses/ValidationFailed'
+  /api/v1/migration/wxr:
+    post:
+      tags:
+        - Migration
+      summary: Import a WordPress WXR export
+      description: "Admin-only. Accepts a multipart/form-data WordPress WXR (.xml) export. With dry_run=true (default) returns a preview plan (what would be imported/skipped) without writing; with dry_run=false executes the import into the active organization (idempotent by slug). Out of scope: media attachments, 301 redirect map, postmeta."
+      operationId: importWxr
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: WordPress WXR export XML.
+                dry_run:
+                  type: string
+                  enum: ['true', 'false']
+                  default: 'true'
+                  description: 'true = preview only; false = execute import.'
+      responses:
+        '200':
+          description: Dry-run import plan (preview).
+          content:
+            application/json:
+              schema:
+                type: object
+        '201':
+          description: Import executed.
+          content:
+            application/json:
+              schema:
+                type: object
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   parameters:
     IdPath:

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -123,6 +123,8 @@ use NeNeRecords\Webhook\WebhookServiceProvider;
 use NeNeRecords\Widget\WidgetNotFoundExceptionHandler;
 use NeNeRecords\Widget\WidgetRouteRegistrar;
 use NeNeRecords\Widget\WidgetServiceProvider;
+use NeNeRecords\WxrImport\WxrImportRouteRegistrar;
+use NeNeRecords\WxrImport\WxrImportServiceProvider;
 use Psr\Container\ContainerInterface;
 
 final readonly class ApplicationServiceProvider implements ServiceProviderInterface
@@ -177,7 +179,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new SystemConfigServiceProvider())
             ->addProvider(new DataMigrationServiceProvider())
             ->addProvider(new OrgExportServiceProvider())
-            ->addProvider(new ThemeServiceProvider());
+            ->addProvider(new ThemeServiceProvider())
+            ->addProvider(new WxrImportServiceProvider());
 
         $builder
             ->set(
@@ -216,6 +219,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $dataMigration = $container->get(DataMigrationRouteRegistrar::class);
                     $orgExport     = $container->get(OrgExportRouteRegistrar::class);
                     $theme = $container->get('nene-records.route_registrar.theme');
+                    $wxrImport = $container->get('nene-records.route_registrar.wxr_import');
 
                     if (
                         !$entityType instanceof EntityTypeRouteRegistrar
@@ -251,6 +255,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !$dataMigration instanceof DataMigrationRouteRegistrar
                         || !$orgExport instanceof OrgExportRouteRegistrar
                         || !$theme instanceof ThemeRouteRegistrar
+                        || !$wxrImport instanceof WxrImportRouteRegistrar
                     ) {
                         throw new LogicException('Route registrar service is invalid.');
                     }
@@ -289,6 +294,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $dataMigration,
                         $orgExport,
                         $theme,
+                        $wxrImport,
                     ];
                 },
             )

--- a/src/Auth/AdminApiAuthMiddleware.php
+++ b/src/Auth/AdminApiAuthMiddleware.php
@@ -51,6 +51,7 @@ final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
         '/api/v1/admin/comments',
         '/api/v1/organizations',
         '/api/v1/themes',
+        '/api/v1/migration',
     ];
 
     public function __construct(

--- a/src/WxrImport/WxrImportHttpHandler.php
+++ b/src/WxrImport/WxrImportHttpHandler.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * WordPress WXR import endpoint (admin-only).
+ *
+ * POST /api/v1/migration/wxr  (multipart/form-data)
+ *   - `file`    : the WordPress WXR export (.xml) — required
+ *   - `dry_run` : "true" (default) returns a preview plan without writing;
+ *                 "false" executes the import into the active organization.
+ */
+final readonly class WxrImportHttpHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private WxrImportExecutor $executor,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $file = $request->getUploadedFiles()['file'] ?? null;
+
+        if (!$file instanceof UploadedFileInterface) {
+            return $this->problemDetails->create(
+                $request,
+                'wxr-no-file',
+                'No WXR File',
+                422,
+                'multipart field "file" (a WordPress WXR export) is required.',
+            );
+        }
+
+        $xml = (string) $file->getStream();
+
+        $body = $request->getParsedBody();
+        $dryRun = !is_array($body) || ($body['dry_run'] ?? 'true') !== 'false';
+
+        try {
+            $document = (new WxrParser())->parse($xml);
+        } catch (WxrParseException $exception) {
+            return $this->problemDetails->create(
+                $request,
+                'wxr-parse-failed',
+                'WXR Parse Failed',
+                422,
+                $exception->getMessage(),
+            );
+        }
+
+        if ($dryRun) {
+            return $this->json->create($this->planToArray((new WxrImportPlanner())->plan($document)));
+        }
+
+        return $this->json->create($this->resultToArray($this->executor->execute($document)), 201);
+    }
+
+    /** @return array<string, mixed> */
+    private function planToArray(WxrImportPlan $plan): array
+    {
+        return [
+            'mode' => 'preview',
+            'planned_count' => count($plan->plannedItems),
+            'skipped_count' => count($plan->skippedItems),
+            'counts_by_entity_type' => $plan->countsByEntityType,
+            'counts_by_status' => $plan->countsByStatus,
+            'tags' => $plan->tagSlugs,
+            'warnings' => $plan->warnings,
+            'planned' => array_map(static fn (WxrImportPlannedItem $i): array => [
+                'title' => $i->title,
+                'slug' => $i->slug,
+                'entity_type' => $i->entityTypeSlug,
+                'status' => $i->status,
+                'tags' => $i->tagSlugs,
+            ], $plan->plannedItems),
+            'skipped' => array_map(static fn (WxrImportSkippedItem $s): array => [
+                'title' => $s->title,
+                'reason' => $s->reason,
+            ], $plan->skippedItems),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function resultToArray(WxrImportResult $result): array
+    {
+        return [
+            'mode' => 'import',
+            'created_entities' => $result->createdEntities,
+            'skipped_existing' => $result->skippedExisting,
+            'tags_ensured' => $result->tagsEnsured,
+            'tag_links' => $result->tagLinks,
+            'skipped' => array_map(static fn (WxrImportSkippedItem $s): array => [
+                'title' => $s->title,
+                'reason' => $s->reason,
+            ], $result->skippedItems),
+            'warnings' => $result->warnings,
+        ];
+    }
+}

--- a/src/WxrImport/WxrImportRouteRegistrar.php
+++ b/src/WxrImport/WxrImportRouteRegistrar.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class WxrImportRouteRegistrar
+{
+    public function __construct(
+        private WxrImportHttpHandler $handler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $handler = $this->handler;
+
+        $router->post(
+            '/api/v1/migration/wxr',
+            static fn (ServerRequestInterface $request) => $handler->handle($request),
+        );
+    }
+}

--- a/src/WxrImport/WxrImportServiceProvider.php
+++ b/src/WxrImport/WxrImportServiceProvider.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\EntityTag\EntityTagRepositoryInterface;
+use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
+use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+use NeNeRecords\Tag\TagRepositoryInterface;
+use NeNeRecords\TextField\TextFieldRepositoryInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class WxrImportServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                WxrImportExecutor::class,
+                static function (ContainerInterface $c): WxrImportExecutor {
+                    $entityTypes = $c->get(EntityTypeRepositoryInterface::class);
+                    $fieldDefs = $c->get(FieldDefRepositoryInterface::class);
+                    $entities = $c->get(EntityRepositoryInterface::class);
+                    $textFields = $c->get(TextFieldRepositoryInterface::class);
+                    $tags = $c->get(TagRepositoryInterface::class);
+                    $entityTags = $c->get(EntityTagRepositoryInterface::class);
+
+                    if (!$entityTypes instanceof EntityTypeRepositoryInterface) {
+                        throw new LogicException('Entity type repository service is invalid.');
+                    }
+                    if (!$fieldDefs instanceof FieldDefRepositoryInterface) {
+                        throw new LogicException('Field def repository service is invalid.');
+                    }
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+                    if (!$textFields instanceof TextFieldRepositoryInterface) {
+                        throw new LogicException('Text field repository service is invalid.');
+                    }
+                    if (!$tags instanceof TagRepositoryInterface) {
+                        throw new LogicException('Tag repository service is invalid.');
+                    }
+                    if (!$entityTags instanceof EntityTagRepositoryInterface) {
+                        throw new LogicException('Entity tag repository service is invalid.');
+                    }
+
+                    return new WxrImportExecutor($entityTypes, $fieldDefs, $entities, $textFields, $tags, $entityTags);
+                },
+            )
+            ->set(
+                WxrImportHttpHandler::class,
+                static function (ContainerInterface $c): WxrImportHttpHandler {
+                    $executor = $c->get(WxrImportExecutor::class);
+                    $json = $c->get(JsonResponseFactory::class);
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$executor instanceof WxrImportExecutor) {
+                        throw new LogicException('WXR import executor service is invalid.');
+                    }
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new WxrImportHttpHandler($executor, $json, $problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.wxr_import',
+                static function (ContainerInterface $c): WxrImportRouteRegistrar {
+                    $handler = $c->get(WxrImportHttpHandler::class);
+
+                    if (!$handler instanceof WxrImportHttpHandler) {
+                        throw new LogicException('WXR import handler service is invalid.');
+                    }
+
+                    return new WxrImportRouteRegistrar($handler);
+                },
+            );
+    }
+}

--- a/tests/WxrImport/WxrImportHttpTest.php
+++ b/tests/WxrImport/WxrImportHttpTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\WxrImport;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\EntityTag\InMemoryEntityTagRepository;
+use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
+use NeNeRecords\Tests\Tag\InMemoryTagRepository;
+use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
+use NeNeRecords\WxrImport\WxrImportExecutor;
+use NeNeRecords\WxrImport\WxrImportHttpHandler;
+use NeNeRecords\WxrImport\WxrImportRouteRegistrar;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class WxrImportHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private RequestHandlerInterface $application;
+    private InMemoryEntityRepository $entities;
+    private InMemoryEntityTypeRepository $entityTypes;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new Psr17Factory();
+        $this->entityTypes = new InMemoryEntityTypeRepository([]);
+        $this->entities = new InMemoryEntityRepository([]);
+        $executor = new WxrImportExecutor(
+            $this->entityTypes,
+            new InMemoryFieldDefRepository([]),
+            $this->entities,
+            new InMemoryTextFieldRepository([], $this->entities),
+            new InMemoryTagRepository([]),
+            new InMemoryEntityTagRepository(),
+        );
+        $handler = new WxrImportHttpHandler(
+            $executor,
+            new JsonResponseFactory($this->factory, $this->factory),
+            new ProblemDetailsResponseFactory($this->factory, $this->factory),
+        );
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            routeRegistrars: [new WxrImportRouteRegistrar($handler)],
+        ))->create();
+    }
+
+    private function uploadRequest(?string $dryRun): ServerRequestInterface
+    {
+        $xml = file_get_contents(__DIR__ . '/fixtures/sample.wxr.xml');
+        self::assertNotFalse($xml);
+        $upload = $this->factory->createUploadedFile(
+            $this->factory->createStream($xml),
+            strlen($xml),
+            UPLOAD_ERR_OK,
+            'sample.wxr.xml',
+            'application/xml',
+        );
+        $request = $this->factory
+            ->createServerRequest('POST', 'https://example.test/api/v1/migration/wxr')
+            ->withUploadedFiles(['file' => $upload]);
+
+        return $dryRun === null ? $request : $request->withParsedBody(['dry_run' => $dryRun]);
+    }
+
+    /** @return array<string, mixed> */
+    private function decode(ResponseInterface $response): array
+    {
+        return json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    public function testPreviewReturnsPlanWithoutWriting(): void
+    {
+        $response = $this->application->handle($this->uploadRequest(null)); // default dry_run
+        $payload = $this->decode($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('preview', $payload['mode']);
+        self::assertSame(4, $payload['planned_count']);
+        self::assertSame(1, $payload['skipped_count']);
+        self::assertSame(['posts' => 3, 'pages' => 1], $payload['counts_by_entity_type']);
+        // Nothing written in preview.
+        self::assertNull($this->entityTypes->findBySlug('posts'));
+    }
+
+    public function testImportExecutesWhenDryRunFalse(): void
+    {
+        $response = $this->application->handle($this->uploadRequest('false'));
+        $payload = $this->decode($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame('import', $payload['mode']);
+        self::assertSame(4, $payload['created_entities']);
+        self::assertSame(2, $payload['tags_ensured']);
+
+        // Entities actually created.
+        $posts = $this->entityTypes->findBySlug('posts');
+        self::assertNotNull($posts?->id);
+        self::assertNotNull($this->entities->findBySlug('hello-world', $posts->id));
+    }
+
+    public function testReturns422WhenFileMissing(): void
+    {
+        $request = $this->factory->createServerRequest('POST', 'https://example.test/api/v1/migration/wxr');
+        $response = $this->application->handle($request);
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function testReturns422OnMalformedXml(): void
+    {
+        $upload = $this->factory->createUploadedFile(
+            $this->factory->createStream('<rss><broken>'),
+            13,
+            UPLOAD_ERR_OK,
+            'bad.xml',
+            'application/xml',
+        );
+        $request = $this->factory
+            ->createServerRequest('POST', 'https://example.test/api/v1/migration/wxr')
+            ->withUploadedFiles(['file' => $upload]);
+
+        self::assertSame(422, $this->application->handle($request)->getStatusCode());
+    }
+}


### PR DESCRIPTION
## 目的
`#539`。S1(#561 パーサ/計画)・S2(#562 実行)のドメインを、**管理者が実際に操作できる API** として公開し、WXR 移行を操作可能にする。

## 変更
- **`POST /api/v1/migration/wxr`**（multipart・**admin-only**）: `file`=WXR(.xml)、`dry_run=true`(既定)でプレビュー計画、`false` で実行インポート。
- `WxrImportHttpHandler`: アップロード取得→パース→dry_run 分岐（計画 or 実行）を JSON で返す。ファイル無し/不正XMLは **422**（Problem Details）。
- `WxrImportServiceProvider` で executor/handler/registrar を **org スコープ repo** と配線、`ApplicationServiceProvider` に登録。`ADMIN_ONLY_PREFIXES` に `/api/v1/migration` を追加。
- OpenAPI に `importWxr`（multipart）を追記。

## 検証
- `composer check` 緑（PHPUnit/PHPStan lvl8/CS/OpenAPI/MCP）。
- `WxrImportHttpTest`（プレビュー=書込なし/実行=201・エンティティ生成/ファイル無し422/不正XML422）。WxrImport 計 **15 テスト**。
- 実機(:18082・フルアプリ): admin token で **200 preview**（planned 4・posts3/pages1・tags news,php）、**token 無しは 401**。

## 残（#539）
- S3: メディア添付・**301 リダイレクトマップ**・postmeta。
- 管理画面UI（WXR アップロード→プレビュー→実行）。

Part of #539