### PR TITLE
feat(migration): WXR取込に301リダイレクトマップを追加しSEO資産を保全する (#539 S3)

### DIFF
--- a/database/migrations/20260708000000_create_url_redirects_table.php
+++ b/database/migrations/20260708000000_create_url_redirects_table.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateUrlRedirectsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('url_redirects')
+            ->addColumn('organization_id', 'integer', ['null' => false, 'signed' => false])
+            ->addColumn('source_path', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('target_path', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            // One redirect per (org, source path); supports upsert-on-import idempotency.
+            ->addIndex(['organization_id', 'source_path'], ['unique' => true])
+            ->create();
+    }
+}

--- a/frontend/src/entities/wxr-import/mutations.ts
+++ b/frontend/src/entities/wxr-import/mutations.ts
@@ -35,6 +35,7 @@ export interface WxrImportResultDto {
   skipped_existing: number
   tags_ensured: number
   tag_links: number
+  redirects_created: number
   skipped: WxrSkippedItem[]
   warnings: string[]
 }

--- a/frontend/src/features/import-wxr/ui/WxrImportView.tsx
+++ b/frontend/src/features/import-wxr/ui/WxrImportView.tsx
@@ -103,6 +103,7 @@ function ResultCard({ result }: { result: WxrImportResultDto }) {
           <Stat label={t('admin.import.wxr.skippedExisting')} value={result.skipped_existing} />
           <Stat label={t('admin.import.wxr.tagsEnsured')} value={result.tags_ensured} />
           <Stat label={t('admin.import.wxr.tagLinks')} value={result.tag_links} />
+          <Stat label={t('admin.import.wxr.redirects')} value={result.redirects_created} />
         </div>
         <Text muted>{t('admin.import.wxr.done')}</Text>
       </Stack>

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -371,7 +371,7 @@ export const de: Partial<MessageCatalog> = {
   'admin.import.pageDescription': 'Bestehende Inhalte in diese Organisation übernehmen.',
   'admin.import.wxr.title': 'WordPress-Import (WXR)',
   'admin.import.wxr.description':
-    'Laden Sie einen WordPress-WXR-Export (.xml) hoch. Sehen Sie eine Vorschau und führen Sie den Import dann aus. Beiträge und Seiten werden zu Inhalten, Kategorien und Schlagwörter zu Tags. Medien, Weiterleitungen und Kommentare werden noch nicht importiert.',
+    'Laden Sie einen WordPress-WXR-Export (.xml) hoch. Sehen Sie eine Vorschau und führen Sie den Import dann aus. Beiträge und Seiten werden zu Inhalten, Kategorien und Schlagwörter zu Tags; alte URLs werden per 301 auf die neuen Permalinks weitergeleitet. Medien und Kommentare werden noch nicht importiert.',
   'admin.import.wxr.fileLabel': 'WXR-Datei (.xml)',
   'admin.import.wxr.preview': 'Vorschau',
   'admin.import.wxr.previewing': 'Vorschau läuft…',
@@ -387,6 +387,7 @@ export const de: Partial<MessageCatalog> = {
   'admin.import.wxr.skippedExisting': 'Bereits vorhanden',
   'admin.import.wxr.tagsEnsured': 'Tags',
   'admin.import.wxr.tagLinks': 'Tag-Verknüpfungen',
+  'admin.import.wxr.redirects': 'Weiterleitungen',
   'admin.import.wxr.done': 'Import abgeschlossen.',
   'admin.nav.settings': 'Einstellungen',
   'admin.nav.appearance': 'Darstellung',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -370,7 +370,7 @@ export const en = {
   'admin.import.pageDescription': 'Bring existing content into this organization.',
   'admin.import.wxr.title': 'WordPress import (WXR)',
   'admin.import.wxr.description':
-    'Upload a WordPress WXR export (.xml). Preview what would be imported, then run the import. Posts and pages become content records; categories and tags become tags. Media, redirects, and comments are not yet imported.',
+    'Upload a WordPress WXR export (.xml). Preview what would be imported, then run the import. Posts and pages become content records; categories and tags become tags; old URLs get 301 redirects to the new permalinks. Media and comments are not yet imported.',
   'admin.import.wxr.fileLabel': 'WXR file (.xml)',
   'admin.import.wxr.preview': 'Preview',
   'admin.import.wxr.previewing': 'Previewing…',
@@ -386,6 +386,7 @@ export const en = {
   'admin.import.wxr.skippedExisting': 'Already existed',
   'admin.import.wxr.tagsEnsured': 'Tags',
   'admin.import.wxr.tagLinks': 'Tag links',
+  'admin.import.wxr.redirects': 'Redirects',
   'admin.import.wxr.done': 'Import complete.',
   'admin.nav.settings': 'Settings',
   'admin.nav.appearance': 'Appearance',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -371,7 +371,7 @@ export const fr: Partial<MessageCatalog> = {
   'admin.import.pageDescription': 'Importer du contenu existant dans cette organisation.',
   'admin.import.wxr.title': 'Import WordPress (WXR)',
   'admin.import.wxr.description':
-    "Téléversez un export WordPress WXR (.xml). Prévisualisez ce qui serait importé, puis lancez l'import. Les articles et pages deviennent du contenu ; les catégories et étiquettes deviennent des tags. Les médias, redirections et commentaires ne sont pas encore importés.",
+    "Téléversez un export WordPress WXR (.xml). Prévisualisez ce qui serait importé, puis lancez l'import. Les articles et pages deviennent du contenu ; les catégories et étiquettes deviennent des tags ; les anciennes URL sont redirigées en 301 vers les nouveaux permaliens. Les médias et commentaires ne sont pas encore importés.",
   'admin.import.wxr.fileLabel': 'Fichier WXR (.xml)',
   'admin.import.wxr.preview': 'Aperçu',
   'admin.import.wxr.previewing': 'Aperçu en cours…',
@@ -387,6 +387,7 @@ export const fr: Partial<MessageCatalog> = {
   'admin.import.wxr.skippedExisting': 'Déjà existants',
   'admin.import.wxr.tagsEnsured': 'Tags',
   'admin.import.wxr.tagLinks': 'Liens de tags',
+  'admin.import.wxr.redirects': 'Redirections',
   'admin.import.wxr.done': 'Import terminé.',
   'admin.nav.settings': 'Paramètres',
   'admin.nav.appearance': 'Apparence',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -362,7 +362,7 @@ export const ja: Partial<MessageCatalog> = {
   'admin.import.pageDescription': '既存コンテンツをこの組織に取り込みます。',
   'admin.import.wxr.title': 'WordPress インポート (WXR)',
   'admin.import.wxr.description':
-    'WordPress の WXR エクスポート (.xml) をアップロードします。取り込み内容をプレビューしてから実行できます。投稿・固定ページはコンテンツに、カテゴリー・タグはタグになります。メディア・リダイレクト・コメントは未対応です。',
+    'WordPress の WXR エクスポート (.xml) をアップロードします。取り込み内容をプレビューしてから実行できます。投稿・固定ページはコンテンツに、カテゴリー・タグはタグになり、旧URLは新permalinkへ301リダイレクトされます。メディア・コメントは未対応です。',
   'admin.import.wxr.fileLabel': 'WXR ファイル (.xml)',
   'admin.import.wxr.preview': 'プレビュー',
   'admin.import.wxr.previewing': 'プレビュー中…',
@@ -378,6 +378,7 @@ export const ja: Partial<MessageCatalog> = {
   'admin.import.wxr.skippedExisting': '既存スキップ',
   'admin.import.wxr.tagsEnsured': 'タグ',
   'admin.import.wxr.tagLinks': 'タグ紐付け',
+  'admin.import.wxr.redirects': 'リダイレクト',
   'admin.import.wxr.done': 'インポートが完了しました。',
   'admin.nav.settings': '設定',
   'admin.nav.appearance': '外観',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -369,7 +369,7 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.import.pageDescription': 'Traga conteúdo existente para esta organização.',
   'admin.import.wxr.title': 'Importação do WordPress (WXR)',
   'admin.import.wxr.description':
-    'Envie uma exportação WXR do WordPress (.xml). Visualize o que seria importado e então execute a importação. Posts e páginas viram conteúdo; categorias e tags viram tags. Mídia, redirecionamentos e comentários ainda não são importados.',
+    'Envie uma exportação WXR do WordPress (.xml). Visualize o que seria importado e então execute a importação. Posts e páginas viram conteúdo; categorias e tags viram tags; URLs antigas recebem redirecionamentos 301 para os novos permalinks. Mídia e comentários ainda não são importados.',
   'admin.import.wxr.fileLabel': 'Arquivo WXR (.xml)',
   'admin.import.wxr.preview': 'Pré-visualizar',
   'admin.import.wxr.previewing': 'Pré-visualizando…',
@@ -385,6 +385,7 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.import.wxr.skippedExisting': 'Já existentes',
   'admin.import.wxr.tagsEnsured': 'Tags',
   'admin.import.wxr.tagLinks': 'Vínculos de tags',
+  'admin.import.wxr.redirects': 'Redirecionamentos',
   'admin.import.wxr.done': 'Importação concluída.',
   'admin.nav.settings': 'Configurações',
   'admin.nav.appearance': 'Aparência',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -354,7 +354,7 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.import.pageDescription': '将现有内容导入此组织。',
   'admin.import.wxr.title': 'WordPress 导入 (WXR)',
   'admin.import.wxr.description':
-    '上传 WordPress WXR 导出文件 (.xml)。可先预览将导入的内容，再执行导入。文章和页面成为内容记录，分类和标签成为标签。媒体、重定向和评论暂不导入。',
+    '上传 WordPress WXR 导出文件 (.xml)。可先预览将导入的内容，再执行导入。文章和页面成为内容记录，分类和标签成为标签，旧 URL 会 301 重定向到新的固定链接。媒体和评论暂不导入。',
   'admin.import.wxr.fileLabel': 'WXR 文件 (.xml)',
   'admin.import.wxr.preview': '预览',
   'admin.import.wxr.previewing': '预览中…',
@@ -370,6 +370,7 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.import.wxr.skippedExisting': '已存在',
   'admin.import.wxr.tagsEnsured': '标签',
   'admin.import.wxr.tagLinks': '标签关联',
+  'admin.import.wxr.redirects': '重定向',
   'admin.import.wxr.done': '导入完成。',
   'admin.nav.settings': '设置',
   'admin.nav.appearance': '外观',

--- a/frontend/tests/msw/handlers/wxr-import.ts
+++ b/frontend/tests/msw/handlers/wxr-import.ts
@@ -52,6 +52,7 @@ export const wxrImportHandlers = [
         skipped_existing: 0,
         tags_ensured: 2,
         tag_links: 2,
+        redirects_created: 2,
         skipped: [{ title: 'image.jpg', reason: '未対応の post_type: attachment' }],
         warnings: [],
       },

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Nene2\Http\ResponseEmitter;
 use NeNeRecords\Http\RuntimeContainerFactory;
 use NeNeRecords\Http\SpaShellFallback;
+use NeNeRecords\UrlRedirect\UrlRedirectResolver;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7Server\ServerRequestCreator;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -25,6 +26,13 @@ $request = $serverRequestCreator->fromGlobals();
 $application = $container->get(RequestHandlerInterface::class);
 assert($application instanceof RequestHandlerInterface);
 $response = $application->handle($request);
+
+// Single-origin 301s: a migrated old WordPress URL (from the WXR import redirect
+// map) takes precedence over the SPA shell fallback. No-op unless the router 404s
+// and the path matches a stored redirect for the resolved org.
+$redirectResolver = $container->get(UrlRedirectResolver::class);
+assert($redirectResolver instanceof UrlRedirectResolver);
+$response = $redirectResolver->apply($request, $response);
 
 // Single-origin: serve the built SPA shell for unmatched GET HTML navigations
 // (admin/login/search/tag/browse, etc.) so the client router takes over.

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -105,6 +105,7 @@ use NeNeRecords\TextField\TextFieldServiceProvider;
 use NeNeRecords\Theme\ThemeNotFoundExceptionHandler;
 use NeNeRecords\Theme\ThemeRouteRegistrar;
 use NeNeRecords\Theme\ThemeServiceProvider;
+use NeNeRecords\UrlRedirect\UrlRedirectServiceProvider;
 use NeNeRecords\User\CannotDeleteSelfExceptionHandler;
 use NeNeRecords\User\EmailVerificationTokenExceptionHandler;
 use NeNeRecords\User\InvalidCurrentPasswordExceptionHandler;
@@ -180,7 +181,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new DataMigrationServiceProvider())
             ->addProvider(new OrgExportServiceProvider())
             ->addProvider(new ThemeServiceProvider())
-            ->addProvider(new WxrImportServiceProvider());
+            ->addProvider(new WxrImportServiceProvider())
+            ->addProvider(new UrlRedirectServiceProvider());
 
         $builder
             ->set(

--- a/src/UrlRedirect/PdoUrlRedirectRepository.php
+++ b/src/UrlRedirect/PdoUrlRedirectRepository.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UrlRedirect;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
+
+final readonly class PdoUrlRedirectRepository implements UrlRedirectRepositoryInterface
+{
+    /**
+     * @param RequestScopedHolder<int> $orgId
+     */
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    public function findTargetBySource(string $sourcePath): ?string
+    {
+        $row = $this->query->fetchOne(
+            'SELECT target_path FROM url_redirects WHERE organization_id = ? AND source_path = ?',
+            [$this->orgId->get(), $sourcePath],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return (string) $row['target_path'];
+    }
+
+    public function save(string $sourcePath, string $targetPath): void
+    {
+        $this->query->execute(
+            'INSERT INTO url_redirects (organization_id, source_path, target_path, created_at)
+             VALUES (?, ?, ?, NOW())
+             ON DUPLICATE KEY UPDATE target_path = VALUES(target_path)',
+            [$this->orgId->get(), $sourcePath, $targetPath],
+        );
+    }
+}

--- a/src/UrlRedirect/UrlRedirectRepositoryInterface.php
+++ b/src/UrlRedirect/UrlRedirectRepositoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UrlRedirect;
+
+interface UrlRedirectRepositoryInterface
+{
+    /** Resolve the 301 target for a source path within the active org, or null. */
+    public function findTargetBySource(string $sourcePath): ?string;
+
+    /**
+     * Upsert a redirect (one per org + source path). Re-importing the same
+     * source refreshes its target rather than duplicating.
+     */
+    public function save(string $sourcePath, string $targetPath): void;
+}

--- a/src/UrlRedirect/UrlRedirectResolver.php
+++ b/src/UrlRedirect/UrlRedirectResolver.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UrlRedirect;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Single-origin 301 redirect layer: when the router 404s a GET, look up the
+ * request path in the per-org redirect map (populated by WXR import) and issue
+ * a 301 to the new permalink, preserving SEO equity from the old WordPress URLs.
+ *
+ * Runs before {@see \NeNeRecords\Http\SpaShellFallback} so a migrated old URL
+ * redirects instead of falling through to the SPA shell. API / media / view /
+ * asset paths keep their genuine 404.
+ */
+final readonly class UrlRedirectResolver
+{
+    private const PASSTHROUGH = '#^/(api|media|view|assets)(/|$)#';
+
+    public function __construct(
+        private UrlRedirectRepositoryInterface $redirects,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function apply(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        if ($response->getStatusCode() !== 404) {
+            return $response;
+        }
+
+        if (strtoupper($request->getMethod()) !== 'GET') {
+            return $response;
+        }
+
+        $path = $this->normalize($request->getUri()->getPath());
+
+        if ($path === '') {
+            return $response;
+        }
+
+        if (preg_match(self::PASSTHROUGH, $path) === 1) {
+            return $response;
+        }
+
+        $target = $this->redirects->findTargetBySource($path);
+
+        if ($target === null || $target === $path) {
+            return $response;
+        }
+
+        return $this->responseFactory->createResponse(301)->withHeader('Location', $target);
+    }
+
+    /** Strip a single trailing slash so "/a/b/" and "/a/b" map to one source. */
+    public function normalize(string $path): string
+    {
+        if ($path === '/' || $path === '') {
+            return '';
+        }
+
+        return rtrim($path, '/');
+    }
+}

--- a/src/UrlRedirect/UrlRedirectServiceProvider.php
+++ b/src/UrlRedirect/UrlRedirectServiceProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\UrlRedirect;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\RequestScopedHolder;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class UrlRedirectServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                UrlRedirectRepositoryInterface::class,
+                static function (ContainerInterface $c): UrlRedirectRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    $orgId = $c->get('nene-records.org_id_holder');
+                    if (!$orgId instanceof RequestScopedHolder) {
+                        throw new LogicException('Org ID holder service is invalid.');
+                    }
+
+                    return new PdoUrlRedirectRepository($query, $orgId);
+                },
+            )
+            ->set(
+                UrlRedirectResolver::class,
+                static function (ContainerInterface $c): UrlRedirectResolver {
+                    $redirects = $c->get(UrlRedirectRepositoryInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+
+                    if (!$redirects instanceof UrlRedirectRepositoryInterface) {
+                        throw new LogicException('URL redirect repository service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    return new UrlRedirectResolver($redirects, $responseFactory);
+                },
+            );
+    }
+}

--- a/src/WxrImport/WxrImportExecutor.php
+++ b/src/WxrImport/WxrImportExecutor.php
@@ -13,13 +13,15 @@ use NeNeRecords\EntityType\EntityType;
 use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
 use NeNeRecords\FieldDef\FieldDef;
 use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+use NeNeRecords\PublicRecord\PublicPermalinkResolver;
 use NeNeRecords\Tag\Tag;
 use NeNeRecords\Tag\TagRepositoryInterface;
 use NeNeRecords\TextField\TextField;
 use NeNeRecords\TextField\TextFieldRepositoryInterface;
+use NeNeRecords\UrlRedirect\UrlRedirectRepositoryInterface;
 
 /**
- * Executes a parsed WXR import (S2): creates entities (posts/pages), their
+ * Executes a parsed WXR import (S2/S3): creates entities (posts/pages), their
  * title/body text fields, and tags + entity-tag links, scoped to the active
  * organization via the repositories' org-aware writes.
  *
@@ -29,8 +31,10 @@ use NeNeRecords\TextField\TextFieldRepositoryInterface;
  *   is html so imported WordPress content renders sanitized. A pre-existing
  *   markdown `body` is reused as-is (HTML stored verbatim; renders via the
  *   markdown HTML passthrough).
+ * - 301 redirect map (S3): each item's original WordPress URL path is recorded
+ *   as a redirect to the new permalink, preserving SEO equity after migration.
  *
- * Out of scope (later slices): media attachments, 301 redirect map, postmeta.
+ * Out of scope (later slices): media attachments, postmeta.
  */
 final class WxrImportExecutor
 {
@@ -41,6 +45,7 @@ final class WxrImportExecutor
         private TextFieldRepositoryInterface $textFields,
         private TagRepositoryInterface $tags,
         private EntityTagRepositoryInterface $entityTags,
+        private UrlRedirectRepositoryInterface $redirects,
     ) {
     }
 
@@ -49,29 +54,36 @@ final class WxrImportExecutor
         $plan = (new WxrImportPlanner())->plan($document);
         $tagNames = $this->termNameMap($document);
 
-        /** @var array<string, int> $typeIdBySlug */
-        $typeIdBySlug = [];
+        /** @var array<string, EntityType> $typeBySlug */
+        $typeBySlug = [];
         /** @var array<string, int> $tagIdBySlug */
         $tagIdBySlug = [];
 
         $created = 0;
         $skippedExisting = 0;
         $tagLinks = 0;
+        $redirectsCreated = 0;
 
         foreach ($plan->plannedItems as $item) {
-            $typeId = $typeIdBySlug[$item->entityTypeSlug] ??= $this->resolveType($item->entityTypeSlug);
+            $type = $typeBySlug[$item->entityTypeSlug] ??= $this->resolveType($item->entityTypeSlug);
+            $typeId = $type->id;
+            if ($typeId === null) {
+                continue; // resolveType always sets the id; guard satisfies the analyser
+            }
 
             if ($this->entities->findBySlug($item->slug, $typeId) !== null) {
                 ++$skippedExisting;
                 continue;
             }
 
+            $publishedAt = $item->publishedAtIso !== null ? new DateTimeImmutable($item->publishedAtIso) : null;
+
             $entityId = $this->entities->save(new Entity(
                 id: null,
                 entityTypeId: $typeId,
                 slug: $item->slug,
                 status: EntityStatus::from($item->status),
-                publishedAt: $item->publishedAtIso !== null ? new DateTimeImmutable($item->publishedAtIso) : null,
+                publishedAt: $publishedAt,
             ));
 
             $this->textFields->save(new TextField(entityId: $entityId, fieldKey: 'title', value: $item->title));
@@ -85,6 +97,10 @@ final class WxrImportExecutor
                 }
             }
 
+            if ($this->recordRedirect($item, $type, $entityId, $publishedAt)) {
+                ++$redirectsCreated;
+            }
+
             ++$created;
         }
 
@@ -93,25 +109,28 @@ final class WxrImportExecutor
             skippedExisting: $skippedExisting,
             tagsEnsured: count($tagIdBySlug),
             tagLinks: $tagLinks,
+            redirectsCreated: $redirectsCreated,
             skippedItems: $plan->skippedItems,
             warnings: $plan->warnings,
         );
     }
 
-    private function resolveType(string $slug): int
+    private function resolveType(string $slug): EntityType
     {
         $existing = $this->entityTypes->findBySlug($slug);
 
         if ($existing !== null && $existing->id !== null) {
+            $type = $existing;
             $typeId = $existing->id;
         } else {
             $typeId = $this->entityTypes->save(new EntityType(name: ucfirst($slug), slug: $slug));
+            $type = new EntityType(name: ucfirst($slug), slug: $slug, id: $typeId);
         }
 
         $this->ensureFieldDef($typeId, 'title', 'text');
         $this->ensureFieldDef($typeId, 'body', 'html');
 
-        return $typeId;
+        return $type;
     }
 
     private function ensureFieldDef(int $typeId, string $fieldKey, string $dataType): void
@@ -130,6 +149,54 @@ final class WxrImportExecutor
         }
 
         return $this->tags->save(new Tag(slug: $slug, name: $name));
+    }
+
+    /**
+     * Record a 301 from the item's original WordPress URL path to its new
+     * permalink. Returns true when a redirect was stored.
+     */
+    private function recordRedirect(
+        WxrImportPlannedItem $item,
+        EntityType $type,
+        int $entityId,
+        ?DateTimeImmutable $publishedAt,
+    ): bool {
+        if ($item->originalLink === null) {
+            return false;
+        }
+
+        $source = $this->pathFromUrl($item->originalLink);
+        if ($source === '') {
+            return false;
+        }
+
+        $target = PublicPermalinkResolver::resolve(
+            $type->permalinkPattern,
+            $type->slug,
+            $item->slug,
+            $entityId,
+            $publishedAt,
+        );
+
+        if ($source === $target) {
+            return false;
+        }
+
+        $this->redirects->save($source, $target);
+
+        return true;
+    }
+
+    /** Extract the normalized path (no host, no trailing slash) from a URL. */
+    private function pathFromUrl(string $url): string
+    {
+        $path = parse_url($url, PHP_URL_PATH);
+
+        if (!is_string($path) || $path === '' || $path === '/') {
+            return '';
+        }
+
+        return rtrim($path, '/');
     }
 
     /** @return array<string, string> slug → display name from the WXR term definitions */

--- a/src/WxrImport/WxrImportHttpHandler.php
+++ b/src/WxrImport/WxrImportHttpHandler.php
@@ -100,6 +100,7 @@ final readonly class WxrImportHttpHandler implements RequestHandlerInterface
             'skipped_existing' => $result->skippedExisting,
             'tags_ensured' => $result->tagsEnsured,
             'tag_links' => $result->tagLinks,
+            'redirects_created' => $result->redirectsCreated,
             'skipped' => array_map(static fn (WxrImportSkippedItem $s): array => [
                 'title' => $s->title,
                 'reason' => $s->reason,

--- a/src/WxrImport/WxrImportPlannedItem.php
+++ b/src/WxrImport/WxrImportPlannedItem.php
@@ -16,6 +16,7 @@ final readonly class WxrImportPlannedItem
         public array $tagSlugs,
         public string $contentHtml = '',
         public ?string $publishedAtIso = null,
+        public ?string $originalLink = null, // WordPress <link> — source for the 301 map
     ) {
     }
 }

--- a/src/WxrImport/WxrImportPlanner.php
+++ b/src/WxrImport/WxrImportPlanner.php
@@ -74,6 +74,7 @@ final class WxrImportPlanner
                 $tags,
                 $item->contentHtml,
                 $item->publishedAtIso,
+                $item->originalLink,
             );
             $countsByType[$entityType] = ($countsByType[$entityType] ?? 0) + 1;
             $countsByStatus[$status] = ($countsByStatus[$status] ?? 0) + 1;

--- a/src/WxrImport/WxrImportResult.php
+++ b/src/WxrImport/WxrImportResult.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\WxrImport;
 
-/** Outcome of executing a WXR import (S2). */
+/** Outcome of executing a WXR import (S2/S3). */
 final readonly class WxrImportResult
 {
     /**
@@ -16,6 +16,7 @@ final readonly class WxrImportResult
         public int $skippedExisting, // already present (idempotent re-import)
         public int $tagsEnsured,     // distinct tags found-or-created
         public int $tagLinks,
+        public int $redirectsCreated, // 301 map entries (old WP URL → new permalink)
         public array $skippedItems,
         public array $warnings,
     ) {

--- a/src/WxrImport/WxrImportServiceProvider.php
+++ b/src/WxrImport/WxrImportServiceProvider.php
@@ -15,6 +15,7 @@ use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
 use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
 use NeNeRecords\Tag\TagRepositoryInterface;
 use NeNeRecords\TextField\TextFieldRepositoryInterface;
+use NeNeRecords\UrlRedirect\UrlRedirectRepositoryInterface;
 use Psr\Container\ContainerInterface;
 
 final readonly class WxrImportServiceProvider implements ServiceProviderInterface
@@ -31,6 +32,7 @@ final readonly class WxrImportServiceProvider implements ServiceProviderInterfac
                     $textFields = $c->get(TextFieldRepositoryInterface::class);
                     $tags = $c->get(TagRepositoryInterface::class);
                     $entityTags = $c->get(EntityTagRepositoryInterface::class);
+                    $redirects = $c->get(UrlRedirectRepositoryInterface::class);
 
                     if (!$entityTypes instanceof EntityTypeRepositoryInterface) {
                         throw new LogicException('Entity type repository service is invalid.');
@@ -50,8 +52,19 @@ final readonly class WxrImportServiceProvider implements ServiceProviderInterfac
                     if (!$entityTags instanceof EntityTagRepositoryInterface) {
                         throw new LogicException('Entity tag repository service is invalid.');
                     }
+                    if (!$redirects instanceof UrlRedirectRepositoryInterface) {
+                        throw new LogicException('URL redirect repository service is invalid.');
+                    }
 
-                    return new WxrImportExecutor($entityTypes, $fieldDefs, $entities, $textFields, $tags, $entityTags);
+                    return new WxrImportExecutor(
+                        $entityTypes,
+                        $fieldDefs,
+                        $entities,
+                        $textFields,
+                        $tags,
+                        $entityTags,
+                        $redirects,
+                    );
                 },
             )
             ->set(

--- a/tests/UrlRedirect/InMemoryUrlRedirectRepository.php
+++ b/tests/UrlRedirect/InMemoryUrlRedirectRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\UrlRedirect;
+
+use NeNeRecords\UrlRedirect\UrlRedirectRepositoryInterface;
+
+final class InMemoryUrlRedirectRepository implements UrlRedirectRepositoryInterface
+{
+    /** @var array<string, string> source path → target path */
+    private array $map = [];
+
+    public function findTargetBySource(string $sourcePath): ?string
+    {
+        return $this->map[$sourcePath] ?? null;
+    }
+
+    public function save(string $sourcePath, string $targetPath): void
+    {
+        $this->map[$sourcePath] = $targetPath;
+    }
+
+    /** @return array<string, string> test helper: the full redirect map */
+    public function all(): array
+    {
+        return $this->map;
+    }
+}

--- a/tests/UrlRedirect/UrlRedirectResolverTest.php
+++ b/tests/UrlRedirect/UrlRedirectResolverTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\UrlRedirect;
+
+use NeNeRecords\UrlRedirect\UrlRedirectResolver;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class UrlRedirectResolverTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryUrlRedirectRepository $redirects;
+    private UrlRedirectResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new Psr17Factory();
+        $this->redirects = new InMemoryUrlRedirectRepository();
+        $this->redirects->save('/2024/01/hello-world', '/posts/1');
+        $this->resolver = new UrlRedirectResolver($this->redirects, $this->factory);
+    }
+
+    private function notFound(): ResponseInterface
+    {
+        return $this->factory->createResponse(404);
+    }
+
+    private function get(string $path): ServerRequestInterface
+    {
+        return $this->factory->createServerRequest('GET', 'https://site.test' . $path);
+    }
+
+    public function testRedirectsMatchedPathWith301(): void
+    {
+        $response = $this->resolver->apply($this->get('/2024/01/hello-world'), $this->notFound());
+
+        self::assertSame(301, $response->getStatusCode());
+        self::assertSame('/posts/1', $response->getHeaderLine('Location'));
+    }
+
+    public function testNormalizesTrailingSlashBeforeLookup(): void
+    {
+        $response = $this->resolver->apply($this->get('/2024/01/hello-world/'), $this->notFound());
+
+        self::assertSame(301, $response->getStatusCode());
+        self::assertSame('/posts/1', $response->getHeaderLine('Location'));
+    }
+
+    public function testLeavesUnmatchedPathAs404(): void
+    {
+        $response = $this->resolver->apply($this->get('/2024/01/unknown'), $this->notFound());
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testIgnoresNon404Responses(): void
+    {
+        $ok = $this->factory->createResponse(200);
+        $response = $this->resolver->apply($this->get('/2024/01/hello-world'), $ok);
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testIgnoresApiPaths(): void
+    {
+        $this->redirects->save('/api/v1/legacy', '/posts/9');
+        $response = $this->resolver->apply($this->get('/api/v1/legacy'), $this->notFound());
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testIgnoresNonGetMethods(): void
+    {
+        $request = $this->factory->createServerRequest('POST', 'https://site.test/2024/01/hello-world');
+        $response = $this->resolver->apply($request, $this->notFound());
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+}

--- a/tests/WxrImport/WxrImportExecutorTest.php
+++ b/tests/WxrImport/WxrImportExecutorTest.php
@@ -11,6 +11,7 @@ use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
 use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
 use NeNeRecords\Tests\Tag\InMemoryTagRepository;
 use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
+use NeNeRecords\Tests\UrlRedirect\InMemoryUrlRedirectRepository;
 use NeNeRecords\WxrImport\WxrDocument;
 use NeNeRecords\WxrImport\WxrImportExecutor;
 use NeNeRecords\WxrImport\WxrImportResult;
@@ -25,6 +26,7 @@ final class WxrImportExecutorTest extends TestCase
     private InMemoryTextFieldRepository $textFields;
     private InMemoryTagRepository $tags;
     private InMemoryEntityTagRepository $entityTags;
+    private InMemoryUrlRedirectRepository $redirects;
     private WxrImportExecutor $executor;
 
     protected function setUp(): void
@@ -36,6 +38,7 @@ final class WxrImportExecutorTest extends TestCase
         $this->textFields = new InMemoryTextFieldRepository([], $this->entities);
         $this->tags = new InMemoryTagRepository([]);
         $this->entityTags = new InMemoryEntityTagRepository();
+        $this->redirects = new InMemoryUrlRedirectRepository();
         $this->executor = new WxrImportExecutor(
             $this->entityTypes,
             $this->fieldDefs,
@@ -43,6 +46,7 @@ final class WxrImportExecutorTest extends TestCase
             $this->textFields,
             $this->tags,
             $this->entityTags,
+            $this->redirects,
         );
     }
 
@@ -128,5 +132,24 @@ final class WxrImportExecutorTest extends TestCase
         self::assertSame(0, $second->createdEntities);
         self::assertSame(4, $second->skippedExisting);
         self::assertSame(0, $second->tagLinks); // already attached
+    }
+
+    public function testRecordsRedirectMapFromOriginalUrls(): void
+    {
+        $result = $this->executor->execute($this->document());
+
+        // hello-world + about carry <link>; draft/no-slug do not; attachment is skipped.
+        self::assertSame(2, $result->redirectsCreated);
+
+        $posts = $this->entityTypes->findBySlug('posts');
+        self::assertNotNull($posts?->id);
+        $hello = $this->entities->findBySlug('hello-world', $posts->id);
+        self::assertNotNull($hello?->id);
+
+        $map = $this->redirects->all();
+        // old WP URL path (trailing slash stripped) → new permalink (default /{type}/{id})
+        self::assertArrayHasKey('/2024/01/hello-world', $map);
+        self::assertSame('/posts/' . (string) $hello->id, $map['/2024/01/hello-world']);
+        self::assertArrayHasKey('/about', $map);
     }
 }

--- a/tests/WxrImport/WxrImportHttpTest.php
+++ b/tests/WxrImport/WxrImportHttpTest.php
@@ -13,6 +13,7 @@ use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
 use NeNeRecords\Tests\FieldDef\InMemoryFieldDefRepository;
 use NeNeRecords\Tests\Tag\InMemoryTagRepository;
 use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
+use NeNeRecords\Tests\UrlRedirect\InMemoryUrlRedirectRepository;
 use NeNeRecords\WxrImport\WxrImportExecutor;
 use NeNeRecords\WxrImport\WxrImportHttpHandler;
 use NeNeRecords\WxrImport\WxrImportRouteRegistrar;
@@ -42,6 +43,7 @@ final class WxrImportHttpTest extends TestCase
             new InMemoryTextFieldRepository([], $this->entities),
             new InMemoryTagRepository([]),
             new InMemoryEntityTagRepository(),
+            new InMemoryUrlRedirectRepository(),
         );
         $handler = new WxrImportHttpHandler(
             $executor,


### PR DESCRIPTION
## 目的
`#539` S3。WordPress 移行で**旧URLの被リンク/検索評価を失わない**よう、取込時に「旧WP URL → 新permalink」の **301 リダイレクトマップ**を記録し、リクエスト時に 301 で配信する。

## 変更
- **`url_redirects` テーブル**（マイグレーション・org スコープ・`(org, source_path)` 一意でべき等）。
- **UrlRedirect ドメイン**: `UrlRedirectRepository`（`findTargetBySource`/`save`=upsert）・`PdoUrlRedirectRepository`（org スコープ）・`UrlRedirectResolver`（**404 GET** 時に source を正規化し一致すれば **301**、`api/media/view/assets` は素通し）。`UrlRedirectServiceProvider` 登録。
- **`WxrImportExecutor`**: 取込時に item の `<link>` パス（末尾スラッシュ除去）→ 新 permalink（`PublicPermalinkResolver`）を記録。`WxrImportResult`/HTTP/UI に `redirects_created` 追加、`WxrImportPlannedItem` に `originalLink` 追加。
- **`public_html/index.php`**: `SpaShellFallback` の**前**に `UrlRedirectResolver` を配線（301 をシェルより優先）。
- 管理UIの結果カードに「リダイレクト」件数、説明文更新、**i18n 全6ロケール**。

## 検証
- `composer check` / `npm run check` 緑。
- `UrlRedirectResolverTest`（301/末尾スラッシュ正規化/未一致404/非404素通し/api素通し/非GET）＋ executor のリダイレクト記録テスト。WxrImport+UrlRedirect 計 **29 テスト**。
- **実機(:18082 フルアプリ)**: 実行インポートで `redirects_created=2`、`GET /2024/01/hello-world → 301 → /posts/247`・`/about → 301 → /pages/248`、未登録パス → 404（誤爆なし）。

## 残（#539）
- メディア添付・postmeta。

Part of #539