### PR TITLE
feat(migration): WXR取込でメディア添付を取り込み本文の画像URLを差し替える (#539 S4)

### DIFF
--- a/frontend/src/entities/wxr-import/mutations.ts
+++ b/frontend/src/entities/wxr-import/mutations.ts
@@ -36,6 +36,8 @@ export interface WxrImportResultDto {
   tags_ensured: number
   tag_links: number
   redirects_created: number
+  media_imported: number
+  media_skipped: number
   skipped: WxrSkippedItem[]
   warnings: string[]
 }

--- a/frontend/src/features/import-wxr/ui/WxrImportView.tsx
+++ b/frontend/src/features/import-wxr/ui/WxrImportView.tsx
@@ -104,6 +104,7 @@ function ResultCard({ result }: { result: WxrImportResultDto }) {
           <Stat label={t('admin.import.wxr.tagsEnsured')} value={result.tags_ensured} />
           <Stat label={t('admin.import.wxr.tagLinks')} value={result.tag_links} />
           <Stat label={t('admin.import.wxr.redirects')} value={result.redirects_created} />
+          <Stat label={t('admin.import.wxr.media')} value={result.media_imported} />
         </div>
         <Text muted>{t('admin.import.wxr.done')}</Text>
       </Stack>

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -388,6 +388,7 @@ export const de: Partial<MessageCatalog> = {
   'admin.import.wxr.tagsEnsured': 'Tags',
   'admin.import.wxr.tagLinks': 'Tag-Verknüpfungen',
   'admin.import.wxr.redirects': 'Weiterleitungen',
+  'admin.import.wxr.media': 'Medien',
   'admin.import.wxr.done': 'Import abgeschlossen.',
   'admin.nav.settings': 'Einstellungen',
   'admin.nav.appearance': 'Darstellung',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -387,6 +387,7 @@ export const en = {
   'admin.import.wxr.tagsEnsured': 'Tags',
   'admin.import.wxr.tagLinks': 'Tag links',
   'admin.import.wxr.redirects': 'Redirects',
+  'admin.import.wxr.media': 'Media',
   'admin.import.wxr.done': 'Import complete.',
   'admin.nav.settings': 'Settings',
   'admin.nav.appearance': 'Appearance',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -388,6 +388,7 @@ export const fr: Partial<MessageCatalog> = {
   'admin.import.wxr.tagsEnsured': 'Tags',
   'admin.import.wxr.tagLinks': 'Liens de tags',
   'admin.import.wxr.redirects': 'Redirections',
+  'admin.import.wxr.media': 'Médias',
   'admin.import.wxr.done': 'Import terminé.',
   'admin.nav.settings': 'Paramètres',
   'admin.nav.appearance': 'Apparence',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -379,6 +379,7 @@ export const ja: Partial<MessageCatalog> = {
   'admin.import.wxr.tagsEnsured': 'タグ',
   'admin.import.wxr.tagLinks': 'タグ紐付け',
   'admin.import.wxr.redirects': 'リダイレクト',
+  'admin.import.wxr.media': 'メディア',
   'admin.import.wxr.done': 'インポートが完了しました。',
   'admin.nav.settings': '設定',
   'admin.nav.appearance': '外観',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -386,6 +386,7 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.import.wxr.tagsEnsured': 'Tags',
   'admin.import.wxr.tagLinks': 'Vínculos de tags',
   'admin.import.wxr.redirects': 'Redirecionamentos',
+  'admin.import.wxr.media': 'Mídia',
   'admin.import.wxr.done': 'Importação concluída.',
   'admin.nav.settings': 'Configurações',
   'admin.nav.appearance': 'Aparência',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -371,6 +371,7 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.import.wxr.tagsEnsured': '标签',
   'admin.import.wxr.tagLinks': '标签关联',
   'admin.import.wxr.redirects': '重定向',
+  'admin.import.wxr.media': '媒体',
   'admin.import.wxr.done': '导入完成。',
   'admin.nav.settings': '设置',
   'admin.nav.appearance': '外观',

--- a/frontend/tests/msw/handlers/wxr-import.ts
+++ b/frontend/tests/msw/handlers/wxr-import.ts
@@ -53,6 +53,8 @@ export const wxrImportHandlers = [
         tags_ensured: 2,
         tag_links: 2,
         redirects_created: 2,
+        media_imported: 1,
+        media_skipped: 0,
         skipped: [{ title: 'image.jpg', reason: '未対応の post_type: attachment' }],
         warnings: [],
       },

--- a/src/WxrImport/HttpWxrMediaFetcher.php
+++ b/src/WxrImport/HttpWxrMediaFetcher.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+use finfo;
+
+/**
+ * Fetches WordPress attachment files over HTTP(S) during a WXR import.
+ *
+ * Only http/https URLs are fetched (an admin-supplied WXR could otherwise point
+ * at arbitrary schemes). The endpoint is admin-only; private-network egress
+ * hardening (SSRF) is left to deployment-level controls.
+ */
+final readonly class HttpWxrMediaFetcher implements WxrMediaFetcherInterface
+{
+    private const TIMEOUT_SECONDS = 15;
+    private const MAX_BYTES = 10 * 1024 * 1024; // mirrors UploadMediaUseCase cap
+
+    public function fetch(string $url): ?WxrMediaFetchResult
+    {
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+        if ($scheme !== 'http' && $scheme !== 'https') {
+            return null;
+        }
+
+        $context = stream_context_create([
+            'http' => [
+                'timeout' => self::TIMEOUT_SECONDS,
+                'follow_location' => 1,
+                'max_redirects' => 3,
+                'user_agent' => 'NeNeRecords-WXR-Importer',
+                'ignore_errors' => true,
+            ],
+        ]);
+
+        $bytes = @file_get_contents($url, false, $context, 0, self::MAX_BYTES + 1);
+        if ($bytes === false || $bytes === '' || strlen($bytes) > self::MAX_BYTES) {
+            return null;
+        }
+
+        $path = parse_url($url, PHP_URL_PATH);
+        $filename = is_string($path) && $path !== '' ? basename($path) : 'attachment';
+
+        return new WxrMediaFetchResult(
+            bytes: $bytes,
+            mimeType: (new finfo(FILEINFO_MIME_TYPE))->buffer($bytes) ?: 'application/octet-stream',
+            filename: $filename,
+        );
+    }
+}

--- a/src/WxrImport/WxrImportExecutor.php
+++ b/src/WxrImport/WxrImportExecutor.php
@@ -33,8 +33,10 @@ use NeNeRecords\UrlRedirect\UrlRedirectRepositoryInterface;
  *   markdown HTML passthrough).
  * - 301 redirect map (S3): each item's original WordPress URL path is recorded
  *   as a redirect to the new permalink, preserving SEO equity after migration.
+ * - Media (S4): a caller-supplied old→new media URL map rewrites `<img src>`
+ *   references in the body so imported content points at the new media library.
  *
- * Out of scope (later slices): media attachments, postmeta.
+ * Out of scope (later slices): postmeta.
  */
 final class WxrImportExecutor
 {
@@ -49,7 +51,11 @@ final class WxrImportExecutor
     ) {
     }
 
-    public function execute(WxrDocument $document): WxrImportResult
+    /**
+     * @param array<string, string> $mediaUrlMap original attachment URL → new media URL,
+     *                                            used to rewrite `<img src>` in body content
+     */
+    public function execute(WxrDocument $document, array $mediaUrlMap = []): WxrImportResult
     {
         $plan = (new WxrImportPlanner())->plan($document);
         $tagNames = $this->termNameMap($document);
@@ -86,8 +92,9 @@ final class WxrImportExecutor
                 publishedAt: $publishedAt,
             ));
 
+            $body = $mediaUrlMap === [] ? $item->contentHtml : strtr($item->contentHtml, $mediaUrlMap);
             $this->textFields->save(new TextField(entityId: $entityId, fieldKey: 'title', value: $item->title));
-            $this->textFields->save(new TextField(entityId: $entityId, fieldKey: 'body', value: $item->contentHtml));
+            $this->textFields->save(new TextField(entityId: $entityId, fieldKey: 'body', value: $body));
 
             foreach ($item->tagSlugs as $tagSlug) {
                 $tagId = $tagIdBySlug[$tagSlug] ??= $this->ensureTag($tagSlug, $tagNames[$tagSlug] ?? $tagSlug);

--- a/src/WxrImport/WxrImportHttpHandler.php
+++ b/src/WxrImport/WxrImportHttpHandler.php
@@ -23,6 +23,7 @@ final readonly class WxrImportHttpHandler implements RequestHandlerInterface
 {
     public function __construct(
         private WxrImportExecutor $executor,
+        private WxrMediaImporter $mediaImporter,
         private JsonResponseFactory $json,
         private ProblemDetailsResponseFactory $problemDetails,
     ) {
@@ -63,7 +64,12 @@ final readonly class WxrImportHttpHandler implements RequestHandlerInterface
             return $this->json->create($this->planToArray((new WxrImportPlanner())->plan($document)));
         }
 
-        return $this->json->create($this->resultToArray($this->executor->execute($document)), 201);
+        // Import attachments first so the entity importer can rewrite body image
+        // URLs from the old WordPress media to the new media library.
+        $media = $this->mediaImporter->importAttachments($document);
+        $result = $this->executor->execute($document, $media->urlMap);
+
+        return $this->json->create($this->resultToArray($result, $media), 201);
     }
 
     /** @return array<string, mixed> */
@@ -92,7 +98,7 @@ final readonly class WxrImportHttpHandler implements RequestHandlerInterface
     }
 
     /** @return array<string, mixed> */
-    private function resultToArray(WxrImportResult $result): array
+    private function resultToArray(WxrImportResult $result, WxrMediaImportResult $media): array
     {
         return [
             'mode' => 'import',
@@ -101,6 +107,8 @@ final readonly class WxrImportHttpHandler implements RequestHandlerInterface
             'tags_ensured' => $result->tagsEnsured,
             'tag_links' => $result->tagLinks,
             'redirects_created' => $result->redirectsCreated,
+            'media_imported' => $media->imported,
+            'media_skipped' => $media->skipped,
             'skipped' => array_map(static fn (WxrImportSkippedItem $s): array => [
                 'title' => $s->title,
                 'reason' => $s->reason,

--- a/src/WxrImport/WxrImportPlanner.php
+++ b/src/WxrImport/WxrImportPlanner.php
@@ -42,7 +42,12 @@ final class WxrImportPlanner
 
             $entityType = self::POST_TYPE_MAP[$item->postType] ?? null;
             if ($entityType === null) {
-                $skipped[] = new WxrImportSkippedItem($label, "未対応の post_type: {$item->postType}");
+                // Attachments are not entities; they are imported into the media
+                // library on execute (and body image URLs are rewritten).
+                $reason = $item->postType === 'attachment'
+                    ? '添付ファイル（実行時にメディアとして取り込み）'
+                    : "未対応の post_type: {$item->postType}";
+                $skipped[] = new WxrImportSkippedItem($label, $reason);
                 continue;
             }
 

--- a/src/WxrImport/WxrImportServiceProvider.php
+++ b/src/WxrImport/WxrImportServiceProvider.php
@@ -13,6 +13,7 @@ use NeNeRecords\Entity\EntityRepositoryInterface;
 use NeNeRecords\EntityTag\EntityTagRepositoryInterface;
 use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
 use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
+use NeNeRecords\Media\UploadMediaUseCaseInterface;
 use NeNeRecords\Tag\TagRepositoryInterface;
 use NeNeRecords\TextField\TextFieldRepositoryInterface;
 use NeNeRecords\UrlRedirect\UrlRedirectRepositoryInterface;
@@ -68,14 +69,30 @@ final readonly class WxrImportServiceProvider implements ServiceProviderInterfac
                 },
             )
             ->set(
+                WxrMediaImporter::class,
+                static function (ContainerInterface $c): WxrMediaImporter {
+                    $upload = $c->get(UploadMediaUseCaseInterface::class);
+
+                    if (!$upload instanceof UploadMediaUseCaseInterface) {
+                        throw new LogicException('Upload media use case service is invalid.');
+                    }
+
+                    return new WxrMediaImporter(new HttpWxrMediaFetcher(), $upload);
+                },
+            )
+            ->set(
                 WxrImportHttpHandler::class,
                 static function (ContainerInterface $c): WxrImportHttpHandler {
                     $executor = $c->get(WxrImportExecutor::class);
+                    $mediaImporter = $c->get(WxrMediaImporter::class);
                     $json = $c->get(JsonResponseFactory::class);
                     $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
 
                     if (!$executor instanceof WxrImportExecutor) {
                         throw new LogicException('WXR import executor service is invalid.');
+                    }
+                    if (!$mediaImporter instanceof WxrMediaImporter) {
+                        throw new LogicException('WXR media importer service is invalid.');
                     }
                     if (!$json instanceof JsonResponseFactory) {
                         throw new LogicException('JSON response factory service is invalid.');
@@ -84,7 +101,7 @@ final readonly class WxrImportServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('Problem details response factory service is invalid.');
                     }
 
-                    return new WxrImportHttpHandler($executor, $json, $problemDetails);
+                    return new WxrImportHttpHandler($executor, $mediaImporter, $json, $problemDetails);
                 },
             )
             ->set(

--- a/src/WxrImport/WxrItem.php
+++ b/src/WxrImport/WxrItem.php
@@ -27,6 +27,7 @@ final readonly class WxrItem
         public ?string $originalLink,
         public array $categorySlugs,
         public array $tagSlugs,
+        public ?string $attachmentUrl = null, // wp:attachment_url (post_type=attachment)
     ) {
     }
 }

--- a/src/WxrImport/WxrMediaFetchResult.php
+++ b/src/WxrImport/WxrMediaFetchResult.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+/** Bytes + metadata for a media file fetched from its original WordPress URL. */
+final readonly class WxrMediaFetchResult
+{
+    public function __construct(
+        public string $bytes,
+        public string $mimeType,
+        public string $filename,
+    ) {
+    }
+}

--- a/src/WxrImport/WxrMediaFetcherInterface.php
+++ b/src/WxrImport/WxrMediaFetcherInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+interface WxrMediaFetcherInterface
+{
+    /** Fetch a remote media file, or null if it cannot be retrieved. */
+    public function fetch(string $url): ?WxrMediaFetchResult;
+}

--- a/src/WxrImport/WxrMediaImportResult.php
+++ b/src/WxrImport/WxrMediaImportResult.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+/** Outcome of importing WXR attachments into the media library. */
+final readonly class WxrMediaImportResult
+{
+    /** @param array<string, string> $urlMap original attachment URL → new media URL */
+    public function __construct(
+        public int $imported,
+        public int $skipped,
+        public array $urlMap,
+    ) {
+    }
+}

--- a/src/WxrImport/WxrMediaImporter.php
+++ b/src/WxrImport/WxrMediaImporter.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\WxrImport;
+
+use NeNeRecords\Media\UploadMediaInput;
+use NeNeRecords\Media\UploadMediaUseCaseInterface;
+use Throwable;
+
+/**
+ * Imports WordPress attachment items (post_type=attachment) into the NeNe media
+ * library by fetching each file from its original URL and storing it via the
+ * media upload use case. Returns a map of original URL → new media URL so the
+ * entity importer can rewrite `<img src>` references in the imported content.
+ *
+ * Files that cannot be fetched, exceed the size cap, or have a disallowed type
+ * are skipped (the upload use case validates type/size and throws).
+ */
+final readonly class WxrMediaImporter
+{
+    public function __construct(
+        private WxrMediaFetcherInterface $fetcher,
+        private UploadMediaUseCaseInterface $upload,
+    ) {
+    }
+
+    public function importAttachments(WxrDocument $document): WxrMediaImportResult
+    {
+        /** @var array<string, string> $urlMap */
+        $urlMap = [];
+        $imported = 0;
+        $skipped = 0;
+
+        foreach ($document->items as $item) {
+            if ($item->postType !== 'attachment') {
+                continue;
+            }
+
+            $url = $item->attachmentUrl;
+            if ($url === null || $url === '' || isset($urlMap[$url])) {
+                if ($url === null || $url === '') {
+                    ++$skipped;
+                }
+                continue;
+            }
+
+            $fetched = $this->fetcher->fetch($url);
+            if ($fetched === null) {
+                ++$skipped;
+                continue;
+            }
+
+            $newUrl = $this->store($fetched);
+            if ($newUrl === null) {
+                ++$skipped;
+                continue;
+            }
+
+            $urlMap[$url] = $newUrl;
+            ++$imported;
+        }
+
+        return new WxrMediaImportResult($imported, $skipped, $urlMap);
+    }
+
+    private function store(WxrMediaFetchResult $fetched): ?string
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'wxrmedia_');
+        if ($tmp === false) {
+            return null;
+        }
+
+        try {
+            if (file_put_contents($tmp, $fetched->bytes) === false) {
+                return null;
+            }
+
+            return $this->upload->execute(new UploadMediaInput(
+                tmpPath: $tmp,
+                originalName: $fetched->filename,
+                mimeType: $fetched->mimeType,
+                size: strlen($fetched->bytes),
+            ))->url;
+        } catch (Throwable) {
+            return null; // disallowed type / too large / storage failure → skip
+        } finally {
+            @unlink($tmp);
+        }
+    }
+}

--- a/src/WxrImport/WxrParser.php
+++ b/src/WxrImport/WxrParser.php
@@ -104,6 +104,7 @@ final class WxrParser
             originalLink: trim((string) $item->link) ?: null,
             categorySlugs: array_values(array_unique($categorySlugs)),
             tagSlugs: array_values(array_unique($tagSlugs)),
+            attachmentUrl: trim((string) $wp->attachment_url) ?: null,
         );
     }
 

--- a/tests/WxrImport/FakeUploadMediaUseCase.php
+++ b/tests/WxrImport/FakeUploadMediaUseCase.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\WxrImport;
+
+use NeNeRecords\Media\UploadMediaInput;
+use NeNeRecords\Media\UploadMediaOutput;
+use NeNeRecords\Media\UploadMediaUseCaseInterface;
+
+/** Stores nothing; returns a deterministic media URL derived from the file name. */
+final class FakeUploadMediaUseCase implements UploadMediaUseCaseInterface
+{
+    private int $nextId = 1;
+
+    public function execute(UploadMediaInput $input): UploadMediaOutput
+    {
+        $id = $this->nextId++;
+
+        return new UploadMediaOutput(
+            id: $id,
+            url: '/media/imported/' . $input->originalName,
+            originalName: $input->originalName,
+            mimeType: $input->mimeType,
+            size: $input->size,
+        );
+    }
+}

--- a/tests/WxrImport/FakeWxrMediaFetcher.php
+++ b/tests/WxrImport/FakeWxrMediaFetcher.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\WxrImport;
+
+use NeNeRecords\WxrImport\WxrMediaFetcherInterface;
+use NeNeRecords\WxrImport\WxrMediaFetchResult;
+
+final class FakeWxrMediaFetcher implements WxrMediaFetcherInterface
+{
+    /** @param array<string, WxrMediaFetchResult> $byUrl */
+    public function __construct(private array $byUrl = [])
+    {
+    }
+
+    public function fetch(string $url): ?WxrMediaFetchResult
+    {
+        return $this->byUrl[$url] ?? null;
+    }
+}

--- a/tests/WxrImport/WxrImportExecutorTest.php
+++ b/tests/WxrImport/WxrImportExecutorTest.php
@@ -134,6 +134,27 @@ final class WxrImportExecutorTest extends TestCase
         self::assertSame(0, $second->tagLinks); // already attached
     }
 
+    public function testRewritesBodyImageUrlsFromMediaMap(): void
+    {
+        $oldUrl = 'https://old.example.com/wp-content/uploads/2024/01/image.jpg';
+        $this->executor->execute($this->document(), [$oldUrl => '/media/imported/image.jpg']);
+
+        $posts = $this->entityTypes->findBySlug('posts');
+        self::assertNotNull($posts?->id);
+        $hello = $this->entities->findBySlug('hello-world', $posts->id);
+        self::assertNotNull($hello?->id);
+
+        $body = '';
+        foreach ($this->textFields->findByEntityId($hello->id, 100, 0) as $tf) {
+            if ($tf->fieldKey === 'body') {
+                $body = $tf->value;
+            }
+        }
+
+        self::assertStringContainsString('/media/imported/image.jpg', $body);
+        self::assertStringNotContainsString('old.example.com', $body);
+    }
+
     public function testRecordsRedirectMapFromOriginalUrls(): void
     {
         $result = $this->executor->execute($this->document());

--- a/tests/WxrImport/WxrImportHttpTest.php
+++ b/tests/WxrImport/WxrImportHttpTest.php
@@ -17,6 +17,8 @@ use NeNeRecords\Tests\UrlRedirect\InMemoryUrlRedirectRepository;
 use NeNeRecords\WxrImport\WxrImportExecutor;
 use NeNeRecords\WxrImport\WxrImportHttpHandler;
 use NeNeRecords\WxrImport\WxrImportRouteRegistrar;
+use NeNeRecords\WxrImport\WxrMediaFetchResult;
+use NeNeRecords\WxrImport\WxrMediaImporter;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -29,6 +31,7 @@ final class WxrImportHttpTest extends TestCase
     private RequestHandlerInterface $application;
     private InMemoryEntityRepository $entities;
     private InMemoryEntityTypeRepository $entityTypes;
+    private InMemoryTextFieldRepository $textFields;
 
     protected function setUp(): void
     {
@@ -36,17 +39,29 @@ final class WxrImportHttpTest extends TestCase
         $this->factory = new Psr17Factory();
         $this->entityTypes = new InMemoryEntityTypeRepository([]);
         $this->entities = new InMemoryEntityRepository([]);
+        $this->textFields = new InMemoryTextFieldRepository([], $this->entities);
         $executor = new WxrImportExecutor(
             $this->entityTypes,
             new InMemoryFieldDefRepository([]),
             $this->entities,
-            new InMemoryTextFieldRepository([], $this->entities),
+            $this->textFields,
             new InMemoryTagRepository([]),
             new InMemoryEntityTagRepository(),
             new InMemoryUrlRedirectRepository(),
         );
+        $mediaImporter = new WxrMediaImporter(
+            new FakeWxrMediaFetcher([
+                'https://old.example.com/wp-content/uploads/2024/01/image.jpg' => new WxrMediaFetchResult(
+                    'binary-bytes',
+                    'image/jpeg',
+                    'image.jpg',
+                ),
+            ]),
+            new FakeUploadMediaUseCase(),
+        );
         $handler = new WxrImportHttpHandler(
             $executor,
+            $mediaImporter,
             new JsonResponseFactory($this->factory, $this->factory),
             new ProblemDetailsResponseFactory($this->factory, $this->factory),
         );
@@ -104,11 +119,23 @@ final class WxrImportHttpTest extends TestCase
         self::assertSame('import', $payload['mode']);
         self::assertSame(4, $payload['created_entities']);
         self::assertSame(2, $payload['tags_ensured']);
+        self::assertSame(2, $payload['redirects_created']);
+        self::assertSame(1, $payload['media_imported']); // image.jpg fetched + stored
+        self::assertSame(0, $payload['media_skipped']);
 
-        // Entities actually created.
+        // Entities actually created; body image URL rewritten to the new media URL.
         $posts = $this->entityTypes->findBySlug('posts');
         self::assertNotNull($posts?->id);
-        self::assertNotNull($this->entities->findBySlug('hello-world', $posts->id));
+        $hello = $this->entities->findBySlug('hello-world', $posts->id);
+        self::assertNotNull($hello?->id);
+
+        $body = '';
+        foreach ($this->textFields->findByEntityId($hello->id, 100, 0) as $tf) {
+            if ($tf->fieldKey === 'body') {
+                $body = $tf->value;
+            }
+        }
+        self::assertStringContainsString('/media/imported/image.jpg', $body);
     }
 
     public function testReturns422WhenFileMissing(): void

--- a/tests/WxrImport/WxrImportPlannerTest.php
+++ b/tests/WxrImport/WxrImportPlannerTest.php
@@ -25,10 +25,10 @@ final class WxrImportPlannerTest extends TestCase
 
         // hello-world(post), about(page), draft-post(post), no-slug(post) = 4 planned.
         self::assertCount(4, $plan->plannedItems);
-        // attachment skipped.
+        // attachment not an entity; imported into the media library on execute.
         self::assertCount(1, $plan->skippedItems);
         self::assertSame('image.jpg', $plan->skippedItems[0]->title);
-        self::assertStringContainsString('attachment', $plan->skippedItems[0]->reason);
+        self::assertStringContainsString('メディア', $plan->skippedItems[0]->reason);
 
         self::assertSame(['posts' => 3, 'pages' => 1], $plan->countsByEntityType);
         self::assertSame(['published' => 3, 'draft' => 1], $plan->countsByStatus);

--- a/tests/WxrImport/WxrMediaImporterTest.php
+++ b/tests/WxrImport/WxrMediaImporterTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\WxrImport;
+
+use NeNeRecords\WxrImport\WxrDocument;
+use NeNeRecords\WxrImport\WxrMediaFetchResult;
+use NeNeRecords\WxrImport\WxrMediaImporter;
+use NeNeRecords\WxrImport\WxrParser;
+use PHPUnit\Framework\TestCase;
+
+final class WxrMediaImporterTest extends TestCase
+{
+    private const ATTACHMENT_URL = 'https://old.example.com/wp-content/uploads/2024/01/image.jpg';
+
+    private function document(): WxrDocument
+    {
+        $xml = file_get_contents(__DIR__ . '/fixtures/sample.wxr.xml');
+        self::assertNotFalse($xml);
+
+        return (new WxrParser())->parse($xml);
+    }
+
+    public function testImportsAttachmentsAndBuildsUrlMap(): void
+    {
+        $fetcher = new FakeWxrMediaFetcher([
+            self::ATTACHMENT_URL => new WxrMediaFetchResult('binary-bytes', 'image/jpeg', 'image.jpg'),
+        ]);
+        $importer = new WxrMediaImporter($fetcher, new FakeUploadMediaUseCase());
+
+        $result = $importer->importAttachments($this->document());
+
+        self::assertSame(1, $result->imported);
+        self::assertSame(0, $result->skipped);
+        self::assertSame('/media/imported/image.jpg', $result->urlMap[self::ATTACHMENT_URL] ?? null);
+    }
+
+    public function testSkipsUnfetchableAttachments(): void
+    {
+        // Empty fetcher → every fetch returns null.
+        $importer = new WxrMediaImporter(new FakeWxrMediaFetcher(), new FakeUploadMediaUseCase());
+
+        $result = $importer->importAttachments($this->document());
+
+        self::assertSame(0, $result->imported);
+        self::assertSame(1, $result->skipped); // image.jpg has an attachment_url but is unreachable
+        self::assertSame([], $result->urlMap);
+    }
+}

--- a/tests/WxrImport/fixtures/sample.wxr.xml
+++ b/tests/WxrImport/fixtures/sample.wxr.xml
@@ -24,7 +24,7 @@
       <title>Hello World</title>
       <link>https://old.example.com/2024/01/hello-world/</link>
       <dc:creator><![CDATA[admin]]></dc:creator>
-      <content:encoded><![CDATA[<p>Hello <strong>world</strong>.</p>]]></content:encoded>
+      <content:encoded><![CDATA[<p>Hello <strong>world</strong>.</p><img src="https://old.example.com/wp-content/uploads/2024/01/image.jpg" alt="pic" />]]></content:encoded>
       <excerpt:encoded><![CDATA[A greeting.]]></excerpt:encoded>
       <wp:post_id>10</wp:post_id>
       <wp:post_date><![CDATA[2024-01-15 10:00:00]]></wp:post_date>
@@ -64,6 +64,7 @@
       <wp:post_name><![CDATA[image-jpg]]></wp:post_name>
       <wp:status><![CDATA[inherit]]></wp:status>
       <wp:post_type><![CDATA[attachment]]></wp:post_type>
+      <wp:attachment_url><![CDATA[https://old.example.com/wp-content/uploads/2024/01/image.jpg]]></wp:attachment_url>
     </item>
     <item>
       <title>No Slug Here</title>


### PR DESCRIPTION
## 目的
`#539` S4。WordPress の**添付ファイルを NeNe メディアライブラリへ取り込み**、本文中の旧画像URLを新URLへ**差し替え**ることで、移行後も画像が表示され続けるようにする。

## 変更
- **`WxrMediaImporter`**: `post_type=attachment` の `wp:attachment_url` を `WxrMediaFetcher` で取得し `UploadMediaUseCase` で保存、**旧URL→新URLのマップ**を返す。取得不可/サイズ超過/非対応MIMEは skip。
- **`HttpWxrMediaFetcher`**: http/https のみ取得（admin専用・SSRFは配備側で制御）、`finfo` で MIME 判定、10MiB 上限。`WxrMediaFetcherInterface` 注入で**テスト可能**。
- **`WxrImportExecutor`**: `execute(doc, mediaUrlMap)` で body の `<img src>` を `strtr` で差し替えてから保存。
- **`WxrImportHttpHandler`**: 実行時にメディア取込 → urlMap を executor へ → 結果に `media_imported`/`media_skipped`。`WxrItem.attachmentUrl` 追加、parser が `wp:attachment_url` 取得。
- planner: attachment のスキップ理由を「実行時にメディアとして取り込み」に明確化。
- 管理UI結果カードに「メディア」件数、**i18n 全6ロケール**。

## 検証
- `composer check` / `npm run check` 緑。
- `WxrMediaImporterTest`（取込+urlMap / 到達不能skip）・executor の本文URL差し替え・HTTP の `media_imported=1`＋本文差し替えを fake fetcher/upload で検証。WXR+UrlRedirect 計 **26 テスト**。
- 実機(:18082): 到達不能URLは **graceful skip**（`media_skipped=1`・クラッシュなし＝DI配線解決）、冪等、preview のスキップ理由明確化を確認。

## 残・今後
- postmeta（カスタムフィールド）。
- サイズ違いバリアントURL（`image-300x200.jpg`）の本文差し替えは今後の改善（現状はフルサイズURL一致）。

Part of #539