### PR TITLE
fix(migration): WXRメディア取得のSSRFを塞ぎ内部アドレスへの到達を拒否する (#539)

### DIFF
--- a/src/WxrImport/HttpWxrMediaFetcher.php
+++ b/src/WxrImport/HttpWxrMediaFetcher.php
@@ -9,9 +9,18 @@ use finfo;
 /**
  * Fetches WordPress attachment files over HTTP(S) during a WXR import.
  *
- * Only http/https URLs are fetched (an admin-supplied WXR could otherwise point
- * at arbitrary schemes). The endpoint is admin-only; private-network egress
- * hardening (SSRF) is left to deployment-level controls.
+ * SSRF hardening (the WXR is admin-supplied but an org admin is not infra-trusted
+ * in a multi-tenant deployment):
+ *   - only http/https schemes are fetched;
+ *   - the host is resolved up-front and every resolved A/AAAA address must be
+ *     publicly routable — private, loopback, link-local (incl. the cloud
+ *     metadata endpoint 169.254.169.254) and reserved ranges are rejected
+ *     without any network call;
+ *   - HTTP redirects are NOT followed, so a public URL cannot bounce the request
+ *     to an internal address after the check.
+ *
+ * Residual DNS-rebinding (resolve-then-connect TOCTOU) is left to deployment-level
+ * egress controls.
  */
 final readonly class HttpWxrMediaFetcher implements WxrMediaFetcherInterface
 {
@@ -25,11 +34,15 @@ final readonly class HttpWxrMediaFetcher implements WxrMediaFetcherInterface
             return null;
         }
 
+        if (!$this->hostIsPubliclyRoutable($url)) {
+            return null;
+        }
+
         $context = stream_context_create([
             'http' => [
                 'timeout' => self::TIMEOUT_SECONDS,
-                'follow_location' => 1,
-                'max_redirects' => 3,
+                'follow_location' => 0, // never follow a redirect into an internal address
+                'max_redirects' => 0,
                 'user_agent' => 'NeNeRecords-WXR-Importer',
                 'ignore_errors' => true,
             ],
@@ -48,5 +61,62 @@ final readonly class HttpWxrMediaFetcher implements WxrMediaFetcherInterface
             mimeType: (new finfo(FILEINFO_MIME_TYPE))->buffer($bytes) ?: 'application/octet-stream',
             filename: $filename,
         );
+    }
+
+    /** Resolve the URL's host and require every resolved address to be public. */
+    private function hostIsPubliclyRoutable(string $url): bool
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+        if (!is_string($host) || $host === '') {
+            return false;
+        }
+
+        $host = trim($host, '[]'); // strip IPv6 brackets
+
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return self::isPublicIp($host); // literal IP host — no DNS needed
+        }
+
+        $addresses = $this->resolve($host);
+        if ($addresses === []) {
+            return false; // unresolvable → refuse
+        }
+
+        foreach ($addresses as $ip) {
+            if (!self::isPublicIp($ip)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /** @return list<string> resolved IPv4 + IPv6 addresses for the host */
+    private function resolve(string $host): array
+    {
+        $addresses = [];
+
+        $v4 = gethostbynamel($host);
+        if ($v4 !== false) {
+            $addresses = $v4;
+        }
+
+        foreach (@dns_get_record($host, DNS_AAAA) ?: [] as $record) {
+            if (isset($record['ipv6']) && is_string($record['ipv6'])) {
+                $addresses[] = $record['ipv6'];
+            }
+        }
+
+        return array_values(array_unique($addresses));
+    }
+
+    /** True only for globally routable addresses (rejects private + reserved ranges). */
+    public static function isPublicIp(string $ip): bool
+    {
+        return filter_var(
+            $ip,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
+        ) !== false;
     }
 }

--- a/tests/WxrImport/HttpWxrMediaFetcherTest.php
+++ b/tests/WxrImport/HttpWxrMediaFetcherTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\WxrImport;
+
+use NeNeRecords\WxrImport\HttpWxrMediaFetcher;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * SSRF guard tests. Every blocked case is rejected before any network call
+ * (the IP-range check fails first), so these run offline and deterministically.
+ */
+final class HttpWxrMediaFetcherTest extends TestCase
+{
+    private HttpWxrMediaFetcher $fetcher;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fetcher = new HttpWxrMediaFetcher();
+    }
+
+    /** @return list<array{string}> */
+    public static function publicIps(): array
+    {
+        return [['8.8.8.8'], ['1.1.1.1'], ['203.0.113.10'], ['2001:4860:4860::8888']];
+    }
+
+    /** @return list<array{string}> */
+    public static function blockedIps(): array
+    {
+        return [
+            ['127.0.0.1'],       // loopback
+            ['::1'],             // IPv6 loopback
+            ['10.0.0.5'],        // private
+            ['172.16.0.1'],      // private
+            ['192.168.1.1'],     // private
+            ['169.254.169.254'], // link-local / cloud metadata
+            ['0.0.0.0'],         // reserved
+            ['fc00::1'],         // IPv6 unique-local
+        ];
+    }
+
+    #[DataProvider('publicIps')]
+    public function testPublicIpsAreRoutable(string $ip): void
+    {
+        self::assertTrue(HttpWxrMediaFetcher::isPublicIp($ip));
+    }
+
+    #[DataProvider('blockedIps')]
+    public function testPrivateAndReservedIpsAreBlocked(string $ip): void
+    {
+        self::assertFalse(HttpWxrMediaFetcher::isPublicIp($ip));
+    }
+
+    #[DataProvider('blockedIps')]
+    public function testFetchRefusesInternalHostsWithoutNetwork(string $ip): void
+    {
+        $host = str_contains($ip, ':') ? '[' . $ip . ']' : $ip;
+
+        self::assertNull($this->fetcher->fetch('http://' . $host . '/latest/meta-data/'));
+    }
+
+    public function testFetchRejectsNonHttpSchemes(): void
+    {
+        self::assertNull($this->fetcher->fetch('file:///etc/passwd'));
+        self::assertNull($this->fetcher->fetch('ftp://example.com/x'));
+        self::assertNull($this->fetcher->fetch('gopher://127.0.0.1/'));
+    }
+
+    public function testFetchRejectsMalformedUrl(): void
+    {
+        self::assertNull($this->fetcher->fetch('not a url'));
+        self::assertNull($this->fetcher->fetch('http://'));
+    }
+}


### PR DESCRIPTION
## 目的
アーキテクチャ監査の指摘是正（最優先）。`HttpWxrMediaFetcher` は admin 提供 WXR 内の URL をサーバ側で取得するため、**private/loopback/link-local（クラウドメタデータ `169.254.169.254` 含む）/予約レンジ**へ到達でき SSRF 面だった。マルチテナントで org-admin はインフラ信頼でないため、NENE2 のセキュリティ理念（厳格 CSP・任意 egress を許さない）に照らし在宅で塞ぐ。

## 変更（`HttpWxrMediaFetcher`）
- 取得前にホストを解決し、**全 A/AAAA アドレスが公開ルーティング可能**（`filter_var` の `FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE`）であることを必須化。1つでも内部なら拒否。
- リテラルIPホストは **DNS 無し**で判定。解決不能ホストも拒否。
- **リダイレクト追従を無効化**（`follow_location`/`max_redirects=0`）＝公開URL→内部へのバウンス阻止。http/https 以外も拒否。
- 残存 DNS リバインディング（解決後接続の TOCTOU）は配備側 egress 制御に委譲（docブロック明記）。

## 検証
- `composer check` 緑。
- `HttpWxrMediaFetcherTest`（公開IP通過 / `127.0.0.1`・`::1`・`169.254.169.254`・private・予約 をブロック / 内部ホストは**無通信で null** / 非http・不正URL 拒否、計 **22**）。

Part of #539