### PR TITLE
refactor(server): 単一オリジンの fallback を PSR-15 SingleOriginKernel に集約する (#539)

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 use Nene2\Http\ResponseEmitter;
 use NeNeRecords\Http\RuntimeContainerFactory;
-use NeNeRecords\Http\SpaShellFallback;
-use NeNeRecords\UrlRedirect\UrlRedirectResolver;
+use NeNeRecords\Http\SingleOriginKernel;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7Server\ServerRequestCreator;
-use Psr\Http\Server\RequestHandlerInterface;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
@@ -23,24 +21,12 @@ $serverRequestCreator = new ServerRequestCreator(
 );
 
 $request = $serverRequestCreator->fromGlobals();
-$application = $container->get(RequestHandlerInterface::class);
-assert($application instanceof RequestHandlerInterface);
-$response = $application->handle($request);
 
-// Single-origin 301s: a migrated old WordPress URL (from the WXR import redirect
-// map) takes precedence over the SPA shell fallback. No-op unless the router 404s
-// and the path matches a stored redirect for the resolved org.
-$redirectResolver = $container->get(UrlRedirectResolver::class);
-assert($redirectResolver instanceof UrlRedirectResolver);
-$response = $redirectResolver->apply($request, $response);
-
-// Single-origin: serve the built SPA shell for unmatched GET HTML navigations
-// (admin/login/search/tag/browse, etc.) so the client router takes over.
-$response = (new SpaShellFallback(
-    dirname(__DIR__) . '/frontend/dist/index.html',
-    $psr17Factory,
-    $psr17Factory,
-))->apply($request, $response);
+// SingleOriginKernel wraps the NENE2 application pipeline with the single-origin
+// edge layers (per-org 301 redirect map, then SPA shell fallback). See the kernel.
+$kernel = $container->get(SingleOriginKernel::class);
+assert($kernel instanceof SingleOriginKernel);
+$response = $kernel->handle($request);
 
 $emitter = $container->get(ResponseEmitter::class);
 assert($emitter instanceof ResponseEmitter);

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -58,6 +58,7 @@ use NeNeRecords\FieldDef\FieldDefRouteRegistrar;
 use NeNeRecords\FieldDef\FieldDefServiceProvider;
 use NeNeRecords\FieldDef\FieldKeyNotRegisteredExceptionHandler;
 use NeNeRecords\FieldDef\FieldTypeMismatchExceptionHandler;
+use NeNeRecords\Http\SingleOriginServiceProvider;
 use NeNeRecords\IntField\IntFieldNotFoundExceptionHandler;
 use NeNeRecords\IntField\IntFieldRouteRegistrar;
 use NeNeRecords\IntField\IntFieldServiceProvider;
@@ -182,7 +183,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new OrgExportServiceProvider())
             ->addProvider(new ThemeServiceProvider())
             ->addProvider(new WxrImportServiceProvider())
-            ->addProvider(new UrlRedirectServiceProvider());
+            ->addProvider(new UrlRedirectServiceProvider())
+            ->addProvider(new SingleOriginServiceProvider());
 
         $builder
             ->set(

--- a/src/Http/SingleOriginKernel.php
+++ b/src/Http/SingleOriginKernel.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Http;
+
+use NeNeRecords\UrlRedirect\UrlRedirectResolver;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Outer request handler for single-origin serving: runs the full NENE2
+ * application pipeline, then applies the single-origin edge layers in order on
+ * a 404 — first the per-org 301 redirect map (migrated old WordPress URLs), then
+ * the built SPA shell fallback for client-routed navigations.
+ *
+ * Composing these as one DI-wired PSR-15 handler (rather than procedural code in
+ * the front controller) keeps the ordering explicit and end-to-end testable, and
+ * keeps the org context — resolved inside the pipeline — valid for the redirect
+ * lookup because the request-scoped org holder is read within the same request.
+ */
+final readonly class SingleOriginKernel implements RequestHandlerInterface
+{
+    public function __construct(
+        private RequestHandlerInterface $application,
+        private UrlRedirectResolver $redirects,
+        private SpaShellFallback $shell,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = $this->application->handle($request);
+        $response = $this->redirects->apply($request, $response);
+
+        return $this->shell->apply($request, $response);
+    }
+}

--- a/src/Http/SingleOriginServiceProvider.php
+++ b/src/Http/SingleOriginServiceProvider.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Http;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use NeNeRecords\UrlRedirect\UrlRedirectResolver;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Wires the single-origin edge layer: the SPA shell fallback and the outer
+ * {@see SingleOriginKernel} that composes the application pipeline with the 301
+ * redirect map and shell fallback.
+ */
+final readonly class SingleOriginServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                SpaShellFallback::class,
+                static function (ContainerInterface $c): SpaShellFallback {
+                    $projectRoot = $c->get(RuntimeServiceProvider::PROJECT_ROOT);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+                    $streamFactory = $c->get(StreamFactoryInterface::class);
+
+                    if (!is_string($projectRoot) || $projectRoot === '') {
+                        throw new LogicException('Project root is not configured.');
+                    }
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+                    if (!$streamFactory instanceof StreamFactoryInterface) {
+                        throw new LogicException('Stream factory service is invalid.');
+                    }
+
+                    return new SpaShellFallback(
+                        $projectRoot . '/frontend/dist/index.html',
+                        $responseFactory,
+                        $streamFactory,
+                    );
+                },
+            )
+            ->set(
+                SingleOriginKernel::class,
+                static function (ContainerInterface $c): SingleOriginKernel {
+                    $application = $c->get(RequestHandlerInterface::class);
+                    $redirects = $c->get(UrlRedirectResolver::class);
+                    $shell = $c->get(SpaShellFallback::class);
+
+                    if (!$application instanceof RequestHandlerInterface) {
+                        throw new LogicException('Application request handler service is invalid.');
+                    }
+                    if (!$redirects instanceof UrlRedirectResolver) {
+                        throw new LogicException('URL redirect resolver service is invalid.');
+                    }
+                    if (!$shell instanceof SpaShellFallback) {
+                        throw new LogicException('SPA shell fallback service is invalid.');
+                    }
+
+                    return new SingleOriginKernel($application, $redirects, $shell);
+                },
+            );
+    }
+}

--- a/tests/Http/SingleOriginKernelTest.php
+++ b/tests/Http/SingleOriginKernelTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Http;
+
+use NeNeRecords\Http\SingleOriginKernel;
+use NeNeRecords\Http\SpaShellFallback;
+use NeNeRecords\Tests\UrlRedirect\InMemoryUrlRedirectRepository;
+use NeNeRecords\UrlRedirect\UrlRedirectResolver;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class SingleOriginKernelTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryUrlRedirectRepository $redirects;
+    private string $shellPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new Psr17Factory();
+        $this->redirects = new InMemoryUrlRedirectRepository();
+
+        $shellPath = tempnam(sys_get_temp_dir(), 'shell_');
+        self::assertNotFalse($shellPath);
+        file_put_contents($shellPath, '<!doctype html><div id="root"></div>');
+        $this->shellPath = $shellPath;
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->shellPath);
+        parent::tearDown();
+    }
+
+    /** Inner application handler that always returns the given status. */
+    private function appReturning(int $status): RequestHandlerInterface
+    {
+        $factory = $this->factory;
+
+        return new class ($factory, $status) implements RequestHandlerInterface {
+            public function __construct(
+                private Psr17Factory $factory,
+                private int $status,
+            ) {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->factory->createResponse($this->status);
+            }
+        };
+    }
+
+    private function kernel(RequestHandlerInterface $app): SingleOriginKernel
+    {
+        return new SingleOriginKernel(
+            $app,
+            new UrlRedirectResolver($this->redirects, $this->factory),
+            new SpaShellFallback($this->shellPath, $this->factory, $this->factory),
+        );
+    }
+
+    public function testPassesThroughNon404Responses(): void
+    {
+        $response = $this->kernel($this->appReturning(200))
+            ->handle($this->factory->createServerRequest('GET', 'https://site.test/posts/1'));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testRedirectTakesPrecedenceOverShellOn404(): void
+    {
+        $this->redirects->save('/2024/01/hello-world', '/posts/1');
+
+        $request = $this->factory
+            ->createServerRequest('GET', 'https://site.test/2024/01/hello-world')
+            ->withHeader('Accept', 'text/html');
+
+        $response = $this->kernel($this->appReturning(404))->handle($request);
+
+        self::assertSame(301, $response->getStatusCode());
+        self::assertSame('/posts/1', $response->getHeaderLine('Location'));
+    }
+
+    public function testFallsBackToShellWhenNoRedirectMatches(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('GET', 'https://site.test/admin/dashboard')
+            ->withHeader('Accept', 'text/html');
+
+        $response = $this->kernel($this->appReturning(404))->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
+        self::assertStringContainsString('id="root"', (string) $response->getBody());
+    }
+
+    public function testKeepsGenuine404ForApiPaths(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('GET', 'https://site.test/api/v1/unknown')
+            ->withHeader('Accept', 'application/json');
+
+        $response = $this->kernel($this->appReturning(404))->handle($request);
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
## 目的
アーキテクチャ監査の指摘是正。`public_html/index.php` が `handle()` の**後ろ**で `UrlRedirectResolver`/`SpaShellFallback` を手続き的に適用しており、①パイプライン外で org スコープ repo を読む暗黙依存、②合成順序が未テスト、という匂いがあった。

## 変更
- **`SingleOriginKernel`**（PSR-15 RequestHandler デコレータ）新設：アプリ pipeline → **301 リダイレクトマップ → SPA シェル** の順を1つの DI 配線済みハンドラに集約。**end-to-end テスト可能**にし順序を明示。org は同一リクエスト内で解決済みのため redirect 参照は整合。
- **`SingleOriginServiceProvider`**：`SpaShellFallback`（`PROJECT_ROOT` からシェルパス解決）と Kernel を配線。`SpaShellFallback` の `new`/ハードコードパスを廃し **DI 化**。
- `index.php` は kernel を `get` して `handle` するだけに簡素化。

## 検証
- `composer check` 緑。
- `SingleOriginKernelTest`（200パススルー / 404+redirect→**301 が shell に優先** / redirect無→shell 200 / api は genuine 404、計4）。
- 実機(:18082): `/2024/01/hello-world`→301・`/admin`→shell200・`/api`→404・`/posts/247`→SSR200 を維持。

Part of #539