### PR TITLE
refactor(migration): WXR応答をOpenAPI名前付きスキーマで型付けしTS型を生成する (#539)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -4008,13 +4008,13 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/WxrImportPlanResponse'
         '201':
           description: Import executed.
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/WxrImportResultResponse'
         '422':
           $ref: '#/components/responses/ValidationFailed'
         '500':
@@ -4327,6 +4327,113 @@ components:
                 detail: An unexpected error occurred.
                 instance: /api/v1/entity-types
   schemas:
+    WxrPlannedItem:
+      type: object
+      required: [title, slug, entity_type, status, tags]
+      properties:
+        title:
+          type: string
+        slug:
+          type: string
+        entity_type:
+          type: string
+        status:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+    WxrSkippedItem:
+      type: object
+      required: [title, reason]
+      properties:
+        title:
+          type: string
+        reason:
+          type: string
+    WxrImportPlanResponse:
+      type: object
+      required:
+        - mode
+        - planned_count
+        - skipped_count
+        - counts_by_entity_type
+        - counts_by_status
+        - tags
+        - warnings
+        - planned
+        - skipped
+      properties:
+        mode:
+          type: string
+          enum: [preview]
+        planned_count:
+          type: integer
+        skipped_count:
+          type: integer
+        counts_by_entity_type:
+          type: object
+          additionalProperties:
+            type: integer
+        counts_by_status:
+          type: object
+          additionalProperties:
+            type: integer
+        tags:
+          type: array
+          items:
+            type: string
+        warnings:
+          type: array
+          items:
+            type: string
+        planned:
+          type: array
+          items:
+            $ref: '#/components/schemas/WxrPlannedItem'
+        skipped:
+          type: array
+          items:
+            $ref: '#/components/schemas/WxrSkippedItem'
+    WxrImportResultResponse:
+      type: object
+      required:
+        - mode
+        - created_entities
+        - skipped_existing
+        - tags_ensured
+        - tag_links
+        - redirects_created
+        - media_imported
+        - media_skipped
+        - skipped
+        - warnings
+      properties:
+        mode:
+          type: string
+          enum: [import]
+        created_entities:
+          type: integer
+        skipped_existing:
+          type: integer
+        tags_ensured:
+          type: integer
+        tag_links:
+          type: integer
+        redirects_created:
+          type: integer
+        media_imported:
+          type: integer
+        media_skipped:
+          type: integer
+        skipped:
+          type: array
+          items:
+            $ref: '#/components/schemas/WxrSkippedItem'
+        warnings:
+          type: array
+          items:
+            type: string
     UserResponse:
       type: object
       required:

--- a/frontend/src/entities/wxr-import/mutations.ts
+++ b/frontend/src/entities/wxr-import/mutations.ts
@@ -1,46 +1,14 @@
 import { useMutation, type UseMutationResult } from '@tanstack/react-query'
 import { apiClient, AppError } from '@/shared/api/client'
+import type { components } from '@/shared/api/schema.gen'
 
-/** A single item the import would create (preview). */
-export interface WxrPlannedItem {
-  title: string
-  slug: string
-  entity_type: string
-  status: string
-  tags: string[]
-}
-
-export interface WxrSkippedItem {
-  title: string
-  reason: string
-}
-
+// Types are derived from the OpenAPI contract (docs/openapi/openapi.yaml) via codegen.
+export type WxrPlannedItem = components['schemas']['WxrPlannedItem']
+export type WxrSkippedItem = components['schemas']['WxrSkippedItem']
 /** Dry-run preview returned by POST /api/v1/migration/wxr (dry_run=true). */
-export interface WxrImportPlanDto {
-  mode: 'preview'
-  planned_count: number
-  skipped_count: number
-  counts_by_entity_type: Record<string, number>
-  counts_by_status: Record<string, number>
-  tags: string[]
-  warnings: string[]
-  planned: WxrPlannedItem[]
-  skipped: WxrSkippedItem[]
-}
-
+export type WxrImportPlanDto = components['schemas']['WxrImportPlanResponse']
 /** Result returned when executed (dry_run=false). */
-export interface WxrImportResultDto {
-  mode: 'import'
-  created_entities: number
-  skipped_existing: number
-  tags_ensured: number
-  tag_links: number
-  redirects_created: number
-  media_imported: number
-  media_skipped: number
-  skipped: WxrSkippedItem[]
-  warnings: string[]
-}
+export type WxrImportResultDto = components['schemas']['WxrImportResultResponse']
 
 const ENDPOINT = '/api/v1/migration/wxr'
 

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -1704,10 +1704,70 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/migration/wxr": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Import a WordPress WXR export
+         * @description Admin-only. Accepts a multipart/form-data WordPress WXR (.xml) export. With dry_run=true (default) returns a preview plan (what would be imported/skipped) without writing; with dry_run=false executes the import into the active organization (idempotent by slug). Out of scope: media attachments, 301 redirect map, postmeta.
+         */
+        post: operations["importWxr"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        WxrPlannedItem: {
+            title: string;
+            slug: string;
+            entity_type: string;
+            status: string;
+            tags: string[];
+        };
+        WxrSkippedItem: {
+            title: string;
+            reason: string;
+        };
+        WxrImportPlanResponse: {
+            /** @enum {string} */
+            mode: "preview";
+            planned_count: number;
+            skipped_count: number;
+            counts_by_entity_type: {
+                [key: string]: number;
+            };
+            counts_by_status: {
+                [key: string]: number;
+            };
+            tags: string[];
+            warnings: string[];
+            planned: components["schemas"]["WxrPlannedItem"][];
+            skipped: components["schemas"]["WxrSkippedItem"][];
+        };
+        WxrImportResultResponse: {
+            /** @enum {string} */
+            mode: "import";
+            created_entities: number;
+            skipped_existing: number;
+            tags_ensured: number;
+            tag_links: number;
+            redirects_created: number;
+            media_imported: number;
+            media_skipped: number;
+            skipped: components["schemas"]["WxrSkippedItem"][];
+            warnings: string[];
+        };
         UserResponse: {
             id: number;
             /** Format: email */
@@ -6774,6 +6834,53 @@ export interface operations {
             409: components["responses"]["Conflict"];
             410: components["responses"]["Gone"];
             422: components["responses"]["ValidationFailed"];
+        };
+    };
+    importWxr: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": {
+                    /**
+                     * Format: binary
+                     * @description WordPress WXR export XML.
+                     */
+                    file: string;
+                    /**
+                     * @description true = preview only; false = execute import.
+                     * @default true
+                     * @enum {string}
+                     */
+                    dry_run?: "true" | "false";
+                };
+            };
+        };
+        responses: {
+            /** @description Dry-run import plan (preview). */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WxrImportPlanResponse"];
+                };
+            };
+            /** @description Import executed. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WxrImportResultResponse"];
+                };
+            };
+            422: components["responses"]["ValidationFailed"];
+            500: components["responses"]["InternalServerError"];
         };
     };
 }


### PR DESCRIPTION
## 目的
アーキテクチャ監査の指摘是正。WXR エンドポイントの応答が OpenAPI 上 `type: object`（自由形）で、他APIの「**named schema → TS codegen**」より型契約が緩く、フロントの DTO も手書きだった（NENE2 の型契約徹底に対する一段の緩み）。

## 変更
- `openapi.yaml` に **`WxrImportPlanResponse` / `WxrImportResultResponse` / `WxrPlannedItem` / `WxrSkippedItem`** を定義、200(プレビュー)/201(実行) を `$ref` 化。
- `npm run codegen` で `schema.gen.ts` 再生成（+107行・WXR 限定・削除なし）。
- `entities/wxr-import` の手書き `interface` を **`components['schemas'][...]` 由来の `type`** に置換（CLAUDE.md 規約どおり契約由来へ統一）。

## 検証
- `composer openapi` 緑、`npm run check` 緑（type-check/eslint/prettier/test/validate:themes/knip/storybook）、`ImportPage.test` 緑。

Part of #539