### PR TITLE
fix(seo): SSRでhtml型フィールドをサーバ側サニタイズして忠実配信する (#539)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "async-aws/s3": "^3.3",
         "hideyukimori/nene2": "@dev",
         "league/commonmark": "^2.7",
+        "symfony/html-sanitizer": "^8.1",
         "symfony/http-client": "^8.1",
         "symfony/mailer": "^8.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "68b1d1df46d79f5a5a1081660c2ace82",
+    "content-hash": "cc8ee6ff62193488755a91b99b843f14",
     "packages": [
         {
             "name": "async-aws/core",
@@ -718,6 +718,188 @@
                 }
             ],
             "time": "2022-12-11T20:36:23+00:00"
+        },
+        {
+            "name": "league/uri",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri.git",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri-interfaces": "^7.8.1",
+                "php": "^8.1",
+                "psr/http-factory": "^1"
+            },
+            "conflict": {
+                "league/uri-schemes": "^1.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-dom": "to convert the URI into an HTML anchor tag",
+                "ext-fileinfo": "to create Data URI from file contennts",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "ext-uri": "to use the PHP native URI class",
+                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
+                "league/uri-components": "to provide additional tools to manipulate URI objects components",
+                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "URN",
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "middleware",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc2141",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "rfc8141",
+                "uri",
+                "uri-template",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-15T20:22:25+00:00"
+        },
+        {
+            "name": "league/uri-interfaces",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-interfaces.git",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^8.1",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "uri",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-08T20:05:35+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -1857,6 +2039,78 @@
                 }
             ],
             "time": "2026-01-05T13:30:16+00:00"
+        },
+        {
+            "name": "symfony/html-sanitizer",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/html-sanitizer.git",
+                "reference": "adf86ad7e51344c0b121c9f8a26c95ea35b2b8fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/html-sanitizer/zipball/adf86ad7e51344c0b121c9f8a26c95ea35b2b8fc",
+                "reference": "adf86ad7e51344c0b121c9f8a26c95ea35b2b8fc",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "league/uri": "^6.5|^7.0",
+                "php": ">=8.4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HtmlSanitizer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Titouan Galopin",
+                    "email": "galopintitouan@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to sanitize untrusted HTML input for safe insertion into a document's DOM.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "Purifier",
+                "html",
+                "sanitizer"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/html-sanitizer/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/http-client",

--- a/src/PublicRecord/PublicHtmlSanitizer.php
+++ b/src/PublicRecord/PublicHtmlSanitizer.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
+
+/**
+ * Server-side HTML sanitizer for the crawlable SSR of `html`-typed fields.
+ *
+ * Mirrors the front-end {@see SanitizedHtml} (DOMPurify) policy so the SSR twin
+ * and the SPA render the same trusted markup: rich, styled content is kept while
+ * scripts, `on*` handlers and `javascript:` URLs are stripped — upholding the
+ * "no arbitrary JS" guarantee for imported (e.g. WordPress) content.
+ */
+final readonly class PublicHtmlSanitizer
+{
+    private HtmlSanitizer $sanitizer;
+
+    public function __construct()
+    {
+        $config = (new HtmlSanitizerConfig())
+            ->allowSafeElements()
+            ->allowElement('img', ['src', 'alt', 'title', 'width', 'height'])
+            ->allowRelativeLinks()
+            ->allowRelativeMedias()
+            ->allowAttribute('style', '*');
+
+        $this->sanitizer = new HtmlSanitizer($config);
+    }
+
+    public function sanitize(string $html): string
+    {
+        return $this->sanitizer->sanitize($html);
+    }
+}

--- a/src/PublicRecord/PublicRecordServiceProvider.php
+++ b/src/PublicRecord/PublicRecordServiceProvider.php
@@ -190,7 +190,15 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                         throw new LogicException('Response factory service is invalid.');
                     }
 
-                    return new RenderPublicRecordViewHandler($useCase, $publicSettings, $html, $config, $projectRoot, $responseFactory);
+                    return new RenderPublicRecordViewHandler(
+                        $useCase,
+                        $publicSettings,
+                        $html,
+                        $config,
+                        $projectRoot,
+                        $responseFactory,
+                        new PublicHtmlSanitizer(),
+                    );
                 },
             )
             ->set(

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -23,6 +23,7 @@ final readonly class RenderPublicRecordViewHandler
         private AppConfig $config,
         private string $projectRoot,
         private ResponseFactoryInterface $responseFactory,
+        private PublicHtmlSanitizer $htmlSanitizer,
     ) {
     }
 
@@ -133,6 +134,9 @@ final readonly class RenderPublicRecordViewHandler
             'spaCss' => $spaCss,
             'spaPreload' => $spaPreload,
             'renderMarkdown' => static fn (string $markdown): string => PublicMarkdownRenderer::toSafeHtml($markdown),
+            // html-typed fields (e.g. WXR-imported content): sanitize server-side so the
+            // crawlable SSR shows the same trusted markup the SPA renders via DOMPurify.
+            'renderHtml' => fn (string $rawHtml): string => $this->htmlSanitizer->sanitize($rawHtml),
             // A bundle's crawlable twin (#311): render its seoText markdown server-side
             // (the sandboxed iframe itself is SPA-only / invisible to crawlers).
             'renderBundleSeo' => static fn (string $raw): string => PublicMarkdownRenderer::toSafeHtml(BundleDocumentValidator::seoTextOf($raw)),

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -92,6 +92,11 @@
               </ul>
             <?php endif; ?>
           </section>
+        <?php elseif ($field->dataType === 'html'): ?>
+          <section>
+            <h2><?= $e($field->fieldKey) ?></h2>
+            <div class="markdown-body"><?= $renderHtml($field->displayValue) ?></div>
+          </section>
         <?php elseif ($field->fieldKey === 'body'): ?>
           <section>
             <h2><?= $e($field->fieldKey) ?></h2>

--- a/tests/PublicRecord/PublicCacheHttpTest.php
+++ b/tests/PublicRecord/PublicCacheHttpTest.php
@@ -105,6 +105,7 @@ final class PublicCacheHttpTest extends TestCase
             ),
             dirname(__DIR__, 2),
             $this->factory,
+            new \NeNeRecords\PublicRecord\PublicHtmlSanitizer(),
         );
         $publicRecordRegistrar = new PublicRecordRouteRegistrar(
             new GetPublicRecordViewHandler($useCase, $jsonResponse, $this->factory),

--- a/tests/PublicRecord/PublicHtmlSanitizerTest.php
+++ b/tests/PublicRecord/PublicHtmlSanitizerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use NeNeRecords\PublicRecord\PublicHtmlSanitizer;
+use PHPUnit\Framework\TestCase;
+
+final class PublicHtmlSanitizerTest extends TestCase
+{
+    private PublicHtmlSanitizer $sanitizer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->sanitizer = new PublicHtmlSanitizer();
+    }
+
+    public function testKeepsRichContentMarkup(): void
+    {
+        $html = '<p>Hello <strong>world</strong> and <a href="/posts/1">link</a>.</p>';
+        $clean = $this->sanitizer->sanitize($html);
+
+        self::assertStringContainsString('<strong>world</strong>', $clean);
+        self::assertStringContainsString('<a href="/posts/1">link</a>', $clean);
+    }
+
+    public function testKeepsImagesIncludingRelativeMediaUrls(): void
+    {
+        $clean = $this->sanitizer->sanitize('<img src="/media/imported/image.jpg" alt="pic" />');
+
+        self::assertStringContainsString('<img', $clean);
+        self::assertStringContainsString('/media/imported/image.jpg', $clean);
+    }
+
+    public function testStripsScriptTags(): void
+    {
+        $clean = $this->sanitizer->sanitize('<p>ok</p><script>alert(1)</script>');
+
+        self::assertStringContainsString('ok', $clean);
+        self::assertStringNotContainsString('<script', $clean);
+        self::assertStringNotContainsString('alert(1)', $clean);
+    }
+
+    public function testStripsEventHandlersAndJavascriptUrls(): void
+    {
+        $clean = $this->sanitizer->sanitize('<img src="x" onerror="alert(1)"><a href="javascript:alert(1)">x</a>');
+
+        self::assertStringNotContainsString('onerror', $clean);
+        self::assertStringNotContainsString('javascript:', $clean);
+    }
+
+    public function testStripsStyleBlocksButKeepsInlineStyle(): void
+    {
+        $clean = $this->sanitizer->sanitize('<style>body{display:none}</style><p style="color:red">x</p>');
+
+        self::assertStringNotContainsString('<style', $clean);
+        self::assertStringContainsString('style="color:red"', $clean);
+    }
+}

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -20,6 +20,7 @@ use NeNeRecords\FieldDef\FieldDef;
 use NeNeRecords\PublicRecord\GetPublicRecordViewHandler;
 use NeNeRecords\PublicRecord\GetPublicRecordViewUseCase;
 use NeNeRecords\PublicRecord\PublicEntityTypeNotFoundExceptionHandler;
+use NeNeRecords\PublicRecord\PublicHtmlSanitizer;
 use NeNeRecords\PublicRecord\PublicRecordNotFoundExceptionHandler;
 use NeNeRecords\PublicRecord\PublicRecordRouteRegistrar;
 use NeNeRecords\PublicRecord\RenderPublicPermalinkHandler;
@@ -77,11 +78,18 @@ final class PublicRecordHttpTest extends TestCase
             new FieldDef(entityTypeId: 1, fieldKey: 'title', dataType: 'text', id: 1),
             new FieldDef(entityTypeId: 1, fieldKey: 'body', dataType: 'text', id: 2),
             new FieldDef(entityTypeId: 1, fieldKey: 'hero', dataType: 'image', id: 3),
+            new FieldDef(entityTypeId: 1, fieldKey: 'richbody', dataType: 'html', id: 4),
         ]);
         $textFields = new InMemoryTextFieldRepository([
             new TextField(entityId: 10, fieldKey: 'title', value: 'Hello world', id: 1),
             new TextField(entityId: 10, fieldKey: 'body', value: "## Sample\n\n**bold** line", id: 2),
             new TextField(entityId: 10, fieldKey: 'hero', value: '/media/2026/06/hero.png', id: 3),
+            new TextField(
+                entityId: 10,
+                fieldKey: 'richbody',
+                value: '<p>imported <strong>kept</strong></p><img src="/media/imported/x.jpg" alt="p" /><script>alert(1)</script>',
+                id: 4,
+            ),
         ], $entities);
 
         $publicSettings = new ListPublicSettingsUseCase(new InMemorySettingRepository(), new InMemoryMediaRepository());
@@ -121,7 +129,7 @@ final class PublicRecordHttpTest extends TestCase
             machineApiKey: null,
         );
 
-        $renderHandler = new RenderPublicRecordViewHandler($useCase, $publicSettings, $htmlResponse, $config, $projectRoot, $this->factory);
+        $renderHandler = new RenderPublicRecordViewHandler($useCase, $publicSettings, $htmlResponse, $config, $projectRoot, $this->factory, new PublicHtmlSanitizer());
         $registrar = new PublicRecordRouteRegistrar(
             new GetPublicRecordViewHandler($useCase, $jsonResponse, $this->factory),
             $renderHandler,
@@ -165,6 +173,32 @@ final class PublicRecordHttpTest extends TestCase
         );
 
         self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testRenderPublicRecordViewSanitizesHtmlFieldsServerSide(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        );
+        $html = (string) $response->getBody();
+
+        self::assertSame(200, $response->getStatusCode());
+
+        // Inspect only the rendered <article> (the crawler-visible content), not the
+        // hydration bootstrap JSON below it (which carries the raw value as inert,
+        // hex-escaped data for the SPA to sanitize via DOMPurify).
+        $start = strpos($html, '<article>');
+        $end = strpos($html, '</article>');
+        self::assertNotFalse($start);
+        self::assertNotFalse($end);
+        $article = substr($html, $start, $end - $start);
+
+        // html-typed field: rich markup + images survive in the crawlable SSR…
+        self::assertStringContainsString('<strong>kept</strong>', $article);
+        self::assertStringContainsString('/media/imported/x.jpg', $article);
+        // …but scripts/handlers are stripped server-side (no arbitrary JS in the article).
+        self::assertStringNotContainsString('<script', $article);
+        self::assertStringNotContainsString('alert(1)', $article);
     }
 
     public function testRenderPublicRecordViewReturnsHtmlWithBootstrapAndArticleContent(): void


### PR DESCRIPTION
## 目的
NeNe Records 信念監査の是正①。SSR(`record-detail.php`)が `body` を **fieldKey 固定で markdown 描画**し、WXR 取込の **html 型コンテンツが strip** され、クローラ向け SSR と SPA(`SanitizedHtml`/DOMPurify)で内容が乖離していた（SEO/SSR 投資の忠実性が損なわれる。なお**任意 JS は元から両経路で不発＝安全**で、これは忠実性の修正）。

## 変更
- **`PublicHtmlSanitizer`** 新設（`symfony/html-sanitizer`）。SPA の DOMPurify ポリシーに対応：**リッチマークアップ＋img＋相対URL＋inline style を保持、script/`on*`/`javascript:`/`<style>` を除去**。
- **`record-detail.php` を dataType 準拠化**：`html` 型は `$renderHtml` でサニタイズ出力（`body` 特例の**前**に分岐）。markdown/text body は従来どおり markdown、その他はエスケープ。
- `RenderPublicRecordViewHandler` に sanitizer を注入し `$renderHtml` を提供。

## 検証
- `composer check` 緑。
- `PublicHtmlSanitizerTest`（保持/除去 6）＋ `PublicRecordHttpTest` に **SSR 統合テスト**（html 型フィールドが `<article>` 内で `<strong>`/`<img>` 保持・`<script>`/`alert(1)` 除去。bootstrap JSON は `JSON_HEX_TAG` でブレイクアウト不可）。
- 依存は **symfony/html-sanitizer のみ**追加（`nene2` は path repo のため lock 参照据え置き＝diff クリーン）。

## 補足（別途対応の知見）
実機確認で、**既存の markdown 型 `body` を持つ org** では取込 HTML が markdown-strip で消える（importer が html フィールドへ入れていないため）。本PRは「html 型フィールドの SSR 忠実描画」を保証し、**新規org（importer が body を html 作成）では完全に機能**。既存 markdown body への取込は importer 側の追加対応が必要（フォローアップ）。

Part of #539