### PR TITLE
fix(migration): WXR取込本文を必ずhtml型フィールドへ格納し忠実描画を保証する (#539)

### DIFF
--- a/src/WxrImport/WxrImportExecutor.php
+++ b/src/WxrImport/WxrImportExecutor.php
@@ -6,6 +6,7 @@ namespace NeNeRecords\WxrImport;
 
 use DateTimeImmutable;
 use NeNeRecords\Entity\Entity;
+use NeNeRecords\Entity\EntityListCriteria;
 use NeNeRecords\Entity\EntityRepositoryInterface;
 use NeNeRecords\Entity\EntityStatus;
 use NeNeRecords\EntityTag\EntityTagRepositoryInterface;
@@ -27,10 +28,11 @@ use NeNeRecords\UrlRedirect\UrlRedirectRepositoryInterface;
  *
  * - Idempotent: an item whose slug already exists for its type is skipped, so
  *   re-running the same import does not duplicate.
- * - Target type/fields are ensured (created if missing); `title` is text, `body`
- *   is html so imported WordPress content renders sanitized. A pre-existing
- *   markdown `body` is reused as-is (HTML stored verbatim; renders via the
- *   markdown HTML passthrough).
+ * - Imported content is HTML, so it is written to an html-typed field (see
+ *   {@see resolveContentField}): a fresh type's `body` is created/promoted to
+ *   html; a type that already has native (e.g. markdown) content keeps it and the
+ *   import lands in a dedicated `wp_content` html field. Either way the content
+ *   renders faithfully (sanitized) on SSR and SPA rather than being stripped.
  * - 301 redirect map (S3): each item's original WordPress URL path is recorded
  *   as a redirect to the new permalink, preserving SEO equity after migration.
  * - Media (S4): a caller-supplied old→new media URL map rewrites `<img src>`
@@ -62,8 +64,12 @@ final class WxrImportExecutor
 
         /** @var array<string, EntityType> $typeBySlug */
         $typeBySlug = [];
+        /** @var array<string, string> $contentFieldBySlug */
+        $contentFieldBySlug = [];
         /** @var array<string, int> $tagIdBySlug */
         $tagIdBySlug = [];
+        /** @var list<string> $warnings */
+        $warnings = [];
 
         $created = 0;
         $skippedExisting = 0;
@@ -76,6 +82,9 @@ final class WxrImportExecutor
             if ($typeId === null) {
                 continue; // resolveType always sets the id; guard satisfies the analyser
             }
+
+            $contentField = $contentFieldBySlug[$item->entityTypeSlug]
+                ??= $this->resolveContentField($typeId, $type->slug, $warnings);
 
             if ($this->entities->findBySlug($item->slug, $typeId) !== null) {
                 ++$skippedExisting;
@@ -92,9 +101,11 @@ final class WxrImportExecutor
                 publishedAt: $publishedAt,
             ));
 
+            // Imported WordPress content is HTML — write it to an html-typed field
+            // so it renders faithfully (sanitized) on both SSR and SPA.
             $body = $mediaUrlMap === [] ? $item->contentHtml : strtr($item->contentHtml, $mediaUrlMap);
             $this->textFields->save(new TextField(entityId: $entityId, fieldKey: 'title', value: $item->title));
-            $this->textFields->save(new TextField(entityId: $entityId, fieldKey: 'body', value: $body));
+            $this->textFields->save(new TextField(entityId: $entityId, fieldKey: $contentField, value: $body));
 
             foreach ($item->tagSlugs as $tagSlug) {
                 $tagId = $tagIdBySlug[$tagSlug] ??= $this->ensureTag($tagSlug, $tagNames[$tagSlug] ?? $tagSlug);
@@ -118,7 +129,7 @@ final class WxrImportExecutor
             tagLinks: $tagLinks,
             redirectsCreated: $redirectsCreated,
             skippedItems: $plan->skippedItems,
-            warnings: $plan->warnings,
+            warnings: [...$plan->warnings, ...$warnings],
         );
     }
 
@@ -135,9 +146,57 @@ final class WxrImportExecutor
         }
 
         $this->ensureFieldDef($typeId, 'title', 'text');
-        $this->ensureFieldDef($typeId, 'body', 'html');
 
         return $type;
+    }
+
+    /**
+     * Resolve the html-typed field that imported WordPress content is written to,
+     * so it renders faithfully (sanitized) instead of being stripped by a markdown
+     * field. Returns the field key to write the content into.
+     *
+     * - `body` is html or absent → use (create) `body` as html.
+     * - `body` exists as non-html but the type has no entities yet (a fresh
+     *   migration target) → promote `body` to html (safe — no values to break).
+     * - `body` is non-html and the type already has native content → write to a
+     *   dedicated `wp_content` html field so existing markdown authoring is intact.
+     *
+     * @param list<string> $warnings accumulates operator-visible notes (by reference)
+     */
+    private function resolveContentField(int $typeId, string $typeSlug, array &$warnings): string
+    {
+        $body = $this->fieldDefs->findByEntityTypeIdAndFieldKey($typeId, 'body');
+
+        if ($body === null) {
+            $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'body', dataType: 'html'));
+
+            return 'body';
+        }
+
+        if ($body->dataType === 'html') {
+            return 'body';
+        }
+
+        if ($this->entities->countByCriteria(new EntityListCriteria(entityTypeId: $typeId)) === 0) {
+            $this->fieldDefs->update(new FieldDef(
+                entityTypeId: $body->entityTypeId,
+                fieldKey: $body->fieldKey,
+                dataType: 'html',
+                id: $body->id,
+                targetEntityTypeId: $body->targetEntityTypeId,
+                cardinality: $body->cardinality,
+                region: $body->region,
+                displayOrder: $body->displayOrder,
+            ));
+            $warnings[] = "「{$typeSlug}」の body フィールドを html 型へ昇格しました（取込コンテンツは HTML のため）。";
+
+            return 'body';
+        }
+
+        $this->ensureFieldDef($typeId, 'wp_content', 'html');
+        $warnings[] = "「{$typeSlug}」は既存の body が html 型でないため、取込本文を wp_content フィールドへ格納しました。";
+
+        return 'wp_content';
     }
 
     private function ensureFieldDef(int $typeId, string $fieldKey, string $dataType): void

--- a/tests/WxrImport/WxrImportExecutorTest.php
+++ b/tests/WxrImport/WxrImportExecutorTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Tests\WxrImport;
 
+use NeNeRecords\Entity\Entity;
 use NeNeRecords\Entity\EntityStatus;
+use NeNeRecords\EntityType\EntityType;
+use NeNeRecords\FieldDef\FieldDef;
 use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
 use NeNeRecords\Tests\EntityTag\InMemoryEntityTagRepository;
 use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
@@ -132,6 +135,80 @@ final class WxrImportExecutorTest extends TestCase
         self::assertSame(0, $second->createdEntities);
         self::assertSame(4, $second->skippedExisting);
         self::assertSame(0, $second->tagLinks); // already attached
+    }
+
+    public function testPromotesEmptyMarkdownBodyToHtml(): void
+    {
+        // A type seeded with a markdown `body` but no entities yet (fresh target).
+        $entityTypes = new InMemoryEntityTypeRepository([new EntityType(name: 'Posts', slug: 'posts', id: 1)]);
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'body', dataType: 'markdown', id: 1),
+        ]);
+        $entities = new InMemoryEntityRepository([]);
+        $textFields = new InMemoryTextFieldRepository([], $entities);
+        $executor = new WxrImportExecutor(
+            $entityTypes,
+            $fieldDefs,
+            $entities,
+            $textFields,
+            new InMemoryTagRepository([]),
+            new InMemoryEntityTagRepository(),
+            new InMemoryUrlRedirectRepository(),
+        );
+
+        $result = $executor->execute($this->document());
+
+        // body promoted markdown → html (safe: no values existed).
+        self::assertSame('html', $fieldDefs->findByEntityTypeIdAndFieldKey(1, 'body')?->dataType);
+        // content written to body and faithful.
+        $hello = $entities->findBySlug('hello-world', 1);
+        self::assertNotNull($hello?->id);
+        self::assertStringContainsString('<strong>world</strong>', $this->bodyValue($textFields, $hello->id, 'body'));
+        self::assertNotEmpty(array_filter($result->warnings, static fn (string $w): bool => str_contains($w, '昇格')));
+    }
+
+    public function testWritesToDedicatedFieldWhenTypeHasNativeContent(): void
+    {
+        // A type with a markdown `body` that already holds native content.
+        $entityTypes = new InMemoryEntityTypeRepository([new EntityType(name: 'Posts', slug: 'posts', id: 1)]);
+        $fieldDefs = new InMemoryFieldDefRepository([
+            new FieldDef(entityTypeId: 1, fieldKey: 'body', dataType: 'markdown', id: 1),
+        ]);
+        $entities = new InMemoryEntityRepository([
+            new Entity(id: 5, entityTypeId: 1, slug: 'native-post', status: EntityStatus::Published),
+        ]);
+        $textFields = new InMemoryTextFieldRepository([], $entities);
+        $executor = new WxrImportExecutor(
+            $entityTypes,
+            $fieldDefs,
+            $entities,
+            $textFields,
+            new InMemoryTagRepository([]),
+            new InMemoryEntityTagRepository(),
+            new InMemoryUrlRedirectRepository(),
+        );
+
+        $result = $executor->execute($this->document());
+
+        // Existing markdown body left intact; import lands in a dedicated html field.
+        self::assertSame('markdown', $fieldDefs->findByEntityTypeIdAndFieldKey(1, 'body')?->dataType);
+        self::assertSame('html', $fieldDefs->findByEntityTypeIdAndFieldKey(1, 'wp_content')?->dataType);
+        $hello = $entities->findBySlug('hello-world', 1);
+        self::assertNotNull($hello?->id);
+        self::assertStringContainsString('<strong>world</strong>', $this->bodyValue($textFields, $hello->id, 'wp_content'));
+        self::assertSame('', $this->bodyValue($textFields, $hello->id, 'body'));
+        self::assertNotEmpty(array_filter($result->warnings, static fn (string $w): bool => str_contains($w, 'wp_content')));
+    }
+
+    private function bodyValue(InMemoryTextFieldRepository $textFields, int $entityId, string $fieldKey): string
+    {
+        foreach ($textFields->findByEntityId($entityId, 100, 0) as $tf) {
+            if ($tf->fieldKey === $fieldKey) {
+                return $tf->value;
+            }
+        }
+
+        return '';
     }
 
     public function testRewritesBodyImageUrlsFromMediaMap(): void


### PR DESCRIPTION
## 目的
監査是正①の**完結**。SSR 側(#570)は html 型を忠実描画するが、importer は WP HTML を `body` の**型に関係なく**格納していた。**全 org は既定型を seed され `body`=markdown** のため、取込 HTML が markdown-strip で消失（実機 `/posts/247` で本文空を確認）＝①が実質ほぼ全 org で効かない状態だった。

## 変更（`WxrImportExecutor`）
- **`resolveContentField`** 新設：取込本文を**必ず html 型フィールドへ**。
  - `body` が html or 不在 → `body`(html) を使用/作成。
  - `body` が非html だが type に**エンティティ無し（新規移行先）→ `body` を html へ昇格**（既存値無く安全・本文が HTML である事実に整合）。
  - `body` が非html かつ**既存エンティティあり（native著作と混在）→ 専用 `wp_content`(html)** へ格納し既存 markdown 著作を温存。
  - 昇格/専用フィールド使用は `result.warnings` で可視化。
- `resolveType` から `body` の固定 ensure を除去。

## 検証
- `composer check` 緑。`WxrImportExecutorTest` に**昇格/専用フィールドの2分岐テスト**追加（計 43 Wxr）。
- **実機 end-to-end**: 新スラッグ取込 → 旧URL `→301→ /posts/251` の SSR で `<p>Faithful <strong>HTML</strong> body</p>` を**忠実描画**・`<script>alert(7)</script>` を**除去**。warning「wp_content へ格納」も確認。

Part of #539（① SSR忠実描画 #570 と合わせて完結）