### PR TITLE
feat(migration): WXRのSEOメタ(Yoast/RankMath/AIOSEO)を取り込みSEO継続を完結する (#539)

### DIFF
--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -146,7 +146,10 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             $relationsByFieldKey,
         );
 
-        $pageTitle = $this->resolvePageTitle($textFieldRows, $entityId);
+        // The SEO title override (entity.meta_title, e.g. imported from Yoast) wins
+        // for <title>/og:title; otherwise fall back to the record's title field.
+        $metaTitle = trim($entity->metaTitle ?? '');
+        $pageTitle = $metaTitle !== '' ? $metaTitle : $this->resolvePageTitle($textFieldRows, $entityId);
 
         $bootstrap = PublicRecordViewHttpMapper::toBootstrap(
             entityTypeSlug: $input->entityTypeSlug,

--- a/src/WxrImport/WxrImportExecutor.php
+++ b/src/WxrImport/WxrImportExecutor.php
@@ -99,6 +99,8 @@ final class WxrImportExecutor
                 slug: $item->slug,
                 status: EntityStatus::from($item->status),
                 publishedAt: $publishedAt,
+                metaTitle: $item->metaTitle,
+                metaDescription: $item->metaDescription,
             ));
 
             // Imported WordPress content is HTML — write it to an html-typed field

--- a/src/WxrImport/WxrImportPlannedItem.php
+++ b/src/WxrImport/WxrImportPlannedItem.php
@@ -16,7 +16,9 @@ final readonly class WxrImportPlannedItem
         public array $tagSlugs,
         public string $contentHtml = '',
         public ?string $publishedAtIso = null,
-        public ?string $originalLink = null, // WordPress <link> — source for the 301 map
+        public ?string $originalLink = null,    // WordPress <link> — source for the 301 map
+        public ?string $metaTitle = null,       // SEO title from Yoast/RankMath/AIOSEO postmeta
+        public ?string $metaDescription = null, // SEO meta description from the same
     ) {
     }
 }

--- a/src/WxrImport/WxrImportPlanner.php
+++ b/src/WxrImport/WxrImportPlanner.php
@@ -28,6 +28,12 @@ final class WxrImportPlanner
         'future' => 'scheduled',
     ];
 
+    /** SEO title postmeta keys, in precedence order (Yoast → RankMath → AIOSEO). */
+    private const SEO_TITLE_KEYS = ['_yoast_wpseo_title', 'rank_math_title', '_aioseo_title', '_aioseop_title'];
+
+    /** SEO meta-description postmeta keys, same precedence. */
+    private const SEO_DESCRIPTION_KEYS = ['_yoast_wpseo_metadesc', 'rank_math_description', '_aioseo_description', '_aioseop_description'];
+
     public function plan(WxrDocument $document): WxrImportPlan
     {
         $planned = [];
@@ -80,6 +86,8 @@ final class WxrImportPlanner
                 $item->contentHtml,
                 $item->publishedAtIso,
                 $item->originalLink,
+                self::seoValue($item->postMeta, self::SEO_TITLE_KEYS),
+                self::seoValue($item->postMeta, self::SEO_DESCRIPTION_KEYS),
             );
             $countsByType[$entityType] = ($countsByType[$entityType] ?? 0) + 1;
             $countsByStatus[$status] = ($countsByStatus[$status] ?? 0) + 1;
@@ -93,6 +101,31 @@ final class WxrImportPlanner
             countsByEntityType: $countsByType,
             countsByStatus: $countsByStatus,
         );
+    }
+
+    /**
+     * First non-empty SEO value among the given postmeta keys, ignoring
+     * unexpanded plugin templates (e.g. Yoast `%%title%%`, RankMath `%title%`)
+     * which would render as literal garbage — those fall back to NeNe defaults.
+     *
+     * @param array<string, string> $postMeta
+     * @param list<string>          $keys
+     */
+    private static function seoValue(array $postMeta, array $keys): ?string
+    {
+        foreach ($keys as $key) {
+            $value = trim($postMeta[$key] ?? '');
+            if ($value !== '' && !self::looksLikeTemplate($value)) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    private static function looksLikeTemplate(string $value): bool
+    {
+        return str_contains($value, '%%') || preg_match('/%[a-z][a-z0-9_]*%/i', $value) === 1;
     }
 
     private static function slugify(string $title): string

--- a/src/WxrImport/WxrItem.php
+++ b/src/WxrImport/WxrItem.php
@@ -12,8 +12,9 @@ namespace NeNeRecords\WxrImport;
 final readonly class WxrItem
 {
     /**
-     * @param list<string> $categorySlugs WP category nicenames assigned to this item
-     * @param list<string> $tagSlugs      WP post_tag slugs assigned to this item
+     * @param list<string>          $categorySlugs WP category nicenames assigned to this item
+     * @param list<string>          $tagSlugs      WP post_tag slugs assigned to this item
+     * @param array<string, string> $postMeta      wp:postmeta key → value (SEO plugin fields, etc.)
      */
     public function __construct(
         public ?int $wpPostId,
@@ -28,6 +29,7 @@ final readonly class WxrItem
         public array $categorySlugs,
         public array $tagSlugs,
         public ?string $attachmentUrl = null, // wp:attachment_url (post_type=attachment)
+        public array $postMeta = [],
     ) {
     }
 }

--- a/src/WxrImport/WxrParser.php
+++ b/src/WxrImport/WxrParser.php
@@ -76,6 +76,15 @@ final class WxrParser
         $slug = trim((string) $wp->post_name);
         $publishedAt = $this->normalizeDate(trim((string) $wp->post_date));
 
+        $postMeta = [];
+        foreach ($wp->postmeta as $meta) {
+            $metaChildren = $meta->children('wp', true);
+            $key = trim((string) $metaChildren->meta_key);
+            if ($key !== '') {
+                $postMeta[$key] = (string) $metaChildren->meta_value;
+            }
+        }
+
         $categorySlugs = [];
         $tagSlugs = [];
         foreach ($item->category as $category) {
@@ -105,6 +114,7 @@ final class WxrParser
             categorySlugs: array_values(array_unique($categorySlugs)),
             tagSlugs: array_values(array_unique($tagSlugs)),
             attachmentUrl: trim((string) $wp->attachment_url) ?: null,
+            postMeta: $postMeta,
         );
     }
 

--- a/tests/WxrImport/WxrImportExecutorTest.php
+++ b/tests/WxrImport/WxrImportExecutorTest.php
@@ -108,6 +108,19 @@ final class WxrImportExecutorTest extends TestCase
         self::assertTrue($this->entityTags->isAttached($hello->id, $news->id));
     }
 
+    public function testAppliesImportedSeoMetaToEntity(): void
+    {
+        $this->executor->execute($this->document());
+
+        $posts = $this->entityTypes->findBySlug('posts');
+        self::assertNotNull($posts?->id);
+        $hello = $this->entities->findBySlug('hello-world', $posts->id);
+        self::assertNotNull($hello);
+
+        self::assertSame('Hello World — Custom SEO Title', $hello->metaTitle);
+        self::assertSame('A friendly greeting, search-optimized.', $hello->metaDescription);
+    }
+
     public function testDraftStatusMappedAndPageImportedIntoPagesType(): void
     {
         $this->executor->execute($this->document());

--- a/tests/WxrImport/WxrImportPlannerTest.php
+++ b/tests/WxrImport/WxrImportPlannerTest.php
@@ -54,6 +54,23 @@ final class WxrImportPlannerTest extends TestCase
         self::assertContains('php', $plan->tagSlugs);
     }
 
+    public function testExtractsSeoMetaFromPostmetaAndSkipsTemplates(): void
+    {
+        $plan = $this->plan();
+        $bySlug = [];
+        foreach ($plan->plannedItems as $item) {
+            $bySlug[$item->slug] = $item;
+        }
+
+        // hello-world has custom Yoast title/description → imported.
+        self::assertSame('Hello World — Custom SEO Title', $bySlug['hello-world']->metaTitle);
+        self::assertSame('A friendly greeting, search-optimized.', $bySlug['hello-world']->metaDescription);
+
+        // about's Yoast title is an unexpanded template (%%title%% …) → ignored.
+        self::assertNull($bySlug['about']->metaTitle);
+        self::assertNull($bySlug['about']->metaDescription);
+    }
+
     public function testDerivesSlugFromTitleWithWarning(): void
     {
         $plan = $this->plan();

--- a/tests/WxrImport/WxrParserTest.php
+++ b/tests/WxrImport/WxrParserTest.php
@@ -50,6 +50,9 @@ final class WxrParserTest extends TestCase
         // WP local date → ISO-8601.
         self::assertNotNull($hello->publishedAtIso);
         self::assertStringStartsWith('2024-01-15T10:00:00', $hello->publishedAtIso);
+        // postmeta (SEO plugin fields) parsed as key → value.
+        self::assertSame('Hello World — Custom SEO Title', $hello->postMeta['_yoast_wpseo_title'] ?? null);
+        self::assertSame('A friendly greeting, search-optimized.', $hello->postMeta['_yoast_wpseo_metadesc'] ?? null);
     }
 
     public function testItemWithoutSlugYieldsNull(): void

--- a/tests/WxrImport/fixtures/sample.wxr.xml
+++ b/tests/WxrImport/fixtures/sample.wxr.xml
@@ -33,6 +33,14 @@
       <wp:post_type><![CDATA[post]]></wp:post_type>
       <category domain="category" nicename="news"><![CDATA[News]]></category>
       <category domain="post_tag" nicename="php"><![CDATA[PHP]]></category>
+      <wp:postmeta>
+        <wp:meta_key><![CDATA[_yoast_wpseo_title]]></wp:meta_key>
+        <wp:meta_value><![CDATA[Hello World — Custom SEO Title]]></wp:meta_value>
+      </wp:postmeta>
+      <wp:postmeta>
+        <wp:meta_key><![CDATA[_yoast_wpseo_metadesc]]></wp:meta_key>
+        <wp:meta_value><![CDATA[A friendly greeting, search-optimized.]]></wp:meta_value>
+      </wp:postmeta>
     </item>
     <item>
       <title>About</title>
@@ -44,6 +52,10 @@
       <wp:post_name><![CDATA[about]]></wp:post_name>
       <wp:status><![CDATA[publish]]></wp:status>
       <wp:post_type><![CDATA[page]]></wp:post_type>
+      <wp:postmeta>
+        <wp:meta_key><![CDATA[_yoast_wpseo_title]]></wp:meta_key>
+        <wp:meta_value><![CDATA[%%title%% %%sep%% %%sitename%%]]></wp:meta_value>
+      </wp:postmeta>
     </item>
     <item>
       <title>Draft Post</title>


### PR DESCRIPTION
## 目的
「正しい postmeta」の最小核。移行記事が**検索スニペット（title/description）を失わない**よう、SEO プラグインの postmeta を NeNe の**既存 typed ターゲット**（`entity.metaTitle`/`metaDescription`）へ写し、`#570`/`#571`（body 忠実描画）＋ `#565`（301）＋ media と合わせ **SEO 継続を完結**する。

## 変更
- **`WxrParser`**: `wp:postmeta` を key→value で取得（`WxrItem.postMeta`）。
- **`WxrImportPlanner`**: `_yoast_wpseo_title` / `rank_math_title` / `_aioseo(p)_title`（＋ metadesc 系）を**優先順**で抽出。**未展開テンプレート**（`%%title%%`・`%title%`）は除外し NeNe 既定へフォールバック。
- **`WxrImportExecutor`**: `entity.metaTitle`/`metaDescription` に適用。
- **`GetPublicRecordViewUseCase`**: `pageTitle` を **`entity.metaTitle` 優先**に（Yoast 同等の正しい一般挙動）→ 取込 metaTitle が SSR `<title>`/og:title、metaDescription が meta description/og:description に反映。
- アイキャッチ(`_thumbnail_id`)は本スライス対象外（限界価値・実装コストから見送り）。

## 検証
- `composer check` 緑。parser/planner/executor に**SEOメタ抽出・テンプレ除外・適用**テスト追加（計 64 Wxr+PublicRecord）。
- **実機**: 新スラッグ取込 → 旧URL `→301→ /posts/252` の SSR で `<title>SEO Title Wins — NeNe Records`（フィールド値 "Plain Title" でなく Yoast title）・`description="Imported description here."`・og:title/og:description も Yoast 由来を確認。

Part of #539