### PR TITLE
feat(install): ワンコマンド初回導入(組織+admin)を追加する (#536)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,10 @@
         "migrations:status": "phinx status -c phinx.php",
         "migrations:migrate": "phinx migrate -c phinx.php",
         "migrations:rollback": "phinx rollback -c phinx.php",
+        "app:install": [
+            "@migrations:migrate",
+            "php tools/install.php"
+        ],
         "check": [
             "@test",
             "@analyse",

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,65 @@
+# Deployment & onboarding
+
+NeNe Records ships **single-origin**: one PHP app (Apache, front controller
+`public_html/index.php`) serves the API, the crawlable SSR for public records,
+and the built SPA shell. Point one public domain at it — no separate Node
+runtime.
+
+## First-run onboarding (one command)
+
+After the database is reachable, turn a fresh instance into a usable one with a
+single command. It runs migrations, creates the initial organization (which
+auto-seeds its default content types) and the admin user. **Idempotent** — safe
+to re-run on every deploy.
+
+```bash
+NENE_INSTALL_ADMIN_EMAIL=admin@example.com \
+NENE_INSTALL_ADMIN_PASSWORD='change-me' \
+  docker compose exec -T app composer app:install
+```
+
+| Env var | Required | Default |
+| --- | --- | --- |
+| `NENE_INSTALL_ADMIN_EMAIL` | yes | — |
+| `NENE_INSTALL_ADMIN_PASSWORD` | yes | — |
+| `NENE_INSTALL_ORG_NAME` | no | `NeNe Records` |
+| `NENE_INSTALL_ORG_SLUG` | no | `default` |
+
+The admin is created with the org-level `admin` role. Platform-level
+`superadmin` accounts are provisioned separately (not via this command).
+
+## Frontend assets
+
+The SPA + crawlable SSR mount the built assets via the Vite manifest. Build once
+per release:
+
+```bash
+npm ci --prefix frontend
+npm run build --prefix frontend   # → frontend/dist (+ .vite/manifest.json)
+```
+
+Apache serves `frontend/dist/assets` (see `docker/php/Dockerfile`), and
+`SingleOriginKernel` serves `frontend/dist/index.html` as the SPA shell for
+client-routed paths. Without a build, the app still runs (SSR + API); only the
+SPA shell fallback is a no-op.
+
+## Going live
+
+1. Provision the database and set the app `.env` (DB, JWT secret, ports, public
+   URL). Committed reference values live in `.env.example`.
+2. `composer app:install` (above).
+3. Build the frontend (above).
+4. Point the public domain at the PHP app and verify:
+   - `curl -fsS https://<domain>/health` → `ok`
+   - a public record permalink returns crawlable SSR HTML (`<title>`, OGP,
+     JSON-LD) with the SPA mounting over it.
+
+WordPress migration (WXR import → posts/pages/tags, 301 redirect map for old
+URLs, media, SEO meta) is available in the admin UI under **データ移行**
+(`/admin/import`).
+
+## Not yet productized (tracked follow-ups)
+
+- A dedicated production `compose` profile and a multi-stage `Dockerfile`
+  (frontend build + `composer install --no-dev` + opcache) — today the committed
+  stack is the dev stack.

--- a/src/Install/InstallApplication.php
+++ b/src/Install/InstallApplication.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Install;
+
+use LogicException;
+use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Auth\Role;
+use NeNeRecords\Organization\CreateOrganizationInput;
+use NeNeRecords\Organization\CreateOrganizationUseCaseInterface;
+use NeNeRecords\Organization\OrganizationRepositoryInterface;
+use NeNeRecords\Organization\OrganizationSlugConflictException;
+use NeNeRecords\User\CreateUserInput;
+use NeNeRecords\User\CreateUserUseCaseInterface;
+use NeNeRecords\User\UserEmailConflictException;
+
+/**
+ * First-run onboarding: turns a freshly-migrated database into a usable instance
+ * by creating the initial organization (which auto-seeds its default content
+ * types) and its admin user. Idempotent — re-running skips whatever already
+ * exists — so it is safe to run on every deploy.
+ */
+final readonly class InstallApplication
+{
+    /**
+     * @param RequestScopedHolder<int> $orgHolder
+     */
+    public function __construct(
+        private CreateOrganizationUseCaseInterface $createOrganization,
+        private OrganizationRepositoryInterface $organizations,
+        private CreateUserUseCaseInterface $createUser,
+        private RequestScopedHolder $orgHolder,
+    ) {
+    }
+
+    public function install(InstallConfig $config): InstallResult
+    {
+        [$organizationId, $organizationCreated] = $this->ensureOrganization($config);
+
+        // Scope subsequent writes (and the admin's email-uniqueness check) to the org.
+        $this->orgHolder->set($organizationId);
+
+        $adminCreated = $this->ensureAdmin($config, $organizationId);
+
+        return new InstallResult(
+            organizationId: $organizationId,
+            organizationSlug: $config->organizationSlug,
+            organizationCreated: $organizationCreated,
+            adminEmail: $config->adminEmail,
+            adminCreated: $adminCreated,
+        );
+    }
+
+    /** @return array{0: int, 1: bool} [organizationId, created] */
+    private function ensureOrganization(InstallConfig $config): array
+    {
+        try {
+            $output = $this->createOrganization->execute(new CreateOrganizationInput(
+                name: $config->organizationName,
+                slug: $config->organizationSlug,
+            ));
+
+            return [$output->id, true];
+        } catch (OrganizationSlugConflictException) {
+            $existing = $this->organizations->findBySlug($config->organizationSlug);
+
+            if ($existing === null || $existing->id === null) {
+                throw new LogicException('Organization slug conflict but the organization could not be resolved.');
+            }
+
+            return [$existing->id, false];
+        }
+    }
+
+    private function ensureAdmin(InstallConfig $config, int $organizationId): bool
+    {
+        try {
+            $this->createUser->execute(new CreateUserInput(
+                email: $config->adminEmail,
+                password: $config->adminPassword,
+                role: Role::Admin->value,
+                organizationId: $organizationId,
+            ));
+
+            return true;
+        } catch (UserEmailConflictException) {
+            return false;
+        }
+    }
+}

--- a/src/Install/InstallConfig.php
+++ b/src/Install/InstallConfig.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Install;
+
+/** First-run install inputs (organization + initial admin). */
+final readonly class InstallConfig
+{
+    public function __construct(
+        public string $organizationName,
+        public string $organizationSlug,
+        public string $adminEmail,
+        public string $adminPassword,
+    ) {
+    }
+}

--- a/src/Install/InstallResult.php
+++ b/src/Install/InstallResult.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Install;
+
+/** Outcome of a first-run install (idempotent — `*Created` is false when already present). */
+final readonly class InstallResult
+{
+    public function __construct(
+        public int $organizationId,
+        public string $organizationSlug,
+        public bool $organizationCreated,
+        public string $adminEmail,
+        public bool $adminCreated,
+    ) {
+    }
+}

--- a/tests/Install/InstallApplicationTest.php
+++ b/tests/Install/InstallApplicationTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Install;
+
+use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Install\InstallApplication;
+use NeNeRecords\Install\InstallConfig;
+use NeNeRecords\Organization\CreateOrganizationUseCase;
+use NeNeRecords\Organization\DefaultContentTypeSeederInterface;
+use NeNeRecords\Tests\Organization\InMemoryOrganizationRepository;
+use NeNeRecords\Tests\User\InMemoryUserRepository;
+use NeNeRecords\User\CreateUserUseCase;
+use PHPUnit\Framework\TestCase;
+
+final class InstallApplicationTest extends TestCase
+{
+    private function app(InMemoryOrganizationRepository $orgs, InMemoryUserRepository $users): InstallApplication
+    {
+        $seeder = new class () implements DefaultContentTypeSeederInterface {
+            public int $seededFor = 0;
+
+            public function seed(int $organizationId): void
+            {
+                $this->seededFor = $organizationId;
+            }
+        };
+
+        /** @var RequestScopedHolder<int> $holder */
+        $holder = new RequestScopedHolder();
+
+        return new InstallApplication(
+            new CreateOrganizationUseCase($orgs, $seeder),
+            $orgs,
+            new CreateUserUseCase($users),
+            $holder,
+        );
+    }
+
+    public function testCreatesOrganizationAndAdminOnFreshInstall(): void
+    {
+        $orgs = new InMemoryOrganizationRepository();
+        $users = new InMemoryUserRepository([]);
+
+        $result = $this->app($orgs, $users)->install(
+            new InstallConfig('Acme', 'acme', 'admin@acme.test', 'secret-password'),
+        );
+
+        self::assertTrue($result->organizationCreated);
+        self::assertTrue($result->adminCreated);
+        self::assertSame('acme', $result->organizationSlug);
+        self::assertNotNull($orgs->findBySlug('acme'));
+
+        $admin = $users->findByEmail('admin@acme.test');
+        self::assertNotNull($admin);
+        self::assertSame('admin', $admin->role);
+    }
+
+    public function testIsIdempotentOnReRun(): void
+    {
+        $orgs = new InMemoryOrganizationRepository();
+        $users = new InMemoryUserRepository([]);
+        $config = new InstallConfig('Acme', 'acme', 'admin@acme.test', 'secret-password');
+
+        $this->app($orgs, $users)->install($config);
+        $second = $this->app($orgs, $users)->install($config);
+
+        self::assertFalse($second->organizationCreated);
+        self::assertFalse($second->adminCreated);
+        self::assertSame(1, $orgs->count());
+    }
+}

--- a/tools/install.php
+++ b/tools/install.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * First-run onboarding: create the initial organization (auto-seeding its
+ * default content types) and the admin user, turning a freshly-migrated
+ * database into a usable instance. Idempotent — safe to run on every deploy.
+ *
+ * Run after migrations (the `app:install` composer script chains both):
+ *   NENE_INSTALL_ADMIN_EMAIL=admin@example.com \
+ *   NENE_INSTALL_ADMIN_PASSWORD='change-me' \
+ *     docker compose exec -T app composer app:install
+ *
+ * Environment:
+ *   NENE_INSTALL_ADMIN_EMAIL     (required) initial admin login email
+ *   NENE_INSTALL_ADMIN_PASSWORD  (required) initial admin password
+ *   NENE_INSTALL_ORG_NAME        (default "NeNe Records")
+ *   NENE_INSTALL_ORG_SLUG        (default "default")
+ */
+
+use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\ApplicationServiceProvider;
+use NeNeRecords\Http\RuntimeContainerFactory;
+use NeNeRecords\Install\InstallApplication;
+use NeNeRecords\Install\InstallConfig;
+use NeNeRecords\Organization\CreateOrganizationUseCaseInterface;
+use NeNeRecords\Organization\OrganizationRepositoryInterface;
+use NeNeRecords\User\CreateUserUseCaseInterface;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$email = getenv('NENE_INSTALL_ADMIN_EMAIL');
+$password = getenv('NENE_INSTALL_ADMIN_PASSWORD');
+
+if (!is_string($email) || $email === '' || !is_string($password) || $password === '') {
+    fwrite(STDERR, "ERROR: NENE_INSTALL_ADMIN_EMAIL and NENE_INSTALL_ADMIN_PASSWORD are required.\n");
+    exit(1);
+}
+
+$orgNameEnv = getenv('NENE_INSTALL_ORG_NAME');
+$orgSlugEnv = getenv('NENE_INSTALL_ORG_SLUG');
+$orgName = is_string($orgNameEnv) && $orgNameEnv !== '' ? $orgNameEnv : 'NeNe Records';
+$orgSlug = is_string($orgSlugEnv) && $orgSlugEnv !== '' ? $orgSlugEnv : 'default';
+
+$container = (new RuntimeContainerFactory(dirname(__DIR__)))->create();
+
+$createOrganization = $container->get(CreateOrganizationUseCaseInterface::class);
+$organizations = $container->get(OrganizationRepositoryInterface::class);
+$createUser = $container->get(CreateUserUseCaseInterface::class);
+$orgHolder = $container->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+if (
+    !$createOrganization instanceof CreateOrganizationUseCaseInterface
+    || !$organizations instanceof OrganizationRepositoryInterface
+    || !$createUser instanceof CreateUserUseCaseInterface
+    || !$orgHolder instanceof RequestScopedHolder
+) {
+    fwrite(STDERR, "ERROR: the application container is misconfigured.\n");
+    exit(1);
+}
+
+/** @var RequestScopedHolder<int> $orgHolder */
+$result = (new InstallApplication($createOrganization, $organizations, $createUser, $orgHolder))
+    ->install(new InstallConfig($orgName, $orgSlug, $email, $password));
+
+printf(
+    "✓ Organization '%s' (#%d) %s\n",
+    $result->organizationSlug,
+    $result->organizationId,
+    $result->organizationCreated ? 'created' : 'already existed',
+);
+printf(
+    "✓ Admin '%s' %s\n",
+    $result->adminEmail,
+    $result->adminCreated ? 'created' : 'already existed',
+);
+echo "\nNext steps:\n";
+echo "  1. Build the frontend:  npm ci && npm run build --prefix frontend\n";
+echo "  2. Point your public domain at this app (single-origin); see docs/deployment.md.\n";
+
+exit(0);


### PR DESCRIPTION
## 目的
**②配備/オンボーディング**の第一スライス。3回の市場討論が一貫して指す**採用ゲート**＝「受託 dev が顧客向けに立ち上げる導線」が未整備（committed は dev compose のみ・初回 org/admin 作成が手動でバラバラ・seeder は demo 用）だったのを、コードで埋める。

## 変更
- **`InstallApplication`**: 初回 organization 作成（`CreateOrganizationUseCase` が**既定コンテンツ型を自動シード**）＋ admin ユーザー作成を**冪等**実行（slug/email 既存はスキップ＝毎デプロイ実行で安全）。インターフェース注入で**テスト可能**。
- **`tools/install.php`**: コンテナを boot し env から設定を読む薄い CLI（PHPStan lvl8/CS 準拠の型ガード付き）。
- **`composer app:install`**: `migrations:migrate` → `tools/install.php` を連結（クローン後ほぼ1コマンドで使える管理画面に）。
- **`docs/deployment.md`**: 単一オリジン配信・初回導入・frontend build・本番化の runbook。prod compose/Dockerfile 硬化は次スライスとして明記。

## 検証
- `composer check` 緑。`InstallApplicationTest`（新規作成 / 冪等再実行、**実 UseCase + in-memory repo**）。
- **実機**: `php tools/install.php` を2回 → 「Organization created / Admin created」→「already existed」（冪等）、作成 admin で**ログイン 200**（ユーザーが機能）。

## 次スライス（配備/オンボ）
- 本番 `compose` プロファイル + マルチステージ `Dockerfile`（frontend build + `--no-dev` + opcache）。

Part of #536（配備/オンボーディング）