### PR TITLE
feat(deploy): 本番スタックを追加しfresh DBにmigrationsが通るよう修正する (#536)

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,0 +1,81 @@
+# Production stack: the single-origin PHP app + MySQL (+ cron). No dev tooling
+# (phpMyAdmin / Mailpit / Vite). Reuses the same image as dev (docker/php/Dockerfile)
+# with production env + OPcache tuning — phinx (migrations) is a dev dependency,
+# so dev packages are intentionally kept; a slimmed --no-dev image is a future step.
+#
+# Usage:
+#   1. npm ci --prefix frontend && npm run build --prefix frontend
+#   2. set the required secrets in .env (NENE2_LOCAL_JWT_SECRET, DB_PASSWORD,
+#      MYSQL_ROOT_PASSWORD) — see .env.example / docs/deployment.md
+#   3. docker compose -f compose.prod.yaml up -d --build
+#   4. NENE_INSTALL_ADMIN_EMAIL=... NENE_INSTALL_ADMIN_PASSWORD=... \
+#        docker compose -f compose.prod.yaml exec -T app composer app:install
+services:
+  app:
+    build:
+      context: .
+      dockerfile: docker/php/Dockerfile
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      # Fixed for production — not interpolated, so a stray dev .env (Compose
+      # auto-loads .env) can never accidentally enable debug here.
+      APP_ENV: production
+      APP_DEBUG: "false"
+      APP_NAME: ${APP_NAME:-NeNe Records}
+      NENE2_MACHINE_API_KEY: ${NENE2_MACHINE_API_KEY:-}
+      NENE2_LOCAL_JWT_SECRET: ${NENE2_LOCAL_JWT_SECRET:?set a strong JWT secret in .env}
+      PROBLEM_DETAILS_BASE_URL: ${PROBLEM_DETAILS_BASE_URL:-https://nene-records.dev/problems/}
+      DB_ENV: ${DB_ENV:-production}
+      DB_ADAPTER: mysql
+      DB_HOST: ${DB_HOST:-mysql}
+      DB_PORT: ${DB_PORT:-3306}
+      DB_NAME: ${DB_NAME:-nene_records}
+      DB_USER: ${DB_USER:-nene_records}
+      DB_PASSWORD: ${DB_PASSWORD:?set DB_PASSWORD in .env}
+      DB_CHARSET: utf8mb4
+      MAIL_DSN: ${MAIL_DSN:-}
+      MAIL_FROM: ${MAIL_FROM:-noreply@example.com}
+    ports:
+      - "${NENE_RECORDS_PROD_PORT:-8080}:80"
+    volumes:
+      - .:/var/www/html
+      - ../NENE2:/var/www/NENE2:ro
+      - ./docker/php/opcache-prod.ini:/usr/local/etc/php/conf.d/zz-opcache-prod.ini:ro
+      - composer-cache:/root/.composer/cache
+    command: ["/bin/sh", "/var/www/html/docker/app/entrypoint.sh"]
+
+  mysql:
+    image: mysql:8.4
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: ${DB_NAME:-nene_records}
+      MYSQL_USER: ${DB_USER:-nene_records}
+      MYSQL_PASSWORD: ${DB_PASSWORD:?set DB_PASSWORD in .env}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?set MYSQL_ROOT_PASSWORD in .env}
+    volumes:
+      - mysql-prod-data:/var/lib/mysql
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "mysqladmin ping -h localhost -u$${MYSQL_USER} -p$${MYSQL_PASSWORD} --silent",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  cron:
+    image: alpine:3.21
+    restart: unless-stopped
+    depends_on:
+      - app
+    volumes:
+      - ./docker/cron/crontab:/etc/crontabs/root:ro
+    command: crond -f -l 6
+
+volumes:
+  mysql-prod-data:
+  composer-cache:

--- a/database/migrations/20260524000011_create_entity_relations_table.php
+++ b/database/migrations/20260524000011_create_entity_relations_table.php
@@ -9,8 +9,8 @@ final class CreateEntityRelationsTable extends AbstractMigration
     public function change(): void
     {
         $this->table('entity_relations')
-            ->addColumn('source_entity_id', 'integer', ['null' => false])
-            ->addColumn('target_entity_id', 'integer', ['null' => false])
+            ->addColumn('source_entity_id', 'integer', ['null' => false, 'signed' => false])
+            ->addColumn('target_entity_id', 'integer', ['null' => false, 'signed' => false])
             ->addColumn('field_key', 'string', ['null' => false])
             ->addIndex(['source_entity_id', 'field_key'])
             ->addIndex(['source_entity_id', 'target_entity_id', 'field_key'], ['unique' => true])

--- a/database/migrations/20260528000001_add_email_verification_columns.php
+++ b/database/migrations/20260528000001_add_email_verification_columns.php
@@ -10,9 +10,12 @@ final class AddEmailVerificationColumns extends AbstractMigration
     {
         // Pending email change verification (#283): the new address and a hashed,
         // time-limited token live here until the recipient confirms via the new address.
+        // No positional AFTER on the first column — password_reset_expires_at is added
+        // by a later-versioned migration, so on a fresh (version-ordered) DB it does not
+        // exist yet. Column position is cosmetic; appending keeps this migration self-contained.
         $this->execute('
             ALTER TABLE users
-                ADD COLUMN pending_email VARCHAR(255) NULL DEFAULT NULL AFTER password_reset_expires_at,
+                ADD COLUMN pending_email VARCHAR(255) NULL DEFAULT NULL,
                 ADD COLUMN email_verification_token_hash VARCHAR(64) NULL DEFAULT NULL AFTER pending_email,
                 ADD COLUMN email_verification_expires_at DATETIME NULL DEFAULT NULL AFTER email_verification_token_hash
         ');

--- a/database/migrations/20260530000002_add_display_order_to_entity_types.php
+++ b/database/migrations/20260530000002_add_display_order_to_entity_types.php
@@ -9,8 +9,15 @@ final class AddDisplayOrderToEntityTypes extends AbstractMigration
     public function up(): void
     {
         $this->table('entity_types')
-            ->addColumn('display_order', 'integer', ['null' => false, 'default' => 0, 'after' => 'is_pinned'])
+            ->addColumn('display_order', 'integer', ['null' => false, 'default' => 0])
             ->update();
+
+        // organization_id is added by a later-versioned migration; on a fresh
+        // (version-ordered) DB it does not exist yet and entity_types is empty, so
+        // the per-org backfill is a no-op — skip it to stay forward-reference-free.
+        if (!$this->table('entity_types')->hasColumn('organization_id')) {
+            return;
+        }
 
         // Backfill so the current (id-ascending) order is preserved per organization.
         $pdo = $this->getAdapter()->getConnection();

--- a/database/migrations/20260613000000_add_location_to_navigation_items.php
+++ b/database/migrations/20260613000000_add_location_to_navigation_items.php
@@ -10,9 +10,11 @@ final class AddLocationToNavigationItems extends AbstractMigration
     {
         // Menu items gain a location (header / footer / side). Existing rows
         // default to `header` so they keep rendering where they did before.
+        // No (organization_id, …) index: organization_id is added by a later-versioned
+        // migration, and `location` itself is dropped again by a later migration, so the
+        // index is transient. Omitting it keeps this migration forward-reference-free.
         $this->table('navigation_items')
             ->addColumn('location', 'string', ['limit' => 16, 'null' => false, 'default' => 'header', 'after' => 'url'])
-            ->addIndex(['organization_id', 'location'])
             ->update();
     }
 }

--- a/database/migrations/20260613000002_create_menus_table_and_backfill.php
+++ b/database/migrations/20260613000002_create_menus_table_and_backfill.php
@@ -28,7 +28,7 @@ final class CreateMenusTableAndBackfill extends AbstractMigration
             ->create();
 
         $this->table('navigation_items')
-            ->addColumn('menu_id', 'integer', ['null' => true, 'default' => null, 'after' => 'organization_id'])
+            ->addColumn('menu_id', 'integer', ['null' => true, 'default' => null])
             ->addIndex(['menu_id'])
             ->update();
 
@@ -43,6 +43,13 @@ final class CreateMenusTableAndBackfill extends AbstractMigration
 
     private function backfillMenus(): void
     {
+        // organization_id is added to navigation_items by a later-versioned migration;
+        // on a fresh (version-ordered) DB it does not exist yet and there are no nav
+        // items to backfill — skip to stay forward-reference-free.
+        if (!$this->table('navigation_items')->hasColumn('organization_id')) {
+            return;
+        }
+
         $now = date('Y-m-d H:i:s');
         $labels = ['header' => 'Header', 'footer' => 'Footer', 'side' => 'Side'];
         $connection = $this->getAdapter()->getConnection();

--- a/database/migrations/20260614000000_drop_location_from_navigation_items.php
+++ b/database/migrations/20260614000000_drop_location_from_navigation_items.php
@@ -9,9 +9,10 @@ final class DropLocationFromNavigationItems extends AbstractMigration
     public function change(): void
     {
         // Items now belong to a named menu via `menu_id`; the legacy
-        // header/footer/side `location` bucket (and its index) is retired.
+        // header/footer/side `location` bucket is retired. (No removeIndex: the
+        // earlier migration no longer creates an org-scoped location index, and
+        // dropping the column drops any remaining index on it.)
         $this->table('navigation_items')
-            ->removeIndex(['organization_id', 'location'])
             ->removeColumn('location')
             ->update();
     }

--- a/docker/php/opcache-prod.ini
+++ b/docker/php/opcache-prod.ini
@@ -1,0 +1,10 @@
+; Production OPcache tuning — mounted into conf.d only by compose.prod.yaml.
+; validate_timestamps=0 treats the deployed code as immutable (no per-request
+; stat); restart the app container after deploying new code to refresh the cache.
+opcache.enable=1
+opcache.validate_timestamps=0
+opcache.memory_consumption=192
+opcache.interned_strings_buffer=16
+opcache.max_accelerated_files=20000
+opcache.jit=tracing
+opcache.jit_buffer_size=64M

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -58,8 +58,31 @@ WordPress migration (WXR import → posts/pages/tags, 301 redirect map for old
 URLs, media, SEO meta) is available in the admin UI under **データ移行**
 (`/admin/import`).
 
+## Production stack (`compose.prod.yaml`)
+
+A standalone production stack — the single-origin PHP app + MySQL + cron, with
+`APP_ENV=production`, `APP_DEBUG=false` (both fixed, immune to a stray dev `.env`)
+and OPcache tuned for immutable code (`docker/php/opcache-prod.ini`). No dev
+tooling (phpMyAdmin / Mailpit / Vite).
+
+```bash
+# 1. build the frontend (host)
+npm ci --prefix frontend && npm run build --prefix frontend
+# 2. set required secrets in .env: NENE2_LOCAL_JWT_SECRET, DB_PASSWORD, MYSQL_ROOT_PASSWORD
+# 3. start
+docker compose -f compose.prod.yaml up -d --build
+# 4. first-run onboarding (idempotent)
+NENE_INSTALL_ADMIN_EMAIL=admin@example.com NENE_INSTALL_ADMIN_PASSWORD='change-me' \
+  docker compose -f compose.prod.yaml exec -T app composer app:install
+```
+
+The app entrypoint runs `migrations:migrate` on start; the migration set applies
+cleanly on a fresh MySQL database (verified end-to-end). Set the public host port
+with `NENE_RECORDS_PROD_PORT` (default 8080) and front it with TLS/reverse proxy.
+
 ## Not yet productized (tracked follow-ups)
 
-- A dedicated production `compose` profile and a multi-stage `Dockerfile`
-  (frontend build + `composer install --no-dev` + opcache) — today the committed
-  stack is the dev stack.
+- A multi-stage `Dockerfile` baking a slim `composer install --no-dev` image for
+  registry-based deploys. (Today both dev and prod build from the same
+  `docker/php/Dockerfile`; `--no-dev` is blocked because phinx — used for
+  migrations — is a dev dependency.)


### PR DESCRIPTION
## 目的
②配備の第2スライス。本番モードの実コンテナで検証したところ、**まっさらな MySQL に migrations が通らず新規デプロイが全停止**する潜在 **P0** を発見・修正し、本番スタックを追加する。

## 🔴 発見した P0（fresh-DB migrate 失敗）
multi-tenancy（`organization_id` を全テーブルへ）を旧 migration の seed/backfill に**後付け**し、その追加 migration（`20260628000001`）を**後の版番で採番**したため、fresh DB（版番順適用）では org_id が存在する前に org 依存 migration が走り失敗。**dev は逐次適用済で露見せず・CI は sqlite で露見せず**＝実 MySQL の新規デプロイで初めて出る。

## migrations 修正（fresh-DB 適用・dev は再実行されず無影響）
- **011**: `entity_relations` の FK 列を **unsigned** 化（`entities.id` と型一致）。
- **0528/0530/0613002**: 後続版の列に依存する `AFTER <col>` を除去（位置は cosmetic）。
- **0613000**: 後付け `organization_id` インデックスを除去（`location` は 0614 で drop され一時的）。
- **0614**: 上記で存在しなくなるインデックスの `removeIndex` を除去。
- **0530/0613002**: `organization_id` を使う backfill を `hasColumn` ガード（fresh では列未追加＋対象テーブル空＝no-op）。
- settings シード群(0616-0618)は既存 `hasTable` ガード＋空 orgs で no-op のため**無改変で通過**。

## 本番スタック
- **`compose.prod.yaml`**: app+mysql+cron のみ（phpMyAdmin/Mailpit/Vite 無し）。`APP_ENV=production`・`APP_DEBUG=false` を**固定**（Compose が auto-load する dev `.env` の漏れを無効化）。secret は `${VAR:?}` で必須化。
- **`docker/php/opcache-prod.ini`**: prod 用 OPcache（`validate_timestamps=0` 等、prod のみ mount）。
- **`docs/deployment.md`**: 本番スタック手順を追記。

## 検証
- `composer check` 緑。
- **実 MySQL の fresh-migrate 全70本 → `All Done`**（throwaway DB で確認）。
- **prod スタック e2e**: fresh 起動 → **crash-loop 無し health 200** → `app:install` で org+admin 作成 → **login 200** → opcache `validate_timestamps=Off`・API 404。

## 残（配備フォローアップ）
- 多段 `Dockerfile`（slim `--no-dev` イメージ）= phinx が dev 依存のため別途。

Part of #536（配備/オンボーディング）