### PR TITLE
fix(server): org未解決時にUrlRedirectResolverが落ちないようにする (#536)

### DIFF
--- a/src/UrlRedirect/UrlRedirectResolver.php
+++ b/src/UrlRedirect/UrlRedirectResolver.php
@@ -47,7 +47,15 @@ final readonly class UrlRedirectResolver
             return $response;
         }
 
-        $target = $this->redirects->findTargetBySource($path);
+        // Best-effort layer: the redirect map is org-scoped, so on requests where no
+        // organization was resolved (e.g. /admin and other non-tenant SPA paths) the
+        // org holder is unset and the lookup throws. A failed lookup must never break
+        // the request — fall through so the SPA shell fallback can serve it.
+        try {
+            $target = $this->redirects->findTargetBySource($path);
+        } catch (\Throwable) {
+            return $response;
+        }
 
         if ($target === null || $target === $path) {
             return $response;

--- a/tests/UrlRedirect/UrlRedirectResolverTest.php
+++ b/tests/UrlRedirect/UrlRedirectResolverTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Tests\UrlRedirect;
 
+use NeNeRecords\UrlRedirect\UrlRedirectRepositoryInterface;
 use NeNeRecords\UrlRedirect\UrlRedirectResolver;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
 
 final class UrlRedirectResolverTest extends TestCase
 {
@@ -78,6 +80,28 @@ final class UrlRedirectResolverTest extends TestCase
     {
         $request = $this->factory->createServerRequest('POST', 'https://site.test/2024/01/hello-world');
         $response = $this->resolver->apply($request, $this->notFound());
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testFallsThroughWhenLookupThrows(): void
+    {
+        // No org resolved (e.g. /admin) → the org-scoped repo's holder is unset and
+        // findTargetBySource throws. The resolver must swallow it and return the
+        // original 404 so the SPA shell fallback can serve the request.
+        $throwing = new class () implements UrlRedirectRepositoryInterface {
+            public function findTargetBySource(string $sourcePath): ?string
+            {
+                throw new RuntimeException('RequestScopedHolder::get() called before set()');
+            }
+
+            public function save(string $sourcePath, string $targetPath): void
+            {
+            }
+        };
+        $resolver = new UrlRedirectResolver($throwing, $this->factory);
+
+        $response = $resolver->apply($this->get('/admin'), $this->notFound());
 
         self::assertSame(404, $response->getStatusCode());
     }


### PR DESCRIPTION
## 目的
本番デプロイ（`records.nene-suite.com`・ConoHa VPS）で**実際に顕在化した本番バグ**の修正。監査(PR#568)で指摘した「UrlRedirectResolver の org-holder 結合」が、マルチテナント本番で現実化した。

## 症状
`/admin`（非テナント SPA パス）→ `RequestScopedHolder::get() called before set()` で **500 fatal**。`SingleOriginKernel` が app パイプライン後に `UrlRedirectResolver` を呼ぶが、リダイレクトマップは org スコープのため、**org が解決されないリクエストでは holder 未設定**→`PdoUrlRedirectRepository::findTargetBySource`→`$orgId->get()` が例外→SPAシェルフォールバックに到達できず /admin が落ちる。dev/単一テナントでは org が必ず設定され露見しなかった。

## 修正
- `UrlRedirectResolver::apply`：`findTargetBySource` を `try/catch (\Throwable)` で包み、**失敗時は元レスポンスを返す**（リダイレクトは best-effort 層。org 未解決や DB エラーでリクエストを壊さず、シェルフォールバックに委ねる）。テナントパスでは従来どおり org が設定され 301 は機能。

## 検証
- `composer check` 緑。`UrlRedirectResolverTest` に **throw する repo で握りつぶしを確認**する `testFallsThroughWhenLookupThrows` 追加（計12）。
- 本番（記録スタック）へ反映後、`/admin` → SPAシェル200 を再確認予定。

Part of #536