### PR TITLE
fix(deploy): 本番composeのMAIL_DSN既定をnullトランスポートにする (#536)

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -38,7 +38,9 @@ services:
       DB_USER: ${DB_USER:-nene_records}
       DB_PASSWORD: ${DB_PASSWORD:?set DB_PASSWORD in .env}
       DB_CHARSET: utf8mb4
-      MAIL_DSN: ${MAIL_DSN:-}
+      # Symfony Mailer requires a scheme; default to the null transport so a deploy
+      # without outbound mail configured boots cleanly instead of fataling on "".
+      MAIL_DSN: ${MAIL_DSN:-null://null}
       MAIL_FROM: ${MAIL_FROM:-noreply@example.com}
     ports:
       - "${NENE_RECORDS_PROD_PORT:-8080}:80"


### PR DESCRIPTION
本番デプロイで顕在化。`compose.prod.yaml` の `MAIL_DSN` 既定が空文字だったため、メール未設定の standalone デプロイで Symfony Mailer が「DSN must contain a scheme」で fatal→全リクエスト500（dev は mailpit DSN で露見せず）。既定を `null://null`（送信せず例外も出さない）に。outbound mail は `.env` の `MAIL_DSN` で上書き。Part of #536