### PR TITLE
feat(deploy): 本番運用3点(healthcheck/バックアップ/ログ)を整える (#536)

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -44,6 +44,20 @@ services:
       MAIL_FROM: ${MAIL_FROM:-noreply@example.com}
     ports:
       - "${NENE_RECORDS_PROD_PORT:-8080}:80"
+    healthcheck:
+      # PHP one-liner (no extra packages): the /health route must answer with "ok".
+      # Lets restart:unless-stopped detect a hung app and gates dependents on readiness.
+      test:
+        [
+          "CMD",
+          "php",
+          "-r",
+          "exit((($$c=@file_get_contents('http://127.0.0.1/health'))!==false&&str_contains($$c,'ok'))?0:1);",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 40s
     # No volumes: code, vendor and built assets are baked into the image.
     # No command: the image CMD is docker/app/entrypoint.prod.sh (migrate + serve).
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -85,6 +85,38 @@ database (verified end-to-end). The build requires the nene2 checkout adjacent t
 this repo (`../NENE2`). Set the public host port with `NENE_RECORDS_PROD_PORT`
 (default 8080) and front it with TLS/reverse proxy.
 
+## Operations
+
+**Health.** The `app` service has a Docker `healthcheck` that polls its own
+`/health` route, so `restart: unless-stopped` can recover a hung process and
+dependents wait for readiness. Check it with `docker compose -f compose.prod.yaml ps`
+(the app shows `(healthy)`).
+
+**Logs.** Apache access + error logs stream to the container's stdout/stderr (the
+`php:apache` base image wires them there), so `docker compose -f compose.prod.yaml
+logs -f app` follows live traffic. The app additionally records structured access
+entries to the database (`access_log` table).
+
+**Backups.** Dump the database to a timestamped, gzipped file (keeps the newest 14):
+
+```bash
+bash scripts/backup-db.sh                 # → ./backups/nene_records-YYYYmmdd-HHMMSS.sql.gz
+# schedule it from the host crontab, e.g. nightly at 03:15:
+#   15 3 * * * cd /path/to/deploy && BACKUP_DIR=/var/backups/records bash scripts/backup-db.sh >> /var/log/records-backup.log 2>&1
+```
+
+Restore a dump:
+
+```bash
+gunzip < backups/nene_records-XXXXXXXX-XXXXXX.sql.gz \
+  | docker compose -f compose.prod.yaml exec -T mysql \
+      sh -c 'exec mysql -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"'
+```
+
+The script reads credentials from the running db container's own environment, so no
+secrets are passed on the command line. Override `COMPOSE_FILE` / `DB_SERVICE` when
+the stack uses different names (e.g. a Caddy-fronted deploy with `DB_SERVICE=db`).
+
 ## Not yet productized (tracked follow-ups)
 
 - Pushing the built image to a registry + an orchestrated (multi-host / rolling)

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Dump the NeNe Records MySQL database to a timestamped, gzipped file.
+#
+# Usage:
+#   bash scripts/backup-db.sh [BACKUP_DIR]
+#
+# Overridable env (defaults target the standalone compose.prod.yaml stack):
+#   COMPOSE_FILE   compose file to talk to        (default: compose.prod.yaml)
+#   DB_SERVICE     mysql service name in compose   (default: mysql)
+#   BACKUP_DIR     where dumps are written         (default: ./backups, or $1)
+#   KEEP           how many dumps to retain        (default: 14)
+#
+# Credentials are read from the running db container's own environment
+# (MYSQL_USER / MYSQL_PASSWORD / MYSQL_DATABASE), so no secrets are handled here.
+#
+# Restore a dump:
+#   gunzip < backups/<file>.sql.gz \
+#     | docker compose -f compose.prod.yaml exec -T mysql \
+#         sh -c 'exec mysql -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"'
+set -euo pipefail
+
+COMPOSE_FILE="${COMPOSE_FILE:-compose.prod.yaml}"
+DB_SERVICE="${DB_SERVICE:-mysql}"
+BACKUP_DIR="${1:-${BACKUP_DIR:-./backups}}"
+KEEP="${KEEP:-14}"
+
+mkdir -p "$BACKUP_DIR"
+ts="$(date +%Y%m%d-%H%M%S)"
+out="$BACKUP_DIR/nene_records-${ts}.sql.gz"
+
+# --single-transaction: consistent dump without locking InnoDB tables.
+docker compose -f "$COMPOSE_FILE" exec -T "$DB_SERVICE" sh -c \
+  'exec mysqldump --single-transaction --routines --triggers --no-tablespaces \
+     -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"' \
+  | gzip > "$out"
+
+# Fail loudly if the dump came out empty (e.g. wrong service / creds).
+if [ ! -s "$out" ]; then
+  echo "backup FAILED: $out is empty" >&2
+  rm -f "$out"
+  exit 1
+fi
+
+echo "backup written: $out ($(du -h "$out" | cut -f1))"
+
+# Retention: keep the newest $KEEP dumps, delete the rest.
+ls -1t "$BACKUP_DIR"/nene_records-*.sql.gz 2>/dev/null | tail -n "+$((KEEP + 1))" | xargs -r rm -f


### PR DESCRIPTION
ペルソナ討論(#576)で陳/SRE/山本が一致要求した運用の仕上げ。

- **app healthcheck**（追加パッケージ不要の PHP ワンライナーで /health。`restart:unless-stopped` のハング検知＋`depends_on` readiness が成立。compose 変数展開回避に `$$c` エスケープ）
- **scripts/backup-db.sh**（mysqldump→gzip 時刻印・`--single-transaction`・認証はコンテナ env から・最新14世代保持）＋復旧手順
- **docs/deployment.md** Operations 節（health/ログ/バックアップ/復旧/cron 例）。Apache access/error は base image が stdout/stderr へ配線済＝`docker logs` で追える点も明記

Part of #536