### PR TITLE
fix(server): 単一orgデプロイのorg解決(空seed×ORG_SLUG)を成立させる (#536)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,9 @@ DB_CHARSET=utf8mb4
 # MEDIA_S3_PREFIX=                                    # optional key prefix inside the bucket
 # MEDIA_S3_ENDPOINT=                                  # set for MinIO/R2 (e.g. http://minio:9000)
 # MEDIA_S3_PATH_STYLE=false                           # true for MinIO
+#
+# --- Single-org tenant resolution (single-tenant production deploys) ---
+# The app resolves the organization from ORG_SLUG when system_config has no explicit
+# tenant_org_slug (which migrations seed empty). It MUST match the install org slug
+# (app:install default "default"); otherwise org-scoped requests are org-not-resolved 404.
+# ORG_SLUG=default

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -42,6 +42,10 @@ services:
       # without outbound mail configured boots cleanly instead of fataling on "".
       MAIL_DSN: ${MAIL_DSN:-null://null}
       MAIL_FROM: ${MAIL_FROM:-noreply@example.com}
+      # Single-org tenant resolution: the app resolves the organization from this
+      # slug, which MUST match the install org slug (app:install default "default").
+      # Without it every org-scoped request is org-not-resolved 404. See docs/deployment.md.
+      ORG_SLUG: ${ORG_SLUG:-default}
     ports:
       - "${NENE_RECORDS_PROD_PORT:-8080}:80"
     healthcheck:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -85,6 +85,12 @@ database (verified end-to-end). The build requires the nene2 checkout adjacent t
 this repo (`../NENE2`). Set the public host port with `NENE_RECORDS_PROD_PORT`
 (default 8080) and front it with TLS/reverse proxy.
 
+**Single-org resolution.** A single-tenant deploy resolves its organization from
+`ORG_SLUG`, which must match the install org slug (`app:install` default `default`).
+The stack defaults `ORG_SLUG=default`; if you install with a custom slug, set
+`ORG_SLUG` to match, otherwise every org-scoped request returns `org-not-resolved`
+404. (Alternatively set `tenant_org_slug` via the system-config API.)
+
 ## Operations
 
 **Health.** The `app` service has a Docker `healthcheck` that polls its own

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -307,15 +307,18 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     }
                     /** @var RequestScopedHolder<int> $orgIdHolder */
 
-                    // DB の system_config から解決モードを読む（env フォールバック付き）
+                    // DB の system_config から解決モードを読む（env フォールバック付き）。
+                    // system_config は migration で tenant_* を空文字 '' で seed するため、`??`
+                    // だと空文字（非 null）が env フォールバックを覆い隠す。`?:` で「空なら env」
+                    // とし、単一org デプロイ（ORG_SLUG 指定）が確実に解決できるようにする。
                     $sysConfig      = $container->get(SystemConfigRepositoryInterface::class);
                     $resolvedMode   = 'single';
                     $resolvedSlug   = (string) (getenv('ORG_SLUG') ?: '');
                     $resolvedDomain = (string) (getenv('BASE_DOMAIN') ?: 'localhost');
                     if ($sysConfig instanceof SystemConfigRepositoryInterface) {
-                        $resolvedMode   = $sysConfig->get('tenant_resolution_mode') ?? (string) (getenv('TENANT_RESOLUTION') ?: 'single');
-                        $resolvedSlug   = $sysConfig->get('tenant_org_slug') ?? $resolvedSlug;
-                        $resolvedDomain = $sysConfig->get('tenant_base_domain') ?? $resolvedDomain;
+                        $resolvedMode   = $sysConfig->get('tenant_resolution_mode') ?: (string) (getenv('TENANT_RESOLUTION') ?: 'single');
+                        $resolvedSlug   = $sysConfig->get('tenant_org_slug') ?: $resolvedSlug;
+                        $resolvedDomain = $sysConfig->get('tenant_base_domain') ?: $resolvedDomain;
                     }
 
                     $strategy = match ($resolvedMode) {


### PR DESCRIPTION
## 症状
`records.nene-suite.com` 本番で、有効な admin JWT でも**全 org-scoped リクエストが `org-not-resolved` 404**（ペルソナ討論で観測された現象の真因）。

## 原因
migration `20260629000000` が `system_config` に `tenant_org_slug` を**空文字 `''` で seed**。`RuntimeServiceProvider` が `get('tenant_org_slug') ?? getenv('ORG_SLUG')` で解決していたため、**`??` は null のみ捕捉＝空文字が env フォールバックを覆い隠し**、`EnvResolutionStrategy('')` が null → org 解決不能。dev は別 seeder が値を入れるため露見しない＝**本番 fresh install 限定のオンボーディング破れ**（#577/#578 と同類）。

## 修正
- `RuntimeServiceProvider`：tenant の mode/org_slug/base_domain 解決を **`??`→`?:`**（空文字 seed も env/既定へフォールバック）。
- `compose.prod.yaml` に **`ORG_SLUG`（既定 `default`）** を追加（`app:install` 既定 org slug に一致）。
- `.env.example` / `docs/deployment.md` に単一org解決を明記。

## 検証（本番実機）
`composer check` 緑。反映後 **entity-types 200**、WXR で投稿1件投入 → **旧URL 301 → `/posts/1` がクローラブル SSR で本文＋Yoast SEO title/desc 描画**、**canonical/og:url が https**（X-Forwarded-Proto 尊重）を確認。

Part of #536