### PR TITLE
feat(analytics): GA4/GTM＋Consent Mode v2 のバックエンド核を追加する (#536)

### DIFF
--- a/database/migrations/20260709000000_seed_analytics_settings_for_existing_orgs.php
+++ b/database/migrations/20260709000000_seed_analytics_settings_for_existing_orgs.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * 計測（GA4 / GTM）＋ Consent Mode v2 の公開設定 3 件を全 org に補完する（#536 PR-A1）。
+ *
+ *   - analytics_gtm_id           … Google Tag Manager コンテナ ID（例 GTM-XXXXXXX）。空＝無効。
+ *   - analytics_ga4_id           … GA4 測定 ID（例 G-XXXXXXXXXX）。空＝無効。
+ *   - analytics_consent_default  … 同意の既定（denied / granted）。既定は EU 安全側の denied。
+ *
+ * いずれも公開設定（is_public=1）として、SSR ページ／SPA シェル双方が読み取り、
+ * {@see \NeNeRecords\Http\WebAnalyticsConfig} で解決する。ID 設定時のみ CSP を緩め、
+ * Consent Mode v2 の既定をローダ前に出力する（{@see \NeNeRecords\Http\PublicHtmlCsp::build()}）。
+ *
+ * `setting_defs` は org スコープなので組織ごとに insert。べき等（既存はスキップ）。
+ *
+ * バージョンは現行 max（20260708000000）より後にしてある。`migrations:new` は実日付で
+ * 採番するため過去日付（date-skew）になり、依存より前にソートされて fresh-DB が壊れる。
+ */
+final class SeedAnalyticsSettingsForExistingOrgs extends AbstractMigration
+{
+    /** @var list<array{setting_key: string, default_value: string, label: string}> */
+    private const SETTINGS = [
+        ['setting_key' => 'analytics_gtm_id', 'default_value' => '', 'label' => 'Google Tag Manager container ID'],
+        ['setting_key' => 'analytics_ga4_id', 'default_value' => '', 'label' => 'Google Analytics 4 measurement ID'],
+        ['setting_key' => 'analytics_consent_default', 'default_value' => 'denied', 'label' => 'Analytics consent default (denied/granted)'],
+    ];
+
+    public function up(): void
+    {
+        if (!$this->hasTable('organizations') || !$this->hasTable('setting_defs')) {
+            return;
+        }
+
+        $pdo = $this->getAdapter()->getConnection();
+        $now = date('Y-m-d H:i:s');
+
+        $orgs = $pdo->query('SELECT id FROM organizations ORDER BY id ASC')->fetchAll(PDO::FETCH_COLUMN);
+
+        $check = $pdo->prepare('SELECT id FROM setting_defs WHERE organization_id = ? AND setting_key = ?');
+        $insert = $pdo->prepare(
+            'INSERT INTO setting_defs (organization_id, setting_key, data_type, default_value, is_public, label, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        );
+
+        foreach ($orgs as $orgIdRaw) {
+            $orgId = (int) $orgIdRaw;
+            foreach (self::SETTINGS as $setting) {
+                $check->execute([$orgId, $setting['setting_key']]);
+                if ($check->fetch() !== false) {
+                    continue;
+                }
+                $insert->execute([
+                    $orgId,
+                    $setting['setting_key'],
+                    'text',
+                    $setting['default_value'],
+                    1,
+                    $setting['label'],
+                    $now,
+                    $now,
+                ]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        $this->execute(
+            "DELETE FROM setting_defs WHERE setting_key IN ('analytics_gtm_id', 'analytics_ga4_id', 'analytics_consent_default')",
+        );
+    }
+}

--- a/src/Http/PublicHtmlCsp.php
+++ b/src/Http/PublicHtmlCsp.php
@@ -13,6 +13,12 @@ namespace NeNeRecords\Http;
  * which `default-src 'self'` blocks. This relaxes only `style-src` / `font-src` /
  * `img-src` — scripts stay `'self'` (no `script-src 'unsafe-inline'`), and API
  * responses keep the strict framework default.
+ *
+ * When the org has configured GA4 / GTM ({@see WebAnalyticsConfig}), {@see build()}
+ * widens the policy *only as much as analytics needs*: a per-response `nonce` plus
+ * `https://www.googletagmanager.com` on `script-src`, and the Google Analytics
+ * endpoints on `connect-src` / `img-src`. With no analytics configured the policy
+ * is byte-for-byte {@see POLICY} (scripts stay `'self'`, no nonce, no third party).
  */
 final class PublicHtmlCsp
 {
@@ -23,5 +29,30 @@ final class PublicHtmlCsp
 
     private function __construct()
     {
+    }
+
+    /**
+     * Policy for an analytics-aware public HTML response. Returns the strict
+     * {@see POLICY} unchanged when analytics is disabled; otherwise allows the
+     * nonce'd inline tag and the Google Analytics / Tag Manager hosts.
+     */
+    public static function build(WebAnalyticsConfig $analytics, ?string $scriptNonce = null): string
+    {
+        if (!$analytics->isEnabled()) {
+            return self::POLICY;
+        }
+
+        $scriptSrc = "'self'";
+        if ($scriptNonce !== null && $scriptNonce !== '') {
+            $scriptSrc .= " 'nonce-{$scriptNonce}'";
+        }
+        $scriptSrc .= ' https://www.googletagmanager.com';
+
+        return "default-src 'self'; "
+            . "script-src {$scriptSrc}; "
+            . "style-src 'self' 'unsafe-inline'; "
+            . "font-src 'self' data:; "
+            . "img-src 'self' data: https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com; "
+            . "connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com";
     }
 }

--- a/src/Http/SingleOriginServiceProvider.php
+++ b/src/Http/SingleOriginServiceProvider.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Http;
 use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
 use NeNeRecords\UrlRedirect\UrlRedirectResolver;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -29,6 +30,7 @@ final readonly class SingleOriginServiceProvider implements ServiceProviderInter
                     $projectRoot = $c->get(RuntimeServiceProvider::PROJECT_ROOT);
                     $responseFactory = $c->get(ResponseFactoryInterface::class);
                     $streamFactory = $c->get(StreamFactoryInterface::class);
+                    $publicSettings = $c->get(ListPublicSettingsUseCaseInterface::class);
 
                     if (!is_string($projectRoot) || $projectRoot === '') {
                         throw new LogicException('Project root is not configured.');
@@ -39,11 +41,15 @@ final readonly class SingleOriginServiceProvider implements ServiceProviderInter
                     if (!$streamFactory instanceof StreamFactoryInterface) {
                         throw new LogicException('Stream factory service is invalid.');
                     }
+                    if (!$publicSettings instanceof ListPublicSettingsUseCaseInterface) {
+                        throw new LogicException('Public settings use case service is invalid.');
+                    }
 
                     return new SpaShellFallback(
                         $projectRoot . '/frontend/dist/index.html',
                         $responseFactory,
                         $streamFactory,
+                        $publicSettings,
                     );
                 },
             )

--- a/src/Http/SpaShellFallback.php
+++ b/src/Http/SpaShellFallback.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Http;
 
+use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -15,15 +16,25 @@ use Psr\Http\Message\StreamFactoryInterface;
  * client router can handle `/admin`, `/login`, `/search`, `/tag/:slug`, browse
  * pages, etc. API / media / view / asset paths keep their genuine 404, and the
  * fallback is a no-op when no build is present (dev / unbuilt).
+ *
+ * For public client-routed pages it also injects the org's GA4 / GTM tag with a
+ * Consent Mode v2 default (matching the SSR record pages), so the SPA's initial
+ * shell load is measured too. Analytics is skipped on admin / auth surfaces and
+ * is strictly best-effort: any failure to resolve settings (e.g. no org context
+ * on `/admin`) falls back to the plain shell with the strict baseline CSP.
  */
 final readonly class SpaShellFallback
 {
     private const PASSTHROUGH = '#^/(api|media|view|assets)(/|$)#';
 
+    /** Surfaces that must never carry public analytics (logged-in / back office). */
+    private const ANALYTICS_SKIP = '#^/(admin|login|superadmin)(/|$)#';
+
     public function __construct(
         private string $shellPath,
         private ResponseFactoryInterface $responseFactory,
         private StreamFactoryInterface $streamFactory,
+        private ?ListPublicSettingsUseCaseInterface $publicSettings = null,
     ) {
     }
 
@@ -41,7 +52,9 @@ final readonly class SpaShellFallback
             return $response;
         }
 
-        if (preg_match(self::PASSTHROUGH, $request->getUri()->getPath()) === 1) {
+        $path = $request->getUri()->getPath();
+
+        if (preg_match(self::PASSTHROUGH, $path) === 1) {
             return $response;
         }
 
@@ -55,9 +68,55 @@ final readonly class SpaShellFallback
             return $response;
         }
 
+        $analytics = $this->resolveAnalytics($path);
+        $nonce = $analytics->isEnabled() ? bin2hex(random_bytes(16)) : '';
+
+        if ($analytics->isEnabled()) {
+            $html = $this->injectIntoHead($html, WebAnalyticsHeadSnippet::render($analytics, $nonce));
+        }
+
         return $this->responseFactory->createResponse(200)
             ->withHeader('Content-Type', 'text/html; charset=utf-8')
-            ->withHeader('Content-Security-Policy', PublicHtmlCsp::POLICY)
+            ->withHeader('Content-Security-Policy', PublicHtmlCsp::build($analytics, $nonce !== '' ? $nonce : null))
             ->withBody($this->streamFactory->createStream($html));
+    }
+
+    /**
+     * Best-effort analytics resolution for the shell. Disabled on admin / auth
+     * paths and whenever settings can't be read (org-scoped lookup throws when no
+     * org is resolved — same resilience contract as the 301 redirect layer).
+     */
+    private function resolveAnalytics(string $path): WebAnalyticsConfig
+    {
+        if ($this->publicSettings === null || preg_match(self::ANALYTICS_SKIP, $path) === 1) {
+            return WebAnalyticsConfig::disabled();
+        }
+
+        try {
+            $map = [];
+            foreach ($this->publicSettings->execute()->items as $entry) {
+                $map[$entry->def->settingKey] = $entry->effectiveValue;
+            }
+
+            return WebAnalyticsConfig::fromSettings($map);
+        } catch (\Throwable) {
+            return WebAnalyticsConfig::disabled();
+        }
+    }
+
+    /** Insert the snippet immediately before the first `</head>` (no-op if absent). */
+    private function injectIntoHead(string $html, string $snippet): string
+    {
+        if ($snippet === '') {
+            return $html;
+        }
+
+        $pos = stripos($html, '</head>');
+
+        if ($pos === false) {
+            return $html;
+        }
+
+        return substr($html, 0, $pos) . $snippet . substr($html, $pos);
     }
 }

--- a/src/Http/WebAnalyticsConfig.php
+++ b/src/Http/WebAnalyticsConfig.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Http;
+
+/**
+ * Resolved web-analytics configuration for the public surface (GA4 / GTM +
+ * Consent Mode v2 default). Sourced from the org's public settings
+ * (`analytics_gtm_id` / `analytics_ga4_id` / `analytics_consent_default`) and
+ * consumed by {@see PublicHtmlCsp::build()} (CSP allowlist) and
+ * {@see WebAnalyticsHeadSnippet::render()} (the `<head>` tag).
+ *
+ * IDs are validated to a strict `[A-Za-z0-9_-]` shape on construction: a stored
+ * value that does not match is treated as "not set" (null). This both gates the
+ * feature on a real ID and removes any injection surface, since the validated
+ * value is later interpolated verbatim into the CSP header and an inline script.
+ */
+final readonly class WebAnalyticsConfig
+{
+    /** GTM `GTM-XXXXXXX` / GA4 `G-XXXXXXXXXX` shape — alphanumerics, `_` and `-`. */
+    private const ID_PATTERN = '/^[A-Za-z0-9_-]{4,40}$/';
+
+    public function __construct(
+        public ?string $gtmId,
+        public ?string $ga4Id,
+        /** Consent Mode v2 default: `denied` (EU-safe) or `granted`. */
+        public string $consentDefault,
+    ) {
+    }
+
+    public static function disabled(): self
+    {
+        return new self(null, null, 'denied');
+    }
+
+    /**
+     * Build from a flat `settingKey => effectiveValue` map (public settings).
+     *
+     * @param array<string, string> $settings
+     */
+    public static function fromSettings(array $settings): self
+    {
+        return new self(
+            self::normalizeId($settings['analytics_gtm_id'] ?? ''),
+            self::normalizeId($settings['analytics_ga4_id'] ?? ''),
+            ($settings['analytics_consent_default'] ?? 'denied') === 'granted' ? 'granted' : 'denied',
+        );
+    }
+
+    /** Analytics is active only when at least one valid tag id is configured. */
+    public function isEnabled(): bool
+    {
+        return $this->gtmId !== null || $this->ga4Id !== null;
+    }
+
+    private static function normalizeId(string $raw): ?string
+    {
+        $trimmed = trim($raw);
+
+        return preg_match(self::ID_PATTERN, $trimmed) === 1 ? $trimmed : null;
+    }
+}

--- a/src/Http/WebAnalyticsHeadSnippet.php
+++ b/src/Http/WebAnalyticsHeadSnippet.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Http;
+
+/**
+ * Builds the `<head>` analytics tag for public pages: a CSP-nonce'd inline
+ * script that installs the Consent Mode v2 *default* (EU-safe `denied` unless
+ * the admin opted into `granted`) **before** the GA4 / GTM loader runs, so no
+ * storage is read until consent is (later) updated client-side (PR-A2 banner).
+ *
+ * - GTM container present → load GTM (it orchestrates GA4 and any other tags).
+ * - else GA4 id present   → load gtag.js directly and `config` the property.
+ *
+ * The inline script carries `nonce="..."`; the matching nonce is added to
+ * `script-src` by {@see PublicHtmlCsp::build()}. Inputs are pre-validated
+ * ({@see WebAnalyticsConfig}: ids are `[A-Za-z0-9_-]`, consent is an enum, the
+ * nonce is hex) so verbatim interpolation carries no injection surface.
+ */
+final class WebAnalyticsHeadSnippet
+{
+    private function __construct()
+    {
+    }
+
+    public static function render(WebAnalyticsConfig $config, string $nonce): string
+    {
+        if (!$config->isEnabled()) {
+            return '';
+        }
+
+        $consent = $config->consentDefault; // 'denied' | 'granted'
+        $nonceAttr = htmlspecialchars($nonce, ENT_QUOTES, 'UTF-8');
+
+        // Consent Mode v2 defaults — applied before any loader fires.
+        $bootstrap = 'window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}'
+            . "gtag('consent','default',{"
+            . "'ad_storage':'{$consent}',"
+            . "'ad_user_data':'{$consent}',"
+            . "'ad_personalization':'{$consent}',"
+            . "'analytics_storage':'{$consent}',"
+            . "'functionality_storage':'{$consent}',"
+            . "'personalization_storage':'{$consent}',"
+            . "'security_storage':'granted',"
+            . "'wait_for_update':500"
+            . '});'
+            . "gtag('set','ads_data_redaction',true);"
+            . "gtag('set','url_passthrough',true);";
+
+        if ($config->gtmId !== null) {
+            $inline = $bootstrap . self::gtmLoader($config->gtmId);
+
+            return "<script nonce=\"{$nonceAttr}\">{$inline}</script>";
+        }
+
+        // Direct GA4 (gtag.js): external loader + inline init. $config->ga4Id is
+        // non-null here because isEnabled() held and gtmId is null.
+        $inline = $bootstrap . "gtag('js',new Date());gtag('config','{$config->ga4Id}');";
+
+        return "<script async src=\"https://www.googletagmanager.com/gtag/js?id={$config->ga4Id}\" nonce=\"{$nonceAttr}\"></script>"
+            . "<script nonce=\"{$nonceAttr}\">{$inline}</script>";
+    }
+
+    private static function gtmLoader(string $gtmId): string
+    {
+        return "(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});"
+            . "var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';"
+            . "j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;"
+            . "f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','{$gtmId}');";
+    }
+}

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -9,6 +9,8 @@ use Nene2\Routing\Router;
 use Nene2\View\HtmlResponseFactory;
 use NeNeRecords\BundleField\BundleDocumentValidator;
 use NeNeRecords\Http\PublicHtmlCsp;
+use NeNeRecords\Http\WebAnalyticsConfig;
+use NeNeRecords\Http\WebAnalyticsHeadSnippet;
 use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -64,7 +66,14 @@ final readonly class RenderPublicRecordViewHandler
         ServerRequestInterface $request,
     ): ResponseInterface {
         $output = $this->useCase->execute(new GetPublicRecordViewInput($typeSlug, $entitySlug, $entityId));
-        $siteSettings = $this->resolveSiteSettings();
+        $settings = $this->publicSettingsMap();
+        $siteName = $settings['site_name'] ?? 'NeNe Records';
+        $defaultMetaDescription = $settings['default_meta_description'] ?? '';
+
+        // GA4 / GTM + Consent Mode v2 — emitted only when the org configured a tag id.
+        $analytics = WebAnalyticsConfig::fromSettings($settings);
+        $analyticsNonce = $analytics->isEnabled() ? bin2hex(random_bytes(16)) : '';
+        $analyticsHead = WebAnalyticsHeadSnippet::render($analytics, $analyticsNonce);
 
         // Canonical / og:url point at the user-facing permalink (not this /view/ twin).
         $uri = $request->getUri();
@@ -82,7 +91,7 @@ final readonly class RenderPublicRecordViewHandler
         // Prefer the per-entity meta description, falling back to the site default.
         $metaDescription = $output->metaDescription !== ''
             ? $output->metaDescription
-            : $siteSettings['default_meta_description'];
+            : $defaultMetaDescription;
 
         $bootstrapJson = json_encode(
             $output->bootstrap,
@@ -121,8 +130,9 @@ final readonly class RenderPublicRecordViewHandler
             'entityTypeName' => $output->entityTypeName,
             'entityId' => $output->entityId,
             'displayFields' => $output->displayFields,
-            'siteName' => $siteSettings['site_name'],
+            'siteName' => $siteName,
             'metaDescription' => $metaDescription,
+            'analyticsHead' => $analyticsHead,
             'canonicalUrl' => $canonicalUrl,
             'ogImageUrl' => $ogImageUrl,
             'publishedAtIso' => $output->publishedAtIso,
@@ -140,23 +150,26 @@ final readonly class RenderPublicRecordViewHandler
             // A bundle's crawlable twin (#311): render its seoText markdown server-side
             // (the sandboxed iframe itself is SPA-only / invisible to crawlers).
             'renderBundleSeo' => static fn (string $raw): string => PublicMarkdownRenderer::toSafeHtml(BundleDocumentValidator::seoTextOf($raw)),
-        ])->withHeader('Content-Security-Policy', PublicHtmlCsp::POLICY);
+        ])->withHeader(
+            'Content-Security-Policy',
+            PublicHtmlCsp::build($analytics, $analyticsNonce !== '' ? $analyticsNonce : null),
+        );
     }
 
-    /** @return array{site_name: string, default_meta_description: string} */
-    private function resolveSiteSettings(): array
+    /**
+     * All public settings flattened to a `settingKey => effectiveValue` map
+     * (site chrome + analytics ids all read from one query).
+     *
+     * @return array<string, string>
+     */
+    private function publicSettingsMap(): array
     {
-        $settings = [
-            'site_name' => 'NeNe Records',
-            'default_meta_description' => '',
-        ];
+        $map = [];
 
         foreach ($this->publicSettings->execute()->items as $entry) {
-            if (array_key_exists($entry->def->settingKey, $settings)) {
-                $settings[$entry->def->settingKey] = $entry->effectiveValue;
-            }
+            $map[$entry->def->settingKey] = $entry->effectiveValue;
         }
 
-        return $settings;
+        return $map;
     }
 }

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <?php /* GA4 / GTM + Consent Mode v2 — pre-built, nonce'd, '' when analytics is off. */ ?>
+    <?= $analyticsHead ?>
     <?php if ($metaDescription !== ''): ?>
       <meta name="description" content="<?= $e($metaDescription) ?>" />
     <?php endif; ?>

--- a/tests/Http/PublicHtmlCspTest.php
+++ b/tests/Http/PublicHtmlCspTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Http;
+
+use NeNeRecords\Http\PublicHtmlCsp;
+use NeNeRecords\Http\WebAnalyticsConfig;
+use PHPUnit\Framework\TestCase;
+
+final class PublicHtmlCspTest extends TestCase
+{
+    public function testDisabledAnalyticsReturnsStrictBaseline(): void
+    {
+        $csp = PublicHtmlCsp::build(WebAnalyticsConfig::disabled(), 'noncevalue');
+
+        self::assertSame(PublicHtmlCsp::POLICY, $csp);
+        self::assertStringNotContainsString('googletagmanager', $csp);
+        self::assertStringNotContainsString('nonce-', $csp);
+        // Scripts stay 'self' (inherited from default-src) — no script-src directive.
+        self::assertStringNotContainsString('script-src', $csp);
+    }
+
+    public function testEnabledAddsNonceAndTagManagerToScriptSrc(): void
+    {
+        $csp = PublicHtmlCsp::build(new WebAnalyticsConfig(null, 'G-XYZ987', 'denied'), 'abc123nonce');
+
+        self::assertStringContainsString("script-src 'self' 'nonce-abc123nonce' https://www.googletagmanager.com", $csp);
+    }
+
+    public function testEnabledAddsAnalyticsHostsToConnectAndImg(): void
+    {
+        $csp = PublicHtmlCsp::build(new WebAnalyticsConfig('GTM-ABC1234', null, 'denied'), 'n0nce');
+
+        self::assertStringContainsString('connect-src', $csp);
+        self::assertStringContainsString('https://www.google-analytics.com', $csp);
+        self::assertStringContainsString('https://*.analytics.google.com', $csp);
+        self::assertStringContainsString('img-src', $csp);
+        // SPA still needs its own origin for API/XHR.
+        self::assertStringContainsString("connect-src 'self'", $csp);
+    }
+
+    public function testEnabledWithoutNonceStillAllowsTagManager(): void
+    {
+        $csp = PublicHtmlCsp::build(new WebAnalyticsConfig(null, 'G-XYZ987', 'denied'), null);
+
+        self::assertStringContainsString('https://www.googletagmanager.com', $csp);
+        self::assertStringNotContainsString('nonce-', $csp);
+    }
+
+    public function testBaselineRelaxesOnlyStyleFontImg(): void
+    {
+        // Guards the existing SPA contract: inline styles + data: fonts allowed,
+        // scripts not loosened.
+        self::assertStringContainsString("style-src 'self' 'unsafe-inline'", PublicHtmlCsp::POLICY);
+        self::assertStringContainsString("font-src 'self' data:", PublicHtmlCsp::POLICY);
+        self::assertStringNotContainsString("'unsafe-inline'", explode('style-src', PublicHtmlCsp::POLICY)[0]);
+    }
+}

--- a/tests/Http/SpaShellFallbackTest.php
+++ b/tests/Http/SpaShellFallbackTest.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Tests\Http;
 
+use NeNeRecords\Http\PublicHtmlCsp;
 use NeNeRecords\Http\SpaShellFallback;
+use NeNeRecords\Setting\ListPublicSettingsOutput;
+use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
+use NeNeRecords\Setting\SettingDef;
+use NeNeRecords\Setting\SettingEntry;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
 
 final class SpaShellFallbackTest extends TestCase
 {
@@ -97,5 +103,88 @@ final class SpaShellFallbackTest extends TestCase
         $result = $fallback->apply($this->request('GET', '/admin/users'), $this->notFound());
 
         self::assertSame(404, $result->getStatusCode());
+    }
+
+    public function testNoAnalyticsWhenNoSettingsUseCase(): void
+    {
+        // Default construction (no settings) keeps the strict baseline policy.
+        $result = $this->fallback->apply($this->request('GET', '/posts'), $this->notFound());
+
+        self::assertSame(PublicHtmlCsp::POLICY, $result->getHeaderLine('Content-Security-Policy'));
+        self::assertStringNotContainsString('googletagmanager', (string) $result->getBody());
+    }
+
+    public function testInjectsAnalyticsOnPublicPathWhenConfigured(): void
+    {
+        $fallback = $this->fallbackWith(['analytics_ga4_id' => 'G-XYZ987']);
+        $result = $fallback->apply($this->request('GET', '/posts'), $this->notFound());
+
+        $body = (string) $result->getBody();
+        $csp = $result->getHeaderLine('Content-Security-Policy');
+
+        self::assertSame(200, $result->getStatusCode());
+        self::assertStringContainsString('gtag/js?id=G-XYZ987', $body);
+        self::assertStringContainsString('googletagmanager', $csp);
+
+        // The injected script's nonce must match the one in the CSP header.
+        preg_match('/nonce="([0-9a-f]{32})"/', $body, $bodyNonce);
+        $nonce = $bodyNonce[1] ?? '';
+        self::assertNotSame('', $nonce);
+        self::assertStringContainsString("'nonce-{$nonce}'", $csp);
+    }
+
+    public function testSkipsAnalyticsOnAdminPath(): void
+    {
+        $fallback = $this->fallbackWith(['analytics_ga4_id' => 'G-XYZ987']);
+        $result = $fallback->apply($this->request('GET', '/admin/users'), $this->notFound());
+
+        self::assertSame(200, $result->getStatusCode());
+        self::assertStringNotContainsString('googletagmanager', (string) $result->getBody());
+        self::assertStringNotContainsString('googletagmanager', $result->getHeaderLine('Content-Security-Policy'));
+    }
+
+    public function testBestEffortWhenSettingsResolutionThrows(): void
+    {
+        $throwing = new class () implements ListPublicSettingsUseCaseInterface {
+            public function execute(): ListPublicSettingsOutput
+            {
+                throw new RuntimeException('no org resolved');
+            }
+        };
+        $fallback = new SpaShellFallback($this->shellPath, $this->factory, $this->factory, $throwing);
+
+        $result = $fallback->apply($this->request('GET', '/posts'), $this->notFound());
+
+        // A failed lookup must never break the shell — serve it with the strict policy.
+        self::assertSame(200, $result->getStatusCode());
+        self::assertStringContainsString('<div id="root">', (string) $result->getBody());
+        self::assertStringNotContainsString('googletagmanager', (string) $result->getBody());
+    }
+
+    /** @param array<string, string> $settings */
+    private function fallbackWith(array $settings): SpaShellFallback
+    {
+        $entries = [];
+        foreach ($settings as $key => $value) {
+            $entries[] = new SettingEntry(
+                new SettingDef($key, 'text', '', true, $key, 1),
+                $value,
+                null,
+            );
+        }
+
+        $useCase = new class ($entries) implements ListPublicSettingsUseCaseInterface {
+            /** @param list<SettingEntry> $entries */
+            public function __construct(private array $entries)
+            {
+            }
+
+            public function execute(): ListPublicSettingsOutput
+            {
+                return new ListPublicSettingsOutput($this->entries);
+            }
+        };
+
+        return new SpaShellFallback($this->shellPath, $this->factory, $this->factory, $useCase);
     }
 }

--- a/tests/Http/WebAnalyticsConfigTest.php
+++ b/tests/Http/WebAnalyticsConfigTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Http;
+
+use NeNeRecords\Http\WebAnalyticsConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class WebAnalyticsConfigTest extends TestCase
+{
+    public function testDisabledFactoryHasNoIds(): void
+    {
+        $config = WebAnalyticsConfig::disabled();
+
+        self::assertFalse($config->isEnabled());
+        self::assertNull($config->gtmId);
+        self::assertNull($config->ga4Id);
+        self::assertSame('denied', $config->consentDefault);
+    }
+
+    public function testEmptySettingsAreDisabled(): void
+    {
+        $config = WebAnalyticsConfig::fromSettings([]);
+
+        self::assertFalse($config->isEnabled());
+    }
+
+    public function testValidGtmIdEnables(): void
+    {
+        $config = WebAnalyticsConfig::fromSettings(['analytics_gtm_id' => 'GTM-ABC1234']);
+
+        self::assertTrue($config->isEnabled());
+        self::assertSame('GTM-ABC1234', $config->gtmId);
+        self::assertNull($config->ga4Id);
+    }
+
+    public function testValidGa4IdEnables(): void
+    {
+        $config = WebAnalyticsConfig::fromSettings(['analytics_ga4_id' => 'G-XYZ987']);
+
+        self::assertTrue($config->isEnabled());
+        self::assertSame('G-XYZ987', $config->ga4Id);
+        self::assertNull($config->gtmId);
+    }
+
+    public function testWhitespaceAroundIdIsTrimmed(): void
+    {
+        $config = WebAnalyticsConfig::fromSettings(['analytics_ga4_id' => '  G-XYZ987  ']);
+
+        self::assertSame('G-XYZ987', $config->ga4Id);
+    }
+
+    /**
+     * Anything outside `[A-Za-z0-9_-]{4,40}` is treated as "not set" — this both
+     * gates the feature and removes the CSP-header / inline-script injection surface.
+     */
+    #[DataProvider('invalidIds')]
+    public function testInvalidIdsAreRejected(string $raw): void
+    {
+        $config = WebAnalyticsConfig::fromSettings(['analytics_gtm_id' => $raw, 'analytics_ga4_id' => $raw]);
+
+        self::assertFalse($config->isEnabled(), 'invalid id must not enable analytics');
+        self::assertNull($config->gtmId);
+        self::assertNull($config->ga4Id);
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function invalidIds(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'too short' => ['G-1'];
+        yield 'quote injection' => ["G-1';alert(1)//"];
+        yield 'angle bracket' => ['G-<script>'];
+        yield 'space' => ['G ABC'];
+        yield 'semicolon (csp break)' => ['GTM-1; script-src *'];
+        yield 'too long' => [str_repeat('A', 41)];
+    }
+
+    public function testConsentDefaultGranted(): void
+    {
+        $config = WebAnalyticsConfig::fromSettings([
+            'analytics_ga4_id' => 'G-XYZ987',
+            'analytics_consent_default' => 'granted',
+        ]);
+
+        self::assertSame('granted', $config->consentDefault);
+    }
+
+    public function testConsentDefaultFallsBackToDenied(): void
+    {
+        foreach (['', 'yes', 'GRANTED', 'true', 'denied'] as $raw) {
+            $config = WebAnalyticsConfig::fromSettings([
+                'analytics_ga4_id' => 'G-XYZ987',
+                'analytics_consent_default' => $raw,
+            ]);
+
+            self::assertSame('denied', $config->consentDefault, "\"{$raw}\" must normalize to denied");
+        }
+    }
+
+    public function testGtmAndGa4CanCoexist(): void
+    {
+        $config = WebAnalyticsConfig::fromSettings([
+            'analytics_gtm_id' => 'GTM-ABC1234',
+            'analytics_ga4_id' => 'G-XYZ987',
+        ]);
+
+        self::assertTrue($config->isEnabled());
+        self::assertSame('GTM-ABC1234', $config->gtmId);
+        self::assertSame('G-XYZ987', $config->ga4Id);
+    }
+}

--- a/tests/Http/WebAnalyticsHeadSnippetTest.php
+++ b/tests/Http/WebAnalyticsHeadSnippetTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Http;
+
+use NeNeRecords\Http\WebAnalyticsConfig;
+use NeNeRecords\Http\WebAnalyticsHeadSnippet;
+use PHPUnit\Framework\TestCase;
+
+final class WebAnalyticsHeadSnippetTest extends TestCase
+{
+    private const NONCE = 'deadbeefdeadbeefdeadbeefdeadbeef';
+
+    public function testDisabledConfigRendersNothing(): void
+    {
+        self::assertSame('', WebAnalyticsHeadSnippet::render(WebAnalyticsConfig::disabled(), self::NONCE));
+    }
+
+    public function testGa4PathLoadsGtagAndConfigures(): void
+    {
+        $html = WebAnalyticsHeadSnippet::render(
+            new WebAnalyticsConfig(null, 'G-XYZ987', 'denied'),
+            self::NONCE,
+        );
+
+        self::assertStringContainsString('https://www.googletagmanager.com/gtag/js?id=G-XYZ987', $html);
+        self::assertStringContainsString("gtag('config','G-XYZ987')", $html);
+        self::assertStringNotContainsString('/gtm.js', $html);
+    }
+
+    public function testGtmPathLoadsContainerNotGtag(): void
+    {
+        $html = WebAnalyticsHeadSnippet::render(
+            new WebAnalyticsConfig('GTM-ABC1234', null, 'denied'),
+            self::NONCE,
+        );
+
+        self::assertStringContainsString("https://www.googletagmanager.com/gtm.js?id='+i", $html);
+        self::assertStringContainsString('GTM-ABC1234', $html);
+        // GTM orchestrates GA4 itself — no direct gtag.js loader.
+        self::assertStringNotContainsString('/gtag/js', $html);
+    }
+
+    public function testGtmWinsWhenBothConfigured(): void
+    {
+        $html = WebAnalyticsHeadSnippet::render(
+            new WebAnalyticsConfig('GTM-ABC1234', 'G-XYZ987', 'denied'),
+            self::NONCE,
+        );
+
+        self::assertStringContainsString('/gtm.js', $html);
+        self::assertStringNotContainsString('/gtag/js', $html);
+    }
+
+    public function testConsentDefaultDeniedIsEmitted(): void
+    {
+        $html = WebAnalyticsHeadSnippet::render(
+            new WebAnalyticsConfig(null, 'G-XYZ987', 'denied'),
+            self::NONCE,
+        );
+
+        self::assertStringContainsString("gtag('consent','default'", $html);
+        self::assertStringContainsString("'analytics_storage':'denied'", $html);
+        self::assertStringContainsString("'ad_storage':'denied'", $html);
+        // security_storage is always granted regardless of the default.
+        self::assertStringContainsString("'security_storage':'granted'", $html);
+    }
+
+    public function testConsentDefaultGrantedIsEmitted(): void
+    {
+        $html = WebAnalyticsHeadSnippet::render(
+            new WebAnalyticsConfig(null, 'G-XYZ987', 'granted'),
+            self::NONCE,
+        );
+
+        self::assertStringContainsString("'analytics_storage':'granted'", $html);
+        self::assertStringContainsString("'ad_storage':'granted'", $html);
+    }
+
+    public function testEveryScriptTagCarriesTheNonce(): void
+    {
+        $html = WebAnalyticsHeadSnippet::render(
+            new WebAnalyticsConfig(null, 'G-XYZ987', 'denied'),
+            self::NONCE,
+        );
+
+        // Both the external loader and the inline init must be nonce'd to pass CSP.
+        $scriptTags = substr_count($html, '<script');
+        $noncedTags = substr_count($html, 'nonce="' . self::NONCE . '"');
+        self::assertSame($scriptTags, $noncedTags, 'every <script> must carry the nonce');
+        self::assertGreaterThanOrEqual(2, $scriptTags);
+    }
+
+    public function testConsentDefaultPrecedesLoader(): void
+    {
+        $html = WebAnalyticsHeadSnippet::render(
+            new WebAnalyticsConfig('GTM-ABC1234', null, 'denied'),
+            self::NONCE,
+        );
+
+        $consentPos = strpos($html, "gtag('consent','default'");
+        $loaderPos = strpos($html, 'gtm.js');
+        self::assertNotFalse($consentPos);
+        self::assertNotFalse($loaderPos);
+        self::assertLessThan($loaderPos, $consentPos, 'consent default must run before the loader');
+    }
+}

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -58,7 +58,8 @@ final class PublicRecordHttpTest extends TestCase
         $this->application = $this->buildApplication(true, $this->projectRoot);
     }
 
-    private function buildApplication(bool $debug, string $projectRoot): RequestHandlerInterface
+    /** @param list<\NeNeRecords\Setting\SettingDef> $settingDefs */
+    private function buildApplication(bool $debug, string $projectRoot, array $settingDefs = []): RequestHandlerInterface
     {
         $entityTypes = new InMemoryEntityTypeRepository([
             new EntityType(name: 'Article', slug: 'article', id: 1),
@@ -92,7 +93,7 @@ final class PublicRecordHttpTest extends TestCase
             ),
         ], $entities);
 
-        $publicSettings = new ListPublicSettingsUseCase(new InMemorySettingRepository(), new InMemoryMediaRepository());
+        $publicSettings = new ListPublicSettingsUseCase(new InMemorySettingRepository($settingDefs), new InMemoryMediaRepository());
 
         $useCase = new GetPublicRecordViewUseCase(
             $entityTypes,
@@ -284,6 +285,43 @@ final class PublicRecordHttpTest extends TestCase
         $csp = $response->getHeaderLine('Content-Security-Policy');
         self::assertStringContainsString("style-src 'self' 'unsafe-inline'", $csp);
         self::assertStringContainsString("font-src 'self' data:", $csp);
+    }
+
+    public function testSsrInjectsAnalyticsWhenConfigured(): void
+    {
+        // A public GA4 setting whose effective value is a valid measurement id.
+        $app = $this->buildApplication(true, $this->projectRoot, [
+            new \NeNeRecords\Setting\SettingDef('analytics_ga4_id', 'text', 'G-SSRTEST1', true, 'GA4'),
+            new \NeNeRecords\Setting\SettingDef('analytics_consent_default', 'text', 'denied', true, 'Consent'),
+        ]);
+
+        $response = $app->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        );
+        $html = (string) $response->getBody();
+        $csp = $response->getHeaderLine('Content-Security-Policy');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('gtag/js?id=G-SSRTEST1', $html);
+        self::assertStringContainsString("'analytics_storage':'denied'", $html);
+        self::assertStringContainsString('https://www.googletagmanager.com', $csp);
+
+        // CSP nonce must match the nonce on the injected script.
+        preg_match('/nonce="([0-9a-f]{32})"/', $html, $m);
+        $nonce = $m[1] ?? '';
+        self::assertNotSame('', $nonce);
+        self::assertStringContainsString("'nonce-{$nonce}'", $csp);
+    }
+
+    public function testSsrKeepsStrictCspWhenAnalyticsDisabled(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        );
+        $csp = $response->getHeaderLine('Content-Security-Policy');
+
+        self::assertStringNotContainsString('googletagmanager', $csp);
+        self::assertStringNotContainsString('googletagmanager', (string) $response->getBody());
     }
 
     public function testRealPermalinkReturns404ForUnknownId(): void


### PR DESCRIPTION
## 目的（PR-A1）
公開サイトに計測（GA4 / GTM）を導入する**バックエンド核**。CSP の `script-src 'self'` 固定で GTM/GA4 が読み込めなかった制約を、**計測 ID が設定されたときだけ** CSP を緩める方式で解消する。市場ペルソナ討論（第5回）で「見送り最大クラスタの共通ゲートを一手で開ける、最小コスト×最大効果の残り engineering」と特定された項目。フロント側（SPA ルート計測・同意バナー UI・管理 UI の入力欄）は後続の **PR-A2**。

## 変更
- **migration `20260709000000`** — 公開設定 3 件を全 org に補完（idempotent）。
  - `analytics_gtm_id`（GTM-XXXX）/ `analytics_ga4_id`（G-XXXX）/ `analytics_consent_default`（既定 `denied`）。
  - 版番は現行 max（`20260708000000`）より後にして **date-skew を回避**（`migrations:new` は実日付採番のため過去日付になり依存より前にソートされる）。
- **`WebAnalyticsConfig`**（VO）— 公開設定から解決。ID は `^[A-Za-z0-9_-]{4,40}$` で厳格検証し、不正値は「未設定」扱い。機能ゲート兼 **CSP ヘッダ／インライン script へのインジェクション面の除去**。
- **`WebAnalyticsHeadSnippet`** — **nonce 付き**インライン script で Consent Mode v2 の既定（EU 安全側 `denied`、admin が `granted` を選べる）を**ローダより前**に出力。GTM があれば GTM コンテナ、無ければ gtag.js を直接ロード。未設定なら空文字。
- **`PublicHtmlCsp::build()`** — ID 設定時のみ `script-src` に nonce＋`googletagmanager`、`connect-src`/`img-src` に google-analytics 系を追加。未設定は既存の厳格 `POLICY` のまま（`'unsafe-inline'` を script に付けない既存方針を維持）。
- **注入点 2 か所** — SSR（`RenderPublicRecordViewHandler` ＋ `templates/public/record-detail.php`）と SPA シェル（`SpaShellFallback`）の両方。
  - シェルは **best-effort**：org 未解決時（`/admin` 等）は素の厳格 CSP へフォールバック（301 リダイレクト層と同じ耐性契約）。
  - `/admin`・`/login`・`/superadmin` は計測対象外（バックオフィス／ログイン中を計測しない）。

## セキュリティ方針
- 計測 ID は厳格検証 → CSP ヘッダ・インライン JS へ verbatim 展開しても安全。
- インライン script は **per-response nonce** で許可（`'unsafe-inline'` は使わない＝既存のスクリプト厳格性を維持）。
- 既定同意は **denied**（Consent Mode v2 / EU 安全側）。同意取得 UI は PR-A2。

## 検証
- `composer check` 緑：**PHPUnit 974 tests / 2704 assertions**・PHPStan level 8（0 errors）・CS-Fixer・OpenAPI・MCP。
- **実 MySQL の fresh-migrate**：全 migration が版番順に適用（本 migration が最後）／org 在席時に公開設定 3 件を seed（`is_public=1`・consent 既定 `denied`）／rollback→再 migrate で重複なし（idempotent）／`down()` で revert。
- 追加テスト：`WebAnalyticsConfigTest`（ID 検証・consent 正規化）/ `WebAnalyticsHeadSnippetTest`（GTM/GA4 分岐・consent 反映・全 script に nonce・consent がローダ前）/ `PublicHtmlCspTest`（有効時のみ緩和）/ `SpaShellFallbackTest`（公開パス注入・nonce 一致・admin 除外・例外時 best-effort）/ `PublicRecordHttpTest`（SSR 注入の E2E・nonce 一致）。

## 後続・未了
- **PR-A2**（フロント）：SPA ルート遷移の page_view（初回 SSR 分の二重計上排除）／consent バナー UI（許可→`gtag('consent','update')`）／管理 UI に計測 ID・同意既定の入力欄。
- 本番実証：ライブで `analytics_gtm_id` を設定 → CSP ヘッダに googletagmanager が入る・head に consent default＋GTM が出る・GTM が発火することを確認。

Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)