### PR TITLE
feat(analytics): 計測フロント（SPAルートpage_view＋同意バナー）を追加する (#536)

### DIFF
--- a/frontend/src/features/consent-banner/index.ts
+++ b/frontend/src/features/consent-banner/index.ts
@@ -1,0 +1,1 @@
+export { ConsentBanner } from './ui/ConsentBanner'

--- a/frontend/src/features/consent-banner/ui/ConsentBanner.test.tsx
+++ b/frontend/src/features/consent-banner/ui/ConsentBanner.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { I18nProvider } from '@/shared/i18n'
+import type { WebAnalyticsClientConfig } from '@/shared/lib/web-analytics'
+import { ConsentBanner } from './ConsentBanner'
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+  delete window.gtag
+})
+
+const enabledDenied: WebAnalyticsClientConfig = {
+  gtmId: null,
+  ga4Id: 'G-XYZ987',
+  consentDefault: 'denied',
+  enabled: true,
+}
+
+function renderBanner(config: WebAnalyticsClientConfig) {
+  return render(
+    <I18nProvider>
+      <ConsentBanner config={config} />
+    </I18nProvider>,
+  )
+}
+
+describe('ConsentBanner', () => {
+  it('prompts when analytics is enabled, default denied, and no prior choice', () => {
+    renderBanner(enabledDenied)
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    expect(screen.getByText('Allow')).toBeTruthy()
+    expect(screen.getByText('Decline')).toBeTruthy()
+  })
+
+  it('grants consent and hides on Allow', () => {
+    const gtag = vi.fn()
+    window.gtag = gtag
+    renderBanner(enabledDenied)
+
+    fireEvent.click(screen.getByText('Allow'))
+
+    expect(gtag).toHaveBeenCalledWith(
+      'consent',
+      'update',
+      expect.objectContaining({ analytics_storage: 'granted' }),
+    )
+    expect(localStorage.getItem('nene-records:analytics-consent')).toBe('granted')
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('records a denied choice on Decline', () => {
+    const gtag = vi.fn()
+    window.gtag = gtag
+    renderBanner(enabledDenied)
+
+    fireEvent.click(screen.getByText('Decline'))
+
+    expect(localStorage.getItem('nene-records:analytics-consent')).toBe('denied')
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('does not prompt when analytics is disabled', () => {
+    renderBanner({ gtmId: null, ga4Id: null, consentDefault: 'denied', enabled: false })
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('does not prompt when the default is granted', () => {
+    renderBanner({ ...enabledDenied, consentDefault: 'granted' })
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('does not prompt when a choice is already stored', () => {
+    localStorage.setItem('nene-records:analytics-consent', 'denied')
+    renderBanner(enabledDenied)
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+})

--- a/frontend/src/features/consent-banner/ui/ConsentBanner.tsx
+++ b/frontend/src/features/consent-banner/ui/ConsentBanner.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react'
+import { useTranslation } from '@/shared/i18n'
+import {
+  applyConsent,
+  type ConsentChoice,
+  readConsentChoice,
+  storeConsentChoice,
+  type WebAnalyticsClientConfig,
+} from '@/shared/lib/web-analytics'
+import { Button } from '@/shared/ui'
+
+interface ConsentBannerProps {
+  config: WebAnalyticsClientConfig
+}
+
+/**
+ * GDPR-style consent prompt for the public site. Shown only when analytics is
+ * enabled, the configured default is the EU-safe `denied`, and the visitor has
+ * not decided yet — a `granted` default means the admin opted out of the prompt.
+ * The choice persists in localStorage and is pushed to the tag via Consent Mode
+ * v2 `update`.
+ */
+export function ConsentBanner({ config }: ConsentBannerProps) {
+  const { t } = useTranslation()
+  const [choice, setChoice] = useState<ConsentChoice | null>(() => readConsentChoice())
+
+  if (!config.enabled || config.consentDefault === 'granted' || choice !== null) {
+    return null
+  }
+
+  const decide = (granted: boolean): void => {
+    const next: ConsentChoice = granted ? 'granted' : 'denied'
+    applyConsent(next)
+    storeConsentChoice(next)
+    setChoice(next)
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label={t('public.consent.label')}
+      className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-surface shadow-lg"
+    >
+      <div className="mx-auto flex max-w-3xl flex-col gap-stack-sm px-inline-md py-stack-md sm:flex-row sm:items-center sm:justify-between">
+        <p className="font-sans text-body text-text-primary">{t('public.consent.message')}</p>
+        <div className="flex shrink-0 gap-inline-sm">
+          <Button
+            variant="subtle"
+            size="sm"
+            onClick={() => {
+              decide(false)
+            }}
+          >
+            {t('public.consent.decline')}
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => {
+              decide(true)
+            }}
+          >
+            {t('public.consent.accept')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/consumer/PublicShell.tsx
+++ b/frontend/src/pages/consumer/PublicShell.tsx
@@ -2,10 +2,13 @@ import { Suspense, useEffect, useMemo } from 'react'
 import './consumer-theme.css'
 import './public-fonts'
 import { Outlet, ScrollRestoration } from 'react-router-dom'
+import { ConsentBanner } from '@/features/consent-banner'
 import { usePublicNavigationItems } from '@/entities/navigation-item'
 import { publicSettingsToMap, usePublicSettings } from '@/entities/setting'
 import { usePublicThemes } from '@/entities/theme'
 import { parseHeaderConfig } from '@/shared/lib/header-config'
+import { useAnalyticsPageView } from '@/shared/lib/use-analytics-page-view'
+import { resolveWebAnalytics } from '@/shared/lib/web-analytics'
 import { parseLayoutConfig } from '@/shared/lib/layout-config'
 import {
   buildThemeStylesheet,
@@ -58,6 +61,11 @@ export function PublicShell() {
     () => publicSettingsToMap(publicSettingsQuery.data?.items ?? []),
     [publicSettingsQuery.data?.items],
   )
+
+  // GA4 / GTM (PR-A1 injects the loader + consent default server-side). Here the
+  // SPA reports client-side navigations and offers the consent prompt.
+  const analytics = useMemo(() => resolveWebAnalytics(settings), [settings])
+  useAnalyticsPageView(analytics)
 
   // Apply the last-known theme synchronously on first paint, then reconcile with
   // the fetched setting — avoids a default→saved theme flash (FOUC) while the
@@ -156,6 +164,7 @@ export function PublicShell() {
       <Suspense fallback={null}>
         <Outlet context={site} />
       </Suspense>
+      <ConsentBanner config={analytics} />
     </>
   )
 }

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -1140,4 +1140,11 @@ export const de: Partial<MessageCatalog> = {
   'admin.superSettings.toast.error': 'Einstellungen konnten nicht gespeichert werden.',
   'admin.superSettings.currentTitle': 'Aktuelle Einstellungen (in DB gespeichert)',
   'admin.superSettings.currentResolution': 'Auflösungsmodus',
+
+  // ── Public · cookie consent ───────────────────────────────────────────────
+  'public.consent.label': 'Cookie-Einwilligung',
+  'public.consent.message':
+    'Wir verwenden Cookies, um die Zugriffe zu messen. Dürfen wir die Analyse aktivieren?',
+  'public.consent.accept': 'Zulassen',
+  'public.consent.decline': 'Ablehnen',
 }

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -1147,6 +1147,12 @@ export const en = {
   'admin.superSettings.toast.error': 'Could not save settings.',
   'admin.superSettings.currentTitle': 'Current settings (saved in DB)',
   'admin.superSettings.currentResolution': 'Resolution mode',
+
+  // ── Public · cookie consent ───────────────────────────────────────────────
+  'public.consent.label': 'Cookie consent',
+  'public.consent.message': 'We use cookies to measure site traffic. May we enable analytics?',
+  'public.consent.accept': 'Allow',
+  'public.consent.decline': 'Decline',
 } as const
 
 /**

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -1171,4 +1171,11 @@ export const fr: Partial<MessageCatalog> = {
   'admin.superSettings.toast.error': "Impossible d'enregistrer les paramètres.",
   'admin.superSettings.currentTitle': 'Paramètres actuels (enregistrés en BDD)',
   'admin.superSettings.currentResolution': 'Mode de résolution',
+
+  // ── Public · cookie consent ───────────────────────────────────────────────
+  'public.consent.label': 'Consentement aux cookies',
+  'public.consent.message':
+    'Nous utilisons des cookies pour mesurer l’audience du site. Pouvons-nous activer les statistiques ?',
+  'public.consent.accept': 'Autoriser',
+  'public.consent.decline': 'Refuser',
 }

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -1152,4 +1152,11 @@ export const ja: Partial<MessageCatalog> = {
   'admin.superSettings.toast.error': '保存に失敗しました。',
   'admin.superSettings.currentTitle': '現在の設定（DB 保存値）',
   'admin.superSettings.currentResolution': '解決方式',
+
+  // ── Public · cookie consent ───────────────────────────────────────────────
+  'public.consent.label': 'Cookie の同意',
+  'public.consent.message':
+    'サイトのアクセス解析のために Cookie を使用します。解析を有効にしてもよろしいですか？',
+  'public.consent.accept': '許可する',
+  'public.consent.decline': '拒否する',
 }

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -1159,4 +1159,11 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.superSettings.toast.error': 'Não foi possível salvar as configurações.',
   'admin.superSettings.currentTitle': 'Configurações atuais (salvas no BD)',
   'admin.superSettings.currentResolution': 'Modo de resolução',
+
+  // ── Public · cookie consent ───────────────────────────────────────────────
+  'public.consent.label': 'Consentimento de cookies',
+  'public.consent.message':
+    'Usamos cookies para medir o tráfego do site. Podemos ativar a análise?',
+  'public.consent.accept': 'Permitir',
+  'public.consent.decline': 'Recusar',
 }

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -1111,4 +1111,10 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.superSettings.toast.error': '无法保存设置。',
   'admin.superSettings.currentTitle': '当前设置（已保存于数据库）',
   'admin.superSettings.currentResolution': '解析模式',
+
+  // ── Public · cookie consent ───────────────────────────────────────────────
+  'public.consent.label': 'Cookie 同意',
+  'public.consent.message': '我们使用 Cookie 来统计网站访问量。是否允许启用分析？',
+  'public.consent.accept': '允许',
+  'public.consent.decline': '拒绝',
 }

--- a/frontend/src/shared/lib/use-analytics-page-view.test.tsx
+++ b/frontend/src/shared/lib/use-analytics-page-view.test.tsx
@@ -1,0 +1,75 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { Link, Outlet, RouterProvider, createMemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useAnalyticsPageView } from './use-analytics-page-view'
+import type { WebAnalyticsClientConfig } from './web-analytics'
+
+afterEach(() => {
+  cleanup()
+  delete window.gtag
+})
+
+const ga4: WebAnalyticsClientConfig = {
+  gtmId: null,
+  ga4Id: 'G-XYZ987',
+  consentDefault: 'denied',
+  enabled: true,
+}
+
+// The hook lives in the persistent layout route (like PublicShell), so it
+// survives child navigations and observes the location change.
+function Layout({ config }: { config: WebAnalyticsClientConfig }) {
+  useAnalyticsPageView(config)
+  return (
+    <>
+      <Link to="/posts/1">go</Link>
+      <Outlet />
+    </>
+  )
+}
+
+function renderRouter(config: WebAnalyticsClientConfig) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/',
+        element: <Layout config={config} />,
+        children: [
+          { index: true, element: <div>Home</div> },
+          { path: 'posts/1', element: <div>Post</div> },
+        ],
+      },
+    ],
+    { initialEntries: ['/'] },
+  )
+  render(<RouterProvider router={router} />)
+}
+
+describe('useAnalyticsPageView', () => {
+  it('skips the initial render and reports on subsequent navigations', () => {
+    const gtag = vi.fn()
+    window.gtag = gtag
+
+    renderRouter(ga4)
+    // Initial load is counted server-side → no client page_view yet.
+    expect(gtag).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByText('go'))
+
+    expect(gtag).toHaveBeenCalledWith(
+      'event',
+      'page_view',
+      expect.objectContaining({ page_path: '/posts/1' }),
+    )
+  })
+
+  it('does nothing when analytics is disabled', () => {
+    const gtag = vi.fn()
+    window.gtag = gtag
+
+    renderRouter({ ...ga4, enabled: false, ga4Id: null })
+    fireEvent.click(screen.getByText('go'))
+
+    expect(gtag).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/shared/lib/use-analytics-page-view.ts
+++ b/frontend/src/shared/lib/use-analytics-page-view.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from 'react'
+import { useLocation } from 'react-router-dom'
+import { trackPageView, type WebAnalyticsClientConfig } from './web-analytics'
+
+/**
+ * Report a page view on client-side route changes within the public site.
+ *
+ * The initial load is already counted by the server-injected GA4 / GTM snippet
+ * (its `config` / `gtm.js` fires the first page view), so the first render is
+ * skipped to avoid a double count; every subsequent SPA navigation reports the
+ * new path. Config is read through a ref so a late-settling settings query does
+ * not itself trigger a spurious view.
+ */
+export function useAnalyticsPageView(config: WebAnalyticsClientConfig): void {
+  const location = useLocation()
+  const configRef = useRef(config)
+  const isFirstRender = useRef(true)
+
+  useEffect(() => {
+    configRef.current = config
+  }, [config])
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+
+      return
+    }
+
+    trackPageView(configRef.current, {
+      path: location.pathname + location.search,
+      location: window.location.href,
+      title: document.title,
+    })
+  }, [location.pathname, location.search])
+}

--- a/frontend/src/shared/lib/web-analytics.test.ts
+++ b/frontend/src/shared/lib/web-analytics.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  applyConsent,
+  readConsentChoice,
+  resolveWebAnalytics,
+  storeConsentChoice,
+  trackPageView,
+  type WebAnalyticsClientConfig,
+} from './web-analytics'
+
+afterEach(() => {
+  localStorage.clear()
+  delete window.gtag
+  delete window.dataLayer
+  vi.restoreAllMocks()
+})
+
+describe('resolveWebAnalytics', () => {
+  it('is disabled for an empty settings map', () => {
+    const config = resolveWebAnalytics({})
+    expect(config.enabled).toBe(false)
+    expect(config.gtmId).toBeNull()
+    expect(config.ga4Id).toBeNull()
+    expect(config.consentDefault).toBe('denied')
+  })
+
+  it('reads a valid GTM id', () => {
+    const config = resolveWebAnalytics({ analytics_gtm_id: 'GTM-ABC1234' })
+    expect(config.enabled).toBe(true)
+    expect(config.gtmId).toBe('GTM-ABC1234')
+  })
+
+  it('reads a valid GA4 id', () => {
+    const config = resolveWebAnalytics({ analytics_ga4_id: 'G-XYZ987' })
+    expect(config.ga4Id).toBe('G-XYZ987')
+    expect(config.gtmId).toBeNull()
+  })
+
+  it.each(['', 'G ABC', "G-1';x", 'G-<script>', 'x'.repeat(41)])(
+    'rejects the invalid id %p',
+    (raw) => {
+      const config = resolveWebAnalytics({ analytics_gtm_id: raw, analytics_ga4_id: raw })
+      expect(config.enabled).toBe(false)
+    },
+  )
+
+  it('normalizes the consent default to denied unless explicitly granted', () => {
+    expect(resolveWebAnalytics({ analytics_consent_default: 'granted' }).consentDefault).toBe(
+      'granted',
+    )
+    expect(resolveWebAnalytics({ analytics_consent_default: 'yes' }).consentDefault).toBe('denied')
+  })
+})
+
+describe('consent storage', () => {
+  it('round-trips a stored choice', () => {
+    expect(readConsentChoice()).toBeNull()
+    storeConsentChoice('granted')
+    expect(readConsentChoice()).toBe('granted')
+  })
+
+  it('ignores an unrecognized stored value', () => {
+    localStorage.setItem('nene-records:analytics-consent', 'maybe')
+    expect(readConsentChoice()).toBeNull()
+  })
+})
+
+describe('applyConsent', () => {
+  it('pushes a Consent Mode v2 update via gtag', () => {
+    const gtag = vi.fn()
+    window.gtag = gtag
+    applyConsent('granted')
+    expect(gtag).toHaveBeenCalledWith(
+      'consent',
+      'update',
+      expect.objectContaining({ analytics_storage: 'granted', ad_storage: 'granted' }),
+    )
+  })
+
+  it('is a no-op when gtag is absent', () => {
+    expect(() => {
+      applyConsent('denied')
+    }).not.toThrow()
+  })
+})
+
+describe('trackPageView', () => {
+  const info = { path: '/posts/1', location: 'https://x.test/posts/1', title: 'Post' }
+
+  it('pushes a dataLayer event in GTM mode', () => {
+    const dataLayer: unknown[] = []
+    window.dataLayer = dataLayer
+    const config: WebAnalyticsClientConfig = {
+      gtmId: 'GTM-ABC1234',
+      ga4Id: null,
+      consentDefault: 'denied',
+      enabled: true,
+    }
+    trackPageView(config, info)
+    expect(dataLayer).toEqual([
+      {
+        event: 'page_view',
+        page_path: '/posts/1',
+        page_location: info.location,
+        page_title: 'Post',
+      },
+    ])
+  })
+
+  it('uses the gtag event API in GA4-direct mode', () => {
+    const gtag = vi.fn()
+    window.gtag = gtag
+    const config: WebAnalyticsClientConfig = {
+      gtmId: null,
+      ga4Id: 'G-XYZ987',
+      consentDefault: 'denied',
+      enabled: true,
+    }
+    trackPageView(config, info)
+    expect(gtag).toHaveBeenCalledWith(
+      'event',
+      'page_view',
+      expect.objectContaining({ page_path: '/posts/1' }),
+    )
+  })
+
+  it('does nothing when analytics is disabled', () => {
+    const gtag = vi.fn()
+    window.gtag = gtag
+    trackPageView({ gtmId: null, ga4Id: null, consentDefault: 'denied', enabled: false }, info)
+    expect(gtag).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/shared/lib/web-analytics.ts
+++ b/frontend/src/shared/lib/web-analytics.ts
@@ -1,0 +1,116 @@
+/**
+ * Client-side counterpart to the server's `WebAnalyticsConfig` / head snippet
+ * (PR-A1). The server injects the GA4 / GTM loader and the Consent Mode v2
+ * *default* into the initial HTML; this module handles the parts that only the
+ * SPA can do: reporting client-side route changes and updating consent when the
+ * visitor responds to the banner.
+ *
+ * Tag ids are validated to the same strict shape as the backend so a malformed
+ * setting simply disables analytics (rather than emitting a broken tag).
+ */
+
+const ID_PATTERN = /^[A-Za-z0-9_-]{4,40}$/
+const CONSENT_STORAGE_KEY = 'nene-records:analytics-consent'
+
+export type ConsentChoice = 'granted' | 'denied'
+
+export interface WebAnalyticsClientConfig {
+  gtmId: string | null
+  ga4Id: string | null
+  consentDefault: ConsentChoice
+  enabled: boolean
+}
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[]
+    gtag?: (...args: unknown[]) => void
+  }
+}
+
+function normalizeId(raw: string | undefined): string | null {
+  const trimmed = (raw ?? '').trim()
+
+  return ID_PATTERN.test(trimmed) ? trimmed : null
+}
+
+/** Resolve the analytics config from the public settings map. */
+export function resolveWebAnalytics(settings: Record<string, string>): WebAnalyticsClientConfig {
+  const gtmId = normalizeId(settings.analytics_gtm_id)
+  const ga4Id = normalizeId(settings.analytics_ga4_id)
+  const consentDefault: ConsentChoice =
+    settings.analytics_consent_default === 'granted' ? 'granted' : 'denied'
+
+  return { gtmId, ga4Id, consentDefault, enabled: gtmId !== null || ga4Id !== null }
+}
+
+export function readConsentChoice(): ConsentChoice | null {
+  try {
+    const value = localStorage.getItem(CONSENT_STORAGE_KEY)
+
+    return value === 'granted' || value === 'denied' ? value : null
+  } catch {
+    return null
+  }
+}
+
+export function storeConsentChoice(choice: ConsentChoice): void {
+  try {
+    localStorage.setItem(CONSENT_STORAGE_KEY, choice)
+  } catch {
+    // Storage can be unavailable (private mode / disabled cookies) — non-fatal.
+  }
+}
+
+/** Consent Mode v2 storage keys the banner toggles together. */
+const CONSENT_KEYS = [
+  'ad_storage',
+  'ad_user_data',
+  'ad_personalization',
+  'analytics_storage',
+  'functionality_storage',
+  'personalization_storage',
+] as const
+
+/** Push a Consent Mode v2 `update` (works for both GA4-direct and GTM). */
+export function applyConsent(choice: ConsentChoice): void {
+  if (typeof window.gtag !== 'function') {
+    return
+  }
+
+  window.gtag('consent', 'update', Object.fromEntries(CONSENT_KEYS.map((key) => [key, choice])))
+}
+
+export interface PageViewInfo {
+  path: string
+  location: string
+  title: string
+}
+
+/**
+ * Report a page view for an in-app navigation. GTM expects a dataLayer event
+ * (wire a "page_view" custom-event trigger in the container); GA4-direct uses
+ * the gtag event API.
+ */
+export function trackPageView(config: WebAnalyticsClientConfig, info: PageViewInfo): void {
+  if (!config.enabled) {
+    return
+  }
+
+  if (config.gtmId !== null) {
+    window.dataLayer?.push({
+      event: 'page_view',
+      page_path: info.path,
+      page_location: info.location,
+      page_title: info.title,
+    })
+
+    return
+  }
+
+  window.gtag?.('event', 'page_view', {
+    page_path: info.path,
+    page_location: info.location,
+    page_title: info.title,
+  })
+}


### PR DESCRIPTION
## 目的（PR-A2）
PR-A1（#583・バックエンド核、マージ済）で SSR / SPA シェルに GA4/GTM ローダと **Consent Mode v2 の既定**がサーバ注入されるようになった。本 PR は **SPA 側**を担う：クライアントルート遷移の page_view と、訪問者の同意 UI。

## 変更
- **`shared/lib/web-analytics.ts`** — 公開設定 → `WebAnalyticsClientConfig` 解決（ID はバックエンドと同じ `^[A-Za-z0-9_-]{4,40}$` で検証）。同意の localStorage 永続、`applyConsent`（Consent Mode v2 `update`＝GA4/GTM 両対応）、`trackPageView`（GTM=dataLayer event / GA4=gtag event）。`window.gtag`/`dataLayer` の型宣言。
- **`shared/lib/use-analytics-page-view.ts`** — 公開サイトの SPA ルート遷移で page_view。**初回描画はスキップ**（サーバ注入スニペットが初回を計上済＝二重計上防止）。`PublicShell`（永続レイアウト）に置くことで子ルート遷移を観測。
- **`features/consent-banner`** — GDPR 同意バナー。analytics 有効 ∧ 同意既定 `denied` ∧ 未選択のときだけ表示（`granted` 既定ならバナー非表示＝管理者がオプトアウト）。許可 → consent `granted`＋保存、拒否 → `denied`＋保存。公開サーフェスのみ。
- **管理 UI は追加実装不要** — 計測 setting 3件（`analytics_gtm_id`/`ga4_id`/`consent_default`）は `text` 型なので、`/admin/settings` の既存の汎用設定 UI に**ラベル付きの編集可能フィールドとして自動表示**される（PR-A1 の本番実証時に API 経由で設定→反映を確認済）。
- **i18n** — `public.consent.*`（label/message/accept/decline）を全6ロケール（en/ja/de/fr/pt-BR/zh-Hans）に追加。

## 検証
- `npm run check` 緑（type-check / lint / prettier / test / validate:themes / knip / storybook）。
- 追加テスト：`web-analytics`（ID 検証・同意保存ラウンドトリップ・gtag/dataLayer 分岐・disabled no-op）／`ConsentBanner`（表示条件 3 種・許可/拒否の gtag+保存+非表示）／`use-analytics-page-view`（初回スキップ＋遷移で発火、layout route で実アプリ同様に検証）。

## 設計判断
- バナーは consent 既定が `denied` のときだけ提示（`granted` は管理者が既定許可＝バナー不要を選択したケース）。
- page_view の二重計上防止＝初回描画スキップ（初回はサーバ注入の `config`/`gtm.js` が担う）。
- 同意 update は `gtag('consent','update',…)` で GA4-direct / GTM 双方に効く。

## 後続
- 本番実証（A2 マージ後）：実 GTM/GA4 ID 設定 → 公開ページでバナー表示・許可で consent update・SPA 遷移で page_view を確認。

Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)