### PR TITLE
feat(seo): 公開サイトの sitemap.xml を追加する (#536)

### DIFF
--- a/src/PublicRecord/GenerateSitemapUseCase.php
+++ b/src/PublicRecord/GenerateSitemapUseCase.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use DateTimeInterface;
+use NeNeRecords\Entity\EntityListCriteria;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\Entity\EntityStatus;
+use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
+
+/**
+ * Enumerates every published, non-deleted record in the current organization and
+ * resolves it to its canonical permalink (the same {@see PublicPermalinkResolver}
+ * the SSR pages use, so sitemap URLs match the pages' canonical/og:url).
+ *
+ * Records are read in pages per entity type and capped at the sitemap protocol's
+ * 50,000-URL limit; `lastmod` is the record's update (or publish) time.
+ */
+final readonly class GenerateSitemapUseCase implements GenerateSitemapUseCaseInterface
+{
+    private const PAGE_SIZE = 1000;
+    private const MAX_URLS = 50000;
+
+    public function __construct(
+        private EntityTypeRepositoryInterface $entityTypes,
+        private EntityRepositoryInterface $entities,
+    ) {
+    }
+
+    /** @return list<SitemapUrl> */
+    public function execute(): array
+    {
+        $urls = [];
+
+        foreach ($this->entityTypes->findAll(self::PAGE_SIZE, 0) as $type) {
+            if ($type->id === null) {
+                continue;
+            }
+
+            $offset = 0;
+
+            while (count($urls) < self::MAX_URLS) {
+                $batch = $this->entities->findByCriteria(
+                    new EntityListCriteria(entityTypeId: $type->id, status: EntityStatus::Published),
+                    self::PAGE_SIZE,
+                    $offset,
+                );
+
+                if ($batch === []) {
+                    break;
+                }
+
+                foreach ($batch as $entity) {
+                    if ($entity->id === null) {
+                        continue;
+                    }
+
+                    $urls[] = new SitemapUrl(
+                        PublicPermalinkResolver::resolve(
+                            $type->permalinkPattern,
+                            $type->slug,
+                            $entity->slug,
+                            $entity->id,
+                            $entity->publishedAt,
+                        ),
+                        ($entity->updatedAt ?? $entity->publishedAt)?->format(DateTimeInterface::ATOM),
+                    );
+
+                    if (count($urls) >= self::MAX_URLS) {
+                        return $urls;
+                    }
+                }
+
+                if (count($batch) < self::PAGE_SIZE) {
+                    break;
+                }
+
+                $offset += self::PAGE_SIZE;
+            }
+        }
+
+        return $urls;
+    }
+}

--- a/src/PublicRecord/GenerateSitemapUseCaseInterface.php
+++ b/src/PublicRecord/GenerateSitemapUseCaseInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+interface GenerateSitemapUseCaseInterface
+{
+    /**
+     * Site-relative URLs for every published record in the current organization,
+     * resolved through each type's permalink pattern.
+     *
+     * @return list<SitemapUrl>
+     */
+    public function execute(): array;
+}

--- a/src/PublicRecord/PublicRecordRouteRegistrar.php
+++ b/src/PublicRecord/PublicRecordRouteRegistrar.php
@@ -13,6 +13,7 @@ final readonly class PublicRecordRouteRegistrar
         private GetPublicRecordViewHandler $getPublicRecordViewHandler,
         private RenderPublicRecordViewHandler $renderPublicRecordViewHandler,
         private RenderPublicPermalinkHandler $renderPublicPermalinkHandler,
+        private RenderSitemapHandler $renderSitemapHandler,
     ) {
     }
 
@@ -21,10 +22,18 @@ final readonly class PublicRecordRouteRegistrar
         $getPublicRecordViewHandler = $this->getPublicRecordViewHandler;
         $renderPublicRecordViewHandler = $this->renderPublicRecordViewHandler;
         $renderPublicPermalinkHandler = $this->renderPublicPermalinkHandler;
+        $renderSitemapHandler = $this->renderSitemapHandler;
 
         $router->get(
             '/api/v1/public/entity-types/{slug}/records/{entitySlug}',
             static fn (ServerRequestInterface $request) => $getPublicRecordViewHandler->handle($request),
+        );
+
+        // Per-org XML sitemap. A registered route returns 200, so the 301 / SPA-shell
+        // fallback layers (which act only on 404) never intercept it.
+        $router->get(
+            '/sitemap.xml',
+            static fn (ServerRequestInterface $request) => $renderSitemapHandler->handle($request),
         );
 
         $router->get(

--- a/src/PublicRecord/PublicRecordServiceProvider.php
+++ b/src/PublicRecord/PublicRecordServiceProvider.php
@@ -243,11 +243,51 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                 },
             )
             ->set(
+                GenerateSitemapUseCaseInterface::class,
+                static function (ContainerInterface $container): GenerateSitemapUseCaseInterface {
+                    $entityTypes = $container->get(EntityTypeRepositoryInterface::class);
+                    $entities = $container->get(EntityRepositoryInterface::class);
+
+                    if (!$entityTypes instanceof EntityTypeRepositoryInterface) {
+                        throw new LogicException('Entity type repository service is invalid.');
+                    }
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    return new GenerateSitemapUseCase($entityTypes, $entities);
+                },
+            )
+            ->set(
+                RenderSitemapHandler::class,
+                static function (ContainerInterface $container): RenderSitemapHandler {
+                    $useCase = $container->get(GenerateSitemapUseCaseInterface::class);
+                    $responseFactory = $container->get(ResponseFactoryInterface::class);
+                    $streamFactory = $container->get(StreamFactoryInterface::class);
+
+                    if (!$useCase instanceof GenerateSitemapUseCaseInterface) {
+                        throw new LogicException('GenerateSitemap use case service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    if (!$streamFactory instanceof StreamFactoryInterface) {
+                        throw new LogicException('Stream factory service is invalid.');
+                    }
+
+                    return new RenderSitemapHandler($useCase, $responseFactory, $streamFactory);
+                },
+            )
+            ->set(
                 'nene-records.route_registrar.public_record',
                 static function (ContainerInterface $container): PublicRecordRouteRegistrar {
                     $getHandler = $container->get(GetPublicRecordViewHandler::class);
                     $renderHandler = $container->get(RenderPublicRecordViewHandler::class);
                     $permalinkHandler = $container->get(RenderPublicPermalinkHandler::class);
+                    $sitemapHandler = $container->get(RenderSitemapHandler::class);
 
                     if (!$getHandler instanceof GetPublicRecordViewHandler) {
                         throw new LogicException('GetPublicRecordView handler service is invalid.');
@@ -261,7 +301,16 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                         throw new LogicException('RenderPublicPermalink handler service is invalid.');
                     }
 
-                    return new PublicRecordRouteRegistrar($getHandler, $renderHandler, $permalinkHandler);
+                    if (!$sitemapHandler instanceof RenderSitemapHandler) {
+                        throw new LogicException('RenderSitemap handler service is invalid.');
+                    }
+
+                    return new PublicRecordRouteRegistrar(
+                        $getHandler,
+                        $renderHandler,
+                        $permalinkHandler,
+                        $sitemapHandler,
+                    );
                 },
             );
     }

--- a/src/PublicRecord/RenderSitemapHandler.php
+++ b/src/PublicRecord/RenderSitemapHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+/**
+ * `GET /sitemap.xml` — the per-organization XML sitemap. The home page plus every
+ * published record permalink, with absolute URLs built from the request's
+ * scheme+host (so it works behind the single-origin reverse proxy).
+ */
+final readonly class RenderSitemapHandler
+{
+    public function __construct(
+        private GenerateSitemapUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $uri = $request->getUri();
+        $baseUrl = $uri->getScheme() . '://' . $uri->getAuthority();
+
+        $urls = array_merge([new SitemapUrl('/')], $this->useCase->execute());
+        $xml = SitemapXmlRenderer::render($baseUrl, $urls);
+
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'application/xml; charset=UTF-8')
+            ->withBody($this->streamFactory->createStream($xml));
+    }
+}

--- a/src/PublicRecord/SitemapUrl.php
+++ b/src/PublicRecord/SitemapUrl.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+/**
+ * One `<url>` entry for the XML sitemap: a site-relative path (joined with the
+ * request's scheme+host at render time) and an optional W3C-datetime lastmod.
+ */
+final readonly class SitemapUrl
+{
+    public function __construct(
+        public string $path,
+        public ?string $lastmod = null,
+    ) {
+    }
+}

--- a/src/PublicRecord/SitemapXmlRenderer.php
+++ b/src/PublicRecord/SitemapXmlRenderer.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+/**
+ * Renders a sitemaps.org 0.9 `<urlset>` document from resolved {@see SitemapUrl}s.
+ * Paths are joined to the request base URL and XML-escaped.
+ */
+final class SitemapXmlRenderer
+{
+    private function __construct()
+    {
+    }
+
+    /** @param list<SitemapUrl> $urls */
+    public static function render(string $baseUrl, array $urls): string
+    {
+        $base = rtrim($baseUrl, '/');
+
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
+        $xml .= '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+
+        foreach ($urls as $url) {
+            $xml .= '  <url><loc>' . self::escape($base . $url->path) . '</loc>';
+
+            if ($url->lastmod !== null) {
+                $xml .= '<lastmod>' . self::escape($url->lastmod) . '</lastmod>';
+            }
+
+            $xml .= '</url>' . "\n";
+        }
+
+        return $xml . '</urlset>' . "\n";
+    }
+
+    private static function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_XML1 | ENT_QUOTES, 'UTF-8');
+    }
+}

--- a/tests/PublicRecord/GenerateSitemapUseCaseTest.php
+++ b/tests/PublicRecord/GenerateSitemapUseCaseTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use DateTimeImmutable;
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\Entity\EntityStatus;
+use NeNeRecords\EntityType\EntityType;
+use NeNeRecords\PublicRecord\GenerateSitemapUseCase;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use PHPUnit\Framework\TestCase;
+
+final class GenerateSitemapUseCaseTest extends TestCase
+{
+    public function testEnumeratesOnlyPublishedRecordsAcrossTypes(): void
+    {
+        $types = new InMemoryEntityTypeRepository([
+            new EntityType(name: 'Posts', slug: 'posts', id: 1, permalinkPattern: '/{type}/{slug}'),
+            new EntityType(name: 'Pages', slug: 'pages', id: 2), // default /{type}/{id}
+        ]);
+        $entities = new InMemoryEntityRepository([
+            new Entity(
+                id: 10,
+                entityTypeId: 1,
+                slug: 'hello',
+                status: EntityStatus::Published,
+                publishedAt: new DateTimeImmutable('2026-01-15T00:00:00+00:00'),
+                updatedAt: new DateTimeImmutable('2026-02-20T09:00:00+00:00'),
+            ),
+            new Entity(id: 11, entityTypeId: 1, slug: 'draft', status: EntityStatus::Draft),
+            new Entity(
+                id: 20,
+                entityTypeId: 2,
+                slug: 'about',
+                status: EntityStatus::Published,
+                publishedAt: new DateTimeImmutable('2026-03-01T00:00:00+00:00'),
+            ),
+        ]);
+
+        $urls = (new GenerateSitemapUseCase($types, $entities))->execute();
+        $paths = array_map(static fn ($u) => $u->path, $urls);
+
+        self::assertContains('/posts/hello', $paths);
+        self::assertContains('/pages/20', $paths); // default pattern uses id
+        self::assertNotContains('/posts/draft', $paths); // draft excluded
+        self::assertCount(2, $urls);
+    }
+
+    public function testLastmodPrefersUpdatedThenPublished(): void
+    {
+        $types = new InMemoryEntityTypeRepository([
+            new EntityType(name: 'Posts', slug: 'posts', id: 1, permalinkPattern: '/{type}/{id}'),
+        ]);
+        $entities = new InMemoryEntityRepository([
+            new Entity(
+                id: 1,
+                entityTypeId: 1,
+                status: EntityStatus::Published,
+                publishedAt: new DateTimeImmutable('2026-01-01T00:00:00+00:00'),
+                updatedAt: new DateTimeImmutable('2026-05-05T12:00:00+00:00'),
+            ),
+        ]);
+
+        $urls = (new GenerateSitemapUseCase($types, $entities))->execute();
+
+        self::assertCount(1, $urls);
+        self::assertSame('2026-05-05T12:00:00+00:00', $urls[0]->lastmod);
+    }
+
+    public function testEmptyWhenNoPublishedRecords(): void
+    {
+        $types = new InMemoryEntityTypeRepository([
+            new EntityType(name: 'Posts', slug: 'posts', id: 1),
+        ]);
+        $entities = new InMemoryEntityRepository([
+            new Entity(id: 1, entityTypeId: 1, status: EntityStatus::Draft),
+        ]);
+
+        self::assertSame([], (new GenerateSitemapUseCase($types, $entities))->execute());
+    }
+}

--- a/tests/PublicRecord/PublicCacheHttpTest.php
+++ b/tests/PublicRecord/PublicCacheHttpTest.php
@@ -111,6 +111,11 @@ final class PublicCacheHttpTest extends TestCase
             new GetPublicRecordViewHandler($useCase, $jsonResponse, $this->factory),
             $renderHandler,
             new \NeNeRecords\PublicRecord\RenderPublicPermalinkHandler($entityTypes, $renderHandler),
+            new \NeNeRecords\PublicRecord\RenderSitemapHandler(
+                new \NeNeRecords\PublicRecord\GenerateSitemapUseCase($entityTypes, $entities),
+                $this->factory,
+                $this->factory,
+            ),
         );
 
         $settingRegistrar = new SettingRouteRegistrar(

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -17,6 +17,7 @@ use NeNeRecords\Entity\Entity;
 use NeNeRecords\Entity\EntityStatus;
 use NeNeRecords\EntityType\EntityType;
 use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\PublicRecord\GenerateSitemapUseCase;
 use NeNeRecords\PublicRecord\GetPublicRecordViewHandler;
 use NeNeRecords\PublicRecord\GetPublicRecordViewUseCase;
 use NeNeRecords\PublicRecord\PublicEntityTypeNotFoundExceptionHandler;
@@ -25,6 +26,7 @@ use NeNeRecords\PublicRecord\PublicRecordNotFoundExceptionHandler;
 use NeNeRecords\PublicRecord\PublicRecordRouteRegistrar;
 use NeNeRecords\PublicRecord\RenderPublicPermalinkHandler;
 use NeNeRecords\PublicRecord\RenderPublicRecordViewHandler;
+use NeNeRecords\PublicRecord\RenderSitemapHandler;
 use NeNeRecords\Setting\ListPublicSettingsUseCase;
 use NeNeRecords\Tests\BoolField\InMemoryBoolFieldRepository;
 use NeNeRecords\Tests\DateTimeField\InMemoryDateTimeFieldRepository;
@@ -135,6 +137,11 @@ final class PublicRecordHttpTest extends TestCase
             new GetPublicRecordViewHandler($useCase, $jsonResponse, $this->factory),
             $renderHandler,
             new RenderPublicPermalinkHandler($entityTypes, $renderHandler),
+            new RenderSitemapHandler(
+                new GenerateSitemapUseCase($entityTypes, $entities),
+                $this->factory,
+                $this->factory,
+            ),
         );
 
         return (new RuntimeApplicationFactory(
@@ -322,6 +329,26 @@ final class PublicRecordHttpTest extends TestCase
 
         self::assertStringNotContainsString('googletagmanager', $csp);
         self::assertStringNotContainsString('googletagmanager', (string) $response->getBody());
+    }
+
+    public function testSitemapXmlListsHomeAndPublishedRecords(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/sitemap.xml'),
+        );
+        $xml = (string) $response->getBody();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('application/xml', $response->getHeaderLine('Content-Type'));
+        self::assertStringContainsString(
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+            $xml,
+        );
+        self::assertStringContainsString('<loc>https://example.test/</loc>', $xml);
+        // The published article resolves through the default /{type}/{id} permalink.
+        self::assertStringContainsString('<loc>https://example.test/article/10</loc>', $xml);
+        // updatedAt → lastmod (W3C datetime).
+        self::assertStringContainsString('<lastmod>2026-02-20', $xml);
     }
 
     public function testRealPermalinkReturns404ForUnknownId(): void

--- a/tests/PublicRecord/SitemapXmlRendererTest.php
+++ b/tests/PublicRecord/SitemapXmlRendererTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use NeNeRecords\PublicRecord\SitemapUrl;
+use NeNeRecords\PublicRecord\SitemapXmlRenderer;
+use PHPUnit\Framework\TestCase;
+
+final class SitemapXmlRendererTest extends TestCase
+{
+    public function testRendersUrlsetWithAbsoluteLocsAndLastmod(): void
+    {
+        $xml = SitemapXmlRenderer::render('https://x.test', [
+            new SitemapUrl('/', null),
+            new SitemapUrl('/posts/1', '2026-02-20T09:00:00+00:00'),
+        ]);
+
+        self::assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>', $xml);
+        self::assertStringContainsString('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">', $xml);
+        self::assertStringContainsString('<url><loc>https://x.test/</loc></url>', $xml);
+        self::assertStringContainsString(
+            '<url><loc>https://x.test/posts/1</loc><lastmod>2026-02-20T09:00:00+00:00</lastmod></url>',
+            $xml,
+        );
+        self::assertStringContainsString('</urlset>', $xml);
+    }
+
+    public function testTrailingSlashOnBaseIsNormalized(): void
+    {
+        $xml = SitemapXmlRenderer::render('https://x.test/', [new SitemapUrl('/posts/1')]);
+
+        self::assertStringContainsString('<loc>https://x.test/posts/1</loc>', $xml);
+        self::assertStringNotContainsString('x.test//posts', $xml);
+    }
+
+    public function testEscapesSpecialCharactersInLoc(): void
+    {
+        $xml = SitemapXmlRenderer::render('https://x.test', [new SitemapUrl('/posts/a&b<c')]);
+
+        self::assertStringContainsString('/posts/a&amp;b&lt;c', $xml);
+        self::assertStringNotContainsString('a&b<c', $xml);
+    }
+}


### PR DESCRIPTION
## 目的
ペルソナ討論で SEO 価値ありとされた roadmap 項目。`GET /sitemap.xml` で **org スコープの XML サイトマップ**（ホーム＋全公開レコードの正規 permalink）を配信し、クローラのインデックス促進を図る。

## 変更
- **`GenerateSitemapUseCase`** — org の全エンティティタイプを走査し、公開（非削除）レコードを `PublicPermalinkResolver`（SSR の canonical/og:url と同一ロジック）で permalink 化。ページング読み（1000件/回）・**50,000 URL 上限**・`lastmod` = `updatedAt`（無ければ `publishedAt`）。
- **`SitemapXmlRenderer`** — sitemaps.org 0.9 の `<urlset>` を生成。`loc` は base URL と結合し XML エスケープ（`ENT_XML1`）。
- **`RenderSitemapHandler`** — リクエストの scheme+host から絶対 URL を構成（単一オリジンのリバプロ配下で機能・X-Forwarded を尊重）。`Content-Type: application/xml; charset=UTF-8`。
- **`PublicRecordRouteRegistrar`** に `GET /sitemap.xml` を登録。**登録ルートは 200 を返すため、301 / SPA シェルの fallback 層（404 のときだけ作用）に飲み込まれない**。

## 検証
- `composer check` 緑（**PHPUnit 981 tests / 2726 assertions** ・PHPStan level 8（0 errors）・CS-Fixer・OpenAPI・MCP）。
- テスト：
  - `GenerateSitemapUseCase` — 公開のみ列挙・draft 除外・タイプ横断・`lastmod` 優先順（updated→published）・空時。
  - `SitemapXmlRenderer` — `<urlset>` 構造・base 末尾スラッシュ正規化・特殊文字（`&` `<`）エスケープ。
  - `PublicRecordHttpTest`（実ルータ統合）— `/sitemap.xml` が **200・`application/xml`**・ホーム `loc`・公開レコード `loc`（`/article/10`）・`lastmod` を含む。

## 設計判断 / スコープ
- 収録対象＝**ホーム `/` ＋ 公開 SSR レコード permalink**（クローラブルな対象に限定）。タグ/日付アーカイブ等の SPA ページは将来追加候補。
- org スコープ（マルチテナント前提）— リクエストの解決済み org のレコードのみ。
- **robots.txt の `Sitemap:` 参照は follow-up**（別途・小）。

## 後続（任意）
- robots.txt に `Sitemap: https://<host>/sitemap.xml` を追加して自動発見性を上げる。
- 大規模時の sitemap index 分割（現状は 50,000 URL 上限の単一ファイル）。

Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)