### PR TITLE
feat(seo): robots.txt を追加し sitemap を広告する (#536)

### DIFF
--- a/src/PublicRecord/PublicRecordRouteRegistrar.php
+++ b/src/PublicRecord/PublicRecordRouteRegistrar.php
@@ -14,6 +14,7 @@ final readonly class PublicRecordRouteRegistrar
         private RenderPublicRecordViewHandler $renderPublicRecordViewHandler,
         private RenderPublicPermalinkHandler $renderPublicPermalinkHandler,
         private RenderSitemapHandler $renderSitemapHandler,
+        private RenderRobotsHandler $renderRobotsHandler,
     ) {
     }
 
@@ -23,6 +24,7 @@ final readonly class PublicRecordRouteRegistrar
         $renderPublicRecordViewHandler = $this->renderPublicRecordViewHandler;
         $renderPublicPermalinkHandler = $this->renderPublicPermalinkHandler;
         $renderSitemapHandler = $this->renderSitemapHandler;
+        $renderRobotsHandler = $this->renderRobotsHandler;
 
         $router->get(
             '/api/v1/public/entity-types/{slug}/records/{entitySlug}',
@@ -34,6 +36,11 @@ final readonly class PublicRecordRouteRegistrar
         $router->get(
             '/sitemap.xml',
             static fn (ServerRequestInterface $request) => $renderSitemapHandler->handle($request),
+        );
+
+        $router->get(
+            '/robots.txt',
+            static fn (ServerRequestInterface $request) => $renderRobotsHandler->handle($request),
         );
 
         $router->get(

--- a/src/PublicRecord/PublicRecordServiceProvider.php
+++ b/src/PublicRecord/PublicRecordServiceProvider.php
@@ -282,12 +282,30 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                 },
             )
             ->set(
+                RenderRobotsHandler::class,
+                static function (ContainerInterface $container): RenderRobotsHandler {
+                    $responseFactory = $container->get(ResponseFactoryInterface::class);
+                    $streamFactory = $container->get(StreamFactoryInterface::class);
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    if (!$streamFactory instanceof StreamFactoryInterface) {
+                        throw new LogicException('Stream factory service is invalid.');
+                    }
+
+                    return new RenderRobotsHandler($responseFactory, $streamFactory);
+                },
+            )
+            ->set(
                 'nene-records.route_registrar.public_record',
                 static function (ContainerInterface $container): PublicRecordRouteRegistrar {
                     $getHandler = $container->get(GetPublicRecordViewHandler::class);
                     $renderHandler = $container->get(RenderPublicRecordViewHandler::class);
                     $permalinkHandler = $container->get(RenderPublicPermalinkHandler::class);
                     $sitemapHandler = $container->get(RenderSitemapHandler::class);
+                    $robotsHandler = $container->get(RenderRobotsHandler::class);
 
                     if (!$getHandler instanceof GetPublicRecordViewHandler) {
                         throw new LogicException('GetPublicRecordView handler service is invalid.');
@@ -305,11 +323,16 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                         throw new LogicException('RenderSitemap handler service is invalid.');
                     }
 
+                    if (!$robotsHandler instanceof RenderRobotsHandler) {
+                        throw new LogicException('RenderRobots handler service is invalid.');
+                    }
+
                     return new PublicRecordRouteRegistrar(
                         $getHandler,
                         $renderHandler,
                         $permalinkHandler,
                         $sitemapHandler,
+                        $robotsHandler,
                     );
                 },
             );

--- a/src/PublicRecord/RenderRobotsHandler.php
+++ b/src/PublicRecord/RenderRobotsHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+/**
+ * `GET /robots.txt` — crawler directives plus an absolute `Sitemap:` pointer,
+ * built from the request's scheme+host (single-origin reverse proxy aware).
+ */
+final readonly class RenderRobotsHandler
+{
+    public function __construct(
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $uri = $request->getUri();
+        $sitemapUrl = $uri->getScheme() . '://' . $uri->getAuthority() . '/sitemap.xml';
+
+        $body = RobotsTxtRenderer::render($sitemapUrl);
+
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'text/plain; charset=UTF-8')
+            ->withBody($this->streamFactory->createStream($body));
+    }
+}

--- a/src/PublicRecord/RobotsTxtRenderer.php
+++ b/src/PublicRecord/RobotsTxtRenderer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+/**
+ * Builds the `robots.txt` body: keeps crawlers out of the back office while
+ * leaving public content crawlable, and advertises the XML sitemap.
+ *
+ * `/api` is intentionally NOT disallowed — Googlebot fetches it when rendering
+ * the SPA-shell listing pages (home / browse / search), so blocking it would
+ * stop those pages from rendering.
+ */
+final class RobotsTxtRenderer
+{
+    /** Back-office surfaces that should never be crawled or indexed. */
+    private const DISALLOW = ['/admin', '/superadmin', '/login'];
+
+    private function __construct()
+    {
+    }
+
+    public static function render(string $sitemapUrl): string
+    {
+        $lines = ['User-agent: *'];
+
+        foreach (self::DISALLOW as $path) {
+            $lines[] = 'Disallow: ' . $path;
+        }
+
+        $lines[] = '';
+        $lines[] = 'Sitemap: ' . $sitemapUrl;
+
+        return implode("\n", $lines) . "\n";
+    }
+}

--- a/tests/PublicRecord/PublicCacheHttpTest.php
+++ b/tests/PublicRecord/PublicCacheHttpTest.php
@@ -116,6 +116,7 @@ final class PublicCacheHttpTest extends TestCase
                 $this->factory,
                 $this->factory,
             ),
+            new \NeNeRecords\PublicRecord\RenderRobotsHandler($this->factory, $this->factory),
         );
 
         $settingRegistrar = new SettingRouteRegistrar(

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -26,6 +26,7 @@ use NeNeRecords\PublicRecord\PublicRecordNotFoundExceptionHandler;
 use NeNeRecords\PublicRecord\PublicRecordRouteRegistrar;
 use NeNeRecords\PublicRecord\RenderPublicPermalinkHandler;
 use NeNeRecords\PublicRecord\RenderPublicRecordViewHandler;
+use NeNeRecords\PublicRecord\RenderRobotsHandler;
 use NeNeRecords\PublicRecord\RenderSitemapHandler;
 use NeNeRecords\Setting\ListPublicSettingsUseCase;
 use NeNeRecords\Tests\BoolField\InMemoryBoolFieldRepository;
@@ -142,6 +143,7 @@ final class PublicRecordHttpTest extends TestCase
                 $this->factory,
                 $this->factory,
             ),
+            new RenderRobotsHandler($this->factory, $this->factory),
         );
 
         return (new RuntimeApplicationFactory(
@@ -349,6 +351,20 @@ final class PublicRecordHttpTest extends TestCase
         self::assertStringContainsString('<loc>https://example.test/article/10</loc>', $xml);
         // updatedAt → lastmod (W3C datetime).
         self::assertStringContainsString('<lastmod>2026-02-20', $xml);
+    }
+
+    public function testRobotsTxtServesDirectivesAndSitemapPointer(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/robots.txt'),
+        );
+        $body = (string) $response->getBody();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('text/plain', $response->getHeaderLine('Content-Type'));
+        self::assertStringContainsString('User-agent: *', $body);
+        self::assertStringContainsString('Disallow: /admin', $body);
+        self::assertStringContainsString('Sitemap: https://example.test/sitemap.xml', $body);
     }
 
     public function testRealPermalinkReturns404ForUnknownId(): void

--- a/tests/PublicRecord/RobotsTxtRendererTest.php
+++ b/tests/PublicRecord/RobotsTxtRendererTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use NeNeRecords\PublicRecord\RobotsTxtRenderer;
+use PHPUnit\Framework\TestCase;
+
+final class RobotsTxtRendererTest extends TestCase
+{
+    public function testAllowsAllAgentsAndAdvertisesSitemap(): void
+    {
+        $body = RobotsTxtRenderer::render('https://x.test/sitemap.xml');
+
+        self::assertStringContainsString('User-agent: *', $body);
+        self::assertStringContainsString('Sitemap: https://x.test/sitemap.xml', $body);
+        self::assertStringEndsWith("\n", $body);
+    }
+
+    public function testDisallowsBackOfficeButNotApi(): void
+    {
+        $body = RobotsTxtRenderer::render('https://x.test/sitemap.xml');
+
+        self::assertStringContainsString('Disallow: /admin', $body);
+        self::assertStringContainsString('Disallow: /superadmin', $body);
+        self::assertStringContainsString('Disallow: /login', $body);
+        // /api must stay crawlable so Googlebot can render SPA-shell listing pages.
+        self::assertStringNotContainsString('Disallow: /api', $body);
+    }
+}


### PR DESCRIPTION
## 目的
sitemap.xml（#585・マージ＋本番反映済）の**自動発見性**を上げる follow-up。`GET /robots.txt` でクローラ指示と絶対 `Sitemap:` ポインタを配信する。

## 変更
- **`RobotsTxtRenderer`** — `User-agent: *` ＋ バックオフィス（`/admin`・`/superadmin`・`/login`）の `Disallow` ＋ `Sitemap:` 行。**`/api` は Disallow しない**（SPA シェルの一覧ページ＝home/browse/search を Googlebot が JS レンダリングする際に `/api` を取得するため、ブロックすると描画不能になる）。
- **`RenderRobotsHandler`** — リクエストの scheme+host から絶対 sitemap URL を構成（単一オリジン配下対応）。`Content-Type: text/plain; charset=UTF-8`。
- **`PublicRecordRouteRegistrar`** に `GET /robots.txt` を登録（**登録ルート＝200 なので 301/SPAシェル fallback 非介入**）。

## 検証
- `composer check` 緑（**PHPUnit 984 / PHPStan lv8（0 errors）/ CS-Fixer / OpenAPI / MCP**）。
- テスト：`RobotsTxtRenderer`（agent/Disallow/Sitemap 行・`/api` 非 Disallow）／`PublicRecordHttpTest`（`/robots.txt` が 200・text/plain・`Disallow: /admin`・`Sitemap: https://example.test/sitemap.xml`）。

## 設計判断
- 公開コンテンツはクロール許可、バックオフィスのみ Disallow。
- `/api` は意図的に許可（SPA レンダリングのため）。
- `/view`（301）は無害なので未 Disallow。

Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)