### PR TITLE
feat(seo): sitemap を大規模時にインデックス分割する (#536)

### DIFF
--- a/src/PublicRecord/GenerateSitemapUseCase.php
+++ b/src/PublicRecord/GenerateSitemapUseCase.php
@@ -11,17 +11,18 @@ use NeNeRecords\Entity\EntityStatus;
 use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
 
 /**
- * Enumerates every published, non-deleted record in the current organization and
- * resolves it to its canonical permalink (the same {@see PublicPermalinkResolver}
+ * Enumerates published, non-deleted records in the current organization,
+ * resolving each to its canonical permalink (the same {@see PublicPermalinkResolver}
  * the SSR pages use, so sitemap URLs match the pages' canonical/og:url).
  *
- * Records are read in pages per entity type and capped at the sitemap protocol's
- * 50,000-URL limit; `lastmod` is the record's update (or publish) time.
+ * The global order is "entity types in display order, then records within each
+ * type". {@see count()} and {@see page()} let {@see RenderSitemapHandler} split a
+ * large sitemap across an index without loading every URL into memory: a page
+ * only queries the rows in its window.
  */
 final readonly class GenerateSitemapUseCase implements GenerateSitemapUseCaseInterface
 {
-    private const PAGE_SIZE = 1000;
-    private const MAX_URLS = 50000;
+    private const TYPE_PAGE = 1000;
 
     public function __construct(
         private EntityTypeRepositoryInterface $entityTypes,
@@ -29,58 +30,87 @@ final readonly class GenerateSitemapUseCase implements GenerateSitemapUseCaseInt
     ) {
     }
 
-    /** @return list<SitemapUrl> */
-    public function execute(): array
+    public function count(): int
     {
-        $urls = [];
+        $total = 0;
 
-        foreach ($this->entityTypes->findAll(self::PAGE_SIZE, 0) as $type) {
+        foreach ($this->entityTypes->findAll(self::TYPE_PAGE, 0) as $type) {
             if ($type->id === null) {
                 continue;
             }
 
-            $offset = 0;
+            $total += $this->entities->countByCriteria($this->publishedIn($type->id));
+        }
 
-            while (count($urls) < self::MAX_URLS) {
-                $batch = $this->entities->findByCriteria(
-                    new EntityListCriteria(entityTypeId: $type->id, status: EntityStatus::Published),
-                    self::PAGE_SIZE,
-                    $offset,
+        return $total;
+    }
+
+    /** @return list<SitemapUrl> */
+    public function page(int $offset, int $limit): array
+    {
+        if ($limit <= 0) {
+            return [];
+        }
+
+        $windowStart = max(0, $offset);
+        $windowEnd = $windowStart + $limit;
+        $seen = 0; // global index of the first record of the current type
+        $urls = [];
+
+        foreach ($this->entityTypes->findAll(self::TYPE_PAGE, 0) as $type) {
+            if ($type->id === null) {
+                continue;
+            }
+
+            $criteria = $this->publishedIn($type->id);
+            $typeCount = $this->entities->countByCriteria($criteria);
+
+            if ($typeCount === 0) {
+                continue;
+            }
+
+            $typeStart = $seen;
+            $typeEnd = $seen + $typeCount;
+            $seen = $typeEnd;
+
+            if ($typeStart >= $windowEnd) {
+                break; // types are ordered: this and every later type is past the window.
+            }
+
+            if ($typeEnd <= $windowStart) {
+                continue; // this type is entirely before the window.
+            }
+
+            $from = max($windowStart, $typeStart);
+            $to = min($windowEnd, $typeEnd);
+
+            foreach ($this->entities->findByCriteria($criteria, $to - $from, $from - $typeStart) as $entity) {
+                if ($entity->id === null) {
+                    continue;
+                }
+
+                $urls[] = new SitemapUrl(
+                    PublicPermalinkResolver::resolve(
+                        $type->permalinkPattern,
+                        $type->slug,
+                        $entity->slug,
+                        $entity->id,
+                        $entity->publishedAt,
+                    ),
+                    ($entity->updatedAt ?? $entity->publishedAt)?->format(DateTimeInterface::ATOM),
                 );
+            }
 
-                if ($batch === []) {
-                    break;
-                }
-
-                foreach ($batch as $entity) {
-                    if ($entity->id === null) {
-                        continue;
-                    }
-
-                    $urls[] = new SitemapUrl(
-                        PublicPermalinkResolver::resolve(
-                            $type->permalinkPattern,
-                            $type->slug,
-                            $entity->slug,
-                            $entity->id,
-                            $entity->publishedAt,
-                        ),
-                        ($entity->updatedAt ?? $entity->publishedAt)?->format(DateTimeInterface::ATOM),
-                    );
-
-                    if (count($urls) >= self::MAX_URLS) {
-                        return $urls;
-                    }
-                }
-
-                if (count($batch) < self::PAGE_SIZE) {
-                    break;
-                }
-
-                $offset += self::PAGE_SIZE;
+            if ($to >= $windowEnd) {
+                break; // window fully satisfied.
             }
         }
 
         return $urls;
+    }
+
+    private function publishedIn(int $entityTypeId): EntityListCriteria
+    {
+        return new EntityListCriteria(entityTypeId: $entityTypeId, status: EntityStatus::Published);
     }
 }

--- a/src/PublicRecord/GenerateSitemapUseCaseInterface.php
+++ b/src/PublicRecord/GenerateSitemapUseCaseInterface.php
@@ -6,11 +6,16 @@ namespace NeNeRecords\PublicRecord;
 
 interface GenerateSitemapUseCaseInterface
 {
+    /** Total published, non-deleted records in the current organization. */
+    public function count(): int;
+
     /**
-     * Site-relative URLs for every published record in the current organization,
-     * resolved through each type's permalink pattern.
+     * A window of published record URLs in the organization's stable global
+     * order (entity types in display order, records within each type), resolved
+     * through each type's permalink pattern. Used to page the sitemap when it is
+     * split across an index.
      *
      * @return list<SitemapUrl>
      */
-    public function execute(): array;
+    public function page(int $offset, int $limit): array;
 }

--- a/src/PublicRecord/RenderSitemapHandler.php
+++ b/src/PublicRecord/RenderSitemapHandler.php
@@ -10,17 +10,29 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
 /**
- * `GET /sitemap.xml` — the per-organization XML sitemap. The home page plus every
- * published record permalink, with absolute URLs built from the request's
- * scheme+host (so it works behind the single-origin reverse proxy).
+ * `GET /sitemap.xml` — the per-organization XML sitemap.
+ *
+ * The global URL list is the home page plus every published record permalink.
+ * While it fits in one file (≤ chunk size) a single `<urlset>` is served. Beyond
+ * that the same URL returns a `<sitemapindex>` pointing at child sitemaps served
+ * from `/sitemap.xml?page=N` — keeping each file under the sitemap protocol's
+ * 50,000-URL limit. Absolute URLs are built from the request scheme+host so it
+ * works behind the single-origin reverse proxy.
  */
 final readonly class RenderSitemapHandler
 {
+    /** Under the protocol's 50,000 cap, with headroom for the home URL in page 1. */
+    public const DEFAULT_CHUNK_SIZE = 45000;
+
+    private int $chunkSize;
+
     public function __construct(
         private GenerateSitemapUseCaseInterface $useCase,
         private ResponseFactoryInterface $responseFactory,
         private StreamFactoryInterface $streamFactory,
+        ?int $chunkSize = null,
     ) {
+        $this->chunkSize = $chunkSize !== null && $chunkSize > 0 ? $chunkSize : self::DEFAULT_CHUNK_SIZE;
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
@@ -28,11 +40,62 @@ final readonly class RenderSitemapHandler
         $uri = $request->getUri();
         $baseUrl = $uri->getScheme() . '://' . $uri->getAuthority();
 
-        $urls = array_merge([new SitemapUrl('/')], $this->useCase->execute());
-        $xml = SitemapXmlRenderer::render($baseUrl, $urls);
+        // Global list = home page (1) + every published record.
+        $totalUrls = 1 + $this->useCase->count();
+        $chunks = (int) max(1, (int) ceil($totalUrls / $this->chunkSize));
 
+        $page = $this->requestedPage($request);
+
+        if ($page !== null) {
+            if ($page < 1 || $page > $chunks) {
+                return $this->responseFactory->createResponse(404);
+            }
+
+            return $this->xml(SitemapXmlRenderer::render($baseUrl, $this->chunkUrls($page - 1)));
+        }
+
+        // No page param: a single urlset when everything fits, otherwise an index.
+        if ($chunks === 1) {
+            return $this->xml(SitemapXmlRenderer::render($baseUrl, $this->chunkUrls(0)));
+        }
+
+        $children = [];
+        for ($n = 1; $n <= $chunks; $n++) {
+            $children[] = '/sitemap.xml?page=' . $n;
+        }
+
+        return $this->xml(SitemapXmlRenderer::renderIndex($baseUrl, $children));
+    }
+
+    /**
+     * The home page lives in chunk 0; record offsets shift by one to make room.
+     *
+     * @return list<SitemapUrl>
+     */
+    private function chunkUrls(int $chunkIndex): array
+    {
+        if ($chunkIndex === 0) {
+            return array_merge([new SitemapUrl('/')], $this->useCase->page(0, $this->chunkSize - 1));
+        }
+
+        return $this->useCase->page($chunkIndex * $this->chunkSize - 1, $this->chunkSize);
+    }
+
+    private function requestedPage(ServerRequestInterface $request): ?int
+    {
+        $raw = $request->getQueryParams()['page'] ?? null;
+
+        if ($raw === null) {
+            return null;
+        }
+
+        return is_string($raw) && ctype_digit($raw) ? (int) $raw : 0;
+    }
+
+    private function xml(string $body): ResponseInterface
+    {
         return $this->responseFactory->createResponse(200)
             ->withHeader('Content-Type', 'application/xml; charset=UTF-8')
-            ->withBody($this->streamFactory->createStream($xml));
+            ->withBody($this->streamFactory->createStream($body));
     }
 }

--- a/src/PublicRecord/SitemapXmlRenderer.php
+++ b/src/PublicRecord/SitemapXmlRenderer.php
@@ -35,6 +35,26 @@ final class SitemapXmlRenderer
         return $xml . '</urlset>' . "\n";
     }
 
+    /**
+     * Render a `<sitemapindex>` pointing at child sitemaps. Each path is joined to
+     * the base URL (e.g. `/sitemap.xml?page=2`).
+     *
+     * @param list<string> $childPaths
+     */
+    public static function renderIndex(string $baseUrl, array $childPaths): string
+    {
+        $base = rtrim($baseUrl, '/');
+
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
+        $xml .= '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+
+        foreach ($childPaths as $path) {
+            $xml .= '  <sitemap><loc>' . self::escape($base . $path) . '</loc></sitemap>' . "\n";
+        }
+
+        return $xml . '</sitemapindex>' . "\n";
+    }
+
     private static function escape(string $value): string
     {
         return htmlspecialchars($value, ENT_XML1 | ENT_QUOTES, 'UTF-8');

--- a/tests/PublicRecord/GenerateSitemapUseCaseTest.php
+++ b/tests/PublicRecord/GenerateSitemapUseCaseTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 final class GenerateSitemapUseCaseTest extends TestCase
 {
-    public function testEnumeratesOnlyPublishedRecordsAcrossTypes(): void
+    private function useCase(): GenerateSitemapUseCase
     {
         $types = new InMemoryEntityTypeRepository([
             new EntityType(name: 'Posts', slug: 'posts', id: 1, permalinkPattern: '/{type}/{slug}'),
@@ -40,45 +40,47 @@ final class GenerateSitemapUseCaseTest extends TestCase
             ),
         ]);
 
-        $urls = (new GenerateSitemapUseCase($types, $entities))->execute();
-        $paths = array_map(static fn ($u) => $u->path, $urls);
+        return new GenerateSitemapUseCase($types, $entities);
+    }
 
-        self::assertContains('/posts/hello', $paths);
-        self::assertContains('/pages/20', $paths); // default pattern uses id
-        self::assertNotContains('/posts/draft', $paths); // draft excluded
-        self::assertCount(2, $urls);
+    public function testCountsOnlyPublishedRecords(): void
+    {
+        self::assertSame(2, $this->useCase()->count());
+    }
+
+    public function testPageResolvesPermalinksInGlobalOrderAndExcludesDrafts(): void
+    {
+        $paths = array_map(static fn ($u) => $u->path, $this->useCase()->page(0, 100));
+
+        self::assertSame(['/posts/hello', '/pages/20'], $paths); // types in order; default uses id
+    }
+
+    public function testPageSlicesTheWindowAcrossTypes(): void
+    {
+        $useCase = $this->useCase();
+
+        self::assertSame(['/posts/hello'], array_map(static fn ($u) => $u->path, $useCase->page(0, 1)));
+        self::assertSame(['/pages/20'], array_map(static fn ($u) => $u->path, $useCase->page(1, 1)));
+        self::assertSame([], $useCase->page(2, 1)); // past the end
     }
 
     public function testLastmodPrefersUpdatedThenPublished(): void
     {
-        $types = new InMemoryEntityTypeRepository([
-            new EntityType(name: 'Posts', slug: 'posts', id: 1, permalinkPattern: '/{type}/{id}'),
-        ]);
-        $entities = new InMemoryEntityRepository([
-            new Entity(
-                id: 1,
-                entityTypeId: 1,
-                status: EntityStatus::Published,
-                publishedAt: new DateTimeImmutable('2026-01-01T00:00:00+00:00'),
-                updatedAt: new DateTimeImmutable('2026-05-05T12:00:00+00:00'),
-            ),
-        ]);
+        $urls = $this->useCase()->page(0, 100);
 
-        $urls = (new GenerateSitemapUseCase($types, $entities))->execute();
-
-        self::assertCount(1, $urls);
-        self::assertSame('2026-05-05T12:00:00+00:00', $urls[0]->lastmod);
+        self::assertSame('2026-02-20T09:00:00+00:00', $urls[0]->lastmod); // updatedAt wins
+        self::assertSame('2026-03-01T00:00:00+00:00', $urls[1]->lastmod); // falls back to publishedAt
     }
 
     public function testEmptyWhenNoPublishedRecords(): void
     {
-        $types = new InMemoryEntityTypeRepository([
-            new EntityType(name: 'Posts', slug: 'posts', id: 1),
-        ]);
+        $types = new InMemoryEntityTypeRepository([new EntityType(name: 'Posts', slug: 'posts', id: 1)]);
         $entities = new InMemoryEntityRepository([
             new Entity(id: 1, entityTypeId: 1, status: EntityStatus::Draft),
         ]);
+        $useCase = new GenerateSitemapUseCase($types, $entities);
 
-        self::assertSame([], (new GenerateSitemapUseCase($types, $entities))->execute());
+        self::assertSame(0, $useCase->count());
+        self::assertSame([], $useCase->page(0, 100));
     }
 }

--- a/tests/PublicRecord/RenderSitemapHandlerTest.php
+++ b/tests/PublicRecord/RenderSitemapHandlerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use NeNeRecords\PublicRecord\GenerateSitemapUseCaseInterface;
+use NeNeRecords\PublicRecord\RenderSitemapHandler;
+use NeNeRecords\PublicRecord\SitemapUrl;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class RenderSitemapHandlerTest extends TestCase
+{
+    private Psr17Factory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new Psr17Factory();
+    }
+
+    /** A use case backed by a flat list of record paths (global order). */
+    private function useCase(int $recordCount): GenerateSitemapUseCaseInterface
+    {
+        return new class ($recordCount) implements GenerateSitemapUseCaseInterface {
+            public function __construct(private int $recordCount)
+            {
+            }
+
+            public function count(): int
+            {
+                return $this->recordCount;
+            }
+
+            public function page(int $offset, int $limit): array
+            {
+                $urls = [];
+                for ($i = $offset; $i < $offset + $limit && $i < $this->recordCount; $i++) {
+                    $urls[] = new SitemapUrl('/posts/' . $i);
+                }
+
+                return $urls;
+            }
+        };
+    }
+
+    private function request(string $target): ServerRequestInterface
+    {
+        return $this->factory->createServerRequest('GET', 'https://x.test' . $target);
+    }
+
+    public function testServesSingleUrlsetWhenItFits(): void
+    {
+        // chunk size 3, total = home + 2 records = 3 → one chunk.
+        $handler = new RenderSitemapHandler($this->useCase(2), $this->factory, $this->factory, 3);
+        $response = $handler->handle($this->request('/sitemap.xml'));
+        $xml = (string) $response->getBody();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('<urlset', $xml);
+        self::assertStringNotContainsString('<sitemapindex', $xml);
+        self::assertStringContainsString('<loc>https://x.test/</loc>', $xml);
+        self::assertStringContainsString('<loc>https://x.test/posts/0</loc>', $xml);
+        self::assertStringContainsString('<loc>https://x.test/posts/1</loc>', $xml);
+    }
+
+    public function testServesIndexWhenSplit(): void
+    {
+        // chunk size 2, total = home + 3 records = 4 → ceil(4/2) = 2 chunks.
+        $handler = new RenderSitemapHandler($this->useCase(3), $this->factory, $this->factory, 2);
+        $xml = (string) $handler->handle($this->request('/sitemap.xml'))->getBody();
+
+        self::assertStringContainsString('<sitemapindex', $xml);
+        self::assertStringContainsString('<loc>https://x.test/sitemap.xml?page=1</loc>', $xml);
+        self::assertStringContainsString('<loc>https://x.test/sitemap.xml?page=2</loc>', $xml);
+        self::assertStringNotContainsString('page=3', $xml);
+    }
+
+    public function testPagesPartitionTheGlobalListWithHomeInPageOne(): void
+    {
+        $handler = new RenderSitemapHandler($this->useCase(3), $this->factory, $this->factory, 2);
+
+        // page 1: home + first record.
+        $page1 = (string) $handler->handle($this->request('/sitemap.xml?page=1'))->getBody();
+        self::assertStringContainsString('<loc>https://x.test/</loc>', $page1);
+        self::assertStringContainsString('<loc>https://x.test/posts/0</loc>', $page1);
+        self::assertStringNotContainsString('/posts/1', $page1);
+
+        // page 2: remaining records, no home.
+        $page2 = (string) $handler->handle($this->request('/sitemap.xml?page=2'))->getBody();
+        self::assertStringNotContainsString('<loc>https://x.test/</loc>', $page2);
+        self::assertStringContainsString('<loc>https://x.test/posts/1</loc>', $page2);
+        self::assertStringContainsString('<loc>https://x.test/posts/2</loc>', $page2);
+    }
+
+    public function testOutOfRangePageReturns404(): void
+    {
+        $handler = new RenderSitemapHandler($this->useCase(3), $this->factory, $this->factory, 2);
+
+        self::assertSame(404, $handler->handle($this->request('/sitemap.xml?page=3'))->getStatusCode());
+        self::assertSame(404, $handler->handle($this->request('/sitemap.xml?page=0'))->getStatusCode());
+        self::assertSame(404, $handler->handle($this->request('/sitemap.xml?page=abc'))->getStatusCode());
+    }
+}

--- a/tests/PublicRecord/SitemapXmlRendererTest.php
+++ b/tests/PublicRecord/SitemapXmlRendererTest.php
@@ -42,4 +42,17 @@ final class SitemapXmlRendererTest extends TestCase
         self::assertStringContainsString('/posts/a&amp;b&lt;c', $xml);
         self::assertStringNotContainsString('a&b<c', $xml);
     }
+
+    public function testRenderIndexListsChildSitemaps(): void
+    {
+        $xml = SitemapXmlRenderer::renderIndex('https://x.test', [
+            '/sitemap.xml?page=1',
+            '/sitemap.xml?page=2',
+        ]);
+
+        self::assertStringContainsString('<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">', $xml);
+        self::assertStringContainsString('<sitemap><loc>https://x.test/sitemap.xml?page=1</loc></sitemap>', $xml);
+        self::assertStringContainsString('<sitemap><loc>https://x.test/sitemap.xml?page=2</loc></sitemap>', $xml);
+        self::assertStringContainsString('</sitemapindex>', $xml);
+    }
 }


### PR DESCRIPTION
## 目的
公開レコードが増えても **sitemap プロトコルの 50,000 URL/ファイル上限**を守れるよう、`/sitemap.xml` を必要時に**サイトマップインデックス**化する。小規模サイトは従来どおり単一 `<urlset>`（後方互換）。

## 変更
- **`GenerateSitemapUseCase`** — `execute()` を `count()` ＋ `page(offset, limit)` に再構成。`page` はタイプ横断のグローバル順を**パーティション・ページング**（窓内の行だけ COUNT＋スライス取得＝全件をメモリに載せない）。
- **`SitemapXmlRenderer::renderIndex()`** — `<sitemapindex>` を生成。
- **`RenderSitemapHandler`** — 総 URL 数（ホーム＋公開レコード）が chunk 上限（既定 **45,000**＝ホーム分の余裕を見て 50,000 未満）以下なら単一 `<urlset>`、超えたら `<sitemapindex>`。子サイトマップは `/sitemap.xml?page=N`（ルータの intra-segment param 制約を回避・クエリ付き `<loc>` は sitemap 仕様で有効）。`?page=N` で N 番目のチャンクを配信、範囲外/不正は **404**。ホームは page 1 に収め、以降のレコード offset を 1 ずらして整合。

## 検証
- `composer check` 緑（**PHPUnit 990 / PHPStan lv8（0 errors）/ CS-Fixer / OpenAPI / MCP**）。
- テスト：
  - `GenerateSitemapUseCase` — `count`・`page` のスライス（型横断）・グローバル順・draft 除外・`lastmod` 優先順。
  - `SitemapXmlRenderer` — `<urlset>` ＋ `<sitemapindex>`。
  - `RenderSitemapHandler`（スタブ use case・chunk size 注入）— 収まる→urlset、超過→index（N 子）、`?page=N` でチャンク・**ホームは page 1**・範囲外/不正→404。
  - 既存統合（`PublicRecordHttpTest`）— 小サイトは単一 urlset のまま＝**後方互換**。

## 後方互換 / 本番影響
- 本番（現状 1 記事）は ≤45,000 URL なので `/sitemap.xml` は従来どおり単一 urlset。挙動変化なし。

## 設計判断
- 子サイトマップは**クエリ param**方式（`?page=N`）— 新ルート不要・ルータ非依存。
- chunk size は注入可能（既定 45,000）でテスト容易。

Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)