### PR TITLE
feat(settings): 同意既定をドロップダウン化する (#536)

### DIFF
--- a/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.test.tsx
+++ b/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { SettingItem } from '@/entities/setting'
+import { I18nProvider } from '@/shared/i18n'
+import { ManageSiteSettingsView } from './ManageSiteSettingsView'
+
+afterEach(cleanup)
+
+const consentItem: SettingItem = {
+  settingKey: 'analytics_consent_default',
+  label: 'Analytics consent default',
+  dataType: 'text',
+  defaultValue: 'denied',
+  isPublic: true,
+  value: 'denied',
+  updatedAt: null,
+}
+
+function renderView(item: SettingItem = consentItem) {
+  const onSave = vi.fn().mockResolvedValue(undefined)
+  render(
+    <I18nProvider>
+      <ManageSiteSettingsView
+        items={[item]}
+        isLoading={false}
+        isError={false}
+        isSaving={false}
+        expandedKey={null}
+        revisions={[]}
+        revisionsLoading={false}
+        revisionsError={false}
+        canManageSettings={true}
+        onRetry={vi.fn()}
+        onSave={onSave}
+        onToggleExpanded={vi.fn()}
+      />
+    </I18nProvider>,
+  )
+  return { onSave }
+}
+
+describe('ManageSiteSettingsView · analytics_consent_default', () => {
+  it('renders a denied/granted dropdown reflecting the current value', () => {
+    renderView()
+
+    const select = screen.getByLabelText('Analytics consent default')
+    expect(select.tagName).toBe('SELECT')
+    expect((select as HTMLSelectElement).value).toBe('denied')
+    expect(screen.getByRole('option', { name: 'Denied (EU-safe default)' })).toBeTruthy()
+    expect(screen.getByRole('option', { name: 'Granted' })).toBeTruthy()
+  })
+
+  it('saves the selected value', () => {
+    const { onSave } = renderView()
+
+    fireEvent.change(screen.getByLabelText('Analytics consent default'), {
+      target: { value: 'granted' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(onSave).toHaveBeenCalledWith('analytics_consent_default', 'granted')
+  })
+
+  it('keeps a plain text input for other settings', () => {
+    renderView({ ...consentItem, settingKey: 'site_name', label: 'Site name', value: 'NeNe' })
+
+    const input = screen.getByLabelText('Site name')
+    expect(input.tagName).toBe('INPUT')
+  })
+})

--- a/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.tsx
+++ b/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.tsx
@@ -105,6 +105,61 @@ function MediaSettingField({ item, isSaving, canManageSettings, onSave }: MediaS
   )
 }
 
+// ── Consent-default setting field (denied / granted dropdown) ────────────────
+
+interface ConsentDefaultFieldProps {
+  item: SettingItem
+  isSaving: boolean
+  canManageSettings: boolean
+  onSave: (settingKey: string, value: string) => Promise<void>
+}
+
+/**
+ * `analytics_consent_default` is a fixed two-value choice (Consent Mode v2). A
+ * select avoids free-text typos; the backend normalizes anything unexpected to
+ * `denied`, but the dropdown makes the EU-safe default explicit.
+ */
+function ConsentDefaultField({
+  item,
+  isSaving,
+  canManageSettings,
+  onSave,
+}: ConsentDefaultFieldProps) {
+  const { t } = useTranslation()
+  const initial = item.value === 'granted' ? 'granted' : 'denied'
+  const [value, setValue] = useState(initial)
+  const dirty = value !== initial
+
+  return (
+    <div className="flex items-center gap-stack-sm">
+      <select
+        id={`setting-${item.settingKey}`}
+        value={value}
+        disabled={isSaving || !canManageSettings}
+        onChange={(e) => {
+          setValue(e.target.value)
+        }}
+        className={`flex-1 ${inputClass}`}
+      >
+        <option value="denied">{t('admin.settings.consentDefault.denied')}</option>
+        <option value="granted">{t('admin.settings.consentDefault.granted')}</option>
+      </select>
+      {canManageSettings ? (
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={isSaving || !dirty}
+          onClick={() => {
+            void onSave(item.settingKey, value)
+          }}
+        >
+          {isSaving ? t('admin.settings.saving') : t('admin.settings.save')}
+        </Button>
+      ) : null}
+    </div>
+  )
+}
+
 // ── Setting card (local form state only) ─────────────────────────────────────
 
 interface SettingCardProps {
@@ -192,6 +247,13 @@ function SettingCard({
             </div>
           ) : null}
         </div>
+      ) : item.settingKey === 'analytics_consent_default' ? (
+        <ConsentDefaultField
+          item={item}
+          isSaving={isSaving}
+          canManageSettings={canManageSettings}
+          onSave={onSave}
+        />
       ) : (
         <div className="flex items-center gap-stack-sm">
           <input

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -1141,6 +1141,10 @@ export const de: Partial<MessageCatalog> = {
   'admin.superSettings.currentTitle': 'Aktuelle Einstellungen (in DB gespeichert)',
   'admin.superSettings.currentResolution': 'Auflösungsmodus',
 
+  // ── Admin · settings · analytics consent default ──────────────────────────
+  'admin.settings.consentDefault.denied': 'Abgelehnt (EU-sicherer Standard)',
+  'admin.settings.consentDefault.granted': 'Zugelassen',
+
   // ── Public · cookie consent ───────────────────────────────────────────────
   'public.consent.label': 'Cookie-Einwilligung',
   'public.consent.message':

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -1148,6 +1148,10 @@ export const en = {
   'admin.superSettings.currentTitle': 'Current settings (saved in DB)',
   'admin.superSettings.currentResolution': 'Resolution mode',
 
+  // ── Admin · settings · analytics consent default ──────────────────────────
+  'admin.settings.consentDefault.denied': 'Denied (EU-safe default)',
+  'admin.settings.consentDefault.granted': 'Granted',
+
   // ── Public · cookie consent ───────────────────────────────────────────────
   'public.consent.label': 'Cookie consent',
   'public.consent.message': 'We use cookies to measure site traffic. May we enable analytics?',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -1172,6 +1172,10 @@ export const fr: Partial<MessageCatalog> = {
   'admin.superSettings.currentTitle': 'Paramètres actuels (enregistrés en BDD)',
   'admin.superSettings.currentResolution': 'Mode de résolution',
 
+  // ── Admin · settings · analytics consent default ──────────────────────────
+  'admin.settings.consentDefault.denied': 'Refusé (valeur par défaut sûre pour l’UE)',
+  'admin.settings.consentDefault.granted': 'Autorisé',
+
   // ── Public · cookie consent ───────────────────────────────────────────────
   'public.consent.label': 'Consentement aux cookies',
   'public.consent.message':

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -1153,6 +1153,10 @@ export const ja: Partial<MessageCatalog> = {
   'admin.superSettings.currentTitle': '現在の設定（DB 保存値）',
   'admin.superSettings.currentResolution': '解決方式',
 
+  // ── Admin · settings · analytics consent default ──────────────────────────
+  'admin.settings.consentDefault.denied': '拒否（EU 安全側の既定）',
+  'admin.settings.consentDefault.granted': '許可',
+
   // ── Public · cookie consent ───────────────────────────────────────────────
   'public.consent.label': 'Cookie の同意',
   'public.consent.message':

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -1160,6 +1160,10 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.superSettings.currentTitle': 'Configurações atuais (salvas no BD)',
   'admin.superSettings.currentResolution': 'Modo de resolução',
 
+  // ── Admin · settings · analytics consent default ──────────────────────────
+  'admin.settings.consentDefault.denied': 'Negado (padrão seguro na UE)',
+  'admin.settings.consentDefault.granted': 'Concedido',
+
   // ── Public · cookie consent ───────────────────────────────────────────────
   'public.consent.label': 'Consentimento de cookies',
   'public.consent.message':

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -1112,6 +1112,10 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.superSettings.currentTitle': '当前设置（已保存于数据库）',
   'admin.superSettings.currentResolution': '解析模式',
 
+  // ── Admin · settings · analytics consent default ──────────────────────────
+  'admin.settings.consentDefault.denied': '拒绝（欧盟安全默认）',
+  'admin.settings.consentDefault.granted': '允许',
+
   // ── Public · cookie consent ───────────────────────────────────────────────
   'public.consent.label': 'Cookie 同意',
   'public.consent.message': '我们使用 Cookie 来统计网站访问量。是否允许启用分析？',


### PR DESCRIPTION
## 目的
計測の `analytics_consent_default` は `denied` / `granted` の二択。管理画面（`/admin/settings`）の汎用テキスト入力を**セレクト**に置き換え、タイプミスを防ぎ EU 安全側の既定を明示する。

## 変更
- **`ManageSiteSettingsView`** — `analytics_consent_default` のときだけ専用の `ConsentDefaultField`（`denied`/`granted` の `<select>`）を描画。他の設定は従来のテキスト入力のまま。送信値は raw（`denied`/`granted`）、表示ラベルは i18n。
- **i18n** — `admin.settings.consentDefault.denied` / `.granted` を全6ロケール（en/ja/de/fr/pt-BR/zh-Hans）に追加。

## 検証
- `npm run check` 緑（type-check / lint / prettier / test / **locales 完全性** / knip / storybook）。
- テスト：`ManageSiteSettingsView` — consent はセレクト＋`denied`/`granted` の option を描画・選択して保存で `onSave('analytics_consent_default', 'granted')`・他キー（`site_name` 等）はテキスト入力のまま。

## 補足 / スコープ
- バックエンドは既に未知値を `denied` に正規化するため互換（PR-A1）。
- 1 設定の特化対応＝`#541`（設定の生 JSON 露出を構造化 UI へ）の小 follow-up。汎用 choice-setting 機構は将来 choice 設定が増えたときに一般化。

Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)