### PR TITLE
feat(editor): ブロック編集にライブプレビューを追加する (#538 ①)

### DIFF
--- a/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.test.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.test.tsx
@@ -46,6 +46,28 @@ describe('BlocksFieldEditor', () => {
     expect(screen.getByText('Callout')).toBeInTheDocument()
   })
 
+  it('toggles a live preview rendered through BlocksRenderer', async () => {
+    const user = userEvent.setup()
+    const doc = JSON.stringify([
+      { id: 'b1', type: 'callout', data: { kind: 'ok', title: 'Nice', body: 'Done' } },
+    ])
+    renderWithProviders(<Harness initial={doc} />)
+
+    // Hidden by default — no public-scoped render in the DOM.
+    expect(document.querySelector('.nene-public .blocks')).toBeNull()
+
+    await user.click(screen.getByRole('button', { name: 'Show preview' }))
+    expect(document.querySelector('.nene-public .blocks')).not.toBeNull()
+
+    await user.click(screen.getByRole('button', { name: 'Hide preview' }))
+    expect(document.querySelector('.nene-public .blocks')).toBeNull()
+  })
+
+  it('hides the preview toggle when there are no blocks', () => {
+    renderWithProviders(<Harness />)
+    expect(screen.queryByRole('button', { name: 'Show preview' })).not.toBeInTheDocument()
+  })
+
   it('limits the palette to allowedTypes', () => {
     renderWithProviders(
       <BlocksFieldEditor

--- a/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.tsx
@@ -32,6 +32,7 @@ import {
   setBlockDragPayload,
 } from './block-dnd'
 import { BlockInspector } from './BlockInspector'
+import { BlocksPreview } from './BlocksPreview'
 import { RepeaterIconButton } from './inspectors/RepeaterIconButton'
 
 export interface BlocksFieldEditorProps {
@@ -125,6 +126,7 @@ export function BlocksFieldEditor({
   const blocks = useMemo(() => parseBlocksDocument(value), [value])
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [dropIndex, setDropIndex] = useState<number | null>(null)
+  const [showPreview, setShowPreview] = useState(false)
   const boardRef = useRef<HTMLDivElement>(null)
 
   const selected = blocks.find((block) => block.id === selectedId) ?? null
@@ -200,9 +202,22 @@ export function BlocksFieldEditor({
 
   return (
     <div className="flex flex-col gap-stack-sm">
-      <Text as="span" variant="caption" className="font-medium text-text-primary">
-        {label}
-      </Text>
+      <div className="flex items-center justify-between gap-inline-md">
+        <Text as="span" variant="caption" className="font-medium text-text-primary">
+          {label}
+        </Text>
+        {blocks.length > 0 ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setShowPreview((shown) => !shown)
+            }}
+          >
+            {showPreview ? t('admin.blocks.preview.hide') : t('admin.blocks.preview.show')}
+          </Button>
+        ) : null}
+      </div>
 
       <div className="flex flex-wrap gap-inline-sm">
         {palette.map((entry) => (
@@ -350,6 +365,17 @@ export function BlocksFieldEditor({
                 updateData(selected.id, data)
               }}
             />
+          </Stack>
+        </Card>
+      ) : null}
+
+      {showPreview && blocks.length > 0 ? (
+        <Card padding="md">
+          <Stack gap="sm">
+            <Text as="span" variant="caption" muted>
+              {t('admin.blocks.preview.title')}
+            </Text>
+            <BlocksPreview documentJson={value} />
           </Stack>
         </Card>
       ) : null}

--- a/frontend/src/features/edit-entity-text-fields/ui/BlocksPreview.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/BlocksPreview.tsx
@@ -1,0 +1,32 @@
+import { BlocksRenderer } from '@/shared/ui/blocks'
+// The canonical public block styles (`.nene-public`-scoped, so they cannot leak
+// into the admin) plus the default consumer theme tokens (`[data-theme]`-scoped).
+// Reusing them renders the editor preview exactly as the public page would,
+// rather than re-implementing block layout for the admin.
+import '@/pages/consumer/public-site.css'
+import '@/shared/ui/theme/themes/consumer-brand.css'
+
+interface BlocksPreviewProps {
+  /** The live blocks document (JSON string) from the editor. */
+  documentJson: string
+}
+
+/**
+ * Live preview of a `blocks` field (#538): renders the editor's current document
+ * through the same {@see BlocksRenderer} the public site uses, inside a
+ * `.nene-public` scope so the public CSS + default consumer theme tokens apply.
+ * The exact active theme isn't resolved here (default consumer) — structure,
+ * layout and type are what the editor needs to see while composing.
+ */
+export function BlocksPreview({ documentJson }: BlocksPreviewProps) {
+  return (
+    <div
+      className="nene-public overflow-auto rounded-md"
+      data-theme="consumer"
+      data-theme-mode="light"
+      style={{ maxHeight: '70vh' }}
+    >
+      <BlocksRenderer documentJson={documentJson} />
+    </div>
+  )
+}

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -608,6 +608,9 @@ export const de: Partial<MessageCatalog> = {
   'admin.markdownEditor.empty': 'Nichts zum Vorschauen.',
   // ── Blocks editor (#486) ──────────────────────────────────────────────────
   'admin.blocks.add': '{{type}} hinzufügen',
+  'admin.blocks.preview.title': 'Vorschau',
+  'admin.blocks.preview.show': 'Vorschau anzeigen',
+  'admin.blocks.preview.hide': 'Vorschau ausblenden',
   'admin.blocks.empty.title': 'Noch keine Blöcke',
   'admin.blocks.empty.description': 'Fügen Sie oben einen Block hinzu, um den Inhalt zu gestalten.',
   'admin.blocks.type.text': 'Text',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -613,6 +613,9 @@ export const en = {
 
   // ── Blocks editor (#486) ──────────────────────────────────────────────────
   'admin.blocks.add': 'Add {{type}}',
+  'admin.blocks.preview.title': 'Preview',
+  'admin.blocks.preview.show': 'Show preview',
+  'admin.blocks.preview.hide': 'Hide preview',
   'admin.blocks.empty.title': 'No blocks yet',
   'admin.blocks.empty.description': 'Add a block above to start composing the body.',
   'admin.blocks.type.text': 'Text',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -622,6 +622,9 @@ export const fr: Partial<MessageCatalog> = {
 
   // ── Blocks editor (#486) ──────────────────────────────────────────────────
   'admin.blocks.add': 'Ajouter {{type}}',
+  'admin.blocks.preview.title': 'Aperçu',
+  'admin.blocks.preview.show': 'Afficher l’aperçu',
+  'admin.blocks.preview.hide': 'Masquer l’aperçu',
   'admin.blocks.empty.title': 'Aucun bloc pour le moment',
   'admin.blocks.empty.description': 'Ajoutez un bloc ci-dessus pour commencer à composer le corps.',
   'admin.blocks.type.text': 'Texte',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -610,6 +610,9 @@ export const ja: Partial<MessageCatalog> = {
 
   // ── Blocks editor (#486) ──────────────────────────────────────────────────
   'admin.blocks.add': '{{type}}を追加',
+  'admin.blocks.preview.title': 'プレビュー',
+  'admin.blocks.preview.show': 'プレビューを表示',
+  'admin.blocks.preview.hide': 'プレビューを隠す',
   'admin.blocks.empty.title': 'ブロックがありません',
   'admin.blocks.empty.description': '上のボタンからブロックを追加して本文を組み立てましょう。',
   'admin.blocks.type.text': 'テキスト',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -616,6 +616,9 @@ export const ptBR: Partial<MessageCatalog> = {
 
   // ── Blocks editor (#486) ──────────────────────────────────────────────────
   'admin.blocks.add': 'Adicionar {{type}}',
+  'admin.blocks.preview.title': 'Prévia',
+  'admin.blocks.preview.show': 'Mostrar prévia',
+  'admin.blocks.preview.hide': 'Ocultar prévia',
   'admin.blocks.empty.title': 'Nenhum bloco ainda',
   'admin.blocks.empty.description': 'Adicione um bloco acima para começar a compor o corpo.',
   'admin.blocks.type.text': 'Texto',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -588,6 +588,9 @@ export const zhHans: Partial<MessageCatalog> = {
 
   // ── Blocks editor (#486) ──────────────────────────────────────────────────
   'admin.blocks.add': '添加{{type}}',
+  'admin.blocks.preview.title': '预览',
+  'admin.blocks.preview.show': '显示预览',
+  'admin.blocks.preview.hide': '隐藏预览',
   'admin.blocks.empty.title': '还没有区块',
   'admin.blocks.empty.description': '在上方添加一个区块以开始撰写正文。',
   'admin.blocks.type.text': '文本',


### PR DESCRIPTION
## 目的
ブロック編集は縦積みフォームで、**編集中に最終見た目が見えない**（保存→公開側で確認）。#538 ①として、編集盤面に公開と同じ `BlocksRenderer` のライブプレビューをトグルで組み込む。

## 変更
- **`BlocksPreview`** — `.nene-public[data-theme="consumer"]` スコープ内で `BlocksRenderer`（公開と同一）を描画。公開の `public-site.css`（**`.nene-public` 完全スコープ＝admin に漏れない**）＋ 既定 consumer テーマトークン（`consumer-brand.css`・`[data-theme]` スコープ）を再利用し、公開ページと同じ見た目で表示。
- **`BlocksFieldEditor`** — ヘッダに「プレビュー表示/隠す」トグル（ブロックがある時のみ表示）。編集中の `value` をそのまま渡してライブ更新。
- **i18n** — `admin.blocks.preview.{title,show,hide}` を全6ロケールに追加。

## 検証
- `npm run check` 緑（type-check / lint / prettier / test / **locales 完全性** / knip / storybook）。
- テスト：トグルで `.nene-public .blocks` が出現/消滅・ブロック 0 件ではトグル非表示。

## 設計判断 / スコープ
- **iframe ではなくスコープ付きインライン描画**：`public-site.css` は全ルールが `.nene-public` 配下（unscoped セレクタ無しを確認済）＝admin に CSS が漏れないため、iframe 無しで安全かつ軽量に公開スタイルを当てられる。
- 厳密な「アクティブテーマ」反映ではなく既定 consumer で描画（構造・レイアウト・型の確認が主目的の MVP）。
- **本 PR は #538 ①のみ**。②（テーマ iframe ライブプレビュー）は #372 と統合の別 PR。両方完了時に #538 をクローズ（このPRでは閉じない）。

Part of #538 / Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)