### PR TITLE
feat(public-i18n): 公開コンテンツのロケール交渉＋hreflang (#540 S1)

### DIFF
--- a/src/PublicRecord/GetPublicRecordViewHandler.php
+++ b/src/PublicRecord/GetPublicRecordViewHandler.php
@@ -35,7 +35,10 @@ final readonly class GetPublicRecordViewHandler
             );
         }
 
-        $output = $this->useCase->execute(new GetPublicRecordViewInput($typeSlug, $entitySlug));
+        $langParam = $request->getQueryParams()['lang'] ?? null;
+        $locale = PublicLocale::resolve(is_string($langParam) ? $langParam : null);
+
+        $output = $this->useCase->execute(new GetPublicRecordViewInput($typeSlug, $entitySlug, null, $locale));
 
         $etag = '"' . md5(json_encode($output->bootstrap, JSON_THROW_ON_ERROR)) . '"';
 

--- a/src/PublicRecord/GetPublicRecordViewInput.php
+++ b/src/PublicRecord/GetPublicRecordViewInput.php
@@ -10,6 +10,8 @@ final readonly class GetPublicRecordViewInput
         public string $entityTypeSlug,
         public ?string $entitySlug = null,
         public ?int $entityId = null,
+        /** Negotiated content locale (#540); null = base / locale-agnostic rows. */
+        public ?string $locale = null,
     ) {
     }
 }

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -85,7 +85,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
         )));
 
         $textFieldRows = (in_array('text', $dataTypes, true) || in_array('markdown', $dataTypes, true) || in_array('html', $dataTypes, true) || in_array('bundle', $dataTypes, true) || in_array('image', $dataTypes, true) || in_array('file', $dataTypes, true))
-            ? $this->textFields->findByEntityId($entityId, self::FIELD_VALUE_LIMIT, 0)
+            ? $this->resolveLocaleRows($this->textFields->findByEntityId($entityId, self::FIELD_VALUE_LIMIT, 0), $input->locale)
             : [];
         $intFieldRows = in_array('int', $dataTypes, true)
             ? $this->intFields->findByEntityId($entityId, self::FIELD_VALUE_LIMIT, 0)
@@ -348,6 +348,60 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
         }
 
         return 'Record #' . $entityId;
+    }
+
+    /**
+     * Negotiate text-field rows down to one per field key for the requested
+     * locale (#540): prefer the requested locale, then the locale-agnostic (null)
+     * row, then the first available. Resolving here keeps the SSR display fields,
+     * the SPA bootstrap and the page title all consistent for the served locale.
+     *
+     * @param list<TextField> $rows
+     * @return list<TextField>
+     */
+    private function resolveLocaleRows(array $rows, ?string $locale): array
+    {
+        $byKey = [];
+        $order = [];
+
+        foreach ($rows as $row) {
+            if (!array_key_exists($row->fieldKey, $byKey)) {
+                $byKey[$row->fieldKey] = [];
+                $order[] = $row->fieldKey;
+            }
+            $byKey[$row->fieldKey][] = $row;
+        }
+
+        $resolved = [];
+
+        foreach ($order as $fieldKey) {
+            $candidates = $byKey[$fieldKey];
+            $pick = null;
+
+            if ($locale !== null) {
+                $pick = $this->firstWhere($candidates, static fn (TextField $r): bool => $r->locale === $locale);
+            }
+
+            $pick ??= $this->firstWhere($candidates, static fn (TextField $r): bool => $r->locale === null);
+            $resolved[] = $pick ?? $candidates[0];
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param list<TextField> $rows
+     * @param callable(TextField): bool $predicate
+     */
+    private function firstWhere(array $rows, callable $predicate): ?TextField
+    {
+        foreach ($rows as $row) {
+            if ($predicate($row)) {
+                return $row;
+            }
+        }
+
+        return null;
     }
 
     /** @param list<TextField> $rows */

--- a/src/PublicRecord/PublicLocale.php
+++ b/src/PublicRecord/PublicLocale.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+/**
+ * Public content locales (#540). Mirrors the frontend's `SupportedLocale` set.
+ * The public site negotiates content per request via `?lang=`; an absent or
+ * unsupported value resolves to `null` (serve the base / locale-agnostic rows).
+ */
+final class PublicLocale
+{
+    /** @var list<string> */
+    public const SUPPORTED = ['en', 'ja', 'fr', 'zh-Hans', 'pt-BR', 'de'];
+
+    /** `<html lang>` when no locale is negotiated (base content). */
+    public const DEFAULT_LANG = 'ja';
+
+    private function __construct()
+    {
+    }
+
+    /** A supported locale id, or null when absent / unsupported. */
+    public static function resolve(?string $requested): ?string
+    {
+        $value = trim((string) $requested);
+
+        return in_array($value, self::SUPPORTED, true) ? $value : null;
+    }
+}

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -65,7 +65,12 @@ final readonly class RenderPublicRecordViewHandler
         ?int $entityId,
         ServerRequestInterface $request,
     ): ResponseInterface {
-        $output = $this->useCase->execute(new GetPublicRecordViewInput($typeSlug, $entitySlug, $entityId));
+        $langParam = $request->getQueryParams()['lang'] ?? null;
+        $locale = PublicLocale::resolve(is_string($langParam) ? $langParam : null);
+
+        $output = $this->useCase->execute(
+            new GetPublicRecordViewInput($typeSlug, $entitySlug, $entityId, $locale),
+        );
         $settings = $this->publicSettingsMap();
         $siteName = $settings['site_name'] ?? 'NeNe Records';
         $defaultMetaDescription = $settings['default_meta_description'] ?? '';
@@ -76,9 +81,17 @@ final readonly class RenderPublicRecordViewHandler
         $analyticsHead = WebAnalyticsHeadSnippet::render($analytics, $analyticsNonce);
 
         // Canonical / og:url point at the user-facing permalink (not this /view/ twin).
+        // For a negotiated locale the canonical self-references with `?lang=`, and
+        // hreflang alternates advertise every locale variant (#540).
         $uri = $request->getUri();
         $baseUrl = $uri->getScheme() . '://' . $uri->getAuthority();
-        $canonicalUrl = $baseUrl . $output->canonicalPath;
+        $permalinkUrl = $baseUrl . $output->canonicalPath;
+        $canonicalUrl = $locale !== null ? $permalinkUrl . '?lang=' . $locale : $permalinkUrl;
+        $htmlLang = $locale ?? PublicLocale::DEFAULT_LANG;
+        $alternateLinks = [['hreflang' => 'x-default', 'href' => $permalinkUrl]];
+        foreach (PublicLocale::SUPPORTED as $supported) {
+            $alternateLinks[] = ['hreflang' => $supported, 'href' => $permalinkUrl . '?lang=' . $supported];
+        }
 
         // og:image / twitter:image — absolutize the entity's social-card derivative.
         $ogImageUrl = null;
@@ -133,6 +146,8 @@ final readonly class RenderPublicRecordViewHandler
             'siteName' => $siteName,
             'metaDescription' => $metaDescription,
             'analyticsHead' => $analyticsHead,
+            'htmlLang' => $htmlLang,
+            'alternateLinks' => $alternateLinks,
             'canonicalUrl' => $canonicalUrl,
             'ogImageUrl' => $ogImageUrl,
             'publishedAtIso' => $output->publishedAtIso,

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="ja">
+<html lang="<?= $e($htmlLang) ?>">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -10,6 +10,10 @@
     <?php endif; ?>
     <title><?= $e($pageTitle) ?> — <?= $e($siteName) ?></title>
     <link rel="canonical" href="<?= $e($canonicalUrl) ?>" />
+    <?php /* hreflang alternates for the public content locales (#540). */ ?>
+    <?php foreach ($alternateLinks as $alt): ?>
+      <link rel="alternate" hreflang="<?= $e($alt['hreflang']) ?>" href="<?= $e($alt['href']) ?>" />
+    <?php endforeach; ?>
 
     <meta property="og:type" content="article" />
     <meta property="og:title" content="<?= $e($pageTitle) ?>" />

--- a/tests/PublicRecord/PublicLocaleTest.php
+++ b/tests/PublicRecord/PublicLocaleTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use NeNeRecords\PublicRecord\PublicLocale;
+use PHPUnit\Framework\TestCase;
+
+final class PublicLocaleTest extends TestCase
+{
+    public function testResolvesSupportedLocales(): void
+    {
+        self::assertSame('de', PublicLocale::resolve('de'));
+        self::assertSame('zh-Hans', PublicLocale::resolve('zh-Hans'));
+        self::assertSame('pt-BR', PublicLocale::resolve('pt-BR'));
+    }
+
+    public function testTrimsWhitespace(): void
+    {
+        self::assertSame('ja', PublicLocale::resolve('  ja  '));
+    }
+
+    public function testRejectsUnsupportedOrAbsent(): void
+    {
+        self::assertNull(PublicLocale::resolve(null));
+        self::assertNull(PublicLocale::resolve(''));
+        self::assertNull(PublicLocale::resolve('xx'));
+        self::assertNull(PublicLocale::resolve('en-US'));
+    }
+}

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -94,6 +94,8 @@ final class PublicRecordHttpTest extends TestCase
                 value: '<p>imported <strong>kept</strong></p><img src="/media/imported/x.jpg" alt="p" /><script>alert(1)</script>',
                 id: 4,
             ),
+            // German title variant for the content-locale negotiation tests (#540).
+            new TextField(entityId: 10, fieldKey: 'title', value: 'Hallo Welt', id: 5, locale: 'de'),
         ], $entities);
 
         $publicSettings = new ListPublicSettingsUseCase(new InMemorySettingRepository($settingDefs), new InMemoryMediaRepository());
@@ -365,6 +367,40 @@ final class PublicRecordHttpTest extends TestCase
         self::assertStringContainsString('User-agent: *', $body);
         self::assertStringContainsString('Disallow: /admin', $body);
         self::assertStringContainsString('Sitemap: https://example.test/sitemap.xml', $body);
+    }
+
+    public function testSsrNegotiatesContentLocaleAndEmitsHreflang(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10?lang=de'),
+        );
+        $html = (string) $response->getBody();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('<html lang="de">', $html);
+        self::assertStringContainsString('Hallo Welt', $html); // German title row served
+        self::assertStringNotContainsString('<h1>Hello world</h1>', $html); // base title not used
+        // Self-referencing canonical + hreflang alternates.
+        self::assertStringContainsString(
+            '<link rel="canonical" href="https://example.test/article/10?lang=de" />',
+            $html,
+        );
+        self::assertStringContainsString('hreflang="de"', $html);
+        self::assertStringContainsString('hreflang="x-default"', $html);
+    }
+
+    public function testSsrFallsBackToBaseLocaleWithoutLangParam(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        );
+        $html = (string) $response->getBody();
+
+        self::assertStringContainsString('<html lang="ja">', $html); // default lang
+        self::assertStringContainsString('<h1>Hello world</h1>', $html); // base (null-locale) title
+        self::assertStringNotContainsString('Hallo Welt', $html);
+        // hreflang alternates are advertised even on the base page.
+        self::assertStringContainsString('hreflang="de"', $html);
     }
 
     public function testRealPermalinkReturns404ForUnknownId(): void


### PR DESCRIPTION
## 目的
管理画面は6言語だが**公開コンテンツは単一言語**だった（#540）。S1 として、公開 detail を `?lang=` でロケール交渉し、クローラブル SSR に正しい `<html lang>` ＋ hreflang を出力する（SEO 中核・代理店/報道/デザイナーの採用条件）。ロケール経路はクエリ `?lang=de` 方式（合意済）。

## 変更
- **`PublicLocale`** — 対応ロケール allowlist（en/ja/fr/zh-Hans/pt-BR/de）＋ `resolve()`（未対応/空→null）。
- **`GetPublicRecordViewInput` に `locale`** ／ **`GetPublicRecordViewUseCase`** が text_fields を**フィールドキーごとに交渉ロケールへ解決**（要求ロケール → null(基底) → 先頭でフォールバック）。SSR displayFields・SPA bootstrap・pageTitle が同一ロケールで一貫 ＝ **ハイドレーション無矛盾**。
- **SSR `RenderPublicRecordViewHandler`** — `?lang` 読取り、canonical を `?lang` 付き自己参照に、`<html lang>` を交渉ロケールに、**hreflang alternates（全6＋x-default）** を head に出力。
- **JSON `GetPublicRecordViewHandler`** — `?lang` 読取り（クライアント遷移 fetch 用に API が対応）。
- **`record-detail.php`** — `<html lang>` 動的化 ＋ alternate リンク。

## 検証
- `composer check` 緑（PHPUnit / PHPStan level 8 0 errors / CS-Fixer / OpenAPI / MCP）。
- テスト：`PublicLocale.resolve`／`/article/10?lang=de` → `<html lang="de">`・`Hallo Welt`・canonical `?lang=de`・hreflang(de/x-default)／lang 無し → 基底（ja・`Hello world`）＋hreflang。

## 設計判断 / スコープ
- フォールバックは locale → null(基底) → 先頭。`<html lang>` の既定は従来どおり `ja`（サイト既定ロケール設定は将来課題）。
- **本 PR は S1（SEO 中核・サーバ側）**。残（S2）＝公開の言語スイッチャ UI ＋ クライアント遷移時の `?lang` 引継ぎ ＋ アーカイブ/一覧のロケール交渉。
- bootstrap をサーバ側で解決するため**フロント変更不要**（SSR↔ハイドレーション一貫）。

Part of #540 / Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)