### PR TITLE
feat(public-i18n): 公開の言語スイッチャ＋一覧のロケール解決 (#540 S2)

### DIFF
--- a/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.ts
+++ b/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { defaultEntityListParams, useEntityList } from '@/entities/entity'
 import { useEntityTypeList } from '@/entities/entity-type'
 import { defaultTextFieldListParamsForEntityType, useTextFieldList } from '@/entities/text-field'
+import { useTranslation } from '@/shared/i18n'
 import { findEntityTypeBySlug } from '@/shared/lib/find-entity-type-by-slug'
 import { formatPublishedDate } from '@/shared/lib/format-published-date'
 import { getRecordDisplayLabel } from '@/shared/lib/get-record-display-label'
@@ -25,6 +26,7 @@ export interface PublicBrowseType {
 }
 
 export function usePublicBrowseEntityRecordsPage(entityTypeSlug: string, offset: number) {
+  const { locale } = useTranslation()
   const entityTypeQuery = useEntityTypeList()
   const entityType = useMemo(
     () => findEntityTypeBySlug(entityTypeQuery.data?.items ?? [], entityTypeSlug),
@@ -55,7 +57,7 @@ export function usePublicBrowseEntityRecordsPage(entityTypeSlug: string, offset:
       const id = Number(entity.id)
       return {
         id,
-        label: getRecordDisplayLabel(id, textFields, `Record #${String(id)}`),
+        label: getRecordDisplayLabel(id, textFields, `Record #${String(id)}`, locale),
         publicUrl: resolvePermalink(pattern, {
           typeSlug: entityTypeSlug,
           entitySlug: entity.slug ?? null,
@@ -70,6 +72,7 @@ export function usePublicBrowseEntityRecordsPage(entityTypeSlug: string, offset:
     textFieldQuery.data?.items,
     entityType?.permalinkPattern,
     entityTypeSlug,
+    locale,
   ])
 
   const entityTypes = useMemo(

--- a/frontend/src/features/public-entity-results/ui/PublicEntityResultGroup.tsx
+++ b/frontend/src/features/public-entity-results/ui/PublicEntityResultGroup.tsx
@@ -13,7 +13,7 @@ export interface PublicEntityResultGroupProps {
 
 /** One entity type's results, with titles resolved from its text fields. */
 export function PublicEntityResultGroup({ entityType, entities }: PublicEntityResultGroupProps) {
-  const { t } = useTranslation()
+  const { t, locale } = useTranslation()
   const entityTypeId = Number(entityType.id)
   const textFieldQuery = useTextFieldList(defaultTextFieldListParamsForEntityType(entityTypeId), {
     enabled: entityTypeId > 0,
@@ -46,6 +46,7 @@ export function PublicEntityResultGroup({ entityType, entities }: PublicEntityRe
                       id,
                       textFields,
                       t('public.results.recordFallback', { id }),
+                      locale,
                     )}
                   </Link>
                 </h3>

--- a/frontend/src/features/public-view-entity-record/hooks/use-public-relation-field-display.ts
+++ b/frontend/src/features/public-view-entity-record/hooks/use-public-relation-field-display.ts
@@ -3,6 +3,7 @@ import { defaultEntityListParams, useEntityList } from '@/entities/entity'
 import { useEntityRelationList } from '@/entities/entity-relation'
 import type { RelationFieldDef } from '@/entities/field-def'
 import { defaultTextFieldListParamsForEntityType, useTextFieldList } from '@/entities/text-field'
+import { useTranslation } from '@/shared/i18n'
 import { getRecordDisplayLabel } from '@/shared/lib/get-record-display-label'
 import { resolvePermalink } from '@/shared/lib/resolve-permalink'
 
@@ -18,6 +19,7 @@ export function usePublicRelationFieldDisplay(
   entityTypeSlugById: Record<number, string>,
   entityTypePatternById: Record<number, string | null | undefined>,
 ) {
+  const { locale } = useTranslation()
   const relationQuery = useEntityRelationList(entityId, fieldDef.fieldKey)
 
   // Load text fields for label generation
@@ -52,6 +54,7 @@ export function usePublicRelationFieldDisplay(
           relation.targetEntityId,
           textFields,
           `Record #${String(relation.targetEntityId)}`,
+          locale,
         ),
         href: resolvePermalink(targetPattern, {
           typeSlug: targetSlug,
@@ -68,6 +71,7 @@ export function usePublicRelationFieldDisplay(
     relationQuery.data?.items,
     targetEntityListQuery.data?.items,
     textFieldQuery.data?.items,
+    locale,
   ])
 
   const isLoading =

--- a/frontend/src/features/render-widgets/hooks/use-recent-posts.ts
+++ b/frontend/src/features/render-widgets/hooks/use-recent-posts.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { defaultEntityListParams, useEntityList } from '@/entities/entity'
 import { useEntityTypeList } from '@/entities/entity-type'
 import { defaultTextFieldListParamsForEntityType, useTextFieldList } from '@/entities/text-field'
+import { useTranslation } from '@/shared/i18n'
 import { findEntityTypeBySlug } from '@/shared/lib/find-entity-type-by-slug'
 import { getRecordDisplayLabel } from '@/shared/lib/get-record-display-label'
 import { resolvePermalink } from '@/shared/lib/resolve-permalink'
@@ -18,6 +19,7 @@ export interface RecentPostItem {
 
 /** Recent published records of a type, newest first, resolved to label + URL. */
 export function useRecentPosts(entityTypeSlug: string, limit: number) {
+  const { locale } = useTranslation()
   const entityTypeQuery = useEntityTypeList()
   const entityType = useMemo(
     () => findEntityTypeBySlug(entityTypeQuery.data?.items ?? [], entityTypeSlug),
@@ -55,7 +57,7 @@ export function useRecentPosts(entityTypeSlug: string, limit: number) {
       const id = Number(entity.id)
       return {
         id,
-        label: getRecordDisplayLabel(id, textFields, `Record #${String(id)}`),
+        label: getRecordDisplayLabel(id, textFields, `Record #${String(id)}`, locale),
         publicUrl: resolvePermalink(pattern, {
           typeSlug: entityTypeSlug,
           entitySlug: entity.slug ?? null,
@@ -72,6 +74,7 @@ export function useRecentPosts(entityTypeSlug: string, limit: number) {
     entityType?.permalinkPattern,
     entityTypeSlug,
     limit,
+    locale,
   ])
 
   return {

--- a/frontend/src/pages/consumer/PublicSiteShell.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.tsx
@@ -1,8 +1,9 @@
-import { type ReactNode, useMemo, useRef, useState } from 'react'
-import { Link, useLocation } from 'react-router-dom'
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useLocation, useSearchParams } from 'react-router-dom'
 import { useEntityTypeList } from '@/entities/entity-type'
 import { usePublicWidgets } from '@/entities/widget'
 import { SiteWidgets } from '@/features/render-widgets'
+import { LOCALES, SUPPORTED_LOCALE_IDS, type SupportedLocale, useTranslation } from '@/shared/i18n'
 import { hasCta, hasTopbarContent, safeHref } from '@/shared/lib/header-config'
 import { useHeaderShrink } from '@/shared/lib/motion/use-header-shrink'
 import { useScrollReveal } from '@/shared/lib/motion/use-scroll-reveal'
@@ -73,6 +74,37 @@ function ThemeSwitch({ mode, onMode }: { mode: ThemeMode; onMode: (mode: ThemeMo
         </button>
       ))}
     </div>
+  )
+}
+
+/**
+ * Public language switcher (#540 S2). Sets the i18n locale (UI + locale-resolved
+ * listing titles react instantly) and mirrors the choice to `?lang=` so the URL
+ * is shareable / crawlable and the SSR detail serves that locale on reload.
+ */
+function LanguageSwitch() {
+  const { t, locale, setLocale } = useTranslation()
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  return (
+    <select
+      className="langsw"
+      aria-label={t('public.nav.language')}
+      value={locale}
+      onChange={(event) => {
+        const next = event.target.value as SupportedLocale
+        setLocale(next)
+        const params = new URLSearchParams(searchParams)
+        params.set('lang', next)
+        setSearchParams(params)
+      }}
+    >
+      {SUPPORTED_LOCALE_IDS.map((id) => (
+        <option key={id} value={id}>
+          {LOCALES[id].label}
+        </option>
+      ))}
+    </select>
   )
 }
 
@@ -152,6 +184,21 @@ export function PublicSiteShell({
 }: PublicSiteShellProps) {
   const { mode, resolvedTheme, setMode } = useConsumerTheme(site.activeTheme)
   const [drawerOpen, setDrawerOpen] = useState(false)
+
+  // Adopt a shared/crawled `?lang=` as the UI locale so the page (UI strings +
+  // locale-resolved listing titles) matches the URL the visitor arrived on (#540).
+  const { locale: uiLocale, setLocale: setUiLocale } = useTranslation()
+  const [searchParams] = useSearchParams()
+  const langParam = searchParams.get('lang')
+  useEffect(() => {
+    if (
+      langParam !== null &&
+      SUPPORTED_LOCALE_IDS.includes(langParam as SupportedLocale) &&
+      langParam !== uiLocale
+    ) {
+      setUiLocale(langParam as SupportedLocale)
+    }
+  }, [langParam, uiLocale, setUiLocale])
 
   // Live theme preview (#538 ②): when embedded in the admin customizer's iframe,
   // apply the draft override CSS + flag attrs it posts instead of saved settings.
@@ -246,6 +293,7 @@ export function PublicSiteShell({
             <Link className="iconbtn hd__search" to="/search" aria-label="Search" title="Search">
               <IconSearch size={18} />
             </Link>
+            <LanguageSwitch />
             <ThemeSwitch mode={mode} onMode={setMode} />
             <button
               type="button"
@@ -353,7 +401,8 @@ export function PublicSiteShell({
               {link.label}
             </Link>
           ))}
-          <div style={{ marginTop: 'auto' }}>
+          <div style={{ marginTop: 'auto' }} className="flex flex-col gap-stack-sm">
+            <LanguageSwitch />
             <ThemeSwitch mode={mode} onMode={setMode} />
           </div>
         </div>

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -257,6 +257,20 @@
   border-radius: var(--radius-full);
   background: var(--color-surface-raised);
 }
+/* Public language switcher (#540 S2). */
+.nene-public .langsw {
+  font: inherit;
+  font-size: var(--text-meta);
+  color: var(--color-text-primary);
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  padding: 5px 10px;
+  cursor: pointer;
+}
+.nene-public .langsw:hover {
+  border-color: var(--color-border-strong);
+}
 .nene-public .themesw__btn {
   width: 30px;
   height: 28px;

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -324,6 +324,7 @@ export const de: Partial<MessageCatalog> = {
   // ── Public View i18n (WS-10): browse / home / nav / records / relation ──
   'public.nav.allRecords': 'Alle Datensätze',
   'public.nav.backToLatest': 'Zurück zu den neuesten',
+  'public.nav.language': 'Sprache',
   'public.browse.subRange': '{{total}} Datensätze · zeige {{start}}–{{end}}',
   'public.browse.recordCount.one': '{{count}} Datensatz',
   'public.browse.recordCount.other': '{{count}} Datensätze',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -323,6 +323,7 @@ export const en = {
   // ── Public View i18n (WS-10): browse / home / nav / records / relation ──
   'public.nav.allRecords': 'All records',
   'public.nav.backToLatest': 'Back to latest',
+  'public.nav.language': 'Language',
   'public.browse.subRange': '{{total}} records · showing {{start}}–{{end}}',
   'public.browse.recordCount.one': '{{count}} record',
   'public.browse.recordCount.other': '{{count}} records',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -324,6 +324,7 @@ export const fr: Partial<MessageCatalog> = {
   // ── Public View i18n (WS-10): browse / home / nav / records / relation ──
   'public.nav.allRecords': 'Toutes les fiches',
   'public.nav.backToLatest': 'Retour aux plus récentes',
+  'public.nav.language': 'Langue',
   'public.browse.subRange': '{{total}} fiches · affichage de {{start}} à {{end}}',
   'public.browse.recordCount.one': '{{count}} fiche',
   'public.browse.recordCount.other': '{{count}} fiches',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -315,6 +315,7 @@ export const ja: Partial<MessageCatalog> = {
   // ── Public View i18n (WS-10): browse / home / nav / records / relation ──
   'public.nav.allRecords': 'すべての記事',
   'public.nav.backToLatest': '最新の記事へ戻る',
+  'public.nav.language': '言語',
   'public.browse.subRange': '{{total}} 件 · {{start}}–{{end}} を表示',
   'public.browse.recordCount.one': '{{count}} 件',
   'public.browse.recordCount.other': '{{count}} 件',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -322,6 +322,7 @@ export const ptBR: Partial<MessageCatalog> = {
   // ── Public View i18n (WS-10): browse / home / nav / records / relation ──
   'public.nav.allRecords': 'Todos os registros',
   'public.nav.backToLatest': 'Voltar aos mais recentes',
+  'public.nav.language': 'Idioma',
   'public.browse.subRange': '{{total}} registros · exibindo {{start}}–{{end}}',
   'public.browse.recordCount.one': '{{count}} registro',
   'public.browse.recordCount.other': '{{count}} registros',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -307,6 +307,7 @@ export const zhHans: Partial<MessageCatalog> = {
   // ── Public View i18n (WS-10): browse / home / nav / records / relation ──
   'public.nav.allRecords': '所有记录',
   'public.nav.backToLatest': '返回最新',
+  'public.nav.language': '语言',
   'public.browse.subRange': '共 {{total}} 条记录 · 显示 {{start}}–{{end}}',
   'public.browse.recordCount.one': '{{count}} 条记录',
   'public.browse.recordCount.other': '{{count}} 条记录',

--- a/frontend/src/shared/lib/get-record-display-label.test.ts
+++ b/frontend/src/shared/lib/get-record-display-label.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { type TextField, toTextFieldId } from '@/entities/text-field'
+import { getRecordDisplayLabel } from './get-record-display-label'
+
+let nextId = 1
+const tf = (
+  entityId: number,
+  fieldKey: string,
+  value: string,
+  locale: string | null = null,
+): TextField => ({
+  id: toTextFieldId(nextId++),
+  entityId,
+  fieldKey,
+  value,
+  locale,
+})
+
+describe('getRecordDisplayLabel', () => {
+  it('returns the title field, else the first non-empty field, else the fallback', () => {
+    expect(getRecordDisplayLabel(1, [tf(1, 'title', 'Hello')], 'fb')).toBe('Hello')
+    expect(getRecordDisplayLabel(1, [tf(1, 'body', 'Body only')], 'fb')).toBe('Body only')
+    expect(getRecordDisplayLabel(1, [], 'fb')).toBe('fb')
+    expect(getRecordDisplayLabel(1, [tf(1, 'title', '   ')], 'fb')).toBe('fb')
+  })
+
+  it('ignores other entities', () => {
+    expect(getRecordDisplayLabel(1, [tf(2, 'title', 'Other')], 'fb')).toBe('fb')
+  })
+
+  describe('with a requested locale', () => {
+    const fields = [
+      tf(1, 'title', 'Hello', null),
+      tf(1, 'title', 'Hallo', 'de'),
+      tf(1, 'title', 'Bonjour', 'fr'),
+    ]
+
+    it('prefers the requested locale', () => {
+      expect(getRecordDisplayLabel(1, fields, 'fb', 'de')).toBe('Hallo')
+      expect(getRecordDisplayLabel(1, fields, 'fb', 'fr')).toBe('Bonjour')
+    })
+
+    it('falls back to the locale-agnostic (null) row when the locale is missing', () => {
+      expect(getRecordDisplayLabel(1, fields, 'fb', 'zh-Hans')).toBe('Hello')
+    })
+
+    it('falls back to the first available when there is no null row either', () => {
+      const noBase = [tf(1, 'title', 'Hallo', 'de'), tf(1, 'title', 'Bonjour', 'fr')]
+      expect(getRecordDisplayLabel(1, noBase, 'fb', 'zh-Hans')).toBe('Hallo')
+    })
+
+    it('without a locale keeps the original first-match behavior', () => {
+      // No locale arg → first matching title row, regardless of locale tags.
+      expect(getRecordDisplayLabel(1, fields, 'fb')).toBe('Hello')
+    })
+  })
+})

--- a/frontend/src/shared/lib/get-record-display-label.ts
+++ b/frontend/src/shared/lib/get-record-display-label.ts
@@ -1,20 +1,46 @@
 import type { TextField } from '@/entities/text-field'
 
+/**
+ * Resolve a record's display label from its text fields: the `title` field if
+ * present, else the first non-empty field, else the fallback.
+ *
+ * When `locale` is given (public i18n, #540) each step prefers that locale, then
+ * the locale-agnostic (null) row, then the first — so listings show titles in the
+ * visitor's language and fall back gracefully. With no `locale` the behavior is
+ * unchanged (first match), so admin callers are unaffected.
+ */
 export function getRecordDisplayLabel(
   entityId: number,
   textFields: TextField[],
   fallback: string,
+  locale: string | null = null,
 ): string {
-  const forEntity = textFields.filter((item) => item.entityId === entityId)
+  const forEntity = textFields.filter(
+    (item) => item.entityId === entityId && item.value.trim() !== '',
+  )
 
-  const titleField = forEntity.find((item) => item.fieldKey === 'title')
-  if (titleField !== undefined && titleField.value.trim() !== '') {
-    return titleField.value.trim()
+  const pick = (candidates: TextField[]): TextField | undefined => {
+    if (candidates.length === 0) {
+      return undefined
+    }
+    if (locale !== null) {
+      return (
+        candidates.find((c) => c.locale === locale) ??
+        candidates.find((c) => c.locale === null) ??
+        candidates[0]
+      )
+    }
+    return candidates[0]
   }
 
-  const firstWithValue = forEntity.find((item) => item.value.trim() !== '')
-  if (firstWithValue !== undefined) {
-    return firstWithValue.value.trim()
+  const title = pick(forEntity.filter((item) => item.fieldKey === 'title'))
+  if (title !== undefined) {
+    return title.value.trim()
+  }
+
+  const first = pick(forEntity)
+  if (first !== undefined) {
+    return first.value.trim()
   }
 
   return fallback


### PR DESCRIPTION
## 目的
S1（サーバ側ロケール交渉＋`<html lang>`＋hreflang）に続く **S2**。公開サイトに**言語スイッチャ**を置き、**一覧/アーカイブのタイトル**を来訪者の言語で解決する。これで **#540 完了**。

## 変更
- **`PublicSiteShell`** — ヘッダ（デスクトップ＋モバイルドロワー）に `LanguageSwitch`。選択で i18n ロケール設定＋`?lang=` を URL に反映。逆に共有/クロールされた `?lang=` を読み取り i18n へ同期（UI＋一覧が URL と一致）。
- **`getRecordDisplayLabel(…, locale?)`** — locale 指定時は「そのロケール → null(基底) → 先頭」でタイトル解決。locale 無しは従来どおり（**管理側は不変**）。
- **公開一覧フック**（browse / recent-posts / search・tag・archive 結果 / relation）が現在の i18n ロケールを渡し、タイトルを言語別解決（**クライアント側・追加 API なし**：一覧は既に全ロケールの text_fields を取得済）。
- **i18n** `public.nav.language`（全6ロケール）＋ `.langsw` スタイル。

## 検証
- `npm run check` 緑（type-check / lint / prettier / test / **locales 完全性** / knip / storybook）。
- テスト：`getRecordDisplayLabel` のロケール解決（locale→null(基底)→先頭・他エンティティ除外・locale 無しは原挙動）。

## スコープ / 既知
- **内容ロケール＝i18n ロケール**（localStorage 永続）＝クライアント遷移でも UI/一覧で保持。`?lang=` は共有/SSR 用に URL へも反映。
- detail 本文はサーバ側（S1）で配信。ページ内で言語切替した瞬間の本文再翻訳は**リロード/遷移時に反映**（detail は bootstrap 合成のため即時再取得は軽微な follow-up）。

Closes #540 / Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)