### PR TITLE
feat(deploy): サブディレクトリ設置の base path 基盤(バックエンド) (base-path S1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,10 @@ DB_CHARSET=utf8mb4
 # tenant_org_slug (which migrations seed empty). It MUST match the install org slug
 # (app:install default "default"); otherwise org-scoped requests are org-not-resolved 404.
 # ORG_SLUG=default
+
+# --- Sub-directory install (serve from a path like https://example.com/blog/) ---
+# Public URL generation (canonical / permalink / og:url / sitemap / robots /
+# redirects / SSR asset URLs) is prefixed with this. Routing stays root-relative,
+# so the web server must strip the prefix (Caddy `handle_path` / Apache rewrite).
+# Empty (default) = served at the domain root. Leading slash, no trailing slash.
+# APP_BASE_PATH=/blog

--- a/src/Http/BasePath.php
+++ b/src/Http/BasePath.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Http;
+
+/**
+ * Public base path support (#540-adjacent / zip-install foundation): lets the
+ * app be served from a sub-directory (e.g. `https://example.com/blog/`) like
+ * WordPress, set explicitly via the `APP_BASE_PATH` env var.
+ *
+ * Only URL *generation* is base-aware (canonical / permalink / og:url / sitemap /
+ * redirect / asset URLs); request routing stays root-relative because the web
+ * server strips the prefix (Caddy `handle_path` / Apache rewrite). Default `''`
+ * = root, so the whole thing is a no-op until configured.
+ */
+final class BasePath
+{
+    private function __construct()
+    {
+    }
+
+    /** The configured base path from `APP_BASE_PATH`, normalized. */
+    public static function fromEnv(): string
+    {
+        $raw = getenv('APP_BASE_PATH');
+
+        return self::normalize($raw === false ? null : $raw);
+    }
+
+    /** Normalize to `''` (root) or `/segment` (leading slash, no trailing slash). */
+    public static function normalize(?string $raw): string
+    {
+        $trimmed = trim((string) $raw);
+        $trimmed = trim($trimmed, '/');
+
+        return $trimmed === '' ? '' : '/' . $trimmed;
+    }
+
+    /**
+     * Prefix a root-relative path (starting with `/`) with the base. A base of
+     * `''` returns the path unchanged; the site root `/` becomes `{base}/`.
+     */
+    public static function prefix(string $base, string $path): string
+    {
+        if ($base === '') {
+            return $path;
+        }
+
+        return $path === '/' ? $base . '/' : $base . $path;
+    }
+}

--- a/src/PublicRecord/PublicRecordServiceProvider.php
+++ b/src/PublicRecord/PublicRecordServiceProvider.php
@@ -198,6 +198,7 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                         $projectRoot,
                         $responseFactory,
                         new PublicHtmlSanitizer(),
+                        \NeNeRecords\Http\BasePath::fromEnv(),
                     );
                 },
             )
@@ -278,7 +279,13 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                         throw new LogicException('Stream factory service is invalid.');
                     }
 
-                    return new RenderSitemapHandler($useCase, $responseFactory, $streamFactory);
+                    return new RenderSitemapHandler(
+                        $useCase,
+                        $responseFactory,
+                        $streamFactory,
+                        null,
+                        \NeNeRecords\Http\BasePath::fromEnv(),
+                    );
                 },
             )
             ->set(
@@ -295,7 +302,11 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                         throw new LogicException('Stream factory service is invalid.');
                     }
 
-                    return new RenderRobotsHandler($responseFactory, $streamFactory);
+                    return new RenderRobotsHandler(
+                        $responseFactory,
+                        $streamFactory,
+                        \NeNeRecords\Http\BasePath::fromEnv(),
+                    );
                 },
             )
             ->set(

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -8,6 +8,7 @@ use Nene2\Config\AppConfig;
 use Nene2\Routing\Router;
 use Nene2\View\HtmlResponseFactory;
 use NeNeRecords\BundleField\BundleDocumentValidator;
+use NeNeRecords\Http\BasePath;
 use NeNeRecords\Http\PublicHtmlCsp;
 use NeNeRecords\Http\WebAnalyticsConfig;
 use NeNeRecords\Http\WebAnalyticsHeadSnippet;
@@ -26,6 +27,8 @@ final readonly class RenderPublicRecordViewHandler
         private string $projectRoot,
         private ResponseFactoryInterface $responseFactory,
         private PublicHtmlSanitizer $htmlSanitizer,
+        /** Sub-directory install prefix (`APP_BASE_PATH`); '' = served at root. */
+        private string $basePath = '',
     ) {
     }
 
@@ -50,7 +53,8 @@ final readonly class RenderPublicRecordViewHandler
         // Resolve to the canonical permalink (also 404s via the use case if missing).
         $output = $this->useCase->execute(new GetPublicRecordViewInput($typeSlug, $entitySlug));
         $uri = $request->getUri();
-        $location = $uri->getScheme() . '://' . $uri->getAuthority() . $output->canonicalPath;
+        $location = $uri->getScheme() . '://' . $uri->getAuthority()
+            . BasePath::prefix($this->basePath, $output->canonicalPath);
 
         return $this->responseFactory->createResponse(301)->withHeader('Location', $location);
     }
@@ -85,7 +89,7 @@ final readonly class RenderPublicRecordViewHandler
         // hreflang alternates advertise every locale variant (#540).
         $uri = $request->getUri();
         $baseUrl = $uri->getScheme() . '://' . $uri->getAuthority();
-        $permalinkUrl = $baseUrl . $output->canonicalPath;
+        $permalinkUrl = $baseUrl . BasePath::prefix($this->basePath, $output->canonicalPath);
         $canonicalUrl = $locale !== null ? $permalinkUrl . '?lang=' . $locale : $permalinkUrl;
         $htmlLang = $locale ?? PublicLocale::DEFAULT_LANG;
         $alternateLinks = [['hreflang' => 'x-default', 'href' => $permalinkUrl]];
@@ -98,7 +102,7 @@ final readonly class RenderPublicRecordViewHandler
         if ($output->ogImagePath !== null) {
             $ogImageUrl = str_starts_with($output->ogImagePath, 'http')
                 ? $output->ogImagePath
-                : $baseUrl . $output->ogImagePath;
+                : $baseUrl . BasePath::prefix($this->basePath, $output->ogImagePath);
         }
 
         // Prefer the per-entity meta description, falling back to the site default.
@@ -148,6 +152,7 @@ final readonly class RenderPublicRecordViewHandler
             'analyticsHead' => $analyticsHead,
             'htmlLang' => $htmlLang,
             'alternateLinks' => $alternateLinks,
+            'basePath' => $this->basePath,
             'canonicalUrl' => $canonicalUrl,
             'ogImageUrl' => $ogImageUrl,
             'publishedAtIso' => $output->publishedAtIso,

--- a/src/PublicRecord/RenderRobotsHandler.php
+++ b/src/PublicRecord/RenderRobotsHandler.php
@@ -18,15 +18,17 @@ final readonly class RenderRobotsHandler
     public function __construct(
         private ResponseFactoryInterface $responseFactory,
         private StreamFactoryInterface $streamFactory,
+        /** Sub-directory install prefix (`APP_BASE_PATH`); '' = served at root. */
+        private string $basePath = '',
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $uri = $request->getUri();
-        $sitemapUrl = $uri->getScheme() . '://' . $uri->getAuthority() . '/sitemap.xml';
+        $sitemapUrl = $uri->getScheme() . '://' . $uri->getAuthority() . $this->basePath . '/sitemap.xml';
 
-        $body = RobotsTxtRenderer::render($sitemapUrl);
+        $body = RobotsTxtRenderer::render($sitemapUrl, $this->basePath);
 
         return $this->responseFactory->createResponse(200)
             ->withHeader('Content-Type', 'text/plain; charset=UTF-8')

--- a/src/PublicRecord/RenderSitemapHandler.php
+++ b/src/PublicRecord/RenderSitemapHandler.php
@@ -31,6 +31,8 @@ final readonly class RenderSitemapHandler
         private ResponseFactoryInterface $responseFactory,
         private StreamFactoryInterface $streamFactory,
         ?int $chunkSize = null,
+        /** Sub-directory install prefix (`APP_BASE_PATH`); '' = served at root. */
+        private string $basePath = '',
     ) {
         $this->chunkSize = $chunkSize !== null && $chunkSize > 0 ? $chunkSize : self::DEFAULT_CHUNK_SIZE;
     }
@@ -38,7 +40,9 @@ final readonly class RenderSitemapHandler
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $uri = $request->getUri();
-        $baseUrl = $uri->getScheme() . '://' . $uri->getAuthority();
+        // The renderer joins paths onto this; folding the base path in keeps every
+        // <loc> / child-sitemap URL under the sub-directory install (#zip-install).
+        $baseUrl = $uri->getScheme() . '://' . $uri->getAuthority() . $this->basePath;
 
         // Global list = home page (1) + every published record.
         $totalUrls = 1 + $this->useCase->count();

--- a/src/PublicRecord/RobotsTxtRenderer.php
+++ b/src/PublicRecord/RobotsTxtRenderer.php
@@ -21,12 +21,12 @@ final class RobotsTxtRenderer
     {
     }
 
-    public static function render(string $sitemapUrl): string
+    public static function render(string $sitemapUrl, string $basePath = ''): string
     {
         $lines = ['User-agent: *'];
 
         foreach (self::DISALLOW as $path) {
-            $lines[] = 'Disallow: ' . $path;
+            $lines[] = 'Disallow: ' . $basePath . $path;
         }
 
         $lines[] = '';

--- a/src/UrlRedirect/UrlRedirectResolver.php
+++ b/src/UrlRedirect/UrlRedirectResolver.php
@@ -24,6 +24,8 @@ final readonly class UrlRedirectResolver
     public function __construct(
         private UrlRedirectRepositoryInterface $redirects,
         private ResponseFactoryInterface $responseFactory,
+        /** Sub-directory install prefix (`APP_BASE_PATH`); '' = served at root. */
+        private string $basePath = '',
     ) {
     }
 
@@ -61,7 +63,9 @@ final readonly class UrlRedirectResolver
             return $response;
         }
 
-        return $this->responseFactory->createResponse(301)->withHeader('Location', $target);
+        $location = $this->basePath === '' ? $target : $this->basePath . $target;
+
+        return $this->responseFactory->createResponse(301)->withHeader('Location', $location);
     }
 
     /** Strip a single trailing slash so "/a/b/" and "/a/b" map to one source. */

--- a/src/UrlRedirect/UrlRedirectServiceProvider.php
+++ b/src/UrlRedirect/UrlRedirectServiceProvider.php
@@ -48,7 +48,11 @@ final readonly class UrlRedirectServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Response factory service is invalid.');
                     }
 
-                    return new UrlRedirectResolver($redirects, $responseFactory);
+                    return new UrlRedirectResolver(
+                        $redirects,
+                        $responseFactory,
+                        \NeNeRecords\Http\BasePath::fromEnv(),
+                    );
                 },
             );
     }

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -69,7 +69,7 @@
     </style>
     <?php if ($spaMode === 'prod'): ?>
       <?php foreach ($spaCss as $href): ?>
-      <link rel="stylesheet" crossorigin href="<?= $e($href) ?>" />
+      <link rel="stylesheet" crossorigin href="<?= $e($basePath . $href) ?>" />
       <?php endforeach; ?>
     <?php elseif ($spaMode === 'dev'): ?>
       <script type="module" src="<?= $e($viteUrl) ?>/@vite/client"></script>
@@ -80,7 +80,7 @@
          (createRoot().render) replaces it with the interactive app on mount. -->
     <div id="root">
     <header>
-      <p><a href="/view/<?= $e($entityTypeSlug) ?>">← <?= $e($entityTypeName) ?></a></p>
+      <p><a href="<?= $e($basePath) ?>/view/<?= $e($entityTypeSlug) ?>">← <?= $e($entityTypeName) ?></a></p>
       <h1><?= $e($pageTitle) ?></h1>
     </header>
     <article>
@@ -93,7 +93,7 @@
             <?php else: ?>
               <ul>
                 <?php foreach ($field->relationLinks as $link): ?>
-                  <li><a href="<?= $e($link['href']) ?>"><?= $e($link['label']) ?></a></li>
+                  <li><a href="<?= $e($basePath . $link['href']) ?>"><?= $e($link['label']) ?></a></li>
                 <?php endforeach; ?>
               </ul>
             <?php endif; ?>
@@ -129,9 +129,9 @@
       <script type="module" src="<?= $e($viteUrl) ?>/src/main.tsx"></script>
     <?php elseif ($spaMode === 'prod' && $spaJs !== null): ?>
       <?php foreach ($spaPreload as $href): ?>
-      <link rel="modulepreload" crossorigin href="<?= $e($href) ?>" />
+      <link rel="modulepreload" crossorigin href="<?= $e($basePath . $href) ?>" />
       <?php endforeach; ?>
-      <script type="module" crossorigin src="<?= $e($spaJs) ?>"></script>
+      <script type="module" crossorigin src="<?= $e($basePath . $spaJs) ?>"></script>
     <?php endif; ?>
   </body>
 </html>

--- a/tests/Http/BasePathTest.php
+++ b/tests/Http/BasePathTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Http;
+
+use NeNeRecords\Http\BasePath;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class BasePathTest extends TestCase
+{
+    /** @return iterable<string, array{?string, string}> */
+    public static function normalizeCases(): iterable
+    {
+        yield 'null is root' => [null, ''];
+        yield 'empty is root' => ['', ''];
+        yield 'slash is root' => ['/', ''];
+        yield 'leading slash kept' => ['/blog', '/blog'];
+        yield 'bare segment gets slash' => ['blog', '/blog'];
+        yield 'trailing slash stripped' => ['/blog/', '/blog'];
+        yield 'both slashes' => ['blog/', '/blog'];
+        yield 'nested' => ['/a/b', '/a/b'];
+        yield 'whitespace trimmed' => ['  /blog  ', '/blog'];
+    }
+
+    #[DataProvider('normalizeCases')]
+    public function testNormalize(?string $raw, string $expected): void
+    {
+        self::assertSame($expected, BasePath::normalize($raw));
+    }
+
+    public function testPrefixIsNoOpAtRoot(): void
+    {
+        self::assertSame('/posts/1', BasePath::prefix('', '/posts/1'));
+        self::assertSame('/', BasePath::prefix('', '/'));
+    }
+
+    public function testPrefixUnderSubdirectory(): void
+    {
+        self::assertSame('/blog/posts/1', BasePath::prefix('/blog', '/posts/1'));
+        self::assertSame('/blog/assets/x.js', BasePath::prefix('/blog', '/assets/x.js'));
+        self::assertSame('/blog/', BasePath::prefix('/blog', '/')); // site root
+    }
+
+    public function testFromEnvReadsAndNormalizes(): void
+    {
+        putenv('APP_BASE_PATH=/blog/');
+        try {
+            self::assertSame('/blog', BasePath::fromEnv());
+        } finally {
+            putenv('APP_BASE_PATH');
+        }
+
+        self::assertSame('', BasePath::fromEnv()); // unset → root
+    }
+}

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -62,8 +62,12 @@ final class PublicRecordHttpTest extends TestCase
     }
 
     /** @param list<\NeNeRecords\Setting\SettingDef> $settingDefs */
-    private function buildApplication(bool $debug, string $projectRoot, array $settingDefs = []): RequestHandlerInterface
-    {
+    private function buildApplication(
+        bool $debug,
+        string $projectRoot,
+        array $settingDefs = [],
+        string $basePath = '',
+    ): RequestHandlerInterface {
         $entityTypes = new InMemoryEntityTypeRepository([
             new EntityType(name: 'Article', slug: 'article', id: 1),
         ]);
@@ -135,7 +139,7 @@ final class PublicRecordHttpTest extends TestCase
             machineApiKey: null,
         );
 
-        $renderHandler = new RenderPublicRecordViewHandler($useCase, $publicSettings, $htmlResponse, $config, $projectRoot, $this->factory, new PublicHtmlSanitizer());
+        $renderHandler = new RenderPublicRecordViewHandler($useCase, $publicSettings, $htmlResponse, $config, $projectRoot, $this->factory, new PublicHtmlSanitizer(), $basePath);
         $registrar = new PublicRecordRouteRegistrar(
             new GetPublicRecordViewHandler($useCase, $jsonResponse, $this->factory),
             $renderHandler,
@@ -144,8 +148,10 @@ final class PublicRecordHttpTest extends TestCase
                 new GenerateSitemapUseCase($entityTypes, $entities),
                 $this->factory,
                 $this->factory,
+                null,
+                $basePath,
             ),
-            new RenderRobotsHandler($this->factory, $this->factory),
+            new RenderRobotsHandler($this->factory, $this->factory, $basePath),
         );
 
         return (new RuntimeApplicationFactory(
@@ -353,6 +359,43 @@ final class PublicRecordHttpTest extends TestCase
         self::assertStringContainsString('<loc>https://example.test/article/10</loc>', $xml);
         // updatedAt → lastmod (W3C datetime).
         self::assertStringContainsString('<lastmod>2026-02-20', $xml);
+    }
+
+    public function testBasePathPrefixesPublicUrls(): void
+    {
+        // App served from a sub-directory (APP_BASE_PATH=/blog).
+        $app = $this->buildApplication(true, $this->projectRoot, [], '/blog');
+
+        $detail = (string) $app->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        )->getBody();
+        self::assertStringContainsString(
+            '<link rel="canonical" href="https://example.test/blog/article/10" />',
+            $detail,
+        );
+        self::assertStringContainsString('hreflang="de" href="https://example.test/blog/article/10?lang=de"', $detail);
+        self::assertStringContainsString('href="/blog/view/article"', $detail); // back link prefixed
+
+        // /view/ → 301 to the base-prefixed canonical.
+        $redirect = $app->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/view/article/hello-world'),
+        );
+        self::assertSame(301, $redirect->getStatusCode());
+        self::assertSame('https://example.test/blog/article/10', $redirect->getHeaderLine('Location'));
+
+        // Sitemap <loc> under the sub-directory.
+        $sitemap = (string) $app->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/sitemap.xml'),
+        )->getBody();
+        self::assertStringContainsString('<loc>https://example.test/blog/article/10</loc>', $sitemap);
+        self::assertStringContainsString('<loc>https://example.test/blog/</loc>', $sitemap);
+
+        // robots.txt Disallow + Sitemap pointer under the sub-directory.
+        $robots = (string) $app->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/robots.txt'),
+        )->getBody();
+        self::assertStringContainsString('Disallow: /blog/admin', $robots);
+        self::assertStringContainsString('Sitemap: https://example.test/blog/sitemap.xml', $robots);
     }
 
     public function testRobotsTxtServesDirectivesAndSitemapPointer(): void


### PR DESCRIPTION
## 目的
WordPress のように**任意のサブディレクトリ**（例 `example.com/blog/`）へ設置できるよう、公開 URL 生成を `APP_BASE_PATH` で前置可能にする基盤の **S1（バックエンド）**。共有レンタルサーバ向けの **zip インストーラ**（非技術者の自前ホスト入口）の前提。**既定 `''` ＝ルート＝完全に挙動不変。**

## 設計判断
- **ランタイム base（明示設定）**: `APP_BASE_PATH` env を `BasePath::fromEnv()` で正規化（`/blog`）。設置ディレクトリが**実行時**に決まる zip 設置に合わせ、ビルド時 Vite base ではなくランタイムで決める。
- **URL 生成だけ base-aware**。ルーティング（入力）は root-relative のまま＝**Web サーバが prefix を strip**（Caddy `handle_path` / Apache rewrite。S3 で文書化）＝ルート改修の回帰リスクをゼロに。

## 変更（前置した公開 URL）
- **SSR `record-detail.php`**: canonical / og:url / og:image / hreflang / 戻りリンク / relation リンク / prod アセット（css/js/preload）。
- **`RenderPublicRecordViewHandler`**: `/view/`→canonical の 301。
- **`RenderSitemapHandler`**: `<loc>` ＋ インデックス子（`?page=N`）。
- **`RobotsTxtRenderer` / `RenderRobotsHandler`**: Disallow パス ＋ `Sitemap:` URL。
- **`UrlRedirectResolver`**: 旧URL→新permalink の 301 Location。
- 各サービスプロバイダが `BasePath::fromEnv()` を注入（ハンドラの基底引数は**既定 `''`** ＝既存テスト無変更）。
- `.env.example` に `APP_BASE_PATH` を文書化。

## 検証
- `composer check` 緑（PHPUnit / PHPStan level 8 0 errors / CS-Fixer / OpenAPI / MCP）。
- テスト：`BasePath`（normalize / prefix / fromEnv）＋ http 統合（`APP_BASE_PATH=/blog` で canonical・hreflang・戻りリンク・/view 301・sitemap `<loc>`・robots Disallow/Sitemap が `/blog` 前置）。既定 `''` で全既存テスト不変。

## スコープ
- 本 PR ＝ **S1（バックエンド URL 生成）**。残：
  - **S2** フロント（ランタイム base 注入＋react-router `basename`＋API base＋Vite 相対アセット）
  - **S3** Web サーバ設定（Caddy/Apache の prefix strip）＋ zip パッケージング

Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)