### PR TITLE
feat(deploy): サブディレクトリ設置の base path 基盤(フロント・ランタイム) (base-path S2)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,11 +2,15 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml" />
-    <link rel="icon" href="/assets/favicon/favicon-32.png" sizes="32x32" />
-    <link rel="icon" href="/assets/favicon/favicon-16.png" sizes="16x16" />
-    <link rel="apple-touch-icon" href="/assets/favicon/apple-touch-icon.png" />
-    <link rel="manifest" href="/assets/favicon/site.webmanifest" />
+    <!-- Anchors all relative URLs (assets) to the install dir. Served at root in
+         dev; the prod SPA-shell rewrites this to the configured base path so the
+         app works from a sub-directory (#zip-install S2). -->
+    <base href="/" />
+    <link rel="icon" href="assets/favicon/favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href="assets/favicon/favicon-32.png" sizes="32x32" />
+    <link rel="icon" href="assets/favicon/favicon-16.png" sizes="16x16" />
+    <link rel="apple-touch-icon" href="assets/favicon/apple-touch-icon.png" />
+    <link rel="manifest" href="assets/favicon/site.webmanifest" />
     <meta name="theme-color" content="#C77DFF" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NeNe Records Admin</title>

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, type ComponentType } from 'react'
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
+import { getBasePath } from '@/shared/lib/base-path'
 // Eager: route frame + entry/error pages (needed immediately; the shells render
 // the Suspense fallback while a lazy content page chunk loads).
 import { PublicShell } from '@/pages/consumer/PublicShell'
@@ -59,96 +60,101 @@ function SuperadminGuard() {
   )
 }
 
-const router = createBrowserRouter([
-  {
-    path: '/login',
-    element: <LoginPage />,
-  },
-  {
-    path: '/admin/accept-invite',
-    element: <AcceptInvitePage />,
-  },
-  {
-    path: '/admin/reset-password',
-    element: <ResetPasswordPage />,
-  },
-  {
-    path: '/admin/verify-email',
-    element: <VerifyEmailPage />,
-  },
-  {
-    path: '/forbidden',
-    element: (
-      <RequireAuth>
-        <ForbiddenPage />
-      </RequireAuth>
-    ),
-  },
-  {
-    path: '/admin',
-    element: <AdminShell />,
-    errorElement: <NotFoundPage />,
-    children: [
-      { index: true, element: <HomePage /> },
-      { path: 'entity-types', element: <EntityTypesPage /> },
-      { path: 'tags', element: <TagsPage /> },
-      { path: 'comments', element: <CommentsPage /> },
-      // Appearance › Layout builder (tabs: layout / menus). Old routes redirect.
-      { path: 'appearance', element: <Navigate to="/admin/appearance/layout" replace /> },
-      { path: 'appearance/:tab', element: <AppearanceLayoutPage /> },
-      { path: 'navigation', element: <Navigate to="/admin/appearance/menus" replace /> },
-      { path: 'widgets', element: <Navigate to="/admin/appearance/layout" replace /> },
-      { path: 'media', element: <MediaPage /> },
-      { path: 'webhooks', element: <WebhooksPage /> },
-      { path: 'notifications', element: <NotificationChannelsPage /> },
-      { path: 'settings', element: <SiteSettingsPage /> },
-      { path: 'import', element: <ImportPage /> },
-      { path: 'users', element: <UsersPage /> },
-      { path: 'users/:id', element: <UserEditPage /> },
-      { path: 'entity-types/:entityTypeSlug/fields', element: <FieldDefsPage /> },
-      // Legacy long-form routes kept for schema management links
-      { path: 'entity-types/:entityTypeSlug/entities', element: <EntityRecordsPage /> },
-      { path: 'entity-types/:entityTypeSlug/entities/:entityId', element: <EntityRecordPage /> },
-      // Short-form catch-all: /admin/:slug and /admin/:slug/:entityId
-      // Must be last — specific routes above take priority
-      { path: ':entityTypeSlug', element: <EntityRecordsPage /> },
-      { path: ':entityTypeSlug/:entityId', element: <EntityRecordPage /> },
-    ],
-  },
-  {
-    path: '/superadmin',
-    element: <SuperadminGuard />,
-    errorElement: <NotFoundPage />,
-    children: [
-      { index: true, element: <OrganizationsPage /> },
-      { path: 'organizations', element: <OrganizationsPage /> },
-      { path: 'organizations/:id', element: <OrganizationDetailPage /> },
-      { path: 'data-migration', element: <DataMigrationPage /> },
-      { path: 'settings', element: <SettingsPage /> },
-    ],
-  },
-  {
-    path: '/',
-    element: <PublicShell />,
-    errorElement: <NotFoundPage />,
-    children: [
-      { index: true, element: <PublicIndexPage /> },
-      // Static routes before `:entityTypeSlug` so they are not treated as types.
-      { path: 'search', element: <PublicSearchPage /> },
-      { path: 'tag/:tagSlug', element: <PublicTagArchivePage /> },
-      { path: 'archive/:year/:month', element: <PublicDateArchivePage /> },
-      { path: 'archive/:year/:month/:day', element: <PublicDateArchivePage /> },
-      { path: ':entityTypeSlug', element: <PublicBrowsePage /> },
-      // Wildcard captures any permalink pattern after the entity type slug
-      // e.g. /posts/42, /posts/my-article, /posts/2024/01/my-article
-      { path: ':entityTypeSlug/*', element: <PublicRecordDetailPage /> },
-    ],
-  },
-  {
-    path: '*',
-    element: <NotFoundPage />,
-  },
-])
+const router = createBrowserRouter(
+  [
+    {
+      path: '/login',
+      element: <LoginPage />,
+    },
+    {
+      path: '/admin/accept-invite',
+      element: <AcceptInvitePage />,
+    },
+    {
+      path: '/admin/reset-password',
+      element: <ResetPasswordPage />,
+    },
+    {
+      path: '/admin/verify-email',
+      element: <VerifyEmailPage />,
+    },
+    {
+      path: '/forbidden',
+      element: (
+        <RequireAuth>
+          <ForbiddenPage />
+        </RequireAuth>
+      ),
+    },
+    {
+      path: '/admin',
+      element: <AdminShell />,
+      errorElement: <NotFoundPage />,
+      children: [
+        { index: true, element: <HomePage /> },
+        { path: 'entity-types', element: <EntityTypesPage /> },
+        { path: 'tags', element: <TagsPage /> },
+        { path: 'comments', element: <CommentsPage /> },
+        // Appearance › Layout builder (tabs: layout / menus). Old routes redirect.
+        { path: 'appearance', element: <Navigate to="/admin/appearance/layout" replace /> },
+        { path: 'appearance/:tab', element: <AppearanceLayoutPage /> },
+        { path: 'navigation', element: <Navigate to="/admin/appearance/menus" replace /> },
+        { path: 'widgets', element: <Navigate to="/admin/appearance/layout" replace /> },
+        { path: 'media', element: <MediaPage /> },
+        { path: 'webhooks', element: <WebhooksPage /> },
+        { path: 'notifications', element: <NotificationChannelsPage /> },
+        { path: 'settings', element: <SiteSettingsPage /> },
+        { path: 'import', element: <ImportPage /> },
+        { path: 'users', element: <UsersPage /> },
+        { path: 'users/:id', element: <UserEditPage /> },
+        { path: 'entity-types/:entityTypeSlug/fields', element: <FieldDefsPage /> },
+        // Legacy long-form routes kept for schema management links
+        { path: 'entity-types/:entityTypeSlug/entities', element: <EntityRecordsPage /> },
+        { path: 'entity-types/:entityTypeSlug/entities/:entityId', element: <EntityRecordPage /> },
+        // Short-form catch-all: /admin/:slug and /admin/:slug/:entityId
+        // Must be last — specific routes above take priority
+        { path: ':entityTypeSlug', element: <EntityRecordsPage /> },
+        { path: ':entityTypeSlug/:entityId', element: <EntityRecordPage /> },
+      ],
+    },
+    {
+      path: '/superadmin',
+      element: <SuperadminGuard />,
+      errorElement: <NotFoundPage />,
+      children: [
+        { index: true, element: <OrganizationsPage /> },
+        { path: 'organizations', element: <OrganizationsPage /> },
+        { path: 'organizations/:id', element: <OrganizationDetailPage /> },
+        { path: 'data-migration', element: <DataMigrationPage /> },
+        { path: 'settings', element: <SettingsPage /> },
+      ],
+    },
+    {
+      path: '/',
+      element: <PublicShell />,
+      errorElement: <NotFoundPage />,
+      children: [
+        { index: true, element: <PublicIndexPage /> },
+        // Static routes before `:entityTypeSlug` so they are not treated as types.
+        { path: 'search', element: <PublicSearchPage /> },
+        { path: 'tag/:tagSlug', element: <PublicTagArchivePage /> },
+        { path: 'archive/:year/:month', element: <PublicDateArchivePage /> },
+        { path: 'archive/:year/:month/:day', element: <PublicDateArchivePage /> },
+        { path: ':entityTypeSlug', element: <PublicBrowsePage /> },
+        // Wildcard captures any permalink pattern after the entity type slug
+        // e.g. /posts/42, /posts/my-article, /posts/2024/01/my-article
+        { path: ':entityTypeSlug/*', element: <PublicRecordDetailPage /> },
+      ],
+    },
+    {
+      path: '*',
+      element: <NotFoundPage />,
+    },
+    // Sub-directory install (#zip-install S2): when served from `/blog/`, the
+    // server injects `window.__BASE_PATH__` and the router strips that prefix.
+  ],
+  { basename: getBasePath() || '/' },
+)
 
 export function AppRouter() {
   // Top-level boundary for lazy routes that sit outside a shell (the auth pages);

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -1,6 +1,7 @@
 import { authStore } from '@/entities/auth/model'
 import { env } from '@/shared/config/env'
 import { AppError, parseProblemDetails } from '@/shared/api/errors'
+import { withBasePath } from '@/shared/lib/base-path'
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 
@@ -21,10 +22,10 @@ interface RequestOptions {
 function handleErrorResponse(response: Response, path: string): void {
   if (response.status === 401 && !path.includes('/auth/login')) {
     authStore.clearSession()
-    window.location.href = '/login'
+    window.location.href = withBasePath('/login')
   }
   if (response.status === 403) {
-    window.location.href = '/forbidden'
+    window.location.href = withBasePath('/forbidden')
   }
 }
 
@@ -75,7 +76,7 @@ export const apiClient = {
   },
   async upload<T>(path: string, formData: FormData): Promise<T> {
     const base = env.apiBaseUrl.replace(/\/$/, '')
-    const url = `${base}${path}`
+    const url = `${base}${withBasePath(path)}`
 
     const response = await fetch(url, {
       method: 'POST',

--- a/frontend/src/shared/lib/base-path.test.ts
+++ b/frontend/src/shared/lib/base-path.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { getBasePath, normalizeBasePath, withBasePath } from './base-path'
+
+afterEach(() => {
+  delete window.__BASE_PATH__
+})
+
+describe('normalizeBasePath', () => {
+  it('treats empty / slash as root', () => {
+    expect(normalizeBasePath('')).toBe('')
+    expect(normalizeBasePath('/')).toBe('')
+    expect(normalizeBasePath('  ')).toBe('')
+  })
+
+  it('normalizes to a leading-slash, no-trailing-slash segment', () => {
+    expect(normalizeBasePath('blog')).toBe('/blog')
+    expect(normalizeBasePath('/blog')).toBe('/blog')
+    expect(normalizeBasePath('/blog/')).toBe('/blog')
+    expect(normalizeBasePath('a/b')).toBe('/a/b')
+  })
+})
+
+describe('getBasePath', () => {
+  it('is root when the global is unset', () => {
+    expect(getBasePath()).toBe('')
+  })
+
+  it('reads and normalizes window.__BASE_PATH__', () => {
+    window.__BASE_PATH__ = '/blog/'
+    expect(getBasePath()).toBe('/blog')
+  })
+})
+
+describe('withBasePath', () => {
+  it('is a no-op at root', () => {
+    expect(withBasePath('/api/v1/x')).toBe('/api/v1/x')
+  })
+
+  it('prefixes under a sub-directory', () => {
+    window.__BASE_PATH__ = '/blog'
+    expect(withBasePath('/api/v1/x')).toBe('/blog/api/v1/x')
+    expect(withBasePath('/login')).toBe('/blog/login')
+  })
+})

--- a/frontend/src/shared/lib/base-path.ts
+++ b/frontend/src/shared/lib/base-path.ts
@@ -1,0 +1,35 @@
+/**
+ * Runtime base path (#zip-install S2). The app can be served from a sub-directory
+ * (e.g. `https://example.com/blog/`); the server injects `window.__BASE_PATH__`
+ * (from `APP_BASE_PATH`) into the HTML, and the SPA reads it here to set the
+ * router basename and prefix API requests. Default `''` = served at root.
+ *
+ * Asset loading is handled separately by the injected `<base href>` + Vite's
+ * relative `base` — this value is only for router/navigation and fetch URLs.
+ */
+declare global {
+  interface Window {
+    __BASE_PATH__?: string
+  }
+}
+
+/** The configured base path (`''` or `/segment`) from `window.__BASE_PATH__`. */
+export function getBasePath(): string {
+  const raw = typeof window !== 'undefined' ? window.__BASE_PATH__ : undefined
+
+  return normalizeBasePath(typeof raw === 'string' ? raw : '')
+}
+
+/** `''` (root) or `/segment` (leading slash, no trailing slash). */
+export function normalizeBasePath(raw: string): string {
+  const trimmed = raw.trim().replace(/^\/+|\/+$/g, '')
+
+  return trimmed === '' ? '' : '/' + trimmed
+}
+
+/** Prefix a root-relative path (e.g. `/api/v1/x`) with the base path. */
+export function withBasePath(path: string): string {
+  const base = getBasePath()
+
+  return base === '' ? path : base + path
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,6 +17,10 @@ export default defineConfig(({ mode }) => {
   const frontendPort = parseInt(projectEnv['NENE_RECORDS_FRONTEND_PORT'] ?? '18084', 10)
 
   return {
+    // Relative asset URLs so the built SPA works from any sub-directory at
+    // runtime (#zip-install S2). The injected `<base href>` anchors them to the
+    // configured base path; internal chunk imports resolve next to the entry.
+    base: './',
     plugins: [react(), tailwindcss()],
     build: {
       // Emit dist/.vite/manifest.json so the PHP single-origin SSR can resolve

--- a/src/Http/SingleOriginServiceProvider.php
+++ b/src/Http/SingleOriginServiceProvider.php
@@ -50,6 +50,7 @@ final readonly class SingleOriginServiceProvider implements ServiceProviderInter
                         $responseFactory,
                         $streamFactory,
                         $publicSettings,
+                        BasePath::fromEnv(),
                     );
                 },
             )

--- a/src/Http/SpaShellFallback.php
+++ b/src/Http/SpaShellFallback.php
@@ -35,6 +35,8 @@ final readonly class SpaShellFallback
         private ResponseFactoryInterface $responseFactory,
         private StreamFactoryInterface $streamFactory,
         private ?ListPublicSettingsUseCaseInterface $publicSettings = null,
+        /** Sub-directory install prefix (`APP_BASE_PATH`); '' = served at root. */
+        private string $basePath = '',
     ) {
     }
 
@@ -67,6 +69,8 @@ final readonly class SpaShellFallback
         if ($html === false) {
             return $response;
         }
+
+        $html = $this->injectBasePath($html);
 
         $analytics = $this->resolveAnalytics($path);
         $nonce = $analytics->isEnabled() ? bin2hex(random_bytes(16)) : '';
@@ -118,5 +122,24 @@ final readonly class SpaShellFallback
         }
 
         return substr($html, 0, $pos) . $snippet . substr($html, $pos);
+    }
+
+    /**
+     * Make the built shell base-path-aware (#zip-install S2): repoint its
+     * `<base href="/">` to the install sub-directory (which anchors the shell's
+     * relative asset URLs) and expose the base to the SPA router / API client via
+     * `window.__BASE_PATH__`. A no-op for assets at root; the global is always set.
+     */
+    private function injectBasePath(string $html): string
+    {
+        if ($this->basePath !== '') {
+            $html = str_replace('<base href="/"', '<base href="' . $this->basePath . '/"', $html);
+        }
+
+        $script = '<script>window.__BASE_PATH__ = '
+            . json_encode($this->basePath, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES)
+            . ';</script>';
+
+        return $this->injectIntoHead($html, $script);
     }
 }

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <?php /* Runtime base path for the SPA router / API client (#zip-install S2). */ ?>
+    <script>window.__BASE_PATH__ = <?= json_encode($basePath, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES) ?>;</script>
     <?php /* GA4 / GTM + Consent Mode v2 — pre-built, nonce'd, '' when analytics is off. */ ?>
     <?= $analyticsHead ?>
     <?php if ($metaDescription !== ''): ?>

--- a/tests/Http/SpaShellFallbackTest.php
+++ b/tests/Http/SpaShellFallbackTest.php
@@ -105,6 +105,26 @@ final class SpaShellFallbackTest extends TestCase
         self::assertSame(404, $result->getStatusCode());
     }
 
+    public function testInjectsRuntimeBasePathAtRoot(): void
+    {
+        $result = $this->fallback->apply($this->request('GET', '/admin/users'), $this->notFound());
+        $body = (string) $result->getBody();
+
+        // Root: base href unchanged, global exposed as empty.
+        self::assertStringContainsString('<base href="/" />', $body);
+        self::assertStringContainsString('window.__BASE_PATH__ = "";', $body);
+    }
+
+    public function testRepointsBaseHrefAndBasePathUnderSubdirectory(): void
+    {
+        $fallback = new SpaShellFallback($this->shellPath, $this->factory, $this->factory, null, '/blog');
+        $body = (string) $fallback->apply($this->request('GET', '/admin/users'), $this->notFound())->getBody();
+
+        self::assertStringContainsString('<base href="/blog/" />', $body);
+        self::assertStringContainsString('window.__BASE_PATH__ = "/blog";', $body);
+        self::assertStringNotContainsString('<base href="/" />', $body);
+    }
+
     public function testNoAnalyticsWhenNoSettingsUseCase(): void
     {
         // Default construction (no settings) keeps the strict baseline policy.

--- a/tests/Http/fixtures/spa-index.html
+++ b/tests/Http/fixtures/spa-index.html
@@ -1,5 +1,5 @@
 <!doctype html>
 <html lang="en">
-  <head><title>NeNe Records</title></head>
+  <head><base href="/" /><title>NeNe Records</title></head>
   <body><div id="root"></div></body>
 </html>


### PR DESCRIPTION
## 目的
S1（バックエンド URL 生成）に続く **S2**。SPA を**ランタイム base**で任意のサブディレクトリ（例 `example.com/blog/`）から動かせるようにする。zip インストーラ（設置ディレクトリが実行時に決まる）の前提。**既定 `''` ＝ root ＝挙動不変。**

## 設計（ランタイム base ＝ ビルド時 Vite base ではない）
- **Vite `base: './'`**（相対アセット）＋ `index.html` に静的 `<base href="/">`（Vite が保持）。内部チャンク import はエントリ隣で解決、相対参照は `<base href>` が**深さ非依存**で base に固定。
- サーバが `window.__BASE_PATH__`（=`APP_BASE_PATH`）を注入：
  - **SSR `record-detail.php`** head に script（SSR アセットは S1 で絶対）。
  - **`SpaShellFallback`** がシェルの `<base href="/">` → `<base href="{base}/">` 書換 ＋ `window.__BASE_PATH__` 注入（`SingleOriginServiceProvider` が `BasePath::fromEnv()` 注入）。
- フロント `base-path.ts`：`getBasePath()` / `withBasePath()`。
  - react-router `basename = getBasePath() || '/'`。
  - API クライアント ＋ 401/403 リダイレクトを `withBasePath()` で前置。
- `index.html` の favicon を相対化（`<base href>` で固定）。

## 検証
- `composer check` 緑 ／ `npm run check` 緑（type-check / lint / prettier / test / locales / knip / storybook）。
- `npm run build` 成功＝`dist/index.html` が `<base href="/">` ＋ 相対 `./assets` / favicon（**Vite が `<base>` を保持**）。
- テスト：`base-path`（normalize / getBasePath / withBasePath）／`SpaShellFallback`（root は base href 不変・`__BASE_PATH__=""`／`/blog` で base href 書換 ＋ `__BASE_PATH__="/blog"`）。

## スコープ / ⚠️要注意
- 本 PR ＝ **S2（フロント・ランタイム base）**。残：**S3**＝Web サーバ（Caddy `handle_path` / Apache rewrite で prefix strip）＋ zip パッケージング。
- **アセット配信機構を変更**（Vite base `'/'`→`'./'` ＋ `<base href>`）。既定 `''` で root は等価のはずだが、**本番反映後に `/admin`・公開ページのアセット読込スモークテスト必須**。

Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)