### PR TITLE
fix(deploy): ランタイム base を <base href> 由来にし CSP ブロックを解消 (base-path)

### DIFF
--- a/frontend/src/shared/lib/base-path.test.ts
+++ b/frontend/src/shared/lib/base-path.test.ts
@@ -1,43 +1,54 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { getBasePath, normalizeBasePath, withBasePath } from './base-path'
 
+function setBaseHref(href: string | null): void {
+  document.querySelector('base')?.remove()
+  if (href !== null) {
+    const base = document.createElement('base')
+    base.setAttribute('href', href)
+    document.head.appendChild(base)
+  }
+}
+
 afterEach(() => {
-  delete window.__BASE_PATH__
+  setBaseHref(null)
 })
 
 describe('normalizeBasePath', () => {
   it('treats empty / slash as root', () => {
     expect(normalizeBasePath('')).toBe('')
     expect(normalizeBasePath('/')).toBe('')
-    expect(normalizeBasePath('  ')).toBe('')
   })
 
   it('normalizes to a leading-slash, no-trailing-slash segment', () => {
     expect(normalizeBasePath('blog')).toBe('/blog')
-    expect(normalizeBasePath('/blog')).toBe('/blog')
     expect(normalizeBasePath('/blog/')).toBe('/blog')
     expect(normalizeBasePath('a/b')).toBe('/a/b')
   })
 })
 
 describe('getBasePath', () => {
-  it('is root when the global is unset', () => {
+  it('is root when <base> is absent or points at /', () => {
+    setBaseHref(null)
+    expect(getBasePath()).toBe('')
+    setBaseHref('/')
     expect(getBasePath()).toBe('')
   })
 
-  it('reads and normalizes window.__BASE_PATH__', () => {
-    window.__BASE_PATH__ = '/blog/'
+  it('derives the base from <base href>', () => {
+    setBaseHref('/blog/')
     expect(getBasePath()).toBe('/blog')
   })
 })
 
 describe('withBasePath', () => {
   it('is a no-op at root', () => {
+    setBaseHref('/')
     expect(withBasePath('/api/v1/x')).toBe('/api/v1/x')
   })
 
   it('prefixes under a sub-directory', () => {
-    window.__BASE_PATH__ = '/blog'
+    setBaseHref('/blog/')
     expect(withBasePath('/api/v1/x')).toBe('/blog/api/v1/x')
     expect(withBasePath('/login')).toBe('/blog/login')
   })

--- a/frontend/src/shared/lib/base-path.ts
+++ b/frontend/src/shared/lib/base-path.ts
@@ -1,23 +1,31 @@
 /**
  * Runtime base path (#zip-install S2). The app can be served from a sub-directory
- * (e.g. `https://example.com/blog/`); the server injects `window.__BASE_PATH__`
- * (from `APP_BASE_PATH`) into the HTML, and the SPA reads it here to set the
- * router basename and prefix API requests. Default `''` = served at root.
+ * (e.g. `https://example.com/blog/`); the server emits a `<base href="{base}/">`
+ * (which also anchors the SPA's relative asset URLs), and the SPA derives the base
+ * from it here to set the router basename and prefix API requests.
  *
- * Asset loading is handled separately by the injected `<base href>` + Vite's
- * relative `base` — this value is only for router/navigation and fetch URLs.
+ * Reading the `<base>` element — rather than an injected inline script — keeps the
+ * strict public CSP (`default-src 'self'`, no `script-src 'unsafe-inline'`) intact.
+ * Default `''` = served at root.
  */
-declare global {
-  interface Window {
-    __BASE_PATH__?: string
-  }
-}
 
-/** The configured base path (`''` or `/segment`) from `window.__BASE_PATH__`. */
+/** The configured base path (`''` or `/segment`), derived from `<base href>`. */
 export function getBasePath(): string {
-  const raw = typeof window !== 'undefined' ? window.__BASE_PATH__ : undefined
+  if (typeof document === 'undefined') {
+    return ''
+  }
 
-  return normalizeBasePath(typeof raw === 'string' ? raw : '')
+  const href = document.querySelector('base')?.getAttribute('href')
+
+  if (href === null || href === undefined) {
+    return ''
+  }
+
+  try {
+    return normalizeBasePath(new URL(href, window.location.origin).pathname)
+  } catch {
+    return ''
+  }
 }
 
 /** `''` (root) or `/segment` (leading slash, no trailing slash). */

--- a/src/Http/SpaShellFallback.php
+++ b/src/Http/SpaShellFallback.php
@@ -125,21 +125,17 @@ final readonly class SpaShellFallback
     }
 
     /**
-     * Make the built shell base-path-aware (#zip-install S2): repoint its
-     * `<base href="/">` to the install sub-directory (which anchors the shell's
-     * relative asset URLs) and expose the base to the SPA router / API client via
-     * `window.__BASE_PATH__`. A no-op for assets at root; the global is always set.
+     * Repoint the built shell's `<base href="/">` to the install sub-directory
+     * (#zip-install S2). The `<base>` anchors the shell's relative asset URLs and
+     * is what the SPA reads to derive the router basename / API prefix — no inline
+     * script, so the strict public CSP stays intact. A no-op at root.
      */
     private function injectBasePath(string $html): string
     {
-        if ($this->basePath !== '') {
-            $html = str_replace('<base href="/"', '<base href="' . $this->basePath . '/"', $html);
+        if ($this->basePath === '') {
+            return $html;
         }
 
-        $script = '<script>window.__BASE_PATH__ = '
-            . json_encode($this->basePath, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES)
-            . ';</script>';
-
-        return $this->injectIntoHead($html, $script);
+        return str_replace('<base href="/"', '<base href="' . $this->basePath . '/"', $html);
     }
 }

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <?php /* Runtime base path for the SPA router / API client (#zip-install S2). */ ?>
-    <script>window.__BASE_PATH__ = <?= json_encode($basePath, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES) ?>;</script>
+    <?php /* Runtime base path: anchors the SPA (router/API derive it from <base>). #zip-install S2 */ ?>
+    <base href="<?= $e($basePath . '/') ?>" />
     <?php /* GA4 / GTM + Consent Mode v2 — pre-built, nonce'd, '' when analytics is off. */ ?>
     <?= $analyticsHead ?>
     <?php if ($metaDescription !== ''): ?>

--- a/tests/Http/SpaShellFallbackTest.php
+++ b/tests/Http/SpaShellFallbackTest.php
@@ -105,24 +105,22 @@ final class SpaShellFallbackTest extends TestCase
         self::assertSame(404, $result->getStatusCode());
     }
 
-    public function testInjectsRuntimeBasePathAtRoot(): void
+    public function testKeepsBaseHrefAtRoot(): void
     {
         $result = $this->fallback->apply($this->request('GET', '/admin/users'), $this->notFound());
-        $body = (string) $result->getBody();
 
-        // Root: base href unchanged, global exposed as empty.
-        self::assertStringContainsString('<base href="/" />', $body);
-        self::assertStringContainsString('window.__BASE_PATH__ = "";', $body);
+        self::assertStringContainsString('<base href="/" />', (string) $result->getBody());
     }
 
-    public function testRepointsBaseHrefAndBasePathUnderSubdirectory(): void
+    public function testRepointsBaseHrefUnderSubdirectory(): void
     {
         $fallback = new SpaShellFallback($this->shellPath, $this->factory, $this->factory, null, '/blog');
         $body = (string) $fallback->apply($this->request('GET', '/admin/users'), $this->notFound())->getBody();
 
+        // The SPA derives its base from <base href> — no inline script (CSP-safe).
         self::assertStringContainsString('<base href="/blog/" />', $body);
-        self::assertStringContainsString('window.__BASE_PATH__ = "/blog";', $body);
         self::assertStringNotContainsString('<base href="/" />', $body);
+        self::assertStringNotContainsString('__BASE_PATH__', $body);
     }
 
     public function testNoAnalyticsWhenNoSettingsUseCase(): void


### PR DESCRIPTION
## 背景
S2（#596）の `window.__BASE_PATH__` **インラインスクリプト注入**が、公開 HTML の厳格 CSP（`default-src 'self'`・`script-src` の inline 不許可）に**ブロックされ**、本番ヘッドレス・スモークテストで `__BASE_PATH__` が `undefined` だった。※ アセット読込・SPA マウントは正常（CSP がスクリプトのみ遮断）。

## 修正（CSP を一切緩めない）
- フロント `getBasePath()`：`window.__BASE_PATH__` をやめ、**`<base href>` から導出**（`new URL(href, origin).pathname` → 正規化）。インラインスクリプト不要。
- SSR `record-detail.php`：インライン script を `<base href="{base}/">` に置換。
- `SpaShellFallback`：インライン注入を撤去、`<base href>` 書換のみ。
- `<base href>` は元々アセット相対参照のアンカー（S2）でもあり、**二役を一本化**。

## 検証
- `composer check` ／ `npm run check` 緑（テスト更新済：`base-path` は `<base>` 由来、`SpaShellFallback` は base href 書換のみ＝`__BASE_PATH__` 非出力を確認）。
- マージ後、本番再デプロイ＋ヘッドレス・スモークテストで CSP エラー解消・`<base href>` 導出を実証。

Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)