### PR TITLE
feat(tenant): ディレクトリ方式マルチテナントの公開SEO配線を完成 (base-path S-path)

### DIFF
--- a/src/Http/SpaShellFallback.php
+++ b/src/Http/SpaShellFallback.php
@@ -70,7 +70,7 @@ final readonly class SpaShellFallback
             return $response;
         }
 
-        $html = $this->injectBasePath($html);
+        $html = $this->injectBasePath($html, $request);
 
         $analytics = $this->resolveAnalytics($path);
         $nonce = $analytics->isEnabled() ? bin2hex(random_bytes(16)) : '';
@@ -130,12 +130,16 @@ final readonly class SpaShellFallback
      * is what the SPA reads to derive the router basename / API prefix — no inline
      * script, so the strict public CSP stays intact. A no-op at root.
      */
-    private function injectBasePath(string $html): string
+    private function injectBasePath(string $html, ServerRequestInterface $request): string
     {
-        if ($this->basePath === '') {
+        // Fixed install prefix + per-request tenant prefix (directory mode), so the
+        // <base href> anchors assets and the SPA derives its router/API base.
+        $base = $this->basePath . (string) $request->getAttribute('nene2.base_prefix', '');
+
+        if ($base === '') {
             return $html;
         }
 
-        return str_replace('<base href="/"', '<base href="' . $this->basePath . '/"', $html);
+        return str_replace('<base href="/"', '<base href="' . $base . '/"', $html);
     }
 }

--- a/src/Organization/Resolution/OrgResolverMiddleware.php
+++ b/src/Organization/Resolution/OrgResolverMiddleware.php
@@ -107,9 +107,25 @@ final readonly class OrgResolverMiddleware implements MiddlewareInterface
 
         $this->orgId->set($org->id ?? 0);
 
-        return $handler->handle(
-            $request->withAttribute('nene2.org.id', $org->id)
-                     ->withAttribute('nene2.org.slug', $org->slug),
-        );
+        // Directory / path mode: strip the tenant's leading path segment so the
+        // router sees `/posts/1`, and expose it on `nene2.base_prefix` so public
+        // URL generation re-adds it (canonical / sitemap / <base href>). Other
+        // strategies (subdomain / env / custom domain) carry an empty prefix.
+        $basePrefix = $this->strategy instanceof UriPrefixStrippingStrategyInterface
+            ? $this->strategy->basePrefix($request)
+            : '';
+
+        $request = $request
+            ->withAttribute('nene2.org.id', $org->id)
+            ->withAttribute('nene2.org.slug', $org->slug)
+            ->withAttribute('nene2.base_prefix', $basePrefix);
+
+        if ($basePrefix !== '') {
+            $uri = $request->getUri();
+            $stripped = substr($uri->getPath(), strlen($basePrefix));
+            $request = $request->withUri($uri->withPath($stripped === '' ? '/' : $stripped));
+        }
+
+        return $handler->handle($request);
     }
 }

--- a/src/Organization/Resolution/PathPrefixResolutionStrategy.php
+++ b/src/Organization/Resolution/PathPrefixResolutionStrategy.php
@@ -14,7 +14,7 @@ use Psr\Http\Message\ServerRequestInterface;
  *
  * Best for shared-host deployments where wildcard subdomains are not available.
  */
-final readonly class PathPrefixResolutionStrategy implements OrgResolutionStrategyInterface
+final readonly class PathPrefixResolutionStrategy implements OrgResolutionStrategyInterface, UriPrefixStrippingStrategyInterface
 {
     /** @var list<string> Paths that skip org resolution (superadmin, health, auth). */
     private const BYPASS_PREFIXES = [
@@ -38,5 +38,12 @@ final readonly class PathPrefixResolutionStrategy implements OrgResolutionStrate
         $candidate = $parts[0];
 
         return $candidate !== '' ? $candidate : null;
+    }
+
+    public function basePrefix(ServerRequestInterface $request): string
+    {
+        $slug = $this->resolve($request);
+
+        return $slug === null ? '' : '/' . $slug;
     }
 }

--- a/src/Organization/Resolution/UriPrefixStrippingStrategyInterface.php
+++ b/src/Organization/Resolution/UriPrefixStrippingStrategyInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Organization\Resolution;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Marker for resolution strategies that consume a leading URI path segment as
+ * the tenant identifier (directory / path mode: `/org1/posts/1`).
+ *
+ * The middleware strips this prefix before routing so downstream handlers see
+ * `/posts/1`, and re-exposes it on the `nene2.base_prefix` request attribute so
+ * public URL generation (canonical / sitemap / `<base href>`) can re-add it —
+ * keeping every emitted URL under the tenant's sub-directory.
+ *
+ * Strategies that resolve the tenant from elsewhere (subdomain / env / custom
+ * domain) do NOT implement this: their base prefix is empty.
+ */
+interface UriPrefixStrippingStrategyInterface
+{
+    /** The URI path prefix this strategy consumes (e.g. `/org1`), `''` if none. */
+    public function basePrefix(ServerRequestInterface $request): string;
+}

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -33,6 +33,16 @@ final readonly class RenderPublicRecordViewHandler
     }
 
     /**
+     * The base every generated URL is prefixed with: the fixed install prefix
+     * plus the per-request tenant prefix in directory mode (`/org1`), set by
+     * OrgResolverMiddleware on `nene2.base_prefix`. '' = root single-tenant.
+     */
+    private function effectiveBase(ServerRequestInterface $request): string
+    {
+        return $this->basePath . (string) $request->getAttribute('nene2.base_prefix', '');
+    }
+
+    /**
      * Legacy `/view/{type}/{entitySlug}` twin → 301 to the canonical permalink.
      * The crawlable SSR now lives at the real permalink; this keeps one canonical
      * URL and avoids a duplicate-content twin.
@@ -54,7 +64,7 @@ final readonly class RenderPublicRecordViewHandler
         $output = $this->useCase->execute(new GetPublicRecordViewInput($typeSlug, $entitySlug));
         $uri = $request->getUri();
         $location = $uri->getScheme() . '://' . $uri->getAuthority()
-            . BasePath::prefix($this->basePath, $output->canonicalPath);
+            . BasePath::prefix($this->effectiveBase($request), $output->canonicalPath);
 
         return $this->responseFactory->createResponse(301)->withHeader('Location', $location);
     }
@@ -89,7 +99,8 @@ final readonly class RenderPublicRecordViewHandler
         // hreflang alternates advertise every locale variant (#540).
         $uri = $request->getUri();
         $baseUrl = $uri->getScheme() . '://' . $uri->getAuthority();
-        $permalinkUrl = $baseUrl . BasePath::prefix($this->basePath, $output->canonicalPath);
+        $effectiveBase = $this->effectiveBase($request);
+        $permalinkUrl = $baseUrl . BasePath::prefix($effectiveBase, $output->canonicalPath);
         $canonicalUrl = $locale !== null ? $permalinkUrl . '?lang=' . $locale : $permalinkUrl;
         $htmlLang = $locale ?? PublicLocale::DEFAULT_LANG;
         $alternateLinks = [['hreflang' => 'x-default', 'href' => $permalinkUrl]];
@@ -102,7 +113,7 @@ final readonly class RenderPublicRecordViewHandler
         if ($output->ogImagePath !== null) {
             $ogImageUrl = str_starts_with($output->ogImagePath, 'http')
                 ? $output->ogImagePath
-                : $baseUrl . BasePath::prefix($this->basePath, $output->ogImagePath);
+                : $baseUrl . BasePath::prefix($effectiveBase, $output->ogImagePath);
         }
 
         // Prefer the per-entity meta description, falling back to the site default.
@@ -152,7 +163,7 @@ final readonly class RenderPublicRecordViewHandler
             'analyticsHead' => $analyticsHead,
             'htmlLang' => $htmlLang,
             'alternateLinks' => $alternateLinks,
-            'basePath' => $this->basePath,
+            'basePath' => $effectiveBase,
             'canonicalUrl' => $canonicalUrl,
             'ogImageUrl' => $ogImageUrl,
             'publishedAtIso' => $output->publishedAtIso,

--- a/src/PublicRecord/RenderRobotsHandler.php
+++ b/src/PublicRecord/RenderRobotsHandler.php
@@ -26,9 +26,10 @@ final readonly class RenderRobotsHandler
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $uri = $request->getUri();
-        $sitemapUrl = $uri->getScheme() . '://' . $uri->getAuthority() . $this->basePath . '/sitemap.xml';
+        $base = $this->basePath . (string) $request->getAttribute('nene2.base_prefix', '');
+        $sitemapUrl = $uri->getScheme() . '://' . $uri->getAuthority() . $base . '/sitemap.xml';
 
-        $body = RobotsTxtRenderer::render($sitemapUrl, $this->basePath);
+        $body = RobotsTxtRenderer::render($sitemapUrl, $base);
 
         return $this->responseFactory->createResponse(200)
             ->withHeader('Content-Type', 'text/plain; charset=UTF-8')

--- a/src/PublicRecord/RenderSitemapHandler.php
+++ b/src/PublicRecord/RenderSitemapHandler.php
@@ -41,8 +41,10 @@ final readonly class RenderSitemapHandler
     {
         $uri = $request->getUri();
         // The renderer joins paths onto this; folding the base path in keeps every
-        // <loc> / child-sitemap URL under the sub-directory install (#zip-install).
-        $baseUrl = $uri->getScheme() . '://' . $uri->getAuthority() . $this->basePath;
+        // <loc> / child-sitemap URL under the sub-directory install (#zip-install)
+        // and the per-request tenant prefix in directory mode (nene2.base_prefix).
+        $baseUrl = $uri->getScheme() . '://' . $uri->getAuthority()
+            . $this->basePath . (string) $request->getAttribute('nene2.base_prefix', '');
 
         // Global list = home page (1) + every published record.
         $totalUrls = 1 + $this->useCase->count();

--- a/src/UrlRedirect/UrlRedirectResolver.php
+++ b/src/UrlRedirect/UrlRedirectResolver.php
@@ -63,7 +63,10 @@ final readonly class UrlRedirectResolver
             return $response;
         }
 
-        $location = $this->basePath === '' ? $target : $this->basePath . $target;
+        // Re-add the install prefix + per-request tenant prefix (directory mode)
+        // that OrgResolverMiddleware stripped, so the 301 stays under the tenant.
+        $base = $this->basePath . (string) $request->getAttribute('nene2.base_prefix', '');
+        $location = $base === '' ? $target : $base . $target;
 
         return $this->responseFactory->createResponse(301)->withHeader('Location', $location);
     }

--- a/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
+++ b/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
@@ -6,8 +6,10 @@ namespace NeNeRecords\Tests\Organization\Resolution;
 
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Organization\Organization;
 use NeNeRecords\Organization\Resolution\OrgResolutionStrategyInterface;
 use NeNeRecords\Organization\Resolution\OrgResolverMiddleware;
+use NeNeRecords\Organization\Resolution\PathPrefixResolutionStrategy;
 use NeNeRecords\Tests\Organization\InMemoryOrganizationRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
@@ -57,5 +59,53 @@ final class OrgResolverMiddlewareTest extends TestCase
 
         self::assertSame(200, $response->getStatusCode());
         self::assertSame(0, $orgId->get());
+    }
+
+    /**
+     * Directory / path mode: the tenant's leading path segment is stripped before
+     * routing (downstream sees /posts/1) and re-exposed on nene2.base_prefix so
+     * public URL generation can re-add it. #536 base-path S-path.
+     */
+    public function testPathModeStripsPrefixAndExposesBasePrefix(): void
+    {
+        $factory = new Psr17Factory();
+        /** @var RequestScopedHolder<int> $orgId */
+        $orgId = new RequestScopedHolder();
+        $repository = new InMemoryOrganizationRepository();
+        $repository->save(new Organization('My Shop', 'myshop', 'free', true));
+
+        $middleware = new OrgResolverMiddleware(
+            $orgId,
+            $repository,
+            new ProblemDetailsResponseFactory($factory, $factory),
+            new PathPrefixResolutionStrategy(),
+        );
+
+        $capture = new class ($factory) implements RequestHandlerInterface {
+            public ?ServerRequestInterface $seen = null;
+
+            public function __construct(private readonly Psr17Factory $factory)
+            {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $this->seen = $request;
+
+                return $this->factory->createResponse(200);
+            }
+        };
+
+        $middleware->process(
+            $factory->createServerRequest('GET', 'https://example.test/myshop/posts/1'),
+            $capture,
+        );
+
+        self::assertNotNull($capture->seen);
+        // Tenant segment stripped for routing…
+        self::assertSame('/posts/1', $capture->seen->getUri()->getPath());
+        // …and re-exposed for URL generation, alongside the resolved org.
+        self::assertSame('/myshop', $capture->seen->getAttribute('nene2.base_prefix'));
+        self::assertSame('myshop', $capture->seen->getAttribute('nene2.org.slug'));
     }
 }

--- a/tests/Organization/Resolution/PathPrefixResolutionStrategyTest.php
+++ b/tests/Organization/Resolution/PathPrefixResolutionStrategyTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Organization\Resolution;
+
+use NeNeRecords\Organization\Resolution\PathPrefixResolutionStrategy;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class PathPrefixResolutionStrategyTest extends TestCase
+{
+    private function basePrefixFor(string $path): string
+    {
+        $factory = new Psr17Factory();
+
+        return (new PathPrefixResolutionStrategy())->basePrefix(
+            $factory->createServerRequest('GET', 'https://example.test' . $path),
+        );
+    }
+
+    public function testBasePrefixIsTheLeadingSegment(): void
+    {
+        self::assertSame('/myshop', $this->basePrefixFor('/myshop/posts/1'));
+        self::assertSame('/myshop', $this->basePrefixFor('/myshop'));
+    }
+
+    public function testBasePrefixEmptyForBypassPaths(): void
+    {
+        // Global routes (auth / health / org management) carry no tenant prefix.
+        self::assertSame('', $this->basePrefixFor('/health'));
+        self::assertSame('', $this->basePrefixFor('/api/v1/auth/login'));
+        self::assertSame('', $this->basePrefixFor('/'));
+    }
+}

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -398,6 +398,30 @@ final class PublicRecordHttpTest extends TestCase
         self::assertStringContainsString('Sitemap: https://example.test/blog/sitemap.xml', $robots);
     }
 
+    public function testDirectoryModeTenantPrefixComposesIntoPublicUrls(): void
+    {
+        // Directory (path) mode: OrgResolverMiddleware exposes the stripped tenant
+        // prefix on nene2.base_prefix; URL generation re-adds it (composes with the
+        // fixed install base too — here APP_BASE_PATH=/blog + tenant /myshop).
+        $app = $this->buildApplication(true, $this->projectRoot, [], '/blog');
+        $request = $this->factory
+            ->createServerRequest('GET', 'https://example.test/article/10')
+            ->withAttribute('nene2.base_prefix', '/myshop');
+
+        $detail = (string) $app->handle($request)->getBody();
+        self::assertStringContainsString(
+            '<link rel="canonical" href="https://example.test/blog/myshop/article/10" />',
+            $detail,
+        );
+        self::assertStringContainsString('href="/blog/myshop/view/article"', $detail);
+
+        $sitemapReq = $this->factory
+            ->createServerRequest('GET', 'https://example.test/sitemap.xml')
+            ->withAttribute('nene2.base_prefix', '/myshop');
+        $sitemap = (string) $app->handle($sitemapReq)->getBody();
+        self::assertStringContainsString('<loc>https://example.test/blog/myshop/article/10</loc>', $sitemap);
+    }
+
     public function testRobotsTxtServesDirectivesAndSitemapPointer(): void
     {
         $response = $this->application->handle(


### PR DESCRIPTION
## 目的
ディレクトリ（path）方式マルチテナントを**公開SEOサイトとして成立**させる。org 解決は実装済だったが、**(a) URI prefix の strip が未実装**で公開ルーティングが 404、**(b) URL 生成がテナント prefix を吐かず** canonical/sitemap が誤る、という未完状態だった。

base path 基盤（#595/#596）が作った "URL 前置 seam" と S2 の `<base href>` 由来フロントを活かし、**per-request のテナント prefix を seam に供給**して完成。**subdomain/single モードは無影響（prefix=''）。**

## 変更
- **`UriPrefixStrippingStrategyInterface`（新）＋ `PathPrefixResolutionStrategy::basePrefix()`**：消費する URI prefix（`/org1`）を返す marker。他戦略は非実装＝prefix `''`（既存4戦略・テストダブル無改修）。
- **`OrgResolverMiddleware`**：path モードで **URI prefix を strip**（router は `/posts/1` を見る）＋ `nene2.base_prefix` 属性に re-expose。
- **公開 URL 生成が実効 base = `APP_BASE_PATH + nene2.base_prefix`**：`RenderPublicRecordViewHandler`（canonical/og/hreflang/permalink/`/view`301/relation リンク/`<base href>`）、`RenderSitemapHandler`、`RenderRobotsHandler`、`UrlRedirectResolver`、`SpaShellFallback`（`<base href>` 書換）。
- **フロント（S2）は `<base href>` 由来なので無改修で追従**（router basename / API / アセット）。

## 検証
- `composer check` 緑（PHPUnit / PHPStan level 8 / CS / OpenAPI / MCP）。フロント変更なし。
- テスト：
  - `PathPrefixResolutionStrategy::basePrefix`（leading segment / bypass='')
  - `OrgResolverMiddleware`（path モードで strip → `/posts/1` ＋ `base_prefix=/myshop` ＋ `org.slug`）
  - http 統合（`base_prefix=/myshop` で canonical / sitemap `<loc>` / relation リンクが `/blog/myshop/...` ＝ **APP_BASE_PATH と合成**）

## 背景
討論（`docs/review/tenant-url-strategy-personas-2026-06-26.md`・PR #598）＝自社 SaaS は subdomain だが、ディレクトリは **"ワイルドカード TLS 不可な共有鯖の自前マルチテナント" fallback** として保持。本番マルチテナントを立てる節目で **3モード（single/subdomain/path）を本物にして抽象を完成**。

Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)