### PR TITLE
feat(tenant): on-demand TLS の ask エンドポイント (subdomain-saas ①)

### DIFF
--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -81,6 +81,7 @@ use NeNeRecords\Organization\OrganizationNotFoundExceptionHandler;
 use NeNeRecords\Organization\OrganizationRouteRegistrar;
 use NeNeRecords\Organization\OrganizationServiceProvider;
 use NeNeRecords\Organization\OrganizationSlugConflictExceptionHandler;
+use NeNeRecords\Organization\TlsCheckRouteRegistrar;
 use NeNeRecords\OrgExport\OrgExportRouteRegistrar;
 use NeNeRecords\OrgExport\OrgExportServiceProvider;
 use NeNeRecords\PreviewToken\PreviewTokenNotFoundExceptionHandler;
@@ -219,6 +220,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $notification = $container->get(NotificationRouteRegistrar::class);
                     $comment = $container->get(CommentRouteRegistrar::class);
                     $organization = $container->get(OrganizationRouteRegistrar::class);
+                    $tlsCheck = $container->get(TlsCheckRouteRegistrar::class);
                     $systemConfig = $container->get(SystemConfigRouteRegistrar::class);
                     $dataMigration = $container->get(DataMigrationRouteRegistrar::class);
                     $orgExport     = $container->get(OrgExportRouteRegistrar::class);
@@ -255,6 +257,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !$notification instanceof NotificationRouteRegistrar
                         || !$comment instanceof CommentRouteRegistrar
                         || !$organization instanceof OrganizationRouteRegistrar
+                        || !$tlsCheck instanceof TlsCheckRouteRegistrar
                         || !$systemConfig instanceof SystemConfigRouteRegistrar
                         || !$dataMigration instanceof DataMigrationRouteRegistrar
                         || !$orgExport instanceof OrgExportRouteRegistrar
@@ -294,6 +297,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $notification,
                         $comment,
                         $organization,
+                        $tlsCheck,
                         $systemConfig,
                         $dataMigration,
                         $orgExport,

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -10,6 +10,7 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\SystemConfig\SystemConfigRepositoryInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 
@@ -250,6 +251,42 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
                     }
 
                     return new OrganizationRouteRegistrar($list, $get, $create, $update, $delete);
+                },
+            )
+            // ── On-demand TLS gate (subdomain SaaS) ─────────────────────────────
+            ->set(
+                TlsCheckHandler::class,
+                static function (ContainerInterface $c): TlsCheckHandler {
+                    $repo            = $c->get(OrganizationRepositoryInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+                    $sysConfig       = $c->get(SystemConfigRepositoryInterface::class);
+
+                    if (!$repo instanceof OrganizationRepositoryInterface) {
+                        throw new LogicException('OrganizationRepositoryInterface is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('ResponseFactoryInterface is invalid.');
+                    }
+
+                    // Same source as OrgResolverMiddleware's subdomain strategy.
+                    $baseDomain = (string) (getenv('BASE_DOMAIN') ?: 'localhost');
+                    if ($sysConfig instanceof SystemConfigRepositoryInterface) {
+                        $baseDomain = $sysConfig->get('tenant_base_domain') ?: $baseDomain;
+                    }
+
+                    return new TlsCheckHandler($repo, $responseFactory, $baseDomain);
+                },
+            )
+            ->set(
+                TlsCheckRouteRegistrar::class,
+                static function (ContainerInterface $c): TlsCheckRouteRegistrar {
+                    $handler = $c->get(TlsCheckHandler::class);
+                    if (!$handler instanceof TlsCheckHandler) {
+                        throw new LogicException('TlsCheckHandler service is invalid.');
+                    }
+
+                    return new TlsCheckRouteRegistrar($handler);
                 },
             );
     }

--- a/src/Organization/Resolution/OrgResolverMiddleware.php
+++ b/src/Organization/Resolution/OrgResolverMiddleware.php
@@ -37,6 +37,7 @@ final readonly class OrgResolverMiddleware implements MiddlewareInterface
      */
     private const BYPASS_PREFIXES = [
         '/health',
+        '/internal/tls-check',
         '/api/v1/organizations',
         '/api/v1/superadmin/',
         '/api/v1/auth/',

--- a/src/Organization/TlsCheckHandler.php
+++ b/src/Organization/TlsCheckHandler.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Organization;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * On-demand TLS gate for the subdomain SaaS (`GET /internal/tls-check?domain=…`).
+ *
+ * Caddy's `on_demand_tls { ask … }` calls this before issuing a certificate for an
+ * incoming SNI host: a 2xx authorizes issuance, anything else denies it. Without
+ * this gate any `random.nene-records.com` request would trigger a cert order and
+ * exhaust the Let's Encrypt per-registered-domain rate limit.
+ *
+ * Authorized hosts: the base domain itself (apex landing / signup), a subdomain
+ * whose first label is an active org slug, or a registered custom domain.
+ *
+ * Org-resolution is bypassed for this route (it answers for *other* hosts), so it
+ * must never assume a tenant context.
+ */
+final readonly class TlsCheckHandler
+{
+    public function __construct(
+        private OrganizationRepositoryInterface $organizations,
+        private ResponseFactoryInterface $responseFactory,
+        /** The SaaS base domain, e.g. `nene-records.com`. */
+        private string $baseDomain,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getQueryParams();
+        $domain = is_string($params['domain'] ?? null) ? trim($params['domain']) : '';
+
+        if (str_contains($domain, ':')) {
+            $domain = explode(':', $domain)[0];
+        }
+
+        if ($domain === '' || $this->baseDomain === '') {
+            return $this->responseFactory->createResponse(400);
+        }
+
+        // Apex (base domain) = the global landing / signup surface — always allowed.
+        if ($domain === $this->baseDomain) {
+            return $this->decide(true);
+        }
+
+        $baseParts = explode('.', $this->baseDomain);
+        $hostParts = explode('.', $domain);
+
+        // Subdomain of the base domain → the first label is the org slug.
+        if (count($hostParts) > count($baseParts)
+            && array_slice($hostParts, -count($baseParts)) === $baseParts) {
+            return $this->decide($this->isActiveOrg($this->organizations->findBySlug($hostParts[0])));
+        }
+
+        // Otherwise treat it as a custom domain mapped to a tenant.
+        return $this->decide($this->isActiveOrg($this->organizations->findByCustomDomain($domain)));
+    }
+
+    private function isActiveOrg(?Organization $org): bool
+    {
+        return $org !== null && $org->isActive;
+    }
+
+    private function decide(bool $allow): ResponseInterface
+    {
+        return $this->responseFactory->createResponse($allow ? 200 : 403);
+    }
+}

--- a/src/Organization/TlsCheckRouteRegistrar.php
+++ b/src/Organization/TlsCheckRouteRegistrar.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Organization;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Registers the on-demand TLS gate (`GET /internal/tls-check`). Org-resolution
+ * bypasses this path (see OrgResolverMiddleware::BYPASS_PREFIXES) because it
+ * answers about other hosts and carries no tenant context of its own.
+ */
+final readonly class TlsCheckRouteRegistrar
+{
+    public function __construct(
+        private TlsCheckHandler $handler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $handler = $this->handler;
+        $router->get('/internal/tls-check', static fn (ServerRequestInterface $r) => $handler->handle($r));
+    }
+}

--- a/tests/Organization/TlsCheckHandlerTest.php
+++ b/tests/Organization/TlsCheckHandlerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Organization;
+
+use NeNeRecords\Organization\Organization;
+use NeNeRecords\Organization\TlsCheckHandler;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class TlsCheckHandlerTest extends TestCase
+{
+    private function handler(): TlsCheckHandler
+    {
+        $repo = new InMemoryOrganizationRepository();
+        $repo->save(new Organization('Shop', 'shop', 'free', true));
+        $repo->save(new Organization('Gone', 'gone', 'free', false)); // inactive
+        $repo->save(new Organization('Custom', 'custom', 'free', true, customDomain: 'mycustom.example'));
+
+        return new TlsCheckHandler($repo, new Psr17Factory(), 'nene-records.com');
+    }
+
+    private function statusFor(string $domain): int
+    {
+        $request = (new Psr17Factory())
+            ->createServerRequest('GET', 'http://records-app/internal/tls-check')
+            ->withQueryParams(['domain' => $domain]);
+
+        return $this->handler()->handle($request)->getStatusCode();
+    }
+
+    public function testApexIsAllowed(): void
+    {
+        self::assertSame(200, $this->statusFor('nene-records.com'));
+    }
+
+    public function testActiveTenantSubdomainIsAllowed(): void
+    {
+        self::assertSame(200, $this->statusFor('shop.nene-records.com'));
+        self::assertSame(200, $this->statusFor('shop.nene-records.com:443'));
+    }
+
+    public function testUnknownSubdomainIsDenied(): void
+    {
+        self::assertSame(403, $this->statusFor('nope.nene-records.com'));
+    }
+
+    public function testInactiveTenantIsDenied(): void
+    {
+        self::assertSame(403, $this->statusFor('gone.nene-records.com'));
+    }
+
+    public function testRegisteredCustomDomainIsAllowed(): void
+    {
+        self::assertSame(200, $this->statusFor('mycustom.example'));
+    }
+
+    public function testUnregisteredHostIsDenied(): void
+    {
+        self::assertSame(403, $this->statusFor('evil.example.com'));
+    }
+
+    public function testEmptyDomainIsBadRequest(): void
+    {
+        self::assertSame(400, $this->statusFor(''));
+    }
+}


### PR DESCRIPTION
## 目的
subdomain SaaS（A-simplified）の土台 **①**。ムームードメインは Caddy 対応の DNS-01 API が無いため、ワイルドカード証明書でなく **on-demand TLS（HTTP-01・サブドメイン毎発行）** を使う。その濫用防止ゲート（Caddy `on_demand_tls { ask … }`）に応える HTTP エンドポイント。

## 追加
- **`GET /internal/tls-check?domain=<host>`**（`TlsCheckHandler`）：
  - apex（base ドメイン＝landing/signup 面）→ **200**
  - base のサブドメインで第1ラベルが **active な org slug** → **200**
  - 登録済み **custom domain** → **200**
  - それ以外 / inactive → **403**、空 → **400**
  - これが無いと任意の `random.nene-records.com` が証明書発行を誘発し Let's Encrypt の登録ドメイン毎レート上限（50/週）を枯らす。
- `OrgResolverMiddleware::BYPASS_PREFIXES` に `/internal/tls-check` を追加（他ホストの可否を答える＝テナント文脈なし）。base ドメインは `tenant_base_domain` / `BASE_DOMAIN` から解決（subdomain 戦略と同源）。

## 検証
- `composer check` 緑（PHPUnit / PHPStan level 8 / CS / OpenAPI / MCP）。**本番箱は無変更**。
- テスト：apex / active slug / custom domain → 200、unknown / inactive → 403、空 → 400、port 付きホスト対応。

## 次工程（A-simplified の残り）
- ② apex / グローバル面（host=base で signup/landing をテナント解決バイパス）
- ③ Caddy 切替（`*.nene-records.com` on_demand+ask、apex、records.nene-suite.com→301）＋ `tenant_resolution_mode=subdomain`
- ④ 公開 signup（本質ギャップ）

Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)