### PR TITLE
feat(tenant): subdomain SaaS の apex をグローバル面として通す (subdomain-saas ②)

### DIFF
--- a/src/Organization/Resolution/ApexAwareStrategyInterface.php
+++ b/src/Organization/Resolution/ApexAwareStrategyInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Organization\Resolution;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Marker for strategies that have an "apex" host carrying no tenant — the bare
+ * base domain of a subdomain SaaS (`nene-records.com`), which serves the global
+ * landing / signup surface rather than any organization's site.
+ *
+ * When the strategy resolves no tenant AND the request is for the apex, the
+ * middleware passes through as no-tenant (org 0) instead of 404, so the global
+ * surface renders. Non-apex unresolved hosts still 404.
+ */
+interface ApexAwareStrategyInterface
+{
+    /** True when the request targets the tenant-less base domain (apex). */
+    public function isApex(ServerRequestInterface $request): bool;
+}

--- a/src/Organization/Resolution/OrgResolverMiddleware.php
+++ b/src/Organization/Resolution/OrgResolverMiddleware.php
@@ -73,6 +73,15 @@ final readonly class OrgResolverMiddleware implements MiddlewareInterface
 
         // Strategy returned null (e.g. EnvResolutionStrategy with no ORG_SLUG set)
         if ($identifier === null) {
+            // Subdomain SaaS apex (host === base domain): no tenant, but serve the
+            // global landing / signup surface instead of 404. Non-apex unresolved
+            // hosts still fall through to the error below.
+            if ($this->strategy instanceof ApexAwareStrategyInterface && $this->strategy->isApex($request)) {
+                $this->orgId->set(0);
+
+                return $handler->handle($request->withAttribute('nene2.apex', true));
+            }
+
             return $this->problemDetails->create(
                 $request,
                 'org-not-resolved',

--- a/src/Organization/Resolution/SubdomainResolutionStrategy.php
+++ b/src/Organization/Resolution/SubdomainResolutionStrategy.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\ServerRequestInterface;
  * Configure BASE_DOMAIN=nene-records.com in .env.
  * Requests to the bare base domain (no subdomain) return null.
  */
-final readonly class SubdomainResolutionStrategy implements OrgResolutionStrategyInterface
+final readonly class SubdomainResolutionStrategy implements OrgResolutionStrategyInterface, ApexAwareStrategyInterface
 {
     public function __construct(
         private string $baseDomain,
@@ -21,12 +21,7 @@ final readonly class SubdomainResolutionStrategy implements OrgResolutionStrateg
 
     public function resolve(ServerRequestInterface $request): ?string
     {
-        $host = $request->getUri()->getHost();
-
-        // Strip port if present
-        if (str_contains($host, ':')) {
-            $host = explode(':', $host)[0];
-        }
+        $host = $this->host($request);
 
         $baseParts = explode('.', $this->baseDomain);
         $hostParts = explode('.', $host);
@@ -43,5 +38,17 @@ final readonly class SubdomainResolutionStrategy implements OrgResolutionStrateg
         }
 
         return $hostParts[0]; // e.g. "org1"
+    }
+
+    public function isApex(ServerRequestInterface $request): bool
+    {
+        return $this->host($request) === $this->baseDomain;
+    }
+
+    private function host(ServerRequestInterface $request): string
+    {
+        $host = $request->getUri()->getHost();
+
+        return str_contains($host, ':') ? explode(':', $host)[0] : $host;
     }
 }

--- a/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
+++ b/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
@@ -10,6 +10,7 @@ use NeNeRecords\Organization\Organization;
 use NeNeRecords\Organization\Resolution\OrgResolutionStrategyInterface;
 use NeNeRecords\Organization\Resolution\OrgResolverMiddleware;
 use NeNeRecords\Organization\Resolution\PathPrefixResolutionStrategy;
+use NeNeRecords\Organization\Resolution\SubdomainResolutionStrategy;
 use NeNeRecords\Tests\Organization\InMemoryOrganizationRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
@@ -107,5 +108,78 @@ final class OrgResolverMiddlewareTest extends TestCase
         // …and re-exposed for URL generation, alongside the resolved org.
         self::assertSame('/myshop', $capture->seen->getAttribute('nene2.base_prefix'));
         self::assertSame('myshop', $capture->seen->getAttribute('nene2.org.slug'));
+    }
+
+    /**
+     * Subdomain SaaS apex (host === base domain) carries no tenant but must serve
+     * the global landing / signup surface, not 404. #536 subdomain-saas ②.
+     */
+    public function testSubdomainApexServesGlobalSurfaceAsNoTenant(): void
+    {
+        $factory = new Psr17Factory();
+        /** @var RequestScopedHolder<int> $orgId */
+        $orgId = new RequestScopedHolder();
+
+        $middleware = new OrgResolverMiddleware(
+            $orgId,
+            new InMemoryOrganizationRepository(),
+            new ProblemDetailsResponseFactory($factory, $factory),
+            new SubdomainResolutionStrategy('nene-records.com'),
+        );
+
+        $capture = new class ($factory) implements RequestHandlerInterface {
+            public ?ServerRequestInterface $seen = null;
+
+            public function __construct(private readonly Psr17Factory $factory)
+            {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $this->seen = $request;
+
+                return $this->factory->createResponse(200);
+            }
+        };
+
+        $response = $middleware->process(
+            $factory->createServerRequest('GET', 'https://nene-records.com/'),
+            $capture,
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(0, $orgId->get()); // no-tenant sentinel
+        self::assertNotNull($capture->seen);
+        self::assertTrue($capture->seen->getAttribute('nene2.apex'));
+    }
+
+    public function testSubdomainUnknownTenantStill404s(): void
+    {
+        $factory = new Psr17Factory();
+        /** @var RequestScopedHolder<int> $orgId */
+        $orgId = new RequestScopedHolder();
+
+        $middleware = new OrgResolverMiddleware(
+            $orgId,
+            new InMemoryOrganizationRepository(), // empty → "nope" not found
+            new ProblemDetailsResponseFactory($factory, $factory),
+            new SubdomainResolutionStrategy('nene-records.com'),
+        );
+
+        $response = $middleware->process(
+            $factory->createServerRequest('GET', 'https://nope.nene-records.com/'),
+            new readonly class ($factory) implements RequestHandlerInterface {
+                public function __construct(private Psr17Factory $factory)
+                {
+                }
+
+                public function handle(ServerRequestInterface $request): ResponseInterface
+                {
+                    return $this->factory->createResponse(200);
+                }
+            },
+        );
+
+        self::assertSame(404, $response->getStatusCode());
     }
 }


### PR DESCRIPTION
## 目的
subdomain SaaS の土台 **②**。subdomain モードで host が base ドメイン（apex `nene-records.com`）のとき `resolve()` は null → 従来は org-not-resolved 404。これだと landing/signup を置く apex が表示できない。**apex だけ no-tenant パススルー**にする。

## 変更
- **`ApexAwareStrategyInterface`（新 marker）** ＋ `SubdomainResolutionStrategy::isApex()`（host === base ドメイン）。
- **`OrgResolverMiddleware`**：`resolve()===null` かつ apex のとき、404 でなく **orgId=0（no-tenant sentinel）＋ `nene2.apex` 属性で handler に通す** → SPA シェル（landing/signup）が出せる。signup API（`/api/v1/organizations`）は既に bypass。
- **未解決サブドメイン（`nope.〜`）は従来通り 404**（apex のみ特別扱い・他モード無影響）。

## 検証
- `composer check` 緑。テスト：apex → 200・orgId=0・`nene2.apex=true`／未知サブドメイン → 404。

## スコープ
- 本 PR は ② バックエンドの apex パススルー。apex の landing/signup **UI** は ④（signup）で実装。

Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)