### PR TITLE
feat(tenant): 公開セルフサーブ signup (subdomain-saas ④-backend)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -94,6 +94,46 @@ paths:
       responses:
         '204':
           description: Session cookie cleared.
+  /api/v1/public/signup:
+    post:
+      tags:
+        - Signup
+      summary: Public self-serve tenant signup
+      description: >-
+        Provisions a new tenant (organization + admin user, default content types
+        auto-seeded) and signs the admin straight in, setting the session as an
+        HttpOnly `nene_session` cookie. Open endpoint (no authentication, no tenant
+        context). The slug becomes the tenant subdomain `{slug}.<base-domain>`.
+      operationId: publicSignup
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SignupRequest'
+            example:
+              organization_name: My Shop
+              slug: my-shop
+              email: owner@example.com
+              password: a-strong-password
+      responses:
+        '201':
+          description: Tenant provisioned and admin signed in.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SignupResponse'
+              example:
+                token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+                expires_at: '2026-06-27T00:00:00Z'
+                slug: my-shop
+                org_id: 42
+                email: owner@example.com
+                role: admin
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
   /health:
     get:
       tags:
@@ -6121,6 +6161,57 @@ components:
         expires_at:
           type: string
           format: date-time
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+          minLength: 1
+      additionalProperties: false
+    SignupRequest:
+      type: object
+      required:
+        - organization_name
+        - slug
+        - email
+        - password
+      properties:
+        organization_name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        slug:
+          type: string
+          description: Tenant subdomain label (3–30 lowercase letters, numbers or hyphens).
+          pattern: '^[a-z0-9](?:[a-z0-9-]{1,28}[a-z0-9])$'
+        email:
+          type: string
+          format: email
+          minLength: 1
+        password:
+          type: string
+          minLength: 8
+      additionalProperties: false
+    SignupResponse:
+      type: object
+      required:
+        - token
+        - expires_at
+        - slug
+        - org_id
+        - email
+        - role
+      properties:
+        token:
+          type: string
+          minLength: 1
+        expires_at:
+          type: string
+          format: date-time
+        slug:
+          type: string
+        org_id:
+          type: integer
         email:
           type: string
           format: email

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -44,6 +44,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/public/signup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Public self-serve tenant signup
+         * @description Provisions a new tenant (organization + admin user, default content types auto-seeded) and signs the admin straight in, setting the session as an HttpOnly `nene_session` cookie. Open endpoint (no authentication, no tenant context). The slug becomes the tenant subdomain `{slug}.<base-domain>`.
+         */
+        post: operations["publicSignup"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/health": {
         parameters: {
             query?: never;
@@ -2422,6 +2442,24 @@ export interface components {
             email: string;
             role: string;
         };
+        SignupRequest: {
+            organization_name: string;
+            /** @description Tenant subdomain label (3–30 lowercase letters, numbers or hyphens). */
+            slug: string;
+            /** Format: email */
+            email: string;
+            password: string;
+        };
+        SignupResponse: {
+            token: string;
+            /** Format: date-time */
+            expires_at: string;
+            slug: string;
+            org_id: number;
+            /** Format: email */
+            email: string;
+            role: string;
+        };
         WidgetResponse: {
             id: number;
             /** @enum {string} */
@@ -3013,6 +3051,50 @@ export interface operations {
                 };
                 content?: never;
             };
+        };
+    };
+    publicSignup: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                /**
+                 * @example {
+                 *       "organization_name": "My Shop",
+                 *       "slug": "my-shop",
+                 *       "email": "owner@example.com",
+                 *       "password": "a-strong-password"
+                 *     }
+                 */
+                "application/json": components["schemas"]["SignupRequest"];
+            };
+        };
+        responses: {
+            /** @description Tenant provisioned and admin signed in. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                     *       "expires_at": "2026-06-27T00:00:00Z",
+                     *       "slug": "my-shop",
+                     *       "org_id": 42,
+                     *       "email": "owner@example.com",
+                     *       "role": "admin"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SignupResponse"];
+                };
+            };
+            409: components["responses"]["Conflict"];
+            422: components["responses"]["ValidationFailed"];
         };
     };
     getHealth: {

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -95,6 +95,8 @@ use NeNeRecords\Setting\SettingKeyNotFoundExceptionHandler;
 use NeNeRecords\Setting\SettingRouteRegistrar;
 use NeNeRecords\Setting\SettingServiceProvider;
 use NeNeRecords\Setting\SettingValueInvalidExceptionHandler;
+use NeNeRecords\Signup\PublicSignupRouteRegistrar;
+use NeNeRecords\Signup\SignupServiceProvider;
 use NeNeRecords\SystemConfig\SystemConfigRouteRegistrar;
 use NeNeRecords\SystemConfig\SystemConfigServiceProvider;
 use NeNeRecords\Tag\TagNotFoundExceptionHandler;
@@ -179,6 +181,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new NotificationServiceProvider())
             ->addProvider(new CommentServiceProvider())
             ->addProvider(new OrganizationServiceProvider())
+            ->addProvider(new SignupServiceProvider())
             ->addProvider(new SystemConfigServiceProvider())
             ->addProvider(new DataMigrationServiceProvider())
             ->addProvider(new OrgExportServiceProvider())
@@ -221,6 +224,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $comment = $container->get(CommentRouteRegistrar::class);
                     $organization = $container->get(OrganizationRouteRegistrar::class);
                     $tlsCheck = $container->get(TlsCheckRouteRegistrar::class);
+                    $signup = $container->get(PublicSignupRouteRegistrar::class);
                     $systemConfig = $container->get(SystemConfigRouteRegistrar::class);
                     $dataMigration = $container->get(DataMigrationRouteRegistrar::class);
                     $orgExport     = $container->get(OrgExportRouteRegistrar::class);
@@ -258,6 +262,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !$comment instanceof CommentRouteRegistrar
                         || !$organization instanceof OrganizationRouteRegistrar
                         || !$tlsCheck instanceof TlsCheckRouteRegistrar
+                        || !$signup instanceof PublicSignupRouteRegistrar
                         || !$systemConfig instanceof SystemConfigRouteRegistrar
                         || !$dataMigration instanceof DataMigrationRouteRegistrar
                         || !$orgExport instanceof OrgExportRouteRegistrar
@@ -298,6 +303,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $comment,
                         $organization,
                         $tlsCheck,
+                        $signup,
                         $systemConfig,
                         $dataMigration,
                         $orgExport,

--- a/src/Organization/Resolution/OrgResolverMiddleware.php
+++ b/src/Organization/Resolution/OrgResolverMiddleware.php
@@ -38,6 +38,7 @@ final readonly class OrgResolverMiddleware implements MiddlewareInterface
     private const BYPASS_PREFIXES = [
         '/health',
         '/internal/tls-check',
+        '/api/v1/public/signup',
         '/api/v1/organizations',
         '/api/v1/superadmin/',
         '/api/v1/auth/',

--- a/src/Signup/PublicSignupHandler.php
+++ b/src/Signup/PublicSignupHandler.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Signup;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeNeRecords\Auth\SessionCookie;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * `POST /api/v1/public/signup` — public self-serve tenant registration. Validates
+ * the requested slug / admin credentials, provisions the tenant, and returns the
+ * session (HttpOnly cookie) so the new admin is immediately signed in.
+ *
+ * Always-open (AdminApiAuthMiddleware `/api/v1/public/`) and org-resolution
+ * bypassed (it creates a *new* org and carries no tenant context of its own).
+ */
+final readonly class PublicSignupHandler
+{
+    private const PASSWORD_MIN = 8;
+
+    public function __construct(
+        private PublicSignupUseCase $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $name = $this->string($body, 'organization_name');
+        $slug = strtolower($this->string($body, 'slug'));
+        $email = $this->string($body, 'email');
+        $password = isset($body['password']) && is_string($body['password']) ? $body['password'] : '';
+
+        $errors = [];
+
+        if ($name === '') {
+            $errors[] = new ValidationError('organization_name', 'Organization name is required.', 'required');
+        } elseif (mb_strlen($name) > 100) {
+            $errors[] = new ValidationError('organization_name', 'Organization name is too long.', 'max_length');
+        }
+
+        if ($slug === '') {
+            $errors[] = new ValidationError('slug', 'Slug is required.', 'required');
+        } elseif (!ReservedSlugs::isValidFormat($slug)) {
+            $errors[] = new ValidationError('slug', 'Slug must be 3–30 lowercase letters, numbers or hyphens.', 'format');
+        } elseif (ReservedSlugs::isReserved($slug)) {
+            $errors[] = new ValidationError('slug', 'This slug is reserved. Please choose another.', 'reserved');
+        }
+
+        if ($email === '') {
+            $errors[] = new ValidationError('email', 'Email is required.', 'required');
+        } elseif (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+            $errors[] = new ValidationError('email', 'Email is invalid.', 'format');
+        }
+
+        if ($password === '') {
+            $errors[] = new ValidationError('password', 'Password is required.', 'required');
+        } elseif (mb_strlen($password) < self::PASSWORD_MIN) {
+            $errors[] = new ValidationError('password', 'Password must be at least 8 characters.', 'min_length');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        // Slug / email uniqueness raise domain exceptions (→ 409) past this point.
+        $output = $this->useCase->execute(new PublicSignupInput(
+            organizationName: $name,
+            slug: $slug,
+            email: $email,
+            password: $password,
+        ));
+
+        $cookie = SessionCookie::build(
+            $output->token,
+            $output->expiresAt - time(),
+            SessionCookie::isSecureRequest($request),
+        );
+
+        return $this->response->create([
+            'token'      => $output->token,
+            'expires_at' => (new DateTimeImmutable('@' . $output->expiresAt))->format(DateTimeInterface::ATOM),
+            'slug'       => $output->slug,
+            'org_id'     => $output->organizationId,
+            'email'      => $output->email,
+            'role'       => $output->role,
+        ], 201, ['Set-Cookie' => $cookie]);
+    }
+
+    /** @param array<string, mixed> $body */
+    private function string(array $body, string $key): string
+    {
+        return isset($body[$key]) && is_string($body[$key]) ? trim($body[$key]) : '';
+    }
+}

--- a/src/Signup/PublicSignupInput.php
+++ b/src/Signup/PublicSignupInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Signup;
+
+final readonly class PublicSignupInput
+{
+    public function __construct(
+        public string $organizationName,
+        public string $slug,
+        public string $email,
+        public string $password,
+    ) {
+    }
+}

--- a/src/Signup/PublicSignupOutput.php
+++ b/src/Signup/PublicSignupOutput.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Signup;
+
+final readonly class PublicSignupOutput
+{
+    public function __construct(
+        public string $token,
+        public int $expiresAt,
+        public int $organizationId,
+        public string $slug,
+        public string $email,
+        public string $role,
+    ) {
+    }
+}

--- a/src/Signup/PublicSignupRouteRegistrar.php
+++ b/src/Signup/PublicSignupRouteRegistrar.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Signup;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Registers `POST /api/v1/public/signup`. Public (AdminApiAuthMiddleware opens
+ * `/api/v1/public/`) and org-resolution bypassed (OrgResolverMiddleware) since it
+ * provisions a brand-new tenant.
+ */
+final readonly class PublicSignupRouteRegistrar
+{
+    public function __construct(
+        private PublicSignupHandler $handler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $handler = $this->handler;
+        $router->post('/api/v1/public/signup', static fn (ServerRequestInterface $r) => $handler->handle($r));
+    }
+}

--- a/src/Signup/PublicSignupUseCase.php
+++ b/src/Signup/PublicSignupUseCase.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Signup;
+
+use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Auth\LoginInput;
+use NeNeRecords\Auth\LoginUseCase;
+use NeNeRecords\Auth\Role;
+use NeNeRecords\Organization\CreateOrganizationInput;
+use NeNeRecords\Organization\CreateOrganizationUseCaseInterface;
+use NeNeRecords\User\CreateUserInput;
+use NeNeRecords\User\CreateUserUseCaseInterface;
+
+/**
+ * Public self-serve signup for the subdomain SaaS: provisions a new tenant in one
+ * step — organization (active, free plan, default content types auto-seeded) plus
+ * its admin user — then logs that admin straight in so the URL "register → use" is
+ * a single round trip.
+ *
+ * Mirrors {@see \NeNeRecords\Install\InstallApplication} but for an
+ * untrusted public caller: the org is always active/free, never superadmin, and
+ * the slug has already been format/reservation-checked by the handler. Slug and
+ * email uniqueness are enforced by the underlying use cases (which raise
+ * OrganizationSlugConflictException / UserEmailConflictException → 409).
+ */
+final readonly class PublicSignupUseCase
+{
+    /**
+     * @param RequestScopedHolder<int> $orgHolder
+     */
+    public function __construct(
+        private CreateOrganizationUseCaseInterface $createOrganization,
+        private CreateUserUseCaseInterface $createUser,
+        private LoginUseCase $login,
+        private RequestScopedHolder $orgHolder,
+    ) {
+    }
+
+    public function execute(PublicSignupInput $input): PublicSignupOutput
+    {
+        // 1. Organization (active + free + seeded). 409 on slug conflict.
+        $org = $this->createOrganization->execute(new CreateOrganizationInput(
+            name: $input->organizationName,
+            slug: $input->slug,
+        ));
+
+        // 2. Scope subsequent writes (and the admin's email-uniqueness check) to it.
+        $this->orgHolder->set($org->id);
+
+        // 3. Admin user. 409 on email conflict (unlikely within a brand-new org).
+        $this->createUser->execute(new CreateUserInput(
+            email: $input->email,
+            password: $input->password,
+            role: Role::Admin->value,
+            organizationId: $org->id,
+        ));
+
+        // 4. Auto-login through the normal login path (same token + TTL).
+        $session = $this->login->execute(new LoginInput(email: $input->email, password: $input->password));
+
+        return new PublicSignupOutput(
+            token: $session->token,
+            expiresAt: $session->expiresAt,
+            organizationId: $org->id,
+            slug: $org->slug,
+            email: $session->email,
+            role: $session->role,
+        );
+    }
+}

--- a/src/Signup/ReservedSlugs.php
+++ b/src/Signup/ReservedSlugs.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Signup;
+
+/**
+ * Validates a requested tenant slug for public self-serve signup: it becomes a
+ * subdomain (`{slug}.nene-records.com`), so it must be a DNS-safe label and must
+ * not collide with infrastructure / app hostnames or routes.
+ */
+final class ReservedSlugs
+{
+    /** 3–30 chars, lowercase alphanumeric + internal hyphens, no leading/trailing hyphen. */
+    private const FORMAT = '/^[a-z0-9](?:[a-z0-9-]{1,28}[a-z0-9])$/';
+
+    /**
+     * Hostnames / route prefixes that must never be a tenant: mail + infra labels,
+     * the apex's own global surfaces, and reserved app paths.
+     *
+     * @var list<string>
+     */
+    private const RESERVED = [
+        'www', 'api', 'app', 'admin', 'superadmin', 'login', 'logout', 'signup', 'register',
+        'mail', 'email', 'smtp', 'imap', 'pop', 'pop3', 'ftp', 'sftp', 'ssh', 'webmail',
+        'ns', 'ns1', 'ns2', 'dns', 'mx', 'cdn', 'static', 'assets', 'public', 'internal',
+        'media', 'files', 'img', 'images', 'js', 'css', 'fonts',
+        'status', 'health', 'metrics', 'dashboard', 'account', 'accounts', 'billing',
+        'help', 'support', 'docs', 'doc', 'blog', 'news', 'about', 'contact', 'legal',
+        'test', 'tests', 'demo', 'example', 'staging', 'stage', 'dev', 'beta', 'sandbox',
+        'root', 'system', 'sys', 'config', 'settings',
+        'noreply', 'no-reply', 'webmaster', 'postmaster', 'hostmaster', 'abuse', 'security',
+        'nene', 'records', 'nene-records', 'suite',
+    ];
+
+    private function __construct()
+    {
+    }
+
+    public static function isValidFormat(string $slug): bool
+    {
+        return preg_match(self::FORMAT, $slug) === 1;
+    }
+
+    public static function isReserved(string $slug): bool
+    {
+        return in_array($slug, self::RESERVED, true);
+    }
+
+    /** True when the slug is a usable, non-reserved tenant label. */
+    public static function isAvailable(string $slug): bool
+    {
+        return self::isValidFormat($slug) && !self::isReserved($slug);
+    }
+}

--- a/src/Signup/SignupServiceProvider.php
+++ b/src/Signup/SignupServiceProvider.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Signup;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\ApplicationServiceProvider;
+use NeNeRecords\Auth\LoginUseCase;
+use NeNeRecords\Organization\CreateOrganizationUseCaseInterface;
+use NeNeRecords\User\CreateUserUseCaseInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class SignupServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                PublicSignupUseCase::class,
+                static function (ContainerInterface $c): PublicSignupUseCase {
+                    $createOrg  = $c->get(CreateOrganizationUseCaseInterface::class);
+                    $createUser = $c->get(CreateUserUseCaseInterface::class);
+                    $login      = $c->get(LoginUseCase::class);
+                    $orgHolder  = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+                    if (!$createOrg instanceof CreateOrganizationUseCaseInterface) {
+                        throw new LogicException('CreateOrganizationUseCaseInterface is invalid.');
+                    }
+
+                    if (!$createUser instanceof CreateUserUseCaseInterface) {
+                        throw new LogicException('CreateUserUseCaseInterface is invalid.');
+                    }
+
+                    if (!$login instanceof LoginUseCase) {
+                        throw new LogicException('LoginUseCase is invalid.');
+                    }
+
+                    if (!$orgHolder instanceof RequestScopedHolder) {
+                        throw new LogicException('Org ID holder service is invalid.');
+                    }
+
+                    /** @var RequestScopedHolder<int> $orgHolder */
+                    return new PublicSignupUseCase($createOrg, $createUser, $login, $orgHolder);
+                },
+            )
+            ->set(
+                PublicSignupHandler::class,
+                static function (ContainerInterface $c): PublicSignupHandler {
+                    $useCase = $c->get(PublicSignupUseCase::class);
+                    $json    = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof PublicSignupUseCase) {
+                        throw new LogicException('PublicSignupUseCase is invalid.');
+                    }
+
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory is invalid.');
+                    }
+
+                    return new PublicSignupHandler($useCase, $json);
+                },
+            )
+            ->set(
+                PublicSignupRouteRegistrar::class,
+                static function (ContainerInterface $c): PublicSignupRouteRegistrar {
+                    $handler = $c->get(PublicSignupHandler::class);
+
+                    if (!$handler instanceof PublicSignupHandler) {
+                        throw new LogicException('PublicSignupHandler is invalid.');
+                    }
+
+                    return new PublicSignupRouteRegistrar($handler);
+                },
+            );
+    }
+}

--- a/tests/Signup/PublicSignupUseCaseTest.php
+++ b/tests/Signup/PublicSignupUseCaseTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Signup;
+
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Auth\LoginUseCase;
+use NeNeRecords\Organization\CreateOrganizationUseCase;
+use NeNeRecords\Organization\OrganizationSlugConflictException;
+use NeNeRecords\Signup\PublicSignupInput;
+use NeNeRecords\Signup\PublicSignupUseCase;
+use NeNeRecords\Tests\Organization\InMemoryOrganizationRepository;
+use NeNeRecords\Tests\Organization\RecordingDefaultContentTypeSeeder;
+use NeNeRecords\Tests\User\InMemoryUserRepository;
+use NeNeRecords\User\CreateUserUseCase;
+use PHPUnit\Framework\TestCase;
+
+final class PublicSignupUseCaseTest extends TestCase
+{
+    private InMemoryOrganizationRepository $orgs;
+    private InMemoryUserRepository $users;
+    private RecordingDefaultContentTypeSeeder $seeder;
+
+    private function useCase(): PublicSignupUseCase
+    {
+        $this->orgs = new InMemoryOrganizationRepository();
+        $this->users = new InMemoryUserRepository([]);
+        $this->seeder = new RecordingDefaultContentTypeSeeder();
+
+        $tokenIssuer = new class () implements TokenIssuerInterface {
+            /** @param array<string, mixed> $claims */
+            public function issue(array $claims): string
+            {
+                return 'tok-' . (is_string($claims['sub'] ?? null) ? $claims['sub'] : '');
+            }
+        };
+
+        /** @var RequestScopedHolder<int> $holder */
+        $holder = new RequestScopedHolder();
+
+        return new PublicSignupUseCase(
+            new CreateOrganizationUseCase($this->orgs, $this->seeder),
+            new CreateUserUseCase($this->users),
+            new LoginUseCase($this->users, $tokenIssuer),
+            $holder,
+        );
+    }
+
+    public function testProvisionsTenantAndAutoLogsIn(): void
+    {
+        $output = $this->useCase()->execute(
+            new PublicSignupInput('My Shop', 'my-shop', 'owner@shop.test', 'secret-password'),
+        );
+
+        // Organization created (active, seeded) …
+        $org = $this->orgs->findBySlug('my-shop');
+        self::assertNotNull($org);
+        self::assertTrue($org->isActive);
+        self::assertSame('free', $org->plan);
+        self::assertSame([$org->id], $this->seeder->seededOrgIds);
+
+        // … admin user created …
+        $admin = $this->users->findByEmail('owner@shop.test');
+        self::assertNotNull($admin);
+        self::assertSame('admin', $admin->role);
+
+        // … and signed straight in.
+        self::assertSame('tok-owner@shop.test', $output->token);
+        self::assertSame('my-shop', $output->slug);
+        self::assertSame('admin', $output->role);
+        self::assertSame($org->id, $output->organizationId);
+    }
+
+    public function testDuplicateSlugIsRejected(): void
+    {
+        $useCase = $this->useCase();
+        $useCase->execute(new PublicSignupInput('First', 'taken', 'a@x.test', 'secret-password'));
+
+        $this->expectException(OrganizationSlugConflictException::class);
+        $useCase->execute(new PublicSignupInput('Second', 'taken', 'b@y.test', 'secret-password'));
+    }
+}

--- a/tests/Signup/ReservedSlugsTest.php
+++ b/tests/Signup/ReservedSlugsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Signup;
+
+use NeNeRecords\Signup\ReservedSlugs;
+use PHPUnit\Framework\TestCase;
+
+final class ReservedSlugsTest extends TestCase
+{
+    public function testValidFormats(): void
+    {
+        self::assertTrue(ReservedSlugs::isValidFormat('shop'));
+        self::assertTrue(ReservedSlugs::isValidFormat('my-shop'));
+        self::assertTrue(ReservedSlugs::isValidFormat('shop2024'));
+        self::assertTrue(ReservedSlugs::isValidFormat('a1b'));
+    }
+
+    public function testInvalidFormats(): void
+    {
+        self::assertFalse(ReservedSlugs::isValidFormat('ab'));        // too short
+        self::assertFalse(ReservedSlugs::isValidFormat('-shop'));     // leading hyphen
+        self::assertFalse(ReservedSlugs::isValidFormat('shop-'));     // trailing hyphen
+        self::assertFalse(ReservedSlugs::isValidFormat('Shop'));      // uppercase
+        self::assertFalse(ReservedSlugs::isValidFormat('my_shop'));   // underscore
+        self::assertFalse(ReservedSlugs::isValidFormat(str_repeat('a', 31))); // too long
+    }
+
+    public function testReservedLabels(): void
+    {
+        self::assertTrue(ReservedSlugs::isReserved('www'));
+        self::assertTrue(ReservedSlugs::isReserved('api'));
+        self::assertTrue(ReservedSlugs::isReserved('admin'));
+        self::assertTrue(ReservedSlugs::isReserved('mail'));
+        self::assertFalse(ReservedSlugs::isReserved('shop'));
+    }
+
+    public function testIsAvailableCombinesBoth(): void
+    {
+        self::assertTrue(ReservedSlugs::isAvailable('my-cafe'));
+        self::assertFalse(ReservedSlugs::isAvailable('admin'));   // reserved
+        self::assertFalse(ReservedSlugs::isAvailable('-bad'));    // malformed
+    }
+}


### PR DESCRIPTION
## 目的
managed入口の**本質ギャップ＝公開サインアップ**を実装。`POST /api/v1/public/signup` で新テナントを1往復でプロビジョン（org＋管理者＋既定コンテンツ型 seed）し、その管理者を**即ログイン**（HttpOnly セッション cookie）。URL「登録すれば使える」を成立させる。

## 追加（`src/Signup/`）
- **`PublicSignupUseCase`**：`CreateOrganizationUseCase`（active/free/seed）→ `orgHolder.set` → `CreateUserUseCase`（admin）→ `LoginUseCase` で auto-login。`InstallApplication` の公開版。
- **`PublicSignupHandler`**：入力検証（org名 / slug / email / password）→ provision → セッション cookie（201）。
- **`ReservedSlugs`**：slug format（3–30・小文字英数+ハイフン・前後ハイフン不可）＋予約語（www/api/admin/mail/… ＋ apex グローバル面 ＋ infra ラベル）。
- **`SignupServiceProvider`** ＋ route 登録。slug/email 重複は既存ドメイン例外（→ **409**）。

## 公開性・テナント分離
- `AdminApiAuthMiddleware` が `/api/v1/public/` を always-open（認証不要）。
- `OrgResolverMiddleware::BYPASS_PREFIXES` に `/api/v1/public/signup`（新 org を作る＝テナント文脈なし）。
- 仕様（MVP）：**plan=free 固定 / slug=ユーザー指定 / メール認証ゲートなし＝即ログイン / abuse は予約語＋format（rate limit は follow-up）**。

## 検証
- `composer check` 緑（PHPUnit / PHPStan level 8 / CS / OpenAPI / MCP）。**本番箱は無変更**。
- テスト：`ReservedSlugs`（format / 予約 / 可用）／`PublicSignupUseCase`（org+admin+seed+auto-login、slug 重複→409）。
- OpenAPI に `/api/v1/public/signup` ＋ `SignupRequest/Response` を追記、`schema.gen.ts` 再生成・フロント type-check 緑。

## 残（④-frontend / ③）
- apex の landing＋signup フォーム UI（`nene2.apex` / hostname 判定）。
- ③ Caddy 切替（cutover）＋ `tenant_resolution_mode=subdomain`。

Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)