### PR TITLE
feat(signup): 公開 signup フォーム(apex) (subdomain-saas ④-frontend)

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -7,6 +7,7 @@ import { PublicShell } from '@/pages/consumer/PublicShell'
 import { ForbiddenPage } from '@/pages/forbidden/ForbiddenPage'
 import { AppShell } from '@/pages/layout/AppShell'
 import { LoginPage } from '@/pages/login/LoginPage'
+import { SignupPage } from '@/pages/signup/SignupPage'
 import { NotFoundPage } from '@/pages/not-found/NotFoundPage'
 import { SuperadminShell } from '@/pages/superadmin/SuperadminShell'
 import { RequireAuth } from '@/app/RequireAuth'
@@ -65,6 +66,11 @@ const router = createBrowserRouter(
     {
       path: '/login',
       element: <LoginPage />,
+    },
+    {
+      // Public self-serve signup (subdomain SaaS apex).
+      path: '/signup',
+      element: <SignupPage />,
     },
     {
       path: '/admin/accept-invite',

--- a/frontend/src/entities/auth/api-types.ts
+++ b/frontend/src/entities/auth/api-types.ts
@@ -1,3 +1,5 @@
+import type { components } from '@/shared/api/schema.gen'
+
 export interface LoginRequestDto {
   email: string
   password: string
@@ -9,3 +11,6 @@ export interface LoginResponseDto {
   email: string
   role: string
 }
+
+export type SignupRequestDto = components['schemas']['SignupRequest']
+export type SignupResponseDto = components['schemas']['SignupResponse']

--- a/frontend/src/entities/auth/index.ts
+++ b/frontend/src/entities/auth/index.ts
@@ -1,6 +1,7 @@
 export { authStore } from './model'
 export type { AuthSession } from './model'
-export { useLogin, useLogout } from './mutations'
+export { useLogin, useLogout, useSignup } from './mutations'
+export type { SignupRequestDto, SignupResponseDto } from './api-types'
 export { hasCapability, isAdmin, isSuperadmin } from './capabilities'
 export type { Capability, UserRole } from './capabilities'
 export {

--- a/frontend/src/entities/auth/mutations.ts
+++ b/frontend/src/entities/auth/mutations.ts
@@ -1,7 +1,23 @@
 import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
 import { apiClient, AppError } from '@/shared/api/client'
-import type { LoginRequestDto, LoginResponseDto } from './api-types'
+import type {
+  LoginRequestDto,
+  LoginResponseDto,
+  SignupRequestDto,
+  SignupResponseDto,
+} from './api-types'
 import { authStore, type AuthSession } from './model'
+
+/**
+ * Public self-serve signup. Provisions a tenant and returns its slug; the session
+ * cookie it sets is host-only (apex), so the caller hands the new admin off to
+ * their own subdomain to sign in — keeping tenant cookies isolated.
+ */
+export function useSignup(): UseMutationResult<SignupResponseDto, AppError, SignupRequestDto> {
+  return useMutation({
+    mutationFn: (input) => apiClient.post<SignupResponseDto>('/api/v1/public/signup', input),
+  })
+}
 
 export function useLogin(): UseMutationResult<AuthSession, AppError, LoginRequestDto> {
   const queryClient = useQueryClient()

--- a/frontend/src/pages/signup/SignupPage.tsx
+++ b/frontend/src/pages/signup/SignupPage.tsx
@@ -1,0 +1,158 @@
+import { useState, type ReactNode, type SyntheticEvent } from 'react'
+import { useSignup, type SignupResponseDto } from '@/entities/auth'
+import { useTranslation } from '@/shared/i18n'
+import { Button, Card, Input, NeneMark, Stack, Text } from '@/shared/ui'
+
+/**
+ * Public self-serve signup (subdomain SaaS apex). Provisions a tenant, then hands
+ * the new admin off to their own subdomain to sign in — the session cookie is
+ * host-only, so it never crosses into another tenant.
+ */
+export function SignupPage() {
+  const [organizationName, setOrganizationName] = useState('')
+  const [slug, setSlug] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [done, setDone] = useState<SignupResponseDto | null>(null)
+  const signup = useSignup()
+  const { t } = useTranslation()
+
+  // At the apex, the current host IS the SaaS base domain.
+  const baseDomain = typeof window !== 'undefined' ? window.location.hostname : 'nene-records.com'
+  const previewUrl = `${slug || t('admin.signup.slugPlaceholder')}.${baseDomain}`
+
+  const handleSubmit = (e: SyntheticEvent) => {
+    e.preventDefault()
+    signup.mutate(
+      { organization_name: organizationName, slug, email, password },
+      {
+        onSuccess: (dto) => {
+          setDone(dto)
+        },
+      },
+    )
+  }
+
+  if (done !== null) {
+    const tenantUrl = `https://${done.slug}.${baseDomain}`
+    return (
+      <Centered>
+        <Card padding="lg" className="w-full max-w-sm">
+          <Stack gap="lg">
+            <Stack gap="xs">
+              <Text as="h1" variant="heading-md">
+                {t('admin.signup.successTitle')}
+              </Text>
+              <Text muted>
+                {t('admin.signup.successBody', { url: `${done.slug}.${baseDomain}` })}
+              </Text>
+            </Stack>
+            <Button
+              type="button"
+              className="w-full"
+              onClick={() => {
+                window.location.href = `${tenantUrl}/login`
+              }}
+            >
+              {t('admin.signup.goToLogin')}
+            </Button>
+          </Stack>
+        </Card>
+      </Centered>
+    )
+  }
+
+  const isConflict = signup.error?.status === 409
+
+  return (
+    <Centered>
+      <Card padding="lg" className="w-full max-w-sm">
+        <Stack gap="lg">
+          <Stack gap="md">
+            <div className="flex items-center gap-inline-sm">
+              <NeneMark size={26} className="text-accent" />
+              <span className="font-chrome text-base font-bold tracking-tight text-text-primary">
+                NeNe Records
+              </span>
+            </div>
+            <Stack gap="xs">
+              <Text as="h1" variant="heading-md">
+                {t('admin.signup.appTitle')}
+              </Text>
+              <Text muted>{t('admin.signup.subtitle')}</Text>
+            </Stack>
+          </Stack>
+
+          {signup.isError && (
+            <div
+              role="alert"
+              className="rounded-sm border border-danger bg-danger/10 px-inline-sm py-stack-xs text-caption font-medium text-danger"
+            >
+              {isConflict ? t('admin.signup.errorTaken') : t('admin.signup.errorGeneric')}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit}>
+            <Stack gap="md">
+              <Input
+                id="organization_name"
+                label={t('admin.signup.orgNameLabel')}
+                value={organizationName}
+                onChange={(e) => {
+                  setOrganizationName(e.target.value)
+                }}
+                autoComplete="organization"
+              />
+              <Stack gap="xs">
+                <Input
+                  id="slug"
+                  label={t('admin.signup.slugLabel')}
+                  value={slug}
+                  onChange={(e) => {
+                    setSlug(e.target.value.toLowerCase())
+                  }}
+                  autoComplete="off"
+                />
+                <Text variant="caption" muted>
+                  {t('admin.signup.slugHint', { url: previewUrl })}
+                </Text>
+              </Stack>
+              <Input
+                id="email"
+                label={t('admin.signup.emailLabel')}
+                type="email"
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value)
+                }}
+                autoComplete="email"
+              />
+              <Input
+                id="password"
+                label={t('admin.signup.passwordLabel')}
+                type="password"
+                value={password}
+                onChange={(e) => {
+                  setPassword(e.target.value)
+                }}
+                autoComplete="new-password"
+              />
+
+              <Button type="submit" disabled={signup.isPending} className="mt-stack-xs w-full">
+                {signup.isPending ? t('admin.signup.submitting') : t('admin.signup.submit')}
+              </Button>
+            </Stack>
+          </form>
+        </Stack>
+      </Card>
+    </Centered>
+  )
+}
+
+function Centered({ children }: { children: ReactNode }) {
+  return (
+    <div className="relative flex min-h-screen items-center justify-center bg-surface px-inline-md">
+      {children}
+    </div>
+  )
+}

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -418,6 +418,23 @@ export const de: Partial<MessageCatalog> = {
   'admin.auth.signIn': 'Anmelden',
   'admin.auth.signingIn': 'Anmeldung…',
   'admin.auth.invalidCredentials': 'E-Mail oder Passwort falsch',
+
+  'admin.signup.appTitle': 'Website erstellen',
+  'admin.signup.subtitle': 'Starte deine NeNe-Records-Website in Sekunden.',
+  'admin.signup.orgNameLabel': 'Website-Name',
+  'admin.signup.slugLabel': 'Subdomain',
+  'admin.signup.slugPlaceholder': 'deine-seite',
+  'admin.signup.slugHint': 'Deine Website liegt unter {{url}}',
+  'admin.signup.emailLabel': 'E-Mail',
+  'admin.signup.passwordLabel': 'Passwort',
+  'admin.signup.submit': 'Website erstellen',
+  'admin.signup.submitting': 'Wird erstellt …',
+  'admin.signup.errorTaken': 'Diese Subdomain oder E-Mail ist bereits vergeben.',
+  'admin.signup.errorGeneric':
+    'Website konnte nicht erstellt werden. Bitte überprüfe deine Angaben.',
+  'admin.signup.successTitle': 'Deine Website ist bereit!',
+  'admin.signup.successBody': 'Melde dich an, um {{url}} aufzubauen.',
+  'admin.signup.goToLogin': 'Zu deiner Website',
   // ── Forbidden page ───────────────────────────────────────────────────────
   'admin.forbidden.title': 'Zugriff verweigert',
   'admin.forbidden.description':

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -419,6 +419,24 @@ export const en = {
   'admin.auth.signingIn': 'Signing in…',
   'admin.auth.invalidCredentials': 'Invalid email or password',
 
+  // ── Public signup (subdomain SaaS) ───────────────────────────────────────
+  'admin.signup.appTitle': 'Create your site',
+  'admin.signup.subtitle': 'Start your NeNe Records site in seconds.',
+  'admin.signup.orgNameLabel': 'Site name',
+  'admin.signup.slugLabel': 'Subdomain',
+  'admin.signup.slugPlaceholder': 'your-site',
+  'admin.signup.slugHint': 'Your site will live at {{url}}',
+  'admin.signup.emailLabel': 'Email',
+  'admin.signup.passwordLabel': 'Password',
+  'admin.signup.submit': 'Create site',
+  'admin.signup.submitting': 'Creating…',
+  'admin.signup.errorTaken': 'That subdomain or email is already taken.',
+  'admin.signup.errorGeneric':
+    'Could not create your site. Please check your details and try again.',
+  'admin.signup.successTitle': 'Your site is ready!',
+  'admin.signup.successBody': 'Sign in to start building {{url}}.',
+  'admin.signup.goToLogin': 'Go to your site',
+
   // ── Forbidden page ───────────────────────────────────────────────────────
   'admin.forbidden.title': 'Access denied',
   'admin.forbidden.description':

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -420,6 +420,23 @@ export const fr: Partial<MessageCatalog> = {
   'admin.auth.signingIn': 'Connexion…',
   'admin.auth.invalidCredentials': 'E-mail ou mot de passe incorrect',
 
+  'admin.signup.appTitle': 'Créer votre site',
+  'admin.signup.subtitle': 'Lancez votre site NeNe Records en quelques secondes.',
+  'admin.signup.orgNameLabel': 'Nom du site',
+  'admin.signup.slugLabel': 'Sous-domaine',
+  'admin.signup.slugPlaceholder': 'votre-site',
+  'admin.signup.slugHint': 'Votre site sera accessible sur {{url}}',
+  'admin.signup.emailLabel': 'E-mail',
+  'admin.signup.passwordLabel': 'Mot de passe',
+  'admin.signup.submit': 'Créer le site',
+  'admin.signup.submitting': 'Création…',
+  'admin.signup.errorTaken': 'Ce sous-domaine ou cet e-mail est déjà pris.',
+  'admin.signup.errorGeneric':
+    'Impossible de créer votre site. Vérifiez vos informations et réessayez.',
+  'admin.signup.successTitle': 'Votre site est prêt !',
+  'admin.signup.successBody': 'Connectez-vous pour commencer à construire {{url}}.',
+  'admin.signup.goToLogin': 'Aller à votre site',
+
   // ── Forbidden page ───────────────────────────────────────────────────────
   'admin.forbidden.title': 'Accès refusé',
   'admin.forbidden.description':

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -411,6 +411,24 @@ export const ja: Partial<MessageCatalog> = {
   'admin.auth.signingIn': 'サインイン中…',
   'admin.auth.invalidCredentials': 'メールアドレスまたはパスワードが正しくありません',
 
+  // ── 公開サインアップ（サブドメイン SaaS） ───────────────────────────────────
+  'admin.signup.appTitle': 'サイトを作成',
+  'admin.signup.subtitle': 'NeNe Records のサイトを数秒で開設できます。',
+  'admin.signup.orgNameLabel': 'サイト名',
+  'admin.signup.slugLabel': 'サブドメイン',
+  'admin.signup.slugPlaceholder': 'your-site',
+  'admin.signup.slugHint': 'サイトの URL は {{url}} になります',
+  'admin.signup.emailLabel': 'メールアドレス',
+  'admin.signup.passwordLabel': 'パスワード',
+  'admin.signup.submit': 'サイトを作成',
+  'admin.signup.submitting': '作成中…',
+  'admin.signup.errorTaken': 'そのサブドメインまたはメールアドレスは既に使われています。',
+  'admin.signup.errorGeneric':
+    'サイトを作成できませんでした。入力内容を確認して再度お試しください。',
+  'admin.signup.successTitle': 'サイトの準備ができました！',
+  'admin.signup.successBody': '{{url}} にサインインして作成を始めましょう。',
+  'admin.signup.goToLogin': 'サイトへ移動',
+
   // ── Forbidden ────────────────────────────────────────────────────────────
   'admin.forbidden.title': 'アクセス拒否',
   'admin.forbidden.description':

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -418,6 +418,23 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.auth.signingIn': 'Entrando…',
   'admin.auth.invalidCredentials': 'E-mail ou senha incorretos',
 
+  'admin.signup.appTitle': 'Crie seu site',
+  'admin.signup.subtitle': 'Comece seu site NeNe Records em segundos.',
+  'admin.signup.orgNameLabel': 'Nome do site',
+  'admin.signup.slugLabel': 'Subdomínio',
+  'admin.signup.slugPlaceholder': 'seu-site',
+  'admin.signup.slugHint': 'Seu site ficará em {{url}}',
+  'admin.signup.emailLabel': 'E-mail',
+  'admin.signup.passwordLabel': 'Senha',
+  'admin.signup.submit': 'Criar site',
+  'admin.signup.submitting': 'Criando…',
+  'admin.signup.errorTaken': 'Esse subdomínio ou e-mail já está em uso.',
+  'admin.signup.errorGeneric':
+    'Não foi possível criar seu site. Verifique seus dados e tente novamente.',
+  'admin.signup.successTitle': 'Seu site está pronto!',
+  'admin.signup.successBody': 'Entre para começar a construir {{url}}.',
+  'admin.signup.goToLogin': 'Ir para seu site',
+
   // ── Forbidden page ───────────────────────────────────────────────────────
   'admin.forbidden.title': 'Acesso negado',
   'admin.forbidden.description':

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -402,6 +402,22 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.auth.signingIn': '登录中…',
   'admin.auth.invalidCredentials': '邮箱或密码错误',
 
+  'admin.signup.appTitle': '创建你的站点',
+  'admin.signup.subtitle': '几秒钟即可开通你的 NeNe Records 站点。',
+  'admin.signup.orgNameLabel': '站点名称',
+  'admin.signup.slugLabel': '子域名',
+  'admin.signup.slugPlaceholder': 'your-site',
+  'admin.signup.slugHint': '你的站点地址将是 {{url}}',
+  'admin.signup.emailLabel': '邮箱',
+  'admin.signup.passwordLabel': '密码',
+  'admin.signup.submit': '创建站点',
+  'admin.signup.submitting': '创建中…',
+  'admin.signup.errorTaken': '该子域名或邮箱已被占用。',
+  'admin.signup.errorGeneric': '无法创建站点。请检查信息后重试。',
+  'admin.signup.successTitle': '你的站点已就绪！',
+  'admin.signup.successBody': '登录即可开始构建 {{url}}。',
+  'admin.signup.goToLogin': '前往你的站点',
+
   // ── Forbidden page ───────────────────────────────────────────────────────
   'admin.forbidden.title': '访问被拒绝',
   'admin.forbidden.description': '您已登录，但您的账户没有执行此操作的权限。',


### PR DESCRIPTION
## 目的
④-backend の `POST /api/v1/public/signup` を叩く UI。apex（nene-records.com）で新規テナントを登録し、作成後はテナントのサブドメインにハンドオフして1回サインインする。

## 設計（cookie 分離を保つハンドオフ）
- セッション cookie は **host-only**（apex 用）＝サブドメインに渡らない（テナント分離の要）。signup 成功後は `https://{slug}.{baseDomain}/login` へ誘導して1回ログイン。真のクロスサブドメイン auto-login（ワンタイムトークン交換）は follow-up。

## 追加
- **`entities/auth`**：`useSignup`（mutation）＋ `SignupRequestDto/ResponseDto`（生成型）。
- **`pages/signup/SignupPage`**：サイト名 / サブドメイン（`{slug}.{baseDomain}` プレビュー）/ メール / パスワード → 成功で「サイトの準備ができました」＋テナントへ移動。409→重複、422→入力エラー表示。`baseDomain = window.location.hostname`。
- route `/signup`。i18n キー（`admin.signup.*`）を**全6ロケール**（en/ja/de/fr/pt-BR/zh-Hans）に追加（locales key-coverage テスト必須）。

## 検証
- `npm run check` 緑（type-check / lint / prettier / test 418 / themes / knip / storybook）。

## 残（③ / follow-up）
- ③ Caddy 切替（cutover）＋ `tenant_resolution_mode=subdomain`＝本番で `slug.nene-records.com` を実際に立てる。
- apex の landing（マーケ面）＋ 真のクロスサブドメイン auto-login（OTT）。

Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)