### PR TITLE
fix(tenant): cron バッチを全テナント対応にする (subdomain-saas ③ blocker)

### DIFF
--- a/src/Entity/EntityServiceProvider.php
+++ b/src/Entity/EntityServiceProvider.php
@@ -12,6 +12,7 @@ use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
+use NeNeRecords\Organization\OrganizationIterator;
 use NeNeRecords\Setting\SettingRepositoryInterface;
 use NeNeRecords\TextField\TextFieldRepositoryInterface;
 use NeNeRecords\Webhook\WebhookDispatcherInterface;
@@ -353,6 +354,7 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $c): ProcessScheduledPublishHandler {
                     $useCase = $c->get(ProcessScheduledPublishUseCaseInterface::class);
                     $response = $c->get(JsonResponseFactory::class);
+                    $organizations = $c->get(OrganizationIterator::class);
 
                     if (!$useCase instanceof ProcessScheduledPublishUseCaseInterface) {
                         throw new LogicException('ProcessScheduledPublish use case service is invalid.');
@@ -362,7 +364,11 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
                         throw new LogicException('JSON response factory service is invalid.');
                     }
 
-                    return new ProcessScheduledPublishHandler($useCase, $response);
+                    if (!$organizations instanceof OrganizationIterator) {
+                        throw new LogicException('OrganizationIterator service is invalid.');
+                    }
+
+                    return new ProcessScheduledPublishHandler($useCase, $response, $organizations);
                 },
             )
             ->set(

--- a/src/Entity/ProcessScheduledPublishHandler.php
+++ b/src/Entity/ProcessScheduledPublishHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Entity;
 
 use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Organization\OrganizationIterator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -13,16 +14,30 @@ final readonly class ProcessScheduledPublishHandler
     public function __construct(
         private ProcessScheduledPublishUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        // Prod wires this so the cron covers every tenant; null = current org only
+        // (the request-resolved org, e.g. single-org deploys / focused tests).
+        private ?OrganizationIterator $organizations = null,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $output = $this->useCase->execute();
+        // The use case is org-scoped (findDueScheduled reads the org holder), so run
+        // it once per active tenant. In subdomain mode the org-less cron cannot
+        // resolve a tenant, so the iterator drives the per-org scoping.
+        $published = [];
+
+        if ($this->organizations === null) {
+            $published = $this->useCase->execute()->publishedIds;
+        } else {
+            $this->organizations->forEachActive(function () use (&$published): void {
+                $published = array_merge($published, $this->useCase->execute()->publishedIds);
+            });
+        }
 
         return $this->response->create([
-            'published_count' => count($output->publishedIds),
-            'published_ids' => $output->publishedIds,
+            'published_count' => count($published),
+            'published_ids' => $published,
         ]);
     }
 }

--- a/src/Organization/OrganizationIterator.php
+++ b/src/Organization/OrganizationIterator.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Organization;
+
+use Nene2\Http\RequestScopedHolder;
+
+/**
+ * Runs org-scoped work once per active organization, scoping the shared org-id
+ * holder to each in turn so org-scoped repositories operate on that tenant.
+ *
+ * For org-agnostic batch jobs that must cover every tenant — notably the
+ * scheduled-publish cron, which in subdomain (multi-tenant) mode has no single
+ * org context (the cron hits the app with an internal host).
+ */
+final readonly class OrganizationIterator
+{
+    /**
+     * @param RequestScopedHolder<int> $orgHolder
+     */
+    public function __construct(
+        private OrganizationRepositoryInterface $organizations,
+        private RequestScopedHolder $orgHolder,
+    ) {
+    }
+
+    /**
+     * @param callable(int $organizationId): void $work
+     */
+    public function forEachActive(callable $work): void
+    {
+        foreach ($this->organizations->findAllActive() as $org) {
+            if ($org->id === null) {
+                continue;
+            }
+
+            $this->orgHolder->set($org->id);
+            $work($org->id);
+        }
+    }
+}

--- a/src/Organization/OrganizationRepositoryInterface.php
+++ b/src/Organization/OrganizationRepositoryInterface.php
@@ -15,6 +15,14 @@ interface OrganizationRepositoryInterface
     /** @return list<Organization> */
     public function findAll(int $limit, int $offset): array;
 
+    /**
+     * Every active organization — for org-agnostic batch work (e.g. the
+     * multi-tenant scheduled-publish cron iterating each tenant).
+     *
+     * @return list<Organization>
+     */
+    public function findAllActive(): array;
+
     public function count(): int;
 
     /** @throws OrganizationSlugConflictException */

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -10,6 +10,8 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\ApplicationServiceProvider;
 use NeNeRecords\SystemConfig\SystemConfigRepositoryInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -287,6 +289,25 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
                     }
 
                     return new TlsCheckRouteRegistrar($handler);
+                },
+            )
+            // ── Multi-tenant batch iteration (cron jobs) ────────────────────────
+            ->set(
+                OrganizationIterator::class,
+                static function (ContainerInterface $c): OrganizationIterator {
+                    $repo = $c->get(OrganizationRepositoryInterface::class);
+                    $orgHolder = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+                    if (!$repo instanceof OrganizationRepositoryInterface) {
+                        throw new LogicException('OrganizationRepositoryInterface is invalid.');
+                    }
+
+                    if (!$orgHolder instanceof RequestScopedHolder) {
+                        throw new LogicException('Org ID holder service is invalid.');
+                    }
+
+                    /** @var RequestScopedHolder<int> $orgHolder */
+                    return new OrganizationIterator($repo, $orgHolder);
                 },
             );
     }

--- a/src/Organization/PdoOrganizationRepository.php
+++ b/src/Organization/PdoOrganizationRepository.php
@@ -57,6 +57,16 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
         return array_map(fn (array $row) => $this->mapRow($row), $rows);
     }
 
+    public function findAllActive(): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM organizations WHERE is_active = 1 ORDER BY id ASC',
+            [],
+        );
+
+        return array_map(fn (array $row) => $this->mapRow($row), $rows);
+    }
+
     public function count(): int
     {
         $row = $this->query->fetchOne('SELECT COUNT(*) AS cnt FROM organizations', []);

--- a/src/Organization/Resolution/OrgResolverMiddleware.php
+++ b/src/Organization/Resolution/OrgResolverMiddleware.php
@@ -39,6 +39,10 @@ final readonly class OrgResolverMiddleware implements MiddlewareInterface
         '/health',
         '/internal/tls-check',
         '/api/v1/public/signup',
+        // Cron batch jobs run org-agnostically (all tenants), so they carry no
+        // tenant host — bypass resolution instead of 404ing in subdomain mode.
+        '/api/v1/entities/process-scheduled',
+        '/api/v1/webhooks/process-deliveries',
         '/api/v1/organizations',
         '/api/v1/superadmin/',
         '/api/v1/auth/',

--- a/tests/Organization/InMemoryOrganizationRepository.php
+++ b/tests/Organization/InMemoryOrganizationRepository.php
@@ -49,6 +49,11 @@ final class InMemoryOrganizationRepository implements OrganizationRepositoryInte
         return array_slice(array_values($this->store), $offset, $limit);
     }
 
+    public function findAllActive(): array
+    {
+        return array_values(array_filter($this->store, static fn (Organization $o): bool => $o->isActive));
+    }
+
     public function count(): int
     {
         return count($this->store);

--- a/tests/Organization/OrganizationIteratorTest.php
+++ b/tests/Organization/OrganizationIteratorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Organization;
+
+use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Organization\Organization;
+use NeNeRecords\Organization\OrganizationIterator;
+use PHPUnit\Framework\TestCase;
+
+final class OrganizationIteratorTest extends TestCase
+{
+    public function testRunsWorkPerActiveOrgWithHolderScoped(): void
+    {
+        $repo = new InMemoryOrganizationRepository();
+        $a = $repo->save(new Organization('A', 'a', 'free', true));
+        $b = $repo->save(new Organization('B', 'b', 'free', true));
+        $repo->save(new Organization('Off', 'off', 'free', false)); // inactive → skipped
+
+        /** @var RequestScopedHolder<int> $holder */
+        $holder = new RequestScopedHolder();
+        $iterator = new OrganizationIterator($repo, $holder);
+
+        $seen = [];
+        $iterator->forEachActive(function (int $orgId) use (&$seen, $holder): void {
+            // The holder is scoped to the current org during the callback.
+            $seen[] = [$orgId, $holder->get()];
+        });
+
+        self::assertSame([[$a, $a], [$b, $b]], $seen);
+    }
+
+    public function testNoActiveOrgsRunsNothing(): void
+    {
+        $repo = new InMemoryOrganizationRepository();
+        $repo->save(new Organization('Off', 'off', 'free', false));
+
+        /** @var RequestScopedHolder<int> $holder */
+        $holder = new RequestScopedHolder();
+
+        $count = 0;
+        (new OrganizationIterator($repo, $holder))->forEachActive(function () use (&$count): void {
+            $count++;
+        });
+
+        self::assertSame(0, $count);
+    }
+}


### PR DESCRIPTION
## 背景
本番 ③ cutover の実行で判明したブロッカー。cron（`process-scheduled` / `process-deliveries`）は `Host: app` でアプリを叩くが、**subdomain モードでは org を解決できず 404** → 全テナントの予定公開・Webhook 配信が停止。single モードは EnvResolution が常に default org を返すため顕在化していなかった。

## 修正
- **両 cron を `OrgResolverMiddleware::BYPASS_PREFIXES` に追加**（org 非依存のバッチ＝テナント host を持たない。subdomain で 404 にせず `orgId=0` で通す）。
- **webhook 配信**：processor は元々 org 横断（"intentionally not org-scoped, drains all tenants"）＝**bypass だけで成立**。
- **予定公開**：`ProcessScheduledPublishUseCase` は org-scoped（`findDueScheduled` が holder 依存）なので、**`OrganizationIterator`（新）で全 active org を巡回**（org 毎に holder を set→処理）→ ハンドラで集約。iterator は**任意注入**（null＝現在 org のみ＝既存単一org/テスト挙動。prod は注入）。
- `OrganizationRepositoryInterface::findAllActive()`（＋ Pdo / InMemory 実装）。

## 検証
- `composer check` 緑（PHPUnit / PHPStan level 8 / CS / OpenAPI / MCP）。
- テスト：`OrganizationIterator`（active のみ巡回・holder スコープ・空時 no-op）。既存 scheduled-publish HTTP テストは null fallback で不変。

## 経緯
PR #604 までで subdomain SaaS のアプリ側（①②④＋apex LP）完了 → ③ cutover を本番実行 → `mode=subdomain` にした瞬間 **records.nene-suite.com 404 ＋ cron 停止**を観測 → **即 single へ revert（prod 復旧済・mysqldump バックアップ取得済）** → 本 PR が cutover 再実行の前提。

Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)