### PR TITLE
fix(http): ブラウザの / で SPA シェルを返す（apex LP/公開ホーム）

### DIFF
--- a/src/Http/SpaShellFallback.php
+++ b/src/Http/SpaShellFallback.php
@@ -44,19 +44,26 @@ final readonly class SpaShellFallback
 
     public function apply(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
-        if ($response->getStatusCode() !== 404) {
-            return $response;
-        }
-
-        if (strtoupper($request->getMethod()) !== 'GET') {
-            return $response;
-        }
-
-        if (!str_contains($request->getHeaderLine('Accept'), 'text/html')) {
-            return $response;
-        }
-
+        $isGet = strtoupper($request->getMethod()) === 'GET';
+        $wantsHtml = str_contains($request->getHeaderLine('Accept'), 'text/html');
         $path = $request->getUri()->getPath();
+
+        // The home `/` is the NENE2 framework-info JSON for API clients, but a
+        // browser there wants the public site / SaaS landing — serve the SPA shell
+        // for `/` + text/html even though the framework answered 200 (not 404).
+        $isHtmlHome = $isGet && $wantsHtml && $path === '/';
+
+        if ($response->getStatusCode() !== 404 && !$isHtmlHome) {
+            return $response;
+        }
+
+        if (!$isGet) {
+            return $response;
+        }
+
+        if (!$wantsHtml) {
+            return $response;
+        }
 
         if (preg_match(self::PASSTHROUGH, $path) === 1) {
             return $response;

--- a/tests/Http/SpaShellFallbackTest.php
+++ b/tests/Http/SpaShellFallbackTest.php
@@ -123,6 +123,30 @@ final class SpaShellFallbackTest extends TestCase
         self::assertStringNotContainsString('__BASE_PATH__', $body);
     }
 
+    public function testServesShellForHtmlHomeOverFrameworkJson(): void
+    {
+        // The NENE2 framework answers `/` with 200 JSON; a browser must still get
+        // the SPA shell (public home / SaaS landing).
+        $frameworkJson = $this->factory->createResponse(200)
+            ->withHeader('Content-Type', 'application/json');
+
+        $result = $this->fallback->apply($this->request('GET', '/'), $frameworkJson);
+
+        self::assertSame(200, $result->getStatusCode());
+        self::assertStringContainsString('text/html', $result->getHeaderLine('Content-Type'));
+        self::assertStringContainsString('<div id="root">', (string) $result->getBody());
+    }
+
+    public function testLeavesJsonHomeForApiClients(): void
+    {
+        // No text/html Accept → the framework JSON passes through untouched.
+        $frameworkJson = $this->factory->createResponse(200);
+
+        $result = $this->fallback->apply($this->request('GET', '/', 'application/json'), $frameworkJson);
+
+        self::assertSame('', (string) $result->getBody());
+    }
+
     public function testInjectsApexFlagOnBaseDomainOnly(): void
     {
         $fallback = new SpaShellFallback($this->shellPath, $this->factory, $this->factory, null, '', 'nene-records.com');


### PR DESCRIPTION
## 背景
本番 ③ cutover の最終検証で判明。`/` は NENE2 の `FrameworkInfo`（API root JSON）が **200 で返す**ため `SpaShellFallback`（404 のみ作動）に届かず、**apex LP も各テナントの公開ホームも `/` で描画できなかった**（ブラウザでも JSON）。

## 修正
- `SpaShellFallback`：**`/` ＋ `Accept: text/html` のとき、framework の 200 JSON を上書きして SPA シェルを返す**（ブラウザのホーム＝SPA／API クライアント＝framework JSON のまま）。→ apex `/`→LandingPage、テナント `/`→PublicIndexPage が成立。

## 検証
- `composer check` 緑。テスト：`/`+html→シェル（framework 200 JSON 上書き）／`/`+json→不変。
- **本番 cutover で実証済**：apex LP 描画、signup→tenant 作成（201）、on-demand TLS 自動発行、tenant 解決・login、records.nene-suite.com→301、cron 全テナント、CSP クリーン。

Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)