### PR TITLE
docs(env): メール送信の env キーを実コードに合わせる (MAIL_FROM_ADDRESS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,9 +32,14 @@ DB_CHARSET=utf8mb4
 # NENE_RECORDS_MAILPIT_WEB_PORT=18026
 # NENE_RECORDS_FRONTEND_PORT=18084
 #
-# --- Mail (Docker Mailpit; production uses your host SMTP relay) ---
+# --- Mail (Docker Mailpit in dev; production uses a transactional relay) ---
+# Dev: Mailpit catches everything. Prod: point MAIL_DSN at a provider (Resend /
+# SES / SendGrid …) and verify your sending domain (SPF/DKIM) so mail isn't spam.
+#   MAIL_DSN=smtp://resend:re_xxxxxxxx@smtp.resend.com:587
+# The from address/name use these exact keys (NOT MAIL_FROM):
 # MAIL_DSN=smtp://mailpit:1025
-# MAIL_FROM=noreply@nene-records.local
+# MAIL_FROM_ADDRESS=noreply@nene-records.local
+# MAIL_FROM_NAME=NeNe Records
 #
 # --- Media storage (default: local disk under var/media) ---
 # MEDIA_STORAGE_DRIVER=local


### PR DESCRIPTION
## 背景
本番で Resend を繋いだ際に踏んだ罠：`.env.example` は `MAIL_FROM` を案内していたが、実コード（`UserInviteServiceProvider`）は **`MAIL_FROM_ADDRESS` / `MAIL_FROM_NAME`** を読む。`MAIL_FROM` を設定しても無視され、既定 `noreply@nene-records.local` で送信 → 検証済みドメインでないため Resend が **550** 拒否。

## 修正
- `.env.example` の `MAIL_FROM` → **`MAIL_FROM_ADDRESS`** ＋ `MAIL_FROM_NAME`。
- プロダクションはプロバイダ relay（Resend 例の DSN）＋ドメイン認証（SPF/DKIM）が要る旨の注記を追加。

## 補足
- 本番（nene-records.com）は既に Resend で送信成功（リセットメール 204）。本 PR は**ドキュメント整合のみ**（自己ホスト勢の罠回避）。コード変更なし。

Refs #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)