### PR TITLE
feat(signup): メール認証(ソフトゲート) (subdomain-saas)

### DIFF
--- a/database/migrations/20260710000000_add_email_verified_at_to_users.php
+++ b/database/migrations/20260710000000_add_email_verified_at_to_users.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddEmailVerifiedAtToUsers extends AbstractMigration
+{
+    public function up(): void
+    {
+        // Self-serve signup email verification: NULL = unverified, a timestamp =
+        // the address has been confirmed. Appended (no positional AFTER) so it is
+        // independent of other users-table migrations' column order.
+        $this->execute('ALTER TABLE users ADD COLUMN email_verified_at DATETIME NULL DEFAULT NULL');
+
+        // Grandfather every existing user as verified — they were provisioned by
+        // install / invite (trusted), so only NEW self-serve signups start NULL.
+        $this->execute('UPDATE users SET email_verified_at = NOW() WHERE email_verified_at IS NULL');
+    }
+
+    public function down(): void
+    {
+        $this->execute('ALTER TABLE users DROP COLUMN email_verified_at');
+    }
+}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -6154,6 +6154,7 @@ components:
         - expires_at
         - email
         - role
+        - email_verified
       properties:
         token:
           type: string
@@ -6167,6 +6168,8 @@ components:
         role:
           type: string
           minLength: 1
+        email_verified:
+          type: boolean
       additionalProperties: false
     SignupRequest:
       type: object

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -9,6 +9,7 @@ import { AppShell } from '@/pages/layout/AppShell'
 import { LandingPage } from '@/pages/landing/LandingPage'
 import { LoginPage } from '@/pages/login/LoginPage'
 import { SignupPage } from '@/pages/signup/SignupPage'
+import { VerifyEmailSignupPage } from '@/pages/verify-email-signup/VerifyEmailSignupPage'
 import { NotFoundPage } from '@/pages/not-found/NotFoundPage'
 import { isApex } from '@/shared/lib/apex'
 import { SuperadminShell } from '@/pages/superadmin/SuperadminShell'
@@ -79,6 +80,11 @@ const router = createBrowserRouter(
       // Public self-serve signup (subdomain SaaS apex).
       path: '/signup',
       element: <SignupPage />,
+    },
+    {
+      // Public signup email-verification link target.
+      path: '/verify-email',
+      element: <VerifyEmailSignupPage />,
     },
     {
       path: '/admin/accept-invite',

--- a/frontend/src/entities/auth/api-types.ts
+++ b/frontend/src/entities/auth/api-types.ts
@@ -10,6 +10,7 @@ export interface LoginResponseDto {
   expires_at: string
   email: string
   role: string
+  email_verified: boolean
 }
 
 export type SignupRequestDto = components['schemas']['SignupRequest']

--- a/frontend/src/entities/auth/index.ts
+++ b/frontend/src/entities/auth/index.ts
@@ -1,6 +1,6 @@
 export { authStore } from './model'
 export type { AuthSession } from './model'
-export { useLogin, useLogout, useSignup } from './mutations'
+export { useLogin, useLogout, useSignup, useConfirmEmail } from './mutations'
 export type { SignupRequestDto, SignupResponseDto } from './api-types'
 export { hasCapability, isAdmin, isSuperadmin } from './capabilities'
 export type { Capability, UserRole } from './capabilities'

--- a/frontend/src/entities/auth/model.ts
+++ b/frontend/src/entities/auth/model.ts
@@ -7,6 +7,8 @@ export interface AuthSession {
   expiresAt: string
   email: string
   role: string
+  /** False when the admin's email is not yet confirmed (self-serve signup). */
+  emailVerified: boolean
 }
 
 const STORAGE_KEY = 'nene_records_session'

--- a/frontend/src/entities/auth/mutations.test.tsx
+++ b/frontend/src/entities/auth/mutations.test.tsx
@@ -45,7 +45,12 @@ describe('auth mutations clear the org-scoped query cache', () => {
   it('useLogin wipes any data cached before the session starts', async () => {
     mswServer.use(
       http.post('/api/v1/auth/login', () =>
-        HttpResponse.json({ expires_at: null, email: 'a@b.co', role: 'admin' }),
+        HttpResponse.json({
+          expires_at: null,
+          email: 'a@b.co',
+          role: 'admin',
+          email_verified: true,
+        }),
       ),
     )
     const queryClient = freshClient()

--- a/frontend/src/entities/auth/mutations.ts
+++ b/frontend/src/entities/auth/mutations.ts
@@ -19,6 +19,19 @@ export function useSignup(): UseMutationResult<SignupResponseDto, AppError, Sign
   })
 }
 
+/** Confirm a signup email from its token; clears the unverified banner locally. */
+export function useConfirmEmail(): UseMutationResult<void, AppError, string> {
+  return useMutation({
+    mutationFn: async (token) => {
+      await apiClient.post('/api/v1/auth/confirm-email', { token })
+      const session = authStore.getSession()
+      if (session !== null) {
+        authStore.setSession({ ...session, emailVerified: true })
+      }
+    },
+  })
+}
+
 export function useLogin(): UseMutationResult<AuthSession, AppError, LoginRequestDto> {
   const queryClient = useQueryClient()
   return useMutation({
@@ -30,6 +43,7 @@ export function useLogin(): UseMutationResult<AuthSession, AppError, LoginReques
         expiresAt: dto.expires_at,
         email: dto.email,
         role: dto.role,
+        emailVerified: dto.email_verified,
       }
       authStore.setSession(session)
       return session

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -533,6 +533,14 @@ export function AppShell() {
               <IconBell size={16} />
             </button>
           </div>
+          {session?.emailVerified === false && (
+            <div
+              role="status"
+              className="border-b border-warn bg-warn/10 px-4 py-2.5 text-caption font-medium text-text-primary sm:px-6"
+            >
+              {t('admin.emailBanner.unverified')}
+            </div>
+          )}
           <div className="px-4 py-6 sm:px-6 sm:py-8">
             <Suspense fallback={null}>
               <Outlet />

--- a/frontend/src/pages/verify-email-signup/VerifyEmailSignupPage.tsx
+++ b/frontend/src/pages/verify-email-signup/VerifyEmailSignupPage.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useConfirmEmail } from '@/entities/auth'
+import { useTranslation } from '@/shared/i18n'
+import { Button, Card, NeneMark, Stack, Text } from '@/shared/ui'
+
+/**
+ * Public landing for the signup email-verification link (`/verify-email?token=…`).
+ * Confirms the token on mount; token-based, so it works before the new admin has
+ * signed in on their tenant subdomain.
+ */
+export function VerifyEmailSignupPage() {
+  const [params] = useSearchParams()
+  const token = params.get('token') ?? ''
+  const confirm = useConfirmEmail()
+  const navigate = useNavigate()
+  const { t } = useTranslation()
+  const fired = useRef(false)
+
+  useEffect(() => {
+    if (fired.current || token === '') return
+    fired.current = true
+    confirm.mutate(token)
+  }, [token, confirm])
+
+  const body = (() => {
+    if (token === '') return t('admin.verifySignup.missing')
+    if (confirm.isPending) return t('admin.verifySignup.pending')
+    if (confirm.isSuccess) return t('admin.verifySignup.success')
+    if (confirm.isError) return t('admin.verifySignup.failed')
+    return t('admin.verifySignup.pending')
+  })()
+
+  return (
+    <div className="relative flex min-h-screen items-center justify-center bg-surface px-inline-md">
+      <Card padding="lg" className="w-full max-w-sm">
+        <Stack gap="lg">
+          <div className="flex items-center gap-inline-sm">
+            <NeneMark size={26} className="text-accent" />
+            <span className="font-chrome text-base font-bold tracking-tight text-text-primary">
+              NeNe Records
+            </span>
+          </div>
+          <Stack gap="xs">
+            <Text as="h1" variant="heading-md">
+              {t('admin.verifySignup.title')}
+            </Text>
+            <Text muted>{body}</Text>
+          </Stack>
+          {confirm.isSuccess && (
+            <Button
+              type="button"
+              className="w-full"
+              onClick={() => {
+                void navigate('/admin')
+              }}
+            >
+              {t('admin.verifySignup.goToAdmin')}
+            </Button>
+          )}
+        </Stack>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -2441,6 +2441,7 @@ export interface components {
             /** Format: email */
             email: string;
             role: string;
+            email_verified: boolean;
         };
         SignupRequest: {
             organization_name: string;

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -439,6 +439,14 @@ export const de: Partial<MessageCatalog> = {
   'admin.signup.successTitle': 'Deine Website ist bereit!',
   'admin.signup.successBody': 'Melde dich an, um {{url}} aufzubauen.',
   'admin.signup.goToLogin': 'Zu deiner Website',
+  'admin.verifySignup.title': 'E-Mail bestätigen',
+  'admin.verifySignup.pending': 'Wird bestätigt …',
+  'admin.verifySignup.success': 'Deine E-Mail ist bestätigt. Danke!',
+  'admin.verifySignup.failed': 'Dieser Link ist ungültig oder abgelaufen.',
+  'admin.verifySignup.missing': 'Es wurde kein Bestätigungstoken übergeben.',
+  'admin.verifySignup.goToAdmin': 'Zum Adminbereich',
+  'admin.emailBanner.unverified':
+    'Bitte bestätige deine E-Mail — nutze den Link, den wir dir gesendet haben.',
   // ── Forbidden page ───────────────────────────────────────────────────────
   'admin.forbidden.title': 'Zugriff verweigert',
   'admin.forbidden.description':

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -440,6 +440,14 @@ export const en = {
   'admin.signup.successTitle': 'Your site is ready!',
   'admin.signup.successBody': 'Sign in to start building {{url}}.',
   'admin.signup.goToLogin': 'Go to your site',
+  'admin.verifySignup.title': 'Verify your email',
+  'admin.verifySignup.pending': 'Verifying…',
+  'admin.verifySignup.success': 'Your email is verified. Thanks!',
+  'admin.verifySignup.failed': 'This link is invalid or has expired.',
+  'admin.verifySignup.missing': 'No verification token was provided.',
+  'admin.verifySignup.goToAdmin': 'Go to admin',
+  'admin.emailBanner.unverified':
+    'Please verify your email — check the link we sent to confirm your address.',
 
   // ── Forbidden page ───────────────────────────────────────────────────────
   'admin.forbidden.title': 'Access denied',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -440,6 +440,14 @@ export const fr: Partial<MessageCatalog> = {
   'admin.signup.successTitle': 'Votre site est prêt !',
   'admin.signup.successBody': 'Connectez-vous pour commencer à construire {{url}}.',
   'admin.signup.goToLogin': 'Aller à votre site',
+  'admin.verifySignup.title': 'Vérifiez votre e-mail',
+  'admin.verifySignup.pending': 'Vérification…',
+  'admin.verifySignup.success': 'Votre e-mail est vérifié. Merci !',
+  'admin.verifySignup.failed': 'Ce lien est invalide ou a expiré.',
+  'admin.verifySignup.missing': "Aucun jeton de vérification n'a été fourni.",
+  'admin.verifySignup.goToAdmin': "Aller à l'administration",
+  'admin.emailBanner.unverified':
+    'Veuillez vérifier votre e-mail — utilisez le lien que nous vous avons envoyé.',
 
   // ── Forbidden page ───────────────────────────────────────────────────────
   'admin.forbidden.title': 'Accès refusé',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -432,6 +432,14 @@ export const ja: Partial<MessageCatalog> = {
   'admin.signup.successTitle': 'サイトの準備ができました！',
   'admin.signup.successBody': '{{url}} にサインインして作成を始めましょう。',
   'admin.signup.goToLogin': 'サイトへ移動',
+  'admin.verifySignup.title': 'メールアドレスの確認',
+  'admin.verifySignup.pending': '確認しています…',
+  'admin.verifySignup.success': 'メールアドレスを確認しました。ありがとうございます！',
+  'admin.verifySignup.failed': 'このリンクは無効か、有効期限が切れています。',
+  'admin.verifySignup.missing': '確認トークンがありません。',
+  'admin.verifySignup.goToAdmin': '管理画面へ',
+  'admin.emailBanner.unverified':
+    'メールアドレスが未確認です。送信されたメールのリンクから確認してください。',
 
   // ── Forbidden ────────────────────────────────────────────────────────────
   'admin.forbidden.title': 'アクセス拒否',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -438,6 +438,14 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.signup.successTitle': 'Seu site está pronto!',
   'admin.signup.successBody': 'Entre para começar a construir {{url}}.',
   'admin.signup.goToLogin': 'Ir para seu site',
+  'admin.verifySignup.title': 'Verifique seu e-mail',
+  'admin.verifySignup.pending': 'Verificando…',
+  'admin.verifySignup.success': 'Seu e-mail foi verificado. Obrigado!',
+  'admin.verifySignup.failed': 'Este link é inválido ou expirou.',
+  'admin.verifySignup.missing': 'Nenhum token de verificação foi fornecido.',
+  'admin.verifySignup.goToAdmin': 'Ir para o admin',
+  'admin.emailBanner.unverified':
+    'Verifique seu e-mail — use o link que enviamos para confirmar seu endereço.',
 
   // ── Forbidden page ───────────────────────────────────────────────────────
   'admin.forbidden.title': 'Acesso negado',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -420,6 +420,13 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.signup.successTitle': '你的站点已就绪！',
   'admin.signup.successBody': '登录即可开始构建 {{url}}。',
   'admin.signup.goToLogin': '前往你的站点',
+  'admin.verifySignup.title': '验证你的邮箱',
+  'admin.verifySignup.pending': '正在验证…',
+  'admin.verifySignup.success': '邮箱已验证，谢谢！',
+  'admin.verifySignup.failed': '此链接无效或已过期。',
+  'admin.verifySignup.missing': '未提供验证令牌。',
+  'admin.verifySignup.goToAdmin': '前往管理后台',
+  'admin.emailBanner.unverified': '请验证你的邮箱——点击我们发送的链接以确认你的邮箱地址。',
 
   // ── Forbidden page ───────────────────────────────────────────────────────
   'admin.forbidden.title': '访问被拒绝',

--- a/frontend/tests/helpers/auth-session.ts
+++ b/frontend/tests/helpers/auth-session.ts
@@ -5,6 +5,7 @@ export function seedAdminSession(): void {
     expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
     email: 'admin@example.com',
     role: 'admin',
+    emailVerified: true,
   })
 }
 
@@ -13,6 +14,7 @@ export function seedEditorSession(): void {
     expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
     email: 'editor@example.com',
     role: 'editor',
+    emailVerified: true,
   })
 }
 

--- a/src/Auth/LoginHandler.php
+++ b/src/Auth/LoginHandler.php
@@ -50,11 +50,12 @@ final readonly class LoginHandler
         $cookie = SessionCookie::build($output->token, $maxAge, SessionCookie::isSecureRequest($request));
 
         return $this->response->create([
-            'token'      => $output->token,
-            'expires_at' => (new DateTimeImmutable('@' . $output->expiresAt))->format(DateTimeInterface::ATOM),
-            'email'      => $output->email,
-            'role'       => $output->role,
-            'org_id'     => $output->orgId,
+            'token'          => $output->token,
+            'expires_at'     => (new DateTimeImmutable('@' . $output->expiresAt))->format(DateTimeInterface::ATOM),
+            'email'          => $output->email,
+            'role'           => $output->role,
+            'org_id'         => $output->orgId,
+            'email_verified' => $output->emailVerified,
         ], 200, ['Set-Cookie' => $cookie]);
     }
 }

--- a/src/Auth/LoginOutput.php
+++ b/src/Auth/LoginOutput.php
@@ -12,6 +12,7 @@ final readonly class LoginOutput
         public string $email,
         public string $role,
         public ?int $orgId = null,
+        public bool $emailVerified = true,
     ) {
     }
 }

--- a/src/Auth/LoginUseCase.php
+++ b/src/Auth/LoginUseCase.php
@@ -50,6 +50,7 @@ final readonly class LoginUseCase
             email: $user->email,
             role: $role->value,
             orgId: $orgId,
+            emailVerified: $user->emailVerifiedAt !== null,
         );
     }
 }

--- a/src/Auth/PdoUserRepository.php
+++ b/src/Auth/PdoUserRepository.php
@@ -14,6 +14,7 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
         password_reset_token_hash, password_reset_expires_at,
         pending_email, email_verification_token_hash,
         UNIX_TIMESTAMP(email_verification_expires_at) AS email_verification_expires_at,
+        UNIX_TIMESTAMP(email_verified_at) AS email_verified_at,
         UNIX_TIMESTAMP(created_at) AS created_at,
         UNIX_TIMESTAMP(updated_at) AS updated_at
     ';
@@ -245,6 +246,19 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
         );
     }
 
+    public function markEmailVerified(int $id): void
+    {
+        // Confirm the address and clear the one-time token in one step.
+        $this->query->execute(
+            'UPDATE users
+                SET email_verified_at = NOW(),
+                    pending_email = NULL, email_verification_token_hash = NULL, email_verification_expires_at = NULL,
+                    updated_at = NOW()
+                WHERE id = ?',
+            [$id],
+        );
+    }
+
     public function delete(int $id): void
     {
         $this->query->execute('DELETE FROM users WHERE id = ?', [$id]);
@@ -278,6 +292,7 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
             pendingEmail: isset($row['pending_email']) ? (string) $row['pending_email'] : null,
             emailVerificationTokenHash: isset($row['email_verification_token_hash']) ? (string) $row['email_verification_token_hash'] : null,
             emailVerificationExpiresAt: isset($row['email_verification_expires_at']) ? (int) $row['email_verification_expires_at'] : null,
+            emailVerifiedAt: isset($row['email_verified_at']) ? (int) $row['email_verified_at'] : null,
             createdAt: isset($row['created_at']) ? (int) $row['created_at'] : null,
             updatedAt: isset($row['updated_at']) ? (int) $row['updated_at'] : null,
         );

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -21,6 +21,8 @@ final readonly class User
         public ?string $pendingEmail = null,
         public ?string $emailVerificationTokenHash = null,
         public ?int $emailVerificationExpiresAt = null,
+        /** When the address was confirmed; null = unverified (self-serve signup). */
+        public ?int $emailVerifiedAt = null,
         public ?int $createdAt = null,
         public ?int $updatedAt = null,
     ) {

--- a/src/Auth/UserRepositoryInterface.php
+++ b/src/Auth/UserRepositoryInterface.php
@@ -56,6 +56,9 @@ interface UserRepositoryInterface
 
     public function clearEmailVerification(int $id): void;
 
+    /** Mark the address confirmed (self-serve signup) and clear the token. */
+    public function markEmailVerified(int $id): void;
+
     public function delete(int $id): void;
 
     public function countByRole(string $role): int;

--- a/src/Signup/ConfirmEmailHandler.php
+++ b/src/Signup/ConfirmEmailHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Signup;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * `POST /api/v1/auth/confirm-email` — confirm a signup email from its token.
+ * Public (under the always-open `/api/v1/auth/` prefix); invalid/expired tokens
+ * surface via EmailVerificationTokenException → 400/410.
+ */
+final readonly class ConfirmEmailHandler
+{
+    public function __construct(
+        private ConfirmEmailUseCase $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+        $token = isset($body['token']) && is_string($body['token']) ? trim($body['token']) : '';
+
+        if ($token === '') {
+            throw new ValidationException([new ValidationError('token', 'Token is required.', 'required')]);
+        }
+
+        $this->useCase->execute($token);
+
+        return $this->response->create(['verified' => true], 200);
+    }
+}

--- a/src/Signup/ConfirmEmailUseCase.php
+++ b/src/Signup/ConfirmEmailUseCase.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Signup;
+
+use Nene2\Http\SecureTokenHelper;
+use NeNeRecords\Auth\UserRepositoryInterface;
+use NeNeRecords\User\EmailVerificationTokenException;
+
+/**
+ * Confirms a self-serve signup email via its one-time token: marks the address
+ * verified and clears the token. Token-based (no auth), so the link works before
+ * the new admin has signed in on their tenant subdomain.
+ */
+final readonly class ConfirmEmailUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(string $token): void
+    {
+        $user = $this->users->findByEmailVerificationToken(SecureTokenHelper::hash($token));
+
+        if ($user === null) {
+            throw EmailVerificationTokenException::invalid();
+        }
+
+        if ($user->emailVerificationExpiresAt === null || $user->emailVerificationExpiresAt < time()) {
+            $this->users->clearEmailVerification($user->id);
+
+            throw EmailVerificationTokenException::expired();
+        }
+
+        $this->users->markEmailVerified($user->id);
+    }
+}

--- a/src/Signup/PublicSignupHandler.php
+++ b/src/Signup/PublicSignupHandler.php
@@ -73,12 +73,18 @@ final readonly class PublicSignupHandler
             throw new ValidationException($errors);
         }
 
+        // The verification link points back at the host the signup came from
+        // (the apex), where /verify-email confirms via the global token endpoint.
+        $uri = $request->getUri();
+        $verifyUrlBase = $uri->getScheme() . '://' . $uri->getAuthority();
+
         // Slug / email uniqueness raise domain exceptions (→ 409) past this point.
         $output = $this->useCase->execute(new PublicSignupInput(
             organizationName: $name,
             slug: $slug,
             email: $email,
             password: $password,
+            verifyUrlBase: $verifyUrlBase,
         ));
 
         $cookie = SessionCookie::build(

--- a/src/Signup/PublicSignupInput.php
+++ b/src/Signup/PublicSignupInput.php
@@ -11,6 +11,8 @@ final readonly class PublicSignupInput
         public string $slug,
         public string $email,
         public string $password,
+        /** Origin for the verification link, e.g. `https://nene-records.com`. */
+        public string $verifyUrlBase = '',
     ) {
     }
 }

--- a/src/Signup/PublicSignupRouteRegistrar.php
+++ b/src/Signup/PublicSignupRouteRegistrar.php
@@ -16,12 +16,16 @@ final readonly class PublicSignupRouteRegistrar
 {
     public function __construct(
         private PublicSignupHandler $handler,
+        private ConfirmEmailHandler $confirmEmail,
     ) {
     }
 
     public function __invoke(Router $router): void
     {
         $handler = $this->handler;
+        $confirm = $this->confirmEmail;
         $router->post('/api/v1/public/signup', static fn (ServerRequestInterface $r) => $handler->handle($r));
+        // Public (always-open /api/v1/auth/) email-verification confirm.
+        $router->post('/api/v1/auth/confirm-email', static fn (ServerRequestInterface $r) => $confirm->handle($r));
     }
 }

--- a/src/Signup/PublicSignupUseCase.php
+++ b/src/Signup/PublicSignupUseCase.php
@@ -5,13 +5,18 @@ declare(strict_types=1);
 namespace NeNeRecords\Signup;
 
 use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\SecureTokenHelper;
 use NeNeRecords\Auth\LoginInput;
 use NeNeRecords\Auth\LoginUseCase;
 use NeNeRecords\Auth\Role;
+use NeNeRecords\Auth\UserRepositoryInterface;
+use NeNeRecords\Mail\MailerInterface;
+use NeNeRecords\Mail\MailMessage;
 use NeNeRecords\Organization\CreateOrganizationInput;
 use NeNeRecords\Organization\CreateOrganizationUseCaseInterface;
 use NeNeRecords\User\CreateUserInput;
 use NeNeRecords\User\CreateUserUseCaseInterface;
+use Throwable;
 
 /**
  * Public self-serve signup for the subdomain SaaS: provisions a new tenant in one
@@ -27,6 +32,8 @@ use NeNeRecords\User\CreateUserUseCaseInterface;
  */
 final readonly class PublicSignupUseCase
 {
+    private const VERIFICATION_TTL_SECONDS = 24 * 3600;
+
     /**
      * @param RequestScopedHolder<int> $orgHolder
      */
@@ -35,6 +42,8 @@ final readonly class PublicSignupUseCase
         private CreateUserUseCaseInterface $createUser,
         private LoginUseCase $login,
         private RequestScopedHolder $orgHolder,
+        private UserRepositoryInterface $users,
+        private MailerInterface $mailer,
     ) {
     }
 
@@ -60,6 +69,10 @@ final readonly class PublicSignupUseCase
         // 4. Auto-login through the normal login path (same token + TTL).
         $session = $this->login->execute(new LoginInput(email: $input->email, password: $input->password));
 
+        // 5. Send the email-verification link. Best-effort: onboarding is not blocked
+        //    if mail hiccups — the admin can resend, and unverified state is a soft gate.
+        $this->sendVerificationEmail($input->email, $input->verifyUrlBase);
+
         return new PublicSignupOutput(
             token: $session->token,
             expiresAt: $session->expiresAt,
@@ -68,5 +81,34 @@ final readonly class PublicSignupUseCase
             email: $session->email,
             role: $session->role,
         );
+    }
+
+    private function sendVerificationEmail(string $email, string $verifyUrlBase): void
+    {
+        try {
+            $user = $this->users->findByEmail($email);
+            if ($user === null) {
+                return;
+            }
+
+            [$rawToken, $tokenHash] = SecureTokenHelper::generateWithHash();
+            $this->users->storeEmailVerification(
+                $user->id,
+                $email,
+                $tokenHash,
+                time() + self::VERIFICATION_TTL_SECONDS,
+            );
+
+            $verifyUrl = rtrim($verifyUrlBase, '/') . '/verify-email?token=' . $rawToken;
+
+            $this->mailer->send(new MailMessage(
+                to: $email,
+                subject: 'NeNe Records — メールアドレスの確認',
+                textBody: "ご登録ありがとうございます。\n\n下記のリンクからメールアドレスを確認してください（24時間有効）。\n{$verifyUrl}\n\n心当たりがない場合はこのメールを無視してください。",
+                htmlBody: "<p>ご登録ありがとうございます。</p><p>下記のボタンからメールアドレスを確認してください（24時間有効）。</p><p><a href=\"{$verifyUrl}\">メールアドレスを確認</a></p><p>心当たりがない場合はこのメールを無視してください。</p>",
+            ));
+        } catch (Throwable) {
+            // Swallow: the tenant + admin already exist and are signed in.
+        }
     }
 }

--- a/src/Signup/SignupServiceProvider.php
+++ b/src/Signup/SignupServiceProvider.php
@@ -11,6 +11,8 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\ApplicationServiceProvider;
 use NeNeRecords\Auth\LoginUseCase;
+use NeNeRecords\Auth\UserRepositoryInterface;
+use NeNeRecords\Mail\MailerInterface;
 use NeNeRecords\Organization\CreateOrganizationUseCaseInterface;
 use NeNeRecords\User\CreateUserUseCaseInterface;
 use Psr\Container\ContainerInterface;
@@ -27,6 +29,8 @@ final readonly class SignupServiceProvider implements ServiceProviderInterface
                     $createUser = $c->get(CreateUserUseCaseInterface::class);
                     $login      = $c->get(LoginUseCase::class);
                     $orgHolder  = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+                    $users      = $c->get(UserRepositoryInterface::class);
+                    $mailer     = $c->get(MailerInterface::class);
 
                     if (!$createOrg instanceof CreateOrganizationUseCaseInterface) {
                         throw new LogicException('CreateOrganizationUseCaseInterface is invalid.');
@@ -44,8 +48,16 @@ final readonly class SignupServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Org ID holder service is invalid.');
                     }
 
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('UserRepositoryInterface is invalid.');
+                    }
+
+                    if (!$mailer instanceof MailerInterface) {
+                        throw new LogicException('MailerInterface is invalid.');
+                    }
+
                     /** @var RequestScopedHolder<int> $orgHolder */
-                    return new PublicSignupUseCase($createOrg, $createUser, $login, $orgHolder);
+                    return new PublicSignupUseCase($createOrg, $createUser, $login, $orgHolder, $users, $mailer);
                 },
             )
             ->set(
@@ -66,15 +78,45 @@ final readonly class SignupServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                ConfirmEmailUseCase::class,
+                static function (ContainerInterface $c): ConfirmEmailUseCase {
+                    $users = $c->get(UserRepositoryInterface::class);
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('UserRepositoryInterface is invalid.');
+                    }
+
+                    return new ConfirmEmailUseCase($users);
+                },
+            )
+            ->set(
+                ConfirmEmailHandler::class,
+                static function (ContainerInterface $c): ConfirmEmailHandler {
+                    $useCase = $c->get(ConfirmEmailUseCase::class);
+                    $json    = $c->get(JsonResponseFactory::class);
+                    if (!$useCase instanceof ConfirmEmailUseCase) {
+                        throw new LogicException('ConfirmEmailUseCase is invalid.');
+                    }
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory is invalid.');
+                    }
+
+                    return new ConfirmEmailHandler($useCase, $json);
+                },
+            )
+            ->set(
                 PublicSignupRouteRegistrar::class,
                 static function (ContainerInterface $c): PublicSignupRouteRegistrar {
                     $handler = $c->get(PublicSignupHandler::class);
+                    $confirm = $c->get(ConfirmEmailHandler::class);
 
                     if (!$handler instanceof PublicSignupHandler) {
                         throw new LogicException('PublicSignupHandler is invalid.');
                     }
+                    if (!$confirm instanceof ConfirmEmailHandler) {
+                        throw new LogicException('ConfirmEmailHandler is invalid.');
+                    }
 
-                    return new PublicSignupRouteRegistrar($handler);
+                    return new PublicSignupRouteRegistrar($handler, $confirm);
                 },
             );
     }

--- a/tests/Mail/RecordingMailer.php
+++ b/tests/Mail/RecordingMailer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Mail;
+
+use NeNeRecords\Mail\MailerInterface;
+use NeNeRecords\Mail\MailMessage;
+
+/** Test double: records every sent message for assertions. */
+final class RecordingMailer implements MailerInterface
+{
+    /** @var list<MailMessage> */
+    public array $sent = [];
+
+    public function send(MailMessage $message): void
+    {
+        $this->sent[] = $message;
+    }
+}

--- a/tests/Signup/ConfirmEmailUseCaseTest.php
+++ b/tests/Signup/ConfirmEmailUseCaseTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Signup;
+
+use Nene2\Http\SecureTokenHelper;
+use NeNeRecords\Signup\ConfirmEmailUseCase;
+use NeNeRecords\Tests\User\InMemoryUserRepository;
+use NeNeRecords\User\CreateUserInput;
+use NeNeRecords\User\CreateUserUseCase;
+use NeNeRecords\User\EmailVerificationTokenException;
+use PHPUnit\Framework\TestCase;
+
+final class ConfirmEmailUseCaseTest extends TestCase
+{
+    private function repoWithPendingUser(int $expiresInSeconds): InMemoryUserRepository
+    {
+        $users = new InMemoryUserRepository([]);
+        (new CreateUserUseCase($users))->execute(new CreateUserInput('a@b.test', 'secret-password', 'admin', 1));
+        $user = $users->findByEmail('a@b.test');
+        self::assertNotNull($user);
+
+        [$raw, $hash] = $this->token;
+        $users->storeEmailVerification($user->id, 'a@b.test', $hash, time() + $expiresInSeconds);
+
+        return $users;
+    }
+
+    /** @var array{0: string, 1: string} */
+    private array $token;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->token = SecureTokenHelper::generateWithHash();
+    }
+
+    public function testConfirmsValidToken(): void
+    {
+        $users = $this->repoWithPendingUser(3600);
+
+        (new ConfirmEmailUseCase($users))->execute($this->token[0]);
+
+        $user = $users->findByEmail('a@b.test');
+        self::assertNotNull($user);
+        self::assertNotNull($user->emailVerifiedAt);
+        self::assertNull($user->emailVerificationTokenHash); // token cleared
+    }
+
+    public function testRejectsInvalidToken(): void
+    {
+        $users = $this->repoWithPendingUser(3600);
+
+        $this->expectException(EmailVerificationTokenException::class);
+        (new ConfirmEmailUseCase($users))->execute('not-a-real-token');
+    }
+
+    public function testRejectsExpiredToken(): void
+    {
+        $users = $this->repoWithPendingUser(-10); // already expired
+
+        $this->expectException(EmailVerificationTokenException::class);
+        (new ConfirmEmailUseCase($users))->execute($this->token[0]);
+    }
+}

--- a/tests/Signup/PublicSignupUseCaseTest.php
+++ b/tests/Signup/PublicSignupUseCaseTest.php
@@ -11,6 +11,7 @@ use NeNeRecords\Organization\CreateOrganizationUseCase;
 use NeNeRecords\Organization\OrganizationSlugConflictException;
 use NeNeRecords\Signup\PublicSignupInput;
 use NeNeRecords\Signup\PublicSignupUseCase;
+use NeNeRecords\Tests\Mail\RecordingMailer;
 use NeNeRecords\Tests\Organization\InMemoryOrganizationRepository;
 use NeNeRecords\Tests\Organization\RecordingDefaultContentTypeSeeder;
 use NeNeRecords\Tests\User\InMemoryUserRepository;
@@ -22,12 +23,14 @@ final class PublicSignupUseCaseTest extends TestCase
     private InMemoryOrganizationRepository $orgs;
     private InMemoryUserRepository $users;
     private RecordingDefaultContentTypeSeeder $seeder;
+    private RecordingMailer $mailer;
 
     private function useCase(): PublicSignupUseCase
     {
         $this->orgs = new InMemoryOrganizationRepository();
         $this->users = new InMemoryUserRepository([]);
         $this->seeder = new RecordingDefaultContentTypeSeeder();
+        $this->mailer = new RecordingMailer();
 
         $tokenIssuer = new class () implements TokenIssuerInterface {
             /** @param array<string, mixed> $claims */
@@ -45,6 +48,8 @@ final class PublicSignupUseCaseTest extends TestCase
             new CreateUserUseCase($this->users),
             new LoginUseCase($this->users, $tokenIssuer),
             $holder,
+            $this->users,
+            $this->mailer,
         );
     }
 
@@ -71,6 +76,14 @@ final class PublicSignupUseCaseTest extends TestCase
         self::assertSame('my-shop', $output->slug);
         self::assertSame('admin', $output->role);
         self::assertSame($org->id, $output->organizationId);
+
+        // … and a verification email was queued to the new admin (unverified).
+        self::assertCount(1, $this->mailer->sent);
+        self::assertSame('owner@shop.test', $this->mailer->sent[0]->to);
+        self::assertStringContainsString('/verify-email?token=', $this->mailer->sent[0]->htmlBody);
+        $admin = $this->users->findByEmail('owner@shop.test');
+        self::assertNotNull($admin);
+        self::assertNull($admin->emailVerifiedAt); // starts unverified
     }
 
     public function testDuplicateSlugIsRejected(): void

--- a/tests/User/InMemoryUserRepository.php
+++ b/tests/User/InMemoryUserRepository.php
@@ -477,6 +477,39 @@ final class InMemoryUserRepository implements UserRepositoryInterface
         );
     }
 
+    public function markEmailVerified(int $id): void
+    {
+        $user = $this->byId[$id] ?? null;
+
+        if ($user === null) {
+            return;
+        }
+
+        if ($user->emailVerificationTokenHash !== null) {
+            unset($this->emailVerificationTokenToId[$user->emailVerificationTokenHash]);
+        }
+
+        $this->byId[$id] = new User(
+            id: $user->id,
+            email: $user->email,
+            passwordHash: $user->passwordHash,
+            role: $user->role,
+            organizationId: $user->organizationId,
+            orgRole: $user->orgRole,
+            status: $user->status,
+            inviteTokenHash: $user->inviteTokenHash,
+            inviteExpiresAt: $user->inviteExpiresAt,
+            passwordResetTokenHash: $user->passwordResetTokenHash,
+            passwordResetExpiresAt: $user->passwordResetExpiresAt,
+            pendingEmail: null,
+            emailVerificationTokenHash: null,
+            emailVerificationExpiresAt: null,
+            emailVerifiedAt: time(),
+            createdAt: $user->createdAt,
+            updatedAt: time(),
+        );
+    }
+
     public function delete(int $id): void
     {
         $user = $this->byId[$id] ?? null;


### PR DESCRIPTION
## 目的
公開 signup に**メール認証**を追加。**「登録→即利用のまま＋検証メール＋未認証バナー」**のソフトゲート方式（onboarding を止めない）。実メール送信（Resend）が動いたので実装可能に。

## バックエンド
- migration `email_verified_at`（NULL=未確認）＋**既存ユーザーは grandfather で確認済に backfill**（install/invite 由来＝信頼済。新規 self-serve signup のみ未確認スタート）。
- 既存トークン基盤を再利用：signup 時に `storeEmailVerification` ＋検証メール送信（`{apexHost}/verify-email?token=`）。`MailerInterface` はベストエフォート（送信失敗で signup を壊さない＝org/admin は作成済）。
- 公開確認 endpoint **`POST /api/v1/auth/confirm-email`**（always-open）＝`ConfirmEmailUseCase` → `markEmailVerified`＋token クリア。invalid/expired → `EmailVerificationTokenException`（400/410）。
- login 応答に `email_verified` を追加（`LoginOutput` / OpenAPI / schema.gen）。

## フロント
- **`/verify-email`（公開）** ＝メールリンク先。mount で confirm → 成功/失敗表示＋管理画面へ。
- 管理画面に**未確認バナー**（`session.emailVerified===false`）。
- `AuthSession.emailVerified` ＋ login マッピング ＋ `useConfirmEmail`。i18n 全6ロケール。

## 検証
- `composer check` ／ `npm run check` 緑。テスト：`PublicSignupUseCase`（検証メール送信・未確認スタート）／`ConfirmEmailUseCase`（valid→verified・invalid/expired→例外）。
- 移行版番号 `20260710000000`（現行 max `20260709` より大＝順序安全。grandfather backfill 込み）。

## 残 follow-up
- 検証メールの resend（バナーからの再送）／公開操作のハードゲート。

Part of #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)