### PR TITLE
fix(signup): メール確認後にテナントのログインへ案内する

### DIFF
--- a/frontend/src/entities/auth/mutations.ts
+++ b/frontend/src/entities/auth/mutations.ts
@@ -19,15 +19,24 @@ export function useSignup(): UseMutationResult<SignupResponseDto, AppError, Sign
   })
 }
 
+interface ConfirmEmailResult {
+  /** The verified admin's tenant slug, for directing them to their own login. */
+  slug: string | null
+}
+
 /** Confirm a signup email from its token; clears the unverified banner locally. */
-export function useConfirmEmail(): UseMutationResult<void, AppError, string> {
+export function useConfirmEmail(): UseMutationResult<ConfirmEmailResult, AppError, string> {
   return useMutation({
     mutationFn: async (token) => {
-      await apiClient.post('/api/v1/auth/confirm-email', { token })
+      const res = await apiClient.post<{ verified: boolean; slug: string | null }>(
+        '/api/v1/auth/confirm-email',
+        { token },
+      )
       const session = authStore.getSession()
       if (session !== null) {
         authStore.setSession({ ...session, emailVerified: true })
       }
+      return { slug: res.slug }
     },
   })
 }

--- a/frontend/src/pages/verify-email-signup/VerifyEmailSignupPage.tsx
+++ b/frontend/src/pages/verify-email-signup/VerifyEmailSignupPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router-dom'
 import { useConfirmEmail } from '@/entities/auth'
 import { useTranslation } from '@/shared/i18n'
 import { Button, Card, NeneMark, Stack, Text } from '@/shared/ui'
@@ -13,9 +13,16 @@ export function VerifyEmailSignupPage() {
   const [params] = useSearchParams()
   const token = params.get('token') ?? ''
   const confirm = useConfirmEmail()
-  const navigate = useNavigate()
   const { t } = useTranslation()
   const fired = useRef(false)
+
+  // Verification is served from the apex; send the admin to their own subdomain
+  // (slug.<this-host>) to sign in, since the session cookie is host-only per tenant.
+  const slug = confirm.data?.slug ?? null
+  const tenantLoginUrl =
+    slug !== null && typeof window !== 'undefined'
+      ? `https://${slug}.${window.location.hostname}/login`
+      : null
 
   useEffect(() => {
     if (fired.current || token === '') return
@@ -47,15 +54,15 @@ export function VerifyEmailSignupPage() {
             </Text>
             <Text muted>{body}</Text>
           </Stack>
-          {confirm.isSuccess && (
+          {confirm.isSuccess && tenantLoginUrl !== null && (
             <Button
               type="button"
               className="w-full"
               onClick={() => {
-                void navigate('/admin')
+                window.location.href = tenantLoginUrl
               }}
             >
-              {t('admin.verifySignup.goToAdmin')}
+              {t('admin.verifySignup.goToLogin')}
             </Button>
           )}
         </Stack>

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -444,7 +444,7 @@ export const de: Partial<MessageCatalog> = {
   'admin.verifySignup.success': 'Deine E-Mail ist bestätigt. Danke!',
   'admin.verifySignup.failed': 'Dieser Link ist ungültig oder abgelaufen.',
   'admin.verifySignup.missing': 'Es wurde kein Bestätigungstoken übergeben.',
-  'admin.verifySignup.goToAdmin': 'Zum Adminbereich',
+  'admin.verifySignup.goToLogin': 'Bei deiner Website anmelden',
   'admin.emailBanner.unverified':
     'Bitte bestätige deine E-Mail — nutze den Link, den wir dir gesendet haben.',
   // ── Forbidden page ───────────────────────────────────────────────────────

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -445,7 +445,7 @@ export const en = {
   'admin.verifySignup.success': 'Your email is verified. Thanks!',
   'admin.verifySignup.failed': 'This link is invalid or has expired.',
   'admin.verifySignup.missing': 'No verification token was provided.',
-  'admin.verifySignup.goToAdmin': 'Go to admin',
+  'admin.verifySignup.goToLogin': 'Sign in to your site',
   'admin.emailBanner.unverified':
     'Please verify your email — check the link we sent to confirm your address.',
 

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -445,7 +445,7 @@ export const fr: Partial<MessageCatalog> = {
   'admin.verifySignup.success': 'Votre e-mail est vérifié. Merci !',
   'admin.verifySignup.failed': 'Ce lien est invalide ou a expiré.',
   'admin.verifySignup.missing': "Aucun jeton de vérification n'a été fourni.",
-  'admin.verifySignup.goToAdmin': "Aller à l'administration",
+  'admin.verifySignup.goToLogin': 'Se connecter à votre site',
   'admin.emailBanner.unverified':
     'Veuillez vérifier votre e-mail — utilisez le lien que nous vous avons envoyé.',
 

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -437,7 +437,7 @@ export const ja: Partial<MessageCatalog> = {
   'admin.verifySignup.success': 'メールアドレスを確認しました。ありがとうございます！',
   'admin.verifySignup.failed': 'このリンクは無効か、有効期限が切れています。',
   'admin.verifySignup.missing': '確認トークンがありません。',
-  'admin.verifySignup.goToAdmin': '管理画面へ',
+  'admin.verifySignup.goToLogin': 'サイトにログイン',
   'admin.emailBanner.unverified':
     'メールアドレスが未確認です。送信されたメールのリンクから確認してください。',
 

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -443,7 +443,7 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.verifySignup.success': 'Seu e-mail foi verificado. Obrigado!',
   'admin.verifySignup.failed': 'Este link é inválido ou expirou.',
   'admin.verifySignup.missing': 'Nenhum token de verificação foi fornecido.',
-  'admin.verifySignup.goToAdmin': 'Ir para o admin',
+  'admin.verifySignup.goToLogin': 'Entrar no seu site',
   'admin.emailBanner.unverified':
     'Verifique seu e-mail — use o link que enviamos para confirmar seu endereço.',
 

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -425,7 +425,7 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.verifySignup.success': '邮箱已验证，谢谢！',
   'admin.verifySignup.failed': '此链接无效或已过期。',
   'admin.verifySignup.missing': '未提供验证令牌。',
-  'admin.verifySignup.goToAdmin': '前往管理后台',
+  'admin.verifySignup.goToLogin': '登录你的站点',
   'admin.emailBanner.unverified': '请验证你的邮箱——点击我们发送的链接以确认你的邮箱地址。',
 
   // ── Forbidden page ───────────────────────────────────────────────────────

--- a/src/Signup/ConfirmEmailHandler.php
+++ b/src/Signup/ConfirmEmailHandler.php
@@ -33,8 +33,8 @@ final readonly class ConfirmEmailHandler
             throw new ValidationException([new ValidationError('token', 'Token is required.', 'required')]);
         }
 
-        $this->useCase->execute($token);
+        $slug = $this->useCase->execute($token);
 
-        return $this->response->create(['verified' => true], 200);
+        return $this->response->create(['verified' => true, 'slug' => $slug], 200);
     }
 }

--- a/src/Signup/ConfirmEmailUseCase.php
+++ b/src/Signup/ConfirmEmailUseCase.php
@@ -6,21 +6,26 @@ namespace NeNeRecords\Signup;
 
 use Nene2\Http\SecureTokenHelper;
 use NeNeRecords\Auth\UserRepositoryInterface;
+use NeNeRecords\Organization\OrganizationRepositoryInterface;
 use NeNeRecords\User\EmailVerificationTokenException;
 
 /**
  * Confirms a self-serve signup email via its one-time token: marks the address
  * verified and clears the token. Token-based (no auth), so the link works before
  * the new admin has signed in on their tenant subdomain.
+ *
+ * Returns the verified admin's tenant slug so the UI can send them on to their own
+ * subdomain to sign in (the confirm link itself is served from the apex).
  */
 final readonly class ConfirmEmailUseCase
 {
     public function __construct(
         private UserRepositoryInterface $users,
+        private OrganizationRepositoryInterface $organizations,
     ) {
     }
 
-    public function execute(string $token): void
+    public function execute(string $token): ?string
     {
         $user = $this->users->findByEmailVerificationToken(SecureTokenHelper::hash($token));
 
@@ -35,5 +40,11 @@ final readonly class ConfirmEmailUseCase
         }
 
         $this->users->markEmailVerified($user->id);
+
+        if ($user->organizationId === null) {
+            return null;
+        }
+
+        return $this->organizations->findById($user->organizationId)?->slug;
     }
 }

--- a/src/Signup/SignupServiceProvider.php
+++ b/src/Signup/SignupServiceProvider.php
@@ -14,6 +14,7 @@ use NeNeRecords\Auth\LoginUseCase;
 use NeNeRecords\Auth\UserRepositoryInterface;
 use NeNeRecords\Mail\MailerInterface;
 use NeNeRecords\Organization\CreateOrganizationUseCaseInterface;
+use NeNeRecords\Organization\OrganizationRepositoryInterface;
 use NeNeRecords\User\CreateUserUseCaseInterface;
 use Psr\Container\ContainerInterface;
 
@@ -81,11 +82,15 @@ final readonly class SignupServiceProvider implements ServiceProviderInterface
                 ConfirmEmailUseCase::class,
                 static function (ContainerInterface $c): ConfirmEmailUseCase {
                     $users = $c->get(UserRepositoryInterface::class);
+                    $orgs  = $c->get(OrganizationRepositoryInterface::class);
                     if (!$users instanceof UserRepositoryInterface) {
                         throw new LogicException('UserRepositoryInterface is invalid.');
                     }
+                    if (!$orgs instanceof OrganizationRepositoryInterface) {
+                        throw new LogicException('OrganizationRepositoryInterface is invalid.');
+                    }
 
-                    return new ConfirmEmailUseCase($users);
+                    return new ConfirmEmailUseCase($users, $orgs);
                 },
             )
             ->set(

--- a/tests/Signup/ConfirmEmailUseCaseTest.php
+++ b/tests/Signup/ConfirmEmailUseCaseTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace NeNeRecords\Tests\Signup;
 
 use Nene2\Http\SecureTokenHelper;
+use NeNeRecords\Organization\Organization;
 use NeNeRecords\Signup\ConfirmEmailUseCase;
+use NeNeRecords\Tests\Organization\InMemoryOrganizationRepository;
 use NeNeRecords\Tests\User\InMemoryUserRepository;
 use NeNeRecords\User\CreateUserInput;
 use NeNeRecords\User\CreateUserUseCase;
@@ -14,35 +16,39 @@ use PHPUnit\Framework\TestCase;
 
 final class ConfirmEmailUseCaseTest extends TestCase
 {
-    private function repoWithPendingUser(int $expiresInSeconds): InMemoryUserRepository
-    {
-        $users = new InMemoryUserRepository([]);
-        (new CreateUserUseCase($users))->execute(new CreateUserInput('a@b.test', 'secret-password', 'admin', 1));
-        $user = $users->findByEmail('a@b.test');
-        self::assertNotNull($user);
-
-        [$raw, $hash] = $this->token;
-        $users->storeEmailVerification($user->id, 'a@b.test', $hash, time() + $expiresInSeconds);
-
-        return $users;
-    }
-
+    private InMemoryUserRepository $users;
+    private InMemoryOrganizationRepository $orgs;
     /** @var array{0: string, 1: string} */
     private array $token;
+    private int $orgId;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->token = SecureTokenHelper::generateWithHash();
+        $this->orgs = new InMemoryOrganizationRepository();
+        $this->orgId = $this->orgs->save(new Organization('My Org', 'myorg', 'free', true));
     }
 
-    public function testConfirmsValidToken(): void
+    private function withPendingUser(int $expiresInSeconds): ConfirmEmailUseCase
     {
-        $users = $this->repoWithPendingUser(3600);
+        $this->users = new InMemoryUserRepository([]);
+        (new CreateUserUseCase($this->users))->execute(
+            new CreateUserInput('a@b.test', 'secret-password', 'admin', $this->orgId),
+        );
+        $user = $this->users->findByEmail('a@b.test');
+        self::assertNotNull($user);
+        $this->users->storeEmailVerification($user->id, 'a@b.test', $this->token[1], time() + $expiresInSeconds);
 
-        (new ConfirmEmailUseCase($users))->execute($this->token[0]);
+        return new ConfirmEmailUseCase($this->users, $this->orgs);
+    }
 
-        $user = $users->findByEmail('a@b.test');
+    public function testConfirmsValidTokenAndReturnsSlug(): void
+    {
+        $slug = $this->withPendingUser(3600)->execute($this->token[0]);
+
+        self::assertSame('myorg', $slug);
+        $user = $this->users->findByEmail('a@b.test');
         self::assertNotNull($user);
         self::assertNotNull($user->emailVerifiedAt);
         self::assertNull($user->emailVerificationTokenHash); // token cleared
@@ -50,17 +56,17 @@ final class ConfirmEmailUseCaseTest extends TestCase
 
     public function testRejectsInvalidToken(): void
     {
-        $users = $this->repoWithPendingUser(3600);
+        $useCase = $this->withPendingUser(3600);
 
         $this->expectException(EmailVerificationTokenException::class);
-        (new ConfirmEmailUseCase($users))->execute('not-a-real-token');
+        $useCase->execute('not-a-real-token');
     }
 
     public function testRejectsExpiredToken(): void
     {
-        $users = $this->repoWithPendingUser(-10); // already expired
+        $useCase = $this->withPendingUser(-10); // already expired
 
         $this->expectException(EmailVerificationTokenException::class);
-        (new ConfirmEmailUseCase($users))->execute($this->token[0]);
+        $useCase->execute($this->token[0]);
     }
 }


### PR DESCRIPTION
確認リンクは apex で配信されるため、確認後に apex の /login に飛んでいた。`ConfirmEmailUseCase` がテナント slug を返し、`/verify-email` が `https://{slug}.{apexHost}/login` へ案内するよう修正。`composer check`/`npm run check` 緑。Part of #536