### PR TITLE
feat(signup): 公開 signup に IP 別レート制限を付け大量 org 作成の濫用を防ぐ (#613)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -134,6 +134,8 @@ paths:
           $ref: '#/components/responses/Conflict'
         '422':
           $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
   /health:
     get:
       tags:

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -3096,6 +3096,7 @@ export interface operations {
             };
             409: components["responses"]["Conflict"];
             422: components["responses"]["ValidationFailed"];
+            429: components["responses"]["TooManyRequests"];
         };
     };
     getHealth: {

--- a/src/Http/ClientIp.php
+++ b/src/Http/ClientIp.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Http;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Resolves the originating client IP for rate-limiting / abuse-prevention keys.
+ *
+ * Behind our single trusted reverse proxy (Caddy holds 443 and is the only
+ * ingress — the app container publishes no ports), `REMOTE_ADDR` is the proxy's
+ * address and is identical for every visitor, so keying a limit on it alone would
+ * collapse all clients into one bucket. Caddy records the address it accepted the
+ * connection from as the *last* entry of `X-Forwarded-For`; any entries to its
+ * left are client-supplied and may be spoofed. We therefore take the last
+ * `X-Forwarded-For` hop (the one our proxy appended) and fall back to
+ * `REMOTE_ADDR` when no forwarded header is present (direct / local / dev).
+ *
+ * This mirrors the proxy-header trust already relied on by
+ * {@see \NeNeRecords\Auth\SessionCookie::isSecureRequest()} (X-Forwarded-Proto).
+ *
+ * Assumes exactly one trusted proxy. If a CDN or extra load balancer is ever
+ * placed in front of Caddy, the trustworthy hop shifts and this must be revisited.
+ */
+final class ClientIp
+{
+    public static function resolve(ServerRequestInterface $request): string
+    {
+        $forwarded = $request->getHeaderLine('X-Forwarded-For');
+
+        if ($forwarded !== '') {
+            $hops = array_values(array_filter(
+                array_map('trim', explode(',', $forwarded)),
+                static fn (string $hop): bool => $hop !== '',
+            ));
+
+            if ($hops !== []) {
+                return $hops[array_key_last($hops)];
+            }
+        }
+
+        $remoteAddr = $request->getServerParams()['REMOTE_ADDR'] ?? '';
+
+        return is_string($remoteAddr) && $remoteAddr !== '' ? $remoteAddr : 'unknown';
+    }
+}

--- a/src/Signup/PublicSignupHandler.php
+++ b/src/Signup/PublicSignupHandler.php
@@ -6,11 +6,14 @@ namespace NeNeRecords\Signup;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Middleware\RateLimitStorageInterface;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
 use NeNeRecords\Auth\SessionCookie;
+use NeNeRecords\Http\ClientIp;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -27,8 +30,14 @@ final readonly class PublicSignupHandler
     private const PASSWORD_MIN = 8;
 
     public function __construct(
-        private PublicSignupUseCase $useCase,
+        private PublicSignupUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private ProblemDetailsResponseFactory $problemDetails,
+        private RateLimitStorageInterface $rateLimitStorage,
+        /** Max tenant signups accepted per client IP within the window. */
+        private int $maxSignupsPerWindow = 5,
+        /** Rate-limit window in seconds (default: 1 hour). */
+        private int $rateLimitWindowSeconds = 3600,
     ) {
     }
 
@@ -73,6 +82,14 @@ final readonly class PublicSignupHandler
             throw new ValidationException($errors);
         }
 
+        // Abuse guard: throttle well-formed signups per client IP so a script
+        // can't mass-create tenants. Checked after field validation (a mistyped
+        // form must not burn the budget) and before the expensive provisioning.
+        $rateLimited = $this->enforceRateLimit($request);
+        if ($rateLimited !== null) {
+            return $rateLimited;
+        }
+
         // The verification link points back at the host the signup came from
         // (the apex), where /verify-email confirms via the global token endpoint.
         $uri = $request->getUri();
@@ -101,6 +118,39 @@ final readonly class PublicSignupHandler
             'email'      => $output->email,
             'role'       => $output->role,
         ], 201, ['Set-Cookie' => $cookie]);
+    }
+
+    /**
+     * Throttle well-formed signups per client IP. Returns a 429 Problem Details
+     * response when the limit is exceeded, or null when the request may proceed.
+     */
+    private function enforceRateLimit(ServerRequestInterface $request): ?ResponseInterface
+    {
+        $key = 'signup:' . ClientIp::resolve($request);
+        $result = $this->rateLimitStorage->hit($key, $this->rateLimitWindowSeconds);
+
+        if ($result['count'] <= $this->maxSignupsPerWindow) {
+            return null;
+        }
+
+        $retryAfter = max(0, $result['reset_at'] - time());
+
+        return $this->problemDetails->create(
+            $request,
+            'too-many-requests',
+            'Too Many Requests',
+            429,
+            sprintf(
+                'Signup rate limit of %d per %d seconds exceeded. Try again in %d seconds.',
+                $this->maxSignupsPerWindow,
+                $this->rateLimitWindowSeconds,
+                $retryAfter,
+            ),
+        )
+            ->withHeader('Retry-After', (string) $retryAfter)
+            ->withHeader('X-RateLimit-Limit', (string) $this->maxSignupsPerWindow)
+            ->withHeader('X-RateLimit-Remaining', '0')
+            ->withHeader('X-RateLimit-Reset', (string) $result['reset_at']);
     }
 
     /** @param array<string, mixed> $body */

--- a/src/Signup/PublicSignupUseCase.php
+++ b/src/Signup/PublicSignupUseCase.php
@@ -30,7 +30,7 @@ use Throwable;
  * email uniqueness are enforced by the underlying use cases (which raise
  * OrganizationSlugConflictException / UserEmailConflictException → 409).
  */
-final readonly class PublicSignupUseCase
+final readonly class PublicSignupUseCase implements PublicSignupUseCaseInterface
 {
     private const VERIFICATION_TTL_SECONDS = 24 * 3600;
 

--- a/src/Signup/PublicSignupUseCaseInterface.php
+++ b/src/Signup/PublicSignupUseCaseInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Signup;
+
+/**
+ * Provisions a brand-new tenant (organization + admin user) and signs the admin
+ * in. Extracted so {@see PublicSignupHandler} can depend on the contract rather
+ * than the concrete use case (mirrors {@see \NeNeRecords\Comment\PostCommentUseCaseInterface}).
+ */
+interface PublicSignupUseCaseInterface
+{
+    public function execute(PublicSignupInput $input): PublicSignupOutput;
+}

--- a/src/Signup/SignupServiceProvider.php
+++ b/src/Signup/SignupServiceProvider.php
@@ -7,8 +7,10 @@ namespace NeNeRecords\Signup;
 use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
+use Nene2\Middleware\RateLimitStorageInterface;
 use NeNeRecords\ApplicationServiceProvider;
 use NeNeRecords\Auth\LoginUseCase;
 use NeNeRecords\Auth\UserRepositoryInterface;
@@ -64,8 +66,10 @@ final readonly class SignupServiceProvider implements ServiceProviderInterface
             ->set(
                 PublicSignupHandler::class,
                 static function (ContainerInterface $c): PublicSignupHandler {
-                    $useCase = $c->get(PublicSignupUseCase::class);
-                    $json    = $c->get(JsonResponseFactory::class);
+                    $useCase     = $c->get(PublicSignupUseCase::class);
+                    $json        = $c->get(JsonResponseFactory::class);
+                    $problems    = $c->get(ProblemDetailsResponseFactory::class);
+                    $rateLimiter = $c->get(RateLimitStorageInterface::class);
 
                     if (!$useCase instanceof PublicSignupUseCase) {
                         throw new LogicException('PublicSignupUseCase is invalid.');
@@ -75,7 +79,15 @@ final readonly class SignupServiceProvider implements ServiceProviderInterface
                         throw new LogicException('JsonResponseFactory is invalid.');
                     }
 
-                    return new PublicSignupHandler($useCase, $json);
+                    if (!$problems instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory is invalid.');
+                    }
+
+                    if (!$rateLimiter instanceof RateLimitStorageInterface) {
+                        throw new LogicException('RateLimitStorageInterface is invalid.');
+                    }
+
+                    return new PublicSignupHandler($useCase, $json, $problems, $rateLimiter);
                 },
             )
             ->set(

--- a/tests/Http/ClientIpTest.php
+++ b/tests/Http/ClientIpTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Http;
+
+use NeNeRecords\Http\ClientIp;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class ClientIpTest extends TestCase
+{
+    private Psr17Factory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new Psr17Factory();
+    }
+
+    public function testFallsBackToRemoteAddrWhenNoForwardedHeader(): void
+    {
+        $request = $this->factory->createServerRequest('POST', 'https://example.test/x', ['REMOTE_ADDR' => '203.0.113.7']);
+
+        self::assertSame('203.0.113.7', ClientIp::resolve($request));
+    }
+
+    public function testUsesForwardedForOverRemoteAddr(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('POST', 'https://example.test/x', ['REMOTE_ADDR' => '10.0.0.1'])
+            ->withHeader('X-Forwarded-For', '203.0.113.7');
+
+        self::assertSame('203.0.113.7', ClientIp::resolve($request));
+    }
+
+    public function testTakesLastForwardedHopToResistSpoofing(): void
+    {
+        // A client may prepend a forged entry; our trusted proxy appends the real
+        // peer as the LAST hop, so the rightmost address is the trustworthy one.
+        $request = $this->factory
+            ->createServerRequest('POST', 'https://example.test/x', ['REMOTE_ADDR' => '10.0.0.1'])
+            ->withHeader('X-Forwarded-For', '9.9.9.9, 203.0.113.7');
+
+        self::assertSame('203.0.113.7', ClientIp::resolve($request));
+    }
+
+    public function testTrimsWhitespaceInForwardedChain(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('POST', 'https://example.test/x', ['REMOTE_ADDR' => '10.0.0.1'])
+            ->withHeader('X-Forwarded-For', '9.9.9.9 ,  203.0.113.7 ');
+
+        self::assertSame('203.0.113.7', ClientIp::resolve($request));
+    }
+
+    public function testReturnsUnknownWhenNothingIsAvailable(): void
+    {
+        $request = $this->factory->createServerRequest('POST', 'https://example.test/x');
+
+        self::assertSame('unknown', ClientIp::resolve($request));
+    }
+}

--- a/tests/Signup/PublicSignupHandlerTest.php
+++ b/tests/Signup/PublicSignupHandlerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Signup;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Middleware\InMemoryRateLimitStorage;
+use Nene2\Validation\ValidationException;
+use NeNeRecords\Signup\PublicSignupHandler;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class PublicSignupHandlerTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private RecordingPublicSignupUseCase $useCase;
+    private PublicSignupHandler $handler;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->useCase = new RecordingPublicSignupUseCase();
+
+        // Small window limit (2) keeps the throttle tests fast and explicit.
+        $this->handler = new PublicSignupHandler(
+            $this->useCase,
+            new JsonResponseFactory($this->factory, $this->factory),
+            new ProblemDetailsResponseFactory($this->factory, $this->factory),
+            new InMemoryRateLimitStorage(),
+            maxSignupsPerWindow: 2,
+            rateLimitWindowSeconds: 3600,
+        );
+    }
+
+    public function testValidSignupReturns201(): void
+    {
+        $response = $this->handler->handle($this->signupRequest('shop-a', '203.0.113.7'));
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame(1, $this->useCase->calls);
+    }
+
+    public function testExceedingTheLimitReturns429(): void
+    {
+        self::assertSame(201, $this->handler->handle($this->signupRequest('shop-a', '203.0.113.7'))->getStatusCode());
+        self::assertSame(201, $this->handler->handle($this->signupRequest('shop-b', '203.0.113.7'))->getStatusCode());
+
+        // The 3rd within the window (limit 2) is throttled.
+        $third = $this->handler->handle($this->signupRequest('shop-c', '203.0.113.7'));
+
+        self::assertSame(429, $third->getStatusCode());
+        self::assertNotSame('', $third->getHeaderLine('Retry-After'));
+        self::assertSame('2', $third->getHeaderLine('X-RateLimit-Limit'));
+        // The throttled attempt must never reach provisioning.
+        self::assertSame(2, $this->useCase->calls);
+    }
+
+    public function testRateLimitIsPerClientIp(): void
+    {
+        $this->handler->handle($this->signupRequest('shop-a', '203.0.113.7'));
+        $this->handler->handle($this->signupRequest('shop-b', '203.0.113.7'));
+        self::assertSame(429, $this->handler->handle($this->signupRequest('shop-c', '203.0.113.7'))->getStatusCode());
+
+        // A different client IP keeps its own budget.
+        self::assertSame(201, $this->handler->handle($this->signupRequest('shop-d', '198.51.100.4'))->getStatusCode());
+    }
+
+    public function testSpoofedForwardedForCannotEvadeTheLimit(): void
+    {
+        // Same real last hop, a different forged leftmost entry each time.
+        $this->handler->handle($this->signupRequest('shop-a', '203.0.113.7', '1.1.1.1'));
+        $this->handler->handle($this->signupRequest('shop-b', '203.0.113.7', '2.2.2.2'));
+        $third = $this->handler->handle($this->signupRequest('shop-c', '203.0.113.7', '3.3.3.3'));
+
+        self::assertSame(429, $third->getStatusCode());
+    }
+
+    public function testMalformedRequestsDoNotConsumeBudget(): void
+    {
+        // Two malformed attempts fail validation before the rate-limit gate.
+        for ($i = 0; $i < 2; ++$i) {
+            try {
+                $this->handler->handle($this->malformedRequest('203.0.113.7'));
+                self::fail('Expected ValidationException for malformed signup.');
+            } catch (ValidationException) {
+                // expected — must not spend the rate-limit budget
+            }
+        }
+
+        // The full budget (2) is still available for well-formed signups.
+        self::assertSame(201, $this->handler->handle($this->signupRequest('shop-a', '203.0.113.7'))->getStatusCode());
+        self::assertSame(201, $this->handler->handle($this->signupRequest('shop-b', '203.0.113.7'))->getStatusCode());
+        self::assertSame(429, $this->handler->handle($this->signupRequest('shop-c', '203.0.113.7'))->getStatusCode());
+    }
+
+    private function signupRequest(string $slug, string $clientIp, ?string $spoofedLeftmost = null): ServerRequestInterface
+    {
+        $body = $this->factory->createStream(json_encode([
+            'organization_name' => 'My Shop',
+            'slug'              => $slug,
+            'email'             => $slug . '@example.com',
+            'password'          => 'a-strong-password',
+        ], JSON_THROW_ON_ERROR));
+
+        $forwardedFor = $spoofedLeftmost === null ? $clientIp : $spoofedLeftmost . ', ' . $clientIp;
+
+        return $this->factory
+            ->createServerRequest('POST', 'https://apex.example.test/api/v1/public/signup')
+            ->withHeader('X-Forwarded-For', $forwardedFor)
+            ->withBody($body);
+    }
+
+    private function malformedRequest(string $clientIp): ServerRequestInterface
+    {
+        $body = $this->factory->createStream(json_encode([
+            'organization_name' => '',
+            'slug'              => '',
+            'email'             => 'not-an-email',
+            'password'          => 'short',
+        ], JSON_THROW_ON_ERROR));
+
+        return $this->factory
+            ->createServerRequest('POST', 'https://apex.example.test/api/v1/public/signup')
+            ->withHeader('X-Forwarded-For', $clientIp)
+            ->withBody($body);
+    }
+}

--- a/tests/Signup/RecordingPublicSignupUseCase.php
+++ b/tests/Signup/RecordingPublicSignupUseCase.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Signup;
+
+use NeNeRecords\Signup\PublicSignupInput;
+use NeNeRecords\Signup\PublicSignupOutput;
+use NeNeRecords\Signup\PublicSignupUseCaseInterface;
+
+/**
+ * Test double for {@see PublicSignupUseCaseInterface}: records how many times it
+ * was invoked and returns a canned tenant, so handler tests can assert that
+ * throttled requests never reach provisioning.
+ */
+final class RecordingPublicSignupUseCase implements PublicSignupUseCaseInterface
+{
+    public int $calls = 0;
+
+    public function execute(PublicSignupInput $input): PublicSignupOutput
+    {
+        ++$this->calls;
+
+        return new PublicSignupOutput(
+            token: 'token-' . $this->calls,
+            expiresAt: time() + 3600,
+            organizationId: 42,
+            slug: $input->slug,
+            email: $input->email,
+            role: 'admin',
+        );
+    }
+}


### PR DESCRIPTION
## 目的
`Closes #613`（Part of #536）。公開セルフサーブ signup（`POST /api/v1/public/signup`・認証なし）への**大量 org 作成の濫用**（リソース枯渇・メール評判毀損・slug squatting）を IP 別レート制限で抑止する。ペルソナ討論 第6回で「公開を開く前提・最優先・小」と位置づけられた残課題（引き継ぎ書 §A）。

## 変更
- **`PublicSignupHandler` に signup 専用レート制限**: `PostCommentHandler` と同じ定石で `RateLimitStorageInterface` を注入し、バリデーション後・provisioning 前に `enforceRateLimit()`。既定は実クライアント IP × **5 回 / 1 時間**（コンストラクタで設定可能・グローバル `ThrottleMiddleware` 120/60s に加える第 2 線）。超過時は 429 ProblemDetails（`too-many-requests`）+ `Retry-After` / `X-RateLimit-*`。
- **実クライアント IP ヘルパ `src/Http/ClientIp`**: `X-Forwarded-For` の**最終ホップ**（Caddy が記録した値＝spoof 耐性あり）→ `REMOTE_ADDR` フォールバック。本番は Caddy 単一 ingress で `REMOTE_ADDR` が Caddy IP に潰れ、IP 別制限が全ユーザー 1 バケットに崩れる問題に対応。`SessionCookie::isSecureRequest()` の forwarded 信頼と整合。
- **`PublicSignupUseCaseInterface` を導入**（`PostCommentUseCaseInterface` と同じ規約）→ ハンドラが契約に依存しユニットテスト可能に。
- **OpenAPI**: signup に `429`（`TooManyRequests`）を追加し `schema.gen.ts` を再生成。
- malformed はバリデーションで弾かれレート予算を消費しない（comment と同じ順序＝validate → rate-limit → execute）。

## 検証
- `composer check` 緑: **PHPUnit 1048 tests / 2906 assertions**・PHPStan level 8（1255 files・エラー 0）・CS-Fixer・OpenAPI・MCP。
- frontend 緑: `type-check` / `lint` / `test`（418）。
- 新規テスト: `ClientIpTest`（5・XFF 最終ホップ / spoof 耐性 / フォールバック）+ `PublicSignupHandlerTest`（5・201 / 429 / IP 別バケット / spoof 耐性 / malformed 非消費）。

## チェックリスト
- [x] Issue 紐付け（Closes #613・Part of #536）
- [x] Conventional Commits（`feat(signup)`・日本語本文）
- [x] テスト追加・`composer check` / frontend チェック緑
- [x] OpenAPI 更新 + `schema.gen.ts` 再生成

## フォローアップ（任意・別 PR）
- フロント signup フォームは 429 を汎用エラー表示で扱う（ProblemDetails 経由）。「時間をおいて再試行」専用メッセージ化は小さな follow-up。
- `PostCommentHandler` も `REMOTE_ADDR` 直参照なので、同じ `ClientIp` に寄せると本番で実 IP 別に効く。

Closes #613
