### PR TITLE
feat(tenant): 独自ドメインの org 解決を配線しエンタイトルメント seam（既定無制限）を導入する (#617)

### DIFF
--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -29,6 +29,8 @@ use NeNeRecords\DataMigration\DataMigrationServiceProvider;
 use NeNeRecords\DateTimeField\DateTimeFieldNotFoundExceptionHandler;
 use NeNeRecords\DateTimeField\DateTimeFieldRouteRegistrar;
 use NeNeRecords\DateTimeField\DateTimeFieldServiceProvider;
+use NeNeRecords\Entitlement\EntitlementServiceProvider;
+use NeNeRecords\Entitlement\FeatureNotEntitledExceptionHandler;
 use NeNeRecords\Entity\DuplicateEntitySlugExceptionHandler;
 use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
 use NeNeRecords\Entity\EntityRouteRegistrar;
@@ -180,6 +182,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new UserInviteServiceProvider())
             ->addProvider(new NotificationServiceProvider())
             ->addProvider(new CommentServiceProvider())
+            ->addProvider(new EntitlementServiceProvider())
             ->addProvider(new OrganizationServiceProvider())
             ->addProvider(new SignupServiceProvider())
             ->addProvider(new SystemConfigServiceProvider())
@@ -362,6 +365,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $commentNotFound = $container->get(CommentNotFoundExceptionHandler::class);
                     $organizationNotFound = $container->get(OrganizationNotFoundExceptionHandler::class);
                     $organizationSlugConflict = $container->get(OrganizationSlugConflictExceptionHandler::class);
+                    $featureNotEntitled = $container->get(FeatureNotEntitledExceptionHandler::class);
                     $notificationChannelNotFound = $container->get(NotificationChannelNotFoundExceptionHandler::class);
                     $themeNotFound = $container->get(ThemeNotFoundExceptionHandler::class);
 
@@ -413,6 +417,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $commentNotFound,
                         $organizationNotFound,
                         $organizationSlugConflict,
+                        $featureNotEntitled,
                         $notificationChannelNotFound,
                         $themeNotFound,
                     ] as $handler) {
@@ -469,6 +474,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $commentNotFound,
                         $organizationNotFound,
                         $organizationSlugConflict,
+                        $featureNotEntitled,
                         $notificationChannelNotFound,
                         $themeNotFound,
                     ];

--- a/src/Entitlement/EntitlementResolverInterface.php
+++ b/src/Entitlement/EntitlementResolverInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entitlement;
+
+/**
+ * Single seam answering "what is organization X entitled to?".
+ *
+ * Enforcement sites depend on this interface, not on plan logic, so the deployment
+ * decides the policy:
+ *  - {@see UnlimitedEntitlementResolver} — default; self-host / no billing.
+ *  - a future plan-based resolver — hosted SaaS; maps `organizations.plan` → limits.
+ */
+interface EntitlementResolverInterface
+{
+    public function for(int $organizationId): Entitlements;
+}

--- a/src/Entitlement/EntitlementServiceProvider.php
+++ b/src/Entitlement/EntitlementServiceProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entitlement;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Container\ContainerInterface;
+
+final readonly class EntitlementServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            // Default: unlimited (self-host / no billing). Swap for a plan-based
+            // resolver to opt into commercial limits on the hosted SaaS.
+            ->set(
+                EntitlementResolverInterface::class,
+                static fn (ContainerInterface $container): EntitlementResolverInterface => new UnlimitedEntitlementResolver(),
+            )
+            ->set(
+                FeatureNotEntitledExceptionHandler::class,
+                static function (ContainerInterface $container): FeatureNotEntitledExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new FeatureNotEntitledExceptionHandler($problemDetails);
+                },
+            );
+    }
+}

--- a/src/Entitlement/Entitlements.php
+++ b/src/Entitlement/Entitlements.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entitlement;
+
+/**
+ * What an organization is allowed to do under its current plan.
+ *
+ * Limits are expressed as DATA (this value object), never as hard-coded constants
+ * at the enforcement sites — so the same product code serves both the hosted SaaS
+ * (where {@see EntitlementResolverInterface} maps `plan` → limits) and self-hosted
+ * installs (where {@see UnlimitedEntitlementResolver} grants everything). Operators
+ * opt INTO enforcement; the default is unlimited.
+ *
+ * As of the introducing change only {@see self::$customDomainAllowed} is enforced.
+ * The remaining fields are the schema for future plan-based limits (record /
+ * storage / user quotas, branding removal) and stay effectively unlimited until a
+ * plan-based resolver and the corresponding enforcement points are added.
+ */
+final readonly class Entitlements
+{
+    public function __construct(
+        public bool $customDomainAllowed,
+        public bool $brandingRemovable,
+        public int $maxRecords,
+        public int $maxStorageBytes,
+        public int $maxAdminUsers,
+    ) {
+    }
+
+    /**
+     * Self-host / no-billing default: every feature permitted, no caps.
+     * `PHP_INT_MAX` is the "unlimited" sentinel for the numeric caps.
+     */
+    public static function unlimited(): self
+    {
+        return new self(
+            customDomainAllowed: true,
+            brandingRemovable: true,
+            maxRecords: PHP_INT_MAX,
+            maxStorageBytes: PHP_INT_MAX,
+            maxAdminUsers: PHP_INT_MAX,
+        );
+    }
+}

--- a/src/Entitlement/FeatureNotEntitledException.php
+++ b/src/Entitlement/FeatureNotEntitledException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entitlement;
+
+use RuntimeException;
+
+/**
+ * Raised when an organization attempts to use a feature its plan does not include
+ * (e.g. assigning a custom domain on a plan without `customDomainAllowed`).
+ * Mapped to 402 Payment Required by {@see FeatureNotEntitledExceptionHandler}.
+ */
+final class FeatureNotEntitledException extends RuntimeException
+{
+    public function __construct(string $feature)
+    {
+        parent::__construct("This feature is not available on the current plan: {$feature}.");
+    }
+}

--- a/src/Entitlement/FeatureNotEntitledExceptionHandler.php
+++ b/src/Entitlement/FeatureNotEntitledExceptionHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entitlement;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+/**
+ * Maps {@see FeatureNotEntitledException} to 402 Payment Required — the
+ * semantically apt status for "this needs a higher plan".
+ */
+final readonly class FeatureNotEntitledExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof FeatureNotEntitledException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'feature-not-entitled',
+            'Feature Not Available',
+            402,
+            $exception->getMessage(),
+        );
+    }
+}

--- a/src/Entitlement/UnlimitedEntitlementResolver.php
+++ b/src/Entitlement/UnlimitedEntitlementResolver.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entitlement;
+
+/**
+ * Grants every organization unlimited entitlements.
+ *
+ * This is the default binding, so a fresh `git clone` / self-hosted install (and
+ * the current hosted SaaS, until a plan-based resolver is wired) is never subject
+ * to commercial limits — it's the operator's own instance. Billing/limits are
+ * opt-in by swapping this for a plan-based resolver.
+ */
+final readonly class UnlimitedEntitlementResolver implements EntitlementResolverInterface
+{
+    public function for(int $organizationId): Entitlements
+    {
+        return Entitlements::unlimited();
+    }
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -36,6 +36,7 @@ use NeNeRecords\Organization\OrganizationRepositoryInterface;
 use NeNeRecords\Organization\Resolution\EnvResolutionStrategy;
 use NeNeRecords\Organization\Resolution\OrgResolverMiddleware;
 use NeNeRecords\Organization\Resolution\PathPrefixResolutionStrategy;
+use NeNeRecords\Organization\Resolution\SubdomainOrCustomDomainResolutionStrategy;
 use NeNeRecords\Organization\Resolution\SubdomainResolutionStrategy;
 use NeNeRecords\RateLimit\RateLimitServiceProvider;
 use NeNeRecords\SystemConfig\SystemConfigRepositoryInterface;
@@ -322,7 +323,10 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     }
 
                     $strategy = match ($resolvedMode) {
-                        'subdomain' => new SubdomainResolutionStrategy($resolvedDomain),
+                        // Subdomain SaaS, plus bring-your-own custom domains
+                        // (resolved via findByCustomDomain when the host isn't a
+                        // base-domain subdomain or the apex).
+                        'subdomain' => new SubdomainOrCustomDomainResolutionStrategy(new SubdomainResolutionStrategy($resolvedDomain)),
                         'path'      => new PathPrefixResolutionStrategy(),
                         default     => new EnvResolutionStrategy($resolvedSlug),
                     };

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -12,6 +12,7 @@ use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\ApplicationServiceProvider;
+use NeNeRecords\Entitlement\EntitlementResolverInterface;
 use NeNeRecords\SystemConfig\SystemConfigRepositoryInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -91,12 +92,17 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
                 UpdateOrganizationUseCaseInterface::class,
                 static function (ContainerInterface $c): UpdateOrganizationUseCaseInterface {
                     $repo = $c->get(OrganizationRepositoryInterface::class);
+                    $entitlements = $c->get(EntitlementResolverInterface::class);
 
                     if (!$repo instanceof OrganizationRepositoryInterface) {
                         throw new LogicException('Organization repository service is invalid.');
                     }
 
-                    return new UpdateOrganizationUseCase($repo);
+                    if (!$entitlements instanceof EntitlementResolverInterface) {
+                        throw new LogicException('Entitlement resolver service is invalid.');
+                    }
+
+                    return new UpdateOrganizationUseCase($repo, $entitlements);
                 },
             )
             ->set(

--- a/src/Organization/Resolution/SubdomainOrCustomDomainResolutionStrategy.php
+++ b/src/Organization/Resolution/SubdomainOrCustomDomainResolutionStrategy.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Organization\Resolution;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Subdomain SaaS resolution that also accepts bring-your-own custom domains.
+ *
+ * In subdomain mode the active host is normally `slug.<base-domain>` → org slug.
+ * But a tenant on a paid plan may point their own domain (`blog.example.com`) at
+ * our edge. `SubdomainResolutionStrategy` returns null for such hosts (the tail
+ * doesn't match the base domain), which would 404 before the middleware's custom
+ * domain lookup runs. This composite fills that gap:
+ *
+ *  1. base-domain subdomain → org slug (delegated to {@see SubdomainResolutionStrategy}).
+ *  2. the apex itself → null (the apex landing handles it, via ApexAware).
+ *  3. anything else → the full host, so {@see \NeNeRecords\Organization\Resolution\OrgResolverMiddleware}
+ *     resolves it through `OrganizationRepository::findByCustomDomain()`.
+ *
+ * `TlsCheckHandler` already authorizes certificate issuance for registered custom
+ * domains, so this is the remaining wiring needed for end-to-end custom domains.
+ */
+final readonly class SubdomainOrCustomDomainResolutionStrategy implements OrgResolutionStrategyInterface, ApexAwareStrategyInterface
+{
+    public function __construct(
+        private SubdomainResolutionStrategy $subdomain,
+    ) {
+    }
+
+    public function resolve(ServerRequestInterface $request): ?string
+    {
+        // Prefer a base-domain subdomain (→ org slug).
+        $slug = $this->subdomain->resolve($request);
+        if ($slug !== null) {
+            return $slug;
+        }
+
+        // The bare base domain carries no tenant — let the apex landing handle it.
+        if ($this->subdomain->isApex($request)) {
+            return null;
+        }
+
+        // Otherwise it's a bring-your-own custom domain: hand the full host to the
+        // middleware, which looks it up via findByCustomDomain().
+        $host = $request->getUri()->getHost();
+        if (str_contains($host, ':')) {
+            $host = explode(':', $host)[0];
+        }
+
+        return $host !== '' ? $host : null;
+    }
+
+    public function isApex(ServerRequestInterface $request): bool
+    {
+        return $this->subdomain->isApex($request);
+    }
+}

--- a/src/Organization/UpdateOrganizationUseCase.php
+++ b/src/Organization/UpdateOrganizationUseCase.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Organization;
 
+use NeNeRecords\Entitlement\EntitlementResolverInterface;
+use NeNeRecords\Entitlement\FeatureNotEntitledException;
+
 final readonly class UpdateOrganizationUseCase implements UpdateOrganizationUseCaseInterface
 {
     public function __construct(
         private OrganizationRepositoryInterface $organizations,
+        private EntitlementResolverInterface $entitlements,
     ) {
     }
 
@@ -25,6 +29,20 @@ final readonly class UpdateOrganizationUseCase implements UpdateOrganizationUseC
         $isActive     = $input->isActive ?? $org->isActive;
         $externalId   = $input->updateExternalId ? $input->externalId : $org->externalId;
         $customDomain = $input->updateCustomDomain ? $input->customDomain : $org->customDomain;
+
+        // Custom domain is a plan-gated feature. Enforce only when assigning a new,
+        // non-empty domain — a downgrade never breaks an org that already has one
+        // (existing data is preserved; only new assignments are gated). With the
+        // default UnlimitedEntitlementResolver this is a no-op.
+        if (
+            $input->updateCustomDomain
+            && $customDomain !== null
+            && $customDomain !== ''
+            && $customDomain !== $org->customDomain
+            && !$this->entitlements->for($input->id)->customDomainAllowed
+        ) {
+            throw new FeatureNotEntitledException('custom domain');
+        }
 
         if ($slug !== $org->slug) {
             $existing = $this->organizations->findBySlug($slug);

--- a/tests/Entitlement/FeatureNotEntitledExceptionHandlerTest.php
+++ b/tests/Entitlement/FeatureNotEntitledExceptionHandlerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Entitlement;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use NeNeRecords\Entitlement\FeatureNotEntitledException;
+use NeNeRecords\Entitlement\FeatureNotEntitledExceptionHandler;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class FeatureNotEntitledExceptionHandlerTest extends TestCase
+{
+    private FeatureNotEntitledExceptionHandler $handler;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $factory = new Psr17Factory();
+        $this->handler = new FeatureNotEntitledExceptionHandler(
+            new ProblemDetailsResponseFactory($factory, $factory),
+        );
+    }
+
+    public function testSupportsOnlyFeatureNotEntitled(): void
+    {
+        self::assertTrue($this->handler->supports(new FeatureNotEntitledException('custom domain')));
+        self::assertFalse($this->handler->supports(new RuntimeException('other')));
+    }
+
+    public function testMapsTo402(): void
+    {
+        $factory = new Psr17Factory();
+        $request = $factory->createServerRequest('PATCH', 'https://example.test/api/v1/superadmin/organizations/1');
+
+        $response = $this->handler->handle(new FeatureNotEntitledException('custom domain'), $request);
+
+        self::assertSame(402, $response->getStatusCode());
+    }
+}

--- a/tests/Entitlement/UnlimitedEntitlementResolverTest.php
+++ b/tests/Entitlement/UnlimitedEntitlementResolverTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Entitlement;
+
+use NeNeRecords\Entitlement\UnlimitedEntitlementResolver;
+use PHPUnit\Framework\TestCase;
+
+final class UnlimitedEntitlementResolverTest extends TestCase
+{
+    public function testGrantsEverythingForAnyOrg(): void
+    {
+        $entitlements = (new UnlimitedEntitlementResolver())->for(123);
+
+        self::assertTrue($entitlements->customDomainAllowed);
+        self::assertTrue($entitlements->brandingRemovable);
+        self::assertSame(PHP_INT_MAX, $entitlements->maxRecords);
+        self::assertSame(PHP_INT_MAX, $entitlements->maxStorageBytes);
+        self::assertSame(PHP_INT_MAX, $entitlements->maxAdminUsers);
+    }
+
+    public function testIsStableAcrossOrgs(): void
+    {
+        $resolver = new UnlimitedEntitlementResolver();
+
+        self::assertTrue($resolver->for(1)->customDomainAllowed);
+        self::assertTrue($resolver->for(999)->customDomainAllowed);
+    }
+}

--- a/tests/Organization/OrganizationHttpTest.php
+++ b/tests/Organization/OrganizationHttpTest.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Tests\Organization;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Entitlement\UnlimitedEntitlementResolver;
 use NeNeRecords\Organization\CreateOrganizationHandler;
 use NeNeRecords\Organization\CreateOrganizationUseCase;
 use NeNeRecords\Organization\DeleteOrganizationHandler;
@@ -45,7 +46,7 @@ final class OrganizationHttpTest extends TestCase
             new ListOrganizationsHandler(new ListOrganizationsUseCase($this->repository), $jsonResponse),
             new GetOrganizationByIdHandler(new GetOrganizationByIdUseCase($this->repository), $jsonResponse),
             new CreateOrganizationHandler(new CreateOrganizationUseCase($this->repository, new RecordingDefaultContentTypeSeeder()), $jsonResponse),
-            new UpdateOrganizationHandler(new UpdateOrganizationUseCase($this->repository), $jsonResponse),
+            new UpdateOrganizationHandler(new UpdateOrganizationUseCase($this->repository, new UnlimitedEntitlementResolver()), $jsonResponse),
             new DeleteOrganizationHandler(new DeleteOrganizationUseCase($this->repository), $this->factory),
         );
 

--- a/tests/Organization/OrganizationUseCaseTest.php
+++ b/tests/Organization/OrganizationUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Tests\Organization;
 
+use NeNeRecords\Entitlement\UnlimitedEntitlementResolver;
 use NeNeRecords\Organization\CreateOrganizationInput;
 use NeNeRecords\Organization\CreateOrganizationUseCase;
 use NeNeRecords\Organization\DeleteOrganizationInput;
@@ -84,7 +85,7 @@ final class OrganizationUseCaseTest extends TestCase
             new CreateOrganizationInput(name: 'Original Name', slug: 'my-org'),
         );
 
-        $output = (new UpdateOrganizationUseCase($organizations))->execute(
+        $output = (new UpdateOrganizationUseCase($organizations, new UnlimitedEntitlementResolver()))->execute(
             new UpdateOrganizationInput(
                 id: $created->id,
                 name: 'Updated Name',
@@ -108,7 +109,7 @@ final class OrganizationUseCaseTest extends TestCase
             new CreateOrganizationInput(name: 'My Org', slug: 'old-slug'),
         );
 
-        $output = (new UpdateOrganizationUseCase($organizations))->execute(
+        $output = (new UpdateOrganizationUseCase($organizations, new UnlimitedEntitlementResolver()))->execute(
             new UpdateOrganizationInput(
                 id: $created->id,
                 name: null,
@@ -130,7 +131,7 @@ final class OrganizationUseCaseTest extends TestCase
             new CreateOrganizationInput(name: 'My Org', slug: 'my-org', plan: 'free'),
         );
 
-        $output = (new UpdateOrganizationUseCase($organizations))->execute(
+        $output = (new UpdateOrganizationUseCase($organizations, new UnlimitedEntitlementResolver()))->execute(
             new UpdateOrganizationInput(
                 id: $created->id,
                 name: null,
@@ -152,7 +153,7 @@ final class OrganizationUseCaseTest extends TestCase
             new CreateOrganizationInput(name: 'My Org', slug: 'my-org', isActive: true),
         );
 
-        $output = (new UpdateOrganizationUseCase($organizations))->execute(
+        $output = (new UpdateOrganizationUseCase($organizations, new UnlimitedEntitlementResolver()))->execute(
             new UpdateOrganizationInput(
                 id: $created->id,
                 name: null,
@@ -174,7 +175,7 @@ final class OrganizationUseCaseTest extends TestCase
             new CreateOrganizationInput(name: 'My Org', slug: 'my-org'),
         );
 
-        $output = (new UpdateOrganizationUseCase($organizations))->execute(
+        $output = (new UpdateOrganizationUseCase($organizations, new UnlimitedEntitlementResolver()))->execute(
             new UpdateOrganizationInput(
                 id: $created->id,
                 name: null,
@@ -195,7 +196,7 @@ final class OrganizationUseCaseTest extends TestCase
 
         $this->expectException(OrganizationNotFoundException::class);
 
-        (new UpdateOrganizationUseCase($organizations))->execute(
+        (new UpdateOrganizationUseCase($organizations, new UnlimitedEntitlementResolver()))->execute(
             new UpdateOrganizationInput(
                 id: 999,
                 name: 'New Name',
@@ -218,7 +219,7 @@ final class OrganizationUseCaseTest extends TestCase
 
         $this->expectException(OrganizationSlugConflictException::class);
 
-        (new UpdateOrganizationUseCase($organizations))->execute(
+        (new UpdateOrganizationUseCase($organizations, new UnlimitedEntitlementResolver()))->execute(
             new UpdateOrganizationInput(
                 id: $createdB->id,
                 name: null,

--- a/tests/Organization/Resolution/SubdomainOrCustomDomainResolutionStrategyTest.php
+++ b/tests/Organization/Resolution/SubdomainOrCustomDomainResolutionStrategyTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Organization\Resolution;
+
+use NeNeRecords\Organization\Resolution\SubdomainOrCustomDomainResolutionStrategy;
+use NeNeRecords\Organization\Resolution\SubdomainResolutionStrategy;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class SubdomainOrCustomDomainResolutionStrategyTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private SubdomainOrCustomDomainResolutionStrategy $strategy;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new Psr17Factory();
+        $this->strategy = new SubdomainOrCustomDomainResolutionStrategy(
+            new SubdomainResolutionStrategy('nene-records.com'),
+        );
+    }
+
+    public function testBaseDomainSubdomainResolvesToOrgSlug(): void
+    {
+        self::assertSame('org1', $this->strategy->resolve($this->request('https://org1.nene-records.com/')));
+    }
+
+    public function testApexResolvesToNull(): void
+    {
+        self::assertNull($this->strategy->resolve($this->request('https://nene-records.com/')));
+    }
+
+    public function testCustomSubdomainReturnsFullHost(): void
+    {
+        // Not a base-domain subdomain → hand the full host to findByCustomDomain().
+        self::assertSame('blog.example.com', $this->strategy->resolve($this->request('https://blog.example.com/')));
+    }
+
+    public function testCustomApexDomainReturnsFullHost(): void
+    {
+        self::assertSame('example.com', $this->strategy->resolve($this->request('https://example.com/')));
+    }
+
+    public function testIsApexOnlyForBaseDomain(): void
+    {
+        self::assertTrue($this->strategy->isApex($this->request('https://nene-records.com/')));
+        self::assertFalse($this->strategy->isApex($this->request('https://org1.nene-records.com/')));
+        self::assertFalse($this->strategy->isApex($this->request('https://blog.example.com/')));
+    }
+
+    private function request(string $url): \Psr\Http\Message\ServerRequestInterface
+    {
+        return $this->factory->createServerRequest('GET', $url);
+    }
+}

--- a/tests/Organization/UpdateOrganizationCustomDomainEntitlementTest.php
+++ b/tests/Organization/UpdateOrganizationCustomDomainEntitlementTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Organization;
+
+use NeNeRecords\Entitlement\EntitlementResolverInterface;
+use NeNeRecords\Entitlement\Entitlements;
+use NeNeRecords\Entitlement\FeatureNotEntitledException;
+use NeNeRecords\Entitlement\UnlimitedEntitlementResolver;
+use NeNeRecords\Organization\CreateOrganizationInput;
+use NeNeRecords\Organization\CreateOrganizationUseCase;
+use NeNeRecords\Organization\UpdateOrganizationInput;
+use NeNeRecords\Organization\UpdateOrganizationUseCase;
+use PHPUnit\Framework\TestCase;
+
+final class UpdateOrganizationCustomDomainEntitlementTest extends TestCase
+{
+    public function testAllowsCustomDomainUnderUnlimitedEntitlements(): void
+    {
+        $organizations = new InMemoryOrganizationRepository();
+        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder()))->execute(
+            new CreateOrganizationInput(name: 'Shop', slug: 'shop'),
+        );
+
+        $output = (new UpdateOrganizationUseCase($organizations, new UnlimitedEntitlementResolver()))->execute(
+            $this->setDomainInput($created->id, 'shop.example.com'),
+        );
+
+        self::assertSame('shop.example.com', $output->customDomain);
+    }
+
+    public function testDeniesCustomDomainWhenNotEntitled(): void
+    {
+        $organizations = new InMemoryOrganizationRepository();
+        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder()))->execute(
+            new CreateOrganizationInput(name: 'Shop', slug: 'shop'),
+        );
+
+        $useCase = new UpdateOrganizationUseCase($organizations, $this->denyResolver());
+
+        $this->expectException(FeatureNotEntitledException::class);
+        $useCase->execute($this->setDomainInput($created->id, 'shop.example.com'));
+    }
+
+    public function testNonCustomDomainUpdatesAreNotGated(): void
+    {
+        $organizations = new InMemoryOrganizationRepository();
+        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder()))->execute(
+            new CreateOrganizationInput(name: 'Shop', slug: 'shop'),
+        );
+
+        // A name-only change must succeed even when custom domains aren't entitled.
+        $output = (new UpdateOrganizationUseCase($organizations, $this->denyResolver()))->execute(
+            new UpdateOrganizationInput(
+                id: $created->id,
+                name: 'Renamed',
+                slug: null,
+                plan: null,
+                isActive: null,
+                updateCustomDomain: false,
+                customDomain: null,
+            ),
+        );
+
+        self::assertSame('Renamed', $output->name);
+    }
+
+    public function testClearingCustomDomainIsNotGated(): void
+    {
+        $organizations = new InMemoryOrganizationRepository();
+        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder()))->execute(
+            new CreateOrganizationInput(name: 'Shop', slug: 'shop'),
+        );
+
+        // Clearing (null) must never be blocked — downgrades keep data, only new
+        // non-empty assignments are gated.
+        $output = (new UpdateOrganizationUseCase($organizations, $this->denyResolver()))->execute(
+            new UpdateOrganizationInput(
+                id: $created->id,
+                name: null,
+                slug: null,
+                plan: null,
+                isActive: null,
+                updateCustomDomain: true,
+                customDomain: null,
+            ),
+        );
+
+        self::assertNull($output->customDomain);
+    }
+
+    private function setDomainInput(int $id, string $domain): UpdateOrganizationInput
+    {
+        return new UpdateOrganizationInput(
+            id: $id,
+            name: null,
+            slug: null,
+            plan: null,
+            isActive: null,
+            updateCustomDomain: true,
+            customDomain: $domain,
+        );
+    }
+
+    private function denyResolver(): EntitlementResolverInterface
+    {
+        return new class () implements EntitlementResolverInterface {
+            public function for(int $organizationId): Entitlements
+            {
+                return new Entitlements(
+                    customDomainAllowed: false,
+                    brandingRemovable: false,
+                    maxRecords: 0,
+                    maxStorageBytes: 0,
+                    maxAdminUsers: 0,
+                );
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 目的
`Closes #617`（Part of #536）。第7回（#615）で「独自ドメインを売る前提＝resolver 配線を塞ぐ」「上限/機能は SaaS のみ・**self-host は無制限**＝エンタイトルメントを既定無制限＋オペレータ opt-in で導入」が確認された。本 PR はその最小実装（配線＋seam）。**self-host（git clone / single モード / 既定）は完全無制限のまま。**

## 変更
### 1. 独自ドメインの org 解決（配線）
- `SubdomainOrCustomDomainResolutionStrategy` を新設し subdomain モードに配線（subdomain→custom domain フォールバック）。`SubdomainResolutionStrategy` が `*.base` 以外を null にして 404 にしていた穴を塞ぐ。
- `TlsCheckHandler` は既に custom domain の証明書発行を許可済み → これで **証明書＋org 解決が揃い、独自ドメインが end-to-end で機能**。

### 2. エンタイトルメント seam（open-core 方式）
- `EntitlementResolverInterface::for(orgId): Entitlements` ＋ `Entitlements`(VO) ＋ **`UnlimitedEntitlementResolver`（既定バインド）**。
- 原則: enforcement の*コード*は製品に、上限*値*はオペレータ設定（定数で焼き込まない）。値はデータ。
- `FeatureNotEntitledException` → `FeatureNotEntitledExceptionHandler` で **402 Payment Required**。

### 3. 最初のゲート＝独自ドメイン割当
- `UpdateOrganizationUseCase` に resolver を注入し、**新規・非空・変更時のみ** `customDomainAllowed` を確認。既定 Unlimited なので self-host も現行 SaaS も**無影響**。
- **downgrade はデータ非破壊**（割当時のみ gate・clear は常に許可）。
- `brandingRemovable` は VO に予約（hide-branding 機能が無いため**未 enforce**）。

## 検証
- `composer check` 緑: **PHPUnit 1061 tests / 2927 assertions**・PHPStan level 8（1266 files・エラー0）・CS-Fixer・OpenAPI・MCP。
- 新規テスト: 複合 resolver（subdomain/apex/custom）・Unlimited・402 ハンドラ・gate（allow / deny / 非対象更新 / clear）。既存 Organization テストも resolver 追随。
- フロント変更なし（API 契約不変）。

## チェックリスト
- [x] Issue 紐付け（Closes #617・Part of #536）
- [x] Conventional Commits（`feat(tenant)`・日本語本文）
- [x] テスト追加・`composer check` 緑
- [x] self-host は既定無制限（git clone 勢に影響なし）

## スコープ外（後続）
- `PlanBasedEntitlements` ＋ plan→上限 config（課金時に opt-in）。402 を OpenAPI に記載するのもこの時（既定では到達しないため本 PR では非記載）。
- テナント自助の独自ドメイン追加 UI ＋ DNS 所有権検証。
- レコード/容量/ユーザー quota の enforcement、branding 非表示機能。

Closes #617
