### PR TITLE
feat(extension): コアを deploy-time モジュール機構に対応させる (#621)

### DIFF
--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -54,6 +54,7 @@ use NeNeRecords\EntityType\EntityTypeSlugConflictExceptionHandler;
 use NeNeRecords\EnumField\EnumFieldNotFoundExceptionHandler;
 use NeNeRecords\EnumField\EnumFieldRouteRegistrar;
 use NeNeRecords\EnumField\EnumFieldServiceProvider;
+use NeNeRecords\Extension\ModuleRegistry;
 use NeNeRecords\FieldDef\FieldDefConflictExceptionHandler;
 use NeNeRecords\FieldDef\FieldDefNotFoundExceptionHandler;
 use NeNeRecords\FieldDef\FieldDefRouteRegistrar;
@@ -193,6 +194,12 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new UrlRedirectServiceProvider())
             ->addProvider(new SingleOriginServiceProvider());
 
+        // Optional/private modules (ADR 0005): compose on top of core if present.
+        // Absent (fresh git clone) → nothing added; core stays plain OSS.
+        foreach ((new ModuleRegistry())->modules() as $module) {
+            $builder->addProvider($module);
+        }
+
         $builder
             ->set(
                 self::ROUTE_REGISTRARS,
@@ -275,7 +282,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Route registrar service is invalid.');
                     }
 
-                    return [
+                    $registrars = [
                         $auth,
                         $entityType,
                         $entityArchive,
@@ -313,6 +320,14 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $theme,
                         $wxrImport,
                     ];
+
+                    foreach ((new ModuleRegistry())->modules() as $module) {
+                        foreach ($module->routeRegistrars($container) as $registrar) {
+                            $registrars[] = $registrar;
+                        }
+                    }
+
+                    return $registrars;
                 },
             )
             ->set(
@@ -426,7 +441,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         }
                     }
 
-                    return [
+                    $handlers = [
                         $entityTypeNotFound,
                         $entityTypeHasEntities,
                         $entityTypeSlugConflict,
@@ -478,6 +493,14 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $notificationChannelNotFound,
                         $themeNotFound,
                     ];
+
+                    foreach ((new ModuleRegistry())->modules() as $module) {
+                        foreach ($module->exceptionHandlers($container) as $handler) {
+                            $handlers[] = $handler;
+                        }
+                    }
+
+                    return $handlers;
                 },
             );
     }

--- a/src/Extension/ModuleInterface.php
+++ b/src/Extension/ModuleInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Extension;
+
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Routing\Router;
+use Psr\Container\ContainerInterface;
+
+/**
+ * An optional, deploy-time module that extends the core without forking it.
+ *
+ * A module is a {@see ServiceProviderInterface} (registers its own DI services)
+ * that ALSO contributes route registrars and domain exception handlers. Core
+ * domains are wired directly in {@see \NeNeRecords\ApplicationServiceProvider};
+ * optional/private modules (e.g. a commercial billing package) are discovered by
+ * {@see ModuleRegistry} and composed on top.
+ *
+ * This is the typed, deploy-time extension mechanism chosen in ADR 0005 — NOT a
+ * WordPress-style runtime plugin system. Modules are trusted code shipped with
+ * the build (first-party or vetted), never untrusted user-uploaded code.
+ *
+ * Implementations must be constructible with no arguments (they are instantiated
+ * by the registry); all dependencies are pulled from the container at use time.
+ */
+interface ModuleInterface extends ServiceProviderInterface
+{
+    /**
+     * Route registrars this module contributes, appended after the core routes.
+     *
+     * @return list<callable(Router): void>
+     */
+    public function routeRegistrars(ContainerInterface $container): array;
+
+    /**
+     * Domain exception handlers this module contributes, appended after core.
+     *
+     * @return list<DomainExceptionHandlerInterface>
+     */
+    public function exceptionHandlers(ContainerInterface $container): array;
+}

--- a/src/Extension/ModuleRegistry.php
+++ b/src/Extension/ModuleRegistry.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Extension;
+
+/**
+ * Discovers optional/private modules present in the current build.
+ *
+ * A module activates by PRESENCE: if its entrypoint class is installed (e.g. via a
+ * private composer path package — the same mechanism used to inject NENE2), it is
+ * composed on top of core; otherwise core runs as plain permissive OSS. There is
+ * no config toggle and no obfuscation — see ADR 0005.
+ *
+ * The default candidates are forward references: a name only resolves to a class
+ * when its private package is installed, so a fresh `git clone` discovers nothing.
+ */
+final class ModuleRegistry
+{
+    /**
+     * Well-known optional-module entrypoints (plain strings, NOT class-string
+     * literals, so they don't have to exist for static analysis to pass).
+     *
+     * @var list<string>
+     */
+    private const DEFAULT_CANDIDATES = [
+        // Commercial layer (billing / plan-based entitlements / account) — private
+        // package, present only in the hosted build. See ADR 0005.
+        'NeNeRecords\\Commercial\\CommercialModule',
+    ];
+
+    /** @var list<string> */
+    private array $candidates;
+
+    /** @param list<string>|null $candidates override for tests; null = defaults */
+    public function __construct(?array $candidates = null)
+    {
+        $this->candidates = $candidates ?? self::DEFAULT_CANDIDATES;
+    }
+
+    /** @return list<ModuleInterface> */
+    public function modules(): array
+    {
+        $modules = [];
+
+        foreach ($this->candidates as $candidate) {
+            // class_exists() narrows $candidate to class-string and triggers the
+            // autoloader; a missing private package simply yields false.
+            if (!class_exists($candidate)) {
+                continue;
+            }
+
+            $instance = new $candidate();
+
+            if ($instance instanceof ModuleInterface) {
+                $modules[] = $instance;
+            }
+        }
+
+        return $modules;
+    }
+}

--- a/tests/Extension/FakeModule.php
+++ b/tests/Extension/FakeModule.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Extension;
+
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\Routing\Router;
+use NeNeRecords\Extension\ModuleInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Minimal {@see ModuleInterface} test double: contributes one route registrar and
+ * no exception handlers, so registry/composition behaviour can be asserted without
+ * a real private package.
+ */
+final class FakeModule implements ModuleInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+    }
+
+    public function routeRegistrars(ContainerInterface $container): array
+    {
+        return [static function (Router $router): void {
+        }];
+    }
+
+    public function exceptionHandlers(ContainerInterface $container): array
+    {
+        return [];
+    }
+}

--- a/tests/Extension/ModuleRegistryTest.php
+++ b/tests/Extension/ModuleRegistryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Extension;
+
+use NeNeRecords\Extension\ModuleRegistry;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+final class ModuleRegistryTest extends TestCase
+{
+    public function testDefaultDiscoversNoModulesInOssBuild(): void
+    {
+        // The commercial package is not installed in the core/OSS repo, so a fresh
+        // build composes nothing on top of core.
+        self::assertSame([], (new ModuleRegistry())->modules());
+    }
+
+    public function testDiscoversAnInstalledCandidate(): void
+    {
+        $modules = (new ModuleRegistry([FakeModule::class]))->modules();
+
+        self::assertCount(1, $modules);
+        foreach ($modules as $module) {
+            self::assertInstanceOf(FakeModule::class, $module);
+        }
+    }
+
+    public function testSkipsAMissingClass(): void
+    {
+        self::assertSame([], (new ModuleRegistry(['NeNeRecords\\Nope\\DoesNotExist']))->modules());
+    }
+
+    public function testSkipsAClassThatIsNotAModule(): void
+    {
+        // stdClass exists but does not implement ModuleInterface.
+        self::assertSame([], (new ModuleRegistry([\stdClass::class]))->modules());
+    }
+
+    public function testModuleContributesRoutesAndHandlers(): void
+    {
+        $module = new FakeModule();
+        $container = $this->createStub(ContainerInterface::class);
+
+        self::assertCount(1, $module->routeRegistrars($container));
+        self::assertSame([], $module->exceptionHandlers($container));
+    }
+}


### PR DESCRIPTION
## 目的
`Closes #621`。ADR 0005（#619）D4 の実装①＝**コアの拡張対応化（backbone）**。optional/private モジュール（第1号は将来の `nene-records-commercial`）が **core を fork/編集せず**載る型付き deploy-time モジュール機構を導入する。

## 変更
- 追加 `src/Extension/ModuleInterface.php` — `ServiceProviderInterface` 継承＋`routeRegistrars()` / `exceptionHandlers()`。モジュールが DI＋ルート＋例外ハンドラを供給。
- 追加 `src/Extension/ModuleRegistry.php` — 候補 FQCN を `class_exists` で検出（**presence で活性化**）。private package（NENE2 と同じ composer path repo 注入）が入っていれば合成、無ければ素の OSS。設定/難読化なし。
- 変更 `src/ApplicationServiceProvider.php` — コア provider の後に optional モジュールを `addProvider`、`ROUTE_REGISTRARS` / `EXCEPTION_HANDLERS` にモジュールの貢献を追記。
- **既定候補（`nene-records-commercial`）は未インストール＝コア挙動は不変**（OSS のまま・既存テスト無回帰）。
- WP 式ランタイムプラグインではなく**型付き deploy-time**（任意コード不可・identity 維持）。

## 検証
- `composer check` 緑: **PHPUnit 1066 / 2934**・PHPStan level 8（1270 files・エラー0）・CS-Fixer・OpenAPI・MCP。
- 新規テスト `ModuleRegistryTest`: 候補無→空 / 有→検出 / 不在クラス / 非Module をスキップ ＋ モジュールの contribution。
- フロント変更なし（API 契約不変）。

## チェックリスト
- [x] Issue 紐付け（Closes #621）
- [x] Conventional Commits（`feat(extension)`・日本語本文）
- [x] テスト追加・`composer check` 緑
- [x] self-host は既定でコア不変（optional モジュール 0）

## スコープ外（後続・ADR 0005 の続き）
- `BillingGateway` seam ＋ フロント contribution registry は consumer と同時に（投機実装回避）。
- `nene-records-commercial`（PlanBased＋plan→上限 catalog＋Stripe＋`/account`＋運営課金コンソール）＝ADR 0005 ②。
- `/api/v1/account*`＋`ManageAccount`＋entitlement gate のテナント経路移設＝ADR 0005 ③。

Closes #621
