### PR TITLE
chore(build): commercial モジュールの任意注入を composer-merge-plugin で配線する (#623)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ test-results/
 
 # Design export for ClaudeDesign (generated, not tracked)
 /design-export/
+
+# Private commercial overlay injection (ayane build only, never public) — ADR 0005.
+# composer-merge-plugin merges this if present; absent on a fresh OSS clone.
+/composer.local.json

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "robmorgan/phinx": "^0.16.11",
         "symfony/html-sanitizer": "^8.1",
         "symfony/http-client": "^8.1",
-        "symfony/mailer": "^8.0"
+        "symfony/mailer": "^8.0",
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "repositories": [
         {
@@ -54,7 +55,17 @@
         ]
     },
     "config": {
+        "allow-plugins": {
+            "wikimedia/composer-merge-plugin": true
+        },
         "sort-packages": true
+    },
+    "extra": {
+        "merge-plugin": {
+            "include": [
+                "composer.local.json"
+            ]
+        }
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.95",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "995e6d692da5c5499e71981f81220c10",
+    "content-hash": "aad302b89e4aa0376bd4da0a2143c04a",
     "packages": [
         {
             "name": "async-aws/core",
@@ -750,11 +750,11 @@
         },
         {
             "name": "hideyukimori/nene2",
-            "version": "dev-docs/1042-ft248-content-approval-workflow",
+            "version": "dev-main",
             "dist": {
                 "type": "path",
                 "url": "../NENE2",
-                "reference": "349def332e018d8ab515a71624ae8416753020a9"
+                "reference": "54cb3b5e2596d09396b8bc4b1a7030f80ff22931"
             },
             "require": {
                 "monolog/monolog": "^3.0",
@@ -4056,6 +4056,62 @@
                 }
             ],
             "time": "2025-12-27T19:49:13+00:00"
+        },
+        {
+            "name": "wikimedia/composer-merge-plugin",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wikimedia/composer-merge-plugin.git",
+                "reference": "a03d426c8e9fb2c9c569d9deeb31a083292788bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wikimedia/composer-merge-plugin/zipball/a03d426c8e9fb2c9c569d9deeb31a083292788bc",
+                "reference": "a03d426c8e9fb2c9c569d9deeb31a083292788bc",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1||^2.0",
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.1||^2.0",
+                "ext-json": "*",
+                "mediawiki/mediawiki-phan-config": "0.11.1",
+                "php-parallel-lint/php-parallel-lint": "~1.3.1",
+                "phpspec/prophecy": "~1.15.0",
+                "phpunit/phpunit": "^8.5||^9.0",
+                "squizlabs/php_codesniffer": "~3.7.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Wikimedia\\Composer\\Merge\\V2\\MergePlugin",
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Wikimedia\\Composer\\Merge\\V2\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Davis",
+                    "email": "bd808@wikimedia.org"
+                }
+            ],
+            "description": "Composer plugin to merge multiple composer.json files",
+            "support": {
+                "issues": "https://github.com/wikimedia/composer-merge-plugin/issues",
+                "source": "https://github.com/wikimedia/composer-merge-plugin/tree/v2.1.0"
+            },
+            "time": "2023-04-15T19:07:00+00:00"
         }
     ],
     "packages-dev": [

--- a/tests/Extension/ModuleRegistryTest.php
+++ b/tests/Extension/ModuleRegistryTest.php
@@ -4,17 +4,26 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Tests\Extension;
 
+use NeNeRecords\Extension\ModuleInterface;
 use NeNeRecords\Extension\ModuleRegistry;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 final class ModuleRegistryTest extends TestCase
 {
-    public function testDefaultDiscoversNoModulesInOssBuild(): void
+    public function testEmptyCandidatesYieldNoModules(): void
     {
-        // The commercial package is not installed in the core/OSS repo, so a fresh
-        // build composes nothing on top of core.
-        self::assertSame([], (new ModuleRegistry())->modules());
+        self::assertSame([], (new ModuleRegistry([]))->modules());
+    }
+
+    public function testDefaultCandidatesYieldOnlyModuleInstances(): void
+    {
+        // The default candidate list resolves to nothing on an OSS build and to the
+        // commercial module on the ayane build; either way it must only yield
+        // ModuleInterface instances (assertion is environment-independent).
+        foreach ((new ModuleRegistry())->modules() as $module) {
+            self::assertInstanceOf(ModuleInterface::class, $module);
+        }
     }
 
     public function testDiscoversAnInstalledCandidate(): void


### PR DESCRIPTION
## 目的
`Closes #623`。ADR 0005 D4：private commercial モジュール（`hideyukimori/nene-records-commercial`・別 private repo・sibling）を **ayane ビルドにだけ**合成する任意注入を入れる（方式(1)＝composer-merge-plugin）。**公開側に commercial への参照は一切置かない。**

## 変更
- `composer.json`：`wikimedia/composer-merge-plugin` を追加（require）＋ `extra.merge-plugin.include=["composer.local.json"]` ＋ `config.allow-plugins`。
- `.gitignore`：`composer.local.json`（ayane だけが置く。commercial の autoload を sibling `../nene-records-commercial/src` から合成）。
- `tests/Extension/ModuleRegistryTest.php`：#622 の「既定=空」前提テストは commercial 在環境で壊れるため**環境非依存**（明示候補＋`instanceof`）へ是正。
- `composer.lock`：merge-plugin を追加。あわせて nene2 の `@dev` が sibling 現状（dev-main）へ再解決（path パッケージのため lock は情報的・無害）。

## OSS / CI 安全性
- `composer.local.json` 不在（OSS の `git clone` / CI）＝ merge 何もなし＝**素のコア**（`include` は不在ファイルを黙ってスキップ）。公開 lock には merge-plugin のみ（commercial は入らない）。

## 検証
- **ローカル end-to-end 実証**：`composer.local.json`＋`composer dump-autoload` で `class_exists(NeNeRecords\Commercial\CommercialModule)`=true、コアの `ModuleRegistry`（既定候補）が CommercialModule を**発見**。
- `composer check` 緑：**PHPUnit 1067 / 2935**・PHPStan level 8（1270 files・エラー0）・CS-Fixer・OpenAPI・MCP（commercial 在＝空モジュール合成でもコア不変）。
- フロント変更なし。

## チェックリスト
- [x] Issue 紐付け（Closes #623）
- [x] 公開側に commercial 参照なし・OSS install 不変
- [x] テスト是正・`composer check` 緑

## スコープ外（後続）
- 本番 Docker への commercial 注入（build context）＝サーバ側 compose の作業。
- commercial が外部依存（stripe-php 等）を持ったら autoload-merge → require 方式へ切替（その時 lock を扱う）。
- `nene-records-commercial` 本体の実装（PlanBased＋catalog → Stripe → `/account`）＝ADR 0005 ②。

Closes #623
