### PR TITLE
feat(account): テナント自org 閲覧用 GET /api/v1/account を追加する (#625)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -8,6 +8,8 @@ servers:
   - url: http://localhost:8080
     description: Local development server
 tags:
+  - name: Account
+    description: Tenant self-serve account (plan, entitlements, usage).
   - name: Auth
     description: Authentication endpoints.
   - name: System
@@ -3475,6 +3477,47 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/account:
+    get:
+      tags:
+        - Account
+      summary: Get the current tenant's account
+      description: >-
+        Returns the calling tenant's own organization (name, slug, plan), the
+        entitlements it gets under its plan (custom-domain allowance and limits;
+        null = unlimited) and current usage. The organization is taken from the
+        resolved request context, never a client-supplied id. Requires the
+        ManageAccount capability (admin).
+      operationId: getAccount
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: The tenant's account.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountResponse'
+              examples:
+                ok:
+                  value:
+                    slug: my-shop
+                    name: My Shop
+                    plan: free
+                    custom_domain: null
+                    entitlements:
+                      custom_domain_allowed: false
+                      max_records: 1000
+                      max_storage_bytes: 1073741824
+                      max_admin_users: 1
+                    usage:
+                      records: 12
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
   /api/v1/dashboard:
     get:
       tags:
@@ -4369,6 +4412,42 @@ components:
                 detail: An unexpected error occurred.
                 instance: /api/v1/entity-types
   schemas:
+    AccountResponse:
+      type: object
+      required: [slug, name, plan, custom_domain, entitlements, usage]
+      properties:
+        slug:
+          type: string
+        name:
+          type: string
+        plan:
+          type: string
+        custom_domain:
+          type: string
+          nullable: true
+        entitlements:
+          type: object
+          required: [custom_domain_allowed, max_records, max_storage_bytes, max_admin_users]
+          properties:
+            custom_domain_allowed:
+              type: boolean
+            max_records:
+              type: integer
+              nullable: true
+              description: 'null = unlimited'
+            max_storage_bytes:
+              type: integer
+              format: int64
+              nullable: true
+            max_admin_users:
+              type: integer
+              nullable: true
+        usage:
+          type: object
+          required: [records]
+          properties:
+            records:
+              type: integer
     WxrPlannedItem:
       type: object
       required: [title, slug, entity_type, status, tags]

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -1432,6 +1432,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/account": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the current tenant's account
+         * @description Returns the calling tenant's own organization (name, slug, plan), the entitlements it gets under its plan (custom-domain allowance and limits; null = unlimited) and current usage. The organization is taken from the resolved request context, never a client-supplied id. Requires the ManageAccount capability (admin).
+         */
+        get: operations["getAccount"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/dashboard": {
         parameters: {
             query?: never;
@@ -1748,6 +1768,23 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        AccountResponse: {
+            slug: string;
+            name: string;
+            plan: string;
+            custom_domain: string | null;
+            entitlements: {
+                custom_domain_allowed: boolean;
+                /** @description null = unlimited */
+                max_records: number | null;
+                /** Format: int64 */
+                max_storage_bytes: number | null;
+                max_admin_users: number | null;
+            };
+            usage: {
+                records: number;
+            };
+        };
         WxrPlannedItem: {
             title: string;
             slug: string;
@@ -6338,6 +6375,29 @@ export interface operations {
             };
             404: components["responses"]["NotFound"];
             500: components["responses"]["InternalServerError"];
+        };
+    };
+    getAccount: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The tenant's account. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccountResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
         };
     };
     getDashboardSummary: {

--- a/src/Account/AccountRouteRegistrar.php
+++ b/src/Account/AccountRouteRegistrar.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Account;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class AccountRouteRegistrar
+{
+    public function __construct(
+        private GetAccountHandler $handler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $handler = $this->handler;
+
+        $router->get(
+            '/api/v1/account',
+            static fn (ServerRequestInterface $request) => $handler->handle($request),
+        );
+    }
+}

--- a/src/Account/AccountServiceProvider.php
+++ b/src/Account/AccountServiceProvider.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Account;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Entitlement\EntitlementResolverInterface;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\Organization\OrganizationRepositoryInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class AccountServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                GetAccountUseCaseInterface::class,
+                static function (ContainerInterface $container): GetAccountUseCaseInterface {
+                    $organizations = $container->get(OrganizationRepositoryInterface::class);
+                    $entitlements = $container->get(EntitlementResolverInterface::class);
+                    $entities = $container->get(EntityRepositoryInterface::class);
+
+                    if (!$organizations instanceof OrganizationRepositoryInterface) {
+                        throw new LogicException('Organization repository service is invalid.');
+                    }
+
+                    if (!$entitlements instanceof EntitlementResolverInterface) {
+                        throw new LogicException('Entitlement resolver service is invalid.');
+                    }
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    return new GetAccountUseCase($organizations, $entitlements, $entities);
+                },
+            )
+            ->set(
+                GetAccountHandler::class,
+                static function (ContainerInterface $container): GetAccountHandler {
+                    $useCase = $container->get(GetAccountUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof GetAccountUseCaseInterface) {
+                        throw new LogicException('GetAccount use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new GetAccountHandler($useCase, $response);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.account',
+                static function (ContainerInterface $container): AccountRouteRegistrar {
+                    $handler = $container->get(GetAccountHandler::class);
+
+                    if (!$handler instanceof GetAccountHandler) {
+                        throw new LogicException('GetAccount handler service is invalid.');
+                    }
+
+                    return new AccountRouteRegistrar($handler);
+                },
+            );
+    }
+}

--- a/src/Account/GetAccountHandler.php
+++ b/src/Account/GetAccountHandler.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Account;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * `GET /api/v1/account` — the calling tenant's own account (plan, entitlements,
+ * usage). The organization is taken from the resolved request context
+ * (`nene2.org.id`), never from a client-supplied id, so a tenant can only ever
+ * read its own account.
+ */
+final readonly class GetAccountHandler
+{
+    public function __construct(
+        private GetAccountUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = (int) $request->getAttribute('nene2.org.id');
+
+        $output = $this->useCase->execute($organizationId);
+
+        return $this->response->create([
+            'slug'          => $output->slug,
+            'name'          => $output->name,
+            'plan'          => $output->plan,
+            'custom_domain' => $output->customDomain,
+            'entitlements'  => [
+                'custom_domain_allowed' => $output->customDomainAllowed,
+                // null = unlimited (self-host / enterprise); otherwise the cap.
+                'max_records'       => self::limit($output->maxRecords),
+                'max_storage_bytes' => self::limit($output->maxStorageBytes),
+                'max_admin_users'   => self::limit($output->maxAdminUsers),
+            ],
+            'usage' => [
+                'records' => $output->recordsUsed,
+            ],
+        ]);
+    }
+
+    private static function limit(int $value): ?int
+    {
+        return $value === PHP_INT_MAX ? null : $value;
+    }
+}

--- a/src/Account/GetAccountOutput.php
+++ b/src/Account/GetAccountOutput.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Account;
+
+/**
+ * The current tenant's account snapshot: its organization identity, the
+ * entitlements it gets under its plan (via the core entitlement seam — unlimited
+ * on self-host, plan-based on the hosted build), and current usage.
+ */
+final readonly class GetAccountOutput
+{
+    public function __construct(
+        public string $slug,
+        public string $name,
+        public string $plan,
+        public ?string $customDomain,
+        public bool $customDomainAllowed,
+        public int $maxRecords,
+        public int $maxStorageBytes,
+        public int $maxAdminUsers,
+        public int $recordsUsed,
+    ) {
+    }
+}

--- a/src/Account/GetAccountUseCase.php
+++ b/src/Account/GetAccountUseCase.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Account;
+
+use NeNeRecords\Entitlement\EntitlementResolverInterface;
+use NeNeRecords\Entity\EntityListCriteria;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\Organization\OrganizationNotFoundException;
+use NeNeRecords\Organization\OrganizationRepositoryInterface;
+
+final readonly class GetAccountUseCase implements GetAccountUseCaseInterface
+{
+    public function __construct(
+        private OrganizationRepositoryInterface $organizations,
+        private EntitlementResolverInterface $entitlements,
+        private EntityRepositoryInterface $entities,
+    ) {
+    }
+
+    public function execute(int $organizationId): GetAccountOutput
+    {
+        $organization = $this->organizations->findById($organizationId);
+
+        if ($organization === null) {
+            throw new OrganizationNotFoundException($organizationId);
+        }
+
+        $entitlements = $this->entitlements->for($organizationId);
+
+        // Current usage. The entity repository is org-scoped (RequestScopedHolder),
+        // so an unfiltered criteria counts only this tenant's records.
+        $recordsUsed = $this->entities->countByCriteria(new EntityListCriteria());
+
+        return new GetAccountOutput(
+            slug: $organization->slug,
+            name: $organization->name,
+            plan: $organization->plan,
+            customDomain: $organization->customDomain,
+            customDomainAllowed: $entitlements->customDomainAllowed,
+            maxRecords: $entitlements->maxRecords,
+            maxStorageBytes: $entitlements->maxStorageBytes,
+            maxAdminUsers: $entitlements->maxAdminUsers,
+            recordsUsed: $recordsUsed,
+        );
+    }
+}

--- a/src/Account/GetAccountUseCaseInterface.php
+++ b/src/Account/GetAccountUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Account;
+
+interface GetAccountUseCaseInterface
+{
+    public function execute(int $organizationId): GetAccountOutput;
+}

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -9,6 +9,8 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\DomainExceptionHandlerInterface;
 use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Account\AccountRouteRegistrar;
+use NeNeRecords\Account\AccountServiceProvider;
 use NeNeRecords\Analytics\AnalyticsRouteRegistrar;
 use NeNeRecords\Analytics\AnalyticsServiceProvider;
 use NeNeRecords\Auth\AuthRouteRegistrar;
@@ -156,6 +158,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
         );
 
         $builder
+            ->addProvider(new AccountServiceProvider())
             ->addProvider(new EntityArchiveServiceProvider())
             ->addProvider(new EntityTypeServiceProvider())
             ->addProvider(new FieldDefServiceProvider())
@@ -227,6 +230,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $webhook = $container->get('nene-records.route_registrar.webhook');
                     $previewToken = $container->get('nene-records.route_registrar.preview_token');
                     $dashboard = $container->get('nene-records.route_registrar.dashboard');
+                    $account = $container->get('nene-records.route_registrar.account');
                     $user = $container->get('nene-records.route_registrar.user');
                     $userInvite = $container->get('nene-records.route_registrar.user_invite');
                     $auth = $container->get('nene-records.route_registrar.auth');
@@ -265,6 +269,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !$webhook instanceof WebhookRouteRegistrar
                         || !$previewToken instanceof PreviewTokenRouteRegistrar
                         || !$dashboard instanceof DashboardRouteRegistrar
+                        || !$account instanceof AccountRouteRegistrar
                         || !$user instanceof UserRouteRegistrar
                         || !$userInvite instanceof UserInviteRouteRegistrar
                         || !$auth instanceof AuthRouteRegistrar
@@ -307,6 +312,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $webhook,
                         $previewToken,
                         $dashboard,
+                        $account,
                         $user,
                         $userInvite,
                         $notification,

--- a/src/Auth/AdminApiAuthMiddleware.php
+++ b/src/Auth/AdminApiAuthMiddleware.php
@@ -52,6 +52,7 @@ final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
         '/api/v1/organizations',
         '/api/v1/themes',
         '/api/v1/migration',
+        '/api/v1/account',
     ];
 
     public function __construct(

--- a/src/Auth/Capability.php
+++ b/src/Auth/Capability.php
@@ -12,4 +12,5 @@ enum Capability
     case ManageTags;
     case EditContent;
     case ManageOrganizations;
+    case ManageAccount;
 }

--- a/src/Auth/CapabilityResolver.php
+++ b/src/Auth/CapabilityResolver.php
@@ -25,6 +25,11 @@ final class CapabilityResolver
             return Capability::ManageOrganizations;
         }
 
+        // Tenant self-serve account (own org): admin-only.
+        if (str_starts_with($path, '/api/v1/account')) {
+            return Capability::ManageAccount;
+        }
+
         if (str_starts_with($path, '/api/v1/settings')) {
             return match ($method) {
                 'PUT' => Capability::ManageSettings,

--- a/src/Auth/Role.php
+++ b/src/Auth/Role.php
@@ -21,7 +21,8 @@ enum Role: string
                 Capability::ManageSchema,
                 Capability::ManageSettings,
                 Capability::ManageTags,
-                Capability::ManageOrganizations => false,
+                Capability::ManageOrganizations,
+                Capability::ManageAccount => false,
             },
         };
     }

--- a/tests/Account/GetAccountUseCaseTest.php
+++ b/tests/Account/GetAccountUseCaseTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Account;
+
+use NeNeRecords\Account\GetAccountUseCase;
+use NeNeRecords\Entitlement\UnlimitedEntitlementResolver;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\Organization\Organization;
+use NeNeRecords\Organization\OrganizationNotFoundException;
+use NeNeRecords\Tests\Organization\InMemoryOrganizationRepository;
+use PHPUnit\Framework\TestCase;
+
+final class GetAccountUseCaseTest extends TestCase
+{
+    public function testReturnsOrgPlanEntitlementsAndUsage(): void
+    {
+        $orgs = new InMemoryOrganizationRepository();
+        $id = $orgs->save(new Organization(name: 'My Shop', slug: 'my-shop', plan: 'free', isActive: true));
+
+        $entities = $this->createStub(EntityRepositoryInterface::class);
+        $entities->method('countByCriteria')->willReturn(12);
+
+        $output = (new GetAccountUseCase($orgs, new UnlimitedEntitlementResolver(), $entities))->execute($id);
+
+        self::assertSame('my-shop', $output->slug);
+        self::assertSame('My Shop', $output->name);
+        self::assertSame('free', $output->plan);
+        // Default (self-host) entitlement resolver = unlimited.
+        self::assertTrue($output->customDomainAllowed);
+        self::assertSame(PHP_INT_MAX, $output->maxRecords);
+        self::assertSame(12, $output->recordsUsed);
+    }
+
+    public function testThrowsWhenOrganizationMissing(): void
+    {
+        $orgs = new InMemoryOrganizationRepository();
+        $entities = $this->createStub(EntityRepositoryInterface::class);
+
+        $this->expectException(OrganizationNotFoundException::class);
+        (new GetAccountUseCase($orgs, new UnlimitedEntitlementResolver(), $entities))->execute(999);
+    }
+}

--- a/tests/Auth/CapabilityResolverTest.php
+++ b/tests/Auth/CapabilityResolverTest.php
@@ -29,6 +29,16 @@ final class CapabilityResolverTest extends TestCase
         yield 'delete'     => ['/api/v1/organizations/1', 'DELETE'];
     }
 
+    // ── Account ─────────────────────────────────────────────────────────────────
+
+    public function testAccountRequiresManageAccount(): void
+    {
+        self::assertSame(
+            Capability::ManageAccount,
+            CapabilityResolver::resolve('/api/v1/account', 'GET'),
+        );
+    }
+
     // ── Settings ──────────────────────────────────────────────────────────────
 
     public function testSettingsPutRequiresManageSettings(): void


### PR DESCRIPTION
## 目的
`Closes #625`（Part of #536）。ADR 0005 ③-a の**バックエンド**＝テナント Admin が自分の org の plan/上限/使用量を**閲覧**できる self-serve 面。閲覧はコア（entitlement seam 経由なので SaaS では PlanBased、OSS self-host では Unlimited が自然に出る）。

## 変更
- 追加 `src/Account/`：`GET /api/v1/account`。org は **context 由来（`nene2.org.id`・id を受け取らない）**＝自org しか読めない。返却＝name/slug/plan ＋ entitlements（`custom_domain_allowed`・`max_records`/`max_storage_bytes`/`max_admin_users`・**null=無制限**）＋ usage（`records`）。
- 新 capability **`ManageAccount`**（admin・editor 不可）。`CapabilityResolver`：`/api/v1/account`→ManageAccount。`AdminApiAuthMiddleware` の `ADMIN_ONLY_PREFIXES` に `/api/v1/account`（GET も要認証）。`Role` の Editor 分岐に追加（網羅性）。
- `ApplicationServiceProvider` に `AccountServiceProvider`＋route registrar を登録。
- OpenAPI：`getAccount`＋`AccountResponse`＋`Account` タグ。`schema.gen.ts` 再生成。

## 検証
- `composer check` 緑：**PHPUnit 1069 / 2944**・PHPStan level 8（1277 files・エラー0）・OpenAPI・CS-Fixer・MCP。
- frontend `type-check` 緑（生成型は追加のみ）。
- テスト：`GetAccountUseCaseTest`（集計／org not-found）、`CapabilityResolverTest`（/account→ManageAccount）。

## チェックリスト
- [x] Issue 紐付け（Closes #625・Part of #536）
- [x] テナント系は context 由来 org のみ（id 受け取らない＝横取り防止）
- [x] ADMIN_ONLY_PREFIXES 追加（GET も要認証）
- [x] テスト・`composer check`/type-check 緑

## スコープ外（後続）
- **PR2＝フロント `/admin/account`**（プラン・上限・使用量の表示＋「アップグレード相談」導線）。
- 課金/アップグレード操作（commercial・Stripe）。storage/users の実 usage。

Closes #625
