### PR TITLE
feat(theme): ClaudeDesign 量産向けに activateTheme(MCP)を追加し公開手順を整える (#631)

### DIFF
--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -1515,6 +1515,33 @@
             "responseSchemaRef": null
         },
         {
+            "name": "activateTheme",
+            "title": "Activate Theme",
+            "description": "Make a theme live for the organization. Verifies the key is a built-in id or an existing runtime theme, then sets active_theme. Call after createTheme to publish what you made.",
+            "safety": "write",
+            "source": {
+                "type": "openapi",
+                "operationId": "activateTheme",
+                "method": "POST",
+                "path": "/api/v1/themes/{key}/activate"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9-]{1,40}$",
+                        "description": "Theme key (built-in id or runtime theme key)."
+                    }
+                },
+                "required": [
+                    "key"
+                ],
+                "additionalProperties": false
+            },
+            "responseSchemaRef": null
+        },
+        {
             "name": "listTextFields",
             "title": "List Text Fields",
             "description": "List text field values with optional entity or entity type filters.",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -3334,6 +3334,45 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/themes/{key}/activate:
+    post:
+      tags:
+        - Themes
+      summary: Activate a theme
+      description: >-
+        Makes a theme live for the calling organization. Verifies the key
+        resolves to a built-in theme id or an existing runtime theme, then sets
+        the `active_theme` setting. Returns 404 if no such theme exists.
+      operationId: activateTheme
+      parameters:
+        - name: key
+          in: path
+          required: true
+          description: Theme key (built-in id or runtime theme key).
+          schema:
+            type: string
+            pattern: '^[a-z][a-z0-9-]{1,40}$'
+      responses:
+        '200':
+          description: The theme is now active.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [active_theme]
+                properties:
+                  active_theme:
+                    type: string
+              examples:
+                ok:
+                  value:
+                    active_theme: aurora
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /api/v1/public/menus:
     get:
       tags:

--- a/docs/theming/claudedesign-mcp-guide.md
+++ b/docs/theming/claudedesign-mcp-guide.md
@@ -11,7 +11,7 @@
 2. token/flag を編集する。
 3. **`previewTheme` でコントラスト/落ちる値を確認 → 直す（ループ）。**
 4. OK になったら `createTheme`（新規）/ `updateTheme`（改訂）で確定。
-5. 公開反映は管理者が `active_theme` を選んだ時（再ビルド不要）。
+5. 公開するなら **`activateTheme`**（テーマ存在を検証して `active_theme` を設定・再ビルド不要）。管理者が管理画面で選んでもよい。
 
 **鉄則: `previewTheme` を通さずに commit しない。**
 
@@ -31,6 +31,7 @@
 | `createTheme` | write | 新規登録 | manifest |
 | `updateTheme` | write | 改訂（manifest 置換） | `key` ＋ manifest |
 | `deleteTheme` | destructive | 削除 | `key` |
+| `activateTheme` | write | **公開（存在検証→`active_theme` 設定）** | `key` |
 
 > `key` = テーマの id（`manifest.id`）。`previewTheme`/`createTheme` の入力は**manifest そのもの**（フィールドを直接トップレベルに渡す）。`updateTheme` は `key`（パス）＋ manifest。
 

--- a/src/Theme/ActivateThemeHandler.php
+++ b/src/Theme/ActivateThemeHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ActivateThemeHandler
+{
+    public function __construct(
+        private ActivateThemeUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $key = (string) ($parameters['key'] ?? '');
+
+        $output = $this->useCase->execute(new ActivateThemeInput(themeKey: $key));
+
+        return $this->response->create(['active_theme' => $output->activeTheme]);
+    }
+}

--- a/src/Theme/ActivateThemeInput.php
+++ b/src/Theme/ActivateThemeInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+final readonly class ActivateThemeInput
+{
+    public function __construct(
+        public string $themeKey,
+    ) {
+    }
+}

--- a/src/Theme/ActivateThemeOutput.php
+++ b/src/Theme/ActivateThemeOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+final readonly class ActivateThemeOutput
+{
+    public function __construct(
+        public string $activeTheme,
+    ) {
+    }
+}

--- a/src/Theme/ActivateThemeUseCase.php
+++ b/src/Theme/ActivateThemeUseCase.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+use NeNeRecords\Setting\UpdateSettingInput;
+use NeNeRecords\Setting\UpdateSettingUseCaseInterface;
+
+/**
+ * Activate a theme = set the org's `active_theme` setting, but only after
+ * verifying the key resolves to a real theme (a built-in id or a runtime theme
+ * for this org). The raw setting write has no such check, so a typo / deleted
+ * theme would silently fall back to the default — exactly the footgun an
+ * automated author (ClaudeDesign) must not hit.
+ */
+final readonly class ActivateThemeUseCase implements ActivateThemeUseCaseInterface
+{
+    private const ACTIVE_THEME_SETTING = 'active_theme';
+
+    public function __construct(
+        private ThemeRepositoryInterface $themes,
+        private UpdateSettingUseCaseInterface $settings,
+    ) {
+    }
+
+    public function execute(ActivateThemeInput $input): ActivateThemeOutput
+    {
+        $key = $input->themeKey;
+
+        if (!$this->themes->existsByKey($key) && !ThemeManifestValidator::isBuiltin($key)) {
+            throw new ThemeNotFoundException($key);
+        }
+
+        $this->settings->execute(new UpdateSettingInput(
+            settingKey: self::ACTIVE_THEME_SETTING,
+            value: $key,
+        ));
+
+        return new ActivateThemeOutput(activeTheme: $key);
+    }
+}

--- a/src/Theme/ActivateThemeUseCaseInterface.php
+++ b/src/Theme/ActivateThemeUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Theme;
+
+interface ActivateThemeUseCaseInterface
+{
+    public function execute(ActivateThemeInput $input): ActivateThemeOutput;
+}

--- a/src/Theme/ThemeAuthoringGuide.php
+++ b/src/Theme/ThemeAuthoringGuide.php
@@ -226,6 +226,8 @@ final class ThemeAuthoringGuide
                 'createTheme' => 'Register a new runtime theme from a manifest.',
                 'updateTheme' => 'Replace an existing theme manifest (id must equal the key).',
                 'deleteTheme' => 'Delete a runtime theme by key.',
+                'activateTheme' => 'Make a theme live for the org: verifies the key resolves to a built-in or '
+                    . 'runtime theme, then sets the active_theme setting. Use this to publish what you create.',
             ],
         ];
     }
@@ -322,6 +324,14 @@ final class ThemeAuthoringGuide
                 'steps' => [
                     'Ensure color-on-accent contrasts with color-accent (and the same in dark mode).',
                     'Re-submit via updateTheme.',
+                ],
+            ],
+            [
+                'title' => 'Publish (make live) a theme',
+                'steps' => [
+                    'previewTheme first — contrast is reported, NOT enforced on create, so self-gate on WCAG AA here.',
+                    'createTheme so the key exists (or pick a built-in id from contract.reservedIds).',
+                    'Call activateTheme with the key — it verifies the theme exists, then sets the org active_theme.',
                 ],
             ],
         ];

--- a/src/Theme/ThemeManifestValidator.php
+++ b/src/Theme/ThemeManifestValidator.php
@@ -110,6 +110,12 @@ final class ThemeManifestValidator
         ];
     }
 
+    /** Whether $id is a built-in (static) theme — activatable, but reserved against runtime registration. */
+    public static function isBuiltin(string $id): bool
+    {
+        return in_array($id, self::RESERVED_KEYS, true);
+    }
+
     /**
      * @param array<string, mixed> $manifest
      *

--- a/src/Theme/ThemeRouteRegistrar.php
+++ b/src/Theme/ThemeRouteRegistrar.php
@@ -15,6 +15,7 @@ final readonly class ThemeRouteRegistrar
         private CreateThemeHandler $createHandler,
         private UpdateThemeHandler $updateHandler,
         private DeleteThemeHandler $deleteHandler,
+        private ActivateThemeHandler $activateHandler,
         private ListPublicThemesHandler $listPublicHandler,
         private PreviewThemeHandler $previewHandler,
         private ThemeAuthoringGuideHandler $authoringGuideHandler,
@@ -29,6 +30,7 @@ final readonly class ThemeRouteRegistrar
         $create = $this->createHandler;
         $update = $this->updateHandler;
         $delete = $this->deleteHandler;
+        $activate = $this->activateHandler;
         $listPublic = $this->listPublicHandler;
         $preview = $this->previewHandler;
         $authoringGuide = $this->authoringGuideHandler;
@@ -69,6 +71,11 @@ final readonly class ThemeRouteRegistrar
         $router->delete(
             '/api/v1/themes/{key}',
             static fn (ServerRequestInterface $request) => $delete->handle($request),
+        );
+        // Make a theme live for the org (verifies existence, then sets active_theme).
+        $router->post(
+            '/api/v1/themes/{key}/activate',
+            static fn (ServerRequestInterface $request) => $activate->handle($request),
         );
         // Public read (open via ALWAYS_OPEN_PREFIXES /api/v1/public/) — the
         // public site applies a runtime active theme from this.

--- a/src/Theme/ThemeServiceProvider.php
+++ b/src/Theme/ThemeServiceProvider.php
@@ -12,6 +12,7 @@ use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\Media\MediaRepositoryInterface;
+use NeNeRecords\Setting\UpdateSettingUseCaseInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 
@@ -78,6 +79,21 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                     }
 
                     return new UpdateThemeUseCase($repo);
+                },
+            )
+            ->set(
+                ActivateThemeUseCaseInterface::class,
+                static function (ContainerInterface $container): ActivateThemeUseCaseInterface {
+                    $repo = $container->get(ThemeRepositoryInterface::class);
+                    if (!$repo instanceof ThemeRepositoryInterface) {
+                        throw new LogicException('Theme repository service is invalid.');
+                    }
+                    $settings = $container->get(UpdateSettingUseCaseInterface::class);
+                    if (!$settings instanceof UpdateSettingUseCaseInterface) {
+                        throw new LogicException('UpdateSetting use case service is invalid.');
+                    }
+
+                    return new ActivateThemeUseCase($repo, $settings);
                 },
             )
             ->set(
@@ -165,6 +181,21 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                     }
 
                     return new UpdateThemeHandler($useCase, $response, $thumbnails);
+                },
+            )
+            ->set(
+                ActivateThemeHandler::class,
+                static function (ContainerInterface $container): ActivateThemeHandler {
+                    $useCase = $container->get(ActivateThemeUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+                    if (!$useCase instanceof ActivateThemeUseCaseInterface) {
+                        throw new LogicException('ActivateTheme use case service is invalid.');
+                    }
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ActivateThemeHandler($useCase, $response);
                 },
             )
             ->set(
@@ -265,6 +296,7 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                     $create = $container->get(CreateThemeHandler::class);
                     $update = $container->get(UpdateThemeHandler::class);
                     $delete = $container->get(DeleteThemeHandler::class);
+                    $activate = $container->get(ActivateThemeHandler::class);
                     $listPublic = $container->get(ListPublicThemesHandler::class);
                     $preview = $container->get(PreviewThemeHandler::class);
                     $authoringGuide = $container->get(ThemeAuthoringGuideHandler::class);
@@ -285,6 +317,9 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                     if (!$delete instanceof DeleteThemeHandler) {
                         throw new LogicException('DeleteTheme handler service is invalid.');
                     }
+                    if (!$activate instanceof ActivateThemeHandler) {
+                        throw new LogicException('ActivateTheme handler service is invalid.');
+                    }
                     if (!$listPublic instanceof ListPublicThemesHandler) {
                         throw new LogicException('ListPublicThemes handler service is invalid.');
                     }
@@ -298,7 +333,7 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('ThemeEngineCss handler service is invalid.');
                     }
 
-                    return new ThemeRouteRegistrar($list, $get, $create, $update, $delete, $listPublic, $preview, $authoringGuide, $engineCss);
+                    return new ThemeRouteRegistrar($list, $get, $create, $update, $delete, $activate, $listPublic, $preview, $authoringGuide, $engineCss);
                 },
             );
     }

--- a/tests/Theme/ActivateThemeUseCaseTest.php
+++ b/tests/Theme/ActivateThemeUseCaseTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Theme;
+
+use NeNeRecords\Setting\UpdateSettingInput;
+use NeNeRecords\Setting\UpdateSettingOutput;
+use NeNeRecords\Setting\UpdateSettingUseCaseInterface;
+use NeNeRecords\Theme\ActivateThemeInput;
+use NeNeRecords\Theme\ActivateThemeUseCase;
+use NeNeRecords\Theme\ThemeNotFoundException;
+use NeNeRecords\Theme\ThemeRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+
+final class ActivateThemeUseCaseTest extends TestCase
+{
+    public function testActivatesAnExistingRuntimeTheme(): void
+    {
+        $themes = $this->createStub(ThemeRepositoryInterface::class);
+        $themes->method('existsByKey')->willReturn(true);
+
+        $settings = $this->createMock(UpdateSettingUseCaseInterface::class);
+        $settings->expects($this->once())
+            ->method('execute')
+            ->with($this->callback(
+                static fn (mixed $input): bool => $input instanceof UpdateSettingInput
+                    && $input->settingKey === 'active_theme'
+                    && $input->value === 'midnight',
+            ))
+            ->willReturn(new UpdateSettingOutput(settingKey: 'active_theme', value: 'midnight', updatedAt: ''));
+
+        $output = (new ActivateThemeUseCase($themes, $settings))->execute(new ActivateThemeInput('midnight'));
+
+        self::assertSame('midnight', $output->activeTheme);
+    }
+
+    public function testActivatesABuiltinThemeEvenWhenNotInTheRepository(): void
+    {
+        $themes = $this->createStub(ThemeRepositoryInterface::class);
+        $themes->method('existsByKey')->willReturn(false); // not a runtime theme
+
+        $settings = $this->createMock(UpdateSettingUseCaseInterface::class);
+        $settings->expects($this->once())
+            ->method('execute')
+            ->willReturn(new UpdateSettingOutput(settingKey: 'active_theme', value: 'aurora', updatedAt: ''));
+
+        // 'aurora' is a built-in id (ThemeManifestValidator::isBuiltin).
+        $output = (new ActivateThemeUseCase($themes, $settings))->execute(new ActivateThemeInput('aurora'));
+
+        self::assertSame('aurora', $output->activeTheme);
+    }
+
+    public function testRejectsAnUnknownThemeWithoutTouchingSettings(): void
+    {
+        $themes = $this->createStub(ThemeRepositoryInterface::class);
+        $themes->method('existsByKey')->willReturn(false);
+
+        $settings = $this->createMock(UpdateSettingUseCaseInterface::class);
+        $settings->expects($this->never())->method('execute');
+
+        $this->expectException(ThemeNotFoundException::class);
+        (new ActivateThemeUseCase($themes, $settings))->execute(new ActivateThemeInput('no-such-theme-xyz'));
+    }
+}

--- a/tools/generate-mcp-tools.php
+++ b/tools/generate-mcp-tools.php
@@ -880,6 +880,24 @@ $tools = [
         null,
         ['key'],
     ),
+    readTool(
+        'activateTheme',
+        'Activate Theme',
+        'Make a theme live for the organization. Verifies the key is a built-in id or an existing '
+            . 'runtime theme, then sets active_theme. Call after createTheme to publish what you made.',
+        'activateTheme',
+        'POST',
+        '/api/v1/themes/{key}/activate',
+        [
+            'key' => [
+                'type' => 'string',
+                'pattern' => '^[a-z][a-z0-9-]{1,40}$',
+                'description' => 'Theme key (built-in id or runtime theme key).',
+            ],
+        ],
+        null,
+        ['key'],
+    ),
 ];
 
 /** @return list<array<string, mixed>> */


### PR DESCRIPTION
## 目的
`Closes #631`（follow-up of #367）。調査の結論＝**テーマ量産は既存 MCP でコード変更ゼロでも可能**。唯一の穴＝「公開(activate)の発見性と安全性」を塞ぐ最小仕上げ。

## 変更
- 新 **`POST /api/v1/themes/{key}/activate`（`activateTheme`）**：テーマ存在を検証（built-in id or org の runtime theme）→ `active_theme` 設定を更新。raw `updateSettingByKey('active_theme', x)` と違い**存在検証あり**＝消えた/typo テーマ→既定へ無言フォールバックの footgun を防ぐ。
- **`ThemeAuthoringGuide` に公開レシピ＋relatedTools(`activateTheme`)** を追加 → ブリッジ越しエージェントが **in-band** で公開手順を知れる（repo docs は読めない＝ここが唯一の発見性ギャップだった）。
- MCP カタログに activateTheme（手書き定義 `tools/generate-mcp-tools.php`・**70 tools**）。`docs/theming/claudedesign-mcp-guide.md` 更新。
- `ThemeManifestValidator::isBuiltin()` 公開。

## 検証
- `composer check` 緑：PHPUnit **1073**・PHPStan lv8 **1283**・CS・OpenAPI・MCP。
- テスト `ActivateThemeUseCaseTest`（runtime/ built-in / unknown→404）。

## これで何ができる
ClaudeDesign が MCP だけで **生成→`previewTheme`(AA自己ゲート)→`createTheme`→`activateTheme`(公開)** を完結＝量産パイプラインが in-band で閉じる。

## 注
- #373（MD→バンドル量産）は runtime JSON-over-MCP 方式に置換済で**陳腐化** → 別途 re-scope/close 予定。
- 「全テナント共通ライブラリ」配布は別設計（runtime は org スコープ）— 必要なら別 issue。

Closes #631