### PR TITLE
fix(security): デフォルト資格の seed ユーザーを削除し README から除去する (#641)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,9 @@ docker compose up --build -d
 # Admin UI (dev): in another shell run `npm run dev --prefix frontend` → http://localhost:18084
 ```
 
-Default credentials (local only):
-
-- Admin: `admin@nene-records.local` / `nene1234`
-- Editor: `editor@nene-records.local` / `nene1234`
+Create the first admin via the installer (`composer app:install`) — there are no
+default credentials. (A previous default-credential seed was removed for security;
+see migration `20260711000000_delete_default_seed_users`.)
 
 > See [`docs/development/docker.md`](./docs/development/docker.md) for full setup details.
 

--- a/database/migrations/20260711000000_delete_default_seed_users.php
+++ b/database/migrations/20260711000000_delete_default_seed_users.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Security fix: remove the default-credential seed users that
+ * 20260525000000_seed_default_users created (admin@/editor@nene-records.local,
+ * password "nene1234"). Those credentials are public (repo + README) and the
+ * seed runs in EVERY environment, so they shipped to production as a
+ * known-password admin backdoor. This deletes them everywhere, and — running
+ * after the seed on a fresh DB — keeps fresh installs free of them too. Dev
+ * logins should be created via the installer, never baked into a migration.
+ */
+final class DeleteDefaultSeedUsers extends AbstractMigration
+{
+    public function up(): void
+    {
+        if (!$this->hasTable('users')) {
+            return;
+        }
+
+        // Only the unused, org-less seed accounts — never a real per-org user
+        // who might happen to reuse one of these addresses.
+        $this->execute(
+            "DELETE FROM users
+              WHERE email IN ('admin@nene-records.local', 'editor@nene-records.local')
+                AND organization_id IS NULL",
+        );
+    }
+
+    public function down(): void
+    {
+        // Intentionally irreversible: re-creating a known-password admin would
+        // reopen the security hole. Create users via the installer if needed.
+    }
+}


### PR DESCRIPTION
## セキュリティ
公開マイグレーションが `admin@/editor@nene-records.local` を **`nene1234`（公開リポ＋README 記載）** で seed → 本番でも実行され既知資格 admin が常駐（org_id=NULL・2026-06-24 投入）。

## 対応
1. **本番は即手動削除済み**（id1/id2・`org_id IS NULL` 限定・実管理者 id3–6 健在・削除後 `login=401` 確認）。
2. 恒久対策（本 PR）:
   - マイグレーション `20260711000000_delete_default_seed_users`（DELETE・**版番 > 現行 max 20260710 で順序安全**・`down()` は不可逆＝バックドア再作成防止）。再デプロイ/新規 install でも復活させない。
   - `README.md` からデフォルト資格を除去し installer 誘導。

## 検証
`composer check` 緑（PHPUnit／PHPStan 1283／CS／OpenAPI／MCP）。依存なし（grep で確認：参照は dev docs のみ・コード/テスト非依存）。

Closes #641