### PR TITLE
feat(admin): レコード一覧の permalink ディレクトリ表示＋件数選択 (PR3 of #651)

### DIFF
--- a/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
+++ b/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
@@ -22,8 +22,12 @@ import { useTagList } from '@/entities/tag'
 import { defaultTextFieldListParamsForEntityType, useTextFieldList } from '@/entities/text-field'
 import { useTranslation } from '@/shared/i18n'
 import { getRecordDisplayLabel } from '@/shared/lib/get-record-display-label'
+import { type DirectoryRecord } from '../lib/build-permalink-tree'
 
-const PAGE_LIMIT = 20
+export const PAGE_SIZE_OPTIONS = [20, 50, 100] as const
+const DEFAULT_PAGE_SIZE = 20
+/** Directory mode fetches this many records (the API's max page) to build the tree. */
+const DIRECTORY_FETCH_LIMIT = 100
 
 export function useManageEntitiesPage(entityTypeId: number) {
   const { t } = useTranslation()
@@ -36,21 +40,26 @@ export function useManageEntitiesPage(entityTypeId: number) {
   const [sortKey, setSortKey] = useState<EntitySortKey>('id')
   const [sortOrder, setSortOrder] = useState<EntitySortOrder>('desc')
   const [page, setPage] = useState(0)
+  const [pageSize, setPageSizeState] = useState<number>(DEFAULT_PAGE_SIZE)
+  const [viewMode, setViewMode] = useState<'list' | 'directory'>('list')
   const listParams = useMemo(
-    () =>
-      defaultEntityListParams(
+    () => ({
+      ...defaultEntityListParams(
         entityTypeId,
         selectedTagSlugs,
         selectedRelationFilters,
-        page * PAGE_LIMIT,
+        page * pageSize,
         searchQuery,
         selectedStatus,
         sortKey,
         sortOrder,
       ),
+      limit: pageSize,
+    }),
     [
       entityTypeId,
       page,
+      pageSize,
       selectedRelationFilters,
       selectedTagSlugs,
       searchQuery,
@@ -60,6 +69,11 @@ export function useManageEntitiesPage(entityTypeId: number) {
     ],
   )
   const listQuery = useEntityList(listParams)
+  // Directory mode fetches a larger, unpaginated slice to build the path tree.
+  const directoryQuery = useEntityList(
+    { entityTypeId, limit: DIRECTORY_FETCH_LIMIT, offset: 0 },
+    { enabled: viewMode === 'directory' },
+  )
   const tagListQuery = useTagList({ limit: 100, offset: 0 })
   const fieldDefQuery = useFieldDefList(defaultFieldDefListParams(entityTypeId))
   const textFieldQuery = useTextFieldList(defaultTextFieldListParamsForEntityType(entityTypeId))
@@ -101,6 +115,28 @@ export function useManageEntitiesPage(entityTypeId: number) {
     }
     return result
   }, [items, textFieldQuery.data?.items])
+
+  // Directory-mode records: only those carrying a custom permalink, labelled from
+  // the type-wide title fields (falling back to meta_title or the last segment).
+  const directoryRecords = useMemo((): DirectoryRecord[] => {
+    const textFields = textFieldQuery.data?.items ?? []
+    return (directoryQuery.data?.items ?? [])
+      .filter((entity) => entity.permalink !== null && entity.permalink !== '')
+      .map((entity) => {
+        const permalink = entity.permalink ?? ''
+        const lastSegment = permalink.split('/').filter(Boolean).pop() ?? String(entity.id)
+        const fallback =
+          entity.metaTitle !== null && entity.metaTitle.trim() !== ''
+            ? entity.metaTitle
+            : lastSegment
+        return {
+          id: Number(entity.id),
+          permalink,
+          label: getRecordDisplayLabel(Number(entity.id), textFields, fallback),
+          status: entity.status,
+        }
+      })
+  }, [directoryQuery.data?.items, textFieldQuery.data?.items])
 
   const toggleTagSlug = useCallback((slug: string) => {
     setSelectedTagSlugs((current) =>
@@ -160,6 +196,11 @@ export function useManageEntitiesPage(entityTypeId: number) {
     setPage(0)
   }, [])
 
+  const setPageSize = useCallback((size: number) => {
+    setPageSizeState(size)
+    setPage(0)
+  }, [])
+
   const createEntity = useCallback(async (): Promise<Entity> => {
     return createMutation.mutateAsync({ entityTypeId })
   }, [createMutation, entityTypeId])
@@ -188,7 +229,8 @@ export function useManageEntitiesPage(entityTypeId: number) {
     listQuery.error?.title ?? textFieldQuery.error?.title ?? fieldDefQuery.error?.title ?? null
 
   const total = listQuery.data?.total ?? 0
-  const totalPages = Math.max(1, Math.ceil(total / PAGE_LIMIT))
+  const totalPages = Math.max(1, Math.ceil(total / pageSize))
+  const directoryTruncated = (directoryQuery.data?.total ?? 0) > DIRECTORY_FETCH_LIMIT
 
   return {
     items,
@@ -197,6 +239,16 @@ export function useManageEntitiesPage(entityTypeId: number) {
     total,
     page,
     totalPages,
+    pageSize,
+    setPageSize,
+    pageSizeOptions: PAGE_SIZE_OPTIONS,
+    viewMode,
+    setViewMode,
+    directoryRecords,
+    directoryTruncated,
+    directoryIsLoading: directoryQuery.isLoading,
+    directoryIsError: directoryQuery.isError,
+    directoryErrorTitle: directoryQuery.error?.title ?? null,
     sortKey,
     sortOrder,
     setSort,
@@ -235,6 +287,7 @@ export function useManageEntitiesPage(entityTypeId: number) {
     refetch: async () => {
       await Promise.all([
         listQuery.refetch(),
+        directoryQuery.refetch(),
         textFieldQuery.refetch(),
         tagListQuery.refetch(),
         fieldDefQuery.refetch(),

--- a/frontend/src/features/manage-entities/lib/build-permalink-tree.test.ts
+++ b/frontend/src/features/manage-entities/lib/build-permalink-tree.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { buildPermalinkTree, type DirectoryRecord } from './build-permalink-tree'
+
+function record(id: number, permalink: string): DirectoryRecord {
+  return { id, permalink, label: `Record ${String(id)}`, status: 'published' }
+}
+
+describe('buildPermalinkTree', () => {
+  it('returns an empty tree for no records', () => {
+    expect(buildPermalinkTree([])).toEqual([])
+  })
+
+  it('nests records into folders by path segment', () => {
+    const tree = buildPermalinkTree([record(2, '/company/about/team'), record(1, '/company/about')])
+
+    expect(tree).toHaveLength(1)
+    const company = tree[0]
+    expect(company?.segment).toBe('company')
+    expect(company?.path).toBe('/company')
+    expect(company?.record).toBeNull() // no page exists at /company → pure folder
+
+    const about = company?.children[0]
+    expect(about?.segment).toBe('about')
+    expect(about?.record?.id).toBe(1) // /company/about is both a page and a folder
+    expect(about?.children[0]?.record?.id).toBe(2)
+  })
+
+  it('sorts siblings alphabetically by segment', () => {
+    const tree = buildPermalinkTree([
+      record(1, '/docs/zebra'),
+      record(2, '/docs/alpha'),
+      record(3, '/docs/mango'),
+    ])
+
+    const docs = tree[0]
+    expect(docs?.children.map((node) => node.segment)).toEqual(['alpha', 'mango', 'zebra'])
+  })
+
+  it('keeps independent top-level sections separate', () => {
+    const tree = buildPermalinkTree([record(1, '/company/about'), record(2, '/legal/privacy')])
+
+    expect(tree.map((node) => node.segment)).toEqual(['company', 'legal'])
+  })
+})

--- a/frontend/src/features/manage-entities/lib/build-permalink-tree.ts
+++ b/frontend/src/features/manage-entities/lib/build-permalink-tree.ts
@@ -1,0 +1,60 @@
+import type { EntityStatus } from '@/entities/entity'
+
+export interface DirectoryRecord {
+  id: number
+  permalink: string
+  label: string
+  status: EntityStatus
+}
+
+export interface DirectoryNode {
+  /** The single path segment this node represents (e.g. `about`). */
+  segment: string
+  /** The cumulative path to this node (e.g. `/company/about`). */
+  path: string
+  /** The record whose permalink is exactly this path, or null for a pure folder. */
+  record: DirectoryRecord | null
+  children: DirectoryNode[]
+}
+
+function sortNodes(nodes: DirectoryNode[]): DirectoryNode[] {
+  nodes.sort((a, b) => a.segment.localeCompare(b.segment))
+  for (const node of nodes) {
+    sortNodes(node.children)
+  }
+  return nodes
+}
+
+/**
+ * Builds a directory tree from records' permalink paths (#651 PR3). A record at
+ * `/a/b/c` creates folders `a` → `b` and a leaf `c` carrying the record. A node
+ * can be both a record and a folder — a section page that also has children.
+ * Records without a path segment are skipped.
+ */
+export function buildPermalinkTree(records: DirectoryRecord[]): DirectoryNode[] {
+  const roots: DirectoryNode[] = []
+
+  for (const record of records) {
+    const segments = record.permalink.split('/').filter((segment) => segment !== '')
+    if (segments.length === 0) {
+      continue
+    }
+
+    let siblings = roots
+    let cumulative = ''
+    segments.forEach((segment, index) => {
+      cumulative += `/${segment}`
+      let node = siblings.find((candidate) => candidate.segment === segment)
+      if (node === undefined) {
+        node = { segment, path: cumulative, record: null, children: [] }
+        siblings.push(node)
+      }
+      if (index === segments.length - 1) {
+        node.record = record
+      }
+      siblings = node.children
+    })
+  }
+
+  return sortNodes(roots)
+}

--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.test.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.test.tsx
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { renderWithI18n } from '@/shared/i18n/test-helpers'
+import type { DirectoryRecord } from '../lib/build-permalink-tree'
+import { EntityDirectoryPanel } from './EntityDirectoryPanel'
+
+afterEach(cleanup)
+
+const RECORDS: DirectoryRecord[] = [
+  { id: 1, permalink: '/company/about', label: 'About Us', status: 'published' },
+  { id: 2, permalink: '/company/about/team', label: 'Our Team', status: 'draft' },
+]
+
+function renderPanel(props?: Partial<Parameters<typeof EntityDirectoryPanel>[0]>) {
+  return renderWithI18n(
+    <MemoryRouter>
+      <EntityDirectoryPanel
+        entityTypeSlug="pages"
+        records={RECORDS}
+        truncated={false}
+        isLoading={false}
+        isError={false}
+        errorTitle={null}
+        onRetry={() => {}}
+        {...props}
+      />
+    </MemoryRouter>,
+  )
+}
+
+describe('EntityDirectoryPanel', () => {
+  it('shows an empty state with no record links when there are no permalink records', () => {
+    renderPanel({ records: [] })
+    expect(screen.getByText('No pages with custom paths yet')).toBeInTheDocument()
+    expect(screen.queryAllByRole('link')).toHaveLength(0)
+  })
+
+  it('renders pure folders and record links derived from the permalink paths', () => {
+    renderPanel()
+
+    // `/company` has no page of its own → a pure folder.
+    expect(screen.getByText('company/')).toBeInTheDocument()
+    // Records link to their admin edit page.
+    expect(screen.getByRole('link', { name: 'About Us' })).toHaveAttribute('href', '/admin/pages/1')
+    expect(screen.getByRole('link', { name: 'Our Team' })).toHaveAttribute('href', '/admin/pages/2')
+    // The cumulative path is shown for each node.
+    expect(screen.getByText('/company/about/team')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
@@ -1,0 +1,158 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from '@/shared/i18n'
+import { EmptyState, ErrorState, LoadingState, StatusBadge } from '@/shared/ui'
+import {
+  buildPermalinkTree,
+  type DirectoryNode,
+  type DirectoryRecord,
+} from '../lib/build-permalink-tree'
+
+export interface EntityDirectoryPanelProps {
+  entityTypeSlug: string
+  records: DirectoryRecord[]
+  /** True when the source query hit its row cap and the tree may be incomplete. */
+  truncated: boolean
+  isLoading: boolean
+  isError: boolean
+  errorTitle: string | null
+  onRetry: () => void
+}
+
+/**
+ * Renders records as a collapsible directory tree derived from their permalink
+ * paths (#651 PR3). Only records carrying a custom permalink appear; flat records
+ * stay in the list view. parent_id is never used — the tree is path-derived.
+ */
+export function EntityDirectoryPanel({
+  entityTypeSlug,
+  records,
+  truncated,
+  isLoading,
+  isError,
+  errorTitle,
+  onRetry,
+}: EntityDirectoryPanelProps) {
+  const { t } = useTranslation()
+  const tree = useMemo(() => buildPermalinkTree(records), [records])
+
+  if (isLoading) {
+    return <LoadingState>{t('admin.entityRecords.list.loading')}</LoadingState>
+  }
+
+  if (isError) {
+    return (
+      <ErrorState
+        title={t('admin.entityRecords.list.error')}
+        message={errorTitle ?? t('common.error.unknown')}
+        onRetry={onRetry}
+        retryLabel={t('common.actions.retry')}
+      />
+    )
+  }
+
+  if (records.length === 0) {
+    return (
+      <EmptyState
+        title={t('admin.entityRecords.directory.empty.title')}
+        description={t('admin.entityRecords.directory.empty.description')}
+      />
+    )
+  }
+
+  return (
+    <div>
+      {truncated ? (
+        <p className="mb-stack-sm font-sans text-caption text-text-muted">
+          {t('admin.entityRecords.directory.truncated')}
+        </p>
+      ) : null}
+      <ul
+        className="flex flex-col gap-stack-xs"
+        aria-label={t('admin.entityRecords.view.directory')}
+      >
+        {tree.map((node) => (
+          <DirectoryNodeRow key={node.path} node={node} entityTypeSlug={entityTypeSlug} depth={0} />
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function DirectoryNodeRow({
+  node,
+  entityTypeSlug,
+  depth,
+}: {
+  node: DirectoryNode
+  entityTypeSlug: string
+  depth: number
+}) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(true)
+  const hasChildren = node.children.length > 0
+
+  return (
+    <li>
+      <div
+        className="flex items-center gap-inline-sm rounded-md py-stack-xs pr-inline-sm hover:bg-surface-raised"
+        style={{ paddingLeft: depth * 20 + 8 }}
+      >
+        {hasChildren ? (
+          <button
+            type="button"
+            onClick={() => {
+              setOpen((value) => !value)
+            }}
+            aria-expanded={open}
+            aria-label={
+              open
+                ? t('admin.entityRecords.directory.collapse')
+                : t('admin.entityRecords.directory.expand')
+            }
+            className="shrink-0 font-mono text-caption text-text-muted"
+          >
+            {open ? '▾' : '▸'}
+          </button>
+        ) : (
+          <span aria-hidden="true" className="shrink-0 font-mono text-caption text-text-muted">
+            ·
+          </span>
+        )}
+
+        {node.record !== null ? (
+          <>
+            <Link
+              to={`/admin/${entityTypeSlug}/${String(node.record.id)}`}
+              className="truncate font-sans text-body text-text-primary hover:text-accent"
+            >
+              {node.record.label}
+            </Link>
+            <StatusBadge status={node.record.status}>
+              {t(`admin.entityStatus.status.${node.record.status}`)}
+            </StatusBadge>
+          </>
+        ) : (
+          <span className="font-sans text-body font-medium text-text-muted">{node.segment}/</span>
+        )}
+
+        <code className="ml-auto shrink-0 truncate font-mono text-caption text-text-muted">
+          {node.path}
+        </code>
+      </div>
+
+      {hasChildren && open ? (
+        <ul className="flex flex-col gap-stack-xs">
+          {node.children.map((child) => (
+            <DirectoryNodeRow
+              key={child.path}
+              node={child}
+              entityTypeSlug={entityTypeSlug}
+              depth={depth + 1}
+            />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  )
+}

--- a/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
+++ b/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
@@ -11,6 +11,8 @@ import type { Tag } from '@/entities/tag'
 import { useTranslation } from '@/shared/i18n'
 import { Button, ConfirmDialog, Select, Stack, Text } from '@/shared/ui'
 import { buildExportUrl } from '../lib/build-export-url'
+import type { DirectoryRecord } from '../lib/build-permalink-tree'
+import { EntityDirectoryPanel } from './EntityDirectoryPanel'
 import { EntityListPanel } from './EntityListPanel'
 import { EntityRelationFilterPanel } from './EntityRelationFilterPanel'
 import { EntityTagFilterPanel } from './EntityTagFilterPanel'
@@ -91,6 +93,16 @@ export interface ManageEntitiesViewProps {
   onRequestDelete: (entity: Entity) => void
   onCancelDelete: () => void
   onConfirmDelete: () => Promise<void>
+  viewMode: 'list' | 'directory'
+  onViewModeChange: (mode: 'list' | 'directory') => void
+  pageSize: number
+  pageSizeOptions: readonly number[]
+  onPageSizeChange: (size: number) => void
+  directoryItems: DirectoryRecord[]
+  directoryTruncated: boolean
+  directoryIsLoading: boolean
+  directoryIsError: boolean
+  directoryErrorTitle: string | null
 }
 
 export function ManageEntitiesView({
@@ -129,6 +141,16 @@ export function ManageEntitiesView({
   onRequestDelete,
   onCancelDelete,
   onConfirmDelete,
+  viewMode,
+  onViewModeChange,
+  pageSize,
+  pageSizeOptions,
+  onPageSizeChange,
+  directoryItems,
+  directoryTruncated,
+  directoryIsLoading,
+  directoryIsError,
+  directoryErrorTitle,
 }: ManageEntitiesViewProps) {
   const { t } = useTranslation()
 
@@ -146,14 +168,42 @@ export function ManageEntitiesView({
 
   // 検索・フィルターはコンテンツが存在するか、すでにフィルターが有効な場合のみ表示
   // （Progressive Disclosure: 空ページで絞り込みUI を見せない）
-  const showFilters = total > 0 || isFilterActive
+  const showFilters = (total > 0 || isFilterActive) && viewMode === 'list'
 
   const currentSortValue = `${sortKey}-${sortOrder}`
 
   return (
     <>
       <Stack gap="lg">
-        {/* ── 検索 + ソート + フィルター（コンテンツがあるときのみ） ── */}
+        {/* ── 表示モード切替（リスト / パス由来ディレクトリ） ── */}
+        <div
+          className="flex items-center gap-1"
+          role="group"
+          aria-label={t('admin.entityRecords.view.label')}
+        >
+          <Button
+            variant={viewMode === 'list' ? 'primary' : 'secondary'}
+            size="sm"
+            aria-pressed={viewMode === 'list'}
+            onClick={() => {
+              onViewModeChange('list')
+            }}
+          >
+            {t('admin.entityRecords.view.list')}
+          </Button>
+          <Button
+            variant={viewMode === 'directory' ? 'primary' : 'secondary'}
+            size="sm"
+            aria-pressed={viewMode === 'directory'}
+            onClick={() => {
+              onViewModeChange('directory')
+            }}
+          >
+            {t('admin.entityRecords.view.directory')}
+          </Button>
+        </div>
+
+        {/* ── 検索 + ソート + フィルター（リスト表示・コンテンツがあるときのみ） ── */}
         {showFilters ? (
           <>
             {/* Search */}
@@ -206,6 +256,30 @@ export function ManageEntitiesView({
                   {SORT_OPTIONS.map((opt) => (
                     <option key={opt.value} value={opt.value}>
                       {t(opt.labelKey)}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+
+              {/* 1ページあたりの件数（多数レコードのスケール対策） */}
+              <div className="flex items-center gap-1.5">
+                <label
+                  htmlFor="entity-page-size-select"
+                  className="shrink-0 font-sans text-caption text-text-muted"
+                >
+                  {t('admin.entityRecords.pageSize.label')}
+                </label>
+                <Select
+                  id="entity-page-size-select"
+                  size="sm"
+                  value={String(pageSize)}
+                  onChange={(e) => {
+                    onPageSizeChange(Number(e.target.value))
+                  }}
+                >
+                  {pageSizeOptions.map((size) => (
+                    <option key={size} value={size}>
+                      {size}
                     </option>
                   ))}
                 </Select>
@@ -336,21 +410,33 @@ export function ManageEntitiesView({
             ) : null}
           </div>
 
-          <EntityListPanel
-            entityTypeSlug={entityTypeSlug}
-            items={items}
-            recordLabels={recordLabels}
-            recordBodyMap={recordBodyMap}
-            isLoading={isLoading}
-            isError={isError}
-            errorTitle={errorTitle}
-            isDeleting={isDeleting}
-            isFilterActive={isFilterActive}
-            onRetry={onRetry}
-            onDelete={onRequestDelete}
-          />
+          {viewMode === 'directory' ? (
+            <EntityDirectoryPanel
+              entityTypeSlug={entityTypeSlug}
+              records={directoryItems}
+              truncated={directoryTruncated}
+              isLoading={directoryIsLoading}
+              isError={directoryIsError}
+              errorTitle={directoryErrorTitle}
+              onRetry={onRetry}
+            />
+          ) : (
+            <EntityListPanel
+              entityTypeSlug={entityTypeSlug}
+              items={items}
+              recordLabels={recordLabels}
+              recordBodyMap={recordBodyMap}
+              isLoading={isLoading}
+              isError={isError}
+              errorTitle={errorTitle}
+              isDeleting={isDeleting}
+              isFilterActive={isFilterActive}
+              onRetry={onRetry}
+              onDelete={onRequestDelete}
+            />
+          )}
 
-          {totalPages > 1 || page > 0 ? (
+          {viewMode === 'list' && (totalPages > 1 || page > 0) ? (
             <div className="flex items-center justify-between gap-inline-md pt-stack-xs">
               <Button
                 variant="secondary"

--- a/frontend/src/pages/entity-records/EntityRecordsPage.tsx
+++ b/frontend/src/pages/entity-records/EntityRecordsPage.tsx
@@ -35,6 +35,16 @@ function EntityRecordsContent({ entityType }: { entityType: EntityType }) {
     total,
     page,
     totalPages,
+    pageSize,
+    setPageSize,
+    pageSizeOptions,
+    viewMode,
+    setViewMode,
+    directoryRecords,
+    directoryTruncated,
+    directoryIsLoading,
+    directoryIsError,
+    directoryErrorTitle,
     sortKey,
     sortOrder,
     setSort,
@@ -142,6 +152,16 @@ function EntityRecordsContent({ entityType }: { entityType: EntityType }) {
         onRequestDelete={requestDelete}
         onCancelDelete={cancelDelete}
         onConfirmDelete={confirmDelete}
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
+        pageSize={pageSize}
+        pageSizeOptions={pageSizeOptions}
+        onPageSizeChange={setPageSize}
+        directoryItems={directoryRecords}
+        directoryTruncated={directoryTruncated}
+        directoryIsLoading={directoryIsLoading}
+        directoryIsError={directoryIsError}
+        directoryErrorTitle={directoryErrorTitle}
       />
     </Stack>
   )

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -607,6 +607,17 @@ export const de: Partial<MessageCatalog> = {
   'admin.entityRecords.pagination.prev': '← Zurück',
   'admin.entityRecords.pagination.next': 'Weiter →',
   'admin.entityRecords.pagination.page': 'Seite {{page}} / {{total}}',
+  'admin.entityRecords.view.label': 'Ansicht',
+  'admin.entityRecords.view.list': 'Liste',
+  'admin.entityRecords.view.directory': 'Verzeichnis',
+  'admin.entityRecords.pageSize.label': 'Pro Seite',
+  'admin.entityRecords.directory.empty.title': 'Noch keine Seiten mit eigenem Pfad',
+  'admin.entityRecords.directory.empty.description':
+    'Datensätze mit einem eigenen Permalink-Pfad erscheinen hier als Verzeichnisbaum.',
+  'admin.entityRecords.directory.truncated':
+    'Es werden die ersten 100 Datensätze angezeigt. Nutze die Listenansicht zum Durchsuchen aller.',
+  'admin.entityRecords.directory.expand': 'Aufklappen',
+  'admin.entityRecords.directory.collapse': 'Zuklappen',
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Felder',
   'admin.fieldDefs.schemaFor': 'Felder für {{slug}}',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -610,6 +610,17 @@ export const en = {
   'admin.entityRecords.pagination.prev': '← Prev',
   'admin.entityRecords.pagination.next': 'Next →',
   'admin.entityRecords.pagination.page': 'Page {{page}} / {{total}}',
+  'admin.entityRecords.view.label': 'View',
+  'admin.entityRecords.view.list': 'List',
+  'admin.entityRecords.view.directory': 'Directory',
+  'admin.entityRecords.pageSize.label': 'Per page',
+  'admin.entityRecords.directory.empty.title': 'No pages with custom paths yet',
+  'admin.entityRecords.directory.empty.description':
+    'Records with a custom permalink path appear here as a directory tree.',
+  'admin.entityRecords.directory.truncated':
+    'Showing the first 100 records. Use the list view to search all.',
+  'admin.entityRecords.directory.expand': 'Expand',
+  'admin.entityRecords.directory.collapse': 'Collapse',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Fields',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -617,6 +617,18 @@ export const fr: Partial<MessageCatalog> = {
   'admin.entityRecords.pagination.prev': '← Précédent',
   'admin.entityRecords.pagination.next': 'Suivant →',
   'admin.entityRecords.pagination.page': 'Page {{page}} / {{total}}',
+  'admin.entityRecords.view.label': 'Affichage',
+  'admin.entityRecords.view.list': 'Liste',
+  'admin.entityRecords.view.directory': 'Répertoire',
+  'admin.entityRecords.pageSize.label': 'Par page',
+  'admin.entityRecords.directory.empty.title':
+    'Aucune page avec chemin personnalisé pour le moment',
+  'admin.entityRecords.directory.empty.description':
+    'Les fiches ayant un chemin de permalien personnalisé apparaissent ici sous forme d’arborescence.',
+  'admin.entityRecords.directory.truncated':
+    'Affichage des 100 premières fiches. Utilisez la vue liste pour tout rechercher.',
+  'admin.entityRecords.directory.expand': 'Déplier',
+  'admin.entityRecords.directory.collapse': 'Replier',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Champs',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -606,6 +606,17 @@ export const ja: Partial<MessageCatalog> = {
   'admin.entityRecords.pagination.prev': '← 前へ',
   'admin.entityRecords.pagination.next': '次へ →',
   'admin.entityRecords.pagination.page': '{{page}} / {{total}} ページ',
+  'admin.entityRecords.view.label': '表示',
+  'admin.entityRecords.view.list': 'リスト',
+  'admin.entityRecords.view.directory': 'ディレクトリ',
+  'admin.entityRecords.pageSize.label': '表示件数',
+  'admin.entityRecords.directory.empty.title': 'カスタムパスのページはまだありません',
+  'admin.entityRecords.directory.empty.description':
+    'カスタムパーマリンクを持つレコードがディレクトリツリーで表示されます。',
+  'admin.entityRecords.directory.truncated':
+    '先頭100件を表示しています。全件はリスト表示の検索をご利用ください。',
+  'admin.entityRecords.directory.expand': '展開',
+  'admin.entityRecords.directory.collapse': '折りたたむ',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'フィールド',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -611,6 +611,17 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.entityRecords.pagination.prev': '← Anterior',
   'admin.entityRecords.pagination.next': 'Próximo →',
   'admin.entityRecords.pagination.page': 'Página {{page}} / {{total}}',
+  'admin.entityRecords.view.label': 'Exibição',
+  'admin.entityRecords.view.list': 'Lista',
+  'admin.entityRecords.view.directory': 'Diretório',
+  'admin.entityRecords.pageSize.label': 'Por página',
+  'admin.entityRecords.directory.empty.title': 'Ainda não há páginas com caminho personalizado',
+  'admin.entityRecords.directory.empty.description':
+    'Registros com um caminho de permalink personalizado aparecem aqui como uma árvore de diretórios.',
+  'admin.entityRecords.directory.truncated':
+    'Mostrando os primeiros 100 registros. Use a visualização em lista para pesquisar todos.',
+  'admin.entityRecords.directory.expand': 'Expandir',
+  'admin.entityRecords.directory.collapse': 'Recolher',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Campos',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -581,6 +581,16 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.entityRecords.pagination.prev': '← 上一页',
   'admin.entityRecords.pagination.next': '下一页 →',
   'admin.entityRecords.pagination.page': '第 {{page}} / {{total}} 页',
+  'admin.entityRecords.view.label': '视图',
+  'admin.entityRecords.view.list': '列表',
+  'admin.entityRecords.view.directory': '目录',
+  'admin.entityRecords.pageSize.label': '每页',
+  'admin.entityRecords.directory.empty.title': '尚无自定义路径的页面',
+  'admin.entityRecords.directory.empty.description':
+    '具有自定义永久链接路径的记录将在此处以目录树形式显示。',
+  'admin.entityRecords.directory.truncated': '仅显示前 100 条记录。使用列表视图搜索全部。',
+  'admin.entityRecords.directory.expand': '展开',
+  'admin.entityRecords.directory.collapse': '折叠',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': '字段',

--- a/src/Entity/ListEntitiesHandler.php
+++ b/src/Entity/ListEntitiesHandler.php
@@ -81,6 +81,7 @@ final readonly class ListEntitiesHandler
                             'id' => $item->id,
                             'entity_type_id' => $item->entityTypeId,
                             'slug' => $item->slug,
+                            'permalink' => $item->permalink,
                             'status' => $item->status,
                             'published_at' => $item->publishedAtIso,
                             'scheduled_at' => $item->scheduledAtIso,

--- a/src/Entity/ListEntitiesUseCase.php
+++ b/src/Entity/ListEntitiesUseCase.php
@@ -30,6 +30,7 @@ final readonly class ListEntitiesUseCase implements ListEntitiesUseCaseInterface
                 id: $entityId,
                 entityTypeId: $entity->entityTypeId,
                 slug: $entity->slug,
+                permalink: $entity->permalink,
                 status: $entity->status->value,
                 publishedAtIso: $entity->publishedAt?->format(DateTimeInterface::ATOM),
                 isDeleted: $entity->isDeleted,

--- a/src/Entity/ListEntityItem.php
+++ b/src/Entity/ListEntityItem.php
@@ -10,6 +10,7 @@ final readonly class ListEntityItem
         public int $id,
         public int $entityTypeId,
         public ?string $slug,
+        public ?string $permalink,
         public string $status,
         public ?string $publishedAtIso,
         public bool $isDeleted,

--- a/tests/Entity/ExcerptResolverTest.php
+++ b/tests/Entity/ExcerptResolverTest.php
@@ -64,6 +64,7 @@ final class ExcerptResolverTest extends TestCase
             id: $id,
             entityTypeId: 1,
             slug: 's' . $id,
+            permalink: null,
             status: 'published',
             publishedAtIso: null,
             isDeleted: false,


### PR DESCRIPTION
## 目的
**#651（移行フィデリティ）の PR3。** 管理レコード一覧に「整理・発見性」（ユーザー指摘の②＝WP ツリーの管理側の役割）を、`parent_id` を使わず permalink パスから導出して加える。

## 変更
- **表示モード切替（リスト / ディレクトリ）**。ディレクトリは permalink パスを**折りたたみツリー**で表示（接頭辞グルーピング）。カスタム permalink を持つレコードのみ対象。各レコードは管理編集へリンク。
- **多数レコードのスケール対策**：1ページ件数セレクタ（20 / 50 / 100）。aozora 1114 件の「56ページめくり」を緩和。
- **backend**: 一覧レスポンスに `permalink` を追加（`EntityResponse` は元から必須・ハンドラが未送出だったのを是正）。ディレクトリは別クエリ（上限100件）でツリーを構築し、超過時は注記。
- `buildPermalinkTree`（純関数・テスト済）＋ `EntityDirectoryPanel`（再帰ツリー・`aria-expanded` ディスクロージャ）。i18n 6言語。

## 非対象（フォローアップ）
仮想化（react-window 等）は見送り。件数セレクタ＋ツリー折りたたみで当面のスケールに対応。

## 検証
- `composer check` 緑：PHPUnit **1103 / 3050 assertions**、PHPStan lv8 エラー0、CS、OpenAPI、MCP。
- `npm run check` 緑：type-check / lint / prettier / **vitest 445（92 files）** / themes / knip / storybook。

Part of #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)