### PR TITLE
fix(public): 公開 custom-permalink ページを実SPAで解決・描画 (#656 P0)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2282,6 +2282,38 @@ paths:
                 $ref: '#/components/schemas/PublicRecordHierarchy'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/public/records/resolve:
+    get:
+      tags:
+        - PublicConsumer
+      summary: Resolve a custom-permalink path to its record
+      description: >
+        Resolves an arbitrary custom-permalink path (e.g. `/company/about`) to
+        `{entityTypeSlug, entityId}` so the type-based public SPA router can render
+        it on direct load and client-side navigation (#656). Always 200; `found:false`
+        when no published record owns the path.
+      operationId: resolvePublicPermalink
+      parameters:
+        - name: path
+          in: query
+          required: true
+          description: The custom permalink path, e.g. `/company/about`.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Resolution result.
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+              example: public, max-age=60, stale-while-revalidate=300
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicPermalinkResolution'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /api/v1/notification-channels:
     get:
       tags:
@@ -6427,6 +6459,22 @@ components:
         chapterTotal:
           type: integer
           minimum: 1
+      additionalProperties: false
+    PublicPermalinkResolution:
+      type: object
+      required:
+        - found
+      properties:
+        found:
+          type: boolean
+        entityTypeSlug:
+          type: string
+          description: 'Present when found: the resolved record''s entity type slug.'
+        entityId:
+          type: integer
+          format: int64
+          minimum: 1
+          description: 'Present when found: the resolved record id.'
       additionalProperties: false
     PublicRecordHierarchy:
       type: object

--- a/frontend/src/features/public-view-entity-record/hooks/use-public-permalink-resolution.ts
+++ b/frontend/src/features/public-view-entity-record/hooks/use-public-permalink-resolution.ts
@@ -1,0 +1,21 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import {
+  type PublicPermalinkResolutionDto,
+  publicPermalinkResolveKeys,
+  resolvePublicPermalink,
+} from '@/shared/lib/public-permalink-resolve'
+
+/**
+ * Resolve an arbitrary custom-permalink path → record (#656), so the type-based
+ * public SPA router can render custom-permalink pages on direct load and
+ * client-side navigation. Disabled for empty / root paths.
+ */
+export function usePublicPermalinkResolution(
+  path: string,
+): UseQueryResult<PublicPermalinkResolutionDto> {
+  return useQuery({
+    queryKey: publicPermalinkResolveKeys.byPath(path),
+    queryFn: ({ signal }) => resolvePublicPermalink(path, signal),
+    enabled: path !== '' && path !== '/',
+  })
+}

--- a/frontend/src/features/public-view-entity-record/index.ts
+++ b/frontend/src/features/public-view-entity-record/index.ts
@@ -6,6 +6,7 @@ export type {
   PublicRelationFieldRow,
   PublicScalarFieldDisplay,
 } from './hooks/use-public-view-entity-record-page'
+export { usePublicPermalinkResolution } from './hooks/use-public-permalink-resolution'
 export { usePublicRecordHierarchy } from './hooks/use-public-record-hierarchy'
 export { ChapterNav } from './ui/ChapterNav'
 export { PublicRecordDetailView } from './ui/PublicRecordDetailView'

--- a/frontend/src/pages/consumer/PublicBrowsePage.test.tsx
+++ b/frontend/src/pages/consumer/PublicBrowsePage.test.tsx
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { cleanup, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { PublicBrowsePage } from '@/pages/consumer/PublicBrowsePage'
 import { PublicIndexPage } from '@/pages/consumer/PublicIndexPage'
@@ -83,11 +84,10 @@ describe('PublicBrowsePage', () => {
     expect(screen.getByRole('link', { name: 'Second post' })).toHaveAttribute('href', '/article/2')
   })
 
-  it('shows empty state for unknown entity type slug', async () => {
+  it('treats an unknown slug as a custom permalink, showing not found when unresolved (#656)', async () => {
     renderBrowsePage('/missing-type')
 
-    expect(await screen.findByText('Entity type not found')).toBeInTheDocument()
-    expect(screen.getByText('No public content for “missing-type”.')).toBeInTheDocument()
+    expect(await screen.findByText('Record not found')).toBeInTheDocument()
   })
 
   it('navigates to record detail from the list', async () => {
@@ -118,6 +118,32 @@ describe('PublicBrowsePage', () => {
     await waitFor(() => {
       expect(screen.getByRole('link', { name: 'Back to Article' })).toBeInTheDocument()
     })
+  })
+
+  it('renders a custom-permalink page by resolving its path (#656)', async () => {
+    mswServer.use(
+      http.get('/api/v1/public/records/resolve', () =>
+        HttpResponse.json({ found: true, entityTypeSlug: 'article', entityId: 1 }),
+      ),
+    )
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    seedEntities([
+      {
+        id: 1,
+        entity_type_id: 1,
+        permalink: '/about',
+        status: 'published',
+        is_deleted: false,
+        deleted_at: null,
+      },
+    ])
+    seedTextFields([{ id: 1, entity_id: 1, field_key: 'title', value: 'About Us' }])
+
+    renderBrowsePage('/about')
+
+    // The custom-permalink record resolves → renders the detail in place (no
+    // redirect, since its canonical IS the permalink — exercises the #656 fix).
+    expect(await screen.findByRole('link', { name: 'Back to Article' })).toBeInTheDocument()
   })
 
   it('paginates records with offset query param', async () => {

--- a/frontend/src/pages/consumer/PublicBrowsePage.tsx
+++ b/frontend/src/pages/consumer/PublicBrowsePage.tsx
@@ -7,6 +7,7 @@ import {
   PublicRecordListView,
   usePublicBrowseEntityRecordsPage,
 } from '@/features/public-browse-entity-records'
+import { PublicRecordByPermalink } from './PublicRecordDetailPage'
 import { PublicSiteShell } from './PublicSiteShell'
 import { usePublicSite } from './public-site-context'
 
@@ -39,6 +40,12 @@ export function PublicBrowsePage() {
       params.set('offset', String(nextOffset))
     }
     setSearchParams(params)
+  }
+
+  // A single-segment URL whose slug isn't a known type may be a top-level custom
+  // permalink (e.g. `/about`) → resolve it as one instead of "unknown type" (#656).
+  if (isUnknownType) {
+    return <PublicRecordByPermalink path={`/${entityTypeSlug}`} />
   }
 
   return (

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.test.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.test.tsx
@@ -166,10 +166,10 @@ describe('PublicRecordDetailPage', () => {
     expect(screen.getByText('bold')).toBeInTheDocument()
   })
 
-  it('shows not found for unknown entity type slug', async () => {
+  it('shows not found for a path that is not a known type or a custom permalink', async () => {
     renderDetailPage('unknown', 1)
 
-    expect(await screen.findByText('Not found')).toBeInTheDocument()
+    expect(await screen.findByText('Record not found')).toBeInTheDocument()
   })
 
   it('renders the derived chapter nav and hides series/chapter_no/chapter_total', async () => {

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
@@ -10,6 +10,7 @@ import {
   type PublicFieldRow,
   RecordBreadcrumb,
   RecordChildPages,
+  usePublicPermalinkResolution,
   usePublicRecordHierarchy,
   usePublicViewEntityRecordPage,
 } from '@/features/public-view-entity-record'
@@ -157,14 +158,19 @@ function useCanonicalRedirect(
   entityId: number,
   entitySlug: string | null,
   publishedAt: string | null,
+  permalink: string | null,
 ): string | null {
   const { pathname } = useLocation()
-  const canonical = resolvePermalink(pattern ?? DEFAULT_PERMALINK_PATTERN, {
-    typeSlug: entityTypeSlug,
-    entitySlug,
-    entityId,
-    publishedAt,
-  })
+  // A custom permalink IS the canonical path — never redirect it to the type
+  // pattern (which would bounce custom-permalink pages away). #656
+  const canonical =
+    permalink ??
+    resolvePermalink(pattern ?? DEFAULT_PERMALINK_PATTERN, {
+      typeSlug: entityTypeSlug,
+      entitySlug,
+      entityId,
+      publishedAt,
+    })
   return pathname !== canonical ? canonical : null
 }
 
@@ -277,6 +283,7 @@ function PublicRecordDetailContent({
     entityId,
     entity?.slug ?? null,
     entity?.publishedAt ?? null,
+    entity?.permalink ?? null,
   )
   if (!isLoading && !isError && entity !== null && redirect !== null) {
     return <Navigate to={redirect} replace />
@@ -565,12 +572,87 @@ function PublicRecordDetailById({
   )
 }
 
+// ── Custom-permalink resolver (#656) ──────────────────────────────────────────
+
+/**
+ * Renders a record reached by an arbitrary custom permalink (e.g. `/company/about`).
+ * The type-based router can't resolve such a path, so resolve it server-side to
+ * `{entityTypeSlug, entityId}` and render the detail — for both direct loads and
+ * client-side navigation (breadcrumb / child links).
+ */
+export function PublicRecordByPermalink({ path }: { path: string }) {
+  const site = usePublicSite()
+  const { t } = useTranslation()
+  const resolution = usePublicPermalinkResolution(path)
+  const entityTypeQuery = useEntityTypeList({ limit: 100, offset: 0 })
+
+  const entityTypeSlugById = useMemo(
+    (): Record<number, string> =>
+      Object.fromEntries(
+        (entityTypeQuery.data?.items ?? []).map((item) => [Number(item.id), item.slug]),
+      ),
+    [entityTypeQuery.data?.items],
+  )
+  const entityTypePatternById = useMemo(
+    (): Record<number, string | null | undefined> =>
+      Object.fromEntries(
+        (entityTypeQuery.data?.items ?? []).map((item) => [Number(item.id), item.permalinkPattern]),
+      ),
+    [entityTypeQuery.data?.items],
+  )
+
+  if (resolution.isLoading || entityTypeQuery.isLoading) {
+    return (
+      <RecordShellMessage
+        site={site}
+        entityTypeSlug={null}
+        title="Loading…"
+        description="Fetching this record."
+      />
+    )
+  }
+
+  const data = resolution.data
+  const resolved =
+    data?.found === true && data.entityId !== undefined && data.entityTypeSlug !== undefined
+      ? { entityId: data.entityId, entityTypeSlug: data.entityTypeSlug }
+      : null
+  const type =
+    resolved !== null
+      ? findEntityTypeBySlug(entityTypeQuery.data?.items ?? [], resolved.entityTypeSlug)
+      : undefined
+
+  if (resolved === null || type === undefined) {
+    return (
+      <RecordShellMessage
+        site={site}
+        entityTypeSlug={null}
+        title={t('public.record.notFound.title')}
+        description={t('public.record.notFound.description', { slug: path })}
+        icon
+      />
+    )
+  }
+
+  return (
+    <PublicRecordDetailById
+      entityTypeSlug={type.slug}
+      entityTypeName={type.name}
+      entityTypeId={Number(type.id)}
+      entityId={resolved.entityId}
+      entityTypeSlugById={entityTypeSlugById}
+      entityTypePatternById={entityTypePatternById}
+      currentPattern={type.permalinkPattern}
+      entityTypeDefaultLayout={type.defaultLayout}
+    />
+  )
+}
+
 // ── Page root ─────────────────────────────────────────────────────────────────
 
 export function PublicRecordDetailPage() {
   // React Router v6: splat param is '*'
   const { entityTypeSlug = '', '*': splat = '' } = useParams()
-  const { t } = useTranslation()
   const site = usePublicSite()
 
   const entityTypeQuery = useEntityTypeList({ limit: 100, offset: 0 })
@@ -606,15 +688,10 @@ export function PublicRecordDetailPage() {
   }
 
   if (entityType === undefined) {
-    return (
-      <RecordShellMessage
-        site={site}
-        entityTypeSlug={null}
-        title={t('public.entityType.notFound.title')}
-        description={t('public.entityType.notFound.description', { slug: entityTypeSlug })}
-        icon
-      />
-    )
+    // The first URL segment isn't a known type → try resolving the full path as a
+    // custom permalink (e.g. `/company/about`) so the SPA renders it too (#656).
+    const customPath = splat !== '' ? `/${entityTypeSlug}/${splat}` : `/${entityTypeSlug}`
+    return <PublicRecordByPermalink path={customPath} />
   }
 
   const entityTypeId = Number(entityType.id)

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -793,6 +793,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/public/records/resolve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Resolve a custom-permalink path to its record
+         * @description Resolves an arbitrary custom-permalink path (e.g. `/company/about`) to `{entityTypeSlug, entityId}` so the type-based public SPA router can render it on direct load and client-side navigation (#656). Always 200; `found:false` when no published record owns the path.
+         */
+        get: operations["resolvePublicPermalink"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/notification-channels": {
         parameters: {
             query?: never;
@@ -2558,6 +2578,16 @@ export interface components {
             nextUrl: string | null;
             chapterNo: number;
             chapterTotal: number;
+        };
+        PublicPermalinkResolution: {
+            found: boolean;
+            /** @description Present when found: the resolved record's entity type slug. */
+            entityTypeSlug?: string;
+            /**
+             * Format: int64
+             * @description Present when found: the resolved record id.
+             */
+            entityId?: number;
         };
         PublicRecordHierarchy: {
             /** @description Breadcrumb trail derived from the permalink path; empty for flat records. */
@@ -5249,6 +5279,32 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PublicRecordHierarchy"];
+                };
+            };
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    resolvePublicPermalink: {
+        parameters: {
+            query: {
+                /** @description The custom permalink path, e.g. `/company/about`. */
+                path: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Resolution result. */
+            200: {
+                headers: {
+                    /** @example public, max-age=60, stale-while-revalidate=300 */
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PublicPermalinkResolution"];
                 };
             };
             500: components["responses"]["InternalServerError"];

--- a/frontend/src/shared/lib/public-permalink-resolve.ts
+++ b/frontend/src/shared/lib/public-permalink-resolve.ts
@@ -1,0 +1,24 @@
+import { apiClient } from '@/shared/api/client'
+import type { components } from '@/shared/api/schema.gen'
+
+export type PublicPermalinkResolutionDto = components['schemas']['PublicPermalinkResolution']
+
+export const publicPermalinkResolveKeys = {
+  byPath: (path: string) => ['public-permalink-resolve', path] as const,
+}
+
+/**
+ * Resolve an arbitrary custom-permalink path (e.g. `/company/about`) to its
+ * record (#656). The public SPA router is type-based and can't resolve such a
+ * path on its own; this lets it render the right record on direct load and on
+ * client-side navigation. Resolves to `{ found: false }` for unknown paths.
+ */
+export function resolvePublicPermalink(
+  path: string,
+  signal?: AbortSignal,
+): Promise<PublicPermalinkResolutionDto> {
+  return apiClient.get<PublicPermalinkResolutionDto>(
+    `/api/v1/public/records/resolve?path=${encodeURIComponent(path)}`,
+    signal,
+  )
+}

--- a/frontend/tests/msw/handlers/public-permalink-resolve.ts
+++ b/frontend/tests/msw/handlers/public-permalink-resolve.ts
@@ -1,0 +1,6 @@
+import { http, HttpResponse } from 'msw'
+
+/** Default: nothing resolves (tests opt in by overriding when needed). #656 */
+export const publicPermalinkResolveHandlers = [
+  http.get('/api/v1/public/records/resolve', () => HttpResponse.json({ found: false })),
+]

--- a/frontend/tests/msw/server.ts
+++ b/frontend/tests/msw/server.ts
@@ -12,6 +12,7 @@ import { entityTypeHandlers } from './handlers/entity-type'
 import { enumFieldHandlers } from './handlers/enum-field'
 import { fieldDefHandlers } from './handlers/field-def'
 import { intFieldHandlers } from './handlers/int-field'
+import { publicPermalinkResolveHandlers } from './handlers/public-permalink-resolve'
 import { publicRecordHierarchyHandlers } from './handlers/public-record-hierarchy'
 import { tagHandlers } from './handlers/tag'
 import { textFieldHandlers } from './handlers/text-field'
@@ -37,4 +38,5 @@ export const mswServer = setupServer(
   ...commentHandlers,
   ...wxrImportHandlers,
   ...publicRecordHierarchyHandlers,
+  ...publicPermalinkResolveHandlers,
 )

--- a/src/PublicRecord/PublicRecordRouteRegistrar.php
+++ b/src/PublicRecord/PublicRecordRouteRegistrar.php
@@ -12,6 +12,7 @@ final readonly class PublicRecordRouteRegistrar
     public function __construct(
         private GetPublicRecordViewHandler $getPublicRecordViewHandler,
         private GetPublicRecordHierarchyHandler $getPublicRecordHierarchyHandler,
+        private ResolvePublicPermalinkHandler $resolvePublicPermalinkHandler,
         private RenderPublicRecordViewHandler $renderPublicRecordViewHandler,
         private RenderPublicPermalinkHandler $renderPublicPermalinkHandler,
         private RenderSitemapHandler $renderSitemapHandler,
@@ -23,6 +24,7 @@ final readonly class PublicRecordRouteRegistrar
     {
         $getPublicRecordViewHandler = $this->getPublicRecordViewHandler;
         $getPublicRecordHierarchyHandler = $this->getPublicRecordHierarchyHandler;
+        $resolvePublicPermalinkHandler = $this->resolvePublicPermalinkHandler;
         $renderPublicRecordViewHandler = $this->renderPublicRecordViewHandler;
         $renderPublicPermalinkHandler = $this->renderPublicPermalinkHandler;
         $renderSitemapHandler = $this->renderSitemapHandler;
@@ -38,6 +40,13 @@ final readonly class PublicRecordRouteRegistrar
         $router->get(
             '/api/v1/public/records/{id}/hierarchy',
             static fn (ServerRequestInterface $request) => $getPublicRecordHierarchyHandler->handle($request),
+        );
+
+        // Resolve an arbitrary custom-permalink path → {entityTypeSlug, entityId}
+        // so the type-based SPA router can render it (#656).
+        $router->get(
+            '/api/v1/public/records/resolve',
+            static fn (ServerRequestInterface $request) => $resolvePublicPermalinkHandler->handle($request),
         );
 
         // Per-org XML sitemap. A registered route returns 200, so the 301 / SPA-shell

--- a/src/PublicRecord/PublicRecordServiceProvider.php
+++ b/src/PublicRecord/PublicRecordServiceProvider.php
@@ -198,6 +198,28 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                 },
             )
             ->set(
+                ResolvePublicPermalinkHandler::class,
+                static function (ContainerInterface $container): ResolvePublicPermalinkHandler {
+                    $entities = $container->get(EntityRepositoryInterface::class);
+                    $entityTypes = $container->get(EntityTypeRepositoryInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$entityTypes instanceof EntityTypeRepositoryInterface) {
+                        throw new LogicException('Entity type repository service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ResolvePublicPermalinkHandler($entities, $entityTypes, $response);
+                },
+            )
+            ->set(
                 RenderPublicRecordViewHandler::class,
                 static function (ContainerInterface $container): RenderPublicRecordViewHandler {
                     $useCase = $container->get(GetPublicRecordViewUseCaseInterface::class);
@@ -394,6 +416,7 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                 static function (ContainerInterface $container): PublicRecordRouteRegistrar {
                     $getHandler = $container->get(GetPublicRecordViewHandler::class);
                     $hierarchyHandler = $container->get(GetPublicRecordHierarchyHandler::class);
+                    $resolveHandler = $container->get(ResolvePublicPermalinkHandler::class);
                     $renderHandler = $container->get(RenderPublicRecordViewHandler::class);
                     $permalinkHandler = $container->get(RenderPublicPermalinkHandler::class);
                     $sitemapHandler = $container->get(RenderSitemapHandler::class);
@@ -405,6 +428,10 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
 
                     if (!$hierarchyHandler instanceof GetPublicRecordHierarchyHandler) {
                         throw new LogicException('GetPublicRecordHierarchy handler service is invalid.');
+                    }
+
+                    if (!$resolveHandler instanceof ResolvePublicPermalinkHandler) {
+                        throw new LogicException('ResolvePublicPermalink handler service is invalid.');
                     }
 
                     if (!$renderHandler instanceof RenderPublicRecordViewHandler) {
@@ -426,6 +453,7 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                     return new PublicRecordRouteRegistrar(
                         $getHandler,
                         $hierarchyHandler,
+                        $resolveHandler,
                         $renderHandler,
                         $permalinkHandler,
                         $sitemapHandler,

--- a/src/PublicRecord/ResolvePublicPermalinkHandler.php
+++ b/src/PublicRecord/ResolvePublicPermalinkHandler.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use Nene2\Http\JsonResponseFactory;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\Entity\EntityStatus;
+use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Resolve an arbitrary custom-permalink path to `{entityTypeSlug, entityId}` for
+ * the public SPA (#656). The client router is type-based (`/:entityTypeSlug/*`)
+ * and cannot resolve a path like `/company/about` on its own; this lets it render
+ * the right record on direct load AND on client-side navigation (breadcrumb /
+ * child links). Always 200; `found:false` when no published record owns the path.
+ */
+final readonly class ResolvePublicPermalinkHandler
+{
+    private const CACHE_CONTROL = 'public, max-age=60, stale-while-revalidate=300';
+
+    public function __construct(
+        private EntityRepositoryInterface $entities,
+        private EntityTypeRepositoryInterface $entityTypes,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $rawPath = $request->getQueryParams()['path'] ?? '';
+        $path = is_string($rawPath) ? trim($rawPath) : '';
+
+        $entity = ($path === '' || $path === '/') ? null : $this->entities->findByPermalink($path);
+
+        if (
+            $entity === null
+            || $entity->id === null
+            || $entity->isDeleted
+            || $entity->status !== EntityStatus::Published
+        ) {
+            return $this->response->create(['found' => false], 200, ['Cache-Control' => self::CACHE_CONTROL]);
+        }
+
+        $entityType = $this->entityTypes->findById($entity->entityTypeId);
+
+        if ($entityType === null) {
+            return $this->response->create(['found' => false], 200, ['Cache-Control' => self::CACHE_CONTROL]);
+        }
+
+        return $this->response->create([
+            'found' => true,
+            'entityTypeSlug' => $entityType->slug,
+            'entityId' => $entity->id,
+        ], 200, ['Cache-Control' => self::CACHE_CONTROL]);
+    }
+}

--- a/tests/PublicRecord/PublicCacheHttpTest.php
+++ b/tests/PublicRecord/PublicCacheHttpTest.php
@@ -111,6 +111,7 @@ final class PublicCacheHttpTest extends TestCase
         $publicRecordRegistrar = new PublicRecordRouteRegistrar(
             new GetPublicRecordViewHandler($useCase, $jsonResponse, $this->factory),
             new \NeNeRecords\PublicRecord\GetPublicRecordHierarchyHandler(new \NeNeRecords\PublicRecord\PublicRecordHierarchyBuilder($entities, $textFields), $jsonResponse),
+            new \NeNeRecords\PublicRecord\ResolvePublicPermalinkHandler($entities, $entityTypes, $jsonResponse),
             $renderHandler,
             new \NeNeRecords\PublicRecord\RenderPublicPermalinkHandler(
                 $entityTypes,

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -31,6 +31,7 @@ use NeNeRecords\PublicRecord\RenderPublicPermalinkHandler;
 use NeNeRecords\PublicRecord\RenderPublicRecordViewHandler;
 use NeNeRecords\PublicRecord\RenderRobotsHandler;
 use NeNeRecords\PublicRecord\RenderSitemapHandler;
+use NeNeRecords\PublicRecord\ResolvePublicPermalinkHandler;
 use NeNeRecords\Setting\ListPublicSettingsUseCase;
 use NeNeRecords\Tests\BoolField\InMemoryBoolFieldRepository;
 use NeNeRecords\Tests\DateTimeField\InMemoryDateTimeFieldRepository;
@@ -168,6 +169,7 @@ final class PublicRecordHttpTest extends TestCase
         $registrar = new PublicRecordRouteRegistrar(
             new GetPublicRecordViewHandler($useCase, $jsonResponse, $this->factory),
             new GetPublicRecordHierarchyHandler(new PublicRecordHierarchyBuilder($entities, $textFields), $jsonResponse),
+            new ResolvePublicPermalinkHandler($entities, $entityTypes, $jsonResponse),
             $renderHandler,
             new RenderPublicPermalinkHandler($entityTypes, $renderHandler, $customPermalink),
             new RenderSitemapHandler(


### PR DESCRIPTION
## 目的
**マイルストーン #1 の P0。** type ベースのクライアントルータ(`/:entityTypeSlug/*`)が任意 custom permalink(`/company/about` 等)を解決できず、ハイドレート/クライアント遷移で not-found に差し替わっていた。PR2(#653)のパンくず/子一覧は **SSR では正しいが SPA では機能していなかった**(custom-permalink ページ作成で顕在化)。

## 変更
- **backend**: `GET /api/v1/public/records/resolve?path=` で path → `{found, entityTypeSlug, entityId}` を解決(always 200)。
- **frontend**: self-contained な `PublicRecordByPermalink`(自前で型一覧取得＋解決→描画)。`PublicRecordDetailPage`(multi-segment)と `PublicBrowsePage`(single-segment)の type 未解決時に委譲。
- custom permalink は **canonical=permalink** なので `useCanonicalRedirect` が型パターンへ誤って 301 しないよう修正。

## 実機確認
`/docs/guides`・`/company/about` が **SPA でフル描画**(スタイル適用・パンくず Home›Documentation›Guides・「In this section」子一覧・本文・**無リダイレクト**)。

## 検証
`composer check`(PHPStan lv8 エラー0 / CS / OpenAPI / MCP / PHPUnit)緑、`npm run check`(type/lint/format/vitest/themes/knip/storybook)緑。新規 happy-path テスト(解決→描画・無リダイレクト)＋ not-found テスト更新。

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)