### PR TITLE
feat(admin): ディレクトリ表示拡充＋titleless humanize 統一 (#657 P1)

### DIFF
--- a/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
+++ b/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
@@ -69,11 +69,34 @@ export function useManageEntitiesPage(entityTypeId: number) {
     ],
   )
   const listQuery = useEntityList(listParams)
-  // Directory mode fetches a larger, unpaginated slice to build the path tree.
-  const directoryQuery = useEntityList(
-    { entityTypeId, limit: DIRECTORY_FETCH_LIMIT, offset: 0 },
-    { enabled: viewMode === 'directory' },
+  // Directory mode fetches a larger, unpaginated slice to build the path tree —
+  // honouring the active filters (search / status / tags / relations) so the tree
+  // reflects them too (#657). Sort/pagination don't apply: the tree sorts by path.
+  const directoryParams = useMemo(
+    () => ({
+      ...defaultEntityListParams(
+        entityTypeId,
+        selectedTagSlugs,
+        selectedRelationFilters,
+        0,
+        searchQuery,
+        selectedStatus,
+        sortKey,
+        sortOrder,
+      ),
+      limit: DIRECTORY_FETCH_LIMIT,
+    }),
+    [
+      entityTypeId,
+      selectedTagSlugs,
+      selectedRelationFilters,
+      searchQuery,
+      selectedStatus,
+      sortKey,
+      sortOrder,
+    ],
   )
+  const directoryQuery = useEntityList(directoryParams, { enabled: viewMode === 'directory' })
   const tagListQuery = useTagList({ limit: 100, offset: 0 })
   const fieldDefQuery = useFieldDefList(defaultFieldDefListParams(entityTypeId))
   const textFieldQuery = useTextFieldList(defaultTextFieldListParamsForEntityType(entityTypeId))
@@ -134,6 +157,7 @@ export function useManageEntitiesPage(entityTypeId: number) {
           permalink,
           label: getRecordDisplayLabel(Number(entity.id), textFields, fallback),
           status: entity.status,
+          updatedAt: entity.updatedAt,
         }
       })
   }, [directoryQuery.data?.items, textFieldQuery.data?.items])

--- a/frontend/src/features/manage-entities/lib/build-permalink-tree.test.ts
+++ b/frontend/src/features/manage-entities/lib/build-permalink-tree.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { buildPermalinkTree, type DirectoryRecord } from './build-permalink-tree'
 
 function record(id: number, permalink: string): DirectoryRecord {
-  return { id, permalink, label: `Record ${String(id)}`, status: 'published' }
+  return { id, permalink, label: `Record ${String(id)}`, status: 'published', updatedAt: null }
 }
 
 describe('buildPermalinkTree', () => {

--- a/frontend/src/features/manage-entities/lib/build-permalink-tree.ts
+++ b/frontend/src/features/manage-entities/lib/build-permalink-tree.ts
@@ -5,6 +5,7 @@ export interface DirectoryRecord {
   permalink: string
   label: string
   status: EntityStatus
+  updatedAt: string | null
 }
 
 export interface DirectoryNode {

--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.test.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { cleanup, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { renderWithI18n } from '@/shared/i18n/test-helpers'
 import type { DirectoryRecord } from '../lib/build-permalink-tree'
@@ -8,8 +9,14 @@ import { EntityDirectoryPanel } from './EntityDirectoryPanel'
 afterEach(cleanup)
 
 const RECORDS: DirectoryRecord[] = [
-  { id: 1, permalink: '/company/about', label: 'About Us', status: 'published' },
-  { id: 2, permalink: '/company/about/team', label: 'Our Team', status: 'draft' },
+  { id: 1, permalink: '/company/about', label: 'About Us', status: 'published', updatedAt: null },
+  {
+    id: 2,
+    permalink: '/company/about/team',
+    label: 'Our Team',
+    status: 'draft',
+    updatedAt: '2026-06-20T00:00:00Z',
+  },
 ]
 
 function renderPanel(props?: Partial<Parameters<typeof EntityDirectoryPanel>[0]>) {
@@ -41,10 +48,29 @@ describe('EntityDirectoryPanel', () => {
 
     // `/company` has no page of its own → a pure folder.
     expect(screen.getByText('company/')).toBeInTheDocument()
-    // Records link to their admin edit page.
+    // The top-level `About Us` page links to its admin edit page.
     expect(screen.getByRole('link', { name: 'About Us' })).toHaveAttribute('href', '/admin/pages/1')
+    // The cumulative path is shown for each visible node.
+    expect(screen.getByText('/company/about')).toBeInTheDocument()
+  })
+
+  it('initially collapses below the top level, expanding on demand (#657)', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    // `About Us` (depth 1) starts collapsed → its child `Our Team` is hidden.
+    expect(screen.queryByRole('link', { name: 'Our Team' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Expand' }))
+
     expect(screen.getByRole('link', { name: 'Our Team' })).toHaveAttribute('href', '/admin/pages/2')
-    // The cumulative path is shown for each node.
     expect(screen.getByText('/company/about/team')).toBeInTheDocument()
+  })
+
+  it('shows a child count next to folders and section pages (#657)', () => {
+    renderPanel()
+
+    // `company` (folder) and `About Us` (a page that also has children) each show (1).
+    expect(screen.getAllByText('(1)')).toHaveLength(2)
   })
 })

--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
@@ -8,6 +8,22 @@ import {
   type DirectoryRecord,
 } from '../lib/build-permalink-tree'
 
+/** Compact locale-aware date for tree rows (mirrors EntityListPanel). */
+function formatDate(iso: string | null, locale: string): string {
+  if (iso === null || iso === '') {
+    return ''
+  }
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+  return new Intl.DateTimeFormat(locale, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  }).format(date)
+}
+
 export interface EntityDirectoryPanelProps {
   entityTypeSlug: string
   records: DirectoryRecord[]
@@ -88,8 +104,9 @@ function DirectoryNodeRow({
   entityTypeSlug: string
   depth: number
 }) {
-  const { t } = useTranslation()
-  const [open, setOpen] = useState(true)
+  const { t, locale } = useTranslation()
+  // Initially expand only the top level — a deep tree is otherwise a wall of rows (#657).
+  const [open, setOpen] = useState(depth === 0)
   const hasChildren = node.children.length > 0
 
   return (
@@ -128,17 +145,34 @@ function DirectoryNodeRow({
             >
               {node.record.label}
             </Link>
+            {hasChildren ? (
+              <span className="shrink-0 font-mono text-caption text-text-muted">
+                ({node.children.length})
+              </span>
+            ) : null}
             <StatusBadge status={node.record.status}>
               {t(`admin.entityStatus.status.${node.record.status}`)}
             </StatusBadge>
           </>
         ) : (
-          <span className="font-sans text-body font-medium text-text-muted">{node.segment}/</span>
+          <>
+            <span className="font-sans text-body font-medium text-text-muted">{node.segment}/</span>
+            <span className="shrink-0 font-mono text-caption text-text-muted">
+              ({node.children.length})
+            </span>
+          </>
         )}
 
-        <code className="ml-auto shrink-0 truncate font-mono text-caption text-text-muted">
-          {node.path}
-        </code>
+        <div className="ml-auto flex shrink-0 items-center gap-inline-sm">
+          {node.record !== null && formatDate(node.record.updatedAt, locale) !== '' ? (
+            <span className="font-sans text-caption text-text-muted">
+              {t('admin.entityRecords.list.item.updatedAt', {
+                date: formatDate(node.record.updatedAt, locale),
+              })}
+            </span>
+          ) : null}
+          <code className="truncate font-mono text-caption text-text-muted">{node.path}</code>
+        </div>
       </div>
 
       {hasChildren && open ? (

--- a/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
+++ b/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
@@ -167,8 +167,9 @@ export function ManageEntitiesView({
     total === 1 ? 'admin.entityRecords.recordCount.one' : 'admin.entityRecords.recordCount.other'
 
   // 検索・フィルターはコンテンツが存在するか、すでにフィルターが有効な場合のみ表示
-  // （Progressive Disclosure: 空ページで絞り込みUI を見せない）
-  const showFilters = (total > 0 || isFilterActive) && viewMode === 'list'
+  // （Progressive Disclosure: 空ページで絞り込みUI を見せない）。検索＋絞り込み（status/tag/
+  // relation）は list / directory 両モードに適用、ソートとページ送りのみ list 限定（#657）。
+  const showFilters = total > 0 || isFilterActive
 
   const currentSortValue = `${sortKey}-${sortOrder}`
 
@@ -234,56 +235,60 @@ export function ManageEntitiesView({
 
             {/* Sort + Filter toggle toolbar */}
             <div className="flex items-center gap-inline-md">
-              {/* 並び順セレクト */}
-              <div className="flex items-center gap-1.5">
-                <label
-                  htmlFor="entity-sort-select"
-                  className="shrink-0 font-sans text-caption text-text-muted"
-                >
-                  {t('admin.entityRecords.sort.label')}
-                </label>
-                <Select
-                  id="entity-sort-select"
-                  size="sm"
-                  value={currentSortValue}
-                  onChange={(e) => {
-                    const opt = SORT_OPTIONS.find((o) => o.value === e.target.value)
-                    if (opt !== undefined) {
-                      onSortChange(opt.key, opt.order)
-                    }
-                  }}
-                >
-                  {SORT_OPTIONS.map((opt) => (
-                    <option key={opt.value} value={opt.value}>
-                      {t(opt.labelKey)}
-                    </option>
-                  ))}
-                </Select>
-              </div>
+              {viewMode === 'list' ? (
+                <>
+                  {/* 並び順セレクト */}
+                  <div className="flex items-center gap-1.5">
+                    <label
+                      htmlFor="entity-sort-select"
+                      className="shrink-0 font-sans text-caption text-text-muted"
+                    >
+                      {t('admin.entityRecords.sort.label')}
+                    </label>
+                    <Select
+                      id="entity-sort-select"
+                      size="sm"
+                      value={currentSortValue}
+                      onChange={(e) => {
+                        const opt = SORT_OPTIONS.find((o) => o.value === e.target.value)
+                        if (opt !== undefined) {
+                          onSortChange(opt.key, opt.order)
+                        }
+                      }}
+                    >
+                      {SORT_OPTIONS.map((opt) => (
+                        <option key={opt.value} value={opt.value}>
+                          {t(opt.labelKey)}
+                        </option>
+                      ))}
+                    </Select>
+                  </div>
 
-              {/* 1ページあたりの件数（多数レコードのスケール対策） */}
-              <div className="flex items-center gap-1.5">
-                <label
-                  htmlFor="entity-page-size-select"
-                  className="shrink-0 font-sans text-caption text-text-muted"
-                >
-                  {t('admin.entityRecords.pageSize.label')}
-                </label>
-                <Select
-                  id="entity-page-size-select"
-                  size="sm"
-                  value={String(pageSize)}
-                  onChange={(e) => {
-                    onPageSizeChange(Number(e.target.value))
-                  }}
-                >
-                  {pageSizeOptions.map((size) => (
-                    <option key={size} value={size}>
-                      {size}
-                    </option>
-                  ))}
-                </Select>
-              </div>
+                  {/* 1ページあたりの件数（多数レコードのスケール対策） */}
+                  <div className="flex items-center gap-1.5">
+                    <label
+                      htmlFor="entity-page-size-select"
+                      className="shrink-0 font-sans text-caption text-text-muted"
+                    >
+                      {t('admin.entityRecords.pageSize.label')}
+                    </label>
+                    <Select
+                      id="entity-page-size-select"
+                      size="sm"
+                      value={String(pageSize)}
+                      onChange={(e) => {
+                        onPageSizeChange(Number(e.target.value))
+                      }}
+                    >
+                      {pageSizeOptions.map((size) => (
+                        <option key={size} value={size}>
+                          {size}
+                        </option>
+                      ))}
+                    </Select>
+                  </div>
+                </>
+              ) : null}
 
               <div className="flex-1" />
 

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
@@ -231,10 +231,14 @@ function PublicRecordDetailContent({
     (row): row is Extract<PublicFieldRow, { kind: 'scalar' }> =>
       row.kind === 'scalar' && row.fieldKey === 'title' && row.displayValue !== '—',
   )
+  // No title field? Humanize the slug, then the last permalink segment, before a
+  // bare "Record #N" — matches the breadcrumb / child-list labels (#657).
+  const permalinkSegments = (entity?.permalink ?? '').split('/').filter((part) => part !== '')
   const resolvedTitle =
     titleRow?.displayValue.trim() ||
     entity?.metaTitle?.trim() ||
     humanizeSlug(entity?.slug) ||
+    humanizeSlug(permalinkSegments.at(-1)) ||
     `Record #${String(entityId)}`
   // Reserved chapter-nav metadata (series/chapter_no/chapter_total) is surfaced
   // as the derived chapter navigation, never as an ordinary field row.

--- a/src/PreviewToken/GetPreviewRecordViewUseCase.php
+++ b/src/PreviewToken/GetPreviewRecordViewUseCase.php
@@ -22,6 +22,7 @@ use NeNeRecords\IntField\IntFieldRepositoryInterface;
 use NeNeRecords\Media\MediaDerivativeUrl;
 use NeNeRecords\PublicRecord\ChapterNavBuilder;
 use NeNeRecords\PublicRecord\GetPublicRecordViewOutput;
+use NeNeRecords\PublicRecord\PermalinkLabel;
 use NeNeRecords\PublicRecord\PublicFieldDisplayFormatter;
 use NeNeRecords\PublicRecord\PublicPermalinkResolver;
 use NeNeRecords\PublicRecord\PublicRecordHierarchyBuilder;
@@ -148,7 +149,7 @@ final readonly class GetPreviewRecordViewUseCase implements GetPreviewRecordView
             $relationsByFieldKey,
         );
 
-        $pageTitle = $this->resolvePageTitle($textFieldRows, $entityId);
+        $pageTitle = $this->resolvePageTitle($textFieldRows, $entityId, $entity->permalink);
 
         $bootstrap = PublicRecordViewHttpMapper::toBootstrap(
             entityTypeSlug: $entityTypeSlug,
@@ -338,13 +339,13 @@ final readonly class GetPreviewRecordViewUseCase implements GetPreviewRecordView
     }
 
     /** @param list<TextField> $textFieldRows */
-    private function resolvePageTitle(array $textFieldRows, int $entityId): string
+    private function resolvePageTitle(array $textFieldRows, int $entityId, ?string $permalink): string
     {
-        return $this->resolveRecordLabel($entityId, $textFieldRows);
+        return $this->resolveRecordLabel($entityId, $textFieldRows, $permalink);
     }
 
     /** @param list<TextField> $textFieldRows */
-    private function resolveRecordLabel(int $entityId, array $textFieldRows): string
+    private function resolveRecordLabel(int $entityId, array $textFieldRows, ?string $permalink = null): string
     {
         foreach ($textFieldRows as $textField) {
             if ($textField->entityId === $entityId && $textField->fieldKey === 'title' && trim($textField->value) !== '') {
@@ -356,6 +357,12 @@ final readonly class GetPreviewRecordViewUseCase implements GetPreviewRecordView
             if ($textField->entityId === $entityId && trim($textField->value) !== '') {
                 return $textField->value;
             }
+        }
+
+        // No title field → humanize the permalink's last segment before a bare id (#657).
+        $segment = PermalinkLabel::lastSegment($permalink);
+        if ($segment !== null) {
+            return PermalinkLabel::humanize($segment);
         }
 
         return 'Record #' . $entityId;

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -150,7 +150,9 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
         // The SEO title override (entity.meta_title, e.g. imported from Yoast) wins
         // for <title>/og:title; otherwise fall back to the record's title field.
         $metaTitle = trim($entity->metaTitle ?? '');
-        $pageTitle = $metaTitle !== '' ? $metaTitle : $this->resolvePageTitle($textFieldRows, $entityId);
+        $pageTitle = $metaTitle !== ''
+            ? $metaTitle
+            : $this->resolvePageTitle($textFieldRows, $entityId, $entity->permalink);
 
         $bootstrap = PublicRecordViewHttpMapper::toBootstrap(
             entityTypeSlug: $input->entityTypeSlug,
@@ -355,13 +357,13 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
     }
 
     /** @param list<TextField> $textFieldRows */
-    private function resolvePageTitle(array $textFieldRows, int $entityId): string
+    private function resolvePageTitle(array $textFieldRows, int $entityId, ?string $permalink): string
     {
-        return $this->resolveRecordLabel($entityId, $textFieldRows);
+        return $this->resolveRecordLabel($entityId, $textFieldRows, $permalink);
     }
 
     /** @param list<TextField> $textFieldRows */
-    private function resolveRecordLabel(int $entityId, array $textFieldRows): string
+    private function resolveRecordLabel(int $entityId, array $textFieldRows, ?string $permalink = null): string
     {
         foreach ($textFieldRows as $textField) {
             if ($textField->entityId === $entityId && $textField->fieldKey === 'title' && trim($textField->value) !== '') {
@@ -373,6 +375,12 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             if ($textField->entityId === $entityId && trim($textField->value) !== '') {
                 return $textField->value;
             }
+        }
+
+        // No title field → humanize the permalink's last segment before a bare id (#657).
+        $segment = PermalinkLabel::lastSegment($permalink);
+        if ($segment !== null) {
+            return PermalinkLabel::humanize($segment);
         }
 
         return 'Record #' . $entityId;

--- a/src/PublicRecord/PermalinkLabel.php
+++ b/src/PublicRecord/PermalinkLabel.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+/**
+ * Turns a permalink (or one of its segments) into a human display label — the
+ * shared fallback when a record has no title field (#657). Keeps the public
+ * detail title, breadcrumb, and child-list labels consistent ("about-us" →
+ * "About Us") instead of an opaque "Record #<id>".
+ */
+final class PermalinkLabel
+{
+    /** "about-us" → "About Us"; falls back to the raw segment for non-kebab input. */
+    public static function humanize(string $segment): string
+    {
+        $words = [];
+        foreach (explode('-', $segment) as $part) {
+            if ($part === '') {
+                continue;
+            }
+            $words[] = mb_strtoupper(mb_substr($part, 0, 1)) . mb_substr($part, 1);
+        }
+
+        return $words === [] ? $segment : implode(' ', $words);
+    }
+
+    /** The last non-empty path segment of a permalink, or null when there is none. */
+    public static function lastSegment(?string $permalink): ?string
+    {
+        if ($permalink === null || trim($permalink) === '') {
+            return null;
+        }
+
+        $segments = array_values(array_filter(
+            explode('/', $permalink),
+            static fn (string $segment): bool => $segment !== '',
+        ));
+
+        return $segments === [] ? null : $segments[count($segments) - 1];
+    }
+}

--- a/src/PublicRecord/PublicRecordHierarchyBuilder.php
+++ b/src/PublicRecord/PublicRecordHierarchyBuilder.php
@@ -183,14 +183,6 @@ final readonly class PublicRecordHierarchyBuilder
     /** "about-us" → "About Us"; falls back to the raw segment for non-kebab input. */
     private function humanize(string $segment): string
     {
-        $words = [];
-        foreach (explode('-', $segment) as $part) {
-            if ($part === '') {
-                continue;
-            }
-            $words[] = mb_strtoupper(mb_substr($part, 0, 1)) . mb_substr($part, 1);
-        }
-
-        return $words === [] ? $segment : implode(' ', $words);
+        return PermalinkLabel::humanize($segment);
     }
 }

--- a/tests/PublicRecord/PermalinkLabelTest.php
+++ b/tests/PublicRecord/PermalinkLabelTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use NeNeRecords\PublicRecord\PermalinkLabel;
+use PHPUnit\Framework\TestCase;
+
+final class PermalinkLabelTest extends TestCase
+{
+    public function testHumanizeTitleCasesKebabSegments(): void
+    {
+        self::assertSame('About Us', PermalinkLabel::humanize('about-us'));
+        self::assertSame('Guides', PermalinkLabel::humanize('guides'));
+    }
+
+    public function testHumanizeFallsBackToRawForNonKebabInput(): void
+    {
+        self::assertSame('FAQ', PermalinkLabel::humanize('FAQ'));
+    }
+
+    public function testLastSegmentReturnsFinalPathComponent(): void
+    {
+        self::assertSame('about', PermalinkLabel::lastSegment('/company/about'));
+        self::assertSame('team', PermalinkLabel::lastSegment('/company/about/team/'));
+    }
+
+    public function testLastSegmentIsNullForEmptyOrRootPaths(): void
+    {
+        self::assertNull(PermalinkLabel::lastSegment(null));
+        self::assertNull(PermalinkLabel::lastSegment(''));
+        self::assertNull(PermalinkLabel::lastSegment('/'));
+    }
+}


### PR DESCRIPTION
## 目的
マイルストーン #1 の **P1 quick wins**（directory-view ペルソナレビュー由来）。

## 変更
- **絞り込みの復活**: directory モードでも検索＋絞り込み（status / tag / relation）が効くように（directory クエリにフィルタ適用＋UI を両モードで表示）。ソート/ページ送りは list 限定。
- **表示拡充**: ツリー各行に**最終更新日**、フォルダ／子を持つセクションページに**子件数 `(N)`**。
- **初期折りたたみ**: 初期展開を **top-level のみ**に（深いツリーの行洪水を回避、以降は都度展開）。
- **titleless 見出しの統一**: タイトル無しレコードの公開見出し fallback を `Record #N` → **permalink 末尾セグメントの humanize**（`about-us`→`About Us`）に。SSR（use case ×2）と SPA（resolvedTitle）の両方、パンくず／子一覧の表記と一致。humanize ロジックを共有 `PermalinkLabel` に集約（重複解消）。

## 検証
`composer check` / `npm run check` 緑。新規 `PermalinkLabel` 単体テスト＋ツリーの折りたたみ/子件数テスト、既存テスト更新。

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)