### PR TITLE
feat(admin): ディレクトリの「＋ここに新規」で permalink 接頭辞補完 (#658 P1)

### DIFF
--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.test.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
@@ -30,6 +30,7 @@ function renderPanel(props?: Partial<Parameters<typeof EntityDirectoryPanel>[0]>
         isError={false}
         errorTitle={null}
         onRetry={() => {}}
+        onCreateHere={() => {}}
         {...props}
       />
     </MemoryRouter>,
@@ -72,5 +73,15 @@ describe('EntityDirectoryPanel', () => {
 
     // `company` (folder) and `About Us` (a page that also has children) each show (1).
     expect(screen.getAllByText('(1)')).toHaveLength(2)
+  })
+
+  it('creates a new page under a folder, passing its permalink prefix (#658)', async () => {
+    const user = userEvent.setup()
+    const onCreateHere = vi.fn()
+    renderPanel({ onCreateHere })
+
+    await user.click(screen.getByRole('button', { name: 'New page under /company' }))
+
+    expect(onCreateHere).toHaveBeenCalledWith('/company/')
   })
 })

--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
@@ -33,6 +33,8 @@ export interface EntityDirectoryPanelProps {
   isError: boolean
   errorTitle: string | null
   onRetry: () => void
+  /** Create a new record under a folder, pre-filling its permalink prefix (#658). */
+  onCreateHere: (permalinkPrefix: string) => void
 }
 
 /**
@@ -48,6 +50,7 @@ export function EntityDirectoryPanel({
   isError,
   errorTitle,
   onRetry,
+  onCreateHere,
 }: EntityDirectoryPanelProps) {
   const { t } = useTranslation()
   const tree = useMemo(() => buildPermalinkTree(records), [records])
@@ -88,7 +91,13 @@ export function EntityDirectoryPanel({
         aria-label={t('admin.entityRecords.view.directory')}
       >
         {tree.map((node) => (
-          <DirectoryNodeRow key={node.path} node={node} entityTypeSlug={entityTypeSlug} depth={0} />
+          <DirectoryNodeRow
+            key={node.path}
+            node={node}
+            entityTypeSlug={entityTypeSlug}
+            depth={0}
+            onCreateHere={onCreateHere}
+          />
         ))}
       </ul>
     </div>
@@ -99,10 +108,12 @@ function DirectoryNodeRow({
   node,
   entityTypeSlug,
   depth,
+  onCreateHere,
 }: {
   node: DirectoryNode
   entityTypeSlug: string
   depth: number
+  onCreateHere: (permalinkPrefix: string) => void
 }) {
   const { t, locale } = useTranslation()
   // Initially expand only the top level — a deep tree is otherwise a wall of rows (#657).
@@ -172,6 +183,17 @@ function DirectoryNodeRow({
             </span>
           ) : null}
           <code className="truncate font-mono text-caption text-text-muted">{node.path}</code>
+          <button
+            type="button"
+            onClick={() => {
+              onCreateHere(`${node.path}/`)
+            }}
+            aria-label={t('admin.entityRecords.directory.newHere', { path: node.path })}
+            title={t('admin.entityRecords.directory.newHere', { path: node.path })}
+            className="shrink-0 rounded px-1 font-mono text-body text-text-muted hover:bg-surface-raised hover:text-accent"
+          >
+            +
+          </button>
         </div>
       </div>
 
@@ -183,6 +205,7 @@ function DirectoryNodeRow({
               node={child}
               entityTypeSlug={entityTypeSlug}
               depth={depth + 1}
+              onCreateHere={onCreateHere}
             />
           ))}
         </ul>

--- a/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
+++ b/frontend/src/features/manage-entities/ui/ManageEntitiesView.tsx
@@ -103,6 +103,7 @@ export interface ManageEntitiesViewProps {
   directoryIsLoading: boolean
   directoryIsError: boolean
   directoryErrorTitle: string | null
+  onCreateHere: (permalinkPrefix: string) => void
 }
 
 export function ManageEntitiesView({
@@ -151,6 +152,7 @@ export function ManageEntitiesView({
   directoryIsLoading,
   directoryIsError,
   directoryErrorTitle,
+  onCreateHere,
 }: ManageEntitiesViewProps) {
   const { t } = useTranslation()
 
@@ -424,6 +426,7 @@ export function ManageEntitiesView({
               isError={directoryIsError}
               errorTitle={directoryErrorTitle}
               onRetry={onRetry}
+              onCreateHere={onCreateHere}
             />
           ) : (
             <EntityListPanel

--- a/frontend/src/features/manage-entity-status/hooks/useEntityStatusPanel.ts
+++ b/frontend/src/features/manage-entity-status/hooks/useEntityStatusPanel.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import type { Entity, EntityStatus } from '@/entities/entity'
 import {
   useGeneratePreviewToken,
@@ -64,7 +65,12 @@ export function useEntityStatusPanel(
   const revokePreviewMutation = useRevokePreviewToken()
 
   const [slugInput, setSlugInput] = useState(entity.slug ?? '')
-  const [permalinkInput, setPermalinkInput] = useState(entity.permalink ?? '')
+  const [searchParams] = useSearchParams()
+  // "+ new here" in the directory tree pre-fills a folder prefix via ?permalinkPrefix,
+  // so a new page starts under the right path (only when it has none yet) — #658.
+  const [permalinkInput, setPermalinkInput] = useState(
+    (entity.permalink ?? '') || (searchParams.get('permalinkPrefix') ?? ''),
+  )
   const [showScheduleForm, setShowScheduleForm] = useState(false)
   const [scheduledAtInput, setScheduledAtInput] = useState('')
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)

--- a/frontend/src/pages/entity-records/EntityRecordsPage.tsx
+++ b/frontend/src/pages/entity-records/EntityRecordsPage.tsx
@@ -76,9 +76,13 @@ function EntityRecordsContent({ entityType }: { entityType: EntityType }) {
     isDeleting,
   } = useManageEntitiesPage(Number(entityType.id))
 
-  const handleCreate = async () => {
+  const handleCreate = async (permalinkPrefix?: string) => {
     const newEntity = await createEntity()
-    void navigate(`/admin/${entityType.slug}/${String(newEntity.id)}`)
+    const query =
+      permalinkPrefix !== undefined && permalinkPrefix !== ''
+        ? `?permalinkPrefix=${encodeURIComponent(permalinkPrefix)}`
+        : ''
+    void navigate(`/admin/${entityType.slug}/${String(newEntity.id)}${query}`)
   }
 
   const localizedName = getLocalizedEntityTypeName(entityType, locale)
@@ -162,6 +166,9 @@ function EntityRecordsContent({ entityType }: { entityType: EntityType }) {
         directoryIsLoading={directoryIsLoading}
         directoryIsError={directoryIsError}
         directoryErrorTitle={directoryErrorTitle}
+        onCreateHere={(permalinkPrefix) => {
+          void handleCreate(permalinkPrefix)
+        }}
       />
     </Stack>
   )

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -635,6 +635,7 @@ export const de: Partial<MessageCatalog> = {
     'Es werden die ersten 100 Datensätze angezeigt. Nutze die Listenansicht zum Durchsuchen aller.',
   'admin.entityRecords.directory.expand': 'Aufklappen',
   'admin.entityRecords.directory.collapse': 'Zuklappen',
+  'admin.entityRecords.directory.newHere': 'Neue Seite unter {{path}}',
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Felder',
   'admin.fieldDefs.schemaFor': 'Felder für {{slug}}',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -638,6 +638,7 @@ export const en = {
     'Showing the first 100 records. Use the list view to search all.',
   'admin.entityRecords.directory.expand': 'Expand',
   'admin.entityRecords.directory.collapse': 'Collapse',
+  'admin.entityRecords.directory.newHere': 'New page under {{path}}',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Fields',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -646,6 +646,7 @@ export const fr: Partial<MessageCatalog> = {
     'Affichage des 100 premières fiches. Utilisez la vue liste pour tout rechercher.',
   'admin.entityRecords.directory.expand': 'Déplier',
   'admin.entityRecords.directory.collapse': 'Replier',
+  'admin.entityRecords.directory.newHere': 'Nouvelle page sous {{path}}',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Champs',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -634,6 +634,7 @@ export const ja: Partial<MessageCatalog> = {
     '先頭100件を表示しています。全件はリスト表示の検索をご利用ください。',
   'admin.entityRecords.directory.expand': '展開',
   'admin.entityRecords.directory.collapse': '折りたたむ',
+  'admin.entityRecords.directory.newHere': '{{path}} に新規ページ',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'フィールド',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -639,6 +639,7 @@ export const ptBR: Partial<MessageCatalog> = {
     'Mostrando os primeiros 100 registros. Use a visualização em lista para pesquisar todos.',
   'admin.entityRecords.directory.expand': 'Expandir',
   'admin.entityRecords.directory.collapse': 'Recolher',
+  'admin.entityRecords.directory.newHere': 'Nova página em {{path}}',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Campos',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -608,6 +608,7 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.entityRecords.directory.truncated': '仅显示前 100 条记录。使用列表视图搜索全部。',
   'admin.entityRecords.directory.expand': '展开',
   'admin.entityRecords.directory.collapse': '折叠',
+  'admin.entityRecords.directory.newHere': '在 {{path}} 下新建页面',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': '字段',

--- a/frontend/tests/render/render-with-providers.tsx
+++ b/frontend/tests/render/render-with-providers.tsx
@@ -8,6 +8,7 @@ import {
   type RenderResult,
 } from '@testing-library/react'
 import type { ReactElement, ReactNode } from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import { I18nProvider } from '@/shared/i18n'
 
 export function createTestQueryClient(): QueryClient {
@@ -43,10 +44,15 @@ export function renderHookWithProviders<Result, Props>(
   const queryClient = createTestQueryClient()
 
   return renderHook(hook, {
+    // MemoryRouter so hooks using router context (e.g. useSearchParams) work. Hook
+    // tests never supply their own Router, so there's no nesting risk (unlike
+    // renderWithProviders, where component tests often wrap their own).
     wrapper: ({ children }: { children: ReactNode }) => (
-      <I18nProvider>
-        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-      </I18nProvider>
+      <MemoryRouter>
+        <I18nProvider>
+          <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        </I18nProvider>
+      </MemoryRouter>
     ),
     ...options,
   })


### PR DESCRIPTION
## 目的
マイルストーン #1 の **P1**（WP の親ページ選択相当）。permalink を手打ちせず、フォルダから新規ページを作れるように。

## 変更
- ディレクトリツリーの各ノード脇に **「＋ここに新規」**。クリックで空レコードを作成し、編集画面へ `?permalinkPrefix=<フォルダ>/` 付きで遷移、**permalink 入力をその接頭辞で初期化**。
- 接頭辞は**未確定**（保存するまで DB に書かれない＝中途半端な prefix での自動301を回避）。`showAdvanced` も自動展開。
- i18n 6言語（`directory.newHere`・path 補間）。
- `renderHookWithProviders` に Router を追加（`useSearchParams` を使うフックのテスト用。component 側 `renderWithProviders` は自前 Router を持つテストとの二重化を避けるため据置）。

## スコープ
#658 のうち**接頭辞補完のみ**。**手動並び順（menu_order 相当）は #659（DnD）に統合**（DnD 並べ替え＝順序保存になるため設計を一体化）。

## 検証
`npm run check` 緑。実機: `/company` の＋ → 編集画面で `permalink="/company/"` を確認。ツリーのボタン→prefix 受け渡しの単体テスト追加。

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)