### PR TITLE
feat(api): サブツリー移動エンドポイント＋301カスケード (#659-A1 backend)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -580,6 +580,46 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/entities/{id}/move:
+    post:
+      tags:
+        - Entities
+      summary: Move a record (and its subtree) to a new permalink
+      description: >
+        Rewrites the record's custom permalink prefix and every descendant's,
+        recording a 301 for each changed path so existing links and search
+        results follow the move — no descendant-URL avalanche (#659).
+      operationId: moveEntity
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - permalink
+              properties:
+                permalink:
+                  type: string
+                  description: The record's new custom permalink; its subtree follows.
+                  example: /legal/about
+      responses:
+        '200':
+          description: Move applied (or a no-op when dropped onto its current parent).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityMoveResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /api/v1/entities/{id}/revisions:
     get:
       tags:
@@ -5395,6 +5435,22 @@ components:
             - 'null'
           enum: [standard, full, two-col, three-col, bare, custom, null]
           description: 'Per-entity layout override. Null = inherit the type''s default_layout.'
+      additionalProperties: false
+    EntityMoveResponse:
+      type: object
+      required:
+        - id
+        - permalink
+        - moved_count
+      properties:
+        id:
+          type: integer
+          format: int64
+        permalink:
+          type: string
+        moved_count:
+          type: integer
+          description: Records whose permalink was rewritten (root + descendants); 0 = no-op.
       additionalProperties: false
     ScheduleEntityRequest:
       type: object

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -210,6 +210,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/entities/{id}/move": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Move a record (and its subtree) to a new permalink
+         * @description Rewrites the record's custom permalink prefix and every descendant's, recording a 301 for each changed path so existing links and search results follow the move — no descendant-URL avalanche (#659).
+         */
+        post: operations["moveEntity"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/entities/{id}/revisions": {
         parameters: {
             query?: never;
@@ -2184,6 +2204,13 @@ export interface components {
              */
             layout?: "standard" | "full" | "two-col" | "three-col" | "bare" | "custom" | null;
         };
+        EntityMoveResponse: {
+            /** Format: int64 */
+            id: number;
+            permalink: string;
+            /** @description Records whose permalink was rewritten (root + descendants); 0 = no-op. */
+            moved_count: number;
+        };
         ScheduleEntityRequest: {
             /**
              * Format: date-time
@@ -3653,6 +3680,43 @@ export interface operations {
                 content?: never;
             };
             404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    moveEntity: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @example 1 */
+                id: components["parameters"]["IdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * @description The record's new custom permalink; its subtree follows.
+                     * @example /legal/about
+                     */
+                    permalink: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Move applied (or a no-op when dropped onto its current parent). */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EntityMoveResponse"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+            422: components["responses"]["ValidationFailed"];
             500: components["responses"]["InternalServerError"];
         };
     };

--- a/src/Entity/EntityRepositoryInterface.php
+++ b/src/Entity/EntityRepositoryInterface.php
@@ -22,6 +22,19 @@ interface EntityRepositoryInterface
      */
     public function findDirectChildrenByPermalink(string $parentPermalink, int $limit): array;
 
+    /**
+     * Every descendant record under a permalink prefix — all levels below
+     * `/prefix/`, ANY status, org-scoped, ordered by permalink. Unlike
+     * {@see findDirectChildrenByPermalink} this spans deeper levels and all
+     * statuses. Powers the directory subtree move (#659).
+     *
+     * @return list<Entity>
+     */
+    public function findByPermalinkPrefix(string $prefix): array;
+
+    /** Rewrite only a record's custom permalink (subtree move, #659). */
+    public function updatePermalink(int $id, string $permalink): void;
+
     public function existsBySlug(string $slug, int $entityTypeId, ?int $excludeId = null): bool;
 
     /** True when another record in the org already owns this custom permalink (#651). */

--- a/src/Entity/EntityRouteRegistrar.php
+++ b/src/Entity/EntityRouteRegistrar.php
@@ -14,6 +14,7 @@ final readonly class EntityRouteRegistrar
         private CreateEntityHandler $createHandler,
         private UpdateEntityHandler $updateHandler,
         private DeleteEntityHandler $deleteHandler,
+        private MoveEntityHandler $moveHandler,
         private ListEntitiesHandler $listHandler,
         private ListEntityRevisionsHandler $listRevisionsHandler,
         private ExportEntitiesHandler $exportHandler,
@@ -29,6 +30,7 @@ final readonly class EntityRouteRegistrar
         $createHandler = $this->createHandler;
         $updateHandler = $this->updateHandler;
         $deleteHandler = $this->deleteHandler;
+        $moveHandler = $this->moveHandler;
         $listHandler = $this->listHandler;
         $listRevisionsHandler = $this->listRevisionsHandler;
         $exportHandler = $this->exportHandler;
@@ -42,6 +44,7 @@ final readonly class EntityRouteRegistrar
         $router->get('/api/v1/entities/{id}', static fn (ServerRequestInterface $request) => $getHandler->handle($request));
         $router->post('/api/v1/entities', static fn (ServerRequestInterface $request) => $createHandler->handle($request));
         $router->put('/api/v1/entities/{id}', static fn (ServerRequestInterface $request) => $updateHandler->handle($request));
+        $router->post('/api/v1/entities/{id}/move', static fn (ServerRequestInterface $request) => $moveHandler->handle($request));
         $router->delete('/api/v1/entities/{id}', static fn (ServerRequestInterface $request) => $deleteHandler->handle($request));
         $router->get(
             '/api/v1/entities/{id}/revisions',

--- a/src/Entity/EntityServiceProvider.php
+++ b/src/Entity/EntityServiceProvider.php
@@ -233,6 +233,40 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                MoveEntitySubtreeUseCaseInterface::class,
+                static function (ContainerInterface $c): MoveEntitySubtreeUseCaseInterface {
+                    $entities = $c->get(EntityRepositoryInterface::class);
+                    $redirects = $c->get(UrlRedirectRepositoryInterface::class);
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$redirects instanceof UrlRedirectRepositoryInterface) {
+                        throw new LogicException('URL redirect repository service is invalid.');
+                    }
+
+                    return new MoveEntitySubtreeUseCase($entities, $redirects);
+                },
+            )
+            ->set(
+                MoveEntityHandler::class,
+                static function (ContainerInterface $c): MoveEntityHandler {
+                    $useCase = $c->get(MoveEntitySubtreeUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof MoveEntitySubtreeUseCaseInterface) {
+                        throw new LogicException('MoveEntitySubtree use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new MoveEntityHandler($useCase, $response);
+                },
+            )
+            ->set(
                 DuplicateEntitySlugExceptionHandler::class,
                 static function (ContainerInterface $c): DuplicateEntitySlugExceptionHandler {
                     $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
@@ -418,6 +452,7 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
                     $create = $c->get(CreateEntityHandler::class);
                     $update = $c->get(UpdateEntityHandler::class);
                     $delete = $c->get(DeleteEntityHandler::class);
+                    $move = $c->get(MoveEntityHandler::class);
                     $list = $c->get(ListEntitiesHandler::class);
                     $listRevisions = $c->get(ListEntityRevisionsHandler::class);
                     $export = $c->get(ExportEntitiesHandler::class);
@@ -439,6 +474,10 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
 
                     if (!$delete instanceof DeleteEntityHandler) {
                         throw new LogicException('DeleteEntity handler service is invalid.');
+                    }
+
+                    if (!$move instanceof MoveEntityHandler) {
+                        throw new LogicException('MoveEntity handler service is invalid.');
                     }
 
                     if (!$list instanceof ListEntitiesHandler) {
@@ -465,7 +504,7 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
                         throw new LogicException('ProcessScheduledPublish handler service is invalid.');
                     }
 
-                    return new EntityRouteRegistrar($get, $create, $update, $delete, $list, $listRevisions, $export, $schedule, $unschedule, $processScheduled);
+                    return new EntityRouteRegistrar($get, $create, $update, $delete, $move, $list, $listRevisions, $export, $schedule, $unschedule, $processScheduled);
                 },
             );
     }

--- a/src/Entity/MoveEntityHandler.php
+++ b/src/Entity/MoveEntityHandler.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+use InvalidArgumentException;
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * `POST /api/v1/entities/{id}/move` — move a record (and its subtree) to a new
+ * custom permalink, cascading descendant paths + recording 301s (#659).
+ */
+final readonly class MoveEntityHandler
+{
+    use ParsesPermalinkField;
+
+    public function __construct(
+        private MoveEntitySubtreeUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new EntityNotFoundException($id);
+        }
+
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+        $permalink = $this->parsePermalinkField($body['permalink'] ?? null, $errors);
+
+        // parsePermalinkField returns null for both absent AND invalid input, but
+        // only appends an error in the invalid case — so an empty $errors here means
+        // the field was simply missing.
+        if ($permalink === null && $errors === []) {
+            $errors[] = new ValidationError('permalink', 'A target permalink is required to move a page.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        /** @var string $permalink */
+        try {
+            $output = $this->useCase->execute(new MoveEntitySubtreeInput(
+                entityId: $id,
+                newPermalink: $permalink,
+            ));
+        } catch (InvalidArgumentException $e) {
+            throw new ValidationException([
+                new ValidationError('permalink', $e->getMessage(), 'invalid'),
+            ]);
+        }
+
+        return $this->response->create([
+            'id' => $output->entityId,
+            'permalink' => $output->permalink,
+            'moved_count' => $output->movedCount,
+        ]);
+    }
+}

--- a/src/Entity/MoveEntitySubtreeInput.php
+++ b/src/Entity/MoveEntitySubtreeInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+final readonly class MoveEntitySubtreeInput
+{
+    public function __construct(
+        public int $entityId,
+        /** The record's new custom permalink (its subtree follows). Already normalized. */
+        public string $newPermalink,
+    ) {
+    }
+}

--- a/src/Entity/MoveEntitySubtreeOutput.php
+++ b/src/Entity/MoveEntitySubtreeOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+final readonly class MoveEntitySubtreeOutput
+{
+    public function __construct(
+        public int $entityId,
+        public string $permalink,
+        /** Records whose permalink was rewritten (root + descendants); 0 = no-op. */
+        public int $movedCount,
+    ) {
+    }
+}

--- a/src/Entity/MoveEntitySubtreeUseCase.php
+++ b/src/Entity/MoveEntitySubtreeUseCase.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+use InvalidArgumentException;
+use NeNeRecords\UrlRedirect\UrlRedirectRepositoryInterface;
+
+/**
+ * Move a custom-permalink record AND its whole subtree under a new parent path
+ * (#659). Rewrites the record's permalink prefix and every descendant's, and
+ * records a 301 for each changed path (reusing #651's redirect store) so existing
+ * links / search results follow the move — no descendant-URL avalanche.
+ *
+ * Collisions with records OUTSIDE the moving subtree are validated up front, so a
+ * clash aborts before any write rather than mid-cascade. Org scoping comes from
+ * the injected repositories.
+ */
+final readonly class MoveEntitySubtreeUseCase implements MoveEntitySubtreeUseCaseInterface
+{
+    public function __construct(
+        private EntityRepositoryInterface $entities,
+        /** Records a 301 from each old path on move (#651 store); optional like UpdateEntity. */
+        private ?UrlRedirectRepositoryInterface $redirects = null,
+    ) {
+    }
+
+    public function execute(MoveEntitySubtreeInput $input): MoveEntitySubtreeOutput
+    {
+        $entity = $this->entities->findById($input->entityId);
+
+        if ($entity === null || $entity->id === null) {
+            throw new EntityNotFoundException($input->entityId);
+        }
+
+        $oldPermalink = $entity->permalink;
+
+        if ($oldPermalink === null || $oldPermalink === '') {
+            throw new InvalidArgumentException('Only a record with a custom permalink can be moved.');
+        }
+
+        $newPermalink = $input->newPermalink;
+
+        if ($newPermalink === $oldPermalink) {
+            // Dropped onto its current parent — nothing to do.
+            return new MoveEntitySubtreeOutput($entity->id, $oldPermalink, 0);
+        }
+
+        // A node cannot move into its own subtree (that would orphan it).
+        if (str_starts_with($newPermalink, $oldPermalink . '/')) {
+            throw new InvalidArgumentException('A page cannot be moved inside its own subtree.');
+        }
+
+        $descendants = $this->entities->findByPermalinkPrefix($oldPermalink);
+
+        $subtreeIds = [$entity->id];
+        foreach ($descendants as $descendant) {
+            if ($descendant->id !== null) {
+                $subtreeIds[] = $descendant->id;
+            }
+        }
+
+        // Plan every (id, old, new) rewrite, then validate collisions against
+        // records outside the subtree before touching anything.
+        /** @var list<array{id: int, old: string, new: string}> $moves */
+        $moves = [['id' => $entity->id, 'old' => $oldPermalink, 'new' => $newPermalink]];
+        foreach ($descendants as $descendant) {
+            if ($descendant->id === null || $descendant->permalink === null) {
+                continue;
+            }
+            $moves[] = [
+                'id' => $descendant->id,
+                'old' => $descendant->permalink,
+                'new' => $newPermalink . substr($descendant->permalink, strlen($oldPermalink)),
+            ];
+        }
+
+        foreach ($moves as $move) {
+            $occupant = $this->entities->findByPermalink($move['new']);
+            if ($occupant !== null && !in_array($occupant->id, $subtreeIds, true)) {
+                throw new DuplicateEntityPermalinkException($move['new']);
+            }
+        }
+
+        foreach ($moves as $move) {
+            $this->entities->updatePermalink($move['id'], $move['new']);
+            $this->redirects?->save($move['old'], $move['new']);
+        }
+
+        return new MoveEntitySubtreeOutput($entity->id, $newPermalink, count($moves));
+    }
+}

--- a/src/Entity/MoveEntitySubtreeUseCaseInterface.php
+++ b/src/Entity/MoveEntitySubtreeUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+interface MoveEntitySubtreeUseCaseInterface
+{
+    public function execute(MoveEntitySubtreeInput $input): MoveEntitySubtreeOutput;
+}

--- a/src/Entity/PdoEntityRepository.php
+++ b/src/Entity/PdoEntityRepository.php
@@ -100,6 +100,35 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
         return array_map(fn (array $row) => $this->mapRow($row), $rows);
     }
 
+    /** @return list<Entity> */
+    public function findByPermalinkPrefix(string $prefix): array
+    {
+        // Every descendant under `/prefix/` (all levels, any status), org-scoped.
+        // Permalinks are kebab + slash only, so the LIKE wildcard never collides
+        // with a literal `%`/`_` in the data.
+        $rows = $this->query->fetchAll(
+            <<<'SQL'
+                SELECT id, entity_type_id, slug, permalink, layout, status, published_at, scheduled_at, is_deleted, created_at, updated_at, deleted_at, meta_title, meta_description
+                FROM entities
+                WHERE organization_id = ?
+                  AND is_deleted = 0
+                  AND permalink LIKE ?
+                ORDER BY permalink ASC
+                SQL,
+            [$this->orgId->get(), $prefix . '/%'],
+        );
+
+        return array_map(fn (array $row) => $this->mapRow($row), $rows);
+    }
+
+    public function updatePermalink(int $id, string $permalink): void
+    {
+        $this->query->execute(
+            'UPDATE entities SET permalink = ?, updated_at = NOW() WHERE id = ? AND organization_id = ?',
+            [$permalink, $id, $this->orgId->get()],
+        );
+    }
+
     public function existsByPermalink(string $permalink, ?int $excludeId = null): bool
     {
         // No is_deleted filter: the unique index spans every row, so the pre-check

--- a/tests/BoolField/BoolFieldHttpTest.php
+++ b/tests/BoolField/BoolFieldHttpTest.php
@@ -83,6 +83,7 @@ final class BoolFieldHttpTest extends TestCase
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
+            new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),

--- a/tests/DateTimeField/DateTimeFieldHttpTest.php
+++ b/tests/DateTimeField/DateTimeFieldHttpTest.php
@@ -83,6 +83,7 @@ final class DateTimeFieldHttpTest extends TestCase
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
+            new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),

--- a/tests/Entity/EntityFilterHttpTest.php
+++ b/tests/Entity/EntityFilterHttpTest.php
@@ -71,6 +71,7 @@ final class EntityFilterHttpTest extends TestCase
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $entityTypes), $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
+            new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),

--- a/tests/Entity/EntityHttpTest.php
+++ b/tests/Entity/EntityHttpTest.php
@@ -64,6 +64,7 @@ final class EntityHttpTest extends TestCase
             new CreateEntityHandler($createUseCase, $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
+            new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),

--- a/tests/Entity/EntityRevisionHttpTest.php
+++ b/tests/Entity/EntityRevisionHttpTest.php
@@ -64,6 +64,7 @@ final class EntityRevisionHttpTest extends TestCase
             new CreateEntityHandler($createUseCase, $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
+            new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),

--- a/tests/Entity/InMemoryEntityRepository.php
+++ b/tests/Entity/InMemoryEntityRepository.php
@@ -127,6 +127,50 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
         return array_slice($children, 0, $limit);
     }
 
+    /** @return list<Entity> */
+    public function findByPermalinkPrefix(string $prefix): array
+    {
+        $needle = $prefix . '/';
+        $result = [];
+
+        foreach ($this->entities as $entity) {
+            if ($entity->isDeleted) {
+                continue;
+            }
+
+            $permalink = $entity->permalink;
+            if ($permalink !== null && str_starts_with($permalink, $needle)) {
+                $result[] = $entity;
+            }
+        }
+
+        usort($result, static fn (Entity $a, Entity $b): int => ($a->permalink ?? '') <=> ($b->permalink ?? ''));
+
+        return $result;
+    }
+
+    public function updatePermalink(int $id, string $permalink): void
+    {
+        $existing = $this->entities[$id] ?? null;
+
+        if ($existing === null || $existing->isDeleted) {
+            return;
+        }
+
+        $this->entities[$id] = new Entity(
+            id: $existing->id,
+            entityTypeId: $existing->entityTypeId,
+            slug: $existing->slug,
+            permalink: $permalink,
+            status: $existing->status,
+            publishedAt: $existing->publishedAt,
+            metaTitle: $existing->metaTitle,
+            metaDescription: $existing->metaDescription,
+            scheduledAt: $existing->scheduledAt,
+            layout: $existing->layout,
+        );
+    }
+
     public function existsByPermalink(string $permalink, ?int $excludeId = null): bool
     {
         foreach ($this->entities as $entity) {

--- a/tests/Entity/MoveEntitySubtreeUseCaseTest.php
+++ b/tests/Entity/MoveEntitySubtreeUseCaseTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Entity;
+
+use InvalidArgumentException;
+use NeNeRecords\Entity\DuplicateEntityPermalinkException;
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\Entity\EntityNotFoundException;
+use NeNeRecords\Entity\EntityStatus;
+use NeNeRecords\Entity\MoveEntitySubtreeInput;
+use NeNeRecords\Entity\MoveEntitySubtreeUseCase;
+use NeNeRecords\Tests\UrlRedirect\InMemoryUrlRedirectRepository;
+use PHPUnit\Framework\TestCase;
+
+final class MoveEntitySubtreeUseCaseTest extends TestCase
+{
+    private function entity(int $id, string $permalink): Entity
+    {
+        return new Entity(id: $id, entityTypeId: 1, permalink: $permalink, status: EntityStatus::Published);
+    }
+
+    public function testMovesRecordAndSubtreeRewritingPermalinksAndRecording301s(): void
+    {
+        $entities = new InMemoryEntityRepository([
+            $this->entity(1, '/company/about'),
+            $this->entity(2, '/company/about/team'),
+            $this->entity(3, '/legal'),
+        ]);
+        $redirects = new InMemoryUrlRedirectRepository();
+        $useCase = new MoveEntitySubtreeUseCase($entities, $redirects);
+
+        $output = $useCase->execute(new MoveEntitySubtreeInput(1, '/legal/about'));
+
+        self::assertSame(2, $output->movedCount);
+        self::assertSame('/legal/about', $entities->findById(1)?->permalink);
+        self::assertSame('/legal/about/team', $entities->findById(2)?->permalink);
+        // The unrelated sibling is untouched.
+        self::assertSame('/legal', $entities->findById(3)?->permalink);
+        self::assertSame([
+            '/company/about' => '/legal/about',
+            '/company/about/team' => '/legal/about/team',
+        ], $redirects->all());
+    }
+
+    public function testRejectsMovingIntoOwnSubtree(): void
+    {
+        $entities = new InMemoryEntityRepository([$this->entity(1, '/company/about')]);
+        $useCase = new MoveEntitySubtreeUseCase($entities, new InMemoryUrlRedirectRepository());
+
+        $this->expectException(InvalidArgumentException::class);
+        $useCase->execute(new MoveEntitySubtreeInput(1, '/company/about/deep'));
+    }
+
+    public function testRejectsCollisionWithRecordOutsideSubtree(): void
+    {
+        $entities = new InMemoryEntityRepository([
+            $this->entity(1, '/company/about'),
+            $this->entity(2, '/legal/about'),
+        ]);
+        $useCase = new MoveEntitySubtreeUseCase($entities, new InMemoryUrlRedirectRepository());
+
+        $this->expectException(DuplicateEntityPermalinkException::class);
+        $useCase->execute(new MoveEntitySubtreeInput(1, '/legal/about'));
+    }
+
+    public function testRejectsMovingARecordWithoutAPermalink(): void
+    {
+        $entities = new InMemoryEntityRepository([
+            new Entity(id: 1, entityTypeId: 1, permalink: null, status: EntityStatus::Published),
+        ]);
+        $useCase = new MoveEntitySubtreeUseCase($entities, new InMemoryUrlRedirectRepository());
+
+        $this->expectException(InvalidArgumentException::class);
+        $useCase->execute(new MoveEntitySubtreeInput(1, '/legal/about'));
+    }
+
+    public function testRejectsMovingAMissingRecord(): void
+    {
+        $useCase = new MoveEntitySubtreeUseCase(new InMemoryEntityRepository([]), new InMemoryUrlRedirectRepository());
+
+        $this->expectException(EntityNotFoundException::class);
+        $useCase->execute(new MoveEntitySubtreeInput(999, '/legal/about'));
+    }
+
+    public function testNoOpWhenDroppedOntoItsCurrentLocation(): void
+    {
+        $entities = new InMemoryEntityRepository([$this->entity(1, '/company/about')]);
+        $redirects = new InMemoryUrlRedirectRepository();
+        $useCase = new MoveEntitySubtreeUseCase($entities, $redirects);
+
+        $output = $useCase->execute(new MoveEntitySubtreeInput(1, '/company/about'));
+
+        self::assertSame(0, $output->movedCount);
+        self::assertSame([], $redirects->all());
+    }
+}

--- a/tests/Entity/ScheduledPublishHttpTest.php
+++ b/tests/Entity/ScheduledPublishHttpTest.php
@@ -64,6 +64,7 @@ final class ScheduledPublishHttpTest extends TestCase
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
+            new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),

--- a/tests/EnumField/EnumFieldHttpTest.php
+++ b/tests/EnumField/EnumFieldHttpTest.php
@@ -83,6 +83,7 @@ final class EnumFieldHttpTest extends TestCase
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
+            new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),

--- a/tests/IntField/IntFieldHttpTest.php
+++ b/tests/IntField/IntFieldHttpTest.php
@@ -83,6 +83,7 @@ final class IntFieldHttpTest extends TestCase
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
+            new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),

--- a/tests/TextField/TextFieldHttpTest.php
+++ b/tests/TextField/TextFieldHttpTest.php
@@ -82,6 +82,7 @@ final class TextFieldHttpTest extends TestCase
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
+            new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, $this->textFields, $this->factory),


### PR DESCRIPTION
## 目的
マイルストーン #1 P2 **#659-A の目玉「DnD 親移動＋自動301」のバックエンド**。フロント DnD（#659-A2）が接続する移動 API。

## 変更
- `POST /api/v1/entities/{id}/move` `{ permalink }` → レコードの custom permalink を新しい親パスへ張り替え、**子孫の permalink を一括カスケード書換**、各変更で **301 を記録**（#651 の redirect ストア再利用）。
- `EntityRepository`: `findByPermalinkPrefix`（全階層の子孫・全status）＋ `updatePermalink`（軽量更新）。
- `MoveEntitySubtreeUseCase`: **自サブツリーへの移動拒否**・**移動先衝突**（サブツリー外の既存 permalink）を**書換前に一括検証**、no-op 検出。
- `MoveEntityHandler`: permalink 必須/不正→422、衝突→409、not-found→404。

## 検証
`composer check` 緑。`MoveEntitySubtreeUseCaseTest`（移動＋カスケード＋301記録＋4バリデーション、6本）。OpenAPI 更新＋FE型再生成。

Refs #659（残: A2 フロント DnD＋確認ダイアログ、手動並び順、ツリー内検索）

🤖 Generated with [Claude Code](https://claude.com/claude-code)