### PR TITLE
feat(admin): ディレクトリ DnD 親移動＋確認ダイアログ (#659-A2 frontend)

### DIFF
--- a/frontend/src/entities/entity/api-types.ts
+++ b/frontend/src/entities/entity/api-types.ts
@@ -59,6 +59,12 @@ export interface ScheduleEntityResponseDto {
   scheduled_at: string
 }
 
+export interface EntityMoveResponseDto {
+  id: number
+  permalink: string
+  moved_count: number
+}
+
 export interface GeneratePreviewTokenResponseDto {
   token: string
   expires_at: string

--- a/frontend/src/entities/entity/index.ts
+++ b/frontend/src/entities/entity/index.ts
@@ -25,6 +25,7 @@ export {
   useCreateEntity,
   useDeleteEntity,
   useGeneratePreviewToken,
+  useMoveEntity,
   useRevokePreviewToken,
   useScheduleEntity,
   useUnscheduleEntity,

--- a/frontend/src/entities/entity/mutations.ts
+++ b/frontend/src/entities/entity/mutations.ts
@@ -7,6 +7,7 @@ import {
 import { apiClient, AppError } from '@/shared/api/client'
 import type {
   EntityDto,
+  EntityMoveResponseDto,
   GeneratePreviewTokenResponseDto,
   ScheduleEntityResponseDto,
 } from './api-types'
@@ -84,6 +85,41 @@ export function useUpdateEntity(): UseMutationResult<Entity, AppError, UpdateEnt
     },
     onSuccess: async (data) => {
       queryClient.setQueryData(entityKeys.detail(data.id), data)
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: entityKeys.lists() }),
+        invalidatePublicFeeds(queryClient),
+      ])
+    },
+  })
+}
+
+export interface MoveEntityResult {
+  id: number
+  permalink: string
+  movedCount: number
+}
+
+/**
+ * Move a record (and its subtree) to a new custom permalink (#659). The backend
+ * cascades descendant paths and records 301s; on success we invalidate the lists
+ * so the directory tree reflects the new structure.
+ */
+export function useMoveEntity(): UseMutationResult<
+  MoveEntityResult,
+  AppError,
+  { id: number; permalink: string }
+> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ id, permalink }) => {
+      const dto = await apiClient.post<EntityMoveResponseDto>(
+        `/api/v1/entities/${String(id)}/move`,
+        { permalink },
+      )
+      return { id: dto.id, permalink: dto.permalink, movedCount: dto.moved_count }
+    },
+    onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: entityKeys.lists() }),
         invalidatePublicFeeds(queryClient),

--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.test.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.test.tsx
@@ -1,12 +1,16 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, screen } from '@testing-library/react'
+import { cleanup, fireEvent, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
-import { renderWithI18n } from '@/shared/i18n/test-helpers'
+import { renderWithProviders } from '@tests/render/render-with-providers'
 import type { DirectoryRecord } from '../lib/build-permalink-tree'
+import { clearDirectoryDragPayload, setDirectoryDragPayload } from './directory-dnd'
 import { EntityDirectoryPanel } from './EntityDirectoryPanel'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  clearDirectoryDragPayload()
+})
 
 const RECORDS: DirectoryRecord[] = [
   { id: 1, permalink: '/company/about', label: 'About Us', status: 'published', updatedAt: null },
@@ -20,7 +24,7 @@ const RECORDS: DirectoryRecord[] = [
 ]
 
 function renderPanel(props?: Partial<Parameters<typeof EntityDirectoryPanel>[0]>) {
-  return renderWithI18n(
+  return renderWithProviders(
     <MemoryRouter>
       <EntityDirectoryPanel
         entityTypeSlug="pages"
@@ -83,5 +87,20 @@ describe('EntityDirectoryPanel', () => {
     await user.click(screen.getByRole('button', { name: 'New page under /company' }))
 
     expect(onCreateHere).toHaveBeenCalledWith('/company/')
+  })
+
+  it('opens a move confirmation when a record is dropped onto a folder (#659)', () => {
+    setDirectoryDragPayload({ id: 2, permalink: '/company/about/team', label: 'Our Team' })
+    renderPanel()
+
+    const companyRow = screen.getByText('company/').closest('div')
+    if (companyRow === null) {
+      throw new Error('Expected the /company folder row to render.')
+    }
+    fireEvent.drop(companyRow)
+
+    // The confirm dialog appears, showing the computed target permalink.
+    expect(screen.getByText('Move page?')).toBeInTheDocument()
+    expect(screen.getByText(/\/company\/team/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
@@ -1,12 +1,28 @@
-import { useMemo, useState } from 'react'
+import { type DragEvent, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { useMoveEntity } from '@/entities/entity'
 import { useTranslation } from '@/shared/i18n'
-import { EmptyState, ErrorState, LoadingState, StatusBadge } from '@/shared/ui'
+import {
+  ConfirmDialog,
+  EmptyState,
+  ErrorState,
+  LoadingState,
+  StatusBadge,
+  useToast,
+} from '@/shared/ui'
 import {
   buildPermalinkTree,
   type DirectoryNode,
   type DirectoryRecord,
 } from '../lib/build-permalink-tree'
+import {
+  canDropInto,
+  clearDirectoryDragPayload,
+  type DirectoryDragPayload,
+  getDirectoryDragPayload,
+  moveTargetPermalink,
+  setDirectoryDragPayload,
+} from './directory-dnd'
 
 /** Compact locale-aware date for tree rows (mirrors EntityListPanel). */
 function formatDate(iso: string | null, locale: string): string {
@@ -22,6 +38,13 @@ function formatDate(iso: string | null, locale: string): string {
     month: 'short',
     day: 'numeric',
   }).format(date)
+}
+
+interface PendingMove {
+  id: number
+  label: string
+  newPermalink: string
+  affectedCount: number
 }
 
 export interface EntityDirectoryPanelProps {
@@ -41,6 +64,8 @@ export interface EntityDirectoryPanelProps {
  * Renders records as a collapsible directory tree derived from their permalink
  * paths (#651 PR3). Only records carrying a custom permalink appear; flat records
  * stay in the list view. parent_id is never used — the tree is path-derived.
+ * Records can be dragged onto a folder to move their whole subtree (#659): the
+ * backend cascades descendant paths and writes 301s, gated by a confirm dialog.
  */
 export function EntityDirectoryPanel({
   entityTypeSlug,
@@ -53,6 +78,9 @@ export function EntityDirectoryPanel({
   onCreateHere,
 }: EntityDirectoryPanelProps) {
   const { t } = useTranslation()
+  const { showToast } = useToast()
+  const moveMutation = useMoveEntity()
+  const [pendingMove, setPendingMove] = useState<PendingMove | null>(null)
   const tree = useMemo(() => buildPermalinkTree(records), [records])
 
   if (isLoading) {
@@ -79,6 +107,40 @@ export function EntityDirectoryPanel({
     )
   }
 
+  const requestMove = (payload: DirectoryDragPayload, targetPath: string) => {
+    // Affected = the dragged record plus its descendants (their URLs all change).
+    const affectedCount = records.filter(
+      (record) =>
+        record.permalink === payload.permalink ||
+        record.permalink.startsWith(`${payload.permalink}/`),
+    ).length
+    setPendingMove({
+      id: payload.id,
+      label: payload.label,
+      newPermalink: moveTargetPermalink(payload, targetPath),
+      affectedCount,
+    })
+  }
+
+  const confirmMove = () => {
+    if (pendingMove === null) {
+      return
+    }
+    moveMutation.mutate(
+      { id: pendingMove.id, permalink: pendingMove.newPermalink },
+      {
+        onSuccess: () => {
+          showToast(t('admin.entityRecords.directory.move.success'), 'success')
+          setPendingMove(null)
+        },
+        onError: (error) => {
+          showToast(error.title, 'error')
+          setPendingMove(null)
+        },
+      },
+    )
+  }
+
   return (
     <div>
       {truncated ? (
@@ -97,9 +159,37 @@ export function EntityDirectoryPanel({
             entityTypeSlug={entityTypeSlug}
             depth={0}
             onCreateHere={onCreateHere}
+            onRequestMove={requestMove}
           />
         ))}
       </ul>
+
+      <ConfirmDialog
+        open={pendingMove !== null}
+        title={t('admin.entityRecords.directory.move.confirmTitle')}
+        description={
+          pendingMove === null
+            ? undefined
+            : pendingMove.affectedCount === 1
+              ? t('admin.entityRecords.directory.move.confirmBody.one', {
+                  label: pendingMove.label,
+                  target: pendingMove.newPermalink,
+                })
+              : t('admin.entityRecords.directory.move.confirmBody.other', {
+                  label: pendingMove.label,
+                  target: pendingMove.newPermalink,
+                  count: pendingMove.affectedCount,
+                })
+        }
+        confirmLabel={t('admin.entityRecords.directory.move.confirm')}
+        cancelLabel={t('common.actions.cancel')}
+        isPending={moveMutation.isPending}
+        errorDetail={moveMutation.error?.title ?? null}
+        onConfirm={confirmMove}
+        onCancel={() => {
+          setPendingMove(null)
+        }}
+      />
     </div>
   )
 }
@@ -109,22 +199,57 @@ function DirectoryNodeRow({
   entityTypeSlug,
   depth,
   onCreateHere,
+  onRequestMove,
 }: {
   node: DirectoryNode
   entityTypeSlug: string
   depth: number
   onCreateHere: (permalinkPrefix: string) => void
+  onRequestMove: (payload: DirectoryDragPayload, targetPath: string) => void
 }) {
   const { t, locale } = useTranslation()
   // Initially expand only the top level — a deep tree is otherwise a wall of rows (#657).
   const [open, setOpen] = useState(depth === 0)
+  const [isDropTarget, setIsDropTarget] = useState(false)
   const hasChildren = node.children.length > 0
+  const record = node.record
+
+  const handleDragOver = (event: DragEvent<HTMLElement>) => {
+    const payload = getDirectoryDragPayload()
+    if (payload === null || !canDropInto(payload, node.path)) {
+      return
+    }
+    event.preventDefault()
+    event.stopPropagation()
+    setIsDropTarget(true)
+  }
+
+  const handleDrop = (event: DragEvent<HTMLElement>) => {
+    const payload = getDirectoryDragPayload()
+    setIsDropTarget(false)
+    if (payload === null || !canDropInto(payload, node.path)) {
+      return
+    }
+    event.preventDefault()
+    event.stopPropagation()
+    onRequestMove(payload, node.path)
+    clearDirectoryDragPayload()
+  }
 
   return (
     <li>
       <div
-        className="flex items-center gap-inline-sm rounded-md py-stack-xs pr-inline-sm hover:bg-surface-raised"
+        className={`flex items-center gap-inline-sm rounded-md py-stack-xs pr-inline-sm ${
+          isDropTarget
+            ? 'bg-surface-raised ring-2 ring-inset ring-accent'
+            : 'hover:bg-surface-raised'
+        }`}
         style={{ paddingLeft: depth * 20 + 8 }}
+        onDragOver={handleDragOver}
+        onDragLeave={() => {
+          setIsDropTarget(false)
+        }}
+        onDrop={handleDrop}
       >
         {hasChildren ? (
           <button
@@ -148,21 +273,39 @@ function DirectoryNodeRow({
           </span>
         )}
 
-        {node.record !== null ? (
+        {record !== null ? (
           <>
+            <span
+              draggable
+              onDragStart={(event) => {
+                setDirectoryDragPayload({
+                  id: record.id,
+                  permalink: record.permalink,
+                  label: record.label,
+                })
+                event.dataTransfer.effectAllowed = 'move'
+              }}
+              onDragEnd={() => {
+                clearDirectoryDragPayload()
+              }}
+              aria-label={t('admin.entityRecords.directory.dragHandle', { label: record.label })}
+              className="shrink-0 cursor-grab select-none font-mono text-caption text-text-muted hover:text-text-primary"
+            >
+              ⠿
+            </span>
             <Link
-              to={`/admin/${entityTypeSlug}/${String(node.record.id)}`}
+              to={`/admin/${entityTypeSlug}/${String(record.id)}`}
               className="truncate font-sans text-body text-text-primary hover:text-accent"
             >
-              {node.record.label}
+              {record.label}
             </Link>
             {hasChildren ? (
               <span className="shrink-0 font-mono text-caption text-text-muted">
                 ({node.children.length})
               </span>
             ) : null}
-            <StatusBadge status={node.record.status}>
-              {t(`admin.entityStatus.status.${node.record.status}`)}
+            <StatusBadge status={record.status}>
+              {t(`admin.entityStatus.status.${record.status}`)}
             </StatusBadge>
           </>
         ) : (
@@ -175,10 +318,10 @@ function DirectoryNodeRow({
         )}
 
         <div className="ml-auto flex shrink-0 items-center gap-inline-sm">
-          {node.record !== null && formatDate(node.record.updatedAt, locale) !== '' ? (
+          {record !== null && formatDate(record.updatedAt, locale) !== '' ? (
             <span className="font-sans text-caption text-text-muted">
               {t('admin.entityRecords.list.item.updatedAt', {
-                date: formatDate(node.record.updatedAt, locale),
+                date: formatDate(record.updatedAt, locale),
               })}
             </span>
           ) : null}
@@ -206,6 +349,7 @@ function DirectoryNodeRow({
               entityTypeSlug={entityTypeSlug}
               depth={depth + 1}
               onCreateHere={onCreateHere}
+              onRequestMove={onRequestMove}
             />
           ))}
         </ul>

--- a/frontend/src/features/manage-entities/ui/directory-dnd.test.ts
+++ b/frontend/src/features/manage-entities/ui/directory-dnd.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { canDropInto, type DirectoryDragPayload, moveTargetPermalink } from './directory-dnd'
+
+const payload: DirectoryDragPayload = { id: 1, permalink: '/company/about', label: 'About Us' }
+
+describe('directory-dnd', () => {
+  it('computes the target permalink under a new parent', () => {
+    expect(moveTargetPermalink(payload, '/legal')).toBe('/legal/about')
+    expect(moveTargetPermalink(payload, '/docs/guides')).toBe('/docs/guides/about')
+  })
+
+  it('allows dropping into an unrelated folder', () => {
+    expect(canDropInto(payload, '/legal')).toBe(true)
+  })
+
+  it('rejects dropping onto itself', () => {
+    expect(canDropInto(payload, '/company/about')).toBe(false)
+  })
+
+  it('rejects dropping into its own descendant (would cycle)', () => {
+    expect(canDropInto(payload, '/company/about/team')).toBe(false)
+  })
+
+  it('rejects a no-op drop onto its current parent', () => {
+    // Already at /company/about → dropping onto /company keeps the same permalink.
+    expect(canDropInto(payload, '/company')).toBe(false)
+  })
+})

--- a/frontend/src/features/manage-entities/ui/directory-dnd.ts
+++ b/frontend/src/features/manage-entities/ui/directory-dnd.ts
@@ -1,0 +1,54 @@
+/**
+ * Drag-and-drop payload for moving a directory record under a new parent (#659).
+ * `dataTransfer` is opaque during dragover, so the active payload lives in a
+ * module ref (matches widget-dnd). Only records — not pure folders — are dragged.
+ */
+export interface DirectoryDragPayload {
+  id: number
+  permalink: string
+  label: string
+}
+
+let current: DirectoryDragPayload | null = null
+
+export function setDirectoryDragPayload(payload: DirectoryDragPayload): void {
+  current = payload
+}
+
+export function getDirectoryDragPayload(): DirectoryDragPayload | null {
+  return current
+}
+
+export function clearDirectoryDragPayload(): void {
+  current = null
+}
+
+/** The last path segment of a permalink (`/company/about` → `about`). */
+function lastSegment(permalink: string): string {
+  return (
+    permalink
+      .split('/')
+      .filter((segment) => segment !== '')
+      .pop() ?? ''
+  )
+}
+
+/** The permalink a record would get if moved under `targetPath`. */
+export function moveTargetPermalink(payload: DirectoryDragPayload, targetPath: string): string {
+  return `${targetPath}/${lastSegment(payload.permalink)}`
+}
+
+/**
+ * A node at `targetPath` can receive `payload` when it is neither the record
+ * itself nor one of its descendants (which would orphan / cycle it), and the move
+ * actually changes the permalink (not a drop onto its current parent).
+ */
+export function canDropInto(payload: DirectoryDragPayload, targetPath: string): boolean {
+  if (targetPath === payload.permalink) {
+    return false
+  }
+  if (targetPath.startsWith(`${payload.permalink}/`)) {
+    return false
+  }
+  return moveTargetPermalink(payload, targetPath) !== payload.permalink
+}

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -636,6 +636,14 @@ export const de: Partial<MessageCatalog> = {
   'admin.entityRecords.directory.expand': 'Aufklappen',
   'admin.entityRecords.directory.collapse': 'Zuklappen',
   'admin.entityRecords.directory.newHere': 'Neue Seite unter {{path}}',
+  'admin.entityRecords.directory.dragHandle': '„{{label}}“ zum Verschieben ziehen',
+  'admin.entityRecords.directory.move.confirmTitle': 'Seite verschieben?',
+  'admin.entityRecords.directory.move.confirmBody.one':
+    '„{{label}}“ nach {{target}} verschieben? Die URL ändert sich und eine 301-Weiterleitung vom alten Pfad wird angelegt.',
+  'admin.entityRecords.directory.move.confirmBody.other':
+    '„{{label}}“ nach {{target}} verschieben? {{count}} Seiten erhalten neue URLs, jeweils mit einer 301-Weiterleitung vom alten Pfad.',
+  'admin.entityRecords.directory.move.confirm': 'Verschieben',
+  'admin.entityRecords.directory.move.success': 'Seiten verschoben.',
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Felder',
   'admin.fieldDefs.schemaFor': 'Felder für {{slug}}',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -639,6 +639,14 @@ export const en = {
   'admin.entityRecords.directory.expand': 'Expand',
   'admin.entityRecords.directory.collapse': 'Collapse',
   'admin.entityRecords.directory.newHere': 'New page under {{path}}',
+  'admin.entityRecords.directory.dragHandle': 'Drag to move “{{label}}”',
+  'admin.entityRecords.directory.move.confirmTitle': 'Move page?',
+  'admin.entityRecords.directory.move.confirmBody.one':
+    'Move “{{label}}” to {{target}}? Its URL changes and a 301 redirect from the old path is added.',
+  'admin.entityRecords.directory.move.confirmBody.other':
+    'Move “{{label}}” to {{target}}? {{count}} pages get new URLs, each with a 301 redirect from its old path.',
+  'admin.entityRecords.directory.move.confirm': 'Move',
+  'admin.entityRecords.directory.move.success': 'Pages moved.',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Fields',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -647,6 +647,14 @@ export const fr: Partial<MessageCatalog> = {
   'admin.entityRecords.directory.expand': 'Déplier',
   'admin.entityRecords.directory.collapse': 'Replier',
   'admin.entityRecords.directory.newHere': 'Nouvelle page sous {{path}}',
+  'admin.entityRecords.directory.dragHandle': 'Glisser pour déplacer « {{label}} »',
+  'admin.entityRecords.directory.move.confirmTitle': 'Déplacer la page ?',
+  'admin.entityRecords.directory.move.confirmBody.one':
+    'Déplacer « {{label}} » vers {{target}} ? Son URL change et une redirection 301 depuis l’ancien chemin est ajoutée.',
+  'admin.entityRecords.directory.move.confirmBody.other':
+    'Déplacer « {{label}} » vers {{target}} ? {{count}} pages obtiennent de nouvelles URL, chacune avec une redirection 301 depuis son ancien chemin.',
+  'admin.entityRecords.directory.move.confirm': 'Déplacer',
+  'admin.entityRecords.directory.move.success': 'Pages déplacées.',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Champs',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -635,6 +635,14 @@ export const ja: Partial<MessageCatalog> = {
   'admin.entityRecords.directory.expand': '展開',
   'admin.entityRecords.directory.collapse': '折りたたむ',
   'admin.entityRecords.directory.newHere': '{{path}} に新規ページ',
+  'admin.entityRecords.directory.dragHandle': '「{{label}}」をドラッグして移動',
+  'admin.entityRecords.directory.move.confirmTitle': 'ページを移動しますか？',
+  'admin.entityRecords.directory.move.confirmBody.one':
+    '「{{label}}」を {{target}} へ移動します。URL が変わり、旧パスから301リダイレクトを張ります。',
+  'admin.entityRecords.directory.move.confirmBody.other':
+    '「{{label}}」を {{target}} へ移動します。{{count}} 件のページの URL が変わり、それぞれ旧パスから301リダイレクトを張ります。',
+  'admin.entityRecords.directory.move.confirm': '移動',
+  'admin.entityRecords.directory.move.success': 'ページを移動しました。',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'フィールド',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -640,6 +640,14 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.entityRecords.directory.expand': 'Expandir',
   'admin.entityRecords.directory.collapse': 'Recolher',
   'admin.entityRecords.directory.newHere': 'Nova página em {{path}}',
+  'admin.entityRecords.directory.dragHandle': 'Arraste para mover “{{label}}”',
+  'admin.entityRecords.directory.move.confirmTitle': 'Mover página?',
+  'admin.entityRecords.directory.move.confirmBody.one':
+    'Mover “{{label}}” para {{target}}? A URL muda e um redirecionamento 301 do caminho antigo é adicionado.',
+  'admin.entityRecords.directory.move.confirmBody.other':
+    'Mover “{{label}}” para {{target}}? {{count}} páginas recebem novas URLs, cada uma com um redirecionamento 301 do caminho antigo.',
+  'admin.entityRecords.directory.move.confirm': 'Mover',
+  'admin.entityRecords.directory.move.success': 'Páginas movidas.',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Campos',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -609,6 +609,14 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.entityRecords.directory.expand': '展开',
   'admin.entityRecords.directory.collapse': '折叠',
   'admin.entityRecords.directory.newHere': '在 {{path}} 下新建页面',
+  'admin.entityRecords.directory.dragHandle': '拖动以移动“{{label}}”',
+  'admin.entityRecords.directory.move.confirmTitle': '移动页面？',
+  'admin.entityRecords.directory.move.confirmBody.one':
+    '将“{{label}}”移动到 {{target}}？其 URL 将更改，并从旧路径添加 301 重定向。',
+  'admin.entityRecords.directory.move.confirmBody.other':
+    '将“{{label}}”移动到 {{target}}？{{count}} 个页面将获得新 URL，每个都从旧路径添加 301 重定向。',
+  'admin.entityRecords.directory.move.confirm': '移动',
+  'admin.entityRecords.directory.move.success': '页面已移动。',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': '字段',


### PR DESCRIPTION
## 目的
マイルストーン #1 P2 **#659-A の目玉「DnD 親移動」のフロント**。#666 のサブツリー移動 API に接続。

## 変更
- レコード行の**グリップ(⠿)をドラッグ**して別フォルダ/セクションへ**ドロップ**→ **「{count}件のURLが変わり301を張る」確認ダイアログ**→ `POST /api/v1/entities/{id}/move` を呼び、**サブツリーごと移動**（permalink カスケード＋自動301）。
- `directory-dnd`: ドラッグ payload ストア（widget-dnd 方式）＋ `canDropInto`（自身/子孫への移動・no-op を拒否）＋移動先 permalink 算出。
- `useMoveEntity`: 成功でリスト無効化→ツリー即反映＋ toast。
- ドロップ先の視覚強調、i18n 6言語。

## 検証
`npm run check` 緑。`directory-dnd` 単体テスト＋ `drop→確認ダイアログ表示` テスト。実機でグリップ33個の描画確認。フル DnD の自動E2Eは Playwright のマウス式 `dragTo` が HTML5 drag を発火しない制約のため `fireEvent.drop` で担保。

**これで #659-A（DnD 親移動＋301カスケード）完了**。

Refs #659（残: B 手動並び順、C ツリー内検索）

🤖 Generated with [Claude Code](https://claude.com/claude-code)