### PR TITLE
feat(admin): ディレクトリツリーのインクリメンタル検索＋ハイライト (#659-C)

### DIFF
--- a/frontend/src/features/manage-entities/lib/build-permalink-tree.test.ts
+++ b/frontend/src/features/manage-entities/lib/build-permalink-tree.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { buildPermalinkTree, type DirectoryRecord } from './build-permalink-tree'
+import {
+  buildPermalinkTree,
+  type DirectoryRecord,
+  filterDirectoryTree,
+} from './build-permalink-tree'
 
-function record(id: number, permalink: string): DirectoryRecord {
-  return { id, permalink, label: `Record ${String(id)}`, status: 'published', updatedAt: null }
+function record(id: number, permalink: string, label = `Record ${String(id)}`): DirectoryRecord {
+  return { id, permalink, label, status: 'published', updatedAt: null }
 }
 
 describe('buildPermalinkTree', () => {
@@ -40,5 +44,35 @@ describe('buildPermalinkTree', () => {
     const tree = buildPermalinkTree([record(1, '/company/about'), record(2, '/legal/privacy')])
 
     expect(tree.map((node) => node.segment)).toEqual(['company', 'legal'])
+  })
+})
+
+describe('filterDirectoryTree (#659)', () => {
+  const tree = buildPermalinkTree([
+    record(1, '/company/about', 'About Us'),
+    record(2, '/company/about/team', 'Our Team'),
+    record(3, '/legal/privacy', 'Privacy Policy'),
+  ])
+
+  it('returns the whole tree for an empty query', () => {
+    expect(filterDirectoryTree(tree, '')).toBe(tree)
+  })
+
+  it('keeps only branches whose path matches, preserving ancestors', () => {
+    const filtered = filterDirectoryTree(tree, 'legal')
+    expect(filtered.map((node) => node.segment)).toEqual(['legal'])
+    expect(filtered[0]?.children[0]?.segment).toBe('privacy')
+  })
+
+  it('matches by record label and keeps the ancestor folders', () => {
+    const filtered = filterDirectoryTree(tree, 'our team')
+    expect(filtered.map((node) => node.segment)).toEqual(['company'])
+    const about = filtered[0]?.children[0]
+    expect(about?.segment).toBe('about')
+    expect(about?.children[0]?.record?.label).toBe('Our Team')
+  })
+
+  it('returns an empty tree when nothing matches', () => {
+    expect(filterDirectoryTree(tree, 'nonexistent')).toEqual([])
   })
 })

--- a/frontend/src/features/manage-entities/lib/build-permalink-tree.ts
+++ b/frontend/src/features/manage-entities/lib/build-permalink-tree.ts
@@ -59,3 +59,32 @@ export function buildPermalinkTree(records: DirectoryRecord[]): DirectoryNode[] 
 
   return sortNodes(roots)
 }
+
+/**
+ * Filters a built tree to the branches matching a query (#659): a node is kept
+ * when its path or record label contains the query (case-insensitive), or any
+ * descendant is kept — so a match stays reachable through its ancestors. An empty
+ * query returns the tree unchanged.
+ */
+export function filterDirectoryTree(nodes: DirectoryNode[], query: string): DirectoryNode[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') {
+    return nodes
+  }
+
+  const keep = (node: DirectoryNode): DirectoryNode | null => {
+    const selfMatches =
+      node.path.toLowerCase().includes(needle) ||
+      (node.record?.label.toLowerCase().includes(needle) ?? false)
+    const children = node.children
+      .map(keep)
+      .filter((child): child is DirectoryNode => child !== null)
+
+    if (selfMatches || children.length > 0) {
+      return { ...node, children }
+    }
+    return null
+  }
+
+  return nodes.map(keep).filter((node): node is DirectoryNode => node !== null)
+}

--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.test.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.test.tsx
@@ -103,4 +103,20 @@ describe('EntityDirectoryPanel', () => {
     expect(screen.getByText('Move page?')).toBeInTheDocument()
     expect(screen.getByText(/\/company\/team/)).toBeInTheDocument()
   })
+
+  it('filters the tree as you type, surfacing collapsed matches (#659)', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+    const search = screen.getByPlaceholderText(/Filter by path or title/)
+
+    // `Our Team` sits at depth 2 (normally collapsed); filtering by it forces it open.
+    await user.type(search, 'team')
+    expect(screen.getByRole('link', { name: 'Our Team' })).toBeInTheDocument()
+
+    // A non-matching query hides everything → the no-matches message.
+    await user.clear(search)
+    await user.type(search, 'zzz')
+    expect(screen.getByText(/No pages match/)).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'About Us' })).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
@@ -1,4 +1,4 @@
-import { type DragEvent, useMemo, useState } from 'react'
+import { type DragEvent, type ReactNode, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useMoveEntity } from '@/entities/entity'
 import { useTranslation } from '@/shared/i18n'
@@ -14,6 +14,7 @@ import {
   buildPermalinkTree,
   type DirectoryNode,
   type DirectoryRecord,
+  filterDirectoryTree,
 } from '../lib/build-permalink-tree'
 import {
   canDropInto,
@@ -38,6 +39,27 @@ function formatDate(iso: string | null, locale: string): string {
     month: 'short',
     day: 'numeric',
   }).format(date)
+}
+
+/** Wraps the first case-insensitive match of `query` in `text` for emphasis (#659). */
+function highlightMatch(text: string, query: string): ReactNode {
+  const needle = query.trim()
+  if (needle === '') {
+    return text
+  }
+  const index = text.toLowerCase().indexOf(needle.toLowerCase())
+  if (index === -1) {
+    return text
+  }
+  return (
+    <>
+      {text.slice(0, index)}
+      <mark className="bg-transparent font-semibold text-accent">
+        {text.slice(index, index + needle.length)}
+      </mark>
+      {text.slice(index + needle.length)}
+    </>
+  )
 }
 
 interface PendingMove {
@@ -81,7 +103,9 @@ export function EntityDirectoryPanel({
   const { showToast } = useToast()
   const moveMutation = useMoveEntity()
   const [pendingMove, setPendingMove] = useState<PendingMove | null>(null)
+  const [treeFilter, setTreeFilter] = useState('')
   const tree = useMemo(() => buildPermalinkTree(records), [records])
+  const filteredTree = useMemo(() => filterDirectoryTree(tree, treeFilter), [tree, treeFilter])
 
   if (isLoading) {
     return <LoadingState>{t('admin.entityRecords.list.loading')}</LoadingState>
@@ -148,21 +172,55 @@ export function EntityDirectoryPanel({
           {t('admin.entityRecords.directory.truncated')}
         </p>
       ) : null}
-      <ul
-        className="flex flex-col gap-stack-xs"
-        aria-label={t('admin.entityRecords.view.directory')}
-      >
-        {tree.map((node) => (
-          <DirectoryNodeRow
-            key={node.path}
-            node={node}
-            entityTypeSlug={entityTypeSlug}
-            depth={0}
-            onCreateHere={onCreateHere}
-            onRequestMove={requestMove}
-          />
-        ))}
-      </ul>
+      {/* Tree quick-filter (#659): instant client-side path/title filter over the loaded tree. */}
+      <div className="relative mb-stack-sm">
+        <input
+          type="search"
+          value={treeFilter}
+          onChange={(event) => {
+            setTreeFilter(event.target.value)
+          }}
+          placeholder={t('admin.entityRecords.directory.filter.placeholder')}
+          aria-label={t('admin.entityRecords.directory.filter.placeholder')}
+          className="w-full rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm font-sans text-body text-text-primary shadow-sm focus-visible:shadow-focus focus-visible:outline-none"
+        />
+        {treeFilter !== '' ? (
+          <button
+            type="button"
+            onClick={() => {
+              setTreeFilter('')
+            }}
+            aria-label={t('admin.entityRecords.directory.filter.clear')}
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-text-muted hover:text-text-primary"
+          >
+            ✕
+          </button>
+        ) : null}
+      </div>
+
+      {treeFilter !== '' && filteredTree.length === 0 ? (
+        <p className="font-sans text-body text-text-muted">
+          {t('admin.entityRecords.directory.filter.noMatches', { query: treeFilter })}
+        </p>
+      ) : (
+        <ul
+          className="flex flex-col gap-stack-xs"
+          aria-label={t('admin.entityRecords.view.directory')}
+        >
+          {filteredTree.map((node) => (
+            <DirectoryNodeRow
+              key={node.path}
+              node={node}
+              entityTypeSlug={entityTypeSlug}
+              depth={0}
+              query={treeFilter}
+              forceOpen={treeFilter !== ''}
+              onCreateHere={onCreateHere}
+              onRequestMove={requestMove}
+            />
+          ))}
+        </ul>
+      )}
 
       <ConfirmDialog
         open={pendingMove !== null}
@@ -198,12 +256,16 @@ function DirectoryNodeRow({
   node,
   entityTypeSlug,
   depth,
+  query,
+  forceOpen,
   onCreateHere,
   onRequestMove,
 }: {
   node: DirectoryNode
   entityTypeSlug: string
   depth: number
+  query: string
+  forceOpen: boolean
   onCreateHere: (permalinkPrefix: string) => void
   onRequestMove: (payload: DirectoryDragPayload, targetPath: string) => void
 }) {
@@ -213,6 +275,8 @@ function DirectoryNodeRow({
   const [isDropTarget, setIsDropTarget] = useState(false)
   const hasChildren = node.children.length > 0
   const record = node.record
+  // A tree filter forces every surviving branch open so matches are always shown.
+  const isOpen = forceOpen || open
 
   const handleDragOver = (event: DragEvent<HTMLElement>) => {
     const payload = getDirectoryDragPayload()
@@ -257,15 +321,15 @@ function DirectoryNodeRow({
             onClick={() => {
               setOpen((value) => !value)
             }}
-            aria-expanded={open}
+            aria-expanded={isOpen}
             aria-label={
-              open
+              isOpen
                 ? t('admin.entityRecords.directory.collapse')
                 : t('admin.entityRecords.directory.expand')
             }
             className="shrink-0 font-mono text-caption text-text-muted"
           >
-            {open ? '▾' : '▸'}
+            {isOpen ? '▾' : '▸'}
           </button>
         ) : (
           <span aria-hidden="true" className="shrink-0 font-mono text-caption text-text-muted">
@@ -297,7 +361,7 @@ function DirectoryNodeRow({
               to={`/admin/${entityTypeSlug}/${String(record.id)}`}
               className="truncate font-sans text-body text-text-primary hover:text-accent"
             >
-              {record.label}
+              {highlightMatch(record.label, query)}
             </Link>
             {hasChildren ? (
               <span className="shrink-0 font-mono text-caption text-text-muted">
@@ -310,7 +374,9 @@ function DirectoryNodeRow({
           </>
         ) : (
           <>
-            <span className="font-sans text-body font-medium text-text-muted">{node.segment}/</span>
+            <span className="font-sans text-body font-medium text-text-muted">
+              {highlightMatch(node.segment, query)}/
+            </span>
             <span className="shrink-0 font-mono text-caption text-text-muted">
               ({node.children.length})
             </span>
@@ -325,7 +391,9 @@ function DirectoryNodeRow({
               })}
             </span>
           ) : null}
-          <code className="truncate font-mono text-caption text-text-muted">{node.path}</code>
+          <code className="truncate font-mono text-caption text-text-muted">
+            {highlightMatch(node.path, query)}
+          </code>
           <button
             type="button"
             onClick={() => {
@@ -340,7 +408,7 @@ function DirectoryNodeRow({
         </div>
       </div>
 
-      {hasChildren && open ? (
+      {hasChildren && isOpen ? (
         <ul className="flex flex-col gap-stack-xs">
           {node.children.map((child) => (
             <DirectoryNodeRow
@@ -348,6 +416,8 @@ function DirectoryNodeRow({
               node={child}
               entityTypeSlug={entityTypeSlug}
               depth={depth + 1}
+              query={query}
+              forceOpen={forceOpen}
               onCreateHere={onCreateHere}
               onRequestMove={onRequestMove}
             />

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -644,6 +644,9 @@ export const de: Partial<MessageCatalog> = {
     '„{{label}}“ nach {{target}} verschieben? {{count}} Seiten erhalten neue URLs, jeweils mit einer 301-Weiterleitung vom alten Pfad.',
   'admin.entityRecords.directory.move.confirm': 'Verschieben',
   'admin.entityRecords.directory.move.success': 'Seiten verschoben.',
+  'admin.entityRecords.directory.filter.placeholder': 'Nach Pfad oder Titel filtern…',
+  'admin.entityRecords.directory.filter.noMatches': 'Keine Seiten passen zu „{{query}}“.',
+  'admin.entityRecords.directory.filter.clear': 'Filter zurücksetzen',
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Felder',
   'admin.fieldDefs.schemaFor': 'Felder für {{slug}}',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -647,6 +647,9 @@ export const en = {
     'Move “{{label}}” to {{target}}? {{count}} pages get new URLs, each with a 301 redirect from its old path.',
   'admin.entityRecords.directory.move.confirm': 'Move',
   'admin.entityRecords.directory.move.success': 'Pages moved.',
+  'admin.entityRecords.directory.filter.placeholder': 'Filter by path or title…',
+  'admin.entityRecords.directory.filter.noMatches': 'No pages match “{{query}}”.',
+  'admin.entityRecords.directory.filter.clear': 'Clear filter',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Fields',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -655,6 +655,9 @@ export const fr: Partial<MessageCatalog> = {
     'Déplacer « {{label}} » vers {{target}} ? {{count}} pages obtiennent de nouvelles URL, chacune avec une redirection 301 depuis son ancien chemin.',
   'admin.entityRecords.directory.move.confirm': 'Déplacer',
   'admin.entityRecords.directory.move.success': 'Pages déplacées.',
+  'admin.entityRecords.directory.filter.placeholder': 'Filtrer par chemin ou titre…',
+  'admin.entityRecords.directory.filter.noMatches': 'Aucune page ne correspond à « {{query}} ».',
+  'admin.entityRecords.directory.filter.clear': 'Effacer le filtre',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Champs',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -643,6 +643,9 @@ export const ja: Partial<MessageCatalog> = {
     '「{{label}}」を {{target}} へ移動します。{{count}} 件のページの URL が変わり、それぞれ旧パスから301リダイレクトを張ります。',
   'admin.entityRecords.directory.move.confirm': '移動',
   'admin.entityRecords.directory.move.success': 'ページを移動しました。',
+  'admin.entityRecords.directory.filter.placeholder': 'パスやタイトルで絞り込み…',
+  'admin.entityRecords.directory.filter.noMatches': '「{{query}}」に一致するページはありません。',
+  'admin.entityRecords.directory.filter.clear': '絞り込みをクリア',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'フィールド',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -648,6 +648,9 @@ export const ptBR: Partial<MessageCatalog> = {
     'Mover “{{label}}” para {{target}}? {{count}} páginas recebem novas URLs, cada uma com um redirecionamento 301 do caminho antigo.',
   'admin.entityRecords.directory.move.confirm': 'Mover',
   'admin.entityRecords.directory.move.success': 'Páginas movidas.',
+  'admin.entityRecords.directory.filter.placeholder': 'Filtrar por caminho ou título…',
+  'admin.entityRecords.directory.filter.noMatches': 'Nenhuma página corresponde a “{{query}}”.',
+  'admin.entityRecords.directory.filter.clear': 'Limpar filtro',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': 'Campos',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -617,6 +617,9 @@ export const zhHans: Partial<MessageCatalog> = {
     '将“{{label}}”移动到 {{target}}？{{count}} 个页面将获得新 URL，每个都从旧路径添加 301 重定向。',
   'admin.entityRecords.directory.move.confirm': '移动',
   'admin.entityRecords.directory.move.success': '页面已移动。',
+  'admin.entityRecords.directory.filter.placeholder': '按路径或标题筛选…',
+  'admin.entityRecords.directory.filter.noMatches': '没有页面匹配“{{query}}”。',
+  'admin.entityRecords.directory.filter.clear': '清除筛选',
 
   // ── Field definitions ────────────────────────────────────────────────────
   'admin.fieldDefs.pageTitle': '字段',


### PR DESCRIPTION
## 目的
マイルストーン #1 P2 **#659-C**。ロード済みディレクトリツリーをクライアント側で即時フィルタ（サーバ content 検索とは別の軽量クイックフィルタ）。

## 変更
- ツリー上部に検索入力。**パス/タイトルで増分フィルタ**＋**一致部分をハイライト**。
- 一致枝の**祖先を保持**（到達可能に）、フィルタ中は該当枝を**自動展開**（深い一致もあぶり出す）。一致なしは専用メッセージ。
- `filterDirectoryTree`（純関数）＋ `highlightMatch`＋ `forceOpen`。i18n 6言語。

## 検証
`npm run check` 緑。`filterDirectoryTree` 単体＋パネルのフィルタテスト（折りたたみ一致のあぶり出し・一致なし）。実機で "guide" フィルタ → 18 ハイライトを確認。

Refs #659（残: B 手動並び順）

🤖 Generated with [Claude Code](https://claude.com/claude-code)