### PR TITLE
feat(api): 手動並び順(menu_order)＋並べ替えエンドポイント (#659-B1 backend)

### DIFF
--- a/database/migrations/20260713000000_add_menu_order_to_entities.php
+++ b/database/migrations/20260713000000_add_menu_order_to_entities.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Manual ordering for records (#659): a per-record integer that orders siblings
+ * in the directory tree and public navigation / child-lists, lower first. Defaults
+ * to 0 so existing rows keep their current (path-derived) order until reordered.
+ */
+final class AddMenuOrderToEntities extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('entities')
+            ->addColumn('menu_order', 'integer', [
+                'null' => false,
+                'default' => 0,
+                'after' => 'permalink',
+            ])
+            ->save();
+    }
+}

--- a/database/schema/entities.sql
+++ b/database/schema/entities.sql
@@ -4,6 +4,7 @@ CREATE TABLE entities (
     entity_type_id INTEGER UNSIGNED NOT NULL,
     slug VARCHAR(255) NULL,
     permalink VARCHAR(255) NULL,
+    menu_order INTEGER NOT NULL DEFAULT 0,
     layout VARCHAR(32) NULL,
     status VARCHAR(16) NOT NULL DEFAULT 'draft',
     published_at DATETIME NULL,

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -493,6 +493,47 @@ paths:
                 format: binary
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/entities/reorder:
+    post:
+      tags:
+        - Entities
+      summary: Set manual sibling order
+      description: >
+        Assigns `menu_order = position` to each record id in the given order, so the
+        directory tree and public navigation reflect a manual order (#659).
+      operationId: reorderEntities
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - ids
+              properties:
+                ids:
+                  type: array
+                  items:
+                    type: integer
+                    format: int64
+                  description: Record ids in the desired order.
+      responses:
+        '200':
+          description: Order applied.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - reordered
+                properties:
+                  reordered:
+                    type: integer
+                    description: Number of records whose order was set.
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /api/v1/entities/{id}:
     get:
       tags:
@@ -5343,6 +5384,9 @@ components:
           type:
             - string
             - 'null'
+        menu_order:
+          type: integer
+          description: Manual sibling order in the directory / public nav, lower first (#659).
         excerpt:
           type: string
           description: >-

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -191,6 +191,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/entities/reorder": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Set manual sibling order
+         * @description Assigns `menu_order = position` to each record id in the given order, so the directory tree and public navigation reflect a manual order (#659).
+         */
+        post: operations["reorderEntities"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/entities/{id}": {
         parameters: {
             query?: never;
@@ -2165,6 +2185,8 @@ export interface components {
             deleted_at: string | null;
             meta_title: string | null;
             meta_description: string | null;
+            /** @description Manual sibling order in the directory / public nav, lower first (#659). */
+            menu_order?: number;
             /** @description Server-computed plain-text teaser. Present only when the list is requested with `?include=excerpt` (used by the public feed and post-list widgets). Source/length follow the excerpt_* settings. */
             excerpt?: string;
             /** Format: date-time */
@@ -3602,6 +3624,38 @@ export interface operations {
                     "text/csv": string;
                 };
             };
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    reorderEntities: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Record ids in the desired order. */
+                    ids: number[];
+                };
+            };
+        };
+        responses: {
+            /** @description Order applied. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Number of records whose order was set. */
+                        reordered: number;
+                    };
+                };
+            };
+            422: components["responses"]["ValidationFailed"];
             500: components["responses"]["InternalServerError"];
         };
     };

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -24,6 +24,8 @@ final readonly class Entity
         public ?string $metaDescription = null,
         public ?DateTimeImmutable $scheduledAt = null,
         public ?string $layout = null,
+        /** Manual sibling order in the directory tree / public nav, lower first (#659). */
+        public int $menuOrder = 0,
     ) {
     }
 }

--- a/src/Entity/EntityRepositoryInterface.php
+++ b/src/Entity/EntityRepositoryInterface.php
@@ -35,6 +35,9 @@ interface EntityRepositoryInterface
     /** Rewrite only a record's custom permalink (subtree move, #659). */
     public function updatePermalink(int $id, string $permalink): void;
 
+    /** Set a record's manual sibling order (reorder, #659). */
+    public function updateMenuOrder(int $id, int $menuOrder): void;
+
     public function existsBySlug(string $slug, int $entityTypeId, ?int $excludeId = null): bool;
 
     /** True when another record in the org already owns this custom permalink (#651). */

--- a/src/Entity/EntityRouteRegistrar.php
+++ b/src/Entity/EntityRouteRegistrar.php
@@ -15,6 +15,7 @@ final readonly class EntityRouteRegistrar
         private UpdateEntityHandler $updateHandler,
         private DeleteEntityHandler $deleteHandler,
         private MoveEntityHandler $moveHandler,
+        private ReorderEntitiesHandler $reorderHandler,
         private ListEntitiesHandler $listHandler,
         private ListEntityRevisionsHandler $listRevisionsHandler,
         private ExportEntitiesHandler $exportHandler,
@@ -31,6 +32,7 @@ final readonly class EntityRouteRegistrar
         $updateHandler = $this->updateHandler;
         $deleteHandler = $this->deleteHandler;
         $moveHandler = $this->moveHandler;
+        $reorderHandler = $this->reorderHandler;
         $listHandler = $this->listHandler;
         $listRevisionsHandler = $this->listRevisionsHandler;
         $exportHandler = $this->exportHandler;
@@ -43,6 +45,7 @@ final readonly class EntityRouteRegistrar
         $router->post('/api/v1/entities/process-scheduled', static fn (ServerRequestInterface $request) => $processScheduledHandler->handle($request));
         $router->get('/api/v1/entities/{id}', static fn (ServerRequestInterface $request) => $getHandler->handle($request));
         $router->post('/api/v1/entities', static fn (ServerRequestInterface $request) => $createHandler->handle($request));
+        $router->post('/api/v1/entities/reorder', static fn (ServerRequestInterface $request) => $reorderHandler->handle($request));
         $router->put('/api/v1/entities/{id}', static fn (ServerRequestInterface $request) => $updateHandler->handle($request));
         $router->post('/api/v1/entities/{id}/move', static fn (ServerRequestInterface $request) => $moveHandler->handle($request));
         $router->delete('/api/v1/entities/{id}', static fn (ServerRequestInterface $request) => $deleteHandler->handle($request));

--- a/src/Entity/EntityServiceProvider.php
+++ b/src/Entity/EntityServiceProvider.php
@@ -267,6 +267,35 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                ReorderEntitiesUseCaseInterface::class,
+                static function (ContainerInterface $c): ReorderEntitiesUseCaseInterface {
+                    $entities = $c->get(EntityRepositoryInterface::class);
+
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    return new ReorderEntitiesUseCase($entities);
+                },
+            )
+            ->set(
+                ReorderEntitiesHandler::class,
+                static function (ContainerInterface $c): ReorderEntitiesHandler {
+                    $useCase = $c->get(ReorderEntitiesUseCaseInterface::class);
+                    $response = $c->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ReorderEntitiesUseCaseInterface) {
+                        throw new LogicException('ReorderEntities use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ReorderEntitiesHandler($useCase, $response);
+                },
+            )
+            ->set(
                 DuplicateEntitySlugExceptionHandler::class,
                 static function (ContainerInterface $c): DuplicateEntitySlugExceptionHandler {
                     $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
@@ -453,6 +482,7 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
                     $update = $c->get(UpdateEntityHandler::class);
                     $delete = $c->get(DeleteEntityHandler::class);
                     $move = $c->get(MoveEntityHandler::class);
+                    $reorder = $c->get(ReorderEntitiesHandler::class);
                     $list = $c->get(ListEntitiesHandler::class);
                     $listRevisions = $c->get(ListEntityRevisionsHandler::class);
                     $export = $c->get(ExportEntitiesHandler::class);
@@ -480,6 +510,10 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
                         throw new LogicException('MoveEntity handler service is invalid.');
                     }
 
+                    if (!$reorder instanceof ReorderEntitiesHandler) {
+                        throw new LogicException('ReorderEntities handler service is invalid.');
+                    }
+
                     if (!$list instanceof ListEntitiesHandler) {
                         throw new LogicException('ListEntities handler service is invalid.');
                     }
@@ -504,7 +538,7 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
                         throw new LogicException('ProcessScheduledPublish handler service is invalid.');
                     }
 
-                    return new EntityRouteRegistrar($get, $create, $update, $delete, $move, $list, $listRevisions, $export, $schedule, $unschedule, $processScheduled);
+                    return new EntityRouteRegistrar($get, $create, $update, $delete, $move, $reorder, $list, $listRevisions, $export, $schedule, $unschedule, $processScheduled);
                 },
             );
     }

--- a/src/Entity/ListEntitiesHandler.php
+++ b/src/Entity/ListEntitiesHandler.php
@@ -91,6 +91,7 @@ final readonly class ListEntitiesHandler
                             'updated_at' => $item->updatedAtIso,
                             'meta_title' => $item->metaTitle,
                             'meta_description' => $item->metaDescription,
+                            'menu_order' => $item->menuOrder,
                         ];
                         if ($wantExcerpt) {
                             $row['excerpt'] = $excerptByEntity[$item->id] ?? '';

--- a/src/Entity/ListEntitiesUseCase.php
+++ b/src/Entity/ListEntitiesUseCase.php
@@ -40,6 +40,7 @@ final readonly class ListEntitiesUseCase implements ListEntitiesUseCaseInterface
                 updatedAtIso: $entity->updatedAt?->format(DateTimeInterface::ATOM),
                 metaTitle: $entity->metaTitle,
                 metaDescription: $entity->metaDescription,
+                menuOrder: $entity->menuOrder,
             );
         }, $rows);
 

--- a/src/Entity/ListEntityItem.php
+++ b/src/Entity/ListEntityItem.php
@@ -20,6 +20,7 @@ final readonly class ListEntityItem
         public ?string $updatedAtIso = null,
         public ?string $metaTitle = null,
         public ?string $metaDescription = null,
+        public int $menuOrder = 0,
     ) {
     }
 }

--- a/src/Entity/PdoEntityRepository.php
+++ b/src/Entity/PdoEntityRepository.php
@@ -84,14 +84,14 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
         $prefix = $parentPermalink . '/';
         $rows = $this->query->fetchAll(
             <<<'SQL'
-                SELECT id, entity_type_id, slug, permalink, layout, status, published_at, scheduled_at, is_deleted, created_at, updated_at, deleted_at, meta_title, meta_description
+                SELECT id, entity_type_id, slug, permalink, layout, status, published_at, scheduled_at, is_deleted, created_at, updated_at, deleted_at, meta_title, meta_description, menu_order
                 FROM entities
                 WHERE organization_id = ?
                   AND is_deleted = 0
                   AND status = ?
                   AND permalink LIKE ?
                   AND permalink NOT LIKE ?
-                ORDER BY permalink ASC
+                ORDER BY menu_order ASC, permalink ASC
                 LIMIT ?
                 SQL,
             [$this->orgId->get(), EntityStatus::Published->value, $prefix . '%', $prefix . '%/%', $limit],
@@ -126,6 +126,14 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
         $this->query->execute(
             'UPDATE entities SET permalink = ?, updated_at = NOW() WHERE id = ? AND organization_id = ?',
             [$permalink, $id, $this->orgId->get()],
+        );
+    }
+
+    public function updateMenuOrder(int $id, int $menuOrder): void
+    {
+        $this->query->execute(
+            'UPDATE entities SET menu_order = ?, updated_at = NOW() WHERE id = ? AND organization_id = ?',
+            [$menuOrder, $id, $this->orgId->get()],
         );
     }
 
@@ -196,7 +204,7 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
 
         $rows = $this->query->fetchAll(
             <<<SQL
-                SELECT e.id, e.entity_type_id, e.slug, e.permalink, e.layout, e.status, e.published_at, e.scheduled_at, e.is_deleted, e.created_at, e.updated_at, e.deleted_at, e.meta_title, e.meta_description
+                SELECT e.id, e.entity_type_id, e.slug, e.permalink, e.layout, e.status, e.published_at, e.scheduled_at, e.is_deleted, e.created_at, e.updated_at, e.deleted_at, e.meta_title, e.meta_description, e.menu_order
                 FROM entities e
                 {$titleJoin}
                 WHERE {$where}
@@ -555,6 +563,7 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
             metaDescription: $metaDescription,
             scheduledAt: $scheduledAt,
             layout: $layout,
+            menuOrder: (int) ($row['menu_order'] ?? 0),
         );
     }
 }

--- a/src/Entity/ReorderEntitiesHandler.php
+++ b/src/Entity/ReorderEntitiesHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * `POST /api/v1/entities/reorder` — set the manual sibling order from an ordered
+ * list of record ids (`menu_order = position`). Used by directory drag / up-down
+ * reordering (#659).
+ */
+final readonly class ReorderEntitiesHandler
+{
+    public function __construct(
+        private ReorderEntitiesUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+        $rawIds = $body['ids'] ?? null;
+
+        if (!is_array($rawIds) || $rawIds === []) {
+            throw new ValidationException([
+                new ValidationError('ids', 'A non-empty ordered list of record ids is required.', 'required'),
+            ]);
+        }
+
+        $ids = [];
+        foreach ($rawIds as $rawId) {
+            if (!is_int($rawId) || $rawId <= 0) {
+                throw new ValidationException([
+                    new ValidationError('ids', 'Each id must be a positive integer.', 'invalid'),
+                ]);
+            }
+            $ids[] = $rawId;
+        }
+
+        $output = $this->useCase->execute(new ReorderEntitiesInput($ids));
+
+        return $this->response->create(['reordered' => $output->reordered]);
+    }
+}

--- a/src/Entity/ReorderEntitiesInput.php
+++ b/src/Entity/ReorderEntitiesInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+final readonly class ReorderEntitiesInput
+{
+    /** @param list<int> $ids record ids in the desired order; menu_order = position */
+    public function __construct(
+        public array $ids,
+    ) {
+    }
+}

--- a/src/Entity/ReorderEntitiesOutput.php
+++ b/src/Entity/ReorderEntitiesOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+final readonly class ReorderEntitiesOutput
+{
+    public function __construct(
+        public int $reordered,
+    ) {
+    }
+}

--- a/src/Entity/ReorderEntitiesUseCase.php
+++ b/src/Entity/ReorderEntitiesUseCase.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+/**
+ * Persist a manual sibling order (#659): assign `menu_order = position` to each
+ * record id in the given order. The frontend sends the full reordered sibling
+ * list (after a drag / up-down). Org scoping comes from the repository, so ids
+ * outside the caller's org are silently no-ops.
+ */
+final readonly class ReorderEntitiesUseCase implements ReorderEntitiesUseCaseInterface
+{
+    public function __construct(
+        private EntityRepositoryInterface $entities,
+    ) {
+    }
+
+    public function execute(ReorderEntitiesInput $input): ReorderEntitiesOutput
+    {
+        $position = 0;
+        foreach ($input->ids as $id) {
+            $this->entities->updateMenuOrder($id, $position);
+            $position++;
+        }
+
+        return new ReorderEntitiesOutput(count($input->ids));
+    }
+}

--- a/src/Entity/ReorderEntitiesUseCaseInterface.php
+++ b/src/Entity/ReorderEntitiesUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Entity;
+
+interface ReorderEntitiesUseCaseInterface
+{
+    public function execute(ReorderEntitiesInput $input): ReorderEntitiesOutput;
+}

--- a/tests/BoolField/BoolFieldHttpTest.php
+++ b/tests/BoolField/BoolFieldHttpTest.php
@@ -84,6 +84,7 @@ final class BoolFieldHttpTest extends TestCase
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
+            new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),

--- a/tests/DateTimeField/DateTimeFieldHttpTest.php
+++ b/tests/DateTimeField/DateTimeFieldHttpTest.php
@@ -84,6 +84,7 @@ final class DateTimeFieldHttpTest extends TestCase
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
+            new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),

--- a/tests/Entity/EntityFilterHttpTest.php
+++ b/tests/Entity/EntityFilterHttpTest.php
@@ -72,6 +72,7 @@ final class EntityFilterHttpTest extends TestCase
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
+            new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),

--- a/tests/Entity/EntityHttpTest.php
+++ b/tests/Entity/EntityHttpTest.php
@@ -65,6 +65,7 @@ final class EntityHttpTest extends TestCase
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
+            new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),

--- a/tests/Entity/EntityRevisionHttpTest.php
+++ b/tests/Entity/EntityRevisionHttpTest.php
@@ -65,6 +65,7 @@ final class EntityRevisionHttpTest extends TestCase
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
+            new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),

--- a/tests/Entity/InMemoryEntityRepository.php
+++ b/tests/Entity/InMemoryEntityRepository.php
@@ -122,7 +122,11 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
             $children[] = $entity;
         }
 
-        usort($children, static fn (Entity $a, Entity $b): int => ($a->permalink ?? '') <=> ($b->permalink ?? ''));
+        usort(
+            $children,
+            static fn (Entity $a, Entity $b): int => $a->menuOrder <=> $b->menuOrder
+                ?: (($a->permalink ?? '') <=> ($b->permalink ?? '')),
+        );
 
         return array_slice($children, 0, $limit);
     }
@@ -168,6 +172,30 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
             metaDescription: $existing->metaDescription,
             scheduledAt: $existing->scheduledAt,
             layout: $existing->layout,
+            menuOrder: $existing->menuOrder,
+        );
+    }
+
+    public function updateMenuOrder(int $id, int $menuOrder): void
+    {
+        $existing = $this->entities[$id] ?? null;
+
+        if ($existing === null || $existing->isDeleted) {
+            return;
+        }
+
+        $this->entities[$id] = new Entity(
+            id: $existing->id,
+            entityTypeId: $existing->entityTypeId,
+            slug: $existing->slug,
+            permalink: $existing->permalink,
+            status: $existing->status,
+            publishedAt: $existing->publishedAt,
+            metaTitle: $existing->metaTitle,
+            metaDescription: $existing->metaDescription,
+            scheduledAt: $existing->scheduledAt,
+            layout: $existing->layout,
+            menuOrder: $menuOrder,
         );
     }
 
@@ -380,6 +408,7 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
             metaDescription: $entity->metaDescription,
             scheduledAt: $entity->scheduledAt,
             layout: $entity->layout,
+            menuOrder: $entity->menuOrder,
         );
 
         $this->revisions[] = new \NeNeRecords\Entity\EntityRevision(
@@ -435,6 +464,7 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
             status: $entity->status,
             isDeleted: true,
             deletedAt: new DateTimeImmutable('@1700000000'),
+            menuOrder: $entity->menuOrder,
         );
 
         $this->revisions[] = new \NeNeRecords\Entity\EntityRevision(

--- a/tests/Entity/ReorderEntitiesUseCaseTest.php
+++ b/tests/Entity/ReorderEntitiesUseCaseTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Entity;
+
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\Entity\EntityStatus;
+use NeNeRecords\Entity\ReorderEntitiesInput;
+use NeNeRecords\Entity\ReorderEntitiesUseCase;
+use PHPUnit\Framework\TestCase;
+
+final class ReorderEntitiesUseCaseTest extends TestCase
+{
+    public function testAssignsMenuOrderByPosition(): void
+    {
+        $entities = new InMemoryEntityRepository([
+            new Entity(id: 1, entityTypeId: 1, status: EntityStatus::Published, menuOrder: 9),
+            new Entity(id: 2, entityTypeId: 1, status: EntityStatus::Published, menuOrder: 9),
+            new Entity(id: 3, entityTypeId: 1, status: EntityStatus::Published, menuOrder: 9),
+        ]);
+        $useCase = new ReorderEntitiesUseCase($entities);
+
+        $output = $useCase->execute(new ReorderEntitiesInput([3, 1, 2]));
+
+        self::assertSame(3, $output->reordered);
+        self::assertSame(0, $entities->findById(3)?->menuOrder);
+        self::assertSame(1, $entities->findById(1)?->menuOrder);
+        self::assertSame(2, $entities->findById(2)?->menuOrder);
+    }
+}

--- a/tests/Entity/ScheduledPublishHttpTest.php
+++ b/tests/Entity/ScheduledPublishHttpTest.php
@@ -65,6 +65,7 @@ final class ScheduledPublishHttpTest extends TestCase
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
+            new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),

--- a/tests/EnumField/EnumFieldHttpTest.php
+++ b/tests/EnumField/EnumFieldHttpTest.php
@@ -84,6 +84,7 @@ final class EnumFieldHttpTest extends TestCase
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
+            new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),

--- a/tests/IntField/IntFieldHttpTest.php
+++ b/tests/IntField/IntFieldHttpTest.php
@@ -84,6 +84,7 @@ final class IntFieldHttpTest extends TestCase
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
+            new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),

--- a/tests/TextField/TextFieldHttpTest.php
+++ b/tests/TextField/TextFieldHttpTest.php
@@ -83,6 +83,7 @@ final class TextFieldHttpTest extends TestCase
             new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
+            new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
             new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, $this->textFields, $this->factory),


### PR DESCRIPTION
## 目的
マイルストーン #1 P2 **#659-B（手動並び順 / WP menu_order 相当）のバックエンド**。

## 変更
- **migration 20260713**: entities に `menu_order INT NOT NULL DEFAULT 0`（テスト用 `database/schema/entities.sql` にも追加）。
- 兄弟順を **`menu_order ASC, permalink ASC`** に（`findDirectChildrenByPermalink` = 公開子一覧／ナビ）。`Entity` / `ListEntityItem` / list に `menuOrder` を透過（フロントのツリーソート用）。
- **`POST /api/v1/entities/reorder`** `{ ids: [...] }` → `menu_order = 位置` を一括設定。`updateMenuOrder`（permalink 同様の軽量 write）。menu_order は **reorder 経由のみ**更新（create/update は DB default / 保持）。

## 検証
`composer check` 緑。`ReorderEntitiesUseCaseTest`（位置→menu_order 割当）。OpenAPI 更新＋FE型再生成。

Refs #659（残: B2 フロントの並べ替え UI＋ツリーソート）

🤖 Generated with [Claude Code](https://claude.com/claude-code)