### PR TITLE
feat(admin): ディレクトリの手動並べ替え ▲▼ (#659-B2) — #659 完了

### DIFF
--- a/frontend/src/entities/entity/api-types.ts
+++ b/frontend/src/entities/entity/api-types.ts
@@ -16,6 +16,8 @@ export interface EntityDto {
   deleted_at: string | null
   meta_title: string | null
   meta_description: string | null
+  /** Manual sibling order in the directory / public nav, lower first (#659). */
+  menu_order?: number | null
   /** Server-computed teaser; present only when listed with `?include=excerpt`. */
   excerpt?: string | null
   created_at: string | null

--- a/frontend/src/entities/entity/index.ts
+++ b/frontend/src/entities/entity/index.ts
@@ -26,6 +26,7 @@ export {
   useDeleteEntity,
   useGeneratePreviewToken,
   useMoveEntity,
+  useReorderEntities,
   useRevokePreviewToken,
   useScheduleEntity,
   useUnscheduleEntity,

--- a/frontend/src/entities/entity/mapper.test.ts
+++ b/frontend/src/entities/entity/mapper.test.ts
@@ -34,6 +34,7 @@ describe('entity mapper', () => {
       deletedAt: null,
       metaTitle: null,
       metaDescription: null,
+      menuOrder: 0,
       createdAt: null,
       updatedAt: null,
     })

--- a/frontend/src/entities/entity/mapper.ts
+++ b/frontend/src/entities/entity/mapper.ts
@@ -34,6 +34,7 @@ export function mapEntityDtoToModel(dto: EntityDto): Entity {
     deletedAt: dto.deleted_at,
     metaTitle: dto.meta_title,
     metaDescription: dto.meta_description,
+    menuOrder: dto.menu_order ?? 0,
     ...(dto.excerpt !== undefined ? { excerpt: dto.excerpt } : {}),
     createdAt: dto.created_at,
     updatedAt: dto.updated_at,

--- a/frontend/src/entities/entity/model.ts
+++ b/frontend/src/entities/entity/model.ts
@@ -18,6 +18,8 @@ export interface Entity {
   deletedAt: string | null
   metaTitle: string | null
   metaDescription: string | null
+  /** Manual sibling order in the directory / public nav, lower first (#659). */
+  menuOrder: number
   /** Server-computed teaser; present only when listed with `include=excerpt`. */
   excerpt?: string | null
   createdAt: string | null

--- a/frontend/src/entities/entity/mutations.ts
+++ b/frontend/src/entities/entity/mutations.ts
@@ -128,6 +128,27 @@ export function useMoveEntity(): UseMutationResult<
   })
 }
 
+/**
+ * Persist a manual sibling order (#659): send record ids in their new order and
+ * the backend writes `menu_order = position`. Invalidate the lists so the tree
+ * re-sorts.
+ */
+export function useReorderEntities(): UseMutationResult<void, AppError, { ids: number[] }> {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ ids }) => {
+      await apiClient.post('/api/v1/entities/reorder', { ids })
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: entityKeys.lists() }),
+        invalidatePublicFeeds(queryClient),
+      ])
+    },
+  })
+}
+
 export function useDeleteEntity(): UseMutationResult<
   void,
   AppError,

--- a/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
+++ b/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
@@ -158,6 +158,7 @@ export function useManageEntitiesPage(entityTypeId: number) {
           label: getRecordDisplayLabel(Number(entity.id), textFields, fallback),
           status: entity.status,
           updatedAt: entity.updatedAt,
+          menuOrder: entity.menuOrder,
         }
       })
   }, [directoryQuery.data?.items, textFieldQuery.data?.items])

--- a/frontend/src/features/manage-entities/lib/build-permalink-tree.test.ts
+++ b/frontend/src/features/manage-entities/lib/build-permalink-tree.test.ts
@@ -6,7 +6,7 @@ import {
 } from './build-permalink-tree'
 
 function record(id: number, permalink: string, label = `Record ${String(id)}`): DirectoryRecord {
-  return { id, permalink, label, status: 'published', updatedAt: null }
+  return { id, permalink, label, status: 'published', updatedAt: null, menuOrder: 0 }
 }
 
 describe('buildPermalinkTree', () => {

--- a/frontend/src/features/manage-entities/lib/build-permalink-tree.ts
+++ b/frontend/src/features/manage-entities/lib/build-permalink-tree.ts
@@ -6,6 +6,7 @@ export interface DirectoryRecord {
   label: string
   status: EntityStatus
   updatedAt: string | null
+  menuOrder: number
 }
 
 export interface DirectoryNode {
@@ -19,7 +20,12 @@ export interface DirectoryNode {
 }
 
 function sortNodes(nodes: DirectoryNode[]): DirectoryNode[] {
-  nodes.sort((a, b) => a.segment.localeCompare(b.segment))
+  // Manual order first (records carrying a menu_order), then alphabetical by
+  // segment for ties / pure folders (#659).
+  nodes.sort(
+    (a, b) =>
+      (a.record?.menuOrder ?? 0) - (b.record?.menuOrder ?? 0) || a.segment.localeCompare(b.segment),
+  )
   for (const node of nodes) {
     sortNodes(node.children)
   }

--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.test.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.test.tsx
@@ -13,13 +13,21 @@ afterEach(() => {
 })
 
 const RECORDS: DirectoryRecord[] = [
-  { id: 1, permalink: '/company/about', label: 'About Us', status: 'published', updatedAt: null },
+  {
+    id: 1,
+    permalink: '/company/about',
+    label: 'About Us',
+    status: 'published',
+    updatedAt: null,
+    menuOrder: 0,
+  },
   {
     id: 2,
     permalink: '/company/about/team',
     label: 'Our Team',
     status: 'draft',
     updatedAt: '2026-06-20T00:00:00Z',
+    menuOrder: 0,
   },
 ]
 
@@ -118,5 +126,36 @@ describe('EntityDirectoryPanel', () => {
     await user.type(search, 'zzz')
     expect(screen.getByText(/No pages match/)).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'About Us' })).not.toBeInTheDocument()
+  })
+
+  it('shows up/down reorder controls for sibling records, disabled at the edges (#659)', () => {
+    const siblings: DirectoryRecord[] = [
+      {
+        id: 10,
+        permalink: '/docs/alpha',
+        label: 'Alpha',
+        status: 'published',
+        updatedAt: null,
+        menuOrder: 0,
+      },
+      {
+        id: 11,
+        permalink: '/docs/beta',
+        label: 'Beta',
+        status: 'published',
+        updatedAt: null,
+        menuOrder: 1,
+      },
+    ]
+    renderPanel({ records: siblings })
+
+    const upButtons = screen.getAllByRole('button', { name: 'Move up' })
+    const downButtons = screen.getAllByRole('button', { name: 'Move down' })
+    expect(upButtons).toHaveLength(2)
+    expect(downButtons).toHaveLength(2)
+    // First record can't move up; last can't move down.
+    expect(upButtons[0]).toBeDisabled()
+    expect(downButtons[1]).toBeDisabled()
+    expect(downButtons[0]).toBeEnabled()
   })
 })

--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
@@ -1,6 +1,6 @@
 import { type DragEvent, type ReactNode, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { useMoveEntity } from '@/entities/entity'
+import { useMoveEntity, useReorderEntities } from '@/entities/entity'
 import { useTranslation } from '@/shared/i18n'
 import {
   ConfirmDialog,
@@ -21,6 +21,7 @@ import {
   clearDirectoryDragPayload,
   type DirectoryDragPayload,
   getDirectoryDragPayload,
+  moveInOrder,
   moveTargetPermalink,
   setDirectoryDragPayload,
 } from './directory-dnd'
@@ -102,6 +103,7 @@ export function EntityDirectoryPanel({
   const { t } = useTranslation()
   const { showToast } = useToast()
   const moveMutation = useMoveEntity()
+  const reorderMutation = useReorderEntities()
   const [pendingMove, setPendingMove] = useState<PendingMove | null>(null)
   const [treeFilter, setTreeFilter] = useState('')
   const tree = useMemo(() => buildPermalinkTree(records), [records])
@@ -165,6 +167,10 @@ export function EntityDirectoryPanel({
     )
   }
 
+  const reorderSiblings = (ids: number[]) => {
+    reorderMutation.mutate({ ids })
+  }
+
   return (
     <div>
       {truncated ? (
@@ -211,12 +217,14 @@ export function EntityDirectoryPanel({
             <DirectoryNodeRow
               key={node.path}
               node={node}
+              siblings={filteredTree}
               entityTypeSlug={entityTypeSlug}
               depth={0}
               query={treeFilter}
               forceOpen={treeFilter !== ''}
               onCreateHere={onCreateHere}
               onRequestMove={requestMove}
+              onReorder={reorderSiblings}
             />
           ))}
         </ul>
@@ -254,20 +262,25 @@ export function EntityDirectoryPanel({
 
 function DirectoryNodeRow({
   node,
+  siblings,
   entityTypeSlug,
   depth,
   query,
   forceOpen,
   onCreateHere,
   onRequestMove,
+  onReorder,
 }: {
   node: DirectoryNode
+  /** The sibling array this node belongs to (for manual up/down reorder). */
+  siblings: DirectoryNode[]
   entityTypeSlug: string
   depth: number
   query: string
   forceOpen: boolean
   onCreateHere: (permalinkPrefix: string) => void
   onRequestMove: (payload: DirectoryDragPayload, targetPath: string) => void
+  onReorder: (orderedRecordIds: number[]) => void
 }) {
   const { t, locale } = useTranslation()
   // Initially expand only the top level — a deep tree is otherwise a wall of rows (#657).
@@ -277,6 +290,20 @@ function DirectoryNodeRow({
   const record = node.record
   // A tree filter forces every surviving branch open so matches are always shown.
   const isOpen = forceOpen || open
+
+  // Manual reorder (#659) operates on RECORD siblings only (pure folders have no
+  // menu_order); disabled while a filter is active to avoid reordering a subset.
+  const recordSiblings = siblings.filter((sibling) => sibling.record !== null)
+  const recordIndex = recordSiblings.findIndex((sibling) => sibling.record?.id === record?.id)
+  const canReorder =
+    record !== null && query === '' && recordSiblings.length > 1 && recordIndex !== -1
+
+  const reorderTo = (delta: number) => {
+    const ids = recordSiblings
+      .map((sibling) => sibling.record?.id)
+      .filter((id): id is number => id !== undefined)
+    onReorder(moveInOrder(ids, recordIndex, delta))
+  }
 
   const handleDragOver = (event: DragEvent<HTMLElement>) => {
     const payload = getDirectoryDragPayload()
@@ -394,6 +421,34 @@ function DirectoryNodeRow({
           <code className="truncate font-mono text-caption text-text-muted">
             {highlightMatch(node.path, query)}
           </code>
+          {canReorder ? (
+            <>
+              <button
+                type="button"
+                disabled={recordIndex === 0}
+                onClick={() => {
+                  reorderTo(-1)
+                }}
+                aria-label={t('admin.entityRecords.directory.moveUp')}
+                title={t('admin.entityRecords.directory.moveUp')}
+                className="shrink-0 rounded px-0.5 font-mono text-caption text-text-muted hover:text-accent disabled:cursor-not-allowed disabled:opacity-30"
+              >
+                ▲
+              </button>
+              <button
+                type="button"
+                disabled={recordIndex === recordSiblings.length - 1}
+                onClick={() => {
+                  reorderTo(1)
+                }}
+                aria-label={t('admin.entityRecords.directory.moveDown')}
+                title={t('admin.entityRecords.directory.moveDown')}
+                className="shrink-0 rounded px-0.5 font-mono text-caption text-text-muted hover:text-accent disabled:cursor-not-allowed disabled:opacity-30"
+              >
+                ▼
+              </button>
+            </>
+          ) : null}
           <button
             type="button"
             onClick={() => {
@@ -414,12 +469,14 @@ function DirectoryNodeRow({
             <DirectoryNodeRow
               key={child.path}
               node={child}
+              siblings={node.children}
               entityTypeSlug={entityTypeSlug}
               depth={depth + 1}
               query={query}
               forceOpen={forceOpen}
               onCreateHere={onCreateHere}
               onRequestMove={onRequestMove}
+              onReorder={onReorder}
             />
           ))}
         </ul>

--- a/frontend/src/features/manage-entities/ui/directory-dnd.test.ts
+++ b/frontend/src/features/manage-entities/ui/directory-dnd.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { canDropInto, type DirectoryDragPayload, moveTargetPermalink } from './directory-dnd'
+import {
+  canDropInto,
+  type DirectoryDragPayload,
+  moveInOrder,
+  moveTargetPermalink,
+} from './directory-dnd'
 
 const payload: DirectoryDragPayload = { id: 1, permalink: '/company/about', label: 'About Us' }
 
@@ -24,5 +29,18 @@ describe('directory-dnd', () => {
   it('rejects a no-op drop onto its current parent', () => {
     // Already at /company/about → dropping onto /company keeps the same permalink.
     expect(canDropInto(payload, '/company')).toBe(false)
+  })
+})
+
+describe('moveInOrder (#659)', () => {
+  it('moves an item up and down among its siblings', () => {
+    expect(moveInOrder([1, 2, 3], 1, -1)).toEqual([2, 1, 3])
+    expect(moveInOrder([1, 2, 3], 1, 1)).toEqual([1, 3, 2])
+  })
+
+  it('returns the input unchanged for out-of-range moves', () => {
+    const ids = [1, 2, 3]
+    expect(moveInOrder(ids, 0, -1)).toBe(ids)
+    expect(moveInOrder(ids, 2, 1)).toBe(ids)
   })
 })

--- a/frontend/src/features/manage-entities/ui/directory-dnd.ts
+++ b/frontend/src/features/manage-entities/ui/directory-dnd.ts
@@ -52,3 +52,18 @@ export function canDropInto(payload: DirectoryDragPayload, targetPath: string): 
   }
   return moveTargetPermalink(payload, targetPath) !== payload.permalink
 }
+
+/**
+ * The new ordering after moving the item at `index` by `delta` positions (#659).
+ * Out-of-range moves return the input unchanged.
+ */
+export function moveInOrder(ids: number[], index: number, delta: number): number[] {
+  const moved = ids[index]
+  const to = index + delta
+  if (moved === undefined || to < 0 || to >= ids.length) {
+    return ids
+  }
+  const next = ids.filter((_, i) => i !== index)
+  next.splice(to, 0, moved)
+  return next
+}

--- a/frontend/src/features/manage-entity-status/hooks/useEntityStatusPanel.test.ts
+++ b/frontend/src/features/manage-entity-status/hooks/useEntityStatusPanel.test.ts
@@ -20,6 +20,7 @@ function makeEntity(overrides: Partial<Entity> = {}): Entity {
     deletedAt: null,
     metaTitle: 'SEO Title',
     metaDescription: 'SEO Description',
+    menuOrder: 0,
     createdAt: null,
     updatedAt: null,
     ...overrides,

--- a/frontend/src/features/manage-entity-status/ui/EntityStatusPanel.test.tsx
+++ b/frontend/src/features/manage-entity-status/ui/EntityStatusPanel.test.tsx
@@ -22,6 +22,7 @@ function makeEntity(overrides: Partial<Entity> = {}): Entity {
     deletedAt: null,
     metaTitle: null,
     metaDescription: null,
+    menuOrder: 0,
     createdAt: null,
     updatedAt: null,
     ...overrides,

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -644,6 +644,8 @@ export const de: Partial<MessageCatalog> = {
     '„{{label}}“ nach {{target}} verschieben? {{count}} Seiten erhalten neue URLs, jeweils mit einer 301-Weiterleitung vom alten Pfad.',
   'admin.entityRecords.directory.move.confirm': 'Verschieben',
   'admin.entityRecords.directory.move.success': 'Seiten verschoben.',
+  'admin.entityRecords.directory.moveUp': 'Nach oben',
+  'admin.entityRecords.directory.moveDown': 'Nach unten',
   'admin.entityRecords.directory.filter.placeholder': 'Nach Pfad oder Titel filtern…',
   'admin.entityRecords.directory.filter.noMatches': 'Keine Seiten passen zu „{{query}}“.',
   'admin.entityRecords.directory.filter.clear': 'Filter zurücksetzen',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -647,6 +647,8 @@ export const en = {
     'Move “{{label}}” to {{target}}? {{count}} pages get new URLs, each with a 301 redirect from its old path.',
   'admin.entityRecords.directory.move.confirm': 'Move',
   'admin.entityRecords.directory.move.success': 'Pages moved.',
+  'admin.entityRecords.directory.moveUp': 'Move up',
+  'admin.entityRecords.directory.moveDown': 'Move down',
   'admin.entityRecords.directory.filter.placeholder': 'Filter by path or title…',
   'admin.entityRecords.directory.filter.noMatches': 'No pages match “{{query}}”.',
   'admin.entityRecords.directory.filter.clear': 'Clear filter',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -655,6 +655,8 @@ export const fr: Partial<MessageCatalog> = {
     'Déplacer « {{label}} » vers {{target}} ? {{count}} pages obtiennent de nouvelles URL, chacune avec une redirection 301 depuis son ancien chemin.',
   'admin.entityRecords.directory.move.confirm': 'Déplacer',
   'admin.entityRecords.directory.move.success': 'Pages déplacées.',
+  'admin.entityRecords.directory.moveUp': 'Monter',
+  'admin.entityRecords.directory.moveDown': 'Descendre',
   'admin.entityRecords.directory.filter.placeholder': 'Filtrer par chemin ou titre…',
   'admin.entityRecords.directory.filter.noMatches': 'Aucune page ne correspond à « {{query}} ».',
   'admin.entityRecords.directory.filter.clear': 'Effacer le filtre',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -643,6 +643,8 @@ export const ja: Partial<MessageCatalog> = {
     '「{{label}}」を {{target}} へ移動します。{{count}} 件のページの URL が変わり、それぞれ旧パスから301リダイレクトを張ります。',
   'admin.entityRecords.directory.move.confirm': '移動',
   'admin.entityRecords.directory.move.success': 'ページを移動しました。',
+  'admin.entityRecords.directory.moveUp': '上へ',
+  'admin.entityRecords.directory.moveDown': '下へ',
   'admin.entityRecords.directory.filter.placeholder': 'パスやタイトルで絞り込み…',
   'admin.entityRecords.directory.filter.noMatches': '「{{query}}」に一致するページはありません。',
   'admin.entityRecords.directory.filter.clear': '絞り込みをクリア',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -648,6 +648,8 @@ export const ptBR: Partial<MessageCatalog> = {
     'Mover “{{label}}” para {{target}}? {{count}} páginas recebem novas URLs, cada uma com um redirecionamento 301 do caminho antigo.',
   'admin.entityRecords.directory.move.confirm': 'Mover',
   'admin.entityRecords.directory.move.success': 'Páginas movidas.',
+  'admin.entityRecords.directory.moveUp': 'Mover para cima',
+  'admin.entityRecords.directory.moveDown': 'Mover para baixo',
   'admin.entityRecords.directory.filter.placeholder': 'Filtrar por caminho ou título…',
   'admin.entityRecords.directory.filter.noMatches': 'Nenhuma página corresponde a “{{query}}”.',
   'admin.entityRecords.directory.filter.clear': 'Limpar filtro',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -617,6 +617,8 @@ export const zhHans: Partial<MessageCatalog> = {
     '将“{{label}}”移动到 {{target}}？{{count}} 个页面将获得新 URL，每个都从旧路径添加 301 重定向。',
   'admin.entityRecords.directory.move.confirm': '移动',
   'admin.entityRecords.directory.move.success': '页面已移动。',
+  'admin.entityRecords.directory.moveUp': '上移',
+  'admin.entityRecords.directory.moveDown': '下移',
   'admin.entityRecords.directory.filter.placeholder': '按路径或标题筛选…',
   'admin.entityRecords.directory.filter.noMatches': '没有页面匹配“{{query}}”。',
   'admin.entityRecords.directory.filter.clear': '清除筛选',


### PR DESCRIPTION
## 目的
マイルストーン #1 P2 **#659-B2（手動並び順の UI）**。#669 の `/reorder` API＋ `menu_order` ソートに接続。**これで #659 完了**。

## 変更
- 各**記事行に ▲▼**。記事の**兄弟間**で前後入替→ `POST /reorder` で `menu_order=位置` を保存。
- ツリーを **`menu_order` 昇順（同値は segment）**でソート（公開ナビ/子一覧は #669 で反映済）。
- 純フォルダ（index ページ無し）はスキップ、**フィルタ中は無効化**（部分集合の誤並べ替え防止）。
- entity 層に `menuOrder` を透過（`EntityDto?`/model/mapper）＋ `useReorderEntities`。並べ替え算出を純関数 `moveInOrder` に。i18n 6言語。

## 検証
`npm run check` 緑。`moveInOrder` 単体テスト＋ ▲▼ の表示/端無効テスト。実機で ▲▼ 32対の描画確認。

選択肢A（上下ボタン）で実装。ドロップ間 DnD（#659-A の親移動と判定衝突）は将来拡張。

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)