### PR TITLE
feat(admin): 公開階層の磨き込み（開閉記憶・パス視認性・a11y） (#660)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -2,14 +2,15 @@
 
 Last updated: 2026-06-27
 
-## 短期TODO（directory-view レビュー由来・2026-06-27 / milestone「ページ階層/ディレクトリ 仕上げ」#1）
+## 短期TODO（directory-view レビュー由来・2026-06-27 / milestone「ページ階層/ディレクトリ 仕上げ」#1 — 完了）
 
-> 議事: `docs/review/directory-view-personas-2026-06-27.md`。マイルストーン #1 を**端から対応**。
-> - [ ] **#656 P0**: 公開 custom-permalink ページを実SPAで解決・描画（最優先・実バグ＝SSRは正・SPAルータが任意パス未解決）
-> - [ ] **#657 P1**: ディレクトリ表示拡充（status フィルタ復活・更新日・子件数・初期折りたたみ）＋ titleless fallback の humanize 統一
-> - [ ] **#658 P1**: ページ作成/整理の WP 同等 UX（permalink 接頭辞補完・手動並び順）
-> - [ ] **#659 P2**: DnD 親移動＋自動301・ツリー内検索・「＋ここに新規」（満場一致の目玉）
-> - [ ] **#660 P2**: 公開階層の磨き込み（セクションindex 自動生成・パス視認性・開閉記憶・a11y）
+> 議事: `docs/review/directory-view-personas-2026-06-27.md`。**マイルストーン #1 完了**（P0＋全P1＋目玉P2 着地）。
+> - [x] **#656 P0**: 公開 custom-permalink ページを実SPAで解決・描画（#663・実機確認済）
+> - [x] **#657 P1**: ディレクトリ表示拡充＋ titleless fallback humanize 統一（#664）
+> - [x] **#658 P1**: 「＋ここに新規」permalink 接頭辞補完（#665。手動並び順は #659 へ統合）
+> - [x] **#659 P2**: DnD 親移動＋自動301／ツリー内検索＋ハイライト／手動並び順 ▲▼＋menu_order（#666–#670）
+> - [x] **#660 P2**: 磨き込み — パス視認性・フォルダ開閉記憶・a11y フォーカス・sitemap（custom-permalink 掲載）確認済
+> - 残: **#671** phantom セグメントのセクションindex 自動生成（機能規模のため #660 から分離）。全 PR は `main` 反映のみ＝**本番デプロイ未**（本番に custom-permalink ページが無く非緊急）。
 
 ## 状態サマリー
 

--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.test.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.test.tsx
@@ -158,4 +158,31 @@ describe('EntityDirectoryPanel', () => {
     expect(downButtons[1]).toBeDisabled()
     expect(downButtons[0]).toBeEnabled()
   })
+
+  it('remembers the open/closed folder state across a data refresh (#660)', async () => {
+    const user = userEvent.setup()
+    const ui = (records: DirectoryRecord[]) => (
+      <MemoryRouter>
+        <EntityDirectoryPanel
+          entityTypeSlug="pages"
+          records={records}
+          truncated={false}
+          isLoading={false}
+          isError={false}
+          errorTitle={null}
+          onRetry={() => {}}
+          onCreateHere={() => {}}
+        />
+      </MemoryRouter>
+    )
+    const { rerender } = renderWithProviders(ui(RECORDS))
+
+    // `company` is open by default → collapse it.
+    await user.click(screen.getByRole('button', { name: 'Collapse' }))
+    expect(screen.queryByRole('link', { name: 'About Us' })).not.toBeInTheDocument()
+
+    // A refetch passes a fresh records array — the collapse must persist.
+    rerender(ui([...RECORDS]))
+    expect(screen.queryByRole('link', { name: 'About Us' })).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
@@ -106,6 +106,9 @@ export function EntityDirectoryPanel({
   const reorderMutation = useReorderEntities()
   const [pendingMove, setPendingMove] = useState<PendingMove | null>(null)
   const [treeFilter, setTreeFilter] = useState('')
+  // Remember which folders the user opened/closed so the state survives refetches
+  // (e.g. after a move / reorder) — keyed by path (#660).
+  const [openOverrides, setOpenOverrides] = useState<Map<string, boolean>>(() => new Map())
   const tree = useMemo(() => buildPermalinkTree(records), [records])
   const filteredTree = useMemo(() => filterDirectoryTree(tree, treeFilter), [tree, treeFilter])
 
@@ -171,6 +174,14 @@ export function EntityDirectoryPanel({
     reorderMutation.mutate({ ids })
   }
 
+  const toggleOpen = (path: string, currentlyOpen: boolean) => {
+    setOpenOverrides((prev) => {
+      const next = new Map(prev)
+      next.set(path, !currentlyOpen)
+      return next
+    })
+  }
+
   return (
     <div>
       {truncated ? (
@@ -222,9 +233,11 @@ export function EntityDirectoryPanel({
               depth={0}
               query={treeFilter}
               forceOpen={treeFilter !== ''}
+              openOverrides={openOverrides}
               onCreateHere={onCreateHere}
               onRequestMove={requestMove}
               onReorder={reorderSiblings}
+              onToggle={toggleOpen}
             />
           ))}
         </ul>
@@ -267,9 +280,11 @@ function DirectoryNodeRow({
   depth,
   query,
   forceOpen,
+  openOverrides,
   onCreateHere,
   onRequestMove,
   onReorder,
+  onToggle,
 }: {
   node: DirectoryNode
   /** The sibling array this node belongs to (for manual up/down reorder). */
@@ -278,13 +293,16 @@ function DirectoryNodeRow({
   depth: number
   query: string
   forceOpen: boolean
+  /** Persisted per-path open/closed overrides (#660). */
+  openOverrides: Map<string, boolean>
   onCreateHere: (permalinkPrefix: string) => void
   onRequestMove: (payload: DirectoryDragPayload, targetPath: string) => void
   onReorder: (orderedRecordIds: number[]) => void
+  onToggle: (path: string, currentlyOpen: boolean) => void
 }) {
   const { t, locale } = useTranslation()
-  // Initially expand only the top level — a deep tree is otherwise a wall of rows (#657).
-  const [open, setOpen] = useState(depth === 0)
+  // Initially expand only the top level; remember user toggles across refetches (#657, #660).
+  const open = openOverrides.get(node.path) ?? depth === 0
   const [isDropTarget, setIsDropTarget] = useState(false)
   const hasChildren = node.children.length > 0
   const record = node.record
@@ -346,7 +364,7 @@ function DirectoryNodeRow({
           <button
             type="button"
             onClick={() => {
-              setOpen((value) => !value)
+              onToggle(node.path, open)
             }}
             aria-expanded={isOpen}
             aria-label={
@@ -354,7 +372,7 @@ function DirectoryNodeRow({
                 ? t('admin.entityRecords.directory.collapse')
                 : t('admin.entityRecords.directory.expand')
             }
-            className="shrink-0 font-mono text-caption text-text-muted"
+            className="shrink-0 rounded font-mono text-caption text-text-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
           >
             {isOpen ? '▾' : '▸'}
           </button>
@@ -418,7 +436,7 @@ function DirectoryNodeRow({
               })}
             </span>
           ) : null}
-          <code className="truncate font-mono text-caption text-text-muted">
+          <code title={node.path} className="truncate font-mono text-caption text-text-muted">
             {highlightMatch(node.path, query)}
           </code>
           {canReorder ? (
@@ -431,7 +449,7 @@ function DirectoryNodeRow({
                 }}
                 aria-label={t('admin.entityRecords.directory.moveUp')}
                 title={t('admin.entityRecords.directory.moveUp')}
-                className="shrink-0 rounded px-0.5 font-mono text-caption text-text-muted hover:text-accent disabled:cursor-not-allowed disabled:opacity-30"
+                className="shrink-0 rounded px-0.5 font-mono text-caption text-text-muted hover:text-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-30"
               >
                 ▲
               </button>
@@ -443,7 +461,7 @@ function DirectoryNodeRow({
                 }}
                 aria-label={t('admin.entityRecords.directory.moveDown')}
                 title={t('admin.entityRecords.directory.moveDown')}
-                className="shrink-0 rounded px-0.5 font-mono text-caption text-text-muted hover:text-accent disabled:cursor-not-allowed disabled:opacity-30"
+                className="shrink-0 rounded px-0.5 font-mono text-caption text-text-muted hover:text-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-30"
               >
                 ▼
               </button>
@@ -456,7 +474,7 @@ function DirectoryNodeRow({
             }}
             aria-label={t('admin.entityRecords.directory.newHere', { path: node.path })}
             title={t('admin.entityRecords.directory.newHere', { path: node.path })}
-            className="shrink-0 rounded px-1 font-mono text-body text-text-muted hover:bg-surface-raised hover:text-accent"
+            className="shrink-0 rounded px-1 font-mono text-body text-text-muted hover:bg-surface-raised hover:text-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
           >
             +
           </button>
@@ -474,9 +492,11 @@ function DirectoryNodeRow({
               depth={depth + 1}
               query={query}
               forceOpen={forceOpen}
+              openOverrides={openOverrides}
               onCreateHere={onCreateHere}
               onRequestMove={onRequestMove}
               onReorder={onReorder}
+              onToggle={onToggle}
             />
           ))}
         </ul>


### PR DESCRIPTION
## 目的
マイルストーン #1 **最後の #660（公開階層の磨き込み）**。

## 変更
- **フォルダ開閉記憶**: open/closed を path 単位で保持し、move/reorder の refetch をまたいで維持（毎回 top-level だけに戻らない）。
- **パス視認性**: 各行 path に `title`（truncate 時もフルパスをホバー確認）。
- **a11y**: トグル/＋/▲▼ に `focus-visible` リング（キーボード操作を可視化）。
- **sitemap**: 調査で custom-permalink ページが**実パーマリンクで掲載済**を確認（修正不要）。

## スコープ
**セクションindex 自動生成は機能規模（合成ページ機構が net-new）のため #671 に分離。** 本PRで #660 の磨き込みは完了。`current.md` の短期TODO をマイルストーン #1 完了で更新。

## 検証
`npm run check` 緑。開閉記憶の **refetch 跨ぎ persistence テスト**追加。

Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)