### PR TITLE
feat(admin): ディレクトリのドロップ間 DnD 並べ替え (R4 #675)

### DIFF
--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
@@ -20,9 +20,12 @@ import {
   canDropInto,
   clearDirectoryDragPayload,
   type DirectoryDragPayload,
+  dropPosition,
   getDirectoryDragPayload,
   moveInOrder,
   moveTargetPermalink,
+  parentPath,
+  reorderByInsert,
   setDirectoryDragPayload,
 } from './directory-dnd'
 
@@ -303,7 +306,7 @@ function DirectoryNodeRow({
   const { t, locale } = useTranslation()
   // Initially expand only the top level; remember user toggles across refetches (#657, #660).
   const open = openOverrides.get(node.path) ?? depth === 0
-  const [isDropTarget, setIsDropTarget] = useState(false)
+  const [dropMode, setDropMode] = useState<'into' | 'before' | 'after' | null>(null)
   const hasChildren = node.children.length > 0
   const record = node.record
   // A tree filter forces every surviving branch open so matches are always shown.
@@ -323,25 +326,55 @@ function DirectoryNodeRow({
     onReorder(moveInOrder(ids, recordIndex, delta))
   }
 
-  const handleDragOver = (event: DragEvent<HTMLElement>) => {
+  // Resolve the drop intent from the pointer (#675): the top/bottom edge of a
+  // SIBLING record reorders before/after it; the middle (or any non-sibling row)
+  // moves into the folder. Reorder is suppressed while a filter is active.
+  const resolveDropMode = (event: DragEvent<HTMLElement>): 'into' | 'before' | 'after' | null => {
     const payload = getDirectoryDragPayload()
-    if (payload === null || !canDropInto(payload, node.path)) {
+    if (payload === null) {
+      return null
+    }
+    const targetId = record?.id
+    const canReorderHere =
+      query === '' &&
+      targetId !== undefined &&
+      targetId !== payload.id &&
+      parentPath(payload.permalink) === parentPath(node.path)
+    const rect = event.currentTarget.getBoundingClientRect()
+    const position = dropPosition(event.clientY, rect.top, rect.height)
+    if (canReorderHere && (position === 'before' || position === 'after')) {
+      return position
+    }
+    return canDropInto(payload, node.path) ? 'into' : null
+  }
+
+  const handleDragOver = (event: DragEvent<HTMLElement>) => {
+    const mode = resolveDropMode(event)
+    if (mode === null) {
       return
     }
     event.preventDefault()
     event.stopPropagation()
-    setIsDropTarget(true)
+    setDropMode(mode)
   }
 
   const handleDrop = (event: DragEvent<HTMLElement>) => {
     const payload = getDirectoryDragPayload()
-    setIsDropTarget(false)
-    if (payload === null || !canDropInto(payload, node.path)) {
+    const mode = resolveDropMode(event)
+    setDropMode(null)
+    if (payload === null || mode === null) {
       return
     }
     event.preventDefault()
     event.stopPropagation()
-    onRequestMove(payload, node.path)
+    if (mode === 'into') {
+      onRequestMove(payload, node.path)
+    } else if (record !== null) {
+      const ids = recordSiblings
+        .map((sibling) => sibling.record?.id)
+        .filter((id): id is number => id !== undefined)
+      onReorder(reorderByInsert(ids, payload.id, record.id, mode))
+    }
     clearDirectoryDragPayload()
   }
 
@@ -349,14 +382,18 @@ function DirectoryNodeRow({
     <li>
       <div
         className={`flex items-center gap-inline-sm rounded-md py-stack-xs pr-inline-sm ${
-          isDropTarget
+          dropMode === 'into'
             ? 'bg-surface-raised ring-2 ring-inset ring-accent'
-            : 'hover:bg-surface-raised'
+            : dropMode === 'before'
+              ? 'border-t-2 border-accent'
+              : dropMode === 'after'
+                ? 'border-b-2 border-accent'
+                : 'hover:bg-surface-raised'
         }`}
         style={{ paddingLeft: depth * 20 + 8 }}
         onDragOver={handleDragOver}
         onDragLeave={() => {
-          setIsDropTarget(false)
+          setDropMode(null)
         }}
         onDrop={handleDrop}
       >

--- a/frontend/src/features/manage-entities/ui/directory-dnd.test.ts
+++ b/frontend/src/features/manage-entities/ui/directory-dnd.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest'
 import {
   canDropInto,
   type DirectoryDragPayload,
+  dropPosition,
   moveInOrder,
   moveTargetPermalink,
+  parentPath,
+  reorderByInsert,
 } from './directory-dnd'
 
 const payload: DirectoryDragPayload = { id: 1, permalink: '/company/about', label: 'About Us' }
@@ -42,5 +45,23 @@ describe('moveInOrder (#659)', () => {
     const ids = [1, 2, 3]
     expect(moveInOrder(ids, 0, -1)).toBe(ids)
     expect(moveInOrder(ids, 2, 1)).toBe(ids)
+  })
+})
+
+describe('drop-between reorder (#675)', () => {
+  it('computes the parent path', () => {
+    expect(parentPath('/company/about')).toBe('/company')
+    expect(parentPath('/about')).toBe('')
+  })
+
+  it('reads the drop position from the pointer Y within a row', () => {
+    expect(dropPosition(2, 0, 20)).toBe('before') // top 10%
+    expect(dropPosition(10, 0, 20)).toBe('middle') // 50%
+    expect(dropPosition(18, 0, 20)).toBe('after') // bottom 90%
+  })
+
+  it('reorders by inserting before/after a target sibling', () => {
+    expect(reorderByInsert([1, 2, 3], 1, 2, 'after')).toEqual([2, 1, 3])
+    expect(reorderByInsert([1, 2, 3], 3, 1, 'before')).toEqual([3, 1, 2])
   })
 })

--- a/frontend/src/features/manage-entities/ui/directory-dnd.ts
+++ b/frontend/src/features/manage-entities/ui/directory-dnd.ts
@@ -67,3 +67,50 @@ export function moveInOrder(ids: number[], index: number, delta: number): number
   next.splice(to, 0, moved)
   return next
 }
+
+/** The parent path of a permalink (`/company/about` → `/company`; top-level → ``). */
+export function parentPath(permalink: string): string {
+  const index = permalink.lastIndexOf('/')
+  return index <= 0 ? '' : permalink.slice(0, index)
+}
+
+/**
+ * Where a drop lands within a row by pointer Y (#675): the top/bottom edge (30%)
+ * means "reorder before/after this sibling"; the middle means "move into".
+ */
+export function dropPosition(
+  clientY: number,
+  top: number,
+  height: number,
+): 'before' | 'middle' | 'after' {
+  if (height <= 0) {
+    return 'middle'
+  }
+  const ratio = (clientY - top) / height
+  if (ratio < 0.3) {
+    return 'before'
+  }
+  if (ratio > 0.7) {
+    return 'after'
+  }
+  return 'middle'
+}
+
+/**
+ * The new id ordering after moving `movedId` to just before/after `targetId`
+ * within a sibling list (#675). Returns the input unchanged if target is absent.
+ */
+export function reorderByInsert(
+  ids: number[],
+  movedId: number,
+  targetId: number,
+  position: 'before' | 'after',
+): number[] {
+  const without = ids.filter((id) => id !== movedId)
+  const targetIndex = without.indexOf(targetId)
+  if (targetIndex === -1) {
+    return ids
+  }
+  without.splice(position === 'before' ? targetIndex : targetIndex + 1, 0, movedId)
+  return without
+}


### PR DESCRIPTION
## 目的
改修後再評価 **R4 の本体**＝ペルソナ「本命」の**ドロップ間 DnD 並べ替え**（▲▼ の正式版）。**一括＝#678／Undo＝#679 に分離**。

## 変更
- 1つの DnD で**移動と並べ替えを共存**（ファイラ標準）：対象行の**中央=フォルダへ移動**（既存 #659-A・リング）／**上端=兄弟の前に挿入**（上に線）／**下端=後に挿入**（下に線）。
- 並べ替えは**同一親の兄弟レコード間**で `/reorder`(#669) に接続。フィルタ中は抑止。
- `directory-dnd`: `parentPath` / `dropPosition`（ポインタY→before/middle/after）/ `reorderByInsert`（純関数）。`DirectoryNodeRow`: `dropMode` 判定＋視覚インジケータ。▲▼ は a11y 用に維持。

## 検証
`npm run check` 緑。3ヘルパーの単体テスト。move(into) は従来どおり。フル DnD の自動E2Eは Playwright 制約のため単体で担保。

Closes #675（残: 一括 #678・Undo #679）

🤖 Generated with [Claude Code](https://claude.com/claude-code)