### PR TITLE
feat(admin): ディレクトリ行に閲覧数(30日)を表示 (R2 #674)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -5393,6 +5393,12 @@ components:
             Server-computed plain-text teaser. Present only when the list is
             requested with `?include=excerpt` (used by the public feed and
             post-list widgets). Source/length follow the excerpt_* settings.
+        view_count:
+          type: integer
+          description: >-
+            View count over the last 30 days (same metric as the analytics
+            "popular" view). Present only when the list is requested with
+            `?include=views` (used by the admin directory). (#674)
         created_at:
           type:
             - string

--- a/frontend/src/entities/entity/api-types.ts
+++ b/frontend/src/entities/entity/api-types.ts
@@ -20,6 +20,8 @@ export interface EntityDto {
   menu_order?: number | null
   /** Server-computed teaser; present only when listed with `?include=excerpt`. */
   excerpt?: string | null
+  /** View count over the last 30 days; present only when listed with `?include=views` (#674). */
+  view_count?: number | null
   created_at: string | null
   updated_at: string | null
 }

--- a/frontend/src/entities/entity/mapper.ts
+++ b/frontend/src/entities/entity/mapper.ts
@@ -36,6 +36,9 @@ export function mapEntityDtoToModel(dto: EntityDto): Entity {
     metaDescription: dto.meta_description,
     menuOrder: dto.menu_order ?? 0,
     ...(dto.excerpt !== undefined ? { excerpt: dto.excerpt } : {}),
+    ...(dto.view_count !== undefined && dto.view_count !== null
+      ? { viewCount: dto.view_count }
+      : {}),
     createdAt: dto.created_at,
     updatedAt: dto.updated_at,
   }

--- a/frontend/src/entities/entity/model.ts
+++ b/frontend/src/entities/entity/model.ts
@@ -22,6 +22,8 @@ export interface Entity {
   menuOrder: number
   /** Server-computed teaser; present only when listed with `include=excerpt`. */
   excerpt?: string | null
+  /** View count over the last 30 days; present only when listed with `include=views` (#674). */
+  viewCount?: number
   createdAt: string | null
   updatedAt: string | null
 }

--- a/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
+++ b/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
@@ -85,6 +85,8 @@ export function useManageEntitiesPage(entityTypeId: number) {
         sortOrder,
       ),
       limit: DIRECTORY_FETCH_LIMIT,
+      // Attach per-record view counts so the directory can show readership (#674).
+      include: 'views',
     }),
     [
       entityTypeId,
@@ -159,6 +161,7 @@ export function useManageEntitiesPage(entityTypeId: number) {
           status: entity.status,
           updatedAt: entity.updatedAt,
           menuOrder: entity.menuOrder,
+          viewCount: entity.viewCount ?? 0,
         }
       })
   }, [directoryQuery.data?.items, textFieldQuery.data?.items])

--- a/frontend/src/features/manage-entities/lib/build-permalink-tree.ts
+++ b/frontend/src/features/manage-entities/lib/build-permalink-tree.ts
@@ -7,6 +7,8 @@ export interface DirectoryRecord {
   status: EntityStatus
   updatedAt: string | null
   menuOrder: number
+  /** View count over the last 30 days (#674). */
+  viewCount?: number
 }
 
 export interface DirectoryNode {

--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
@@ -466,6 +466,14 @@ function DirectoryNodeRow({
         )}
 
         <div className="ml-auto flex shrink-0 items-center gap-inline-sm">
+          {record !== null && (record.viewCount ?? 0) > 0 ? (
+            <span
+              className="font-sans text-caption text-text-muted"
+              title={t('admin.entityRecords.directory.views', { count: record.viewCount ?? 0 })}
+            >
+              👁 {record.viewCount ?? 0}
+            </span>
+          ) : null}
           {record !== null && formatDate(record.updatedAt, locale) !== '' ? (
             <span className="font-sans text-caption text-text-muted">
               {t('admin.entityRecords.list.item.updatedAt', {

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -2189,6 +2189,8 @@ export interface components {
             menu_order?: number;
             /** @description Server-computed plain-text teaser. Present only when the list is requested with `?include=excerpt` (used by the public feed and post-list widgets). Source/length follow the excerpt_* settings. */
             excerpt?: string;
+            /** @description View count over the last 30 days (same metric as the analytics "popular" view). Present only when the list is requested with `?include=views` (used by the admin directory). (#674) */
+            view_count?: number;
             /** Format: date-time */
             created_at: string | null;
             /** Format: date-time */

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -646,6 +646,7 @@ export const de: Partial<MessageCatalog> = {
   'admin.entityRecords.directory.move.success': 'Seiten verschoben.',
   'admin.entityRecords.directory.moveUp': 'Nach oben',
   'admin.entityRecords.directory.moveDown': 'Nach unten',
+  'admin.entityRecords.directory.views': 'Aufrufe (30 T.): {{count}}',
   'admin.entityRecords.directory.filter.placeholder': 'Nach Pfad oder Titel filtern…',
   'admin.entityRecords.directory.filter.noMatches': 'Keine Seiten passen zu „{{query}}“.',
   'admin.entityRecords.directory.filter.clear': 'Filter zurücksetzen',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -649,6 +649,7 @@ export const en = {
   'admin.entityRecords.directory.move.success': 'Pages moved.',
   'admin.entityRecords.directory.moveUp': 'Move up',
   'admin.entityRecords.directory.moveDown': 'Move down',
+  'admin.entityRecords.directory.views': 'Views (30d): {{count}}',
   'admin.entityRecords.directory.filter.placeholder': 'Filter by path or title…',
   'admin.entityRecords.directory.filter.noMatches': 'No pages match “{{query}}”.',
   'admin.entityRecords.directory.filter.clear': 'Clear filter',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -657,6 +657,7 @@ export const fr: Partial<MessageCatalog> = {
   'admin.entityRecords.directory.move.success': 'Pages déplacées.',
   'admin.entityRecords.directory.moveUp': 'Monter',
   'admin.entityRecords.directory.moveDown': 'Descendre',
+  'admin.entityRecords.directory.views': 'Vues (30 j) : {{count}}',
   'admin.entityRecords.directory.filter.placeholder': 'Filtrer par chemin ou titre…',
   'admin.entityRecords.directory.filter.noMatches': 'Aucune page ne correspond à « {{query}} ».',
   'admin.entityRecords.directory.filter.clear': 'Effacer le filtre',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -645,6 +645,7 @@ export const ja: Partial<MessageCatalog> = {
   'admin.entityRecords.directory.move.success': 'ページを移動しました。',
   'admin.entityRecords.directory.moveUp': '上へ',
   'admin.entityRecords.directory.moveDown': '下へ',
+  'admin.entityRecords.directory.views': '閲覧数（30日）: {{count}}',
   'admin.entityRecords.directory.filter.placeholder': 'パスやタイトルで絞り込み…',
   'admin.entityRecords.directory.filter.noMatches': '「{{query}}」に一致するページはありません。',
   'admin.entityRecords.directory.filter.clear': '絞り込みをクリア',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -650,6 +650,7 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.entityRecords.directory.move.success': 'Páginas movidas.',
   'admin.entityRecords.directory.moveUp': 'Mover para cima',
   'admin.entityRecords.directory.moveDown': 'Mover para baixo',
+  'admin.entityRecords.directory.views': 'Visualizações (30 d): {{count}}',
   'admin.entityRecords.directory.filter.placeholder': 'Filtrar por caminho ou título…',
   'admin.entityRecords.directory.filter.noMatches': 'Nenhuma página corresponde a “{{query}}”.',
   'admin.entityRecords.directory.filter.clear': 'Limpar filtro',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -619,6 +619,7 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.entityRecords.directory.move.success': '页面已移动。',
   'admin.entityRecords.directory.moveUp': '上移',
   'admin.entityRecords.directory.moveDown': '下移',
+  'admin.entityRecords.directory.views': '浏览量（30天）：{{count}}',
   'admin.entityRecords.directory.filter.placeholder': '按路径或标题筛选…',
   'admin.entityRecords.directory.filter.noMatches': '没有页面匹配“{{query}}”。',
   'admin.entityRecords.directory.filter.clear': '清除筛选',

--- a/src/Entity/EntityServiceProvider.php
+++ b/src/Entity/EntityServiceProvider.php
@@ -11,6 +11,7 @@ use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Analytics\AccessLogRepositoryInterface;
 use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
 use NeNeRecords\Organization\OrganizationIterator;
 use NeNeRecords\Setting\SettingRepositoryInterface;
@@ -153,7 +154,13 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Entity repository service is invalid.');
                     }
 
-                    return new ListEntitiesUseCase($repository);
+                    $accessLogs = $c->get(AccessLogRepositoryInterface::class);
+
+                    if (!$accessLogs instanceof AccessLogRepositoryInterface) {
+                        throw new LogicException('Access log repository service is invalid.');
+                    }
+
+                    return new ListEntitiesUseCase($repository, $accessLogs);
                 },
             )
             ->set(

--- a/src/Entity/ListEntitiesHandler.php
+++ b/src/Entity/ListEntitiesHandler.php
@@ -51,6 +51,14 @@ final readonly class ListEntitiesHandler
         $rawOrder = $request->getQueryParams()['order'] ?? null;
         $sortOrder = is_string($rawOrder) ? (EntitySortOrder::tryFrom($rawOrder) ?? EntitySortOrder::Desc) : EntitySortOrder::Desc;
 
+        // `?include=excerpt,views` opt-ins: `excerpt` adds a server-computed teaser
+        // (public feed / post-list widgets); `views` adds a per-record view count
+        // (#674). Off by default so the admin list stays lean.
+        $rawInclude = $request->getQueryParams()['include'] ?? '';
+        $includes = is_string($rawInclude) ? explode(',', $rawInclude) : [];
+        $wantExcerpt = in_array('excerpt', $includes, true);
+        $wantViews = in_array('views', $includes, true);
+
         $output = $this->useCase->execute(new ListEntitiesInput(
             limit: $pagination->limit,
             offset: $pagination->offset,
@@ -65,18 +73,15 @@ final readonly class ListEntitiesHandler
                 publishedFrom: $publishedFrom,
                 publishedToExclusive: $publishedToExclusive,
             ),
+            includeViews: $wantViews,
         ));
 
-        // `?include=excerpt` adds a server-computed teaser (used by the public
-        // feed and post-list widgets). Off by default so the admin list stays lean.
-        $include = $request->getQueryParams()['include'] ?? '';
-        $wantExcerpt = is_string($include) && in_array('excerpt', explode(',', $include), true);
         $excerptByEntity = $wantExcerpt ? $this->excerpts->resolve($output->items) : [];
 
         return $this->response->create(
             (new PaginationResponse(
                 items: array_map(
-                    function (ListEntityItem $item) use ($wantExcerpt, $excerptByEntity) {
+                    function (ListEntityItem $item) use ($wantExcerpt, $excerptByEntity, $wantViews) {
                         $row = [
                             'id' => $item->id,
                             'entity_type_id' => $item->entityTypeId,
@@ -95,6 +100,9 @@ final readonly class ListEntitiesHandler
                         ];
                         if ($wantExcerpt) {
                             $row['excerpt'] = $excerptByEntity[$item->id] ?? '';
+                        }
+                        if ($wantViews) {
+                            $row['view_count'] = $item->viewCount;
                         }
 
                         return $row;

--- a/src/Entity/ListEntitiesInput.php
+++ b/src/Entity/ListEntitiesInput.php
@@ -10,6 +10,8 @@ final readonly class ListEntitiesInput
         public int $limit = 20,
         public int $offset = 0,
         public EntityListCriteria $criteria = new EntityListCriteria(),
+        /** When true, populate each item's viewCount (opt-in, #674). */
+        public bool $includeViews = false,
     ) {
     }
 }

--- a/src/Entity/ListEntitiesUseCase.php
+++ b/src/Entity/ListEntitiesUseCase.php
@@ -4,13 +4,20 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Entity;
 
+use DateTimeImmutable;
 use DateTimeInterface;
 use LogicException;
+use NeNeRecords\Analytics\AccessLogRepositoryInterface;
 
 final readonly class ListEntitiesUseCase implements ListEntitiesUseCaseInterface
 {
+    /** Rolling window for the opt-in per-record view counts (#674). */
+    private const VIEW_WINDOW_DAYS = 30;
+
     public function __construct(
         private EntityRepositoryInterface $entities,
+        /** Optional — enables `includeViews` (per-record view counts, #674). */
+        private ?AccessLogRepositoryInterface $accessLogs = null,
     ) {
     }
 
@@ -19,7 +26,17 @@ final readonly class ListEntitiesUseCase implements ListEntitiesUseCaseInterface
         $rows = $this->entities->findByCriteria($input->criteria, $input->limit, $input->offset);
         $total = $this->entities->countByCriteria($input->criteria);
 
-        $items = array_map(static function (Entity $entity): ListEntityItem {
+        // Per-record view counts (#674) — the same metric as the analytics "popular"
+        // view. Opt-in so only callers that ask for it pay the GROUP BY aggregation.
+        $viewCounts = [];
+        if ($input->includeViews && $this->accessLogs !== null) {
+            $sinceDate = (new DateTimeImmutable())
+                ->modify(sprintf('-%d days', self::VIEW_WINDOW_DAYS - 1))
+                ->format('Y-m-d');
+            $viewCounts = $this->accessLogs->aggregateEntityViews($sinceDate);
+        }
+
+        $items = array_map(static function (Entity $entity) use ($viewCounts): ListEntityItem {
             $entityId = $entity->id;
 
             if ($entityId === null) {
@@ -41,6 +58,7 @@ final readonly class ListEntitiesUseCase implements ListEntitiesUseCaseInterface
                 metaTitle: $entity->metaTitle,
                 metaDescription: $entity->metaDescription,
                 menuOrder: $entity->menuOrder,
+                viewCount: $viewCounts[$entityId] ?? 0,
             );
         }, $rows);
 

--- a/src/Entity/ListEntityItem.php
+++ b/src/Entity/ListEntityItem.php
@@ -21,6 +21,7 @@ final readonly class ListEntityItem
         public ?string $metaTitle = null,
         public ?string $metaDescription = null,
         public int $menuOrder = 0,
+        public int $viewCount = 0,
     ) {
     }
 }

--- a/tests/Entity/ListEntitiesUseCaseTest.php
+++ b/tests/Entity/ListEntitiesUseCaseTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Entity;
+
+use DateTimeImmutable;
+use NeNeRecords\Analytics\AccessLogEntry;
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\Entity\EntityStatus;
+use NeNeRecords\Entity\ListEntitiesInput;
+use NeNeRecords\Entity\ListEntitiesUseCase;
+use NeNeRecords\Tests\Analytics\InMemoryAccessLogRepository;
+use PHPUnit\Framework\TestCase;
+
+final class ListEntitiesUseCaseTest extends TestCase
+{
+    private function hit(string $path): AccessLogEntry
+    {
+        return new AccessLogEntry(
+            requestId: null,
+            method: 'GET',
+            path: $path,
+            statusCode: 200,
+            durationMs: 1.0,
+            accessedAt: new DateTimeImmutable(),
+        );
+    }
+
+    public function testPopulatesPerEntityViewCountsWhenIncludeViewsIsSet(): void
+    {
+        $entities = new InMemoryEntityRepository([
+            new Entity(id: 1, entityTypeId: 1, permalink: '/a', status: EntityStatus::Published),
+            new Entity(id: 2, entityTypeId: 1, permalink: '/b', status: EntityStatus::Published),
+        ]);
+        $accessLogs = new InMemoryAccessLogRepository();
+        $accessLogs->insert($this->hit('/api/v1/entities/1'));
+        $accessLogs->insert($this->hit('/api/v1/entities/1'));
+        $accessLogs->insert($this->hit('/api/v1/entities/2'));
+        // A nested path must NOT count as a view of entity 1.
+        $accessLogs->insert($this->hit('/api/v1/entities/1/revisions'));
+
+        $useCase = new ListEntitiesUseCase($entities, $accessLogs);
+
+        $output = $useCase->execute(new ListEntitiesInput(includeViews: true));
+
+        $viewCountById = [];
+        foreach ($output->items as $item) {
+            $viewCountById[$item->id] = $item->viewCount;
+        }
+        self::assertSame(2, $viewCountById[1] ?? null);
+        self::assertSame(1, $viewCountById[2] ?? null);
+    }
+
+    public function testLeavesViewCountsAtZeroByDefault(): void
+    {
+        $entities = new InMemoryEntityRepository([
+            new Entity(id: 1, entityTypeId: 1, permalink: '/a', status: EntityStatus::Published),
+        ]);
+        $accessLogs = new InMemoryAccessLogRepository();
+        $accessLogs->insert($this->hit('/api/v1/entities/1'));
+
+        $useCase = new ListEntitiesUseCase($entities, $accessLogs);
+
+        // No includeViews → the GROUP BY is skipped and every viewCount stays 0.
+        $output = $useCase->execute(new ListEntitiesInput());
+
+        self::assertSame(0, $output->items[0]->viewCount ?? null);
+    }
+}


### PR DESCRIPTION
## 目的
再評価 **R2**（運用ペルソナ一致要望「どのセクション/記事が読まれているか」）。

## 変更
- 既存の analytics 集計 **`AccessLogRepository::aggregateEntityViews`**（=「人気エンティティ」と同じ指標・`/api/v1/entities/{id}` GET ヒット）をディレクトリに配線。新規トラッキング不要。
- **opt-in**: `?include=views`（`?include=excerpt` と同方式）＝**ディレクトリのクエリだけが GROUP BY を負担**、他の list 呼び出しは無コスト。
- 直近 **30日**の閲覧数を行に **👁 N**（0 は非表示）。i18n 6言語。
- 型を OpenAPI→`schema.gen` まで反映（entity DTO は手書き api-types も更新）。

## スコープ注記
指標は既存「人気」と同一（`/api/v1/entities/{id}` ヒット）。公開readership の厳密計測は別軸の analytics 改善で、本PRは**既存メトリクスの可視化**。

## 検証
`composer check`（1123 tests）/ `npm run check` 緑。`ListEntitiesUseCaseTest` 追加（ネストパス非カウント・既定 0）。

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)