### PR TITLE
fix(admin): ディレクトリの100件上限を解消（全permalink記事をページング取得） (#682)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -353,6 +353,15 @@ paths:
             type: string
             minLength: 1
           description: Full-text search across slug and text field values (partial match).
+        - name: has_permalink
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: ['1']
+          description: >-
+            When `1`, restrict to records carrying a non-empty custom permalink.
+            Used by the admin directory to page through only the records it renders (#682).
         - name: published_from
           in: query
           required: false

--- a/frontend/src/entities/entity/index.ts
+++ b/frontend/src/entities/entity/index.ts
@@ -33,7 +33,9 @@ export {
   useUpdateEntity,
 } from './mutations'
 export {
+  DIRECTORY_MAX_RECORDS,
   defaultEntityListParams,
+  useDirectoryEntityList,
   useEntitiesByDateRange,
   useEntitiesByTag,
   useEntity,

--- a/frontend/src/entities/entity/queries.test.tsx
+++ b/frontend/src/entities/entity/queries.test.tsx
@@ -1,0 +1,60 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { useDirectoryEntityList } from './queries'
+import { resetEntityStore, seedEntities } from '@tests/msw/handlers/entity'
+import { mswServer } from '@tests/msw/server'
+
+function freshClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+describe('useDirectoryEntityList (#682)', () => {
+  beforeAll(() => {
+    mswServer.listen()
+  })
+  afterEach(() => {
+    mswServer.resetHandlers()
+    resetEntityStore()
+  })
+  afterAll(() => {
+    mswServer.close()
+  })
+
+  it('pages through every record (100 at a time) to build the complete directory set', async () => {
+    seedEntities(
+      Array.from({ length: 250 }, (_, i) => ({
+        id: i + 1,
+        entity_type_id: 1,
+        is_deleted: false,
+        deleted_at: null,
+      })),
+    )
+    const client = freshClient()
+
+    const { result } = renderHook(
+      () =>
+        useDirectoryEntityList({
+          entityTypeId: 1,
+          tagSlugs: [],
+          relationFilters: {},
+          limit: 20,
+          offset: 0,
+        }),
+      {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <QueryClientProvider client={client}>{children}</QueryClientProvider>
+        ),
+      },
+    )
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+    // All 250 records arrive across 3 pages — no silent first-100 cut-off (#682).
+    expect(result.current.data?.items).toHaveLength(250)
+    expect(result.current.data?.total).toBe(250)
+    expect(result.current.data?.truncated).toBe(false)
+  })
+})

--- a/frontend/src/entities/entity/queries.ts
+++ b/frontend/src/entities/entity/queries.ts
@@ -12,6 +12,33 @@ import { entityKeys, type EntityListParams } from './query-keys'
 
 const DEFAULT_LIST_PARAMS = { limit: 20, offset: 0 } as const
 
+/** Append the shared list filters (status / tags / q / sort / relations / include). */
+function appendEntityListFilters(search: URLSearchParams, params: EntityListParams): void {
+  if (params.status !== undefined) {
+    search.set('status', params.status)
+  }
+  if (params.tagSlugs !== undefined && params.tagSlugs.length > 0) {
+    search.set('tags', params.tagSlugs.join(','))
+  }
+  if (params.q !== undefined && params.q !== '') {
+    search.set('q', params.q)
+  }
+  if (params.sortKey !== undefined) {
+    search.set('sort', params.sortKey)
+  }
+  if (params.sortOrder !== undefined) {
+    search.set('order', params.sortOrder)
+  }
+  if (params.relationFilters !== undefined) {
+    for (const [fieldKey, targetEntityId] of Object.entries(params.relationFilters)) {
+      search.set(`relation.${fieldKey}`, String(targetEntityId))
+    }
+  }
+  if (params.include !== undefined && params.include !== '') {
+    search.set('include', params.include)
+  }
+}
+
 export function useEntityList(
   params: EntityListParams,
   options?: { enabled?: boolean },
@@ -25,34 +52,69 @@ export function useEntityList(
         offset: String(params.offset),
         entity_type_id: String(params.entityTypeId),
       })
-      if (params.status !== undefined) {
-        search.set('status', params.status)
-      }
-      if (params.tagSlugs !== undefined && params.tagSlugs.length > 0) {
-        search.set('tags', params.tagSlugs.join(','))
-      }
-      if (params.q !== undefined && params.q !== '') {
-        search.set('q', params.q)
-      }
-      if (params.sortKey !== undefined) {
-        search.set('sort', params.sortKey)
-      }
-      if (params.sortOrder !== undefined) {
-        search.set('order', params.sortOrder)
-      }
-      if (params.relationFilters !== undefined) {
-        for (const [fieldKey, targetEntityId] of Object.entries(params.relationFilters)) {
-          search.set(`relation.${fieldKey}`, String(targetEntityId))
-        }
-      }
-      if (params.include !== undefined && params.include !== '') {
-        search.set('include', params.include)
-      }
+      appendEntityListFilters(search, params)
       const dto = await apiClient.get<EntityListDto>(
         `/api/v1/entities?${search.toString()}`,
         signal,
       )
       return mapEntityListDtoToModel(dto)
+    },
+  })
+}
+
+/** Per-request page size for the directory fetch — the public list endpoint's cap. */
+const DIRECTORY_PAGE_SIZE = 100
+/** Safety bound on how many permalink records the directory tree will load (#682). */
+export const DIRECTORY_MAX_RECORDS = 5000
+
+export interface DirectoryEntityList {
+  items: Entity[]
+  total: number
+  truncated: boolean
+}
+
+/**
+ * Fetches ALL permalink-bearing records for the admin directory tree by paging
+ * through the public list endpoint {@link DIRECTORY_PAGE_SIZE} at a time (its
+ * per-request cap), up to {@link DIRECTORY_MAX_RECORDS}. Each request stays small
+ * (public-safe) while the tree stays complete — no silent first-100 cut-off (#682).
+ */
+export function useDirectoryEntityList(
+  params: EntityListParams,
+  options?: { enabled?: boolean },
+): UseQueryResult<DirectoryEntityList, AppError> {
+  return useQuery({
+    queryKey: [...entityKeys.list(params), 'directory'],
+    enabled: options?.enabled ?? true,
+    queryFn: async ({ signal }) => {
+      const items: Entity[] = []
+      let offset = 0
+      // Assigned on the first (always-run) pass before the while-condition reads it.
+      let total: number
+      do {
+        const search = new URLSearchParams({
+          limit: String(DIRECTORY_PAGE_SIZE),
+          offset: String(offset),
+          entity_type_id: String(params.entityTypeId),
+          has_permalink: '1',
+        })
+        appendEntityListFilters(search, params)
+        search.set('include', 'views')
+        const dto = await apiClient.get<EntityListDto>(
+          `/api/v1/entities?${search.toString()}`,
+          signal,
+        )
+        const page = mapEntityListDtoToModel(dto)
+        items.push(...page.items)
+        total = page.total
+        offset += DIRECTORY_PAGE_SIZE
+      } while (offset < total && items.length < DIRECTORY_MAX_RECORDS)
+
+      return {
+        items: items.slice(0, DIRECTORY_MAX_RECORDS),
+        total,
+        truncated: total > DIRECTORY_MAX_RECORDS,
+      }
     },
   })
 }

--- a/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
+++ b/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
@@ -4,6 +4,7 @@ import {
   defaultEntityListParams,
   useCreateEntity,
   useDeleteEntity,
+  useDirectoryEntityList,
   useEntityList,
   type Entity,
   type EntityId,
@@ -26,8 +27,6 @@ import { type DirectoryRecord } from '../lib/build-permalink-tree'
 
 export const PAGE_SIZE_OPTIONS = [20, 50, 100] as const
 const DEFAULT_PAGE_SIZE = 20
-/** Directory mode fetches this many records (the API's max page) to build the tree. */
-const DIRECTORY_FETCH_LIMIT = 100
 
 export function useManageEntitiesPage(entityTypeId: number) {
   const { t } = useTranslation()
@@ -69,12 +68,13 @@ export function useManageEntitiesPage(entityTypeId: number) {
     ],
   )
   const listQuery = useEntityList(listParams)
-  // Directory mode fetches a larger, unpaginated slice to build the path tree —
-  // honouring the active filters (search / status / tags / relations) so the tree
-  // reflects them too (#657). Sort/pagination don't apply: the tree sorts by path.
+  // Directory mode pages through ALL permalink records (100 at a time, the public
+  // endpoint's per-request cap) to build a COMPLETE path tree — honouring the active
+  // filters (search / status / tags / relations) (#657). The hook adds has_permalink
+  // + include=views; sort/pagination don't apply (the tree sorts by path) (#682).
   const directoryParams = useMemo(
-    () => ({
-      ...defaultEntityListParams(
+    () =>
+      defaultEntityListParams(
         entityTypeId,
         selectedTagSlugs,
         selectedRelationFilters,
@@ -84,10 +84,6 @@ export function useManageEntitiesPage(entityTypeId: number) {
         sortKey,
         sortOrder,
       ),
-      limit: DIRECTORY_FETCH_LIMIT,
-      // Attach per-record view counts so the directory can show readership (#674).
-      include: 'views',
-    }),
     [
       entityTypeId,
       selectedTagSlugs,
@@ -98,7 +94,9 @@ export function useManageEntitiesPage(entityTypeId: number) {
       sortOrder,
     ],
   )
-  const directoryQuery = useEntityList(directoryParams, { enabled: viewMode === 'directory' })
+  const directoryQuery = useDirectoryEntityList(directoryParams, {
+    enabled: viewMode === 'directory',
+  })
   const tagListQuery = useTagList({ limit: 100, offset: 0 })
   const fieldDefQuery = useFieldDefList(defaultFieldDefListParams(entityTypeId))
   const textFieldQuery = useTextFieldList(defaultTextFieldListParamsForEntityType(entityTypeId))
@@ -258,7 +256,7 @@ export function useManageEntitiesPage(entityTypeId: number) {
 
   const total = listQuery.data?.total ?? 0
   const totalPages = Math.max(1, Math.ceil(total / pageSize))
-  const directoryTruncated = (directoryQuery.data?.total ?? 0) > DIRECTORY_FETCH_LIMIT
+  const directoryTruncated = directoryQuery.data?.truncated ?? false
 
   return {
     items,

--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
@@ -1,6 +1,6 @@
 import { type DragEvent, type ReactNode, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { useMoveEntity, useReorderEntities } from '@/entities/entity'
+import { DIRECTORY_MAX_RECORDS, useMoveEntity, useReorderEntities } from '@/entities/entity'
 import { useTranslation } from '@/shared/i18n'
 import {
   ConfirmDialog,
@@ -103,7 +103,7 @@ export function EntityDirectoryPanel({
   onRetry,
   onCreateHere,
 }: EntityDirectoryPanelProps) {
-  const { t } = useTranslation()
+  const { t, locale } = useTranslation()
   const { showToast } = useToast()
   const moveMutation = useMoveEntity()
   const reorderMutation = useReorderEntities()
@@ -189,7 +189,9 @@ export function EntityDirectoryPanel({
     <div>
       {truncated ? (
         <p className="mb-stack-sm font-sans text-caption text-text-muted">
-          {t('admin.entityRecords.directory.truncated')}
+          {t('admin.entityRecords.directory.truncated', {
+            limit: DIRECTORY_MAX_RECORDS.toLocaleString(locale),
+          })}
         </p>
       ) : null}
       {/* Tree quick-filter (#659): instant client-side path/title filter over the loaded tree. */}

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -3540,6 +3540,8 @@ export interface operations {
                 "relation.{field_key}"?: components["parameters"]["RelationFilterQuery"];
                 /** @description Full-text search across slug and text field values (partial match). */
                 q?: string;
+                /** @description When `1`, restrict to records carrying a non-empty custom permalink. Used by the admin directory to page through only the records it renders (#682). */
+                has_permalink?: "1";
                 /** @description Only entities published on or after this date (YYYY-MM-DD). */
                 published_from?: string;
                 /** @description Only entities published on or before this date, inclusive (YYYY-MM-DD). */

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -632,7 +632,7 @@ export const de: Partial<MessageCatalog> = {
   'admin.entityRecords.directory.empty.description':
     'Datensätze mit einem eigenen Permalink-Pfad erscheinen hier als Verzeichnisbaum.',
   'admin.entityRecords.directory.truncated':
-    'Es werden die ersten 100 Datensätze angezeigt. Nutze die Listenansicht zum Durchsuchen aller.',
+    'Es werden die ersten {{limit}} Datensätze angezeigt. Nutze die Listenansicht zum Durchsuchen aller.',
   'admin.entityRecords.directory.expand': 'Aufklappen',
   'admin.entityRecords.directory.collapse': 'Zuklappen',
   'admin.entityRecords.directory.newHere': 'Neue Seite unter {{path}}',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -635,7 +635,7 @@ export const en = {
   'admin.entityRecords.directory.empty.description':
     'Records with a custom permalink path appear here as a directory tree.',
   'admin.entityRecords.directory.truncated':
-    'Showing the first 100 records. Use the list view to search all.',
+    'Showing the first {{limit}} records. Use the list view to search all.',
   'admin.entityRecords.directory.expand': 'Expand',
   'admin.entityRecords.directory.collapse': 'Collapse',
   'admin.entityRecords.directory.newHere': 'New page under {{path}}',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -643,7 +643,7 @@ export const fr: Partial<MessageCatalog> = {
   'admin.entityRecords.directory.empty.description':
     'Les fiches ayant un chemin de permalien personnalisé apparaissent ici sous forme d’arborescence.',
   'admin.entityRecords.directory.truncated':
-    'Affichage des 100 premières fiches. Utilisez la vue liste pour tout rechercher.',
+    'Affichage des {{limit}} premières fiches. Utilisez la vue liste pour tout rechercher.',
   'admin.entityRecords.directory.expand': 'Déplier',
   'admin.entityRecords.directory.collapse': 'Replier',
   'admin.entityRecords.directory.newHere': 'Nouvelle page sous {{path}}',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -631,7 +631,7 @@ export const ja: Partial<MessageCatalog> = {
   'admin.entityRecords.directory.empty.description':
     'カスタムパーマリンクを持つレコードがディレクトリツリーで表示されます。',
   'admin.entityRecords.directory.truncated':
-    '先頭100件を表示しています。全件はリスト表示の検索をご利用ください。',
+    '先頭{{limit}}件を表示しています。全件はリスト表示の検索をご利用ください。',
   'admin.entityRecords.directory.expand': '展開',
   'admin.entityRecords.directory.collapse': '折りたたむ',
   'admin.entityRecords.directory.newHere': '{{path}} に新規ページ',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -636,7 +636,7 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.entityRecords.directory.empty.description':
     'Registros com um caminho de permalink personalizado aparecem aqui como uma árvore de diretórios.',
   'admin.entityRecords.directory.truncated':
-    'Mostrando os primeiros 100 registros. Use a visualização em lista para pesquisar todos.',
+    'Mostrando os primeiros {{limit}} registros. Use a visualização em lista para pesquisar todos.',
   'admin.entityRecords.directory.expand': 'Expandir',
   'admin.entityRecords.directory.collapse': 'Recolher',
   'admin.entityRecords.directory.newHere': 'Nova página em {{path}}',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -605,7 +605,7 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.entityRecords.directory.empty.title': '尚无自定义路径的页面',
   'admin.entityRecords.directory.empty.description':
     '具有自定义永久链接路径的记录将在此处以目录树形式显示。',
-  'admin.entityRecords.directory.truncated': '仅显示前 100 条记录。使用列表视图搜索全部。',
+  'admin.entityRecords.directory.truncated': '仅显示前 {{limit}} 条记录。使用列表视图搜索全部。',
   'admin.entityRecords.directory.expand': '展开',
   'admin.entityRecords.directory.collapse': '折叠',
   'admin.entityRecords.directory.newHere': '在 {{path}} 下新建页面',

--- a/src/Entity/EntityListCriteria.php
+++ b/src/Entity/EntityListCriteria.php
@@ -23,6 +23,8 @@ final readonly class EntityListCriteria
         // the last wanted day) so ISO timestamps within the range still match.
         public ?string $publishedFrom = null,
         public ?string $publishedToExclusive = null,
+        /** When true, restrict to records carrying a non-empty custom permalink (#682). */
+        public bool $hasPermalink = false,
     ) {
     }
 }

--- a/src/Entity/ListEntitiesHandler.php
+++ b/src/Entity/ListEntitiesHandler.php
@@ -59,6 +59,11 @@ final readonly class ListEntitiesHandler
         $wantExcerpt = in_array('excerpt', $includes, true);
         $wantViews = in_array('views', $includes, true);
 
+        // `?has_permalink=1` restricts to records with a custom permalink — the
+        // admin directory fetches only what it renders, so it can page through all
+        // of them rather than the first 100 of every record (#682).
+        $hasPermalink = ($request->getQueryParams()['has_permalink'] ?? null) === '1';
+
         $output = $this->useCase->execute(new ListEntitiesInput(
             limit: $pagination->limit,
             offset: $pagination->offset,
@@ -72,6 +77,7 @@ final readonly class ListEntitiesHandler
                 sortOrder: $sortOrder,
                 publishedFrom: $publishedFrom,
                 publishedToExclusive: $publishedToExclusive,
+                hasPermalink: $hasPermalink,
             ),
             includeViews: $wantViews,
         ));

--- a/src/Entity/PdoEntityRepository.php
+++ b/src/Entity/PdoEntityRepository.php
@@ -259,6 +259,10 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
             $params[] = $criteria->entityTypeId;
         }
 
+        if ($criteria->hasPermalink) {
+            $conditions[] = "(e.permalink IS NOT NULL AND e.permalink != '')";
+        }
+
         if ($criteria->status !== null) {
             $conditions[] = 'e.status = ?';
             $params[] = $criteria->status->value;

--- a/tests/Entity/InMemoryEntityRepository.php
+++ b/tests/Entity/InMemoryEntityRepository.php
@@ -264,6 +264,10 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
                 continue;
             }
 
+            if ($criteria->hasPermalink && ($entity->permalink === null || $entity->permalink === '')) {
+                continue;
+            }
+
             if ($criteria->status !== null && $entity->status !== $criteria->status) {
                 continue;
             }

--- a/tests/Entity/ListEntitiesUseCaseTest.php
+++ b/tests/Entity/ListEntitiesUseCaseTest.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Tests\Entity;
 use DateTimeImmutable;
 use NeNeRecords\Analytics\AccessLogEntry;
 use NeNeRecords\Entity\Entity;
+use NeNeRecords\Entity\EntityListCriteria;
 use NeNeRecords\Entity\EntityStatus;
 use NeNeRecords\Entity\ListEntitiesInput;
 use NeNeRecords\Entity\ListEntitiesUseCase;
@@ -66,5 +67,23 @@ final class ListEntitiesUseCaseTest extends TestCase
         $output = $useCase->execute(new ListEntitiesInput());
 
         self::assertSame(0, $output->items[0]->viewCount ?? null);
+    }
+
+    public function testHasPermalinkRestrictsToRecordsWithACustomPermalink(): void
+    {
+        $entities = new InMemoryEntityRepository([
+            new Entity(id: 1, entityTypeId: 1, permalink: '/a', status: EntityStatus::Published),
+            new Entity(id: 2, entityTypeId: 1, permalink: null, status: EntityStatus::Published),
+            new Entity(id: 3, entityTypeId: 1, permalink: '', status: EntityStatus::Published),
+        ]);
+        $useCase = new ListEntitiesUseCase($entities);
+
+        $output = $useCase->execute(new ListEntitiesInput(
+            criteria: new EntityListCriteria(hasPermalink: true),
+        ));
+
+        // Only the record with a non-empty permalink survives — total reflects that.
+        self::assertSame(1, $output->total);
+        self::assertSame([1], array_map(static fn ($item) => $item->id, $output->items));
     }
 }


### PR DESCRIPTION
## 背景
ディレクトリの「先頭100件」は**ブラウザでなくバックエンド**制約：`PaginationQueryParser` の maxLimit=100。`/api/v1/entities` は**公開**（ADMIN_ONLY 外）なので server cap は上げられない（濫用口）。さらに旧実装は「全レコード先頭100件→permalinkフィルタ」で**101件目以降の permalink 記事が消える**＋通知が total 基準で**誤発火**。

## 修正
- **backend**: `has_permalink` フィルタ（criteria＋Pdo/InMemory）。ディレクトリは*表示対象だけ*を取得（total も正確）。
- **frontend**: `useDirectoryEntityList` が **100件ずつページングして全件取得**（各リクエストは100＝公開安全のまま）。**安全上限 5,000**・超過時のみ通知に**実数表示**（ハードコード100撤廃・`{{limit}}` パラメータ化・6言語）。

これで「100の壁」「101件目以降の欠落」「total 誤通知」を同時に解消し、**公開エンドポイントの濫用リスクを作らない**。新エンドポイント不要。

## 検証
`composer check`(1124) / `npm run check`(469) 緑。has_permalink フィルタ＋ページング(250件→3ページで完全取得)テスト追加。

Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)