### PR TITLE
fix(admin): ブロックエディタの iPhone レイアウト崩れをモバイル対応で修正 (#687)

### DIFF
--- a/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.test.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.test.tsx
@@ -6,6 +6,26 @@ import { renderWithProviders } from '@tests/render/render-with-providers'
 import { BlocksFieldEditor } from './BlocksFieldEditor'
 
 afterEach(cleanup)
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/** Force `useMediaQuery('(max-width: 820px)')` to report a phone-width viewport. */
+function stubMobileViewport() {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue({
+      matches: true,
+      media: '(max-width: 820px)',
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  )
+}
 
 function Harness({ initial = '' }: { initial?: string }) {
   const [value, setValue] = useState(initial)
@@ -66,6 +86,35 @@ describe('BlocksFieldEditor', () => {
   it('hides the preview toggle when there are no blocks', () => {
     renderWithProviders(<Harness />)
     expect(screen.queryByRole('button', { name: 'Show preview' })).not.toBeInTheDocument()
+  })
+
+  it('opens the inspector as a modal and disables card DnD on mobile', async () => {
+    stubMobileViewport()
+    const user = userEvent.setup()
+    const doc = JSON.stringify([
+      { id: 'b1', type: 'callout', data: { kind: 'ok', title: 'Nice', body: 'Done' } },
+    ])
+    renderWithProviders(<Harness initial={doc} />)
+
+    // Touch DnD is unavailable: the card is not draggable.
+    expect(document.querySelector('[data-bcard]')).toHaveAttribute('draggable', 'false')
+
+    // No modal until the card is tapped; then the inspector opens as a dialog.
+    expect(screen.queryByRole('dialog')).toBeNull()
+    await user.click(screen.getByRole('button', { name: /Nice/ }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('keeps the inspector inline (no modal) on desktop', async () => {
+    const user = userEvent.setup()
+    const doc = JSON.stringify([
+      { id: 'b1', type: 'callout', data: { kind: 'ok', title: 'Nice', body: 'Done' } },
+    ])
+    renderWithProviders(<Harness initial={doc} />)
+
+    expect(document.querySelector('[data-bcard]')).toHaveAttribute('draggable', 'true')
+    await user.click(screen.getByRole('button', { name: /Nice/ }))
+    expect(screen.queryByRole('dialog')).toBeNull()
   })
 
   it('limits the palette to allowedTypes', () => {

--- a/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.tsx
@@ -1,6 +1,7 @@
-import { Fragment, useMemo, useRef, useState } from 'react'
+import { Fragment, type ReactNode, useMemo, useRef, useState } from 'react'
 import { useTranslation } from '@/shared/i18n'
-import { Button, Card, EmptyState, Stack, Text } from '@/shared/ui'
+import { useMediaQuery } from '@/shared/lib/use-media-query'
+import { Button, Card, EmptyState, Modal, Stack, Text } from '@/shared/ui'
 import {
   IconChevronDown,
   IconChevronUp,
@@ -116,6 +117,11 @@ export function BlocksFieldEditor({
   onChange,
 }: BlocksFieldEditorProps) {
   const { t } = useTranslation()
+  // Match the handoff's ≤820px breakpoint. Below it, touch DnD is unavailable
+  // (grip hidden, cards not draggable), the card row stacks, and the inspector
+  // opens as a modal instead of an inline panel.
+  const isMobile = useMediaQuery('(max-width: 820px)')
+  const inspectorTitleId = `${id}-inspector-title`
   const palette = useMemo(
     () =>
       allowedTypes === undefined
@@ -219,12 +225,15 @@ export function BlocksFieldEditor({
         ) : null}
       </div>
 
-      <div className="flex flex-wrap gap-inline-sm">
+      <div
+        className={isMobile ? 'flex gap-inline-sm overflow-x-auto' : 'flex flex-wrap gap-inline-sm'}
+      >
         {palette.map((entry) => (
           <Button
             key={entry.type}
             variant="secondary"
             size="sm"
+            className={isMobile ? 'shrink-0' : undefined}
             disabled={disabled || blocks.length >= MAX_BLOCKS_PER_DOCUMENT}
             onClick={() => {
               addBlock(entry.type)
@@ -260,7 +269,7 @@ export function BlocksFieldEditor({
                 <Card
                   padding="row"
                   data-bcard=""
-                  draggable={!disabled}
+                  draggable={!disabled && !isMobile}
                   className={isSelected ? 'ring-2 ring-accent' : undefined}
                   onDragStart={(event) => {
                     setBlockDragPayload({ kind: 'move', id: block.id })
@@ -271,10 +280,16 @@ export function BlocksFieldEditor({
                     setDropIndex(null)
                   }}
                 >
-                  <div className="flex items-center gap-inline-sm">
-                    <span className="text-text-muted" aria-hidden="true">
-                      <IconMenu size={15} />
-                    </span>
+                  <div
+                    className={
+                      isMobile ? 'flex flex-col gap-stack-xs' : 'flex items-center gap-inline-sm'
+                    }
+                  >
+                    {isMobile ? null : (
+                      <span className="text-text-muted" aria-hidden="true">
+                        <IconMenu size={15} />
+                      </span>
+                    )}
                     <button
                       type="button"
                       className="flex min-w-0 flex-1 items-center gap-inline-sm text-left"
@@ -294,41 +309,43 @@ export function BlocksFieldEditor({
                           : blockSummary(block)}
                       </span>
                     </button>
-                    {invalid ? (
-                      <span className="shrink-0 font-sans text-caption text-danger">
-                        {t('admin.blocks.card.invalid')}
+                    <div className="flex items-center gap-inline-sm">
+                      {invalid ? (
+                        <span className="font-sans text-caption text-danger">
+                          {t('admin.blocks.card.invalid')}
+                        </span>
+                      ) : null}
+                      <span className="ml-auto flex items-center gap-inline-xs">
+                        <RepeaterIconButton
+                          title={t('admin.blocks.moveUp')}
+                          disabled={disabled || index === 0}
+                          onClick={() => {
+                            moveBlock(index, -1)
+                          }}
+                        >
+                          <IconChevronUp size={15} />
+                        </RepeaterIconButton>
+                        <RepeaterIconButton
+                          title={t('admin.blocks.moveDown')}
+                          disabled={disabled || index === blocks.length - 1}
+                          onClick={() => {
+                            moveBlock(index, 1)
+                          }}
+                        >
+                          <IconChevronDown size={15} />
+                        </RepeaterIconButton>
+                        <RepeaterIconButton
+                          danger
+                          title={t('common.actions.delete')}
+                          disabled={disabled}
+                          onClick={() => {
+                            deleteBlock(block.id)
+                          }}
+                        >
+                          <IconX size={15} />
+                        </RepeaterIconButton>
                       </span>
-                    ) : null}
-                    <span className="flex items-center gap-inline-xs">
-                      <RepeaterIconButton
-                        title={t('admin.blocks.moveUp')}
-                        disabled={disabled || index === 0}
-                        onClick={() => {
-                          moveBlock(index, -1)
-                        }}
-                      >
-                        <IconChevronUp size={15} />
-                      </RepeaterIconButton>
-                      <RepeaterIconButton
-                        title={t('admin.blocks.moveDown')}
-                        disabled={disabled || index === blocks.length - 1}
-                        onClick={() => {
-                          moveBlock(index, 1)
-                        }}
-                      >
-                        <IconChevronDown size={15} />
-                      </RepeaterIconButton>
-                      <RepeaterIconButton
-                        danger
-                        title={t('common.actions.delete')}
-                        disabled={disabled}
-                        onClick={() => {
-                          deleteBlock(block.id)
-                        }}
-                      >
-                        <IconX size={15} />
-                      </RepeaterIconButton>
-                    </span>
+                    </div>
                   </div>
                 </Card>
               </Fragment>
@@ -339,34 +356,25 @@ export function BlocksFieldEditor({
       )}
 
       {selected !== null ? (
-        <Card padding="md">
-          <Stack gap="sm">
-            <div className="flex items-center justify-between">
-              <Text as="span" variant="caption" muted>
-                {t(blockCatalogEntry(selected.type).labelKey)}
-              </Text>
-              <button
-                type="button"
-                className="rounded p-1 text-text-muted hover:text-text-primary"
-                title={t('admin.blocks.deselect')}
-                onClick={() => {
-                  setSelectedId(null)
-                }}
-              >
-                <IconX size={15} />
-              </button>
-            </div>
-            <BlockInspector
-              block={selected}
-              errorCode={validateBlock(selected)}
-              disabled={disabled}
-              idPrefix={`${id}-${selected.id}`}
-              onChange={(data) => {
-                updateData(selected.id, data)
-              }}
-            />
-          </Stack>
-        </Card>
+        <InspectorPanel
+          asModal={isMobile}
+          titleId={inspectorTitleId}
+          title={t(blockCatalogEntry(selected.type).labelKey)}
+          closeLabel={t('admin.blocks.deselect')}
+          onClose={() => {
+            setSelectedId(null)
+          }}
+        >
+          <BlockInspector
+            block={selected}
+            errorCode={validateBlock(selected)}
+            disabled={disabled}
+            idPrefix={`${id}-${selected.id}`}
+            onChange={(data) => {
+              updateData(selected.id, data)
+            }}
+          />
+        </InspectorPanel>
       ) : null}
 
       {showPreview && blocks.length > 0 ? (
@@ -380,5 +388,70 @@ export function BlocksFieldEditor({
         </Card>
       ) : null}
     </div>
+  )
+}
+
+interface InspectorPanelProps {
+  /** Render as a centered modal (mobile) instead of an inline card (desktop). */
+  asModal: boolean
+  titleId: string
+  title: string
+  closeLabel: string
+  onClose: () => void
+  children: ReactNode
+}
+
+/**
+ * Wraps the selected block's settings form. On desktop it sits inline below the
+ * board (a `Card`); at ≤820px the board has no room beside it, so the form opens
+ * as a `Modal` over the card the user tapped (handoff's "card edit → modal").
+ */
+function InspectorPanel({
+  asModal,
+  titleId,
+  title,
+  closeLabel,
+  onClose,
+  children,
+}: InspectorPanelProps) {
+  const header = (
+    <div className="flex items-center justify-between">
+      <Text as="span" id={titleId} variant="caption" muted>
+        {title}
+      </Text>
+      <button
+        type="button"
+        className="rounded p-1 text-text-muted hover:text-text-primary"
+        title={closeLabel}
+        onClick={onClose}
+      >
+        <IconX size={15} />
+      </button>
+    </div>
+  )
+
+  if (asModal) {
+    return (
+      <Modal
+        onClose={onClose}
+        closeLabel={closeLabel}
+        labelledBy={titleId}
+        panelClassName="max-w-md max-h-full overflow-y-auto shadow-md"
+      >
+        <Stack gap="sm">
+          {header}
+          {children}
+        </Stack>
+      </Modal>
+    )
+  }
+
+  return (
+    <Card padding="md">
+      <Stack gap="sm">
+        {header}
+        {children}
+      </Stack>
+    </Card>
   )
 }

--- a/frontend/tests/setup/vitest.setup.ts
+++ b/frontend/tests/setup/vitest.setup.ts
@@ -1,1 +1,19 @@
 import '@testing-library/jest-dom/vitest'
+
+// jsdom does not implement matchMedia. Provide an inert default (no match, no-op
+// listeners) so components that read viewport media queries via `useMediaQuery`
+// render their desktop branch under test. Tests that assert mobile behavior
+// override this with `vi.stubGlobal('matchMedia', …)`.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  window.matchMedia = (query: string): MediaQueryList =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList
+}


### PR DESCRIPTION
## 目的

iPhone（狭幅）で投稿本文の**ブロックエディタ**（`BlocksFieldEditor`、#486 S1b）のレイアウトが崩れていた。現行はインラインの `blocks` フィールドで、カード行が単一 `flex` 行にグリップ・型ラベル・要約・無効バッジ・操作3ボタンを詰め込み、レスポンシブ分岐が無かった。

claudeDesign ハンドオフ（`design_handoff_block_editor` / epic #486 S1b）の **≤820px モバイル挙動**を、**現行のインライン構造のまま**取り込む（3ペイン全画面エディタへの作り替えは別スコープ）。

## 変更点（`≤820px` で適用）

- **カード行を縦積み**：型情報を上段（要約は `truncate`）、操作ボタンを下段右寄せ（`ml-auto`）。無効バッジは下段左。
- **インスペクタをモーダル表示**：カードタップで既存 `Modal` プリミティブに表示（`max-h-full overflow-y-auto` で長いフォームもスクロール）。デスクトップは従来どおりボード下のインライン `Card`。
- **DnD 無効化**：グリップ非表示＋カード `draggable=false`（タッチで HTML5 DnD は不可）。
- **パレットを横スクロールバー化**：「ブロックを追加」ボタン群を `overflow-x-auto` の1行バーに（縦方向の肥大を解消）。

ブレークポイントは `useMediaQuery('(max-width: 820px)')` に一元化（モーダル切替と CSS 分岐が同一の閾値で揃う）。**デスクトップ表示は不変**（操作ラッパは content 幅のため `ml-auto` は無効＝従来レイアウト）。

## 非スコープ

- 3ペイン全画面エディタ（`/admin/posts/:id` 専用ページ）の新規実装
- ボトムドロワー（パレット/インスペクタのシート）
- API・データモデル変更（`onChange` 契約は不変）

## 検証

- `npm run check --prefix frontend` グリーン（type-check / lint / prettier / test / validate:themes / knip / storybook）
- 追加テスト：
  - モバイル（`matchMedia` を `matches=true` に stub）でカードタップ→`role="dialog"` 出現、カードが `draggable="false"`
  - デスクトップでインスペクタはインライン（`dialog` 無し）、カード `draggable="true"`
- テスト基盤：jsdom に `matchMedia` が無いため `tests/setup/vitest.setup.ts` に inert な既定を追加（既存テストは desktop 分岐で不変、モバイル系は `vi.stubGlobal` で上書き）

### チェックリスト
- [x] Issue 紐付け（Closes #687）
- [x] 品質ゲート通過
- [x] デスクトップ回帰なし

> 視覚確認（実機/エミュレータの ≤820px）は未実施。希望があればローカル dev を立ててスクショ取得します。

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)