### PR TITLE
fix(public): 公開ホーム「最新の記事」見出しのスマホ右寄せ崩れを修正 (#689)

### DIFF
--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -1765,6 +1765,14 @@
     flex-direction: column;
     gap: var(--space-sm);
   }
+  /* Several themes restate `align-items: flex-end` on `.section__head`
+     (selector `.nene-public[data-theme^=…]`, specificity 0,3,0), which outranks
+     the container reset above (0,2,0) and would right-align the stacked phone
+     head. Pinning the children with `align-self` beats the container's
+     `align-items` regardless of theme specificity, so the head stays left-aligned. */
+  .nene-public .section__head > * {
+    align-self: flex-start;
+  }
   .nene-public .pagehead__row {
     align-items: flex-start;
     flex-direction: column;


### PR DESCRIPTION
## 目的
公開ホーム（例 aozora.nene-records.com）の「最新の記事」セクション見出しが **iPhone 幅で縦積み＋右寄せ**に崩れる不具合を修正。

## 原因
`public-site.css` は `≤680px` で `.section__head` を `flex-direction:column; align-items:flex-start`（左寄せ）に reset している。しかし **7テーマ**（botanical / consumer / newsprint / noir / pastel / reading / swiss）が `.nene-public[data-theme^='…'] .section__head { align-items: flex-end }` を**メディアクエリ外で**再宣言しており、特異度 `0,3,0` が base mobile reset の `0,2,0` を上回る → `column`（base）＋ `flex-end`（theme）＝**縦積み＋右寄せ**。

## 修正
`≤680px` クエリに子要素の `align-self: flex-start` を1ルール追加。`align-self`（子）はコンテナの `align-items` を**テーマ特異度に関係なく**上書きするため、現行・将来の全テーマで左寄せを担保（テーマ各ファイルの編集不要）。`.pagehead__row` は align-items を上書きするテーマが無いため対象外。

```css
@media (max-width: 680px) {
  .nene-public .section__head { flex-direction: column; align-items: flex-start; ... }
  .nene-public .section__head > * { align-self: flex-start; }  /* ← 追加 */
}
```

## 検証
- **playwright（390px・実 CSS をロード）**: `.section__head` 子要素の左オフセット = 修正前 **202/240px（右寄せ）** → 修正後 **0/0px（左寄せ）**
- before/after スクショで目視確認（崩れ再現 → 解消）
- `npm run check` グリーン（type-check / lint / prettier / test / validate:themes / knip / storybook）

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)