### PR TITLE
fix(public): 公開ヘッダーの狭幅/中間幅 横あふれを解消する (#693)

### DIFF
--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -1749,6 +1749,30 @@
   .nene-public .hd__menu {
     display: grid;
   }
+  /* Keep the action cluster (language + theme switch + menu) from forcing the
+     page wider than the viewport: let the header row and its parts shrink and
+     tighten the gaps. Without this `.hd__actions` keeps its full intrinsic
+     width (~345px) and `.hd__in` (space-between, no shrink) pushes the whole
+     document to ~599px at 375px, stranding content in the left half. (#693) */
+  .nene-public .hd__in {
+    gap: var(--space-sm);
+  }
+  .nene-public .hd__nav,
+  .nene-public .hd__actions {
+    min-width: 0;
+  }
+  .nene-public .hd__actions {
+    gap: var(--space-sm);
+  }
+  .nene-public .brand {
+    min-width: 0;
+  }
+  .nene-public .brand__name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
   /* Top bar takes too much room on phones — fold it away (spec §6). */
   .nene-public .hd-topbar {
     display: none;
@@ -1792,6 +1816,29 @@
   }
   .nene-public .brand__name {
     white-space: nowrap;
+  }
+  /* Compress the action cluster so language + theme switch + menu fit on the
+     narrowest phones; wrap to a second row as a last resort instead of ever
+     widening the page. Height is auto here so a wrapped row stays visible. (#693) */
+  .nene-public .hd__in {
+    height: auto;
+    min-height: 62px;
+    flex-wrap: wrap;
+    row-gap: var(--space-xs);
+    column-gap: var(--space-sm);
+  }
+  .nene-public .hd__actions {
+    gap: var(--space-xs);
+  }
+  .nene-public .themesw {
+    padding: 2px;
+  }
+  .nene-public .themesw__btn {
+    width: 28px;
+    height: 26px;
+  }
+  .nene-public .langsw {
+    padding: 5px 7px;
   }
 }
 /* ── Motion capability: scroll-reveal (#371 S1) ──────────────────────────────

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -1720,6 +1720,49 @@
     grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   }
 }
+/* Collapse the desktop nav to the drawer BEFORE it stops fitting. The inline
+   header (brand + nav + search + language + theme switch) needs ~950px, but the
+   nav only used to fold at ≤680px, so 681–955px overflowed horizontally with a
+   real menu loaded. Fold at ≤960px and let the (now compact) header row shrink so
+   it never widens the page. (#693) */
+@media (max-width: 960px) {
+  .nene-public .hd__nav .navlink,
+  .nene-public .hd__nav .btn--primary {
+    display: none;
+  }
+  .nene-public .hd__search {
+    display: none;
+  }
+  .nene-public .hd__menu {
+    display: grid;
+  }
+  /* Once the nav is in the drawer, the header can never be allowed to overflow:
+     tighten gaps, let parts shrink, and — as a hard guarantee at any width
+     ≤960 — wrap to a second row instead of widening the page. (#693) */
+  .nene-public .hd__in {
+    gap: var(--space-sm);
+    flex-wrap: wrap;
+    row-gap: var(--space-xs);
+    height: auto;
+    min-height: 62px;
+  }
+  .nene-public .hd__nav,
+  .nene-public .hd__actions {
+    min-width: 0;
+  }
+  .nene-public .hd__actions {
+    gap: var(--space-sm);
+  }
+  .nene-public .brand {
+    min-width: 0;
+  }
+  .nene-public .brand__name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
 @media (max-width: 860px) {
   .nene-public .hero__grid {
     grid-template-columns: 1fr;
@@ -1739,40 +1782,9 @@
   }
 }
 @media (max-width: 680px) {
-  .nene-public .hd__nav .navlink,
-  .nene-public .hd__nav .btn--primary {
-    display: none;
-  }
-  .nene-public .hd__search {
-    display: none;
-  }
-  .nene-public .hd__menu {
-    display: grid;
-  }
-  /* Keep the action cluster (language + theme switch + menu) from forcing the
-     page wider than the viewport: let the header row and its parts shrink and
-     tighten the gaps. Without this `.hd__actions` keeps its full intrinsic
-     width (~345px) and `.hd__in` (space-between, no shrink) pushes the whole
-     document to ~599px at 375px, stranding content in the left half. (#693) */
-  .nene-public .hd__in {
-    gap: var(--space-sm);
-  }
-  .nene-public .hd__nav,
-  .nene-public .hd__actions {
-    min-width: 0;
-  }
-  .nene-public .hd__actions {
-    gap: var(--space-sm);
-  }
-  .nene-public .brand {
-    min-width: 0;
-  }
-  .nene-public .brand__name {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+  /* Header nav-collapse + action-cluster shrink now live in the ≤960px block
+     above (they must trigger before the inline nav stops fitting, ~955px). This
+     block keeps the ≤680 content-area rules. (#693) */
   /* Top bar takes too much room on phones — fold it away (spec §6). */
   .nene-public .hd-topbar {
     display: none;


### PR DESCRIPTION
## 目的
公開サイトを狭幅（例 375px）や中間幅（681–955px）で開くとヘッダーが折り畳まれず、ページ全体が viewport より広くなって本文が左半分に寄り、横スクロールが出ていた（Issue #693）。全27テーマ・light/dark 共通の base バグ。

## 原因
- `.hd__actions`（言語 `.langsw` ＋ テーマ切替 `.themesw` ＋ ハンバーガー `.hd__menu`）が狭幅で畳まれない。
- インラインナビの折り畳みが `≤680px` だが、デスクトップヘッダー実幅は ~950px あり **681–955px でインラインナビが収まらず**あふれる。
- `.hd__in` は `space-between`・非縮小・overflow 制御なしで、最小内容幅がページ全体を押し広げる。

## 変更
`frontend/src/pages/consumer/public-site.css` のみ（CSS）。
- ナビ折り畳み（navlink/検索を隠しハンバーガー表示）＋アクションクラスタの縮小ルールを **`≤680px` → `≤960px`** へ引き上げ（実幅より上で畳む）。
- `≤960px` で `.hd__in` を `flex-wrap` 可能にし、**収まらなければ2段に折り返す**ハード保証を追加（あらゆる幅で横あふれしない）。
- `≤480px` は最小幅向けに `.themesw`/`.langsw` を圧縮。
- DOM 不変・管理画面に影響なし。

## 検証
- `design-export` の計測スクリプトで **320 / 360 / 375 / 400 / 480 / 481 / 600 / 681 / 700 / 768 / 820 / 900 / 960 / 961 / 1000 / 1200px** の全幅で `document.scrollWidth == viewport`（横あふれ0）＋メニュー読込ありを確認。
- 768px タブレットは1行に収まりナビはドロワーへ集約。320px は2段に整然と折返し・本文は全幅。
- `npm run check --prefix frontend` 全段グリーン（type-check / lint / prettier / test / validate:themes / knip / storybook）。prettier 合格・consumer テスト26件パス。

## 補足
本 PR は横あふれ（correctness）の是正。ヘッダーの**意匠のレスポンシブ再設計**は別途 ClaudeDesign にデザイン・プロトタイプを依頼予定（本 PR の上に乗せる）。

## チェックリスト
- [x] Issue 紐付け（#693）
- [x] DOM 不変・公開スコープ維持
- [x] 全幅で横あふれ0を実測
- [x] フルゲート green

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)