### PR TITLE
feat(public): 公開ヘッダーのレスポンシブ再設計（ClaudeDesign 意匠実装） (#695)

### DIFF
--- a/frontend/src/pages/consumer/PublicSiteShell.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.tsx
@@ -187,7 +187,7 @@ export function PublicSiteShell({
 
   // Adopt a shared/crawled `?lang=` as the UI locale so the page (UI strings +
   // locale-resolved listing titles) matches the URL the visitor arrived on (#540).
-  const { locale: uiLocale, setLocale: setUiLocale } = useTranslation()
+  const { t, locale: uiLocale, setLocale: setUiLocale } = useTranslation()
   const [searchParams] = useSearchParams()
   const langParam = searchParams.get('lang')
   useEffect(() => {
@@ -374,7 +374,7 @@ export function PublicSiteShell({
             setDrawerOpen(false)
           }}
         />
-        <div className="drawer__panel" role="dialog" aria-label="Menu">
+        <div className="drawer__panel" role="dialog" aria-modal="true" aria-label="Menu">
           <div className="drawer__head">
             <span className="eyebrow">Menu</span>
             <button
@@ -401,9 +401,15 @@ export function PublicSiteShell({
               {link.label}
             </Link>
           ))}
-          <div style={{ marginTop: 'auto' }} className="flex flex-col gap-stack-sm">
-            <LanguageSwitch />
-            <ThemeSwitch mode={mode} onMode={setMode} />
+          <div className="drawer__prefs">
+            <div className="drawer__pref">
+              <span className="drawer__pref-label">{t('public.nav.language')}</span>
+              <LanguageSwitch />
+            </div>
+            <div className="drawer__pref">
+              <span className="drawer__pref-label">{t('public.nav.theme')}</span>
+              <ThemeSwitch mode={mode} onMode={setMode} />
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -134,15 +134,18 @@
 }
 .nene-public .hd__in {
   display: flex;
+  flex-wrap: nowrap; /* never wrap — the compact bar (≤900px) is engineered to fit */
   align-items: center;
-  justify-content: space-between;
   gap: var(--space-lg);
   height: 72px;
+  transition: height var(--dur-normal) var(--ease);
 }
 .nene-public .brand {
   display: flex;
   align-items: center;
   gap: var(--space-sm);
+  min-width: 0; /* let the name truncate before the row overflows */
+  flex: 0 1 auto;
 }
 .nene-public .brand__mark {
   width: 34px;
@@ -168,6 +171,7 @@
 .nene-public .brand__text {
   display: flex;
   flex-direction: column;
+  min-width: 0;
   line-height: 1.05;
 }
 .nene-public .brand__name {
@@ -175,29 +179,38 @@
   font-weight: var(--weight-bold);
   font-size: 1.25rem;
   letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .nene-public .brand__tag {
   font-size: var(--text-meta);
   color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .nene-public .hd__nav {
   display: flex;
   align-items: center;
-  gap: var(--space-lg);
+  gap: clamp(var(--space-sm), 1.4vw, var(--space-lg));
   /* Default skeleton (= nav-right): primary nav hugs the action cluster on the
      right. `data-header` layouts re-place it (see Style flags → Header layout). */
   margin-left: auto;
+  min-width: 0;
 }
 .nene-public .hd__actions {
   display: flex;
   align-items: center;
-  gap: var(--space-lg);
+  gap: var(--space-md);
+  flex: none;
 }
 /* Header CTA — compact primary button sized for the action cluster. */
 .nene-public .hd__cta {
   padding: 8px 16px;
   font-size: var(--text-body-sm);
+  white-space: nowrap;
 }
 
 /* Top bar — thin contact/announcement row above the (sticky) main header
@@ -213,13 +226,13 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--space-md);
-  min-height: 34px;
-  padding-block: 4px;
+  min-height: 36px;
+  padding-block: 5px;
 }
 .nene-public .hd-topbar__contact {
   display: flex;
   align-items: center;
-  gap: var(--space-md);
+  gap: var(--space-lg);
   margin-left: auto;
 }
 .nene-public .hd-topbar__contact a:hover {
@@ -231,6 +244,7 @@
   color: var(--color-text-muted);
   padding: 6px 2px;
   position: relative;
+  white-space: nowrap;
   transition: color var(--dur-fast) var(--ease);
 }
 .nene-public .navlink:hover,
@@ -265,15 +279,15 @@
   background: var(--color-surface-raised);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-full);
-  padding: 5px 10px;
+  padding: 6px 11px;
   cursor: pointer;
 }
 .nene-public .langsw:hover {
   border-color: var(--color-border-strong);
 }
 .nene-public .themesw__btn {
-  width: 30px;
-  height: 28px;
+  width: 32px;
+  height: 30px;
   display: grid;
   place-items: center;
   border: 0;
@@ -295,8 +309,8 @@
 }
 
 .nene-public .iconbtn {
-  width: 38px;
-  height: 38px;
+  width: 40px;
+  height: 40px;
   display: grid;
   place-items: center;
   flex: none;
@@ -314,7 +328,7 @@
   height: 18px;
 }
 .nene-public .hd__menu {
-  display: none;
+  display: none; /* shown ≤ 900px (compact bar) */
 }
 
 /* ── Buttons ─────────────────────────────────────────────────────────────── */
@@ -1081,15 +1095,17 @@
   font-family: var(--font-mono);
 }
 
-/* ── Mobile drawer ───────────────────────────────────────────────────────── */
+/* ── Mobile drawer (right slide-in; owns nav + language + theme) ───────────── */
 .nene-public .drawer {
   position: fixed;
   inset: 0;
   z-index: 70;
-  display: none;
+  visibility: hidden;
+  pointer-events: none;
 }
 .nene-public .drawer.is-open {
-  display: block;
+  visibility: visible;
+  pointer-events: auto;
 }
 .nene-public .drawer__scrim {
   position: absolute;
@@ -1097,32 +1113,101 @@
   width: 100%;
   border: 0;
   padding: 0;
-  background: oklch(0% 0 0 / 0.45);
+  background: oklch(0% 0 0 / 0.48);
   cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--dur-normal) var(--ease);
+}
+.nene-public .drawer.is-open .drawer__scrim {
+  opacity: 1;
 }
 .nene-public .drawer__panel {
   position: absolute;
   top: 0;
   right: 0;
   bottom: 0;
-  width: min(82vw, 320px);
+  width: min(86vw, 344px);
   background: var(--color-surface-raised);
   border-left: 1px solid var(--color-border);
-  padding: var(--space-lg);
+  padding: var(--space-lg) var(--space-lg) var(--space-md);
   display: flex;
   flex-direction: column;
-  gap: var(--space-md);
+  gap: var(--space-2xs);
   box-shadow: var(--shadow-lg);
+  transform: translateX(100%);
+  transition: transform var(--dur-normal) var(--ease);
+  overflow-y: auto;
 }
-.nene-public .drawer__panel .navlink {
-  font-size: 1.125rem;
-  padding: 10px 0;
-  border-bottom: 1px solid var(--color-border);
+.nene-public .drawer.is-open .drawer__panel {
+  transform: translateX(0);
 }
 .nene-public .drawer__head {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  margin-bottom: var(--space-sm);
+}
+.nene-public .drawer__panel .navlink {
+  display: flex;
+  align-items: center;
+  min-height: 50px;
+  padding: 0 var(--space-sm);
+  margin: 0 calc(-1 * var(--space-sm));
+  font-size: 1.0625rem;
+  font-weight: var(--weight-medium);
+  color: var(--color-text-primary);
+  border-bottom: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  transition:
+    background var(--dur-fast) var(--ease),
+    padding-left var(--dur-fast) var(--ease);
+}
+.nene-public .drawer__panel .navlink:hover {
+  background: var(--color-surface-overlay);
+  padding-left: calc(var(--space-sm) + 4px);
+}
+/* current item: accent text + left rule instead of the header underline */
+.nene-public .drawer__panel .navlink[aria-current='page'] {
+  color: var(--color-accent);
+  box-shadow: inset 3px 0 0 var(--color-accent);
+}
+.nene-public .drawer__panel .navlink[aria-current='page']::after {
+  content: none;
+}
+
+/* Preference block pinned to the bottom of the drawer (language + theme). */
+.nene-public .drawer__prefs {
+  margin-top: auto;
+  padding-top: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+.nene-public .drawer__prefs .drawer__pref {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+.nene-public .drawer__prefs .drawer__pref-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-overline);
+  letter-spacing: var(--tracking-overline);
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+.nene-public .drawer__prefs .langsw {
+  width: 100%;
+  padding: 11px 13px;
+  border-radius: var(--radius-md);
+}
+.nene-public .drawer__prefs .themesw {
+  width: 100%;
+  border-radius: var(--radius-md);
+  padding: 4px;
+}
+.nene-public .drawer__prefs .themesw__btn {
+  flex: 1;
+  height: 40px;
 }
 
 /* ══ Browse (type listing) / archive page heads ════════════════════════════ */
@@ -1720,47 +1805,39 @@
     grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   }
 }
-/* Collapse the desktop nav to the drawer BEFORE it stops fitting. The inline
-   header (brand + nav + search + language + theme switch) needs ~950px, but the
-   nav only used to fold at ≤680px, so 681–955px overflowed horizontally with a
-   real menu loaded. Fold at ≤960px and let the (now compact) header row shrink so
-   it never widens the page. (#693) */
-@media (max-width: 960px) {
-  .nene-public .hd__nav .navlink,
-  .nene-public .hd__nav .btn--primary {
+/* ════════════════════════════════════════════════════════════════════════
+   ≤ 900px — COMPACT BAR (ClaudeDesign header redesign). One structural
+   breakpoint: fold the inline nav into the drawer and strip language + theme
+   from the bar (the drawer owns them). What remains on the right is two fixed
+   40px controls [search][menu], so the bar is identical from 900→320px and
+   CANNOT wrap — that is the overflow guarantee (no flex-wrap / second row). (#693)
+   ════════════════════════════════════════════════════════════════════════ */
+@media (max-width: 900px) {
+  .nene-public .hd__in {
+    height: 60px;
+  }
+  .nene-public .hd__nav {
     display: none;
   }
-  .nene-public .hd__search {
+  /* language + theme live only in the drawer below the fold */
+  .nene-public .hd__actions .langsw,
+  .nene-public .hd__actions .themesw {
     display: none;
+  }
+  /* an optional header CTA would break the fixed-width guarantee — drop it too */
+  .nene-public .hd__actions .hd__cta {
+    display: none;
+  }
+  /* the right cluster is now just [search] [menu] — both fixed 40px */
+  .nene-public .hd__actions {
+    margin-left: auto;
+    gap: var(--space-sm);
   }
   .nene-public .hd__menu {
     display: grid;
   }
-  /* Once the nav is in the drawer, the header can never be allowed to overflow:
-     tighten gaps, let parts shrink, and — as a hard guarantee at any width
-     ≤960 — wrap to a second row instead of widening the page. (#693) */
-  .nene-public .hd__in {
-    gap: var(--space-sm);
-    flex-wrap: wrap;
-    row-gap: var(--space-xs);
-    height: auto;
-    min-height: 62px;
-  }
-  .nene-public .hd__nav,
-  .nene-public .hd__actions {
-    min-width: 0;
-  }
-  .nene-public .hd__actions {
-    gap: var(--space-sm);
-  }
-  .nene-public .brand {
-    min-width: 0;
-  }
-  .nene-public .brand__name {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  .nene-public .brand__tag {
+    display: none;
   }
 }
 @media (max-width: 860px) {
@@ -1782,16 +1859,11 @@
   }
 }
 @media (max-width: 680px) {
-  /* Header nav-collapse + action-cluster shrink now live in the ≤960px block
-     above (they must trigger before the inline nav stops fitting, ~955px). This
-     block keeps the ≤680 content-area rules. (#693) */
+  /* Header nav/actions collapse lives in the ≤900px block above. This block keeps
+     the ≤680 content-area rules + folds away the optional top bar. (#693) */
   /* Top bar takes too much room on phones — fold it away (spec §6). */
   .nene-public .hd-topbar {
     display: none;
-  }
-  /* CTA stays useful on mobile but trims to fit alongside the menu button. */
-  .nene-public .hd__cta {
-    padding: 7px 12px;
   }
   .nene-public .hero__meta {
     gap: var(--space-lg);
@@ -1819,38 +1891,22 @@
     gap: var(--space-lg);
   }
 }
-@media (max-width: 480px) {
+/* ≤ 380px — tightest phones: trim gaps so search + menu keep breathing room next
+   to a long site name. Still no wrap. (#693) */
+@media (max-width: 380px) {
   .nene-public .hd__in {
-    height: 62px;
-  }
-  .nene-public .brand__tag {
-    display: none;
-  }
-  .nene-public .brand__name {
-    white-space: nowrap;
-  }
-  /* Compress the action cluster so language + theme switch + menu fit on the
-     narrowest phones; wrap to a second row as a last resort instead of ever
-     widening the page. Height is auto here so a wrapped row stays visible. (#693) */
-  .nene-public .hd__in {
-    height: auto;
-    min-height: 62px;
-    flex-wrap: wrap;
-    row-gap: var(--space-xs);
-    column-gap: var(--space-sm);
+    gap: var(--space-sm);
   }
   .nene-public .hd__actions {
     gap: var(--space-xs);
   }
-  .nene-public .themesw {
-    padding: 2px;
-  }
-  .nene-public .themesw__btn {
-    width: 28px;
-    height: 26px;
-  }
-  .nene-public .langsw {
-    padding: 5px 7px;
+}
+/* ≤ 360px — smallest phones: drop the standalone search icon too, leaving brand +
+   menu only. Search stays one tap away as the drawer's "Search" nav link, and a
+   normal-length site name no longer needs to truncate. (#693) */
+@media (max-width: 360px) {
+  .nene-public .hd__search {
+    display: none;
   }
 }
 /* ── Motion capability: scroll-reveal (#371 S1) ──────────────────────────────

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -348,6 +348,7 @@ export const de: Partial<MessageCatalog> = {
   'public.nav.allRecords': 'Alle Datensätze',
   'public.nav.backToLatest': 'Zurück zu den neuesten',
   'public.nav.language': 'Sprache',
+  'public.nav.theme': 'Theme',
   'public.browse.subRange': '{{total}} Datensätze · zeige {{start}}–{{end}}',
   'public.browse.recordCount.one': '{{count}} Datensatz',
   'public.browse.recordCount.other': '{{count}} Datensätze',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -347,6 +347,7 @@ export const en = {
   'public.nav.allRecords': 'All records',
   'public.nav.backToLatest': 'Back to latest',
   'public.nav.language': 'Language',
+  'public.nav.theme': 'Theme',
   'public.browse.subRange': '{{total}} records · showing {{start}}–{{end}}',
   'public.browse.recordCount.one': '{{count}} record',
   'public.browse.recordCount.other': '{{count}} records',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -349,6 +349,7 @@ export const fr: Partial<MessageCatalog> = {
   'public.nav.allRecords': 'Toutes les fiches',
   'public.nav.backToLatest': 'Retour aux plus récentes',
   'public.nav.language': 'Langue',
+  'public.nav.theme': 'Thème',
   'public.browse.subRange': '{{total}} fiches · affichage de {{start}} à {{end}}',
   'public.browse.recordCount.one': '{{count}} fiche',
   'public.browse.recordCount.other': '{{count}} fiches',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -339,6 +339,7 @@ export const ja: Partial<MessageCatalog> = {
   'public.nav.allRecords': 'すべての記事',
   'public.nav.backToLatest': '最新の記事へ戻る',
   'public.nav.language': '言語',
+  'public.nav.theme': 'テーマ',
   'public.browse.subRange': '{{total}} 件 · {{start}}–{{end}} を表示',
   'public.browse.recordCount.one': '{{count}} 件',
   'public.browse.recordCount.other': '{{count}} 件',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -346,6 +346,7 @@ export const ptBR: Partial<MessageCatalog> = {
   'public.nav.allRecords': 'Todos os registros',
   'public.nav.backToLatest': 'Voltar aos mais recentes',
   'public.nav.language': 'Idioma',
+  'public.nav.theme': 'Tema',
   'public.browse.subRange': '{{total}} registros · exibindo {{start}}–{{end}}',
   'public.browse.recordCount.one': '{{count}} registro',
   'public.browse.recordCount.other': '{{count}} registros',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -330,6 +330,7 @@ export const zhHans: Partial<MessageCatalog> = {
   'public.nav.allRecords': '所有记录',
   'public.nav.backToLatest': '返回最新',
   'public.nav.language': '语言',
+  'public.nav.theme': '主题',
   'public.browse.subRange': '共 {{total}} 条记录 · 显示 {{start}}–{{end}}',
   'public.browse.recordCount.one': '{{count}} 条记录',
   'public.browse.recordCount.other': '{{count}} 条记录',


### PR DESCRIPTION
## 目的
#693 で横あふれ（correctness）は解消済み。本 PR は未設計だった中間幅〜狭幅の**意匠**を、ClaudeDesign に「デザイン・プロトタイプ」方式で依頼した再設計として base に実装する。

## 設計 → 実装
- **構造ブレークポイントを 900px 1本に集約**（旧 960/680/480 を撤廃）。
  - ≥901 フルバー：ブランド · インラインナビ · [検索 · 言語 · テーマ]。
  - ≤900 コンパクトバー：ブランド · [検索 · ハンバーガー]。ナビ＋言語＋テーマはドロワー全面委譲（右は固定幅40px×2＋伸縮ブランド＝**flex-wrap 撤廃でも構造的に無 overflow**）。
  - ≤360 は検索も外しブランド＋ハンバーガーのみ（検索はドロワーの Search リンク）。
- **ドロワー刷新**：右スライドイン（translateX＋scrim フェード）、現在地の左アクセントバー、末尾に Language/Theme のラベル付き全幅コントロール（`.drawer__prefs`）、`aria-modal`。
- i18n：`public.nav.theme` を6ロケール追加。

## 変更
`public-site.css`（ヘッダー基底＋ドロワー＋レスポンシブ 900/680/380/360）／`PublicSiteShell.tsx`（drawer prefs＋aria-modal＋t）／i18n×6。

## 検証
- `verify-header.mjs`：**320–1200px 全幅で `scrollWidth==viewport`（横あふれ0）＋メニュー読込**。折り畳みは ≤900 でハンバーガー化。
- `npm run check --prefix frontend` 全段グリーン（tsc / eslint / prettier / **test 471(95 files)** / validate:themes / knip / storybook）。
- 実キャプチャで desktop フルバー / 768 コンパクト / 320 ブランド＋ハンバーガー / ドロワー(Language/Theme) を確認。

## 補足
ドロワーの完全なフォーカス管理（Esc/フォーカス移動・復帰）は任意の後追い（aria-modal は付与済み）。handoff: `design-export/header-design-handoff/`（依頼）／`header-redesign-response/`（納品）。

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)