### PR TITLE
feat(public): ヘッダー畳み込みに fit-probe を追加（可変メニュー対応） (#697)

### DIFF
--- a/frontend/src/pages/consumer/PublicSiteShell.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.tsx
@@ -211,6 +211,7 @@ export function PublicSiteShell({
   // first-party JS implements scroll-reveal, gated by prefers-reduced-motion.
   const mainRef = useRef<HTMLElement>(null)
   const sentinelRef = useRef<HTMLDivElement>(null)
+  const headerRef = useRef<HTMLElement>(null)
   const { pathname } = useLocation()
   const motion = useConsumerMotion(flagAttrs)
   useScrollReveal({
@@ -255,6 +256,32 @@ export function PublicSiteShell({
     { label: 'Search', to: '/search', current: false },
   ]
 
+  // Fit-probe (#695): fold the inline nav into the drawer the instant it would
+  // overflow, so a long / many-item nav never overflows or clips the row ABOVE
+  // the 900px width floor (the CSS handles ≤900 on its own, no JS). `.hd__nav`
+  // and `.brand` are `flex:0 0 auto` (never shrink), so an over-long row genuinely
+  // overflows and is measurable; measuring with `data-nav` removed reads the
+  // expanded width, then it is re-applied — synchronously, so no flicker.
+  const navFitKey = navLinks.map((link) => link.label).join('')
+  useEffect(() => {
+    const header = headerRef.current
+    if (header === null) return
+    const row = header.querySelector<HTMLElement>('.hd__in')
+    if (row === null) return
+    const syncNav = () => {
+      header.removeAttribute('data-nav')
+      if (row.scrollWidth > row.clientWidth + 1) {
+        header.setAttribute('data-nav', 'drawer')
+      }
+    }
+    syncNav()
+    const observer = new ResizeObserver(syncNav)
+    observer.observe(row)
+    return () => {
+      observer.disconnect()
+    }
+  }, [navFitKey])
+
   const footerTypeLinks = types.slice(0, 4)
 
   return (
@@ -273,7 +300,7 @@ export function PublicSiteShell({
       {hasTopbarContent(site.headerConfig.topbar) ? (
         <HeaderTopbarRow topbar={site.headerConfig.topbar} />
       ) : null}
-      <header className="hd">
+      <header ref={headerRef} className="hd">
         <div className="wrap hd__in">
           <Brand siteName={site.siteName} tagline={site.tagline} logo={site.logo} />
           <nav className="hd__nav" aria-label="Primary">

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -144,8 +144,11 @@
   display: flex;
   align-items: center;
   gap: var(--space-sm);
-  min-width: 0; /* let the name truncate before the row overflows */
-  flex: 0 1 auto;
+  min-width: 0;
+  /* Full bar: brand does NOT shrink, so a long/short nav never squeezes the site
+     name to an ellipsis — if the row can't fit, the fit-probe folds the nav into
+     the drawer instead. Brand may shrink only once compact (see COMPACT BAR). */
+  flex: 0 0 auto;
 }
 .nene-public .brand__mark {
   width: 34px;
@@ -198,7 +201,9 @@
   /* Default skeleton (= nav-right): primary nav hugs the action cluster on the
      right. `data-header` layouts re-place it (see Style flags → Header layout). */
   margin-left: auto;
-  min-width: 0;
+  /* Do NOT shrink: a too-wide nav must overflow the row (which the fit-probe
+     detects) rather than silently shrinking and overlapping the actions. */
+  flex: 0 0 auto;
 }
 .nene-public .hd__actions {
   display: flex;
@@ -1806,11 +1811,18 @@
   }
 }
 /* ════════════════════════════════════════════════════════════════════════
-   ≤ 900px — COMPACT BAR (ClaudeDesign header redesign). One structural
-   breakpoint: fold the inline nav into the drawer and strip language + theme
-   from the bar (the drawer owns them). What remains on the right is two fixed
-   40px controls [search][menu], so the bar is identical from 900→320px and
-   CANNOT wrap — that is the overflow guarantee (no flex-wrap / second row). (#693)
+   COMPACT BAR (#695) — nav + language + theme fold into the drawer; only
+   brand + [search] + menu remain (fixed-width, cannot wrap).
+
+   Triggered by EITHER condition, so a variable-length nav is handled no matter
+   how many / how long the items are:
+     1. WIDTH FLOOR — @media (max-width: 900px). Phones/tablets always get the
+        hamburger UX, with zero JS.
+     2. FIT PROBE   — .hd[data-nav='drawer'], set by JS (PublicSiteShell) the
+        instant the expanded row would overflow ABOVE 900px (e.g. 7 long labels
+        at 1100px). Stops the inline nav overflowing/clipping and stops the brand
+        name from being pushed to an ellipsis above 900px.
+   Both branches apply the identical compact styling. See NOTES §fit-probe. (#693)
    ════════════════════════════════════════════════════════════════════════ */
 @media (max-width: 900px) {
   .nene-public .hd__in {
@@ -1836,9 +1848,40 @@
   .nene-public .hd__menu {
     display: grid;
   }
+  /* compact: the brand may now shrink + ellipsise (it does not in the full bar) */
+  .nene-public .brand {
+    flex: 0 1 auto;
+  }
   .nene-public .brand__tag {
     display: none;
   }
+}
+/* Fit-probe branch (JS toggles data-nav) — identical compact styling at ANY width. */
+.nene-public .hd[data-nav='drawer'] .hd__in {
+  height: 60px;
+}
+.nene-public .hd[data-nav='drawer'] .hd__nav {
+  display: none;
+}
+.nene-public .hd[data-nav='drawer'] .langsw,
+.nene-public .hd[data-nav='drawer'] .themesw {
+  display: none;
+}
+.nene-public .hd[data-nav='drawer'] .hd__cta {
+  display: none;
+}
+.nene-public .hd[data-nav='drawer'] .hd__actions {
+  margin-left: auto;
+  gap: var(--space-sm);
+}
+.nene-public .hd[data-nav='drawer'] .hd__menu {
+  display: grid;
+}
+.nene-public .hd[data-nav='drawer'] .brand {
+  flex: 0 1 auto;
+}
+.nene-public .hd[data-nav='drawer'] .brand__tag {
+  display: none;
 }
 @media (max-width: 860px) {
   .nene-public .hero__grid {

--- a/frontend/tests/setup/vitest.setup.ts
+++ b/frontend/tests/setup/vitest.setup.ts
@@ -1,5 +1,17 @@
 import '@testing-library/jest-dom/vitest'
 
+// jsdom does not implement ResizeObserver. Components that observe element size
+// (e.g. the public header's nav fit-probe) construct one on mount; provide an
+// inert no-op so they render under test without throwing. Tests that need to
+// drive resize callbacks can stub this global.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+}
+
 // jsdom does not implement matchMedia. Provide an inert default (no match, no-op
 // listeners) so components that read viewport media queries via `useMediaQuery`
 // render their desktop branch under test. Tests that assert mobile behavior


### PR DESCRIPTION
## 背景
#695 の再設計は畳み込みを固定 900px 1本にしたが、900px は**ビューポート幅**であって**ナビが収まるか**ではない。メニュー項目が多い/長い場合、900px 超でもインライン行が溢れうる（施主指摘・ClaudeDesign 調整版 r2）。

## 対応（二段畳み）
1. **幅フロア**：`@media (max-width: 900px)` は常にコンパクト（スマホ/タブレットは JS 無しでハンバーガー）。
2. **fit-probe（JS）**：`>900px` でもインライン行が収まらなくなった瞬間に `.hd[data-nav='drawer']` を付与して畳む。`.hd__nav`/`.brand` を `flex:0 0 auto`（縮ませない）にして**実際に溢れさせて検知**（`row.scrollWidth > row.clientWidth`）。`data-nav` を外して測り再付与＝同期実行でチラつき無し。コンパクトCSSは (1)(2) 両方から同一に当たる。

## 変更
`public-site.css`（`.brand`/`.hd__nav` を `flex:0 0 auto`・コンパクト時のみ縮む／コンパクト規則を `.hd[data-nav='drawer']` でも発火）／`PublicSiteShell.tsx`（ResizeObserver の fit-probe＋`<header>` ref）／`vitest.setup.ts`（jsdom 用 no-op ResizeObserver モック）。

## 検証
- `verify-fitprobe.mjs`：901–959px 帯含む **320–1280px 全幅で横あふれ0**。現行5項目は 901px まで inline（誤発火なし）。
- ナビを広げて >900 のレスポンシブ域へ resize → `data-nav='drawer'` 付与→コンパクト化→横あふれ0 を実証。
- `npm run check --prefix frontend` 全段グリーン（tsc / eslint / prettier / **test 471(95 files)** / validate:themes / knip / storybook）。

Closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)