### PR TITLE
docs(session): セッション文書を保全し current.md を更新する (#703)

### DIFF
--- a/docs/articles/qiita-typed-cms-business-data.md
+++ b/docs/articles/qiita-typed-cms-business-data.md
@@ -1,0 +1,404 @@
+<!--
+Qiita title: 型付きCMSで業務データと公開ページを管理する — NeNe Records を Docker で試す
+Qiita tags: Docker, OSS, CMS, PHP, OpenAPI
+related_issue: #684
+-->
+
+## はじめに
+
+CMS というと、まず WordPress を思い浮かべる人は多いと思います。
+
+WordPress はとても便利です。ブログ、固定ページ、メディア、テーマ、プラグインが揃っていて、小さなサイトから大きなサイトまで幅広く使えます。
+
+一方で、業務データや社内向けの情報管理まで WordPress で扱おうとすると、`postmeta` に文字列として値を詰め込む形になりがちです。プラグインごとの独自仕様に寄り、API / 型 / 権限 / AI 連携の境界も見えにくくなることがあります。
+
+**[NeNe Records](https://github.com/hideyukiMORI/nene-records)** は、NENE2 上で動く API-first な型付きエンティティ / CMS プラットフォームです。
+
+エンティティタイプとフィールド定義を管理画面から作り、レコードを JSON API で保存し、公開ページとして配信し、OpenAPI / MCP 経由で AI ツールからも同じ API 境界を触れるようにすることを目指しています。
+
+基盤には、API-first / OpenAPI / MCP 対応を前提にした軽量 PHP フレームワーク **[NENE2](https://github.com/hideyukiMORI/NENE2)** を使っています。
+
+> **リリース状況（2026年6月時点）** — NeNe Records は OSS として開発中ですが、管理画面、型付きフィールド、公開ページ、SEO/SSR、WordPress WXR インポート、マルチテナント基盤など主要機能はかなり入っています。一方で、設定 UI の磨き込み、2FA / 権限細分化、共有ホスティング向け ZIP 配布などは継続開発中です。この記事は Docker での試用・評価向けです。MIT ライセンスですが **無保証** です。
+
+> **誰向けの記事か** — WordPress 以外の軽量 CMS を試したい人、業務データを型付きで管理したい人、OpenAPI / MCP を前提にした CMS 的なアプリを見たいエンジニア向けです。
+
+---
+
+## NeNe Records でできること（この記事の範囲）
+
+| 項目 | 内容 |
+| --- | --- |
+| 型付きデータ | Entity Type / Field Definition / Record で業務データを定義 |
+| 管理画面 | React 管理 UI でコンテンツタイプ、レコード、メディア、ユーザーを管理 |
+| 公開ページ | 実 permalink、SSR head、OGP、JSON-LD、sitemap、robots.txt |
+| WordPress 移行 | WXR インポート、メディア取込、301 リダイレクト、SEO メタ取込 |
+| API | OpenAPI 3.1 で JSON API 契約を管理 |
+| MCP | OpenAPI に沿った MCP tool catalog を用意 |
+| マルチテナント | organization スコープ、JWT、superadmin / admin / editor |
+
+**しないこと** — WordPress プラグイン互換、WordPress テーマ互換、Elementor 的な任意 JS ページビルダー、AI による DB 直アクセスは扱いません。NeNe Records は WordPress 互換プロダクトではなく、NENE2 上の型付き CMS / 業務データ管理プロダクトです。
+
+---
+
+## 1. Docker で起動する
+
+NeNe Records は NENE2 を sibling checkout として参照します。
+
+そのため、まず `NENE2` と `nene-records` を同じ階層に clone します。
+
+```bash
+git clone https://github.com/hideyukiMORI/NENE2.git
+git clone https://github.com/hideyukiMORI/nene-records.git
+cd nene-records
+cp .env.example .env
+
+# .env を Docker の MySQL 用に切り替える（既定は host PHPUnit 用の SQLite）
+#   DB_ADAPTER=mysql
+#   DB_HOST=mysql
+#   DB_NAME=nene_records
+#   DB_USER=nene_records
+#   DB_PASSWORD=nene_records
+# （.env.example のコメントにある値と同じ。詳細は docs/development/docker.md）
+
+docker compose up --build -d
+```
+
+ヘルスチェック:
+
+```bash
+curl http://localhost:18082/health
+```
+
+ローカルの主な URL:
+
+| 用途 | URL |
+| --- | --- |
+| API | http://localhost:18082 |
+| health | http://localhost:18082/health |
+| OpenAPI | http://localhost:18082/openapi.php |
+| 管理 UI（Vite dev） | http://localhost:18084 |
+| phpMyAdmin | http://localhost:18083 |
+| Mailpit | http://localhost:18026 |
+
+初回に SQLite のまま起動してしまった場合は、DB 設定を変える前に `docker compose down -v` で MySQL の volume を作り直してください（空パスワードで初期化された volume が残ると Access denied になります）。
+
+管理 UI は Compose には含めず、別ターミナルで Vite を起動します。
+
+```bash
+npm ci --prefix frontend   # 初回のみ：管理UIの依存をインストール
+npm run dev --prefix frontend
+```
+
+<!--
+スクリーンショット 1（必須）:
+掲載場所: 「管理 UI は Compose には含めず、別ターミナルで Vite を起動します。」の直後。
+画面: ターミナルで `docker compose up --build -d` と `/health` が通っている画面。
+目的: Docker でローカル検証できることを最初に見せる。
+写す要素: `curl http://localhost:18082/health` の成功、可能なら `docker compose ps` の app/mysql 起動状態。
+-->
+
+---
+
+## 2. 初回セットアップ
+
+NeNe Records には、以前存在した開発用のデフォルトユーザーは残っていません。
+
+初回は installer で organization と admin ユーザーを作成します。
+
+```bash
+docker compose exec -T \
+  -e NENE_INSTALL_ADMIN_EMAIL=admin@example.com \
+  -e NENE_INSTALL_ADMIN_PASSWORD='change-me' \
+  app composer app:install
+```
+
+`docker compose exec` はホストの環境変数を渡さないので、必ず `-e` で指定してください。付けないと「NENE_INSTALL_ADMIN_EMAIL and NENE_INSTALL_ADMIN_PASSWORD are required」で止まります。
+
+このコマンドは冪等です。再実行しても、既存 organization / admin がある場合は安全に扱われます。
+
+ログイン後、`/admin` からエンティティタイプ、レコード、メディア、設定などを管理できます。
+
+<!--
+スクリーンショット 2（必須）:
+掲載場所: 「ログイン後、`/admin` から...管理できます。」の直後。
+画面: ログイン後の管理ダッシュボード、または admin shell。
+目的: WordPress 風の管理入口ではなく、NeNe Records の管理コンソールがあることを見せる。
+写す要素: 左ナビ、ダッシュボード、公開数/アクセスなどの概況。
+注意: 実メールアドレスや本番ドメインの管理情報が写る場合はマスクする。
+-->
+
+---
+
+## 3. 型付き CMS としての基本構造
+
+NeNe Records の中心は、次の3つです。
+
+| 概念 | 内容 |
+| --- | --- |
+| Entity Type | `posts`、`pages`、`products` など、レコードの種類 |
+| Field Definition | title、body、price、published_at など、型付きの項目定義 |
+| Record | 実際のデータ。draft / published / archived / scheduled などの状態を持つ |
+
+WordPress の `postmeta` は柔軟ですが、値の型や検証はプラグインや実装に寄りがちです。
+
+NeNe Records では、フィールド定義を API 側の schema registry として持ち、書き込み時に API が検証します。
+
+主なフィールド型:
+
+- text
+- markdown
+- html
+- blocks
+- int
+- enum
+- bool
+- datetime
+- image
+- file
+- relation
+
+この「管理画面で柔軟に作れるが、保存時は型で守る」という方針が、NeNe Records のいちばん大事なところです。
+
+<!--
+スクリーンショット 3（必須）:
+掲載場所: 「この『管理画面で柔軟に作れるが...』の段落直後。
+画面: Entity Type / Field Definition の編集画面。
+目的: 「型付きCMS」であることを視覚的に伝える。
+写す要素: フィールド名、型、必須設定、並び順。
+おすすめ: `posts` や `pages` のような分かりやすい entity type を使う。
+-->
+
+---
+
+## 4. レコードを作成する
+
+エンティティタイプを作ると、そのタイプに対応したレコード管理画面が使えます。
+
+たとえば `posts` なら、タイトル、本文、公開状態、タグ、SEO 情報などを持ったレコードを作れます。
+
+NeNe Records は、単なる Headless CMS だけではなく、公開ページを持つ CMS としても育っています。
+
+最近の実装では、Markdown や HTML だけでなく、`blocks` フィールドによるリッチページ編集、ライブプレビュー、レイアウト用ブロックも追加されています。
+
+<!--
+スクリーンショット 4（必須）:
+掲載場所: 「ライブプレビュー、レイアウト用ブロックも追加されています。」の直後。
+画面: レコード編集画面。
+目的: 実際にコンテンツや業務データを入力する画面を見せる。
+写す要素: title/body/blocks などの入力、公開状態、保存ボタン。
+おすすめ: blocks エディタや preview toggle が見える画面だと強い。
+-->
+
+---
+
+## 5. ディレクトリビューと permalink
+
+直近で大きく進んでいるのが、ページ階層と permalink まわりです。
+
+NeNe Records は WordPress の親子ページツリーをそのまま真似るのではなく、**任意 permalink と 301 リダイレクト**を中心に設計しています。
+
+たとえば:
+
+```text
+/docs/getting-started
+/docs/api/openapi
+/company/about
+```
+
+のようなパスをレコード単位で持たせ、変更時には旧 URL から新 URL へ 301 を作れます。
+
+管理画面では permalink 由来のディレクトリ表示、ツリー検索、DnD 親移動、手動並び順などが入り始めています。
+
+WordPress から移行するときに、URL 構造や SEO 資産をなるべく壊さないための機能です。
+
+<!--
+スクリーンショット 5（推奨）:
+掲載場所: 「WordPress から移行するときに...」の段落直後。
+画面: ディレクトリビュー。
+目的: 直近の強みである permalink ツリー、検索、DnD、並び替えを見せる。
+写す要素: ディレクトリツリー、子件数、検索、並び替え操作。
+おすすめ: 階層が2〜3段あるデータで、permalink パスが読める状態。
+-->
+
+---
+
+## 6. 公開ページと SEO
+
+公開ページは、SPA だけに寄せず、PHP 側でクローラブルな HTML を返す方針です。
+
+NeNe Records では、公開レコードに対して:
+
+- `<title>`
+- canonical
+- OGP
+- Twitter card
+- JSON-LD
+- BreadcrumbList
+- `sitemap.xml`
+- `robots.txt`
+
+などを扱います。
+
+内部的には、PHP 前段で SSR 相当の head を作り、その上に SPA shell が乗る構成です。Node.js SSR を別に立てるのではなく、単一オリジンの PHP アプリとして扱うのが特徴です。
+
+<!--
+スクリーンショット 6（推奨）:
+掲載場所: 「単一オリジンの PHP アプリとして扱うのが特徴です。」の直後。
+画面: 公開ページをブラウザで表示している画面。
+目的: 管理したレコードが実際に公開ページとして見えることを示す。
+写す要素: 公開 permalink、記事タイトル、本文、テーマ反映。
+余裕があれば DevTools で title / og:title / JSON-LD が入っていることも別カットで見せる。
+-->
+
+---
+
+## 7. WordPress WXR インポート
+
+NeNe Records は WordPress 互換ではありません。
+
+ただし、WordPress から移行するための WXR インポート機能は実装されています。
+
+扱える範囲:
+
+- posts / pages / tags の取り込み
+- メディア添付の取り込み
+- 本文内画像 URL の差し替え
+- 301 リダイレクトマップ
+- Yoast / RankMath / AIOSEO の SEO メタ取り込み
+- インポート計画のプレビュー
+
+これは「WordPress のプラグインやテーマをそのまま動かす」ための機能ではなく、コンテンツと URL / SEO 資産を NeNe Records 側へ移すための機能です。
+
+<!--
+スクリーンショット 7（推奨）:
+掲載場所: 「コンテンツと URL / SEO 資産を...移すための機能です。」の直後。
+画面: `/admin/import` の WordPress WXR インポート画面。
+目的: WordPress 移行に向けた機能があることを見せる。
+写す要素: WXR import、preview、redirect / media / SEO 取り込みの項目。
+注意: 実サイト由来の URL や非公開コンテンツが写る場合はダミー化する。
+-->
+
+---
+
+## 8. 実データでの検証: 青空文庫インポート
+
+最近は、実データを使った soak も進めています。
+
+その一例として、青空文庫の公開テキストを使い、小説をレコードとして投入する importer を用意しています。
+
+```text
+tools/soak-import-aozora.php
+```
+
+検証環境では、夏目漱石の作品を章モードで投入し、1000件を超えるレコードを実際に扱っています。
+
+実際に投入しているテナントはこちらです。
+
+```text
+https://aozora.nene-records.com/
+```
+
+ブラウザからアクセスすると、NeNe Records の公開シェル上で表示されます。`curl` などで `Accept: */*` のまま叩くと API 側の JSON が返ることがありますが、通常のブラウザアクセスでは HTML として表示されます。
+
+この検証で見ているのは、単に「レコードを作れるか」だけではありません。
+
+- 多数レコードで一覧が重くならないか
+- permalink ツリーが破綻しないか
+- 章ナビゲーションが読書 UI として成立するか
+- sitemap / 公開ページ / 検索が実データで動くか
+- 管理画面のディレクトリビューが大きめのデータ量に耐えるか
+
+NeNe Records は「CMSっぽい管理画面を作った」だけでなく、実データを入れて使いながら、ディレクトリ表示、ページング、章ナビ、permalink、公開 SEO を磨いている段階です。
+
+<!--
+スクリーンショット 8（任意だが強い）:
+掲載場所: Aozora セクション末尾、「公開 SEO を磨いている段階です。」の直後。
+画面: 青空文庫データを投入した公開ページ、または章ナビ付きの小説ページ。
+目的: 実データ・多数レコードで動かしていることを見せる。
+写す要素: 章ナビ（前/目次/次）、公開 permalink、一覧またはディレクトリビュー。
+おすすめ: `aozora.nene-records.com` をブラウザで表示した画面。root が期待と違う場合は、見えている章/一覧ページの実URLを使う。
+-->
+
+---
+
+## 9. OpenAPI と MCP
+
+NeNe Records は API-first です。
+
+管理 UI も公開 UI も、基本的には API のクライアントです。
+
+API 契約は OpenAPI 3.1 として管理され、CI で検証されます。
+
+```text
+http://localhost:18082/openapi.php
+```
+
+また、`docs/mcp/tools.json` に MCP tool catalog もあります。
+
+重要なのは、MCP が DB に直接触るのではなく、OpenAPI で定義された HTTP/API 境界を通ることです。
+
+これは NENE2 と NeNe シリーズ全体で共通している方針です。
+
+<!--
+スクリーンショット 9（任意）:
+掲載場所: 「これは NENE2 と NeNe シリーズ全体で共通している方針です。」の直後。
+画面: OpenAPI または MCP tools catalog。
+目的: API-first / MCP-ready な構成を見せる。
+写す要素: `/openapi.php`、または `docs/mcp/tools.json` の一部。
+おすすめ: OpenAPI の方が読者に伝わりやすい。MCP catalog は補助カットで十分。
+-->
+
+---
+
+## 10. 向いているケース、向いていないケース
+
+向いているケース:
+
+- WordPress より型のあるデータ管理をしたい
+- JSON API を中心に CMS / 業務データ管理を作りたい
+- 管理 UI、公開ページ、API、MCP の境界を分けたい
+- WordPress からコンテンツと URL を移行したい
+- self-host できる OSS を試したい
+
+向いていないケース:
+
+- WordPress プラグインをそのまま使いたい
+- WordPress テーマ互換を期待している
+- Elementor のように任意 JS まで自由に入れたい
+- DB を直接触る MCP ツールを作りたい
+- 共有ホスティングに ZIP を置くだけで本番運用したい
+
+特に最後の点は注意です。Docker / VPS 向けの構成は整ってきていますが、共有ホスティング向けの ZIP インストーラーは今後の作業です。
+
+---
+
+## まとめ
+
+NeNe Records は、NENE2 上に作っている API-first な型付き CMS / 業務データ管理 OSS です。
+
+- Entity Type / Field Definition / Record で型付きデータを扱う
+- React 管理 UI で schema と records を編集する
+- 公開ページ、permalink、SEO / SSR も扱える
+- WordPress WXR インポートで移行の入口を持つ
+- 青空文庫のような実データ投入で、公開ページや一覧の挙動を検証している
+- OpenAPI と MCP tool catalog を持つ
+- マルチテナントや role / organization スコープを前提にしている
+
+まだ開発中の部分はありますが、Docker で動かして、型付き CMS としての基本的な流れを試すには十分な状態になっています。
+
+WordPress の完全互換を目指すのではなく、**型、API、AI ツール境界をはっきりさせた軽量 CMS** として育てています。
+
+---
+
+## リンク
+
+| 種類 | URL |
+| --- | --- |
+| リポジトリ | https://github.com/hideyukiMORI/nene-records |
+| NENE2 | https://github.com/hideyukiMORI/NENE2 |
+| OpenAPI | https://github.com/hideyukiMORI/nene-records/blob/main/docs/openapi/openapi.yaml |
+| Product Vision | https://github.com/hideyukiMORI/nene-records/blob/main/docs/explanation/product-vision.md |
+| Docker guide | https://github.com/hideyukiMORI/nene-records/blob/main/docs/development/docker.md |
+| Deployment guide | https://github.com/hideyukiMORI/nene-records/blob/main/docs/deployment.md |
+
+フィードバックは [GitHub Issues](https://github.com/hideyukiMORI/nene-records/issues) へ歓迎します。

--- a/docs/daily/2026-06-26.md
+++ b/docs/daily/2026-06-26.md
@@ -1,0 +1,59 @@
+# 日報 — 2026-06-26（NeNe Records）
+
+## ヘッドライン
+**ペルソナ討論が「最大の残壁」と名指ししていた managed入口（非技術者がセルフホストせずに始める入口）を、ゼロから本番稼働まで完成させた。** `nene-records.com` で登録すると `slug.nene-records.com` で即使えるサブドメイン型マルチテナント SaaS が、自動TLS・テナント分離・実メール送信・メール認証込みで本番ライブ。
+
+---
+
+## 本日の成果（すべて #536 配下・マージ＋本番反映済）
+
+### 1. サブディレクトリ設置の base path 基盤（zip インストーラの前提）
+- バックエンドの URL 生成を `APP_BASE_PATH` で前置可能化（S1・#595）。
+- フロントをランタイム base（`<base href>` 由来）対応（S2・#596）、CSP ブロックを修正（#597）。
+- ディレクトリ方式マルチテナントの公開SEO配線を完成（S-path・#599）。
+
+### 2. subdomain マルチテナント SaaS（本番 cutover）
+- on-demand TLS の `ask` ゲート（#600）。
+- apex をグローバル面として通す（#601）。
+- 公開セルフサーブ signup（バックエンド #602／フロント #603）。
+- apex のデフォルト・プロモ LP（NeNe Records / NENE2 / ayane.co.jp・#604）。
+- 本番 cutover：`tenant_resolution_mode=subdomain` ＋ Caddy（`*.nene-records.com` on-demand TLS ＋ apex ＋ `records.nene-suite.com → 301`）。
+
+### 3. メール基盤＋メール認証
+- Resend を本番接続（DKIM/SPF をムームーDNS に登録）→ 受信トレイ着信を実証。
+- signup メール認証（ソフトゲート：登録→即利用のまま＋検証メール＋未確認バナー・#608）。
+- 確認後にテナントのログインへ案内（#609）。
+
+### 4. 評価（ペルソナ討論 第6回・#610）
+- 判定が **見送り5→2・今すぐ2→4** に前進。
+- 議論が「使えるか」から「商売・信頼に足るか」へ質的転換。
+
+> セッション前半では計測（GA4/GTM＋Consent Mode・#583/584）、SEO（sitemap/robots・#585–588）、WYSIWYG #538（#590/591）、公開i18n #540（#592/593）も完了済み。
+
+---
+
+## 本番で発見し、その場で修正した実運用ギャップ
+cutover を実機検証として使い、subdomain 化でのみ顕在化する問題を3件潰した。
+
+1. **cron が org-scoped** → subdomain モードでは org 解決できず全テナントの予定公開/Webhook が停止 → `OrganizationIterator` で全 active org を巡回（#605）。
+2. **`/` が NENE2 の framework JSON を返す** → ブラウザでも JSON になり apex LP/公開ホームが描画できない → `SpaShellFallback` が `/`+`text/html` で SPA シェルを返すよう修正（#606）。
+3. **メール from の env キー違い**（`.env.example` の `MAIL_FROM` ≠ 実コードの `MAIL_FROM_ADDRESS`）→ 検証済ドメインでない from で送信が 550 拒否 → 修正＋ドキュメント是正（#607）。
+
+いずれも本番を壊さず対処（モード即 revert・mysqldump＋Caddyfile バックアップ取得）。
+
+---
+
+## 現在の状態
+- 本番：**https://nene-records.com**（apex プロモLP・`/signup`・自動TLS・メール認証）／`records.nene-suite.com` → 301。健全稼働。
+- テストテナント `demoshop` / `verifydemo` を作成済み（不要なら削除可）。
+
+---
+
+## 残課題（ペルソナ第6回の処方順）
+1. **signup レート制限**（最優先・小・公開前提＝大量 org 作成の濫用対策。`ThrottleMiddleware` は既存）。
+2. **soak 開始**（実テナント/コンテンツ投入＋数週間の無事故運用で"実績"を積む）。
+3. **収益モデルの事業判断**（有料プラン／独自ドメインSKU／保守SLA。`CustomDomainResolutionStrategy` の土台あり）。
+
+小さな follow-up：検証メールの resend／公開操作のハードゲート／path モードの edge 層 base_prefix／email リンクの per-tenant host／apex LP の CMS 差し替え。
+
+> 詳細・再開手順は引き継ぎ書 `docs/handoff-2026-06-25.md` の §A（2026-06-26）に集約。

--- a/docs/daily/2026-06-27.md
+++ b/docs/daily/2026-06-27.md
@@ -1,0 +1,62 @@
+# 日報 — 2026-06-27（NeNe Records）
+
+> 前報（2026-06-26）の残課題①signupレート制限／②soak／③収益モデルの事業判断、を起点に連続作業。会期は 06-26 深夜〜06-27。
+
+## ヘッドライン
+**「収益・拡張の基盤（ADR 0005）」をゼロから本番稼働まで通し、さらに小説の章リーディング＋青空文庫を本番投入、公開リポに残っていた既定資格 admin バックドアを修正、WordPress 移行フィデリティの方針も確定した。** 経営・市場ペルソナ会議を5回まわして各判断を裏取り。バック `composer check`／フロント `npm run check` は常時グリーン。
+
+---
+
+## 本日の成果（マージ済・大半は本番反映済）
+
+### A. 収益／拡張アーキテクチャ（ADR 0005）＝オープンコア
+- 独自ドメインの org 解決＋**entitlement seam**（既定 UNLIMITED＝self-host 無制限）#618 / **ADR 0005** 決定 #620。
+- コアを **deploy-time モジュール機構**へ（ModuleRegistry）#622 ／ commercial を **composer-merge-plugin で任意注入** #624。
+- private repo `nene-records-commercial`：**PlanBasedEntitlements**（plan→上限）。
+- テナント自助の **`/account`**：API #626 ＋ 画面 #628（admin のみ・plan/上限/使用量）。
+- **本番反映**：commercial 注入込みで PlanBased 稼働 → `demoshop`(pro)/free で差が出ることを実証。
+
+### B. signup レート制限（前報残①）
+- 実クライアントIP解決（`src/Http/ClientIp`）＋ `PublicSignupHandler` に時間窓レート制限（5/h・429）#614。
+
+### C. 🔴→✅ セキュリティ（本日の重大インシデント）
+- 公開マイグレーションが **`admin@/editor@nene-records.local` を `nene1234`（公開リポ＋README 記載）で本番に常駐**させていたのを発見（soak 中）。
+- 本番から削除（org無しの未使用2件・実管理者は無傷・削除後 login=401）＋恒久 delete migration＋README 除去 #641/#642。
+- アクセスログ点検（練習）：**悪用の痕跡なし**（ログイン全成功・失敗0・セットアップ期間に集中／bot スキャンは 429 で弾かれていた）。
+
+### D. テーマ量産（ClaudeDesign）
+- 調査で「EPIC #367 closed＝MCP でテーマ生成→検証→公開まで既に可能」と判明。唯一の穴＝公開の発見性/安全性を **`activateTheme`（存在検証→active_theme）＋authoring guide に公開手順** で塞ぐ #632。#373 は陳腐化（要 close）。
+
+### E. 小説 章モード＋青空文庫（本番）
+- なろう/AO3 式 **目次＋章レコード＋導出チャプターナビ**（series/chapter_no/chapter_total から表示時に前/目次/次＋「第N章/全M章」を算出・SSR＋SPA）#646。
+- **青空 importer**（`tools/soak-import-aozora.php` http/direct・章モード）#638。
+- **本番投入**：org `aozora` に **夏目漱石 全1114レコード live**（`aozora.nene-records.com`）。
+
+### F. zip インストーラの布石
+- 共有ホスティング前提チェック **`tools/hosting-precheck.php`**（PHP8.4＋必要拡張を READY/NOT READY 判定）#634。
+
+### G. ページ移行フィデリティ（#651 PR1）
+- **ページ単位の任意 permalink**（`/` 含むフリーパス・一意・正規化）＋**変更時 自動301**（`url_redirects` 再利用）＋既定不可視の上級欄 #652。WP 親子ツリーは**不採用**。
+
+---
+
+## 会議・意思決定（ペルソナ）
+- **経営 sequencing**（6名）：今＝**D コンシェルジュで初の有料客＋B soak**／C self-serve 課金は後回し／A zip は self-host pull で発火。議事 #630。
+- **価格/初顧客ドラフト**＋**r7 議事録**：価格の"数字"は機密 → **private 販促リポ `nene-records-marketing` 新設**へ集約（公開リポからは削除/非公開化）。
+- **コンテンツ・ページング**（SEO/マーケ/読者UX/パブリッシャー）：長文は単一ページ既定＋章は本/連載のみ・char切り却下。議事 #644。
+- **固定ページ階層化**（WP移行4ペルソナ）：parent_id ツリーは不採用、**任意permalink＋301取込＋BreadcrumbList＋permalinkパス由来の導出階層**を採用。議事 #650・実装 #651。
+
+---
+
+## 現在の状態
+- 本番 **https://nene-records.com** 健全。org 6（default/demoshop/xion/xion1/verifydemo/**aozora**）。PlanBased 稼働・`/account` 反映済・章モード/Aozora live。
+- main 先頭 `d7f5fc1`（PR1 permalink はコード反映・**本番未デプロイ**）。open PR 0・worktree は main のみ（後片付け済）。
+- DBバックアップ：server `~/nene_records_backup_preaozora.sql`。
+
+## 残課題 / 次の一手
+1. **#651（ページ移行フィデリティ）**：PR2 パンくず＋BreadcrumbList＋セクション子一覧 → PR3 管理ディレクトリ＋**多数レコード一覧スケール**（aozora 1114件で顕在）→ PR4 CSV 301取込。
+2. **#647（Aozora 章モード調整）**：過分割（三四郎=117章）→最上位見出しのみ・章タイトル・続きから 等（後日）。
+3. **収益**：コンシェルジュで初の有料客（理想は代理店＝チャネル）→ soak → Stripe 自助は需要後。
+4. **#373 クローズ**（陳腐化）。zip は PHP8.4 gate を実機検証してから。
+
+> 詳細・設計は `docs/review/`（sequencing/pagination/page-hierarchy 各議事）＋ ADR `docs/adr/0005-*`。

--- a/docs/daily/2026-07-03.md
+++ b/docs/daily/2026-07-03.md
@@ -1,0 +1,55 @@
+# 日報 — 2026-07-03（NeNe Records）
+
+> 前報（06-27）以降の 06-28〜07-02 は workspace 側の作業（LP バンドル議論・共有ホスティング installer の NENE2 共通化）で本リポ日報の対象外。本日は本リポで新機能1本を「設計 → 指示書 → Opus 実装 → multi-agent レビュー」まで通した。
+
+## ヘッドライン
+**WordPress の「固定ページをトップページに」相当（`front_page` 設定）を1日で設計から実装・レビューまで貫通。** 4方向並列調査 → 設計指示書 → Issue #701 起票 → Opus が PR-1（#702、バックエンド＋公開SSR）を完走（composer check 1136 tests 全緑・実機 curl 済）→ 8角度×検証1票制の multi-agent レビューで**マージ前修正3件**を特定し PR コメント投稿・引き継ぎ書整備まで完了。
+
+---
+
+## 本日の成果
+
+### A. 設計・指示書（`docs/handoff-2026-07-03-front-page.md`）
+- 4方向並列調査で確定: **未実装・未起票**（唯一の言及は milestone P4 の1行）／現状 `/` は PHP ルート実体なし・SPA シェルのみ（クローラには空HTML）／settings 基盤の最短レール＝`home_hero`（seed migration の手本）＋`logo_media_id`（ID→公開API解決の手本）／「固定ページ」はシードされた entity type にすぎず特別扱いなし。
+- 設計: **任意の公開レコード1件を org 設定 `front_page`（text・ID・is_public）で指定**。元 permalink はリダイレクトで `/` へ、sitemap 重複排除、未設定/無効時は従来トップへ完全フォールバック（既定挙動ゼロ変更）、**v1 から SSR**（EPIC #536 の実URL SSR 方針に整合）。
+- 指示書に既知 footgun を明記（SpaShellFallback の `/` 差し替え、migration 版数スキュー、汎用設定フォームの二重表示、apex 除外、preview 系 Output 共有、i18n 6ロケール 等）。
+
+### B. 実装 PR-1 = **PR #702**（Opus 担当・Issue #701）
+- 4スライス: seed migration `20260714000000_add_front_page_setting` ／ 保存検証（422）＋公開解決（ID→canonical パス）／ `/` SSR（canonical=ルート・og:type=website・パンくず抑制）／ 301＋sitemap 置換＋共通 reader `FrontPageSetting`。
+- **設計変更（妥当と判断）**: 指示書 §4-4 の「`GET /` ルート登録」は NENE2 既存 `/` ルートに登録順で負けることが実機で判明 → **エッジ層方式**（`SingleOriginKernel` の app 後段で `/` を横取り、framework JSON は保持）へ。
+- frontend は hook 層＋`PublicHome` 分岐まで先行実装（View/UI は PR-2）。
+
+### C. multi-agent レビュー（8角度ファインダー → 重複排除 → 検証1票制）
+- **問題なしを確認**: DI配線・preview 経路・エッジ層 org スコープ・apex 除外・CSP/GA パリティ・sitemap N+1 なし・ETag 無効化・境界値・422 マッピング。
+- **マージ前修正3件（必須）**:
+  1. エッジ層が上流レスポンスを見ずに `/` を上書き → **Throttle の 429 / 一時 5xx をフレッシュな 200 SSR でマスク**（CONFIRMED・中）。ガード1行で修正可。
+  2. 可変設定への **301 Permanent**（Cache-Control 無し）＋クエリ捨て → ピン解除後もキャッシュが恒久転送・`?lang` 消失（CONFIRMED・中）。302＋クエリ維持へ。
+  3. PR 本文が「#701 は close しない」と明記しつつ **`Closes #701`** → マージ即 Issue 自動クローズ（`Refs` へ変更）。
+- **PR-2 送り**: トップの JSON-LD が `BlogPosting` のまま（website と矛盾）／SPA 内遷移で permalink→`/` 非対称／front_page ルールの4箇所重複（弱い `pinnedRecordId()`——今日の実バグ無しは検証済み、`FrontPageSetting` に published 解決を集約）／不要な先行解決の効率（実害小）。path モード不発は既知穴の継承で対応不要。
+
+### D. ドキュメント・引き継ぎ
+- レビュー全文を **PR #702 にコメント投稿**（issuecomment-4869767377）。
+- **`docs/handoff-2026-07-03-front-page-review.md`** 新規: 現状詳細＋修正指示書（コード断片つき）＋検証手順＋進め方。
+- 設計指示書冒頭に STATUS ブロック追記（正本の所在とエッジ層変更を明記）。会話メモリにも要点を記録。
+
+---
+
+## 意思決定（設計判断の要点）
+- 「固定ページ専用」ではなく**任意レコード指定**（UI 初期値のみ pages タイプ）— 柔軟エンティティの製品思想に整合。
+- 新 data_type `record` は**作らない**（text＋キー固有バリデーション。将来「404ページ指定」等が増えたら型化を再検討）。
+- WP の「投稿ページ」(page_for_posts) 相当は**やらない**（タイプ別アーカイブ `/{typeSlug}` が既に担う）。
+- リダイレクトは当初 301 で設計 → レビューで**可変設定には 302** に方針修正。
+- 設定 UI の置き場は SiteSettingsPage 先頭「ホームページの表示」（WP ユーザの心理モデル準拠・taste につき変更可）。
+
+## 現在の状態
+- **PR #702: OPEN・未マージ**（feat/701-front-page-setting、composer check 全緑）。Issue #701 open。
+- ローカル checkout は PR ブランチ上。**本番未反映**（マージ後に要デプロイ）。
+- main 先頭は `822f3af`（DEV 記事 #699/#700）から変わらず。
+
+## 残課題 / 次の一手
+1. **マージ前修正3件**を PR #702 に追いコミット（正本: review 文書 §3-1〜3-3。任意で JSON-LD の §3-4 も同乗可）→ マージ。
+2. **PR-2（管理UI）**: 「ホームページの表示」セクション＋i18n 6ロケール＋レビュー指摘 §3-5〜3-7（`FrontPageSetting` 集約含む）。**PR-2 が `Closes #701`**。
+3. マージ後、本番デプロイ（rsync + build + up）で実サイト確認。
+4. 持ち越し（前報から）: #651 PR2 以降／#647 Aozora 章調整／#373 close。
+
+> 詳細: 設計 `docs/handoff-2026-07-03-front-page.md`・現状/修正 `docs/handoff-2026-07-03-front-page-review.md`・レビュー全文 PR #702 コメント。

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,22 @@
 # Current Work
 
-Last updated: 2026-06-27
+Last updated: 2026-07-04
+
+## 直近: WP式「固定ページをトップに」＋セッション文書の保全（2026-07-02〜04）
+
+- **#701 front_page 設定: 完了（PR #702 マージ・2026-07-04）** — 任意の公開レコード1件を
+  org 設定 `front_page` にピン留めし、公開トップ `/` で SSR（canonical=ルート・og:type=website・
+  JSON-LD WebPage）。元 permalink は **302**（クエリ維持）で `/` へ、sitemap は個別 URL を `/` に置換。
+  管理UI「ホームページの表示」（SiteSettingsPage 先頭・i18n 6ロケール）と SPA 側の描画/`/`への再ホームも同 PR。
+  multi-agent レビュー指摘 §3-1〜3-7 対応済み（正本: `docs/handoff-2026-07-03-front-page-review.md`・
+  設計: `docs/handoff-2026-07-03-front-page.md`）。front_page ルールは `FrontPageSetting`
+  （`resolvePublished()` / `assertPinnable()`）に一元化。
+  実装知見: NENE2 の `/` ルートは登録順で勝つため、上書きは `SingleOriginKernel` の**エッジ層**で行う。
+- **セッション文書の保全（#703）** — 日報3本（06-26/06-27/07-03）・Qiita 記事草稿・base-path
+  スモークスクリプトを main へ収録。**handoff-2026-06-25 / 06-27 は運用機密（本番 IP・SSH/DB 手順）を
+  含むため公開リポには置かず、private `nene-records-marketing` の `ops-inbox/records/` へ移設**
+  （本書中の `docs/handoff-2026-06-25.md` §A 参照はそちらを指す）。
+- **本番未反映**: #663 以降〜#702 の main は本番未デプロイ（board タスク・実施は施主 GO 待ち）。
 
 ## 短期TODO（directory-view レビュー由来・2026-06-27 / milestone「ページ階層/ディレクトリ 仕上げ」#1 — 完了）
 

--- a/tests/e2e/smoke-base-path.cjs
+++ b/tests/e2e/smoke-base-path.cjs
@@ -1,0 +1,51 @@
+const { chromium } = require('@playwright/test')
+
+const BASE = 'https://records.nene-suite.com'
+
+async function check(page, url, expectSelector) {
+  const consoleErrors = []
+  const failed = []
+  page.on('console', (m) => {
+    if (m.type() === 'error') consoleErrors.push(m.text())
+  })
+  page.on('requestfailed', (r) => failed.push(`${r.url()} ${r.failure()?.errorText ?? ''}`))
+  page.on('response', (r) => {
+    const u = r.url()
+    if (u.includes('/assets/') && r.status() >= 400) failed.push(`${u} -> ${r.status()}`)
+  })
+
+  await page.goto(url, { waitUntil: 'networkidle', timeout: 30000 })
+  await page.waitForSelector(expectSelector, { timeout: 15000 })
+
+  // Base is derived from <base href> (CSP-safe); root must keep "/".
+  const baseHref = await page.evaluate(() => document.querySelector('base')?.getAttribute('href') ?? null)
+  const rootHtmlLen = await page.evaluate(() => document.getElementById('root')?.innerHTML.length ?? 0)
+  const cspErrors = consoleErrors.filter((e) => /Content Security Policy/i.test(e))
+
+  console.log(`\n== ${url} ==`)
+  console.log('  SPA mounted (#root content len):', rootHtmlLen)
+  console.log('  <base href>:', JSON.stringify(baseHref))
+  console.log('  asset/4xx failures:', failed.length ? failed : 'none')
+  console.log('  CSP errors:', cspErrors.length ? cspErrors.slice(0, 3) : 'none')
+
+  return { ok: failed.length === 0 && rootHtmlLen > 0 && cspErrors.length === 0, baseHref, failed }
+}
+
+;(async () => {
+  const browser = await chromium.launch()
+  try {
+    // Admin SPA shell (login page) — the asset-delivery change matters most here.
+    const admin = await check(await (await browser.newContext()).newPage(), `${BASE}/admin`, 'input, form, [data-testid], main')
+    // Public SSR record → SPA hydration.
+    const pub = await check(await (await browser.newContext()).newPage(), `${BASE}/posts/1`, '#root')
+
+    const allOk = admin.ok && pub.ok && admin.baseHref === '/' && pub.baseHref === '/'
+    console.log('\n==== RESULT:', allOk ? '✅ PASS (root unbroken, <base href>="/", no CSP errors)' : '❌ FAIL', '====')
+    process.exit(allOk ? 0 : 1)
+  } finally {
+    await browser.close()
+  }
+})().catch((e) => {
+  console.error('ERR', e.message)
+  process.exit(1)
+})


### PR DESCRIPTION
## 目的

作業ツリーに untracked のまま残っていたセッション成果物の保全（指示書 2026-07-04）と、`docs/todo/current.md` の現状反映。

## 変更点

- **日報3本**（`docs/daily/2026-06-26.md` / `06-27.md` / `07-03.md`）を収録
- **Qiita 記事草稿**（`docs/articles/qiita-typed-cms-business-data.md`）を収録（記事レーン #684 関連）
- **base-path スモーク**（`tests/e2e/smoke-base-path.cjs`）を収録 — #595–#599 の産物。BASE は旧 URL（records.nene-suite.com）のままだが 301 で現行ドメインに追従するため保全優先でそのまま
- **current.md 更新** — front_page #701（PR #702 マージ済）の完了サマリ・保全結果・本番未デプロイ注意

## 対象外（機微情報 triage）

`handoff-2026-06-25.md` / `handoff-2026-06-27.md` は本番 IP・SSH/DB アクセス手順を含む運用 runbook のため、公開リポには commit せず private 側（`nene-records-marketing` の `ops-inbox/records/`）へ保全済み。

## 検証

- ドキュメントのみ（コード変更は smoke スクリプトの収録のみ・CI 全ゲートで確認）

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)