### PR TITLE
fix(docker): 本番でテーマサムネ /theme-thumbnails が 404 になるのを修正する (#705)

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
     && docker-php-ext-install pdo_mysql pdo_sqlite intl gd \
     && rm -rf /var/lib/apt/lists/* \
     && a2enmod rewrite headers \
-    && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n\n# Single-origin: serve the built SPA assets (Vite /assets/*) directly from the\n# frontend build so the PHP-rendered pages can mount the production SPA.\nAlias /assets /var/www/html/frontend/dist/assets\n<Directory /var/www/html/frontend/dist/assets>\n    Require all granted\n</Directory>\n' > /etc/apache2/conf-available/nene-records.conf \
+    && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n\n# Single-origin: serve the built SPA assets (Vite /assets/*) directly from the\n# frontend build so the PHP-rendered pages can mount the production SPA.\n# Vite copies frontend/public/* to the dist ROOT (not dist/assets), so every\n# public/ passthrough directory the app references needs its own Alias here\n# (theme-thumbnails = built-in theme picker images, #705).\nAlias /assets /var/www/html/frontend/dist/assets\n<Directory /var/www/html/frontend/dist/assets>\n    Require all granted\n</Directory>\nAlias /theme-thumbnails /var/www/html/frontend/dist/theme-thumbnails\n<Directory /var/www/html/frontend/dist/theme-thumbnails>\n    Require all granted\n</Directory>\n' > /etc/apache2/conf-available/nene-records.conf \
     && a2enconf nene-records \
     && sed -ri -e 's!/var/www/html!/var/www/html/public_html!g' /etc/apache2/sites-available/*.conf \
     && sed -ri -e 's!/var/www/!/var/www/html/public_html!g' /etc/apache2/apache2.conf

--- a/docker/php/Dockerfile.prod
+++ b/docker/php/Dockerfile.prod
@@ -29,7 +29,7 @@ RUN apt-get update \
     && docker-php-ext-install pdo_mysql pdo_sqlite intl gd opcache \
     && rm -rf /var/lib/apt/lists/* \
     && a2enmod rewrite headers \
-    && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n\n# Single-origin: serve the built SPA assets (Vite /assets/*) directly.\nAlias /assets /var/www/html/frontend/dist/assets\n<Directory /var/www/html/frontend/dist/assets>\n    Require all granted\n</Directory>\n' > /etc/apache2/conf-available/nene-records.conf \
+    && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n\n# Single-origin: serve the built SPA assets (Vite /assets/*) directly.\n# Vite copies frontend/public/* to the dist ROOT (not dist/assets), so every\n# public/ passthrough directory the app references needs its own Alias here\n# (theme-thumbnails = built-in theme picker images, #705).\nAlias /assets /var/www/html/frontend/dist/assets\n<Directory /var/www/html/frontend/dist/assets>\n    Require all granted\n</Directory>\nAlias /theme-thumbnails /var/www/html/frontend/dist/theme-thumbnails\n<Directory /var/www/html/frontend/dist/theme-thumbnails>\n    Require all granted\n</Directory>\n' > /etc/apache2/conf-available/nene-records.conf \
     && a2enconf nene-records \
     && sed -ri -e 's!/var/www/html!/var/www/html/public_html!g' /etc/apache2/sites-available/*.conf \
     && sed -ri -e 's!/var/www/!/var/www/html/public_html!g' /etc/apache2/apache2.conf


### PR DESCRIPTION
## 目的

本番テナントのテーマ変更ページ（/admin/appearance/theme）でビルトインテーマのサムネイル画像が全てリンク切れになるのを修正する。

## 原因と変更点

Vite は `frontend/public/*`（theme-thumbnails 27枚）を `dist/` **直下**にコピーするが、Apache は `Alias /assets` しか持たず `/theme-thumbnails/*` を誰も配信していなかった（dev は Vite dev server が配るため本番限定）。prod/dev 両 Dockerfile の Apache 設定に `Alias /theme-thumbnails → frontend/dist/theme-thumbnails` を追加し、public/ パススルーには明示 Alias が要る旨を注記。

なお `public/icons.svg` も本番 404 だが frontend/src から参照ゼロ（レガシー）のため対象外。

## 検証

- dev app イメージ再ビルド → Apache 経由 `GET http://localhost:18082/theme-thumbnails/consumer.webp` = **200 image/webp**・`/health` 200 継続
- マージ後、本番へ反映（rsync → build → up）して `https://ayane.nene-records.com/theme-thumbnails/consumer.webp` = 200 とテーマページの画像表示を確認予定

## チェックリスト

- 名称: dev イメージ実機検証
- [x] Issue-driven（#705）
- [x] prod/dev 両 Dockerfile の設定パリティ維持

Closes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)