### PR TITLE
fix(settings): org 作成時に設定定義が seed されず設定 UI がほぼ空になるのを修正する (#711)

### DIFF
--- a/database/migrations/20260715000000_seed_setting_defs_for_all_orgs.php
+++ b/database/migrations/20260715000000_seed_setting_defs_for_all_orgs.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * 全 org に組み込み設定定義 17 種をバックフィルする（#711）。
+ *
+ * 従来の定義 seed は各 migration 内の「実行時点の既存 org」ループにしか無く、
+ * org 作成時の seed が存在しなかったため、migration 適用後に作られた org
+ * （公開セルフサーブ signup / Tier A インストーラ / superadmin CRUD）は
+ * 設定定義がほぼ空だった（site_name も logo も active_theme も無い）。
+ *
+ * 本 migration は既存 org を修復する。以後の新規 org は
+ * {@see \NeNeRecords\Setting\PdoDefaultSettingDefsSeeder}（org 作成時に seed・
+ * カタログは本 migration と同一値）が担う。新しい設定を足すときは
+ * 「per-org backfill migration ＋ seeder カタログ追記」の両方を行うこと。
+ *
+ * べき等（org × key で既存はスキップ）。旧・単一テナント期の organization_id=0
+ * 行は無害な残骸としてそのまま残す（どの org からも参照されない）。
+ *
+ * 版数は手動採番（20260715…）: リポジトリの migration は未来日付を使っており、
+ * 自動採番（当日日付）だと依存より前に sort されて fresh-DB で silent skip になるため。
+ */
+final class SeedSettingDefsForAllOrgs extends AbstractMigration
+{
+    /**
+     * カタログは PdoDefaultSettingDefsSeeder::SETTING_DEFS と同一値のスナップショット
+     * （migration は自己完結が原則のため意図的に重複させる）。
+     */
+    private const SETTING_DEFS = [
+        ['setting_key' => 'site_name', 'data_type' => 'text', 'default_value' => 'NeNe Records', 'is_public' => 1, 'label' => 'Site name'],
+        ['setting_key' => 'tagline', 'data_type' => 'text', 'default_value' => 'API-first flexible entity platform', 'is_public' => 1, 'label' => 'Tagline'],
+        ['setting_key' => 'default_meta_description', 'data_type' => 'text', 'default_value' => '', 'is_public' => 1, 'label' => 'Default meta description'],
+        ['setting_key' => 'footer_markdown', 'data_type' => 'markdown', 'default_value' => '', 'is_public' => 1, 'label' => 'Footer'],
+        ['setting_key' => 'active_theme', 'data_type' => 'text', 'default_value' => 'consumer', 'is_public' => 1, 'label' => 'Public site theme'],
+        ['setting_key' => 'theme_overrides', 'data_type' => 'text', 'default_value' => '{}', 'is_public' => 1, 'label' => 'Theme customizations'],
+        ['setting_key' => 'logo_media_id', 'data_type' => 'media', 'default_value' => '', 'is_public' => 1, 'label' => 'Logo'],
+        ['setting_key' => 'copyright_text', 'data_type' => 'text', 'default_value' => '© {year} {site}', 'is_public' => 1, 'label' => 'Copyright'],
+        ['setting_key' => 'layout_config', 'data_type' => 'text', 'default_value' => '{"home":{"columns":2,"mainPos":"left","swap":false},"record":{"columns":3,"mainPos":"left","swap":false}}', 'is_public' => 1, 'label' => 'Layout'],
+        ['setting_key' => 'excerpt_source', 'data_type' => 'text', 'default_value' => 'auto', 'is_public' => 0, 'label' => 'Excerpt source (auto / body / meta)'],
+        ['setting_key' => 'excerpt_length', 'data_type' => 'text', 'default_value' => '160', 'is_public' => 0, 'label' => 'Excerpt length (characters)'],
+        ['setting_key' => 'header_config', 'data_type' => 'text', 'default_value' => '{"topbar":{"enabled":false,"phone":"","email":"","infoText":""},"cta":{"enabled":false,"label":"","url":""}}', 'is_public' => 1, 'label' => 'Header'],
+        ['setting_key' => 'home_hero', 'data_type' => 'text', 'default_value' => '[]', 'is_public' => 1, 'label' => 'Home hero'],
+        ['setting_key' => 'analytics_gtm_id', 'data_type' => 'text', 'default_value' => '', 'is_public' => 1, 'label' => 'Google Tag Manager container ID'],
+        ['setting_key' => 'analytics_ga4_id', 'data_type' => 'text', 'default_value' => '', 'is_public' => 1, 'label' => 'Google Analytics 4 measurement ID'],
+        ['setting_key' => 'analytics_consent_default', 'data_type' => 'text', 'default_value' => 'denied', 'is_public' => 1, 'label' => 'Analytics consent default (denied/granted)'],
+        ['setting_key' => 'front_page', 'data_type' => 'text', 'default_value' => '', 'is_public' => 1, 'label' => 'Front page'],
+    ];
+
+    public function up(): void
+    {
+        if (!$this->hasTable('organizations') || !$this->hasTable('setting_defs')) {
+            return;
+        }
+
+        $pdo = $this->getAdapter()->getConnection();
+        $now = date('Y-m-d H:i:s');
+
+        $orgs = $pdo->query('SELECT id FROM organizations ORDER BY id ASC')->fetchAll(PDO::FETCH_COLUMN);
+
+        $check = $pdo->prepare('SELECT id FROM setting_defs WHERE organization_id = ? AND setting_key = ?');
+        $insert = $pdo->prepare(
+            'INSERT INTO setting_defs (organization_id, setting_key, data_type, default_value, is_public, label, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        );
+
+        foreach ($orgs as $orgIdRaw) {
+            $orgId = (int) $orgIdRaw;
+
+            foreach (self::SETTING_DEFS as $def) {
+                $check->execute([$orgId, $def['setting_key']]);
+                if ($check->fetch() !== false) {
+                    continue;
+                }
+                $insert->execute([
+                    $orgId,
+                    $def['setting_key'],
+                    $def['data_type'],
+                    $def['default_value'],
+                    $def['is_public'],
+                    $def['label'],
+                    $now,
+                    $now,
+                ]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        // バックフィルの取り消しは「どの行を本 migration が入れたか」を区別できない
+        // ため行わない（冪等な up の再実行に害はない）。no-op。
+    }
+}

--- a/src/Organization/CreateOrganizationUseCase.php
+++ b/src/Organization/CreateOrganizationUseCase.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Organization;
 
+use NeNeRecords\Setting\DefaultSettingDefsSeederInterface;
+
 final readonly class CreateOrganizationUseCase implements CreateOrganizationUseCaseInterface
 {
     public function __construct(
         private OrganizationRepositoryInterface $organizations,
         private DefaultContentTypeSeederInterface $contentTypeSeeder,
+        private DefaultSettingDefsSeederInterface $settingDefsSeeder,
     ) {
     }
 
@@ -30,6 +33,9 @@ final readonly class CreateOrganizationUseCase implements CreateOrganizationUseC
         ));
 
         $this->contentTypeSeeder->seed($id);
+        // Setting defs are org-scoped too: without this, an org created after the def
+        // migrations ran has an almost empty settings surface (#711).
+        $this->settingDefsSeeder->seed($id);
 
         return new CreateOrganizationOutput(
             id: $id,

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -13,6 +13,8 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\ApplicationServiceProvider;
 use NeNeRecords\Entitlement\EntitlementResolverInterface;
+use NeNeRecords\Setting\DefaultSettingDefsSeederInterface;
+use NeNeRecords\Setting\PdoDefaultSettingDefsSeeder;
 use NeNeRecords\SystemConfig\SystemConfigRepositoryInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -32,6 +34,18 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
                     }
 
                     return new PdoDefaultContentTypeSeeder($query);
+                },
+            )
+            ->set(
+                DefaultSettingDefsSeederInterface::class,
+                static function (ContainerInterface $c): DefaultSettingDefsSeederInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoDefaultSettingDefsSeeder($query);
                 },
             )
             ->set(
@@ -76,6 +90,7 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
                 static function (ContainerInterface $c): CreateOrganizationUseCaseInterface {
                     $repo   = $c->get(OrganizationRepositoryInterface::class);
                     $seeder = $c->get(DefaultContentTypeSeederInterface::class);
+                    $settingDefsSeeder = $c->get(DefaultSettingDefsSeederInterface::class);
 
                     if (!$repo instanceof OrganizationRepositoryInterface) {
                         throw new LogicException('Organization repository service is invalid.');
@@ -85,7 +100,11 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
                         throw new LogicException('Default content type seeder service is invalid.');
                     }
 
-                    return new CreateOrganizationUseCase($repo, $seeder);
+                    if (!$settingDefsSeeder instanceof DefaultSettingDefsSeederInterface) {
+                        throw new LogicException('Default setting defs seeder service is invalid.');
+                    }
+
+                    return new CreateOrganizationUseCase($repo, $seeder, $settingDefsSeeder);
                 },
             )
             ->set(

--- a/src/Setting/DefaultSettingDefsSeederInterface.php
+++ b/src/Setting/DefaultSettingDefsSeederInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+/**
+ * Seeds the built-in setting definitions for a newly created organization.
+ *
+ * Setting defs are org-scoped rows; without this seeding an org created after the
+ * def migrations ran has an (almost) empty settings surface — no site name, no logo,
+ * no theme persistence (#711).
+ */
+interface DefaultSettingDefsSeederInterface
+{
+    public function seed(int $organizationId): void;
+}

--- a/src/Setting/PdoDefaultSettingDefsSeeder.php
+++ b/src/Setting/PdoDefaultSettingDefsSeeder.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Setting;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+/**
+ * Seeds the built-in setting definitions for a newly created organization (#711).
+ *
+ * The catalog below is the single canonical list of built-in settings, mirroring what
+ * the per-org def migrations installed for orgs that existed when they ran. Without
+ * org-creation seeding, an org born later (self-serve signup, the Tier A installer,
+ * superadmin CRUD) had an almost empty settings surface — no site name / logo defs
+ * and no active_theme row to persist a theme choice.
+ *
+ * ⚠️ Rule for NEW settings: add them BOTH here (new orgs) AND as a per-org backfill
+ * migration (existing orgs) — the migration and this catalog intentionally duplicate
+ * values because migrations must stay self-contained snapshots.
+ *
+ * SQL lives here (Pdo* class) to keep it out of the UseCase layer. Idempotent: it
+ * checks for an existing (org, key) row before inserting.
+ */
+final readonly class PdoDefaultSettingDefsSeeder implements DefaultSettingDefsSeederInterface
+{
+    /**
+     * @var list<array{setting_key: string, data_type: string, default_value: string, is_public: int, label: string}>
+     */
+    private const SETTING_DEFS = [
+        ['setting_key' => 'site_name', 'data_type' => 'text', 'default_value' => 'NeNe Records', 'is_public' => 1, 'label' => 'Site name'],
+        ['setting_key' => 'tagline', 'data_type' => 'text', 'default_value' => 'API-first flexible entity platform', 'is_public' => 1, 'label' => 'Tagline'],
+        ['setting_key' => 'default_meta_description', 'data_type' => 'text', 'default_value' => '', 'is_public' => 1, 'label' => 'Default meta description'],
+        ['setting_key' => 'footer_markdown', 'data_type' => 'markdown', 'default_value' => '', 'is_public' => 1, 'label' => 'Footer'],
+        ['setting_key' => 'active_theme', 'data_type' => 'text', 'default_value' => 'consumer', 'is_public' => 1, 'label' => 'Public site theme'],
+        ['setting_key' => 'theme_overrides', 'data_type' => 'text', 'default_value' => '{}', 'is_public' => 1, 'label' => 'Theme customizations'],
+        ['setting_key' => 'logo_media_id', 'data_type' => 'media', 'default_value' => '', 'is_public' => 1, 'label' => 'Logo'],
+        ['setting_key' => 'copyright_text', 'data_type' => 'text', 'default_value' => '© {year} {site}', 'is_public' => 1, 'label' => 'Copyright'],
+        ['setting_key' => 'layout_config', 'data_type' => 'text', 'default_value' => '{"home":{"columns":2,"mainPos":"left","swap":false},"record":{"columns":3,"mainPos":"left","swap":false}}', 'is_public' => 1, 'label' => 'Layout'],
+        ['setting_key' => 'excerpt_source', 'data_type' => 'text', 'default_value' => 'auto', 'is_public' => 0, 'label' => 'Excerpt source (auto / body / meta)'],
+        ['setting_key' => 'excerpt_length', 'data_type' => 'text', 'default_value' => '160', 'is_public' => 0, 'label' => 'Excerpt length (characters)'],
+        ['setting_key' => 'header_config', 'data_type' => 'text', 'default_value' => '{"topbar":{"enabled":false,"phone":"","email":"","infoText":""},"cta":{"enabled":false,"label":"","url":""}}', 'is_public' => 1, 'label' => 'Header'],
+        ['setting_key' => 'home_hero', 'data_type' => 'text', 'default_value' => '[]', 'is_public' => 1, 'label' => 'Home hero'],
+        ['setting_key' => 'analytics_gtm_id', 'data_type' => 'text', 'default_value' => '', 'is_public' => 1, 'label' => 'Google Tag Manager container ID'],
+        ['setting_key' => 'analytics_ga4_id', 'data_type' => 'text', 'default_value' => '', 'is_public' => 1, 'label' => 'Google Analytics 4 measurement ID'],
+        ['setting_key' => 'analytics_consent_default', 'data_type' => 'text', 'default_value' => 'denied', 'is_public' => 1, 'label' => 'Analytics consent default (denied/granted)'],
+        ['setting_key' => 'front_page', 'data_type' => 'text', 'default_value' => '', 'is_public' => 1, 'label' => 'Front page'],
+    ];
+
+    public function __construct(private DatabaseQueryExecutorInterface $query)
+    {
+    }
+
+    public function seed(int $organizationId): void
+    {
+        foreach (self::SETTING_DEFS as $def) {
+            $existing = $this->query->fetchOne(
+                'SELECT id FROM setting_defs WHERE organization_id = ? AND setting_key = ?',
+                [$organizationId, $def['setting_key']],
+            );
+
+            if ($existing !== null) {
+                continue;
+            }
+
+            $this->query->execute(
+                'INSERT INTO setting_defs (organization_id, setting_key, data_type, default_value, is_public, label, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW())',
+                [
+                    $organizationId,
+                    $def['setting_key'],
+                    $def['data_type'],
+                    $def['default_value'],
+                    $def['is_public'],
+                    $def['label'],
+                ],
+            );
+        }
+    }
+}

--- a/tests/Install/InstallApplicationTest.php
+++ b/tests/Install/InstallApplicationTest.php
@@ -10,6 +10,7 @@ use NeNeRecords\Install\InstallConfig;
 use NeNeRecords\Organization\CreateOrganizationUseCase;
 use NeNeRecords\Organization\DefaultContentTypeSeederInterface;
 use NeNeRecords\Tests\Organization\InMemoryOrganizationRepository;
+use NeNeRecords\Tests\Organization\RecordingDefaultSettingDefsSeeder;
 use NeNeRecords\Tests\User\InMemoryUserRepository;
 use NeNeRecords\User\CreateUserUseCase;
 use PHPUnit\Framework\TestCase;
@@ -31,7 +32,7 @@ final class InstallApplicationTest extends TestCase
         $holder = new RequestScopedHolder();
 
         return new InstallApplication(
-            new CreateOrganizationUseCase($orgs, $seeder),
+            new CreateOrganizationUseCase($orgs, $seeder, new RecordingDefaultSettingDefsSeeder()),
             $orgs,
             new CreateUserUseCase($users),
             $holder,

--- a/tests/Organization/OrganizationHttpTest.php
+++ b/tests/Organization/OrganizationHttpTest.php
@@ -45,7 +45,7 @@ final class OrganizationHttpTest extends TestCase
         $registrar = new OrganizationRouteRegistrar(
             new ListOrganizationsHandler(new ListOrganizationsUseCase($this->repository), $jsonResponse),
             new GetOrganizationByIdHandler(new GetOrganizationByIdUseCase($this->repository), $jsonResponse),
-            new CreateOrganizationHandler(new CreateOrganizationUseCase($this->repository, new RecordingDefaultContentTypeSeeder()), $jsonResponse),
+            new CreateOrganizationHandler(new CreateOrganizationUseCase($this->repository, new RecordingDefaultContentTypeSeeder(), new RecordingDefaultSettingDefsSeeder()), $jsonResponse),
             new UpdateOrganizationHandler(new UpdateOrganizationUseCase($this->repository, new UnlimitedEntitlementResolver()), $jsonResponse),
             new DeleteOrganizationHandler(new DeleteOrganizationUseCase($this->repository), $this->factory),
         );

--- a/tests/Organization/OrganizationUseCaseTest.php
+++ b/tests/Organization/OrganizationUseCaseTest.php
@@ -22,7 +22,7 @@ final class OrganizationUseCaseTest extends TestCase
     public function testCreateOrganizationSuccessfully(): void
     {
         $organizations = new InMemoryOrganizationRepository();
-        $useCase = new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder());
+        $useCase = new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder(), new RecordingDefaultSettingDefsSeeder());
 
         $output = $useCase->execute(new CreateOrganizationInput(
             name: 'Test Org',
@@ -43,7 +43,7 @@ final class OrganizationUseCaseTest extends TestCase
     public function testCreateOrganizationAssignsSequentialIds(): void
     {
         $organizations = new InMemoryOrganizationRepository();
-        $useCase = new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder());
+        $useCase = new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder(), new RecordingDefaultSettingDefsSeeder());
 
         $first = $useCase->execute(new CreateOrganizationInput(
             name: 'First Org',
@@ -61,7 +61,7 @@ final class OrganizationUseCaseTest extends TestCase
     public function testCreateOrganizationThrowsSlugConflictExceptionForDuplicateSlug(): void
     {
         $organizations = new InMemoryOrganizationRepository();
-        $useCase = new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder());
+        $useCase = new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder(), new RecordingDefaultSettingDefsSeeder());
 
         $useCase->execute(new CreateOrganizationInput(
             name: 'First Org',
@@ -81,7 +81,7 @@ final class OrganizationUseCaseTest extends TestCase
     public function testUpdateOrganizationUpdatesName(): void
     {
         $organizations = new InMemoryOrganizationRepository();
-        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder()))->execute(
+        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder(), new RecordingDefaultSettingDefsSeeder()))->execute(
             new CreateOrganizationInput(name: 'Original Name', slug: 'my-org'),
         );
 
@@ -105,7 +105,7 @@ final class OrganizationUseCaseTest extends TestCase
     public function testUpdateOrganizationUpdatesSlug(): void
     {
         $organizations = new InMemoryOrganizationRepository();
-        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder()))->execute(
+        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder(), new RecordingDefaultSettingDefsSeeder()))->execute(
             new CreateOrganizationInput(name: 'My Org', slug: 'old-slug'),
         );
 
@@ -127,7 +127,7 @@ final class OrganizationUseCaseTest extends TestCase
     public function testUpdateOrganizationUpdatesPlan(): void
     {
         $organizations = new InMemoryOrganizationRepository();
-        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder()))->execute(
+        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder(), new RecordingDefaultSettingDefsSeeder()))->execute(
             new CreateOrganizationInput(name: 'My Org', slug: 'my-org', plan: 'free'),
         );
 
@@ -149,7 +149,7 @@ final class OrganizationUseCaseTest extends TestCase
     public function testUpdateOrganizationUpdatesIsActive(): void
     {
         $organizations = new InMemoryOrganizationRepository();
-        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder()))->execute(
+        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder(), new RecordingDefaultSettingDefsSeeder()))->execute(
             new CreateOrganizationInput(name: 'My Org', slug: 'my-org', isActive: true),
         );
 
@@ -171,7 +171,7 @@ final class OrganizationUseCaseTest extends TestCase
     public function testUpdateOrganizationUpdatesCustomDomain(): void
     {
         $organizations = new InMemoryOrganizationRepository();
-        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder()))->execute(
+        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder(), new RecordingDefaultSettingDefsSeeder()))->execute(
             new CreateOrganizationInput(name: 'My Org', slug: 'my-org'),
         );
 
@@ -212,7 +212,7 @@ final class OrganizationUseCaseTest extends TestCase
     public function testUpdateOrganizationThrowsSlugConflictExceptionWhenChangingSlugToExistingSlug(): void
     {
         $organizations = new InMemoryOrganizationRepository();
-        $createUseCase = new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder());
+        $createUseCase = new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder(), new RecordingDefaultSettingDefsSeeder());
 
         $createUseCase->execute(new CreateOrganizationInput(name: 'Org A', slug: 'org-a'));
         $createdB = $createUseCase->execute(new CreateOrganizationInput(name: 'Org B', slug: 'org-b'));
@@ -237,7 +237,7 @@ final class OrganizationUseCaseTest extends TestCase
     public function testDeleteOrganizationSuccessfully(): void
     {
         $organizations = new InMemoryOrganizationRepository();
-        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder()))->execute(
+        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder(), new RecordingDefaultSettingDefsSeeder()))->execute(
             new CreateOrganizationInput(name: 'My Org', slug: 'my-org'),
         );
 
@@ -265,7 +265,7 @@ final class OrganizationUseCaseTest extends TestCase
     {
         $organizations = new InMemoryOrganizationRepository();
         $seeder        = new RecordingDefaultContentTypeSeeder();
-        $useCase       = new CreateOrganizationUseCase($organizations, $seeder);
+        $useCase       = new CreateOrganizationUseCase($organizations, $seeder, new RecordingDefaultSettingDefsSeeder());
 
         $output = $useCase->execute(new CreateOrganizationInput(
             name: 'Seeded Org',
@@ -280,7 +280,7 @@ final class OrganizationUseCaseTest extends TestCase
     {
         $organizations = new InMemoryOrganizationRepository();
         $seeder        = new RecordingDefaultContentTypeSeeder();
-        $useCase       = new CreateOrganizationUseCase($organizations, $seeder);
+        $useCase       = new CreateOrganizationUseCase($organizations, $seeder, new RecordingDefaultSettingDefsSeeder());
 
         $first  = $useCase->execute(new CreateOrganizationInput(name: 'Org A', slug: 'org-a'));
         $second = $useCase->execute(new CreateOrganizationInput(name: 'Org B', slug: 'org-b'));
@@ -290,11 +290,28 @@ final class OrganizationUseCaseTest extends TestCase
         self::assertSame($second->id, $seeder->seededOrgIds[1]);
     }
 
+    public function testCreateOrganizationSeedsSettingDefsWithNewOrgId(): void
+    {
+        // Setting defs are org-scoped: an org created after the def migrations ran gets
+        // its built-in settings from this seeder, not from any migration (#711).
+        $organizations = new InMemoryOrganizationRepository();
+        $settingDefs   = new RecordingDefaultSettingDefsSeeder();
+        $useCase       = new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder(), $settingDefs);
+
+        $output = $useCase->execute(new CreateOrganizationInput(
+            name: 'Settings Org',
+            slug: 'settings-org',
+        ));
+
+        self::assertCount(1, $settingDefs->seededOrgIds);
+        self::assertSame($output->id, $settingDefs->seededOrgIds[0]);
+    }
+
     public function testCreateOrganizationDoesNotCallSeederOnSlugConflict(): void
     {
         $organizations = new InMemoryOrganizationRepository();
         $seeder        = new RecordingDefaultContentTypeSeeder();
-        $useCase       = new CreateOrganizationUseCase($organizations, $seeder);
+        $useCase       = new CreateOrganizationUseCase($organizations, $seeder, new RecordingDefaultSettingDefsSeeder());
 
         $useCase->execute(new CreateOrganizationInput(name: 'Org A', slug: 'conflict'));
 

--- a/tests/Organization/RecordingDefaultSettingDefsSeeder.php
+++ b/tests/Organization/RecordingDefaultSettingDefsSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Organization;
+
+use NeNeRecords\Setting\DefaultSettingDefsSeederInterface;
+
+/**
+ * Test double: records which organization ids the setting-defs seeder was asked to
+ * seed, so use-case tests can assert org creation triggers it (#711).
+ */
+final class RecordingDefaultSettingDefsSeeder implements DefaultSettingDefsSeederInterface
+{
+    /** @var list<int> */
+    public array $seededOrgIds = [];
+
+    public function seed(int $organizationId): void
+    {
+        $this->seededOrgIds[] = $organizationId;
+    }
+}

--- a/tests/Organization/UpdateOrganizationCustomDomainEntitlementTest.php
+++ b/tests/Organization/UpdateOrganizationCustomDomainEntitlementTest.php
@@ -19,7 +19,7 @@ final class UpdateOrganizationCustomDomainEntitlementTest extends TestCase
     public function testAllowsCustomDomainUnderUnlimitedEntitlements(): void
     {
         $organizations = new InMemoryOrganizationRepository();
-        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder()))->execute(
+        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder(), new RecordingDefaultSettingDefsSeeder()))->execute(
             new CreateOrganizationInput(name: 'Shop', slug: 'shop'),
         );
 
@@ -33,7 +33,7 @@ final class UpdateOrganizationCustomDomainEntitlementTest extends TestCase
     public function testDeniesCustomDomainWhenNotEntitled(): void
     {
         $organizations = new InMemoryOrganizationRepository();
-        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder()))->execute(
+        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder(), new RecordingDefaultSettingDefsSeeder()))->execute(
             new CreateOrganizationInput(name: 'Shop', slug: 'shop'),
         );
 
@@ -46,7 +46,7 @@ final class UpdateOrganizationCustomDomainEntitlementTest extends TestCase
     public function testNonCustomDomainUpdatesAreNotGated(): void
     {
         $organizations = new InMemoryOrganizationRepository();
-        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder()))->execute(
+        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder(), new RecordingDefaultSettingDefsSeeder()))->execute(
             new CreateOrganizationInput(name: 'Shop', slug: 'shop'),
         );
 
@@ -69,7 +69,7 @@ final class UpdateOrganizationCustomDomainEntitlementTest extends TestCase
     public function testClearingCustomDomainIsNotGated(): void
     {
         $organizations = new InMemoryOrganizationRepository();
-        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder()))->execute(
+        $created = (new CreateOrganizationUseCase($organizations, new RecordingDefaultContentTypeSeeder(), new RecordingDefaultSettingDefsSeeder()))->execute(
             new CreateOrganizationInput(name: 'Shop', slug: 'shop'),
         );
 

--- a/tests/Signup/PublicSignupUseCaseTest.php
+++ b/tests/Signup/PublicSignupUseCaseTest.php
@@ -14,6 +14,7 @@ use NeNeRecords\Signup\PublicSignupUseCase;
 use NeNeRecords\Tests\Mail\RecordingMailer;
 use NeNeRecords\Tests\Organization\InMemoryOrganizationRepository;
 use NeNeRecords\Tests\Organization\RecordingDefaultContentTypeSeeder;
+use NeNeRecords\Tests\Organization\RecordingDefaultSettingDefsSeeder;
 use NeNeRecords\Tests\User\InMemoryUserRepository;
 use NeNeRecords\User\CreateUserUseCase;
 use PHPUnit\Framework\TestCase;
@@ -44,7 +45,7 @@ final class PublicSignupUseCaseTest extends TestCase
         $holder = new RequestScopedHolder();
 
         return new PublicSignupUseCase(
-            new CreateOrganizationUseCase($this->orgs, $this->seeder),
+            new CreateOrganizationUseCase($this->orgs, $this->seeder, new RecordingDefaultSettingDefsSeeder()),
             new CreateUserUseCase($this->users),
             new LoginUseCase($this->users, $tokenIssuer),
             $holder,


### PR DESCRIPTION
## 目的

signup / Tier A インストーラ / superadmin CRUD で作られた org の設定定義がほぼ空（本番 ayane/aozora は `front_page` 1 件のみ）で、/admin/settings に site_name / logo が出ず、active_theme 定義も無いためテーマ保存も効かない問題を修正する（#711）。

## 原因

setting_defs（org スコープ）の seed が **migration 内の「実行時点の既存 org」ループにしか無く**、org 作成経路に無かった。初期5定義は organization_id=0 に残存し、org スコープ厳格化以降どの org からも不可視。

## 変更点

1. **`PdoDefaultSettingDefsSeeder`**（カタログ17定義・冪等・`DefaultContentTypeSeeder` と同型）を新設し `CreateOrganizationUseCase` へ配線 — 以後の全 org 作成経路で seed される
2. **バックフィル migration `20260715000000`** — 全既存 org × 17 定義を WHERE NOT EXISTS で冪等 insert（版数は未来日付 max 超の手動採番＝date-skew 回避）
3. 新設定の追加規約（per-org migration ＋ seeder カタログの両方）を docblock に明記

## 検証

- PHPUnit **1143** 全緑（org 作成 → settings seeder 呼び出しのテスト追加・既存テスト 13 箇所更新）/ PHPStan L8 / CS / OpenAPI / MCP
- 実 MySQL migrate: dev org1 の定義 **1 → 17**・`GET /api/v1/public/settings` が front_page のみ → **15 公開キー**に回復
- `RuntimeContainerFactory` 経由で新規 org 作成 → **17 定義 seed** を実機確認（後片付け済み）

## 本番への影響

マージ後のデプロイで entrypoint が migration を自動適用し、ayane/aozora ほか全 org の設定 UI（サイト名・ロゴ・テーマ永続化・GA 設定等）が回復する。既存の値行（setting_values）には触れない。

Closes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)