### PR TITLE
fix(install): .env 無しデプロイで再設置ガードが素通しになるのを修正する (#713)

### DIFF
--- a/public_html/install/index.php
+++ b/public_html/install/index.php
@@ -86,14 +86,15 @@ if (!is_dir(ROOT . '/var')) {
 /**
  * データベースに設置済みインスタンスがあるか。「admin が居る＝設置完了」を正とする
  * （migrate 済みでも admin 未作成ならウィザードは続行可能であるべき）。到達不能・
- * 未スキーマ・.env 不在はすべて「未設置」に倒す（probe 契約どおり throw しない）。
+ * 未スキーマは「未設置」に倒す（probe 契約どおり throw しない）。
+ *
+ * ⚠️ .env 不在でも必ず probe する（#713）: Docker 本番は DB 接続情報をコンテナ
+ * 環境変数で渡し .env を持たない。ConfigLoader は .env が無ければ実環境変数を
+ * 読むので、そのまま接続を試みる。「.env 無し＝未設置」と早期 return すると
+ * 設置済み本番でガードが素通しになる（実際に起きた）。
  */
 function databaseProvisioned(): bool
 {
-    if (!is_file(ENV_FILE)) {
-        return false;
-    }
-
     try {
         $database = (new ConfigLoader(ROOT))->load()->database;
 


### PR DESCRIPTION
## 目的

#708 デプロイ直後の本番実測で、`https://ayane.nene-records.com/install/` が **403 でなく 200** を返すのを発見。Docker 本番は DB 接続情報がコンテナ環境変数で `.env` ファイルが無く、probe の「.env 無し＝未設置」早期 return がガードを素通しにしていた。

## 変更点

`databaseProvisioned()` の `.env` 不在早期 return を撤去し、常に `ConfigLoader`（.env 不在時は実環境変数を読む）→ PDO probe を実行。到達不能・未スキーマは従来どおり「未設置」。

## 検証

- **本番相当**（.env 無し＋コンテナ環境変数で設置済み DB）: `/install/` **403**・installer-blocked 描画
- **fresh ZIP 相当**（.env 無し・DB 到達不能）: 200 でウィザード続行（Tier A 設置フロー無回帰）
- php -l / cs-fixer 緑（install/index.php は phpstan 対象外・実検証は上記コンテナ）

マージ後、即本番反映する（設置ウィザード露出の解消）。

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)