### PR TITLE
docs(todo): Tier A インストーラ公開(v0.5.0)と設定/テーマ修正を反映する

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,24 +1,37 @@
 # Current Work
 
-Last updated: 2026-07-04
+Last updated: 2026-07-05
 
-## 直近: 共有ホスティング Tier A インストーラ（S3・#707・2026-07-04）
+## 直近: 共有ホスティング Tier A インストーラ 公開（S3・#707・2026-07-04〜05）
 
-- **#707 Tier A インストーラ: 関所レビュー全5スライス合格（2026-07-04）・マージ進行** —
+- **#707 Tier A インストーラ: 完了・公開済み（GitHub Release `v0.5.0`）** —
   NENE2 `Nene2\Install` toolkit（v1.6.0・Packagist）を配線した `public_html/install/index.php`
   （要件チェック→DB/tenant→migrate→管理者→完了・再訪403）＋ `tools/build-release.sh`
   （Packagist `^1.6` 実体 vendor・**assets/theme-thumbnails を public_html へ移設**＝共有ホスティングに
-  Apache Alias が無いため）。**ZIP 66MB**（フォント 55MB・font-less 試算 11MB）。
-  設置手順は `docs/install-tier-a.md`。事前契約・関所承認は
-  `_work/handoff-installer-2026-07-04-s3-0-precontract.md`。
-- 併せて直した設置系の本質ギャップ 2 件: ① **共有ホスティング env ブリッジ**（phpdotenv v5 は
+  Apache Alias が無いため）。関所全5スライス合格→PR #708 マージ→施主 GO で
+  **`nene-records-0.5.0.zip`（66MB）＋.sha256 を Release 公開**（Latest・target=main）。
+  版数は既存 v0.4.0 の次＝0.x 継続（1.0 は update 機構＋磨き込み後）。**Origin 独立で配布可**
+  （v1 は自己完結 zip・インストーラは外部 DL しない）。設置手順は `docs/install-tier-a.md`。
+- 併せて直した設置系の本質ギャップ: ① **共有ホスティング env ブリッジ**（phpdotenv v5 は
   putenv しない→ getenv 直読み設定が .env-only 環境で全て既定値化。front controller で写す）
-  ② **APP_BASE_PATH の入口 prefix strip**（base-path 節の「残 S3」を消化 — サブディレクトリ設置が
-  実 URL で完走することを実機確認）。
-- 残: release ZIP の公開・tag・配布・Suite catalog 登録は**施主 GO 必須**（未実施）。
-  フォントのオンデマンド化（font-less 試算 11MB）・アップデート機構は別 Issue/レーン。
-  設計上のトレードオフ（記録）: migration 失敗時も .env は残す（phinx が ConfigLoader 経由で
-  .env を読むため書込先行が構造的に必須。docroot 外・再送信で上書き・ガードは users 基準で実害なし）。
+  ② **APP_BASE_PATH の入口 prefix strip**（base-path 節の「残 S3」を消化）
+  ③ **#713 再設置ガード素通し**（`.env` 無し早期 return が Docker 本番でガードを無効化していたのを probe 常時実行に）。
+- 残（フォローアップ）: #709 フォント on-demand（font-less 11MB）／#710 ウィザードのサイト名を
+  site_name 設定へ反映／NENE2 #1482 参照レンダラ入力型／Suite catalog 登録＋Origin 差替（board C）。
+  設計トレードオフ（記録）: migration 失敗時も .env は残す（phinx が ConfigLoader 経由で .env を読むため
+  書込先行が構造的に必須。docroot 外・再送信で上書き・ガードは users 基準で実害なし）。
+
+## 直近: 設定・テーマ・本番反映のバグ修正（2026-07-04）
+
+- **#705/#706 テーマサムネ 404**: 本番 Apache が `/assets` しか配信せず `/theme-thumbnails/*` が
+  全 404（テーマ選択ページの画像切れ）。prod/dev Dockerfile に Alias 追加。**本番反映済み**。
+- **#711/#712 設定定義シード欠落（systemic）**: org 作成時に `setting_defs` が seed されず、
+  signup/インストーラ産 org は設定 UI がほぼ空（site_name/logo が出ない・active_theme 無しで
+  テーマ保存も不発）だった。`PdoDefaultSettingDefsSeeder`（17定義・org 作成時）＋バックフィル
+  migration `20260715000000`。**本番反映済み**（全 org が 17 定義に回復）。
+- 上記＋#701/#703 の main 差分を **本番（nene-records.com）へデプロイ済み**。🔴 デプロイ知見:
+  toolkit 依存が進んだらサーバーの sibling `NENE2/` も rsync してから build（v1.6.0 未同期だと
+  baked vendor に `Nene2\Install` が欠けて installer が Fatal になる — 実際に踏んだ）。
 
 ## 直近: WP式「固定ページをトップに」＋セッション文書の保全（2026-07-02〜04）
 


### PR DESCRIPTION
## 目的

`docs/todo/current.md`（living SoT）を 2026-07-04〜05 の実績で更新する。

## 反映内容

- **#707 Tier A インストーラ**: 関所全5スライス合格 → PR #708 マージ → 施主 GO で **GitHub Release `v0.5.0`**（`nene-records-0.5.0.zip` 66MB＋.sha256・Latest・Origin 独立配布可）を公開
- **#705/#706** テーマサムネ 404 修正（本番反映済み）
- **#711/#712** 設定定義シード欠落（systemic）修正＋バックフィル（本番反映済み）
- **#713/#714** 再設置ガード素通し修正
- デプロイ知見（sibling NENE2 の rsync 必須）

ドキュメントのみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)