### PR TITLE
docs(daily): 2026-07-05 の日報を追加する

### DIFF
--- a/docs/daily/2026-07-05.md
+++ b/docs/daily/2026-07-05.md
@@ -1,0 +1,62 @@
+# 日報 — 2026-07-05（NeNe Records）
+
+> 前報（07-03）は front_page 設定の設計〜レビュー。以降 07-04 は workspace 側（Tier A インストーラ公開 v0.5.0・設定シード/テーマ修正）で本リポ日報の対象外。本日は Ubuntu クラッシュからの復旧に始まり、**インストーラ UI のデザイン刷新を本番リリース（v0.5.1）まで貫通**。
+
+## ヘッドライン
+**共有ホスティング Tier A インストーラの設置ウィザード UI を ClaudeDesign のデザインシステム（ダーク／oklch／ブランド＋4step stepper／モーション）へ刷新し、`v0.5.1` として GitHub Release 公開まで完了。** 提示層のみの差し替えでロジックは無変更、実関数抽出による全11画面の機械照合＋捨てコンテナ実機確認で裏取り。あわせてクラッシュ復旧・Issue 棚卸し（20→18）も実施。
+
+---
+
+## 本日の成果
+
+### A. クラッシュ復旧・掃除
+- Ubuntu 落ち直後の状態を git で確認 → **破損なし**（作業ツリー clean・未保存の中途ファイル無し）。落ちる直前は v0.5.0 の docs 締め（#715）がマージ済みだった。
+- `main` を #715 まで ff 取り込み、マージ済み/upstream-gone の古いローカルブランチ2本を削除。
+
+### B. インストーラ全画面の素材化 → ClaudeDesign
+- `public_html/install/index.php` が出す**全11状態**（要件OK/NG・DB設定・DB接続エラー・管理者・管理者エラー・DB未設定誘導・完了・再設置ガード403・未完了・vendor欠落500）をスタンドアロン HTML 化し、コンタクトシート＋制約 README 同梱の zip で受け渡し。
+
+### C. デザイン実装 = **PR #717**（Issue #716・提示層のみ）
+- `renderPage()` を分解し純粋ヘルパを追加: `installerStyles($success)`（oklch トークン／完了演出 cardGlow・pop／reduced-motion 対応）・`brandHeader($success)`（インライン SVG ロックアップ、完了はピル「完了」）・`stepper($flow,$step,$allDone)`（フロー位置から done/current 導出）。
+- vendor 欠落画面・再設置ガードも同デザインへ（stepper 無し）。**フロー制御・DB 設定・migration・管理者作成・ガードのロジックは無変更。**
+- 制約維持: 外部アセット無し（単一 PHP ページ・フォントは Noto/system フォールバック）／フォーム `name`・`type=password`・`noindex`・クラスフック・日本語コピー不変／CSRF 非装備。
+
+### D. 検証
+- `php -l`／`composer cs`（public_html は CS-Fixer 対象・PHPStan 対象外）ともにクリーン。
+- index.php から**実関数を抽出**したハーネスで全11画面のブランド＋stepper を design 納品物と機械照合＝**一致**（CSS はバイト一致・差は `<style>` 前後の空白と完了2行の位置のみで描画同一）。
+- `requirements` ステップを実際に実行し新デザインが PHP エラー無く描画されることを確認。
+
+### E. マージ → **リリース公開 v0.5.1**
+- PR #717 を squash マージ（`main 87f6f5d`・`(#716) (#717)`）。
+- `tools/build-release.sh 0.5.1` で zip 再ビルド（既存 v0.5.0 の SHA を上書きしないため必ずバンプ）。zip 内の `install/index.php` に刷新後関数が入っていること（45,747 bytes＝main と一致）を検証。
+- **GitHub Release `v0.5.1`（Latest）公開**（66MB・nene2 v1.6.0・sha256 添付・target=main 87f6f5d）。
+
+### F. Issue 棚卸し（20 → 18）
+- 3並列エージェントで全 open Issue を本文・タイムライン・close 済み PR まで精査。
+- **確定 done を2件クローズ**: `#539`（WordPress 移行 WXR＋メディア＋301＝S1〜S4 の #561–#572 全マージ）・`#684`（Qiita 記事草稿＝PR #704 で `docs/articles/qiita-typed-cms-business-data.md`）。
+- 残18件は**進行中エピック7＋未着手バックログ11**で保持（閉じると作業を隠すため）。
+
+### G. 捨てコンテナで実機確認
+- v0.5.1 zip を捨てディレクトリへ展開 → Apache を使わず `php -S`（docroot=public_html・Alias 無し＝trap④回避）＋使い捨て mysql(tmpfs) を :18090 に起動。
+- 全ステップを通しで確認（要件全通過・DB 接続＋CREATE 権限・DB設定/完了画面）→ 施主 OK → 撤収（コンテナ/ネットワーク/展開物を削除）。
+
+---
+
+## 意思決定
+- **フォント＝フォールバック運用**（Noto Sans JP / system-ui）。**CDN は却下**: 中国等でブロック＝見た目が保証されず結局フォールバック／初回起動で IP を Google に渡すのは「自前ホスティング」の売りと矛盾（独 GFonts GDPR 判例）／レンダーブロッキング。本物書体 Saira の self-host は follow-up。
+- インストーラ刷新は**提示層のみ**。ロジック無変更を検証で担保。
+- リリース zip は**必ずバージョンバンプ**（0.5.0→0.5.1）。既存 Release の成果物 SHA を上書きしない。
+
+## 現在の状態
+- `main` 先頭 = **`87f6f5d`**（#717 マージ済み）。作業ツリー clean。
+- **Release `v0.5.1`（Latest）公開済み**。稼働中の records（設置済み）は無影響＝**新デザインは今後 zip で新規設置する人に届く**。
+- open Issues = **18**（closed 本日: #539 / #684）。
+- 捨てコンテナは撤収済み（残骸なし）。
+
+## 残課題 / 次の一手
+1. **配布経路の仕上げ**: Suite catalog 登録＋Origin 配布経路差し替え（board C）。
+2. **インストーラ follow-up**: `#709` フォント on-demand 化（66MB→約11MB）／`#710` ウィザードのサイト名を `site_name` 設定へ反映／Saira 表示書体の self-host 同梱（Issue 未起票）。
+3. **Issue 見通し改善**: 進行中エピック（#311/#362/#371/#372/#491/#507/#536）を「残スライスだけの小 Issue」に割って親をクローズ、を提案済み。
+4. 持ち越し: `#647` Aozora 章モード調整ほか未着手バックログ。
+
+> 詳細: PR #717（`Closes #716`）／GitHub Release `v0.5.1`／会話メモリ `installer-common-library-nene2`（本日の UI 刷新・公開・follow-up を反映済み）。


### PR DESCRIPTION
本日（2026-07-05）の日報を `docs/daily/2026-07-05.md` に追加します。

- クラッシュ復旧・掃除（#715 取り込み）
- インストーラ UI をデザインシステムへ刷新（#716 / PR #717・提示層のみ）
- マージ → v0.5.1 リリース公開（Latest）
- Issue 棚卸し（open 20→18・#539/#684 クローズ）
- 捨てコンテナで新デザインの実機確認

daily report のみ（コード/挙動の変更なし）。明示依頼のドキュメントのため専用 Issue は起票していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)