### PR TITLE
feat(install): インストーラのサイト名を site_name 設定へ反映する (#710)

### DIFF
--- a/public_html/install/index.php
+++ b/public_html/install/index.php
@@ -45,6 +45,7 @@ use NeNeRecords\Install\InstallApplication;
 use NeNeRecords\Install\InstallConfig;
 use NeNeRecords\Organization\CreateOrganizationUseCaseInterface;
 use NeNeRecords\Organization\OrganizationRepositoryInterface;
+use NeNeRecords\Setting\UpdateSettingUseCaseInterface;
 use NeNeRecords\User\CreateUserUseCaseInterface;
 
 define('ROOT', dirname(__DIR__, 2));
@@ -844,12 +845,14 @@ if ($stepId === 'administrator') {
                 $organizations = $container->get(OrganizationRepositoryInterface::class);
                 $createUser = $container->get(CreateUserUseCaseInterface::class);
                 $orgHolder = $container->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+                $updateSetting = $container->get(UpdateSettingUseCaseInterface::class);
 
                 if (
                     !$createOrganization instanceof CreateOrganizationUseCaseInterface
                     || !$organizations instanceof OrganizationRepositoryInterface
                     || !$createUser instanceof CreateUserUseCaseInterface
                     || !$orgHolder instanceof RequestScopedHolder
+                    || !$updateSetting instanceof UpdateSettingUseCaseInterface
                 ) {
                     throw new RuntimeException('アプリケーションコンテナの構成が不正です。');
                 }
@@ -862,7 +865,7 @@ if ($stepId === 'administrator') {
                     : 'default';
 
                 /** @var RequestScopedHolder<int> $orgHolder */
-                $result = (new InstallApplication($createOrganization, $organizations, $createUser, $orgHolder))
+                $result = (new InstallApplication($createOrganization, $organizations, $createUser, $orgHolder, $updateSetting))
                     ->install(new InstallConfig($orgName, $orgSlug, $adminEmail, $adminPassword));
 
                 $guard->markInstalled(date('c'));

--- a/src/Install/InstallApplication.php
+++ b/src/Install/InstallApplication.php
@@ -11,6 +11,8 @@ use NeNeRecords\Organization\CreateOrganizationInput;
 use NeNeRecords\Organization\CreateOrganizationUseCaseInterface;
 use NeNeRecords\Organization\OrganizationRepositoryInterface;
 use NeNeRecords\Organization\OrganizationSlugConflictException;
+use NeNeRecords\Setting\UpdateSettingInput;
+use NeNeRecords\Setting\UpdateSettingUseCaseInterface;
 use NeNeRecords\User\CreateUserInput;
 use NeNeRecords\User\CreateUserUseCaseInterface;
 use NeNeRecords\User\UserEmailConflictException;
@@ -31,6 +33,7 @@ final readonly class InstallApplication
         private OrganizationRepositoryInterface $organizations,
         private CreateUserUseCaseInterface $createUser,
         private RequestScopedHolder $orgHolder,
+        private UpdateSettingUseCaseInterface $updateSetting,
     ) {
     }
 
@@ -42,6 +45,15 @@ final readonly class InstallApplication
         $this->orgHolder->set($organizationId);
 
         $adminCreated = $this->ensureAdmin($config, $organizationId);
+
+        // Reflect the entered name into the public `site_name` setting so the site
+        // title is correct out of the box (otherwise it stays the "NeNe Records"
+        // default until the user edits it in the admin). Only on fresh creation:
+        // this seam runs on every deploy, so re-runs must not clobber a name the
+        // user has since customized.
+        if ($organizationCreated) {
+            $this->updateSetting->execute(new UpdateSettingInput('site_name', $config->organizationName));
+        }
 
         return new InstallResult(
             organizationId: $organizationId,

--- a/tests/Install/InstallApplicationTest.php
+++ b/tests/Install/InstallApplicationTest.php
@@ -9,6 +9,9 @@ use NeNeRecords\Install\InstallApplication;
 use NeNeRecords\Install\InstallConfig;
 use NeNeRecords\Organization\CreateOrganizationUseCase;
 use NeNeRecords\Organization\DefaultContentTypeSeederInterface;
+use NeNeRecords\Setting\UpdateSettingInput;
+use NeNeRecords\Setting\UpdateSettingOutput;
+use NeNeRecords\Setting\UpdateSettingUseCaseInterface;
 use NeNeRecords\Tests\Organization\InMemoryOrganizationRepository;
 use NeNeRecords\Tests\Organization\RecordingDefaultSettingDefsSeeder;
 use NeNeRecords\Tests\User\InMemoryUserRepository;
@@ -17,8 +20,11 @@ use PHPUnit\Framework\TestCase;
 
 final class InstallApplicationTest extends TestCase
 {
-    private function app(InMemoryOrganizationRepository $orgs, InMemoryUserRepository $users): InstallApplication
-    {
+    private function app(
+        InMemoryOrganizationRepository $orgs,
+        InMemoryUserRepository $users,
+        UpdateSettingUseCaseInterface $updateSetting,
+    ): InstallApplication {
         $seeder = new class () implements DefaultContentTypeSeederInterface {
             public int $seededFor = 0;
 
@@ -36,15 +42,22 @@ final class InstallApplicationTest extends TestCase
             $orgs,
             new CreateUserUseCase($users),
             $holder,
+            $updateSetting,
         );
+    }
+
+    private function recordingUpdateSetting(): RecordingUpdateSetting
+    {
+        return new RecordingUpdateSetting();
     }
 
     public function testCreatesOrganizationAndAdminOnFreshInstall(): void
     {
         $orgs = new InMemoryOrganizationRepository();
         $users = new InMemoryUserRepository([]);
+        $updateSetting = $this->recordingUpdateSetting();
 
-        $result = $this->app($orgs, $users)->install(
+        $result = $this->app($orgs, $users, $updateSetting)->install(
             new InstallConfig('Acme', 'acme', 'admin@acme.test', 'secret-password'),
         );
 
@@ -58,17 +71,51 @@ final class InstallApplicationTest extends TestCase
         self::assertSame('admin', $admin->role);
     }
 
+    public function testReflectsEnteredNameIntoSiteNameSettingOnFreshInstall(): void
+    {
+        $orgs = new InMemoryOrganizationRepository();
+        $users = new InMemoryUserRepository([]);
+        $updateSetting = $this->recordingUpdateSetting();
+
+        $this->app($orgs, $users, $updateSetting)->install(
+            new InstallConfig('Acme Publishing', 'acme', 'admin@acme.test', 'secret-password'),
+        );
+
+        self::assertCount(1, $updateSetting->inputs);
+        self::assertSame('site_name', $updateSetting->inputs[0]->settingKey);
+        self::assertSame('Acme Publishing', $updateSetting->inputs[0]->value);
+    }
+
     public function testIsIdempotentOnReRun(): void
     {
         $orgs = new InMemoryOrganizationRepository();
         $users = new InMemoryUserRepository([]);
         $config = new InstallConfig('Acme', 'acme', 'admin@acme.test', 'secret-password');
 
-        $this->app($orgs, $users)->install($config);
-        $second = $this->app($orgs, $users)->install($config);
+        $this->app($orgs, $users, $this->recordingUpdateSetting())->install($config);
+
+        $secondUpdateSetting = $this->recordingUpdateSetting();
+        $second = $this->app($orgs, $users, $secondUpdateSetting)->install($config);
 
         self::assertFalse($second->organizationCreated);
         self::assertFalse($second->adminCreated);
         self::assertSame(1, $orgs->count());
+        // The org already exists, so the re-run must not overwrite a possibly
+        // user-customized site_name.
+        self::assertSame([], $secondUpdateSetting->inputs);
+    }
+}
+
+/** Records every setting write so tests can assert what the installer reflected. */
+final class RecordingUpdateSetting implements UpdateSettingUseCaseInterface
+{
+    /** @var list<UpdateSettingInput> */
+    public array $inputs = [];
+
+    public function execute(UpdateSettingInput $input): UpdateSettingOutput
+    {
+        $this->inputs[] = $input;
+
+        return new UpdateSettingOutput($input->settingKey, $input->value, '2026-07-05 00:00:00');
     }
 }

--- a/tools/install.php
+++ b/tools/install.php
@@ -26,6 +26,7 @@ use NeNeRecords\Install\InstallApplication;
 use NeNeRecords\Install\InstallConfig;
 use NeNeRecords\Organization\CreateOrganizationUseCaseInterface;
 use NeNeRecords\Organization\OrganizationRepositoryInterface;
+use NeNeRecords\Setting\UpdateSettingUseCaseInterface;
 use NeNeRecords\User\CreateUserUseCaseInterface;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
@@ -49,19 +50,21 @@ $createOrganization = $container->get(CreateOrganizationUseCaseInterface::class)
 $organizations = $container->get(OrganizationRepositoryInterface::class);
 $createUser = $container->get(CreateUserUseCaseInterface::class);
 $orgHolder = $container->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+$updateSetting = $container->get(UpdateSettingUseCaseInterface::class);
 
 if (
     !$createOrganization instanceof CreateOrganizationUseCaseInterface
     || !$organizations instanceof OrganizationRepositoryInterface
     || !$createUser instanceof CreateUserUseCaseInterface
     || !$orgHolder instanceof RequestScopedHolder
+    || !$updateSetting instanceof UpdateSettingUseCaseInterface
 ) {
     fwrite(STDERR, "ERROR: the application container is misconfigured.\n");
     exit(1);
 }
 
 /** @var RequestScopedHolder<int> $orgHolder */
-$result = (new InstallApplication($createOrganization, $organizations, $createUser, $orgHolder))
+$result = (new InstallApplication($createOrganization, $organizations, $createUser, $orgHolder, $updateSetting))
     ->install(new InstallConfig($orgName, $orgSlug, $email, $password));
 
 printf(


### PR DESCRIPTION
## 目的

インストーラ（#707）の管理者ステップ「サイト名（組織名）」が **組織名にしか使われず**、公開サイトのタイトルは `site_name` 設定の既定値「NeNe Records」のままだった。設置直後のユーザーは 設定 → サイト設定 で `site_name` を別途変更する必要があり、気づきにくい。入力したサイト名を公開サイトタイトルへ即反映する。

## 変更内容

- **`src/Install/InstallApplication.php`**: コンストラクタに `UpdateSettingUseCaseInterface` を追加。org 作成＋管理者作成のあと、**フレッシュな org 作成時のみ**（`organizationCreated === true`）入力名を org スコープの `site_name` 設定へ書き込む。
  - この seam は毎デプロイ実行され得る（`tools/install.php` / `composer app:install`・idempotent 契約）ため、**再実行では上書きしない**（ユーザーが後から変更した名前を保護）。
  - org 作成時に `setting_defs` は seed 済み（#711）なので、書込時に `site_name` 定義は存在する。org holder は `InstallApplication` が set 済みで、`UpdateSettingUseCase` が読む共有シングルトン（`nene-records.org_id_holder`）と同一。
- **`public_html/install/index.php`** / **`tools/install.php`**: 両呼び出し元でコンテナから `UpdateSettingUseCaseInterface` を解決して配線（`instanceof` ガード付き）。
- `tagline` / `copyright` は触らない（issue 指定どおり）。

## 検証

- `composer check` 全グリーン: **PHPUnit 1144 tests / 3141 assertions**・PHPStan level 8（1330 files・エラー0）・CS-Fixer・OpenAPI・MCP。
- `tests/Install/InstallApplicationTest.php` に2ケース追加:
  - フレッシュ install → `site_name` に入力名を書き込む。
  - 再実行（org 既存）→ `site_name` を **書き込まない**（idempotency）。
- コンテナ配線は共有 org holder シングルトン経由で `UpdateSettingUseCase` が対象 org に書くことを構成上確認（既存の認証済みリクエストの設定書込と同一機構）。

## チェックリスト

- [x] Issue-driven（Closes #710）
- [x] Conventional Commits（type/scope 英語・本文日本語・`(#710)`）
- [x] `composer check` グリーン
- [x] シークレット・`.env` 不含

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)