### PR TITLE
feat(machine): candidate-database preflight を採用する（inspector 配線＋identity marker＋候補プロファイル） (#648)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,19 @@ DB_USER=nene_records
 DB_PASSWORD=
 DB_CHARSET=utf8mb4
 
+# --- Machine database preflight candidates (optional・#648) ---
+# POST /machine/database/preflight で「候補DB」を read-only 診断する接続先を、アプリ側 env で
+# allowlist する（接続情報はリクエストボディから受けない＝SSRF 封じ）。<KEY> が候補 id
+# （例: RESTORE）。SELECT 専用資格を推奨（framework が read-only トランザクションも強制）。
+# マルチテナント配備なら *_MULTITENANT=true で verdict を needs_review に寄せる。
+# DB_CANDIDATE_RESTORE_ADAPTER=mysql
+# DB_CANDIDATE_RESTORE_HOST=db-restore.internal
+# DB_CANDIDATE_RESTORE_PORT=3306
+# DB_CANDIDATE_RESTORE_NAME=nene_records
+# DB_CANDIDATE_RESTORE_USER=preflight_ro
+# DB_CANDIDATE_RESTORE_PASSWORD=
+# DB_CANDIDATE_RESTORE_MULTITENANT=false
+
 # --- Docker Compose overrides (copy to .env and uncomment for local stack) ---
 # DB_ADAPTER=mysql
 # DB_HOST=mysql

--- a/database/migrations/20260716000000_stamp_app_identity_marker.php
+++ b/database/migrations/20260716000000_stamp_app_identity_marker.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * machine database preflight（#648）用に、この DB を NeNe Records の所有物として識別する
+ * マーカー行を `nene2_app_identity` に書き込む。framework の
+ * {@see \Nene2\Database\Preflight\ApplicationIdentityMarker} と同一スキーマ・同一 1 行
+ * （application_id ＋ nullable tenant_id・主キー無し）。
+ *
+ * これにより `POST /machine/database/preflight` が候補 DB を `app_identity: match` と
+ * 判定でき、同一 NENE2 ledger を持つ別アプリの DB は `mismatch` で refuse できる。既存 DB
+ * は本 migration の適用で marker を後追い書き込み（backfill）する。
+ *
+ * application_id は {@see \NeNeRecords\Database\Preflight\PreflightIdentity::APPLICATION_ID}
+ * と同値（migration 自己完結の原則で literal を意図的に複製）。tenant_id は NULL: 本アプリは
+ * 共有 DB・行レベル（org_id）マルチテナントで DB 単位のテナント識別が not_applicable なため。
+ *
+ * 版数は手動採番（20260716…・現行 max 20260715 の次）。自動採番（当日 20260705）だと依存より
+ * 前に sort され fresh-DB で silent skip になるため（migration-version-date-skew）。
+ */
+final class StampAppIdentityMarker extends AbstractMigration
+{
+    private const TABLE = 'nene2_app_identity';
+    private const APPLICATION_ID = 'nene-records';
+
+    public function up(): void
+    {
+        if (!$this->hasTable(self::TABLE)) {
+            $this->table(self::TABLE, ['id' => false])
+                ->addColumn('application_id', 'string', ['limit' => 190, 'null' => false])
+                ->addColumn('tenant_id', 'string', ['limit' => 190, 'null' => true])
+                ->create();
+        }
+
+        // Idempotent single-row marker, matching ApplicationIdentityMarker::stamp().
+        // APPLICATION_ID is a controlled literal with no special characters.
+        $this->execute(sprintf('DELETE FROM %s', self::TABLE));
+        $this->execute(sprintf(
+            "INSERT INTO %s (application_id, tenant_id) VALUES ('%s', NULL)",
+            self::TABLE,
+            self::APPLICATION_ID,
+        ));
+    }
+
+    public function down(): void
+    {
+        if ($this->hasTable(self::TABLE)) {
+            $this->table(self::TABLE)->drop()->save();
+        }
+    }
+}

--- a/src/Database/Preflight/CandidateProfileFactory.php
+++ b/src/Database/Preflight/CandidateProfileFactory.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Database\Preflight;
+
+use Nene2\Config\ConfigException;
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\Preflight\CandidateProfile;
+
+/**
+ * Builds candidate database profiles for machine database preflight (#648) from the
+ * application's own environment — never from the request body — so a caller of
+ * `POST /machine/database/preflight` can only reference candidates the operator has
+ * allowlisted (this is what keeps the endpoint SSRF-safe and credentials off the wire).
+ *
+ * Each candidate is described by `DB_CANDIDATE_<KEY>_*` variables that mirror the primary
+ * `DB_*` keys; `<KEY>` becomes the candidate id the caller references. A least-privilege
+ * (SELECT-only) credential is recommended; the framework additionally enforces a
+ * read-only transaction during inspection.
+ *
+ *   DB_CANDIDATE_RESTORE_ADAPTER=mysql
+ *   DB_CANDIDATE_RESTORE_HOST=db-restore.internal
+ *   DB_CANDIDATE_RESTORE_PORT=3306
+ *   DB_CANDIDATE_RESTORE_NAME=nene_records
+ *   DB_CANDIDATE_RESTORE_USER=preflight_ro
+ *   DB_CANDIDATE_RESTORE_PASSWORD=...
+ *   DB_CANDIDATE_RESTORE_MULTITENANT=true   # optional, default false
+ *
+ * A malformed candidate (missing required fields) is skipped rather than fatal, so a
+ * misconfigured optional candidate never takes the whole application down — the caller
+ * simply gets a 422 (unknown candidate) for that id.
+ */
+final class CandidateProfileFactory
+{
+    private const PREFIX = 'DB_CANDIDATE_';
+
+    /** Recognised trailing field names; the last `_`-segment of a variable name. */
+    private const FIELDS = ['URL', 'ADAPTER', 'HOST', 'PORT', 'NAME', 'USER', 'PASSWORD', 'CHARSET', 'MULTITENANT'];
+
+    /**
+     * @param array<array-key, mixed> $env Typically `$_SERVER + $_ENV`.
+     * @return array<string, CandidateProfile> Keyed by candidate id.
+     */
+    public static function fromEnv(array $env): array
+    {
+        /** @var array<string, array<string, string>> $grouped */
+        $grouped = [];
+
+        foreach ($env as $name => $value) {
+            if (!is_string($name) || !is_string($value) || !str_starts_with($name, self::PREFIX)) {
+                continue;
+            }
+
+            $rest = substr($name, strlen(self::PREFIX));
+            $parts = explode('_', $rest);
+            $field = array_pop($parts); // explode never yields an empty list, so this is a string
+            $key = implode('_', $parts);
+
+            if ($key === '' || !in_array($field, self::FIELDS, true)) {
+                continue;
+            }
+
+            $grouped[$key][$field] = $value;
+        }
+
+        $profiles = [];
+        foreach ($grouped as $key => $fields) {
+            // A numeric candidate key (e.g. DB_CANDIDATE_2026_*) arrives as an int array
+            // key, so normalise to string before use under strict_types.
+            $id = (string) $key;
+            if ($id === '') {
+                continue;
+            }
+
+            $profile = self::build($id, $fields);
+            if ($profile !== null) {
+                $profiles[$id] = $profile;
+            }
+        }
+
+        return $profiles;
+    }
+
+    /**
+     * @param non-empty-string $key
+     * @param array<string, string> $fields
+     */
+    private static function build(string $key, array $fields): ?CandidateProfile
+    {
+        $url = ($fields['URL'] ?? '') !== '' ? $fields['URL'] : null;
+        $portRaw = $fields['PORT'] ?? '3306';
+        $port = ctype_digit($portRaw) ? (int) $portRaw : 0;
+
+        try {
+            $config = new DatabaseConfig(
+                url: $url,
+                environment: 'candidate',
+                adapter: ($fields['ADAPTER'] ?? '') !== '' ? $fields['ADAPTER'] : 'mysql',
+                host: $fields['HOST'] ?? '',
+                port: $port,
+                name: $fields['NAME'] ?? '',
+                user: $fields['USER'] ?? '',
+                password: $fields['PASSWORD'] ?? '',
+                charset: ($fields['CHARSET'] ?? '') !== '' ? $fields['CHARSET'] : 'utf8mb4',
+            );
+        } catch (ConfigException) {
+            return null;
+        }
+
+        $multiTenant = filter_var($fields['MULTITENANT'] ?? 'false', FILTER_VALIDATE_BOOLEAN);
+
+        return new CandidateProfile($key, new PdoConnectionFactory($config), $multiTenant);
+    }
+}

--- a/src/Database/Preflight/MigrationVersions.php
+++ b/src/Database/Preflight/MigrationVersions.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Database\Preflight;
+
+/**
+ * The Phinx migration version ids this application ships — the numeric prefix of each
+ * `database/migrations/<version>_*.php` file.
+ *
+ * Fed to the framework's `DefaultDatabaseCandidateInspector` so machine database
+ * preflight (#648) can classify a candidate's ledger as fresh / compatible / ahead /
+ * foreign / partial. An empty list makes the inspector return `needs_review`
+ * (`migration_versions_unknown`), so the real set is always passed.
+ */
+final class MigrationVersions
+{
+    /**
+     * Known migration versions, ascending. Empty when the directory is absent.
+     * Pass an explicit $directory only in tests; production reads the shipped folder.
+     *
+     * @return list<string>
+     */
+    public static function known(?string $directory = null): array
+    {
+        $directory ??= dirname(__DIR__, 3) . '/database/migrations';
+
+        if (!is_dir($directory)) {
+            return [];
+        }
+
+        $entries = scandir($directory);
+
+        if ($entries === false) {
+            return [];
+        }
+
+        $versions = [];
+        foreach ($entries as $entry) {
+            if (preg_match('/^(\d+)_.*\.php$/', $entry, $matches) === 1) {
+                $versions[] = $matches[1];
+            }
+        }
+
+        sort($versions);
+
+        return $versions;
+    }
+}

--- a/src/Database/Preflight/PreflightIdentity.php
+++ b/src/Database/Preflight/PreflightIdentity.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Database\Preflight;
+
+/**
+ * NeNe Records' stable database-lineage identity for machine database preflight (#648).
+ *
+ * Stamped into the application's own database (`nene2_app_identity`, by the
+ * `StampAppIdentityMarker` migration) and compared read-only against a candidate by
+ * the framework's `DefaultDatabaseCandidateInspector`, so `/machine/database/preflight`
+ * can refuse a database that belongs to a *different* application even when it carries
+ * the same NENE2 migration ledger.
+ *
+ * The identity's `tenantId` is intentionally null: NeNe Records is a shared-database,
+ * row-level (`org_id`) multi-tenant application, so the database is not partitioned per
+ * tenant and database-level tenant matching is `not_applicable`. Per-candidate caution
+ * for multi-tenant deployments is expressed via `CandidateProfile::$multiTenant` instead.
+ */
+final class PreflightIdentity
+{
+    /** Stable identifier of this application's database lineage (marker `application_id`). */
+    public const APPLICATION_ID = 'nene-records';
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -16,6 +16,8 @@ use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Database\PdoDatabaseTransactionManager;
+use Nene2\Database\Preflight\ApplicationIdentity;
+use Nene2\Database\Preflight\DefaultDatabaseCandidateInspector;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\DomainExceptionHandlerInterface;
@@ -32,6 +34,9 @@ use NeNeRecords\ApplicationServiceProvider;
 use NeNeRecords\Auth\AdminApiAuthMiddleware;
 use NeNeRecords\Auth\AuthServiceProvider;
 use NeNeRecords\Auth\CapabilityMiddleware;
+use NeNeRecords\Database\Preflight\CandidateProfileFactory;
+use NeNeRecords\Database\Preflight\MigrationVersions;
+use NeNeRecords\Database\Preflight\PreflightIdentity;
 use NeNeRecords\Organization\OrganizationRepositoryInterface;
 use NeNeRecords\Organization\Resolution\EnvResolutionStrategy;
 use NeNeRecords\Organization\Resolution\OrgResolverMiddleware;
@@ -357,6 +362,18 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         // Surface our own release version on GET /machine/health so NeNe Suite
                         // can track updates against Origin (#586). Null when VERSION is absent.
                         appVersion: Version::current(),
+                        // Opt into the auth-gated POST /machine/database/preflight endpoint (#648):
+                        // read-only diagnosis of a candidate database before adopting it. The inspector
+                        // knows our shipped migrations and our identity marker; candidate connection
+                        // details come only from the app's own env (SSRF-safe), never the request body.
+                        databaseCandidateInspector: new DefaultDatabaseCandidateInspector(
+                            applicationMigrationVersions: MigrationVersions::known(),
+                            // Phinx's default ledger table (phinx.php does not override
+                            // default_migration_table); the inspector otherwise assumes 'phinx_log'.
+                            ledgerTable: 'phinxlog',
+                            applicationIdentity: new ApplicationIdentity(PreflightIdentity::APPLICATION_ID),
+                        ),
+                        databaseCandidateProfiles: CandidateProfileFactory::fromEnv($_SERVER + $_ENV),
                     );
                 },
             )

--- a/tests/Database/Preflight/CandidateProfileFactoryTest.php
+++ b/tests/Database/Preflight/CandidateProfileFactoryTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Database\Preflight;
+
+use Nene2\Database\PdoConnectionFactory;
+use NeNeRecords\Database\Preflight\CandidateProfileFactory;
+use PHPUnit\Framework\TestCase;
+
+final class CandidateProfileFactoryTest extends TestCase
+{
+    public function testBuildsProfileFromEnvKeyedByCandidateId(): void
+    {
+        $profiles = CandidateProfileFactory::fromEnv([
+            'DB_CANDIDATE_RESTORE_ADAPTER' => 'mysql',
+            'DB_CANDIDATE_RESTORE_HOST' => 'db-restore.internal',
+            'DB_CANDIDATE_RESTORE_PORT' => '3306',
+            'DB_CANDIDATE_RESTORE_NAME' => 'nene_records',
+            'DB_CANDIDATE_RESTORE_USER' => 'preflight_ro',
+            'DB_CANDIDATE_RESTORE_PASSWORD' => 'secret',
+            'DB_CANDIDATE_RESTORE_MULTITENANT' => 'true',
+            'UNRELATED_ENV' => 'ignored',
+        ]);
+
+        self::assertArrayHasKey('RESTORE', $profiles);
+        $profile = $profiles['RESTORE'];
+        self::assertSame('RESTORE', $profile->id);
+        self::assertInstanceOf(PdoConnectionFactory::class, $profile->connectionFactory);
+        self::assertTrue($profile->multiTenant);
+    }
+
+    public function testCandidateIdKeepsUnderscores(): void
+    {
+        $profiles = CandidateProfileFactory::fromEnv([
+            'DB_CANDIDATE_RESTORE_2026_HOST' => 'h',
+            'DB_CANDIDATE_RESTORE_2026_NAME' => 'nene_records',
+            'DB_CANDIDATE_RESTORE_2026_USER' => 'u',
+        ]);
+
+        self::assertArrayHasKey('RESTORE_2026', $profiles);
+        self::assertSame('RESTORE_2026', $profiles['RESTORE_2026']->id);
+    }
+
+    public function testMultiTenantDefaultsFalse(): void
+    {
+        $profiles = CandidateProfileFactory::fromEnv([
+            'DB_CANDIDATE_CLONE_HOST' => 'h',
+            'DB_CANDIDATE_CLONE_NAME' => 'nene_records',
+            'DB_CANDIDATE_CLONE_USER' => 'u',
+        ]);
+
+        self::assertFalse($profiles['CLONE']->multiTenant);
+    }
+
+    public function testSkipsMalformedCandidateInsteadOfFailing(): void
+    {
+        // HOST and NAME missing → DatabaseConfig rejects it → candidate is dropped,
+        // and a valid sibling candidate still builds.
+        $profiles = CandidateProfileFactory::fromEnv([
+            'DB_CANDIDATE_BROKEN_USER' => 'u',
+            'DB_CANDIDATE_GOOD_HOST' => 'h',
+            'DB_CANDIDATE_GOOD_NAME' => 'nene_records',
+            'DB_CANDIDATE_GOOD_USER' => 'u',
+        ]);
+
+        self::assertArrayNotHasKey('BROKEN', $profiles);
+        self::assertArrayHasKey('GOOD', $profiles);
+    }
+
+    public function testIgnoresNonCandidateEnv(): void
+    {
+        self::assertSame([], CandidateProfileFactory::fromEnv([
+            'DB_HOST' => 'h',
+            'DB_CANDIDATE_' => 'no-key',       // empty candidate key
+            'DB_CANDIDATE_ONLYKEY' => 'no-field', // no recognised field suffix
+            'APP_NAME' => 'x',
+        ]));
+    }
+}

--- a/tests/Database/Preflight/MigrationVersionsTest.php
+++ b/tests/Database/Preflight/MigrationVersionsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Database\Preflight;
+
+use NeNeRecords\Database\Preflight\MigrationVersions;
+use PHPUnit\Framework\TestCase;
+
+final class MigrationVersionsTest extends TestCase
+{
+    public function testReturnsSortedVersionPrefixesFromDirectory(): void
+    {
+        $dir = $this->tempDir();
+        $files = [
+            '20260716000000_stamp_app_identity_marker.php',
+            '20260524000000_initial.php',
+            '20260601000000_add_thing.php',
+            'not_a_migration.php',    // no numeric prefix → ignored
+            '20260602000000_readme.txt', // not a .php → ignored
+        ];
+        foreach ($files as $name) {
+            touch($dir . '/' . $name);
+        }
+
+        self::assertSame(
+            ['20260524000000', '20260601000000', '20260716000000'],
+            MigrationVersions::known($dir),
+        );
+
+        foreach ($files as $name) {
+            unlink($dir . '/' . $name);
+        }
+        rmdir($dir);
+    }
+
+    public function testReturnsEmptyWhenDirectoryMissing(): void
+    {
+        self::assertSame([], MigrationVersions::known('/no/such/migrations'));
+    }
+
+    public function testDefaultReadsShippedMigrations(): void
+    {
+        $versions = MigrationVersions::known();
+
+        self::assertNotEmpty($versions);
+        foreach ($versions as $version) {
+            self::assertMatchesRegularExpression('/^\d+$/', $version);
+        }
+        // Ships the identity-marker migration this feature adds.
+        self::assertContains('20260716000000', $versions);
+    }
+
+    private function tempDir(): string
+    {
+        $dir = sys_get_temp_dir() . '/nene-migrations-' . uniqid('', true);
+        mkdir($dir);
+
+        return $dir;
+    }
+}


### PR DESCRIPTION
## 目的

NENE2 の **candidate-database preflight**（NENE2#1419 診断+verdict / #1420 app identity）を本アプリで有効化。既存 DB へ向ける前（環境クローン・リストア/移行・DB サーバ移動）に「その候補 DB が自分にとって正当か」を **read-only** で自己診断できるようにする。

## 変更内容

- **inspector 配線** — `RuntimeApplicationFactory` に `DefaultDatabaseCandidateInspector` を渡し、auth-gated な `POST /machine/database/preflight` を **opt-in** で有効化（machine API キーで自動保護）。
  - `applicationMigrationVersions`: 同梱 migration の版一覧（`MigrationVersions` が `database/migrations` を走査）。空だと `needs_review` になるため必ず渡す。
  - `ledgerTable: 'phinxlog'` — `phinx.php` は `default_migration_table` を上書きせず Phinx 既定を使う。inspector 既定の `'phinx_log'`（アンダースコア）のままだと**自 DB を `foreign` と誤判定**する（実機で検出・修正）。
  - `applicationIdentity: ApplicationIdentity('nene-records')`。`tenant_id` は **null**：本アプリは共有 DB・行レベル（`org_id`）マルチテナントで **DB 単位のテナント識別が `not_applicable`**（詳細は `PreflightIdentity` の docblock）。
- **identity marker** — migration `20260716000000` が `nene2_app_identity` に 1 行（`application_id='nene-records'`）を stamp。既存 DB も適用で**バックフィル**（framework の `ApplicationIdentityMarker` と同一スキーマ・主キー無し）。版数は手動採番（現行 max `20260715…` の次）で date-skew 回避。
- **候補プロファイル** — `CandidateProfileFactory` が env `DB_CANDIDATE_<KEY>_*` を **allowlist** として読み `CandidateProfile` を組む。接続情報はリクエストボディから受けない（**SSRF 封じ**）。不正な候補は fatal にせず skip（未知 id は 422）。マルチテナント配備は `*_MULTITENANT=true` で verdict を保守的（needs_review）に寄せる。

## 検証

- **実機（dev の実 app に dispatch）**: 自 DB を候補にすると
  ```json
  { "reachable":true, "schema_recognized":true, "migration_state":"compatible",
    "populated":true, "recommendation":"safe", "app_identity":"match", "tenant":"not_applicable" }
  ```
  未知候補 → **422**、API キー無し → **401**。※使い捨てスクリプトで実施・削除済み、秘密は非出力。
- **real MySQL に migration 適用**: `20260716000000` が pending→migrated（date-skew skip 無し）、marker 行 `{application_id:"nene-records", tenant_id:null}` を確認。
- `composer check` 全グリーン（PHPUnit / PHPStan L8 / CS / OpenAPI / MCP）。`MigrationVersionsTest`・`CandidateProfileFactoryTest` を追加。

## 設計判断（施主レビュー歓迎）

- **tenant 照合は not_applicable**（`tenantId=null`）: 本アプリは per-tenant DB でなく共有 DB のため、DB 単位のテナント一致は概念的に非該当。`applicationId='nene-records'` が主たるガード（同一 NENE2 ledger を持つ別アプリの DB を refuse）。二つの Records install の DB を区別する per-install identity は将来拡張（要 stored install-id）。
- 機能規模のため #648 の「非対象」（fingerprint/署名=NENE2#1421・実 apply）は含まない。

## 前提・残タスク

- NENE2 は既に v1.6.0（`Database/Preflight/*` 一式・factory 受け口あり）。
- **残（ops・施主）**: 候補診断を使うなら本番で `DB_CANDIDATE_*` を設定（SELECT 専用資格推奨）。未設定でもエンドポイントは有効（任意 id は 422）。

## チェックリスト

- [x] Issue-driven（Closes #648）
- [x] Conventional Commits（type/scope 英語・本文日本語・`(#648)`）
- [x] `composer check` グリーン＋実機確認（endpoint verdict / migration / auth）
- [x] シークレット・`.env` 不含

Closes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)