### PR TITLE
fix(settings): 生 JSON 露出の設定を専用 UI へ委ね一覧から隠す (#541)

### DIFF
--- a/frontend/src/features/manage-settings/hooks/useManageSiteSettingsPage.test.ts
+++ b/frontend/src/features/manage-settings/hooks/useManageSiteSettingsPage.test.ts
@@ -1,0 +1,69 @@
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useManageSiteSettingsPage } from './useManageSiteSettingsPage'
+
+// Mock the entity queries so the hook returns a fixed settings list; we only
+// care about which keys survive the DEDICATED_UI_KEYS filter (#541).
+vi.mock('@/entities/setting', () => {
+  const make = (settingKey: string) => ({
+    settingKey,
+    label: settingKey,
+    dataType: 'text' as const,
+    defaultValue: null,
+    isPublic: true,
+    value: '',
+    updatedAt: null,
+  })
+  const items = [
+    'site_name',
+    'tagline',
+    'theme_overrides',
+    'header_config',
+    'home_hero',
+    'layout_config',
+    'active_theme',
+    'front_page',
+  ].map(make)
+
+  return {
+    useSettingList: () => ({
+      data: { items },
+      isLoading: false,
+      isError: false,
+      refetch: () => {},
+    }),
+    useSettingRevisions: () => ({ data: { items: [] }, isLoading: false, isError: false }),
+    useUpdateSetting: () => ({ mutateAsync: () => Promise.resolve(undefined), isPending: false }),
+  }
+})
+
+afterEach(cleanup)
+
+describe('useManageSiteSettingsPage', () => {
+  const visibleKeys = (): string[] =>
+    renderHook(() => useManageSiteSettingsPage()).result.current.items.map(
+      (item) => item.settingKey,
+    )
+
+  it('hides settings that have a dedicated structured editor, so no raw JSON shows in the generic list (#541)', () => {
+    const keys = visibleKeys()
+
+    for (const dedicated of [
+      'theme_overrides',
+      'header_config',
+      'home_hero',
+      'layout_config',
+      'active_theme',
+      'front_page',
+    ]) {
+      expect(keys).not.toContain(dedicated)
+    }
+  })
+
+  it('keeps plain text settings in the generic list', () => {
+    const keys = visibleKeys()
+
+    expect(keys).toContain('site_name')
+    expect(keys).toContain('tagline')
+  })
+})

--- a/frontend/src/features/manage-settings/hooks/useManageSiteSettingsPage.ts
+++ b/frontend/src/features/manage-settings/hooks/useManageSiteSettingsPage.ts
@@ -4,10 +4,25 @@ import { useSettingList, useSettingRevisions, useUpdateSetting } from '@/entitie
 
 /**
  * Settings with a dedicated editor elsewhere are hidden from this generic
- * key-value form so they aren't edited twice (once here as a raw field, once in
- * their purpose-built UI). `front_page` has the "Home page display" section (#701).
+ * key-value form so they aren't edited twice — and, crucially, so non-technical
+ * admins never face a raw JSON string here (#541). Each key below has a
+ * purpose-built, structured editor:
+ *
+ * - `front_page`     → the "Home page display" section on this page (#701)
+ * - `theme_overrides`→ Appearance → Theme (ThemeCustomizeView: colors/fonts/knobs)
+ * - `header_config`  → Appearance → Theme (HeaderContentView: topbar/CTA toggles)
+ * - `home_hero`      → Appearance → Theme (HomeHeroView: typed block editor, #486)
+ * - `layout_config`  → Appearance → Layout (LayoutConfigBar: columns/position)
+ * - `active_theme`   → Appearance → Theme (PublicThemeView: theme picker)
  */
-const DEDICATED_UI_KEYS = new Set(['front_page'])
+const DEDICATED_UI_KEYS = new Set([
+  'front_page',
+  'theme_overrides',
+  'header_config',
+  'home_hero',
+  'layout_config',
+  'active_theme',
+])
 
 export interface ManageSiteSettingsPageState {
   items: SettingItem[]


### PR DESCRIPTION
## 目的

エピック #536・レポート #534 由来（P1）。汎用の Site Settings 一覧が `theme_overrides` / `header_config` / `home_hero` / `layout_config` を**生の JSON 文字列（1 行テキスト入力）として露出**し、非技術者が触れなかった。

## 調査で分かったこと（重要）

これらのキーは **既に Appearance 配下に構造化エディタが実装済み**（色/フォント/ノブ・トグル・型付きブロック・カラム設定）で、汎用一覧が**重複して生 JSON を見せていた**だけ。つまり本 issue は「ノブ UI を新規実装」ではなく**「専用 UI を持つキーを汎用一覧から隠す」**修正（既存 `DEDICATED_UI_KEYS` の拡張）。

| キー | 既存の専用エディタ |
|---|---|
| `theme_overrides` | Appearance → Theme（`ThemeCustomizeView`：色/フォント/knob） |
| `header_config` | Appearance → Theme（`HeaderContentView`：topbar/CTA トグル） |
| `home_hero` | Appearance → Theme（`HomeHeroView`：型付きブロック #486） |
| `layout_config` | Appearance → Layout（`LayoutConfigBar`：カラム/位置） |
| `active_theme`※ | Appearance → Theme（`PublicThemeView`：テーマピッカー） |

※ `active_theme` は JSON ではないが**同型の重複露出**（生テキストでテーマ id を手打ちできてしまう footgun）だったため併せて除外。#541 の文面（生 JSON）からはやや広いスコープなので分離可。

## 変更内容

- `useManageSiteSettingsPage.ts` の `DEDICATED_UI_KEYS` に上記 5 キーを追加（各キーの委譲先を docblock に明記）。**新規エディタ実装なし**。
- `useManageSiteSettingsPage.test.ts` を追加（除外キーが一覧に出ない／通常キーは残る をフックレベルで検証。entity クエリを mock）。

## 検証

- `npm run check --prefix frontend` 全グリーン（type-check / lint / prettier / test / validate:themes / knip / storybook）。
- バックエンド無変更（フロントのみ）。

## チェックリスト

- [x] Issue-driven（Closes #541）
- [x] Conventional Commits（type/scope 英語・本文日本語・`(#541)`）
- [x] `npm run check --prefix frontend` グリーン

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)