### PR TITLE
fix(security): 本番で JWT 署名鍵が未設定なら起動を拒否する（フェイルクローズ） (#724)

### DIFF
--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Auth\LocalBearerTokenVerifier;
 use Nene2\Auth\TokenIssuerInterface;
 use Nene2\Auth\TokenVerifierInterface;
 use Nene2\Config\AppConfig;
+use Nene2\Config\AppEnvironment;
 use Nene2\Config\ConfigLoader;
 use Nene2\Database\DatabaseConnectionFactoryInterface;
 use Nene2\Database\DatabaseQueryExecutorInterface;
@@ -198,7 +199,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Application config service is invalid.');
                     }
 
-                    return new LocalBearerTokenVerifier($config->localJwtSecret ?? 'nene-records-dev-secret');
+                    return new LocalBearerTokenVerifier(self::resolveJwtSecret($config));
                 },
             )
             ->set(
@@ -390,5 +391,27 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(ResponseEmitter::class, static fn (ContainerInterface $container): ResponseEmitter => new ResponseEmitter());
+    }
+
+    /**
+     * Resolve the local JWT signing key, failing closed in production. When the key
+     * (`NENE2_LOCAL_JWT_SECRET`) is unset or blank, production refuses to boot rather
+     * than falling back to the public dev constant — which would let anyone forge a
+     * token. Dev/test keep the convenience fallback.
+     */
+    private static function resolveJwtSecret(AppConfig $config): string
+    {
+        if ($config->localJwtSecret !== null && $config->localJwtSecret !== '') {
+            return $config->localJwtSecret;
+        }
+
+        if ($config->environment === AppEnvironment::Production) {
+            throw new LogicException(
+                'NENE2_LOCAL_JWT_SECRET must be set in production. '
+                . 'Generate one with: php -r "echo bin2hex(random_bytes(32));"',
+            );
+        }
+
+        return 'nene-records-dev-secret'; // dev/test only
     }
 }

--- a/tests/Http/JwtSecretResolutionTest.php
+++ b/tests/Http/JwtSecretResolutionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Http;
+
+use LogicException;
+use Nene2\Config\AppConfig;
+use Nene2\Config\AppEnvironment;
+use Nene2\Config\DatabaseConfig;
+use NeNeRecords\Http\RuntimeServiceProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * The local JWT signing key must fail closed in production when
+ * NENE2_LOCAL_JWT_SECRET is unset or blank, rather than falling back to the
+ * public dev constant (which would let anyone forge a superadmin token). #724
+ */
+final class JwtSecretResolutionTest extends TestCase
+{
+    public function testProductionWithoutSecretRefusesToBoot(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('NENE2_LOCAL_JWT_SECRET');
+
+        self::resolve(self::config(AppEnvironment::Production, null));
+    }
+
+    public function testProductionWithBlankSecretRefusesToBoot(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('NENE2_LOCAL_JWT_SECRET');
+
+        self::resolve(self::config(AppEnvironment::Production, ''));
+    }
+
+    public function testProductionWithSecretUsesIt(): void
+    {
+        self::assertSame(
+            'a-real-production-secret',
+            self::resolve(self::config(AppEnvironment::Production, 'a-real-production-secret')),
+        );
+    }
+
+    public function testLocalWithoutSecretFallsBackToDevConstant(): void
+    {
+        // Off-production convenience: the dev fallback is allowed only outside production.
+        self::assertNotSame('', self::resolve(self::config(AppEnvironment::Local, null)));
+    }
+
+    private static function resolve(AppConfig $config): string
+    {
+        $method = new ReflectionMethod(RuntimeServiceProvider::class, 'resolveJwtSecret');
+
+        /** @var string $secret */
+        $secret = $method->invoke(null, $config);
+
+        return $secret;
+    }
+
+    private static function config(AppEnvironment $environment, ?string $secret): AppConfig
+    {
+        return new AppConfig(
+            $environment,
+            false,
+            'NeNe Records',
+            new DatabaseConfig(null, 'test', 'sqlite', '', 1, ':memory:', '', '', ''),
+            null,
+            $secret,
+        );
+    }
+}


### PR DESCRIPTION
## 目的

`LocalBearerTokenVerifier` 構築時、`localJwtSecret`（`NENE2_LOCAL_JWT_SECRET`）が未設定だと**開発用の既定鍵にフォールバック**していた＝本番でのフェイルオープン。署名鍵の解決を `resolveJwtSecret` ガードへ置換し、**本番（`APP_ENV=production`）で鍵が未設定（null）または空なら起動を拒否**する（フェイルクローズ）。認証ミドルウェアの配線は変更しない（鍵解決のみ）。

## 変更内容

- `src/Http/RuntimeServiceProvider.php`: 呼び出し（`:201`）を `self::resolveJwtSecret($config)` に置換し、`private static resolveJwtSecret()` を追加。`use Nene2\Config\AppEnvironment;` を追加（`AppConfig` / `LogicException` は import 済み）。
- **空文字も本番拒否**（`!== null && !== ''`）。records の `ConfigLoader::optionalString` は空→null に正規化するため records 単体では `!== ''` は未到達だが、空セット弾き＋横展開テンプレ統一のため含める。
- `tests/Http/JwtSecretResolutionTest.php`: 本番未設定/空→拒否・本番設定→採用・dev→既定鍵（`ReflectionMethod` で private static を検証）。

## 検証

- `composer check` **green**（PHPUnit 4テスト追加 / PHPStan **L8 調整不要** / CS-Fixer / OpenAPI / MCP）。
- **fail-closed 実証（実 app・実 container）**: `APP_ENV=production` かつ鍵未設定で `environment='production'` に**到達している**ことを確認した上で `LocalBearerTokenVerifier` の解決が拒否される（DI が `ServiceResolutionException` で包み、`previous` に `LogicException`「NENE2_LOCAL_JWT_SECRET must be set…」を保持）。
- **dev 非回帰**: `APP_ENV=local` かつ鍵未設定で従来どおり起動（既定鍵）。
- ※検証は使い捨てスクリプトで実施・削除済み、秘密は非出力。

## チェックリスト

- [x] Issue-driven（Closes #724）
- [x] Conventional Commits（type/scope 英語・本文日本語・`(#724)`）
- [x] `composer check` green ＋ fail-closed 実証 ＋ dev 非回帰
- [x] スコープ厳守（この変更のみ・ミドルウェア配線不変）

Closes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)