### PR TITLE
feat(webhook): outbound webhook 送信に SSRF ガードを追加

### DIFF
--- a/src/Http/SsrfGuard.php
+++ b/src/Http/SsrfGuard.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Http;
+
+/**
+ * SSRF guard for outbound HTTP(S) requests to caller/tenant-supplied URLs.
+ *
+ * An org admin is not infra-trusted in a multi-tenant deployment, so any URL they
+ * supply (webhook endpoints, WXR media) must not be allowed to reach internal
+ * infrastructure or the cloud metadata endpoint. This guard:
+ *
+ *   - only accepts http/https schemes (rejects file/ftp/gopher/dict/...);
+ *   - resolves the host up-front and requires every resolved A/AAAA address to be
+ *     publicly routable — private (10/8, 172.16/12, 192.168/16), loopback
+ *     (127/8, ::1), link-local incl. the metadata endpoint 169.254.169.254,
+ *     IPv6 unique-local (fc00::/7), carrier-grade NAT (100.64/10, RFC 6598) and
+ *     the other reserved ranges are rejected without any network call;
+ *   - returns the verified addresses so the caller can pin the connection to them
+ *     (redirects must additionally be disabled by the caller so a public URL
+ *     cannot bounce to an internal address after the check).
+ *
+ * Residual DNS-rebinding (a resolve-then-connect TOCTOU) is closed by pinning the
+ * connection to {@see SsrfInspection::$addresses}; NAT64-embedded literals and
+ * deployment-level egress remain the operator's responsibility.
+ *
+ * Wave1 note: this is the minimal records-local validator called for in the
+ * upstream HTTP-client design (_work/reports/2026-07-06/upstream-design/02-http-client.md §6).
+ * When the Nene2\Http\Client base ships its shared SsrfGuard, absorb this into it.
+ */
+final class SsrfGuard
+{
+    /** @var list<string> */
+    private const ALLOWED_SCHEMES = ['http', 'https'];
+
+    /** Start of the carrier-grade NAT range 100.64.0.0/10 (RFC 6598). */
+    private const CGN_NETWORK = '100.64.0.0';
+
+    /** Mask for a /10 prefix (255.192.0.0). */
+    private const CGN_MASK = 0xFFC00000;
+
+    /**
+     * Inspect an outbound URL, resolving its host and verifying every resolved
+     * address is publicly routable. No network egress happens on rejection.
+     */
+    public function inspect(string $url): SsrfInspection
+    {
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+        if (!is_string($scheme) || !in_array(strtolower($scheme), self::ALLOWED_SCHEMES, true)) {
+            return SsrfInspection::reject('URL scheme must be http or https.');
+        }
+
+        $host = parse_url($url, PHP_URL_HOST);
+        if (!is_string($host) || $host === '') {
+            return SsrfInspection::reject('URL has no host.');
+        }
+
+        $host = trim($host, '[]'); // strip IPv6 brackets
+
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            // Literal IP host — no DNS lookup required.
+            return self::isPublicIp($host)
+                ? SsrfInspection::allow([$host])
+                : SsrfInspection::reject('URL host is a non-public IP address.');
+        }
+
+        $addresses = $this->resolve($host);
+        if ($addresses === []) {
+            return SsrfInspection::reject('URL host could not be resolved.');
+        }
+
+        foreach ($addresses as $ip) {
+            if (!self::isPublicIp($ip)) {
+                return SsrfInspection::reject('URL host resolves to a non-public IP address.');
+            }
+        }
+
+        return SsrfInspection::allow($addresses);
+    }
+
+    /**
+     * Cheap, DNS-free pre-check for request-time validation: the scheme must be
+     * http/https and any literal-IP host must be public. Hostnames pass here and
+     * are authoritatively re-checked (with resolution + pinning) at egress by
+     * {@see inspect()}.
+     */
+    public function isLikelySafeUrl(string $url): bool
+    {
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+        if (!is_string($scheme) || !in_array(strtolower($scheme), self::ALLOWED_SCHEMES, true)) {
+            return false;
+        }
+
+        $host = parse_url($url, PHP_URL_HOST);
+        if (!is_string($host) || $host === '') {
+            return false;
+        }
+
+        $host = trim($host, '[]');
+
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return self::isPublicIp($host);
+        }
+
+        return true; // hostname — deferred to inspect() at egress
+    }
+
+    /** True only for globally routable addresses (rejects private + reserved + CGN). */
+    public static function isPublicIp(string $ip): bool
+    {
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+            return false;
+        }
+
+        // PHP's reserved-range flag does not cover carrier-grade NAT (100.64.0.0/10).
+        return !self::isCarrierGradeNat($ip);
+    }
+
+    private static function isCarrierGradeNat(string $ip): bool
+    {
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false) {
+            return false;
+        }
+
+        $long = ip2long($ip);
+        if ($long === false) {
+            return false;
+        }
+
+        return ($long & self::CGN_MASK) === (ip2long(self::CGN_NETWORK) & self::CGN_MASK);
+    }
+
+    /** @return list<string> resolved IPv4 + IPv6 addresses for the host */
+    private function resolve(string $host): array
+    {
+        $addresses = [];
+
+        $v4 = gethostbynamel($host);
+        if ($v4 !== false) {
+            $addresses = $v4;
+        }
+
+        foreach (@dns_get_record($host, DNS_AAAA) ?: [] as $record) {
+            if (isset($record['ipv6']) && is_string($record['ipv6'])) {
+                $addresses[] = $record['ipv6'];
+            }
+        }
+
+        return array_values(array_unique($addresses));
+    }
+}

--- a/src/Http/SsrfInspection.php
+++ b/src/Http/SsrfInspection.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Http;
+
+/**
+ * Result of an {@see SsrfGuard} inspection of an outbound URL.
+ *
+ * On success it carries the resolved, verified-public IP addresses so the caller
+ * can pin the connection to them (e.g. cURL's {@see CURLOPT_RESOLVE}) and avoid a
+ * DNS-rebinding TOCTOU between the check and the actual connect.
+ */
+final readonly class SsrfInspection
+{
+    /** @param list<string> $addresses */
+    private function __construct(
+        public bool $allowed,
+        public ?string $reason,
+        public array $addresses,
+    ) {
+    }
+
+    /** @param list<string> $addresses resolved, verified-public IP addresses */
+    public static function allow(array $addresses): self
+    {
+        return new self(true, null, $addresses);
+    }
+
+    public static function reject(string $reason): self
+    {
+        return new self(false, $reason, []);
+    }
+}

--- a/src/Webhook/CreateWebhookHandler.php
+++ b/src/Webhook/CreateWebhookHandler.php
@@ -8,6 +8,7 @@ use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
+use NeNeRecords\Http\SsrfGuard;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -74,6 +75,11 @@ final readonly class CreateWebhookHandler
             $errors[] = new ValidationError('url', 'URL is required.', 'required');
         } elseif (filter_var($url, FILTER_VALIDATE_URL) === false) {
             $errors[] = new ValidationError('url', 'URL must be a valid URL.', 'invalid');
+        } elseif (!(new SsrfGuard())->isLikelySafeUrl($url)) {
+            // SSRF guard: reject non-http(s) schemes and literal private/reserved
+            // IP hosts up-front. Hostnames are authoritatively re-checked (with
+            // DNS resolution + connection pinning) when the webhook is delivered.
+            $errors[] = new ValidationError('url', 'URL must be an http(s) endpoint on a public host.', 'invalid');
         }
 
         $events = $this->parseEvents($body);

--- a/src/Webhook/CurlWebhookSender.php
+++ b/src/Webhook/CurlWebhookSender.php
@@ -4,21 +4,43 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Webhook;
 
+use NeNeRecords\Http\SsrfGuard;
 use Throwable;
 
 /**
  * Delivers a webhook payload over HTTP via cURL (5 s timeout).
  *
- * A 2xx response is a success; any other status, transport error, or exception is a
- * failure that the {@see WebhookDeliveryProcessor} can retry.
+ * The destination URL is supplied by an org admin, who is not infra-trusted in a
+ * multi-tenant deployment, so every send is SSRF-guarded ({@see SsrfGuard}):
+ *   - only http/https destinations are allowed;
+ *   - the host is resolved and every resolved address must be publicly routable —
+ *     private, loopback, link-local (incl. the metadata endpoint 169.254.169.254),
+ *     CGN and reserved ranges are refused before any connection;
+ *   - the connection is pinned to the verified IP(s) via CURLOPT_RESOLVE and
+ *     redirects are disabled, so DNS rebinding cannot bounce the request to an
+ *     internal address after the check.
+ *
+ * A 2xx response is a success; any other status, a rejected URL, a transport
+ * error, or an exception is a failure that the {@see WebhookDeliveryProcessor}
+ * can retry.
  */
 final readonly class CurlWebhookSender implements WebhookSenderInterface
 {
     private const TIMEOUT_SECONDS = 5;
 
+    public function __construct(
+        private SsrfGuard $ssrfGuard = new SsrfGuard(),
+    ) {
+    }
+
     public function send(string $url, ?string $secret, string $payload): WebhookSendResult
     {
         try {
+            $inspection = $this->ssrfGuard->inspect($url);
+            if (!$inspection->allowed) {
+                return WebhookSendResult::failure('Webhook URL rejected: ' . ($inspection->reason ?? 'not allowed.'));
+            }
+
             $headers = [
                 'Content-Type: application/json',
                 'User-Agent: NeNeRecords-Webhook/1.0',
@@ -42,6 +64,9 @@ final readonly class CurlWebhookSender implements WebhookSenderInterface
                 CURLOPT_TIMEOUT => self::TIMEOUT_SECONDS,
                 CURLOPT_CONNECTTIMEOUT => self::TIMEOUT_SECONDS,
                 CURLOPT_FOLLOWLOCATION => false,
+                CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+                CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+                CURLOPT_RESOLVE => $this->pinnedAddresses($url, $inspection->addresses),
             ]);
 
             $result = curl_exec($ch);
@@ -61,5 +86,34 @@ final readonly class CurlWebhookSender implements WebhookSenderInterface
         } catch (Throwable $e) {
             return WebhookSendResult::failure($e->getMessage());
         }
+    }
+
+    /**
+     * Pin the host to the addresses already verified public so cURL connects to
+     * them instead of re-resolving (DNS-rebinding defence).
+     *
+     * @param list<string> $addresses
+     * @return list<string> CURLOPT_RESOLVE entries "host:port:ip"
+     */
+    private function pinnedAddresses(string $url, array $addresses): array
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+        if (!is_string($host) || $host === '') {
+            return [];
+        }
+        $host = trim($host, '[]');
+
+        $port = parse_url($url, PHP_URL_PORT);
+        if (!is_int($port)) {
+            $scheme = parse_url($url, PHP_URL_SCHEME);
+            $port = is_string($scheme) && strtolower($scheme) === 'https' ? 443 : 80;
+        }
+
+        $entries = [];
+        foreach ($addresses as $ip) {
+            $entries[] = $host . ':' . $port . ':' . $ip;
+        }
+
+        return $entries;
     }
 }

--- a/src/Webhook/UpdateWebhookHandler.php
+++ b/src/Webhook/UpdateWebhookHandler.php
@@ -9,6 +9,7 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
+use NeNeRecords\Http\SsrfGuard;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -78,6 +79,11 @@ final readonly class UpdateWebhookHandler
             $errors[] = new ValidationError('url', 'URL is required.', 'required');
         } elseif (filter_var($url, FILTER_VALIDATE_URL) === false) {
             $errors[] = new ValidationError('url', 'URL must be a valid URL.', 'invalid');
+        } elseif (!(new SsrfGuard())->isLikelySafeUrl($url)) {
+            // SSRF guard: reject non-http(s) schemes and literal private/reserved
+            // IP hosts up-front. Hostnames are authoritatively re-checked (with
+            // DNS resolution + connection pinning) when the webhook is delivered.
+            $errors[] = new ValidationError('url', 'URL must be an http(s) endpoint on a public host.', 'invalid');
         }
 
         $events = $this->parseEvents($body);

--- a/src/WxrImport/HttpWxrMediaFetcher.php
+++ b/src/WxrImport/HttpWxrMediaFetcher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\WxrImport;
 
 use finfo;
+use NeNeRecords\Http\SsrfGuard;
 
 /**
  * Fetches WordPress attachment files over HTTP(S) during a WXR import.
@@ -27,14 +28,14 @@ final readonly class HttpWxrMediaFetcher implements WxrMediaFetcherInterface
     private const TIMEOUT_SECONDS = 15;
     private const MAX_BYTES = 10 * 1024 * 1024; // mirrors UploadMediaUseCase cap
 
+    public function __construct(
+        private SsrfGuard $ssrfGuard = new SsrfGuard(),
+    ) {
+    }
+
     public function fetch(string $url): ?WxrMediaFetchResult
     {
-        $scheme = parse_url($url, PHP_URL_SCHEME);
-        if ($scheme !== 'http' && $scheme !== 'https') {
-            return null;
-        }
-
-        if (!$this->hostIsPubliclyRoutable($url)) {
+        if (!$this->ssrfGuard->inspect($url)->allowed) {
             return null;
         }
 
@@ -63,60 +64,9 @@ final readonly class HttpWxrMediaFetcher implements WxrMediaFetcherInterface
         );
     }
 
-    /** Resolve the URL's host and require every resolved address to be public. */
-    private function hostIsPubliclyRoutable(string $url): bool
-    {
-        $host = parse_url($url, PHP_URL_HOST);
-        if (!is_string($host) || $host === '') {
-            return false;
-        }
-
-        $host = trim($host, '[]'); // strip IPv6 brackets
-
-        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
-            return self::isPublicIp($host); // literal IP host — no DNS needed
-        }
-
-        $addresses = $this->resolve($host);
-        if ($addresses === []) {
-            return false; // unresolvable → refuse
-        }
-
-        foreach ($addresses as $ip) {
-            if (!self::isPublicIp($ip)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /** @return list<string> resolved IPv4 + IPv6 addresses for the host */
-    private function resolve(string $host): array
-    {
-        $addresses = [];
-
-        $v4 = gethostbynamel($host);
-        if ($v4 !== false) {
-            $addresses = $v4;
-        }
-
-        foreach (@dns_get_record($host, DNS_AAAA) ?: [] as $record) {
-            if (isset($record['ipv6']) && is_string($record['ipv6'])) {
-                $addresses[] = $record['ipv6'];
-            }
-        }
-
-        return array_values(array_unique($addresses));
-    }
-
-    /** True only for globally routable addresses (rejects private + reserved ranges). */
+    /** True only for globally routable addresses (rejects private + reserved + CGN ranges). */
     public static function isPublicIp(string $ip): bool
     {
-        return filter_var(
-            $ip,
-            FILTER_VALIDATE_IP,
-            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
-        ) !== false;
+        return SsrfGuard::isPublicIp($ip);
     }
 }

--- a/tests/Http/SsrfGuardTest.php
+++ b/tests/Http/SsrfGuardTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Http;
+
+use NeNeRecords\Http\SsrfGuard;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * SSRF guard tests. Every blocked case is rejected by the IP-range / scheme check
+ * before any network call, so these run offline and deterministically. Literal-IP
+ * hosts are used for the allowed cases so no DNS lookup is needed either.
+ */
+final class SsrfGuardTest extends TestCase
+{
+    private SsrfGuard $guard;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->guard = new SsrfGuard();
+    }
+
+    /** @return list<array{string}> */
+    public static function publicIps(): array
+    {
+        return [['8.8.8.8'], ['1.1.1.1'], ['203.0.113.10'], ['2001:4860:4860::8888']];
+    }
+
+    /** @return list<array{string}> */
+    public static function blockedIps(): array
+    {
+        return [
+            ['127.0.0.1'],       // loopback
+            ['::1'],             // IPv6 loopback
+            ['10.0.0.5'],        // private
+            ['172.16.0.1'],      // private
+            ['192.168.1.1'],     // private
+            ['169.254.169.254'], // link-local / cloud metadata
+            ['100.64.0.1'],      // carrier-grade NAT (RFC 6598)
+            ['0.0.0.0'],         // reserved
+            ['fc00::1'],         // IPv6 unique-local
+            ['fe80::1'],         // IPv6 link-local
+            ['::ffff:127.0.0.1'], // IPv4-mapped loopback
+        ];
+    }
+
+    #[DataProvider('publicIps')]
+    public function testPublicIpsAreRoutable(string $ip): void
+    {
+        self::assertTrue(SsrfGuard::isPublicIp($ip));
+    }
+
+    #[DataProvider('blockedIps')]
+    public function testPrivateAndReservedIpsAreBlocked(string $ip): void
+    {
+        self::assertFalse(SsrfGuard::isPublicIp($ip));
+    }
+
+    public function testInspectRejectsCloudMetadataEndpoint(): void
+    {
+        $inspection = $this->guard->inspect('http://169.254.169.254/latest/meta-data/iam/');
+
+        self::assertFalse($inspection->allowed);
+        self::assertNotNull($inspection->reason);
+        self::assertSame([], $inspection->addresses);
+    }
+
+    #[DataProvider('blockedIps')]
+    public function testInspectRejectsInternalLiteralHosts(string $ip): void
+    {
+        $host = str_contains($ip, ':') ? '[' . $ip . ']' : $ip;
+
+        self::assertFalse($this->guard->inspect('http://' . $host . '/hook')->allowed);
+        self::assertFalse($this->guard->inspect('https://' . $host . '/hook')->allowed);
+    }
+
+    public function testInspectRejectsNonHttpSchemes(): void
+    {
+        self::assertFalse($this->guard->inspect('file:///etc/passwd')->allowed);
+        self::assertFalse($this->guard->inspect('ftp://8.8.8.8/x')->allowed);
+        self::assertFalse($this->guard->inspect('gopher://127.0.0.1/')->allowed);
+        self::assertFalse($this->guard->inspect('dict://8.8.8.8:11211/')->allowed);
+    }
+
+    public function testInspectRejectsMalformedUrl(): void
+    {
+        self::assertFalse($this->guard->inspect('not a url')->allowed);
+        self::assertFalse($this->guard->inspect('http://')->allowed);
+    }
+
+    public function testInspectAllowsPublicHostsAndReturnsPinnableAddress(): void
+    {
+        $v4 = $this->guard->inspect('https://8.8.8.8/webhook');
+        self::assertTrue($v4->allowed);
+        self::assertNull($v4->reason);
+        self::assertSame(['8.8.8.8'], $v4->addresses);
+
+        $http = $this->guard->inspect('http://203.0.113.10:8080/webhook');
+        self::assertTrue($http->allowed);
+        self::assertSame(['203.0.113.10'], $http->addresses);
+
+        $v6 = $this->guard->inspect('https://[2001:4860:4860::8888]/webhook');
+        self::assertTrue($v6->allowed);
+        self::assertSame(['2001:4860:4860::8888'], $v6->addresses);
+    }
+
+    public function testIsLikelySafeUrlGuardsSchemeAndLiteralHosts(): void
+    {
+        // rejected: bad scheme / literal internal hosts
+        self::assertFalse($this->guard->isLikelySafeUrl('ftp://8.8.8.8/x'));
+        self::assertFalse($this->guard->isLikelySafeUrl('http://127.0.0.1/hook'));
+        self::assertFalse($this->guard->isLikelySafeUrl('http://169.254.169.254/'));
+        self::assertFalse($this->guard->isLikelySafeUrl('http://[::1]/hook'));
+
+        // allowed: public literal IP and hostnames (deferred to egress inspect())
+        self::assertTrue($this->guard->isLikelySafeUrl('https://8.8.8.8/hook'));
+        self::assertTrue($this->guard->isLikelySafeUrl('https://hooks.example.com/hook'));
+    }
+}

--- a/tests/Webhook/CurlWebhookSenderTest.php
+++ b/tests/Webhook/CurlWebhookSenderTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Webhook;
+
+use NeNeRecords\Webhook\CurlWebhookSender;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The sender is the authoritative SSRF egress guard. Internal / non-http(s)
+ * destinations are refused before any connection is attempted, and the refusal
+ * is surfaced as a failure result (never swallowed as a success).
+ */
+final class CurlWebhookSenderTest extends TestCase
+{
+    /** @return list<array{string}> */
+    public static function rejectedUrls(): array
+    {
+        return [
+            ['http://169.254.169.254/latest/meta-data/'], // cloud metadata
+            ['http://127.0.0.1/hook'],                    // loopback
+            ['http://10.0.0.1/hook'],                     // private
+            ['https://192.168.1.1/hook'],                 // private
+            ['http://[::1]/hook'],                        // IPv6 loopback
+            ['ftp://8.8.8.8/hook'],                       // non-http(s) scheme
+        ];
+    }
+
+    #[DataProvider('rejectedUrls')]
+    public function testSendRejectsInternalOrNonHttpTargets(string $url): void
+    {
+        $result = (new CurlWebhookSender())->send($url, 'shhh', '{"event":"entity.created"}');
+
+        self::assertFalse($result->success);
+        self::assertNull($result->statusCode);
+        self::assertNotNull($result->error);
+        self::assertStringContainsString('Webhook URL rejected', (string) $result->error);
+    }
+}


### PR DESCRIPTION
## 目的
records の webhook 送信は org-admin が供給する URL を `FILTER_VALIDATE_URL` だけで検証しており、private/loopback/link-local/CGN やクラウドメタデータ(`169.254.169.254`)への到達を弾いていなかった (SSRF)。内部ネット到達・メタデータ窃取のリスクを塞ぐ。

設計根拠: `_work/reports/2026-07-06/upstream-design/02-http-client.md` §6（検品 C レーン先行セキュリティ S1）。

## 変更
- **`NeNeRecords\Http\SsrfGuard` を新設**（共有ガード）
  - `http`/`https` のみ許可（`file`/`ftp`/`gopher`/`dict` 等を拒否）。
  - ホストを解決し、全 A/AAAA アドレスが公開ルーティング可能であることを要求。private(10/8,172.16/12,192.168/16)・loopback(127/8,::1)・link-local/metadata(169.254/16)・IPv6 ULA(fc00::/7)・**CGN(100.64.0.0/10, PHP の予約フラグが対象外なので独自実装)**・予約レンジを拒否。IPv4-mapped IPv6 も遮断。
  - 解決済みアドレスを `SsrfInspection` で返し、接続ピン留めに使う。
- **`CurlWebhookSender`**: 送信前に `inspect()` で拒否。`CURLOPT_RESOLVE` で検証済み IP に接続をピン留めし **DNS リバインディング(TOCTOU)** を封じる。redirect 禁止は従来どおり維持、`CURLOPT_PROTOCOLS`/`CURLOPT_REDIR_PROTOCOLS` を http/https に限定。拒否は `WebhookSendResult::failure` として表面化させ**握り潰さない**。
- **`Create/UpdateWebhookHandler`**: 作成/更新時に DNS 不要の早期バリデーション（スキーム + リテラル private IP 拒否）を追加。ホスト名は egress で最終検証（多層防御）。
- **`HttpWxrMediaFetcher`**: 既存の重複 SSRF ロジック(#567)を共有 `SsrfGuard` へ集約（挙動据え置き＝既存テスト緑）。

Wave1 の `Nene2\Http\Client` 共通基底が出たら `SsrfGuard` はそこへ吸収する前提でコメント済み。

## 検証
- `composer test` → **OK (1196 tests, 3336 assertions)**
- 新規 SSRF テスト → **OK (37 tests, 83 assertions)**（メタデータ/private/CGN/IPv6 loopback/非http拒否・公開 literal IP 許可・sender 拒否経路）
- `composer analyse`（PHPStan level 8）→ No errors
- `composer cs` → 0 files to fix
- `php -l` 変更ファイル全て pass

## チェックリスト
- [x] tests / analyse / cs すべて緑
- [x] 破壊的変更なし（戻り値型・公開 API 温存）
- [x] secret/署名鍵は従来どおりログ非出力

🤖 Generated with [Claude Code](https://claude.com/claude-code)