### PR TITLE
準拠 sweep: 業務コードの生 time API を NENE2 ClockInterface へ置換 (Clock)

### DIFF
--- a/src/Analytics/AccessLogMiddleware.php
+++ b/src/Analytics/AccessLogMiddleware.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Analytics;
 
-use DateTimeImmutable;
+use Nene2\Http\ClockInterface;
 use Nene2\Middleware\RequestIdMiddleware;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -19,6 +19,7 @@ final readonly class AccessLogMiddleware implements MiddlewareInterface
     public function __construct(
         private AccessLogRepositoryInterface $accessLogs,
         private LoggerInterface $logger,
+        private ClockInterface $clock,
         private array $excludedPaths = ['/health', '/', '/machine/health', '/examples/ping'],
     ) {
     }
@@ -41,7 +42,7 @@ final readonly class AccessLogMiddleware implements MiddlewareInterface
                 path: $path,
                 statusCode: $response->getStatusCode(),
                 durationMs: $this->durationMilliseconds($startedAt),
-                accessedAt: new DateTimeImmutable('now', new \DateTimeZone('UTC')),
+                accessedAt: $this->clock->now(),
             ));
         } catch (Throwable $exception) {
             $this->logger->error('Failed to persist access log entry.', [

--- a/src/Analytics/AnalyticsServiceProvider.php
+++ b/src/Analytics/AnalyticsServiceProvider.php
@@ -8,6 +8,7 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\Entity\EntityRepositoryInterface;
@@ -85,7 +86,12 @@ final readonly class AnalyticsServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('Text field repository service is invalid.');
                     }
 
-                    return new GetPopularEntitiesUseCase($accessLogs, $entities, $textFields);
+                    $clock = $c->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new GetPopularEntitiesUseCase($accessLogs, $entities, $textFields, $clock);
                 },
             )
             ->set(
@@ -119,7 +125,12 @@ final readonly class AnalyticsServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('Logger service is invalid.');
                     }
 
-                    return new AccessLogMiddleware($repository, $logger);
+                    $clock = $c->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new AccessLogMiddleware($repository, $logger, $clock);
                 },
             )
             ->set(

--- a/src/Analytics/GetPopularEntitiesUseCase.php
+++ b/src/Analytics/GetPopularEntitiesUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Analytics;
 
 use DateTimeImmutable;
+use Nene2\Http\ClockInterface;
 use NeNeRecords\Entity\EntityRepositoryInterface;
 use NeNeRecords\Entity\EntityStatus;
 use NeNeRecords\TextField\TextFieldRepositoryInterface;
@@ -15,12 +16,13 @@ final readonly class GetPopularEntitiesUseCase implements GetPopularEntitiesUseC
         private AccessLogRepositoryInterface $accessLogs,
         private EntityRepositoryInterface $entities,
         private TextFieldRepositoryInterface $textFields,
+        private ClockInterface $clock,
     ) {
     }
 
     public function execute(GetPopularEntitiesInput $input): GetPopularEntitiesOutput
     {
-        $sinceDate = (new DateTimeImmutable())
+        $sinceDate = $this->clock->now()
             ->modify(sprintf('-%d days', max(0, $input->days - 1)))
             ->format('Y-m-d');
 

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -10,6 +10,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -23,12 +24,17 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                 UserRepositoryInterface::class,
                 static function (ContainerInterface $container): UserRepositoryInterface {
                     $query = $container->get(DatabaseQueryExecutorInterface::class);
+                    $clock = $container->get(ClockInterface::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('DatabaseQueryExecutorInterface service is invalid.');
                     }
 
-                    return new PdoUserRepository($query);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new PdoUserRepository($query, $clock);
                 },
             )
             ->set(
@@ -36,6 +42,7 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $container): LoginUseCase {
                     $users = $container->get(UserRepositoryInterface::class);
                     $tokenIssuer = $container->get('nene-records.token_issuer');
+                    $clock = $container->get(ClockInterface::class);
 
                     if (!$users instanceof UserRepositoryInterface) {
                         throw new LogicException('UserRepositoryInterface service is invalid.');
@@ -45,8 +52,12 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                         throw new LogicException('TokenIssuerInterface service is invalid.');
                     }
 
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
                     /** @var TokenIssuerInterface $tokenIssuer */
-                    return new LoginUseCase($users, $tokenIssuer);
+                    return new LoginUseCase($users, $tokenIssuer, $clock);
                 },
             )
             ->set(
@@ -54,6 +65,7 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $container): LoginHandler {
                     $useCase = $container->get(LoginUseCase::class);
                     $response = $container->get(JsonResponseFactory::class);
+                    $clock = $container->get(ClockInterface::class);
 
                     if (!$useCase instanceof LoginUseCase) {
                         throw new LogicException('LoginUseCase service is invalid.');
@@ -63,7 +75,11 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                         throw new LogicException('JsonResponseFactory service is invalid.');
                     }
 
-                    return new LoginHandler($useCase, $response);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new LoginHandler($useCase, $response, $clock);
                 },
             )
             ->set(

--- a/src/Auth/LoginHandler.php
+++ b/src/Auth/LoginHandler.php
@@ -6,6 +6,7 @@ namespace NeNeRecords\Auth;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
@@ -18,6 +19,7 @@ final readonly class LoginHandler
     public function __construct(
         private LoginUseCase $useCase,
         private JsonResponseFactory $response,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -46,7 +48,7 @@ final readonly class LoginHandler
 
         // Set the session token as an HttpOnly cookie so page JS can't read it.
         // The token is still returned in the body for non-browser/machine clients.
-        $maxAge = $output->expiresAt - time();
+        $maxAge = $output->expiresAt - $this->clock->now()->getTimestamp();
         $cookie = SessionCookie::build($output->token, $maxAge, SessionCookie::isSecureRequest($request));
 
         return $this->response->create([

--- a/src/Auth/LoginUseCase.php
+++ b/src/Auth/LoginUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Auth;
 
 use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Http\ClockInterface;
 
 final readonly class LoginUseCase
 {
@@ -13,6 +14,7 @@ final readonly class LoginUseCase
     public function __construct(
         private UserRepositoryInterface $users,
         private TokenIssuerInterface $tokenIssuer,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -30,7 +32,8 @@ final readonly class LoginUseCase
             throw new InvalidCredentialsException();
         }
 
-        $expiresAt = time() + self::TOKEN_TTL_SECONDS;
+        $now = $this->clock->now()->getTimestamp();
+        $expiresAt = $now + self::TOKEN_TTL_SECONDS;
 
         // superadmin はどの組織にも属さないため org_id は null。
         // admin / editor は所属組織の ID を JWT に埋め込む。
@@ -40,7 +43,7 @@ final readonly class LoginUseCase
             'sub'    => $user->email,
             'role'   => $role->value,
             'org_id' => $orgId,
-            'iat'    => time(),
+            'iat'    => $now,
             'exp'    => $expiresAt,
         ]);
 

--- a/src/Auth/PdoUserRepository.php
+++ b/src/Auth/PdoUserRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Auth;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 
 final readonly class PdoUserRepository implements UserRepositoryInterface
 {
@@ -21,6 +22,7 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -81,7 +83,7 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
         ?int $organizationId = null,
         ?string $orgRole = null,
     ): User {
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
         $this->query->execute(
             'INSERT INTO users (email, password_hash, role, organization_id, org_role, status, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?)',

--- a/src/Comment/CommentServiceProvider.php
+++ b/src/Comment/CommentServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use Nene2\Middleware\RateLimitStorageInterface;
@@ -104,6 +105,7 @@ final readonly class CommentServiceProvider implements ServiceProviderInterface
                     $response = $c->get(JsonResponseFactory::class);
                     $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
                     $rateLimitStorage = $c->get(RateLimitStorageInterface::class);
+                    $clock = $c->get(ClockInterface::class);
                     if (!$useCase instanceof PostCommentUseCaseInterface) {
                         throw new LogicException('PostComment use case service is invalid.');
                     }
@@ -116,8 +118,11 @@ final readonly class CommentServiceProvider implements ServiceProviderInterface
                     if (!$rateLimitStorage instanceof RateLimitStorageInterface) {
                         throw new LogicException('Rate limit storage service is invalid.');
                     }
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
 
-                    return new PostCommentHandler($useCase, $response, $problemDetails, $rateLimitStorage);
+                    return new PostCommentHandler($useCase, $response, $problemDetails, $rateLimitStorage, $clock);
                 },
             )
             ->set(

--- a/src/Comment/PostCommentHandler.php
+++ b/src/Comment/PostCommentHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Comment;
 
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Middleware\RateLimitStorageInterface;
@@ -24,6 +25,7 @@ final readonly class PostCommentHandler
         private JsonResponseFactory $response,
         private ProblemDetailsResponseFactory $problemDetails,
         private RateLimitStorageInterface $rateLimitStorage,
+        private ClockInterface $clock,
         /** Max comments accepted per IP, per entity, within the window. */
         private int $maxCommentsPerWindow = 3,
         /** Rate-limit window in seconds (default: 1 hour). */
@@ -105,7 +107,7 @@ final readonly class PostCommentHandler
             return null;
         }
 
-        $retryAfter = max(0, $result['reset_at'] - time());
+        $retryAfter = max(0, $result['reset_at'] - $this->clock->now()->getTimestamp());
 
         return $this->problemDetails->create(
             $request,

--- a/src/Dashboard/DashboardServiceProvider.php
+++ b/src/Dashboard/DashboardServiceProvider.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Dashboard;
 use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeNeRecords\Analytics\AccessLogRepositoryInterface;
 use NeNeRecords\Entity\EntityRepositoryInterface;
@@ -37,7 +38,12 @@ final readonly class DashboardServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('Access log repository service is invalid.');
                     }
 
-                    return new GetDashboardSummaryUseCase($entities, $entityTypes, $accessLogs);
+                    $clock = $container->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new GetDashboardSummaryUseCase($entities, $entityTypes, $accessLogs, $clock);
                 },
             )
             ->set(

--- a/src/Dashboard/GetDashboardSummaryUseCase.php
+++ b/src/Dashboard/GetDashboardSummaryUseCase.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Dashboard;
 
-use DateTimeImmutable;
 use DateTimeInterface;
+use Nene2\Http\ClockInterface;
 use NeNeRecords\Analytics\AccessLogRepositoryInterface;
 use NeNeRecords\Entity\EntityRepositoryInterface;
 use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
@@ -20,12 +20,13 @@ final readonly class GetDashboardSummaryUseCase implements GetDashboardSummaryUs
         private EntityRepositoryInterface $entities,
         private EntityTypeRepositoryInterface $entityTypes,
         private AccessLogRepositoryInterface $accessLogs,
+        private ClockInterface $clock,
     ) {
     }
 
     public function execute(): GetDashboardSummaryOutput
     {
-        $now = new DateTimeImmutable();
+        $now = $this->clock->now();
 
         // ── Recent published entities ──────────────────────────────────────
         $recentEntities = $this->entities->findRecentPublished(self::RECENT_PUBLISHED_LIMIT);

--- a/src/Entity/EntityServiceProvider.php
+++ b/src/Entity/EntityServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\Analytics\AccessLogRepositoryInterface;
@@ -40,7 +41,12 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Org ID holder service is invalid.');
                     }
 
-                    return new PdoEntityRepository($query, $orgId);
+                    $clock = $c->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new PdoEntityRepository($query, $orgId, $clock);
                 },
             )
             ->set(
@@ -160,7 +166,12 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Access log repository service is invalid.');
                     }
 
-                    return new ListEntitiesUseCase($repository, $accessLogs);
+                    $clock = $c->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new ListEntitiesUseCase($repository, $clock, $accessLogs);
                 },
             )
             ->set(
@@ -219,7 +230,12 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
                         throw new LogicException('URL redirect repository service is invalid.');
                     }
 
-                    return new UpdateEntityUseCase($entities, $entityTypes, $webhooks, $redirects);
+                    $clock = $c->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new UpdateEntityUseCase($entities, $entityTypes, $clock, $webhooks, $redirects);
                 },
             )
             ->set(
@@ -376,7 +392,12 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Entity repository service is invalid.');
                     }
 
-                    return new ScheduleEntityUseCase($repository);
+                    $clock = $c->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new ScheduleEntityUseCase($repository, $clock);
                 },
             )
             ->set(
@@ -434,7 +455,12 @@ final readonly class EntityServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Entity repository service is invalid.');
                     }
 
-                    return new ProcessScheduledPublishUseCase($repository);
+                    $clock = $c->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new ProcessScheduledPublishUseCase($repository, $clock);
                 },
             )
             ->set(

--- a/src/Entity/ListEntitiesUseCase.php
+++ b/src/Entity/ListEntitiesUseCase.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Entity;
 
-use DateTimeImmutable;
 use DateTimeInterface;
 use LogicException;
+use Nene2\Http\ClockInterface;
 use NeNeRecords\Analytics\AccessLogRepositoryInterface;
 
 final readonly class ListEntitiesUseCase implements ListEntitiesUseCaseInterface
@@ -16,6 +16,7 @@ final readonly class ListEntitiesUseCase implements ListEntitiesUseCaseInterface
 
     public function __construct(
         private EntityRepositoryInterface $entities,
+        private ClockInterface $clock,
         /** Optional — enables `includeViews` (per-record view counts, #674). */
         private ?AccessLogRepositoryInterface $accessLogs = null,
     ) {
@@ -30,7 +31,7 @@ final readonly class ListEntitiesUseCase implements ListEntitiesUseCaseInterface
         // view. Opt-in so only callers that ask for it pay the GROUP BY aggregation.
         $viewCounts = [];
         if ($input->includeViews && $this->accessLogs !== null) {
-            $sinceDate = (new DateTimeImmutable())
+            $sinceDate = $this->clock->now()
                 ->modify(sprintf('-%d days', self::VIEW_WINDOW_DAYS - 1))
                 ->format('Y-m-d');
             $viewCounts = $this->accessLogs->aggregateEntityViews($sinceDate);

--- a/src/Entity/PdoEntityRepository.php
+++ b/src/Entity/PdoEntityRepository.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 
 final readonly class PdoEntityRepository implements EntityRepositoryInterface
@@ -18,6 +19,7 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
         private RequestScopedHolder $orgId,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -346,7 +348,7 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
     {
         $publishedAt = $entity->publishedAt?->format(DateTimeInterface::ATOM);
         $scheduledAt = $entity->scheduledAt?->format(DateTimeInterface::ATOM);
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $this->query->execute(
             'INSERT INTO entities (organization_id, entity_type_id, slug, permalink, layout, status, published_at, scheduled_at, created_at, updated_at, meta_title, meta_description) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
@@ -373,7 +375,7 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
         }
 
         $existing = $this->findById($id);
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
         $publishedAt = $entity->publishedAt?->format(DateTimeInterface::ATOM);
         $scheduledAt = $entity->scheduledAt?->format(DateTimeInterface::ATOM);
 
@@ -404,7 +406,7 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
     public function softDelete(int $id): void
     {
         $existing = $this->findById($id);
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $this->query->execute(
             <<<'SQL'

--- a/src/Entity/ProcessScheduledPublishUseCase.php
+++ b/src/Entity/ProcessScheduledPublishUseCase.php
@@ -4,20 +4,21 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Entity;
 
-use DateTimeImmutable;
 use LogicException;
+use Nene2\Http\ClockInterface;
 
 final readonly class ProcessScheduledPublishUseCase implements ProcessScheduledPublishUseCaseInterface
 {
     public function __construct(
         private EntityRepositoryInterface $entities,
+        private ClockInterface $clock,
     ) {
     }
 
     public function execute(): ProcessScheduledPublishOutput
     {
         $due = $this->entities->findDueScheduled();
-        $now = new DateTimeImmutable();
+        $now = $this->clock->now();
         $publishedIds = [];
 
         foreach ($due as $entity) {

--- a/src/Entity/ScheduleEntityUseCase.php
+++ b/src/Entity/ScheduleEntityUseCase.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Entity;
 
-use DateTimeImmutable;
 use DateTimeInterface;
 use InvalidArgumentException;
 use LogicException;
+use Nene2\Http\ClockInterface;
 
 final readonly class ScheduleEntityUseCase implements ScheduleEntityUseCaseInterface
 {
     public function __construct(
         private EntityRepositoryInterface $entities,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -30,7 +31,7 @@ final readonly class ScheduleEntityUseCase implements ScheduleEntityUseCaseInter
             throw new LogicException('Loaded entity missing id.');
         }
 
-        if ($input->scheduledAt <= new DateTimeImmutable()) {
+        if ($input->scheduledAt <= $this->clock->now()) {
             throw new InvalidArgumentException('scheduled_at must be in the future.');
         }
 

--- a/src/Entity/UpdateEntityUseCase.php
+++ b/src/Entity/UpdateEntityUseCase.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Entity;
 
-use DateTimeImmutable;
 use DateTimeInterface;
 use LogicException;
+use Nene2\Http\ClockInterface;
 use NeNeRecords\EntityType\EntityTypeNotFoundException;
 use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
 use NeNeRecords\PublicRecord\PublicPermalinkResolver;
@@ -18,6 +18,7 @@ final readonly class UpdateEntityUseCase implements UpdateEntityUseCaseInterface
     public function __construct(
         private EntityRepositoryInterface $entities,
         private EntityTypeRepositoryInterface $entityTypes,
+        private ClockInterface $clock,
         private ?WebhookDispatcherInterface $webhooks = null,
         /** Records a 301 from the old canonical path when the permalink changes (#651). */
         private ?UrlRedirectRepositoryInterface $redirects = null,
@@ -61,7 +62,7 @@ final readonly class UpdateEntityUseCase implements UpdateEntityUseCaseInterface
         // Auto-set published_at when transitioning to published for the first time.
         $publishedAt = $input->publishedAt ?? $existing->publishedAt;
         if ($input->status === EntityStatus::Published && $publishedAt === null) {
-            $publishedAt = new DateTimeImmutable();
+            $publishedAt = $this->clock->now();
         }
 
         // scheduled_at is only preserved when status is scheduled; clear otherwise.

--- a/src/EntityArchive/EntityArchiveServiceProvider.php
+++ b/src/EntityArchive/EntityArchiveServiceProvider.php
@@ -8,6 +8,7 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -31,7 +32,12 @@ final readonly class EntityArchiveServiceProvider implements ServiceProviderInte
                         throw new LogicException('Org ID holder service is invalid.');
                     }
 
-                    return new PdoEntityArchiveRepository($query, $orgId);
+                    $clock = $c->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new PdoEntityArchiveRepository($query, $orgId, $clock);
                 },
             )
             ->set(
@@ -60,7 +66,12 @@ final readonly class EntityArchiveServiceProvider implements ServiceProviderInte
                         throw new LogicException('Response factory service is invalid.');
                     }
 
-                    return new GetEntityArchiveCsvHandler($useCase, $responseFactory);
+                    $clock = $c->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new GetEntityArchiveCsvHandler($useCase, $responseFactory, $clock);
                 },
             )
             ->set(

--- a/src/EntityArchive/GetEntityArchiveCsvHandler.php
+++ b/src/EntityArchive/GetEntityArchiveCsvHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\EntityArchive;
 
+use Nene2\Http\ClockInterface;
 use Nene2\Routing\Router;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -16,6 +17,7 @@ final readonly class GetEntityArchiveCsvHandler
     public function __construct(
         private GetEntityArchiveCsvUseCaseInterface $useCase,
         private ResponseFactoryInterface $responseFactory,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -28,7 +30,7 @@ final readonly class GetEntityArchiveCsvHandler
         $output = $this->useCase->execute($input);
 
         $csv      = $this->buildCsv($output->rows);
-        $filename = "entity_archive_{$output->entityTypeId}_" . date('Ymd_His') . '.csv';
+        $filename = "entity_archive_{$output->entityTypeId}_" . $this->clock->now()->format('Ymd_His') . '.csv';
 
         return $this->responseFactory->createResponse(200)
             ->withHeader('Content-Type', 'text/csv; charset=UTF-8')

--- a/src/EntityArchive/PdoEntityArchiveRepository.php
+++ b/src/EntityArchive/PdoEntityArchiveRepository.php
@@ -6,6 +6,7 @@ namespace NeNeRecords\EntityArchive;
 
 use DateTimeImmutable;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\EntityType\EntityType;
 
@@ -17,6 +18,7 @@ final readonly class PdoEntityArchiveRepository implements EntityArchiveReposito
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
         private RequestScopedHolder $orgId,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -71,7 +73,7 @@ final readonly class PdoEntityArchiveRepository implements EntityArchiveReposito
         $tagsByEntity = $this->groupBy($tags, 'entity_id');
         $relationsByEntity = $this->groupBy($relations, 'source_entity_id');
 
-        $now = new DateTimeImmutable();
+        $now = $this->clock->now();
         $archivedAt = $now->format('Y-m-d H:i:s');
 
         foreach ($rows as $row) {

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -23,10 +23,12 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\DomainExceptionHandlerInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use Nene2\Http\ResponseEmitter;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use Nene2\Log\MonologLoggerFactory;
 use Nene2\Log\RequestIdHolder;
 use Nene2\Middleware\ThrottleMiddleware;
@@ -200,6 +202,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(RequestIdHolder::class, static fn (ContainerInterface $container): RequestIdHolder => new RequestIdHolder())
+            ->set(ClockInterface::class, static fn (ContainerInterface $container): ClockInterface => new UtcClock())
             ->set(
                 LocalBearerTokenVerifier::class,
                 static function (ContainerInterface $container): LocalBearerTokenVerifier {

--- a/src/Media/MediaServiceProvider.php
+++ b/src/Media/MediaServiceProvider.php
@@ -10,6 +10,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\Http\RuntimeServiceProvider;
@@ -75,7 +76,12 @@ final readonly class MediaServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Media storage service is invalid.');
                     }
 
-                    return new UploadMediaUseCase($repository, $storage);
+                    $clock = $c->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new UploadMediaUseCase($repository, $storage, $clock);
                 },
             )
             ->set(

--- a/src/Media/UploadMediaUseCase.php
+++ b/src/Media/UploadMediaUseCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Media;
 
+use Nene2\Http\ClockInterface;
+
 final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
 {
     /** @var list<string> */
@@ -46,6 +48,7 @@ final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
     public function __construct(
         private MediaRepositoryInterface $mediaRepository,
         private StorageInterface $storage,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -69,9 +72,10 @@ final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
             return $this->storeSvg($input);
         }
 
+        $now = $this->clock->now();
         $ext = $this->extensionForMimeType($input->mimeType);
         $storedName = bin2hex(random_bytes(16)) . '.' . $ext;
-        $key = date('Y') . '/' . date('m') . '/' . $storedName;
+        $key = $now->format('Y') . '/' . $now->format('m') . '/' . $storedName;
 
         // Read pixel dimensions from the header only (no full decode) before the
         // temp file is moved into storage. Returns null for non-image uploads.
@@ -80,7 +84,7 @@ final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
         $this->storage->writeFromUpload($key, $input->tmpPath);
 
         $url = $this->storage->publicUrl($key);
-        $now = date('Y-m-d H:i:s');
+        $createdAt = $now->format('Y-m-d H:i:s');
 
         $media = new Media(
             id: null,
@@ -89,7 +93,7 @@ final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
             mimeType: $input->mimeType,
             size: $input->size,
             url: $url,
-            createdAt: $now,
+            createdAt: $createdAt,
             storageKey: $key,
             width: $width,
             height: $height,
@@ -103,7 +107,7 @@ final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
             originalName: $input->originalName,
             mimeType: $input->mimeType,
             size: $input->size,
-            createdAt: $now,
+            createdAt: $createdAt,
             width: $width,
             height: $height,
         );
@@ -127,13 +131,14 @@ final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
         $clean = (new SvgSanitizer())->sanitize($raw);
         $size = strlen($clean);
 
+        $now = $this->clock->now();
         $storedName = bin2hex(random_bytes(16)) . '.svg';
-        $key = date('Y') . '/' . date('m') . '/' . $storedName;
+        $key = $now->format('Y') . '/' . $now->format('m') . '/' . $storedName;
 
         $this->storage->write($key, $clean);
 
         $url = $this->storage->publicUrl($key);
-        $now = date('Y-m-d H:i:s');
+        $createdAt = $now->format('Y-m-d H:i:s');
 
         $media = new Media(
             id: null,
@@ -142,7 +147,7 @@ final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
             mimeType: 'image/svg+xml',
             size: $size,
             url: $url,
-            createdAt: $now,
+            createdAt: $createdAt,
             storageKey: $key,
             width: null,
             height: null,
@@ -156,7 +161,7 @@ final readonly class UploadMediaUseCase implements UploadMediaUseCaseInterface
             originalName: $input->originalName,
             mimeType: 'image/svg+xml',
             size: $size,
-            createdAt: $now,
+            createdAt: $createdAt,
             width: null,
             height: null,
         );

--- a/src/Menu/MenuServiceProvider.php
+++ b/src/Menu/MenuServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use Psr\Container\ContainerInterface;
@@ -32,7 +33,12 @@ final readonly class MenuServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Org ID holder service is invalid.');
                     }
 
-                    return new PdoMenuRepository($query, $orgId);
+                    $clock = $container->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new PdoMenuRepository($query, $orgId, $clock);
                 },
             )
             ->set(

--- a/src/Menu/PdoMenuRepository.php
+++ b/src/Menu/PdoMenuRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Menu;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 
 final readonly class PdoMenuRepository implements MenuRepositoryInterface
@@ -15,6 +16,7 @@ final readonly class PdoMenuRepository implements MenuRepositoryInterface
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
         private readonly RequestScopedHolder $orgId,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -63,7 +65,7 @@ final readonly class PdoMenuRepository implements MenuRepositoryInterface
 
     public function save(Menu $menu): int
     {
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $this->query->execute(
             'INSERT INTO menus (organization_id, name, slug, location, created_at, updated_at)
@@ -76,7 +78,7 @@ final readonly class PdoMenuRepository implements MenuRepositoryInterface
 
     public function update(Menu $menu): void
     {
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $this->query->execute(
             'UPDATE menus

--- a/src/NavigationItem/NavigationItemServiceProvider.php
+++ b/src/NavigationItem/NavigationItemServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use Psr\Container\ContainerInterface;
@@ -33,7 +34,12 @@ final readonly class NavigationItemServiceProvider implements ServiceProviderInt
                         throw new LogicException('Org ID holder service is invalid.');
                     }
 
-                    return new PdoNavigationItemRepository($query, $orgId);
+                    $clock = $container->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new PdoNavigationItemRepository($query, $orgId, $clock);
                 },
             )
             ->set(

--- a/src/NavigationItem/PdoNavigationItemRepository.php
+++ b/src/NavigationItem/PdoNavigationItemRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\NavigationItem;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 
 final readonly class PdoNavigationItemRepository implements NavigationItemRepositoryInterface
@@ -15,6 +16,7 @@ final readonly class PdoNavigationItemRepository implements NavigationItemReposi
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
         private readonly RequestScopedHolder $orgId,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -46,7 +48,7 @@ final readonly class PdoNavigationItemRepository implements NavigationItemReposi
 
     public function save(NavigationItem $item): int
     {
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $this->query->execute(
             'INSERT INTO navigation_items (organization_id, menu_id, label, url, display_order, created_at, updated_at)
@@ -59,7 +61,7 @@ final readonly class PdoNavigationItemRepository implements NavigationItemReposi
 
     public function update(NavigationItem $item): void
     {
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $this->query->execute(
             'UPDATE navigation_items

--- a/src/Notification/Channel/WebhookChannel.php
+++ b/src/Notification/Channel/WebhookChannel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Notification\Channel;
 
+use Nene2\Http\ClockInterface;
 use NeNeRecords\Notification\NotificationChannelInterface;
 use NeNeRecords\Notification\NotificationMessage;
 use Throwable;
@@ -19,6 +20,11 @@ final readonly class WebhookChannel implements NotificationChannelInterface
 {
     private const TIMEOUT_SECONDS = 5;
 
+    public function __construct(
+        private ClockInterface $clock,
+    ) {
+    }
+
     public function send(NotificationMessage $message, array $config): void
     {
         try {
@@ -33,7 +39,7 @@ final readonly class WebhookChannel implements NotificationChannelInterface
                 'title' => $message->title,
                 'body' => $message->body,
                 'url' => $message->url,
-                'occurred_at' => date('c'),
+                'occurred_at' => $this->clock->now()->format('c'),
             ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
 
             $extraHeaders = $this->parseHeaders($config);

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\Mail\MailerInterface;
@@ -39,7 +40,12 @@ final readonly class NotificationServiceProvider implements ServiceProviderInter
                     throw new LogicException('Org ID holder service is invalid.');
                 }
 
-                return new PdoNotificationChannelRepository($query, $orgId);
+                $clock = $c->get(ClockInterface::class);
+                if (!$clock instanceof ClockInterface) {
+                    throw new LogicException('ClockInterface service is invalid.');
+                }
+
+                return new PdoNotificationChannelRepository($query, $orgId, $clock);
             },
         );
 
@@ -60,7 +66,17 @@ final readonly class NotificationServiceProvider implements ServiceProviderInter
         $builder->set(SlackChannel::class, static fn (): SlackChannel => new SlackChannel());
         $builder->set(DiscordChannel::class, static fn (): DiscordChannel => new DiscordChannel());
         $builder->set(ChatWorkChannel::class, static fn (): ChatWorkChannel => new ChatWorkChannel());
-        $builder->set(WebhookChannel::class, static fn (): WebhookChannel => new WebhookChannel());
+        $builder->set(
+            WebhookChannel::class,
+            static function (ContainerInterface $c): WebhookChannel {
+                $clock = $c->get(ClockInterface::class);
+                if (!$clock instanceof ClockInterface) {
+                    throw new LogicException('ClockInterface service is invalid.');
+                }
+
+                return new WebhookChannel($clock);
+            },
+        );
 
         // ── Notifier ──────────────────────────────────────────────────────────
 

--- a/src/Notification/PdoNotificationChannelRepository.php
+++ b/src/Notification/PdoNotificationChannelRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Notification;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 
 final readonly class PdoNotificationChannelRepository implements NotificationChannelRepositoryInterface
@@ -15,6 +16,7 @@ final readonly class PdoNotificationChannelRepository implements NotificationCha
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
         private RequestScopedHolder $orgId,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -51,7 +53,7 @@ final readonly class PdoNotificationChannelRepository implements NotificationCha
     public function create(string $channelType, string $label, bool $isEnabled, array $config): NotificationChannel
     {
         $configJson = json_encode($config, JSON_THROW_ON_ERROR);
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $this->query->execute(
             'INSERT INTO notification_channels (organization_id, channel_type, label, is_enabled, config_json, created_at, updated_at)
@@ -76,7 +78,7 @@ final readonly class PdoNotificationChannelRepository implements NotificationCha
     public function update(int $id, string $label, bool $isEnabled, array $config): void
     {
         $configJson = json_encode($config, JSON_THROW_ON_ERROR);
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $this->query->execute(
             'UPDATE notification_channels SET label = ?, is_enabled = ?, config_json = ?, updated_at = ? WHERE id = ? AND organization_id = ?',

--- a/src/OrgExport/ExportOrganizationHandler.php
+++ b/src/OrgExport/ExportOrganizationHandler.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace NeNeRecords\OrgExport;
 
-use DateTimeImmutable;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeNeRecords\Organization\OrganizationRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -24,6 +24,7 @@ final readonly class ExportOrganizationHandler implements RequestHandlerInterfac
         private OrganizationRepositoryInterface $orgs,
         private JsonResponseFactory $json,
         private ProblemDetailsResponseFactory $problemDetails,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -42,7 +43,7 @@ final readonly class ExportOrganizationHandler implements RequestHandlerInterfac
             );
         }
 
-        $now = (new DateTimeImmutable('now'))->format('c');
+        $now = $this->clock->now()->format('c');
 
         $payload = [
             'meta'             => [

--- a/src/OrgExport/OrgExportServiceProvider.php
+++ b/src/OrgExport/OrgExportServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeNeRecords\Organization\OrganizationRepositoryInterface;
 use Psr\Container\ContainerInterface;
@@ -37,7 +38,12 @@ final readonly class OrgExportServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('DatabaseQueryExecutorInterface is invalid.');
                     }
 
-                    return new PdoOrgImportRepository($query);
+                    $clock = $c->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface is invalid.');
+                    }
+
+                    return new PdoOrgImportRepository($query, $clock);
                 },
             )
             ->set(
@@ -47,16 +53,18 @@ final readonly class OrgExportServiceProvider implements ServiceProviderInterfac
                     $orgs    = $c->get(OrganizationRepositoryInterface::class);
                     $json    = $c->get(JsonResponseFactory::class);
                     $problem = $c->get(ProblemDetailsResponseFactory::class);
+                    $clock   = $c->get(ClockInterface::class);
                     if (
                         !$repo instanceof OrgExportRepositoryInterface
                         || !$orgs instanceof OrganizationRepositoryInterface
                         || !$json instanceof JsonResponseFactory
                         || !$problem instanceof ProblemDetailsResponseFactory
+                        || !$clock instanceof ClockInterface
                     ) {
                         throw new LogicException('ExportOrganizationHandler dependencies are invalid.');
                     }
 
-                    return new ExportOrganizationHandler($repo, $orgs, $json, $problem);
+                    return new ExportOrganizationHandler($repo, $orgs, $json, $problem, $clock);
                 },
             )
             ->set(

--- a/src/OrgExport/PdoOrgImportRepository.php
+++ b/src/OrgExport/PdoOrgImportRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\OrgExport;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 
 /**
  * Inserts an exported org payload into the target organization.
@@ -17,6 +18,7 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
 {
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -211,8 +213,8 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
                     (string) $row['label'],
                     (string) $row['url'],
                     (int) $row['display_order'],
-                    (string) ($row['created_at'] ?? date('Y-m-d H:i:s')),
-                    (string) ($row['updated_at'] ?? date('Y-m-d H:i:s')),
+                    (string) ($row['created_at'] ?? $this->clock->now()->format('Y-m-d H:i:s')),
+                    (string) ($row['updated_at'] ?? $this->clock->now()->format('Y-m-d H:i:s')),
                 ],
             );
             $navCount++;
@@ -232,8 +234,8 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
                     isset($row['default_value']) ? (string) $row['default_value'] : null,
                     (int) $row['is_public'],
                     (string) $row['label'],
-                    (string) ($row['created_at'] ?? date('Y-m-d H:i:s')),
-                    (string) ($row['updated_at'] ?? date('Y-m-d H:i:s')),
+                    (string) ($row['created_at'] ?? $this->clock->now()->format('Y-m-d H:i:s')),
+                    (string) ($row['updated_at'] ?? $this->clock->now()->format('Y-m-d H:i:s')),
                 ],
             );
             $settingDefCount++;
@@ -252,8 +254,8 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
                     isset($row['value']) ? (string) $row['value'] : null,
                     (int) $row['is_deleted'],
                     isset($row['deleted_at']) ? (string) $row['deleted_at'] : null,
-                    (string) ($row['created_at'] ?? date('Y-m-d H:i:s')),
-                    (string) ($row['updated_at'] ?? date('Y-m-d H:i:s')),
+                    (string) ($row['created_at'] ?? $this->clock->now()->format('Y-m-d H:i:s')),
+                    (string) ($row['updated_at'] ?? $this->clock->now()->format('Y-m-d H:i:s')),
                 ],
             );
             $settingValueCount++;
@@ -273,7 +275,7 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
                     (string) $row['mime_type'],
                     (int) $row['size'],
                     (string) $row['url'],
-                    (string) ($row['created_at'] ?? date('Y-m-d H:i:s')),
+                    (string) ($row['created_at'] ?? $this->clock->now()->format('Y-m-d H:i:s')),
                 ],
             );
             $mediaCount++;

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\ApplicationServiceProvider;
@@ -57,7 +58,12 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoOrganizationRepository($query);
+                    $clock = $c->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new PdoOrganizationRepository($query, $clock);
                 },
             )
             // ── Use cases ──────────────────────────────────────────────────────

--- a/src/Organization/PdoOrganizationRepository.php
+++ b/src/Organization/PdoOrganizationRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Organization;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 use PDOException;
 
 final readonly class PdoOrganizationRepository implements OrganizationRepositoryInterface
@@ -13,6 +14,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -76,7 +78,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
 
     public function save(Organization $organization): int
     {
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         try {
             $this->query->execute(
@@ -110,7 +112,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
             throw new OrganizationNotFoundException(0);
         }
 
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $this->query->execute(
             'UPDATE organizations SET name = ?, slug = ?, external_id = ?, custom_domain = ?, plan = ?, is_active = ?, updated_at = ? WHERE id = ?',

--- a/src/PreviewToken/GeneratePreviewTokenUseCase.php
+++ b/src/PreviewToken/GeneratePreviewTokenUseCase.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace NeNeRecords\PreviewToken;
 
-use DateTimeImmutable;
 use DateTimeInterface;
+use Nene2\Http\ClockInterface;
 use NeNeRecords\Entity\EntityNotFoundException;
 use NeNeRecords\Entity\EntityRepositoryInterface;
 
@@ -16,6 +16,7 @@ final readonly class GeneratePreviewTokenUseCase implements GeneratePreviewToken
     public function __construct(
         private EntityRepositoryInterface $entities,
         private EntityPreviewTokenRepositoryInterface $previewTokens,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -30,7 +31,7 @@ final readonly class GeneratePreviewTokenUseCase implements GeneratePreviewToken
         // Revoke any existing token for this entity before issuing a new one.
         $this->previewTokens->deleteByEntityId($input->entityId);
 
-        $now = new DateTimeImmutable();
+        $now = $this->clock->now();
         $expiresAt = $now->modify('+' . self::TOKEN_TTL_SECONDS . ' seconds');
         $token = bin2hex(random_bytes(32));
 

--- a/src/PreviewToken/GetPreviewRecordViewUseCase.php
+++ b/src/PreviewToken/GetPreviewRecordViewUseCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\PreviewToken;
 
-use DateTimeImmutable;
+use Nene2\Http\ClockInterface;
 use NeNeRecords\BoolField\BoolField;
 use NeNeRecords\BoolField\BoolFieldRepositoryInterface;
 use NeNeRecords\DateTimeField\DateTimeField;
@@ -53,6 +53,7 @@ final readonly class GetPreviewRecordViewUseCase implements GetPreviewRecordView
         private EntityRelationRepositoryInterface $entityRelations,
         private ListPublicSettingsUseCaseInterface $publicSettings,
         private PublicRecordHierarchyBuilder $hierarchyBuilder,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -60,7 +61,7 @@ final readonly class GetPreviewRecordViewUseCase implements GetPreviewRecordView
     {
         $tokenRecord = $this->previewTokens->findByToken($input->token);
 
-        if ($tokenRecord === null || $tokenRecord->expiresAt <= new DateTimeImmutable()) {
+        if ($tokenRecord === null || $tokenRecord->expiresAt <= $this->clock->now()) {
             throw new PreviewTokenNotFoundException($input->token);
         }
 

--- a/src/PreviewToken/PreviewTokenServiceProvider.php
+++ b/src/PreviewToken/PreviewTokenServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\BoolField\BoolFieldRepositoryInterface;
@@ -61,7 +62,12 @@ final readonly class PreviewTokenServiceProvider implements ServiceProviderInter
                         throw new LogicException('EntityPreviewToken repository service is invalid.');
                     }
 
-                    return new GeneratePreviewTokenUseCase($entities, $previewTokens);
+                    $clock = $container->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new GeneratePreviewTokenUseCase($entities, $previewTokens, $clock);
                 },
             )
             ->set(
@@ -145,6 +151,11 @@ final readonly class PreviewTokenServiceProvider implements ServiceProviderInter
                         throw new LogicException('ListPublicSettings use case service is invalid.');
                     }
 
+                    $clock = $container->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
                     return new GetPreviewRecordViewUseCase(
                         $previewTokens,
                         $entityTypes,
@@ -158,6 +169,7 @@ final readonly class PreviewTokenServiceProvider implements ServiceProviderInter
                         $entityRelations,
                         $publicSettings,
                         $hierarchyBuilder,
+                        $clock,
                     );
                 },
             )

--- a/src/RateLimit/PdoRateLimitStorage.php
+++ b/src/RateLimit/PdoRateLimitStorage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\RateLimit;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Middleware\RateLimitStorageInterface;
 
 /**
@@ -22,6 +23,7 @@ final readonly class PdoRateLimitStorage implements RateLimitStorageInterface
 {
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -31,7 +33,7 @@ final readonly class PdoRateLimitStorage implements RateLimitStorageInterface
     public function hit(string $key, int $windowSeconds): array
     {
         $keyHash = hash('sha256', $key);
-        $now = time();
+        $now = $this->clock->now()->getTimestamp();
         $newResetAt = $now + $windowSeconds;
 
         // Upsert: insert with count=1, or increment if the window is still open,

--- a/src/RateLimit/RateLimitServiceProvider.php
+++ b/src/RateLimit/RateLimitServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Middleware\RateLimitStorageInterface;
 use Nene2\Middleware\ThrottleMiddleware;
 use Psr\Container\ContainerInterface;
@@ -27,7 +28,12 @@ final readonly class RateLimitServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoRateLimitStorage($query);
+                    $clock = $container->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new PdoRateLimitStorage($query, $clock);
                 },
             )
             ->set(

--- a/src/Setting/PdoSettingRepository.php
+++ b/src/Setting/PdoSettingRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Setting;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 
 final readonly class PdoSettingRepository implements SettingRepositoryInterface
@@ -15,6 +16,7 @@ final readonly class PdoSettingRepository implements SettingRepositoryInterface
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
         private readonly RequestScopedHolder $orgId,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -104,7 +106,7 @@ final readonly class PdoSettingRepository implements SettingRepositoryInterface
         $action = $existing === null || $existing->isDeleted
             ? SettingRevisionAction::Created
             : SettingRevisionAction::Updated;
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $this->query->execute(
             'INSERT INTO setting_revisions (setting_key, value, previous_value, action, actor_user_id, created_at)

--- a/src/Setting/SettingServiceProvider.php
+++ b/src/Setting/SettingServiceProvider.php
@@ -10,6 +10,7 @@ use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\Media\MediaRepositoryInterface;
@@ -36,7 +37,12 @@ final readonly class SettingServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Org ID holder service is invalid.');
                     }
 
-                    return new PdoSettingRepository($query, $orgId);
+                    $clock = $container->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new PdoSettingRepository($query, $orgId, $clock);
                 },
             )
             ->set(
@@ -95,7 +101,12 @@ final readonly class SettingServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Front page setting service is invalid.');
                     }
 
-                    return new UpdateSettingUseCase($transactions, $orgId, $frontPage);
+                    $clock = $container->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new UpdateSettingUseCase($transactions, $orgId, $frontPage, $clock);
                 },
             )
             ->set(

--- a/src/Setting/UpdateSettingUseCase.php
+++ b/src/Setting/UpdateSettingUseCase.php
@@ -6,6 +6,7 @@ namespace NeNeRecords\Setting;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\BlocksField\BlocksDocumentValidator;
 use NeNeRecords\PublicRecord\FrontPageSetting;
@@ -25,6 +26,7 @@ final readonly class UpdateSettingUseCase implements UpdateSettingUseCaseInterfa
         private DatabaseTransactionManagerInterface $transactions,
         private RequestScopedHolder $orgId,
         private FrontPageSetting $frontPage,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -44,9 +46,10 @@ final readonly class UpdateSettingUseCase implements UpdateSettingUseCaseInterfa
         }
 
         $orgId = $this->orgId;
+        $clock = $this->clock;
         $stored = $this->transactions->transactional(
-            function (DatabaseQueryExecutorInterface $query) use ($input, $orgId): SettingValue {
-                $repository = new PdoSettingRepository($query, $orgId);
+            function (DatabaseQueryExecutorInterface $query) use ($input, $orgId, $clock): SettingValue {
+                $repository = new PdoSettingRepository($query, $orgId, $clock);
 
                 return $repository->applyValue($input->settingKey, $input->value, $input->actorUserId);
             },

--- a/src/Signup/ConfirmEmailUseCase.php
+++ b/src/Signup/ConfirmEmailUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Signup;
 
+use Nene2\Http\ClockInterface;
 use Nene2\Http\SecureTokenHelper;
 use NeNeRecords\Auth\UserRepositoryInterface;
 use NeNeRecords\Organization\OrganizationRepositoryInterface;
@@ -22,6 +23,7 @@ final readonly class ConfirmEmailUseCase
     public function __construct(
         private UserRepositoryInterface $users,
         private OrganizationRepositoryInterface $organizations,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -33,7 +35,7 @@ final readonly class ConfirmEmailUseCase
             throw EmailVerificationTokenException::invalid();
         }
 
-        if ($user->emailVerificationExpiresAt === null || $user->emailVerificationExpiresAt < time()) {
+        if ($user->emailVerificationExpiresAt === null || $user->emailVerificationExpiresAt < $this->clock->now()->getTimestamp()) {
             $this->users->clearEmailVerification($user->id);
 
             throw EmailVerificationTokenException::expired();

--- a/src/Signup/PublicSignupHandler.php
+++ b/src/Signup/PublicSignupHandler.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Signup;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Middleware\RateLimitStorageInterface;
@@ -34,6 +35,7 @@ final readonly class PublicSignupHandler
         private JsonResponseFactory $response,
         private ProblemDetailsResponseFactory $problemDetails,
         private RateLimitStorageInterface $rateLimitStorage,
+        private ClockInterface $clock,
         /** Max tenant signups accepted per client IP within the window. */
         private int $maxSignupsPerWindow = 5,
         /** Rate-limit window in seconds (default: 1 hour). */
@@ -106,7 +108,7 @@ final readonly class PublicSignupHandler
 
         $cookie = SessionCookie::build(
             $output->token,
-            $output->expiresAt - time(),
+            $output->expiresAt - $this->clock->now()->getTimestamp(),
             SessionCookie::isSecureRequest($request),
         );
 
@@ -133,7 +135,7 @@ final readonly class PublicSignupHandler
             return null;
         }
 
-        $retryAfter = max(0, $result['reset_at'] - time());
+        $retryAfter = max(0, $result['reset_at'] - $this->clock->now()->getTimestamp());
 
         return $this->problemDetails->create(
             $request,

--- a/src/Signup/PublicSignupUseCase.php
+++ b/src/Signup/PublicSignupUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Signup;
 
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 use Nene2\Http\SecureTokenHelper;
 use NeNeRecords\Auth\LoginInput;
@@ -44,6 +45,7 @@ final readonly class PublicSignupUseCase implements PublicSignupUseCaseInterface
         private RequestScopedHolder $orgHolder,
         private UserRepositoryInterface $users,
         private MailerInterface $mailer,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -96,7 +98,7 @@ final readonly class PublicSignupUseCase implements PublicSignupUseCaseInterface
                 $user->id,
                 $email,
                 $tokenHash,
-                time() + self::VERIFICATION_TTL_SECONDS,
+                $this->clock->now()->getTimestamp() + self::VERIFICATION_TTL_SECONDS,
             );
 
             $verifyUrl = rtrim($verifyUrlBase, '/') . '/verify-email?token=' . $rawToken;

--- a/src/Signup/SignupServiceProvider.php
+++ b/src/Signup/SignupServiceProvider.php
@@ -8,6 +8,7 @@ use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use Nene2\Middleware\RateLimitStorageInterface;
@@ -34,6 +35,7 @@ final readonly class SignupServiceProvider implements ServiceProviderInterface
                     $orgHolder  = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
                     $users      = $c->get(UserRepositoryInterface::class);
                     $mailer     = $c->get(MailerInterface::class);
+                    $clock      = $c->get(ClockInterface::class);
 
                     if (!$createOrg instanceof CreateOrganizationUseCaseInterface) {
                         throw new LogicException('CreateOrganizationUseCaseInterface is invalid.');
@@ -59,8 +61,12 @@ final readonly class SignupServiceProvider implements ServiceProviderInterface
                         throw new LogicException('MailerInterface is invalid.');
                     }
 
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface is invalid.');
+                    }
+
                     /** @var RequestScopedHolder<int> $orgHolder */
-                    return new PublicSignupUseCase($createOrg, $createUser, $login, $orgHolder, $users, $mailer);
+                    return new PublicSignupUseCase($createOrg, $createUser, $login, $orgHolder, $users, $mailer, $clock);
                 },
             )
             ->set(
@@ -70,6 +76,7 @@ final readonly class SignupServiceProvider implements ServiceProviderInterface
                     $json        = $c->get(JsonResponseFactory::class);
                     $problems    = $c->get(ProblemDetailsResponseFactory::class);
                     $rateLimiter = $c->get(RateLimitStorageInterface::class);
+                    $clock       = $c->get(ClockInterface::class);
 
                     if (!$useCase instanceof PublicSignupUseCase) {
                         throw new LogicException('PublicSignupUseCase is invalid.');
@@ -87,7 +94,11 @@ final readonly class SignupServiceProvider implements ServiceProviderInterface
                         throw new LogicException('RateLimitStorageInterface is invalid.');
                     }
 
-                    return new PublicSignupHandler($useCase, $json, $problems, $rateLimiter);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface is invalid.');
+                    }
+
+                    return new PublicSignupHandler($useCase, $json, $problems, $rateLimiter, $clock);
                 },
             )
             ->set(
@@ -95,14 +106,18 @@ final readonly class SignupServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $c): ConfirmEmailUseCase {
                     $users = $c->get(UserRepositoryInterface::class);
                     $orgs  = $c->get(OrganizationRepositoryInterface::class);
+                    $clock = $c->get(ClockInterface::class);
                     if (!$users instanceof UserRepositoryInterface) {
                         throw new LogicException('UserRepositoryInterface is invalid.');
                     }
                     if (!$orgs instanceof OrganizationRepositoryInterface) {
                         throw new LogicException('OrganizationRepositoryInterface is invalid.');
                     }
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface is invalid.');
+                    }
 
-                    return new ConfirmEmailUseCase($users, $orgs);
+                    return new ConfirmEmailUseCase($users, $orgs, $clock);
                 },
             )
             ->set(

--- a/src/Theme/PdoThemeRepository.php
+++ b/src/Theme/PdoThemeRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Theme;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 
 final readonly class PdoThemeRepository implements ThemeRepositoryInterface
@@ -15,6 +16,7 @@ final readonly class PdoThemeRepository implements ThemeRepositoryInterface
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
         private RequestScopedHolder $orgId,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -56,7 +58,7 @@ final readonly class PdoThemeRepository implements ThemeRepositoryInterface
 
     public function save(Theme $theme): int
     {
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $this->query->execute(
             'INSERT INTO themes (organization_id, theme_key, name, version, source, manifest, created_at, updated_at)
@@ -78,7 +80,7 @@ final readonly class PdoThemeRepository implements ThemeRepositoryInterface
 
     public function update(Theme $theme): void
     {
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $this->query->execute(
             'UPDATE themes

--- a/src/Theme/ThemeServiceProvider.php
+++ b/src/Theme/ThemeServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\Media\MediaRepositoryInterface;
@@ -45,7 +46,12 @@ final readonly class ThemeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Org ID holder service is invalid.');
                     }
 
-                    return new PdoThemeRepository($query, $orgId);
+                    $clock = $container->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new PdoThemeRepository($query, $orgId, $clock);
                 },
             )
             ->set(

--- a/src/User/ChangeEmailUseCase.php
+++ b/src/User/ChangeEmailUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\User;
 
+use Nene2\Http\ClockInterface;
 use Nene2\Http\SecureTokenHelper;
 use NeNeRecords\Auth\UserRepositoryInterface;
 use NeNeRecords\Mail\MailerInterface;
@@ -21,6 +22,7 @@ final readonly class ChangeEmailUseCase implements ChangeEmailUseCaseInterface
     public function __construct(
         private UserRepositoryInterface $users,
         private MailerInterface $mailer,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -43,7 +45,7 @@ final readonly class ChangeEmailUseCase implements ChangeEmailUseCaseInterface
         }
 
         [$rawToken, $tokenHash] = SecureTokenHelper::generateWithHash();
-        $expiresAt = time() + self::VERIFICATION_TTL_SECONDS;
+        $expiresAt = $this->clock->now()->getTimestamp() + self::VERIFICATION_TTL_SECONDS;
         $this->users->storeEmailVerification($input->userId, $input->email, $tokenHash, $expiresAt);
 
         $verifyUrl = rtrim($input->appBaseUrl, '/') . '/admin/verify-email?token=' . $rawToken;

--- a/src/User/PdoUserProfileRepository.php
+++ b/src/User/PdoUserProfileRepository.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace NeNeRecords\User;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 
 final readonly class PdoUserProfileRepository implements UserProfileRepositoryInterface
 {
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -39,7 +41,7 @@ final readonly class PdoUserProfileRepository implements UserProfileRepositoryIn
         $existing = $this->findByUserId($userId);
 
         if ($existing === null) {
-            $now = date('Y-m-d H:i:s');
+            $now = $this->clock->now()->format('Y-m-d H:i:s');
             $this->query->execute(
                 'INSERT INTO user_profiles (user_id, display_name, full_name, job_title, created_at, updated_at)
                  VALUES (?, ?, ?, ?, ?, ?)',

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeNeRecords\Auth\UserRepositoryInterface;
 use NeNeRecords\Mail\MailerInterface;
@@ -36,12 +37,17 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
                 UserProfileRepositoryInterface::class,
                 static function (ContainerInterface $c): UserProfileRepositoryInterface {
                     $query = $c->get(DatabaseQueryExecutorInterface::class);
+                    $clock = $c->get(ClockInterface::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('DatabaseQueryExecutorInterface service is invalid.');
                     }
 
-                    return new PdoUserProfileRepository($query);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new PdoUserProfileRepository($query, $clock);
                 },
             )
             ->set(
@@ -114,6 +120,7 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $c): ChangeEmailUseCaseInterface {
                     $users = $c->get(UserRepositoryInterface::class);
                     $mailer = $c->get(MailerInterface::class);
+                    $clock = $c->get(ClockInterface::class);
 
                     if (!$users instanceof UserRepositoryInterface) {
                         throw new LogicException('UserRepositoryInterface service is invalid.');
@@ -123,19 +130,28 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
                         throw new LogicException('MailerInterface service is invalid.');
                     }
 
-                    return new ChangeEmailUseCase($users, $mailer);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new ChangeEmailUseCase($users, $mailer, $clock);
                 },
             )
             ->set(
                 VerifyEmailChangeUseCaseInterface::class,
                 static function (ContainerInterface $c): VerifyEmailChangeUseCaseInterface {
                     $users = $c->get(UserRepositoryInterface::class);
+                    $clock = $c->get(ClockInterface::class);
 
                     if (!$users instanceof UserRepositoryInterface) {
                         throw new LogicException('UserRepositoryInterface service is invalid.');
                     }
 
-                    return new VerifyEmailChangeUseCase($users);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new VerifyEmailChangeUseCase($users, $clock);
                 },
             )
             ->set(

--- a/src/User/VerifyEmailChangeUseCase.php
+++ b/src/User/VerifyEmailChangeUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\User;
 
+use Nene2\Http\ClockInterface;
 use Nene2\Http\SecureTokenHelper;
 use NeNeRecords\Auth\UserRepositoryInterface;
 
@@ -15,6 +16,7 @@ final readonly class VerifyEmailChangeUseCase implements VerifyEmailChangeUseCas
 {
     public function __construct(
         private UserRepositoryInterface $users,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -27,7 +29,7 @@ final readonly class VerifyEmailChangeUseCase implements VerifyEmailChangeUseCas
             throw EmailVerificationTokenException::invalid();
         }
 
-        if ($user->emailVerificationExpiresAt === null || $user->emailVerificationExpiresAt < time()) {
+        if ($user->emailVerificationExpiresAt === null || $user->emailVerificationExpiresAt < $this->clock->now()->getTimestamp()) {
             // Drop the stale token so it cannot be retried.
             $this->users->clearEmailVerification($user->id);
 

--- a/src/UserInvite/AcceptInviteUseCase.php
+++ b/src/UserInvite/AcceptInviteUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\UserInvite;
 
+use Nene2\Http\ClockInterface;
 use Nene2\Http\SecureTokenHelper;
 use NeNeRecords\Auth\UserRepositoryInterface;
 
@@ -11,6 +12,7 @@ final readonly class AcceptInviteUseCase implements AcceptInviteUseCaseInterface
 {
     public function __construct(
         private UserRepositoryInterface $users,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -19,7 +21,7 @@ final readonly class AcceptInviteUseCase implements AcceptInviteUseCaseInterface
         $tokenHash = SecureTokenHelper::hash($input->token);
         $user = $this->users->findByInviteToken($tokenHash);
 
-        if ($user === null || $user->inviteExpiresAt === null || $user->inviteExpiresAt < time()) {
+        if ($user === null || $user->inviteExpiresAt === null || $user->inviteExpiresAt < $this->clock->now()->getTimestamp()) {
             throw new InvalidInviteTokenException();
         }
 

--- a/src/UserInvite/ConfirmPasswordResetUseCase.php
+++ b/src/UserInvite/ConfirmPasswordResetUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\UserInvite;
 
+use Nene2\Http\ClockInterface;
 use Nene2\Http\SecureTokenHelper;
 use NeNeRecords\Auth\UserRepositoryInterface;
 
@@ -11,6 +12,7 @@ final readonly class ConfirmPasswordResetUseCase implements ConfirmPasswordReset
 {
     public function __construct(
         private UserRepositoryInterface $users,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -19,7 +21,7 @@ final readonly class ConfirmPasswordResetUseCase implements ConfirmPasswordReset
         $tokenHash = SecureTokenHelper::hash($input->token);
         $user = $this->users->findByPasswordResetToken($tokenHash);
 
-        if ($user === null || $user->passwordResetExpiresAt === null || $user->passwordResetExpiresAt < time()) {
+        if ($user === null || $user->passwordResetExpiresAt === null || $user->passwordResetExpiresAt < $this->clock->now()->getTimestamp()) {
             throw new InvalidPasswordResetTokenException();
         }
 

--- a/src/UserInvite/InviteUserUseCase.php
+++ b/src/UserInvite/InviteUserUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\UserInvite;
 
+use Nene2\Http\ClockInterface;
 use Nene2\Http\SecureTokenHelper;
 use NeNeRecords\Auth\Role;
 use NeNeRecords\Auth\UserRepositoryInterface;
@@ -19,6 +20,7 @@ final readonly class InviteUserUseCase implements InviteUserUseCaseInterface
     public function __construct(
         private UserRepositoryInterface $users,
         private MailerInterface $mailer,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -45,7 +47,7 @@ final readonly class InviteUserUseCase implements InviteUserUseCaseInterface
         );
 
         [$rawToken, $tokenHash] = SecureTokenHelper::generateWithHash();
-        $expiresAt = time() + self::INVITE_TTL_SECONDS;
+        $expiresAt = $this->clock->now()->getTimestamp() + self::INVITE_TTL_SECONDS;
         $this->users->storeInviteToken($user->id, $tokenHash, $expiresAt);
 
         $acceptUrl = rtrim($input->appBaseUrl, '/') . '/admin/accept-invite?token=' . $rawToken;

--- a/src/UserInvite/RequestPasswordResetUseCase.php
+++ b/src/UserInvite/RequestPasswordResetUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\UserInvite;
 
+use Nene2\Http\ClockInterface;
 use Nene2\Http\SecureTokenHelper;
 use NeNeRecords\Auth\UserRepositoryInterface;
 use NeNeRecords\Mail\MailerInterface;
@@ -16,6 +17,7 @@ final readonly class RequestPasswordResetUseCase implements RequestPasswordReset
     public function __construct(
         private UserRepositoryInterface $users,
         private MailerInterface $mailer,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -29,7 +31,7 @@ final readonly class RequestPasswordResetUseCase implements RequestPasswordReset
         }
 
         [$rawToken, $tokenHash] = SecureTokenHelper::generateWithHash();
-        $expiresAt = time() + self::RESET_TTL_SECONDS;
+        $expiresAt = $this->clock->now()->getTimestamp() + self::RESET_TTL_SECONDS;
         $this->users->storePasswordResetToken($user->id, $tokenHash, $expiresAt);
 
         $resetUrl = rtrim($input->appBaseUrl, '/') . '/admin/reset-password?token=' . $rawToken;

--- a/src/UserInvite/UserInviteServiceProvider.php
+++ b/src/UserInvite/UserInviteServiceProvider.php
@@ -8,6 +8,7 @@ use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeNeRecords\Auth\UserRepositoryInterface;
 use NeNeRecords\Mail\MailerInterface;
@@ -37,6 +38,7 @@ final readonly class UserInviteServiceProvider implements ServiceProviderInterfa
                 static function (ContainerInterface $c): InviteUserUseCaseInterface {
                     $users = $c->get(UserRepositoryInterface::class);
                     $mailer = $c->get(MailerInterface::class);
+                    $clock = $c->get(ClockInterface::class);
 
                     if (!$users instanceof UserRepositoryInterface) {
                         throw new LogicException('UserRepositoryInterface service is invalid.');
@@ -46,19 +48,28 @@ final readonly class UserInviteServiceProvider implements ServiceProviderInterfa
                         throw new LogicException('MailerInterface service is invalid.');
                     }
 
-                    return new InviteUserUseCase($users, $mailer);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new InviteUserUseCase($users, $mailer, $clock);
                 },
             )
             ->set(
                 AcceptInviteUseCaseInterface::class,
                 static function (ContainerInterface $c): AcceptInviteUseCaseInterface {
                     $users = $c->get(UserRepositoryInterface::class);
+                    $clock = $c->get(ClockInterface::class);
 
                     if (!$users instanceof UserRepositoryInterface) {
                         throw new LogicException('UserRepositoryInterface service is invalid.');
                     }
 
-                    return new AcceptInviteUseCase($users);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new AcceptInviteUseCase($users, $clock);
                 },
             )
             ->set(
@@ -66,6 +77,7 @@ final readonly class UserInviteServiceProvider implements ServiceProviderInterfa
                 static function (ContainerInterface $c): RequestPasswordResetUseCaseInterface {
                     $users = $c->get(UserRepositoryInterface::class);
                     $mailer = $c->get(MailerInterface::class);
+                    $clock = $c->get(ClockInterface::class);
 
                     if (!$users instanceof UserRepositoryInterface) {
                         throw new LogicException('UserRepositoryInterface service is invalid.');
@@ -75,19 +87,28 @@ final readonly class UserInviteServiceProvider implements ServiceProviderInterfa
                         throw new LogicException('MailerInterface service is invalid.');
                     }
 
-                    return new RequestPasswordResetUseCase($users, $mailer);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new RequestPasswordResetUseCase($users, $mailer, $clock);
                 },
             )
             ->set(
                 ConfirmPasswordResetUseCaseInterface::class,
                 static function (ContainerInterface $c): ConfirmPasswordResetUseCaseInterface {
                     $users = $c->get(UserRepositoryInterface::class);
+                    $clock = $c->get(ClockInterface::class);
 
                     if (!$users instanceof UserRepositoryInterface) {
                         throw new LogicException('UserRepositoryInterface service is invalid.');
                     }
 
-                    return new ConfirmPasswordResetUseCase($users);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new ConfirmPasswordResetUseCase($users, $clock);
                 },
             )
             ->set(

--- a/src/Webhook/CreateWebhookUseCase.php
+++ b/src/Webhook/CreateWebhookUseCase.php
@@ -4,16 +4,19 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Webhook;
 
+use Nene2\Http\ClockInterface;
+
 final readonly class CreateWebhookUseCase implements CreateWebhookUseCaseInterface
 {
     public function __construct(
         private WebhookRepositoryInterface $webhooks,
+        private ClockInterface $clock,
     ) {
     }
 
     public function execute(CreateWebhookInput $input): CreateWebhookOutput
     {
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $webhook = new Webhook(
             id: null,

--- a/src/Webhook/PdoWebhookDeliveryRepository.php
+++ b/src/Webhook/PdoWebhookDeliveryRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Webhook;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 
 /**
  * Database-backed webhook delivery queue (#285).
@@ -23,6 +24,7 @@ final readonly class PdoWebhookDeliveryRepository implements WebhookDeliveryRepo
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -37,7 +39,7 @@ final readonly class PdoWebhookDeliveryRepository implements WebhookDeliveryRepo
         int $maxAttempts,
         int $nextAttemptAt,
     ): int {
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         return $this->query->insert(
             'INSERT INTO webhook_deliveries

--- a/src/Webhook/PdoWebhookRepository.php
+++ b/src/Webhook/PdoWebhookRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Webhook;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 
 final readonly class PdoWebhookRepository implements WebhookRepositoryInterface
@@ -15,6 +16,7 @@ final readonly class PdoWebhookRepository implements WebhookRepositoryInterface
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
         private readonly RequestScopedHolder $orgId,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -70,7 +72,7 @@ final readonly class PdoWebhookRepository implements WebhookRepositoryInterface
 
     public function save(Webhook $webhook): int
     {
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $this->query->execute(
             'INSERT INTO webhooks (organization_id, url, events, entity_type_id, secret, is_active, created_at, updated_at)
@@ -92,7 +94,7 @@ final readonly class PdoWebhookRepository implements WebhookRepositoryInterface
 
     public function update(Webhook $webhook): void
     {
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $this->query->execute(
             'UPDATE webhooks

--- a/src/Webhook/QueueingWebhookDispatcher.php
+++ b/src/Webhook/QueueingWebhookDispatcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Webhook;
 
+use Nene2\Http\ClockInterface;
 use Throwable;
 
 /**
@@ -22,6 +23,7 @@ final readonly class QueueingWebhookDispatcher implements WebhookDispatcherInter
     public function __construct(
         private WebhookRepositoryInterface $webhooks,
         private WebhookDeliveryRepositoryInterface $deliveries,
+        private ClockInterface $clock,
         private int $maxAttempts = self::DEFAULT_MAX_ATTEMPTS,
     ) {
     }
@@ -35,14 +37,16 @@ final readonly class QueueingWebhookDispatcher implements WebhookDispatcherInter
                 return;
             }
 
+            $now = $this->clock->now();
+
             $payload = json_encode([
                 'event' => $event,
                 'entity_type_id' => $entityTypeId,
                 'entity_id' => $entityId,
-                'occurred_at' => date('c'),
+                'occurred_at' => $now->format('c'),
             ], JSON_THROW_ON_ERROR);
 
-            $now = time();
+            $nowTs = $now->getTimestamp();
 
             foreach ($matching as $webhook) {
                 if ($webhook->id === null) {
@@ -58,7 +62,7 @@ final readonly class QueueingWebhookDispatcher implements WebhookDispatcherInter
                     $webhook->secret,
                     $payload,
                     $this->maxAttempts,
-                    $now,
+                    $nowTs,
                 );
             }
         } catch (Throwable) {

--- a/src/Webhook/UpdateWebhookUseCase.php
+++ b/src/Webhook/UpdateWebhookUseCase.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Webhook;
 
+use Nene2\Http\ClockInterface;
+
 final readonly class UpdateWebhookUseCase implements UpdateWebhookUseCaseInterface
 {
     public function __construct(
         private WebhookRepositoryInterface $webhooks,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -19,7 +22,7 @@ final readonly class UpdateWebhookUseCase implements UpdateWebhookUseCaseInterfa
             throw new WebhookNotFoundException($input->id);
         }
 
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $updated = new Webhook(
             id: $input->id,

--- a/src/Webhook/WebhookDeliveryProcessor.php
+++ b/src/Webhook/WebhookDeliveryProcessor.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Webhook;
 
+use Nene2\Http\ClockInterface;
+
 /**
  * Worker that drains the webhook delivery queue (#285).
  *
@@ -19,6 +21,7 @@ final readonly class WebhookDeliveryProcessor
     public function __construct(
         private WebhookDeliveryRepositoryInterface $deliveries,
         private WebhookSenderInterface $sender,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -29,7 +32,7 @@ final readonly class WebhookDeliveryProcessor
      */
     public function process(int $limit = 50, ?int $now = null): array
     {
-        $now ??= time();
+        $now ??= $this->clock->now()->getTimestamp();
         $due = $this->deliveries->claimDue($now, $limit);
 
         $delivered = 0;

--- a/src/Webhook/WebhookServiceProvider.php
+++ b/src/Webhook/WebhookServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use Psr\Container\ContainerInterface;
@@ -32,7 +33,12 @@ final readonly class WebhookServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Org ID holder service is invalid.');
                     }
 
-                    return new PdoWebhookRepository($query, $orgId);
+                    $clock = $container->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new PdoWebhookRepository($query, $orgId, $clock);
                 },
             )
             ->set(
@@ -44,7 +50,12 @@ final readonly class WebhookServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoWebhookDeliveryRepository($query);
+                    $clock = $container->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new PdoWebhookDeliveryRepository($query, $clock);
                 },
             )
             ->set(
@@ -65,7 +76,12 @@ final readonly class WebhookServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Webhook delivery repository service is invalid.');
                     }
 
-                    return new QueueingWebhookDispatcher($repo, $deliveries);
+                    $clock = $container->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new QueueingWebhookDispatcher($repo, $deliveries, $clock);
                 },
             )
             ->set(
@@ -82,7 +98,12 @@ final readonly class WebhookServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Webhook sender service is invalid.');
                     }
 
-                    return new WebhookDeliveryProcessor($deliveries, $sender);
+                    $clock = $container->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new WebhookDeliveryProcessor($deliveries, $sender, $clock);
                 },
             )
             ->set(
@@ -118,7 +139,12 @@ final readonly class WebhookServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Webhook repository service is invalid.');
                     }
 
-                    return new CreateWebhookUseCase($repo);
+                    $clock = $container->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new CreateWebhookUseCase($repo, $clock);
                 },
             )
             ->set(
@@ -130,7 +156,12 @@ final readonly class WebhookServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Webhook repository service is invalid.');
                     }
 
-                    return new UpdateWebhookUseCase($repo);
+                    $clock = $container->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new UpdateWebhookUseCase($repo, $clock);
                 },
             )
             ->set(

--- a/src/Widget/PdoWidgetRepository.php
+++ b/src/Widget/PdoWidgetRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Widget;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 
 final readonly class PdoWidgetRepository implements WidgetRepositoryInterface
@@ -17,6 +18,7 @@ final readonly class PdoWidgetRepository implements WidgetRepositoryInterface
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
         private RequestScopedHolder $orgId,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -43,7 +45,7 @@ final readonly class PdoWidgetRepository implements WidgetRepositoryInterface
 
     public function save(Widget $widget): int
     {
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $this->query->execute(
             'INSERT INTO widgets (organization_id, widget_type, region, display_order, title, settings, created_at, updated_at)
@@ -65,7 +67,7 @@ final readonly class PdoWidgetRepository implements WidgetRepositoryInterface
 
     public function update(Widget $widget): void
     {
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $this->query->execute(
             'UPDATE widgets SET widget_type = ?, region = ?, display_order = ?, title = ?, settings = ?, updated_at = ?

--- a/src/Widget/WidgetServiceProvider.php
+++ b/src/Widget/WidgetServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use Psr\Container\ContainerInterface;
@@ -32,7 +33,12 @@ final readonly class WidgetServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Org ID holder service is invalid.');
                     }
 
-                    return new PdoWidgetRepository($query, $orgId);
+                    $clock = $container->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new PdoWidgetRepository($query, $orgId, $clock);
                 },
             )
             ->set(

--- a/tests/Analytics/AccessLogMiddlewareTest.php
+++ b/tests/Analytics/AccessLogMiddlewareTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Tests\Analytics;
 
 use DateTimeImmutable;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Analytics\AccessLogMiddleware;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
@@ -28,7 +29,7 @@ final class AccessLogMiddlewareTest extends TestCase
 
     public function testPersistsAccessLogForApiRequest(): void
     {
-        $middleware = new AccessLogMiddleware($this->repository, new NullLogger(), excludedPaths: ['/health']);
+        $middleware = new AccessLogMiddleware($this->repository, new NullLogger(), new UtcClock(), excludedPaths: ['/health']);
 
         $response = $middleware->process(
             $this->factory->createServerRequest('GET', 'https://example.test/api/v1/tags')
@@ -58,7 +59,7 @@ final class AccessLogMiddlewareTest extends TestCase
 
     public function testSkipsExcludedPaths(): void
     {
-        $middleware = new AccessLogMiddleware($this->repository, new NullLogger());
+        $middleware = new AccessLogMiddleware($this->repository, new NullLogger(), new UtcClock());
 
         $middleware->process(
             $this->factory->createServerRequest('GET', 'https://example.test/health'),
@@ -107,6 +108,7 @@ final class AccessLogMiddlewareTest extends TestCase
                 }
             },
             new NullLogger(),
+            new UtcClock(),
             excludedPaths: ['/health'],
         );
 

--- a/tests/Analytics/AnalyticsHttpTest.php
+++ b/tests/Analytics/AnalyticsHttpTest.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Analytics\AccessLogEntry;
 use NeNeRecords\Analytics\AnalyticsRouteRegistrar;
 use NeNeRecords\Analytics\GetAccessStatsByDateHandler;
@@ -68,6 +69,7 @@ final class AnalyticsHttpTest extends TestCase
                     $this->repository,
                     $entities,
                     new InMemoryTextFieldRepository(),
+                    new UtcClock(),
                 ),
                 $jsonResponse,
             ),

--- a/tests/Analytics/GetPopularEntitiesUseCaseTest.php
+++ b/tests/Analytics/GetPopularEntitiesUseCaseTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Tests\Analytics;
 
 use DateTimeImmutable;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Analytics\AccessLogEntry;
 use NeNeRecords\Analytics\GetPopularEntitiesInput;
 use NeNeRecords\Analytics\GetPopularEntitiesUseCase;
@@ -45,7 +46,7 @@ final class GetPopularEntitiesUseCaseTest extends TestCase
             new TextField(entityId: 2, fieldKey: 'title', value: 'Beta', id: 2),
         ]);
 
-        $useCase = new GetPopularEntitiesUseCase($accessLogs, $entities, $textFields);
+        $useCase = new GetPopularEntitiesUseCase($accessLogs, $entities, $textFields, new UtcClock());
         $output = $useCase->execute(new GetPopularEntitiesInput(days: 30, limit: 5));
 
         self::assertCount(2, $output->items);
@@ -68,7 +69,7 @@ final class GetPopularEntitiesUseCaseTest extends TestCase
             new Entity(id: 2, entityTypeId: 10, slug: 'live', status: EntityStatus::Published),
         ]);
 
-        $useCase = new GetPopularEntitiesUseCase($accessLogs, $entities, new InMemoryTextFieldRepository());
+        $useCase = new GetPopularEntitiesUseCase($accessLogs, $entities, new InMemoryTextFieldRepository(), new UtcClock());
         $output = $useCase->execute(new GetPopularEntitiesInput(days: 30, limit: 5));
 
         self::assertCount(1, $output->items);
@@ -89,7 +90,7 @@ final class GetPopularEntitiesUseCaseTest extends TestCase
             new Entity(id: 3, entityTypeId: 10, status: EntityStatus::Published),
         ]);
 
-        $useCase = new GetPopularEntitiesUseCase($accessLogs, $entities, new InMemoryTextFieldRepository());
+        $useCase = new GetPopularEntitiesUseCase($accessLogs, $entities, new InMemoryTextFieldRepository(), new UtcClock());
         $output = $useCase->execute(new GetPopularEntitiesInput(days: 30, limit: 2));
 
         self::assertCount(2, $output->items);

--- a/tests/Auth/LoginUseCaseTest.php
+++ b/tests/Auth/LoginUseCaseTest.php
@@ -9,24 +9,36 @@ use NeNeRecords\Auth\InvalidCredentialsException;
 use NeNeRecords\Auth\LoginInput;
 use NeNeRecords\Auth\LoginUseCase;
 use NeNeRecords\Auth\User;
+use NeNeRecords\Tests\Support\FixedClock;
 use NeNeRecords\Tests\User\InMemoryUserRepository;
 use PHPUnit\Framework\TestCase;
 
 final class StubTokenIssuer implements TokenIssuerInterface
 {
+    /** @var array<string, mixed>|null */
+    public ?array $lastClaims = null;
+
     public function issue(array $claims): string
     {
+        $this->lastClaims = $claims;
+
         return 'stub-token';
     }
 }
 
 final class LoginUseCaseTest extends TestCase
 {
+    /** Fixed instant so token iat/exp are deterministic under test. */
+    private const FIXED_INSTANT = '2026-06-01T10:00:00+00:00';
+
     private StubTokenIssuer $tokenIssuer;
+
+    private FixedClock $clock;
 
     protected function setUp(): void
     {
         $this->tokenIssuer = new StubTokenIssuer();
+        $this->clock = new FixedClock(self::FIXED_INSTANT);
     }
 
     public function testReturnsOutputOnValidCredentials(): void
@@ -36,19 +48,19 @@ final class LoginUseCaseTest extends TestCase
             new User(id: 1, email: 'admin@example.com', passwordHash: $hash, role: 'admin'),
         ]);
 
-        $useCase = new LoginUseCase($users, $this->tokenIssuer);
+        $useCase = new LoginUseCase($users, $this->tokenIssuer, $this->clock);
         $output = $useCase->execute(new LoginInput(email: 'admin@example.com', password: 'secret'));
 
         self::assertSame('stub-token', $output->token);
         self::assertSame('admin@example.com', $output->email);
         self::assertSame('admin', $output->role);
-        self::assertGreaterThan(time(), $output->expiresAt);
+        self::assertSame((new \DateTimeImmutable(self::FIXED_INSTANT))->getTimestamp() + 86400, $output->expiresAt);
     }
 
     public function testThrowsInvalidCredentialsExceptionWhenUserNotFound(): void
     {
         $users = new InMemoryUserRepository([]);
-        $useCase = new LoginUseCase($users, $this->tokenIssuer);
+        $useCase = new LoginUseCase($users, $this->tokenIssuer, $this->clock);
 
         $this->expectException(InvalidCredentialsException::class);
 
@@ -62,7 +74,7 @@ final class LoginUseCaseTest extends TestCase
             new User(id: 1, email: 'admin@example.com', passwordHash: $hash, role: 'admin'),
         ]);
 
-        $useCase = new LoginUseCase($users, $this->tokenIssuer);
+        $useCase = new LoginUseCase($users, $this->tokenIssuer, $this->clock);
 
         $this->expectException(InvalidCredentialsException::class);
 
@@ -76,7 +88,7 @@ final class LoginUseCaseTest extends TestCase
             new User(id: 1, email: 'ghost@example.com', passwordHash: $hash, role: 'unknown_role'),
         ]);
 
-        $useCase = new LoginUseCase($users, $this->tokenIssuer);
+        $useCase = new LoginUseCase($users, $this->tokenIssuer, $this->clock);
 
         $this->expectException(InvalidCredentialsException::class);
 
@@ -95,7 +107,7 @@ final class LoginUseCaseTest extends TestCase
             new User(id: 1, email: 'admin@example.com', passwordHash: $hash, role: 'admin', organizationId: 42),
         ]);
 
-        $useCase = new LoginUseCase($users, $this->tokenIssuer);
+        $useCase = new LoginUseCase($users, $this->tokenIssuer, $this->clock);
         $output = $useCase->execute(new LoginInput(email: 'admin@example.com', password: 'secret'));
 
         self::assertSame(42, $output->orgId);
@@ -113,7 +125,7 @@ final class LoginUseCaseTest extends TestCase
             new User(id: 2, email: 'sa@example.com', passwordHash: $hash, role: 'superadmin', organizationId: null),
         ]);
 
-        $useCase = new LoginUseCase($users, $this->tokenIssuer);
+        $useCase = new LoginUseCase($users, $this->tokenIssuer, $this->clock);
         $output = $useCase->execute(new LoginInput(email: 'sa@example.com', password: 'secret'));
 
         self::assertNull($output->orgId);
@@ -130,7 +142,7 @@ final class LoginUseCaseTest extends TestCase
             new User(id: 3, email: 'editor@example.com', passwordHash: $hash, role: 'editor', organizationId: 7),
         ]);
 
-        $useCase = new LoginUseCase($users, $this->tokenIssuer);
+        $useCase = new LoginUseCase($users, $this->tokenIssuer, $this->clock);
         $output = $useCase->execute(new LoginInput(email: 'editor@example.com', password: 'secret'));
 
         self::assertSame(7, $output->orgId);
@@ -147,10 +159,32 @@ final class LoginUseCaseTest extends TestCase
             new User(id: 4, email: 'unassigned@example.com', passwordHash: $hash, role: 'admin', organizationId: null),
         ]);
 
-        $useCase = new LoginUseCase($users, $this->tokenIssuer);
+        $useCase = new LoginUseCase($users, $this->tokenIssuer, $this->clock);
         $output = $useCase->execute(new LoginInput(email: 'unassigned@example.com', password: 'secret'));
 
         self::assertNull($output->orgId);
         self::assertSame('admin', $output->role);
+    }
+
+    /**
+     * FixedClock を注入すると iat / exp / expiresAt が実クロックに依存せず決定論的になる。
+     * iat は固定時刻の Unix 秒、exp と expiresAt は固定時刻 + TOKEN_TTL(86400) に厳密一致する。
+     */
+    public function testTokenClaimsAreDeterministicWithFixedClock(): void
+    {
+        $fixed = (new \DateTimeImmutable(self::FIXED_INSTANT))->getTimestamp();
+
+        $hash = password_hash('secret', PASSWORD_BCRYPT);
+        $users = new InMemoryUserRepository([
+            new User(id: 1, email: 'admin@example.com', passwordHash: $hash, role: 'admin', organizationId: 42),
+        ]);
+
+        $useCase = new LoginUseCase($users, $this->tokenIssuer, $this->clock);
+        $output = $useCase->execute(new LoginInput(email: 'admin@example.com', password: 'secret'));
+
+        self::assertSame($fixed + 86400, $output->expiresAt);
+        self::assertNotNull($this->tokenIssuer->lastClaims);
+        self::assertSame($fixed, $this->tokenIssuer->lastClaims['iat']);
+        self::assertSame($fixed + 86400, $this->tokenIssuer->lastClaims['exp']);
     }
 }

--- a/tests/BoolField/BoolFieldHttpTest.php
+++ b/tests/BoolField/BoolFieldHttpTest.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Tests\BoolField;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use NeNeRecords\BoolField\BoolFieldNotFoundExceptionHandler;
 use NeNeRecords\BoolField\BoolFieldRouteRegistrar;
 use NeNeRecords\BoolField\CreateBoolFieldHandler;
@@ -81,16 +82,16 @@ final class BoolFieldHttpTest extends TestCase
         $entityRegistrar = new EntityRouteRegistrar(
             new GetEntityByIdHandler(new GetEntityByIdUseCase($this->entities), $jsonResponse),
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
-            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
+            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes, new UtcClock()), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities, new UtcClock()), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),
-            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),
+            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities, new UtcClock()), $jsonResponse),
             new UnscheduleEntityHandler(new UnscheduleEntityUseCase($this->entities), $this->factory),
-            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities), $jsonResponse),
+            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities, new UtcClock()), $jsonResponse),
         );
 
         $boolFieldRegistrar = new BoolFieldRouteRegistrar(

--- a/tests/Comment/CommentHttpTest.php
+++ b/tests/Comment/CommentHttpTest.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Tests\Comment;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use Nene2\Middleware\InMemoryRateLimitStorage;
 use NeNeRecords\Comment\ApproveCommentHandler;
 use NeNeRecords\Comment\ApproveCommentUseCase;
@@ -48,6 +49,7 @@ final class CommentHttpTest extends TestCase
                 $jsonResponse,
                 $problemDetails,
                 new InMemoryRateLimitStorage(),
+                new UtcClock(),
             ),
             new ListCommentsHandler(new ListCommentsUseCase($this->repository), $jsonResponse),
             new ListAllCommentsHandler(new ListAllCommentsUseCase($this->repository), $jsonResponse),

--- a/tests/Dashboard/DashboardHttpTest.php
+++ b/tests/Dashboard/DashboardHttpTest.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Tests\Dashboard;
 use DateTimeImmutable;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Dashboard\DashboardRouteRegistrar;
 use NeNeRecords\Dashboard\GetDashboardSummaryHandler;
 use NeNeRecords\Dashboard\GetDashboardSummaryUseCase;
@@ -43,6 +44,7 @@ final class DashboardHttpTest extends TestCase
             $this->entities,
             $this->entityTypes,
             $this->accessLogs,
+            new UtcClock(),
         );
 
         $registrar = new DashboardRouteRegistrar(
@@ -89,7 +91,7 @@ final class DashboardHttpTest extends TestCase
         $this->entities = new InMemoryEntityRepository([$entity]);
 
         $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
-        $useCase = new GetDashboardSummaryUseCase($this->entities, $this->entityTypes, $this->accessLogs);
+        $useCase = new GetDashboardSummaryUseCase($this->entities, $this->entityTypes, $this->accessLogs, new UtcClock());
         $registrar = new DashboardRouteRegistrar(
             new GetDashboardSummaryHandler($useCase, $jsonResponse),
         );
@@ -143,7 +145,7 @@ final class DashboardHttpTest extends TestCase
         $this->accessLogs->insert($entry2);
 
         $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
-        $useCase = new GetDashboardSummaryUseCase($this->entities, $this->entityTypes, $this->accessLogs);
+        $useCase = new GetDashboardSummaryUseCase($this->entities, $this->entityTypes, $this->accessLogs, new UtcClock());
         $registrar = new DashboardRouteRegistrar(
             new GetDashboardSummaryHandler($useCase, $jsonResponse),
         );
@@ -177,7 +179,7 @@ final class DashboardHttpTest extends TestCase
         $this->entities = new InMemoryEntityRepository([$published1, $published2, $draft]);
 
         $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
-        $useCase = new GetDashboardSummaryUseCase($this->entities, $this->entityTypes, $this->accessLogs);
+        $useCase = new GetDashboardSummaryUseCase($this->entities, $this->entityTypes, $this->accessLogs, new UtcClock());
         $registrar = new DashboardRouteRegistrar(
             new GetDashboardSummaryHandler($useCase, $jsonResponse),
         );

--- a/tests/DateTimeField/DateTimeFieldHttpTest.php
+++ b/tests/DateTimeField/DateTimeFieldHttpTest.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Tests\DateTimeField;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use NeNeRecords\DateTimeField\CreateDateTimeFieldHandler;
 use NeNeRecords\DateTimeField\CreateDateTimeFieldUseCase;
 use NeNeRecords\DateTimeField\DateTimeFieldNotFoundExceptionHandler;
@@ -81,16 +82,16 @@ final class DateTimeFieldHttpTest extends TestCase
         $entityRegistrar = new EntityRouteRegistrar(
             new GetEntityByIdHandler(new GetEntityByIdUseCase($this->entities), $jsonResponse),
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
-            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
+            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes, new UtcClock()), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities, new UtcClock()), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),
-            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),
+            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities, new UtcClock()), $jsonResponse),
             new UnscheduleEntityHandler(new UnscheduleEntityUseCase($this->entities), $this->factory),
-            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities), $jsonResponse),
+            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities, new UtcClock()), $jsonResponse),
         );
 
         $dateTimeFieldRegistrar = new DateTimeFieldRouteRegistrar(

--- a/tests/Entity/EntityFilterHttpTest.php
+++ b/tests/Entity/EntityFilterHttpTest.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Tests\Entity;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Entity\CreateEntityHandler;
 use NeNeRecords\Entity\CreateEntityUseCase;
 use NeNeRecords\Entity\DeleteEntityHandler;
@@ -69,16 +70,16 @@ final class EntityFilterHttpTest extends TestCase
         $registrar = new EntityRouteRegistrar(
             new GetEntityByIdHandler(new GetEntityByIdUseCase($this->entities), $jsonResponse),
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $entityTypes), $jsonResponse),
-            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $entityTypes), $jsonResponse),
+            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $entityTypes, new UtcClock()), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities, new UtcClock()), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),
-            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),
+            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities, new UtcClock()), $jsonResponse),
             new UnscheduleEntityHandler(new UnscheduleEntityUseCase($this->entities), $this->factory),
-            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities), $jsonResponse),
+            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities, new UtcClock()), $jsonResponse),
         );
 
         $this->application = (new RuntimeApplicationFactory(

--- a/tests/Entity/EntityHttpTest.php
+++ b/tests/Entity/EntityHttpTest.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Tests\Entity;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Entity\CreateEntityHandler;
 use NeNeRecords\Entity\CreateEntityUseCase;
 use NeNeRecords\Entity\DeleteEntityHandler;
@@ -62,16 +63,16 @@ final class EntityHttpTest extends TestCase
         $registrar = new EntityRouteRegistrar(
             new GetEntityByIdHandler(new GetEntityByIdUseCase($this->entities), $jsonResponse),
             new CreateEntityHandler($createUseCase, $jsonResponse),
-            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
+            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes, new UtcClock()), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities, new UtcClock()), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),
-            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),
+            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities, new UtcClock()), $jsonResponse),
             new UnscheduleEntityHandler(new UnscheduleEntityUseCase($this->entities), $this->factory),
-            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities), $jsonResponse),
+            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities, new UtcClock()), $jsonResponse),
         );
 
         $this->application = (new RuntimeApplicationFactory(

--- a/tests/Entity/EntityRevisionHttpTest.php
+++ b/tests/Entity/EntityRevisionHttpTest.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Tests\Entity;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Entity\CreateEntityHandler;
 use NeNeRecords\Entity\CreateEntityUseCase;
 use NeNeRecords\Entity\DeleteEntityHandler;
@@ -62,16 +63,16 @@ final class EntityRevisionHttpTest extends TestCase
         $registrar = new EntityRouteRegistrar(
             new GetEntityByIdHandler(new GetEntityByIdUseCase($this->entities), $jsonResponse),
             new CreateEntityHandler($createUseCase, $jsonResponse),
-            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
+            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes, new UtcClock()), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities, new UtcClock()), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),
-            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),
+            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities, new UtcClock()), $jsonResponse),
             new UnscheduleEntityHandler(new UnscheduleEntityUseCase($this->entities), $this->factory),
-            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities), $jsonResponse),
+            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities, new UtcClock()), $jsonResponse),
         );
 
         $this->application = (new RuntimeApplicationFactory(

--- a/tests/Entity/EntityScheduleUseCaseTest.php
+++ b/tests/Entity/EntityScheduleUseCaseTest.php
@@ -6,6 +6,7 @@ namespace NeNeRecords\Tests\Entity;
 
 use DateTimeImmutable;
 use InvalidArgumentException;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Entity\DeleteEntityInput;
 use NeNeRecords\Entity\DeleteEntityUseCase;
 use NeNeRecords\Entity\Entity;
@@ -28,7 +29,7 @@ final class EntityScheduleUseCaseTest extends TestCase
         $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
 
         $scheduledAt = new DateTimeImmutable('+1 hour');
-        $useCase = new ScheduleEntityUseCase($entities);
+        $useCase = new ScheduleEntityUseCase($entities, new UtcClock());
 
         $output = $useCase->execute(new ScheduleEntityInput(id: $entityId, scheduledAt: $scheduledAt));
 
@@ -48,7 +49,7 @@ final class EntityScheduleUseCaseTest extends TestCase
     public function testScheduleEntityThrowsEntityNotFoundExceptionWhenEntityMissing(): void
     {
         $entities = new InMemoryEntityRepository([]);
-        $useCase = new ScheduleEntityUseCase($entities);
+        $useCase = new ScheduleEntityUseCase($entities, new UtcClock());
 
         $this->expectException(EntityNotFoundException::class);
 
@@ -60,7 +61,7 @@ final class EntityScheduleUseCaseTest extends TestCase
         $entities = new InMemoryEntityRepository([]);
         $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
 
-        $useCase = new ScheduleEntityUseCase($entities);
+        $useCase = new ScheduleEntityUseCase($entities, new UtcClock());
 
         $this->expectException(InvalidArgumentException::class);
 
@@ -135,7 +136,7 @@ final class EntityScheduleUseCaseTest extends TestCase
             scheduledAt: new DateTimeImmutable('-1 minute'),
         ));
 
-        $useCase = new ProcessScheduledPublishUseCase($entities);
+        $useCase = new ProcessScheduledPublishUseCase($entities, new UtcClock());
 
         $output = $useCase->execute();
 
@@ -151,7 +152,7 @@ final class EntityScheduleUseCaseTest extends TestCase
     {
         $entities = new InMemoryEntityRepository([]);
 
-        $useCase = new ProcessScheduledPublishUseCase($entities);
+        $useCase = new ProcessScheduledPublishUseCase($entities, new UtcClock());
 
         $output = $useCase->execute();
 
@@ -168,7 +169,7 @@ final class EntityScheduleUseCaseTest extends TestCase
             scheduledAt: new DateTimeImmutable('+1 hour'),
         ));
 
-        $useCase = new ProcessScheduledPublishUseCase($entities);
+        $useCase = new ProcessScheduledPublishUseCase($entities, new UtcClock());
 
         $output = $useCase->execute();
 

--- a/tests/Entity/ListEntitiesUseCaseTest.php
+++ b/tests/Entity/ListEntitiesUseCaseTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Tests\Entity;
 
 use DateTimeImmutable;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Analytics\AccessLogEntry;
 use NeNeRecords\Entity\Entity;
 use NeNeRecords\Entity\EntityListCriteria;
@@ -41,7 +42,7 @@ final class ListEntitiesUseCaseTest extends TestCase
         // A nested path must NOT count as a view of entity 1.
         $accessLogs->insert($this->hit('/api/v1/entities/1/revisions'));
 
-        $useCase = new ListEntitiesUseCase($entities, $accessLogs);
+        $useCase = new ListEntitiesUseCase($entities, new UtcClock(), $accessLogs);
 
         $output = $useCase->execute(new ListEntitiesInput(includeViews: true));
 
@@ -61,7 +62,7 @@ final class ListEntitiesUseCaseTest extends TestCase
         $accessLogs = new InMemoryAccessLogRepository();
         $accessLogs->insert($this->hit('/api/v1/entities/1'));
 
-        $useCase = new ListEntitiesUseCase($entities, $accessLogs);
+        $useCase = new ListEntitiesUseCase($entities, new UtcClock(), $accessLogs);
 
         // No includeViews → the GROUP BY is skipped and every viewCount stays 0.
         $output = $useCase->execute(new ListEntitiesInput());
@@ -76,7 +77,7 @@ final class ListEntitiesUseCaseTest extends TestCase
             new Entity(id: 2, entityTypeId: 1, permalink: null, status: EntityStatus::Published),
             new Entity(id: 3, entityTypeId: 1, permalink: '', status: EntityStatus::Published),
         ]);
-        $useCase = new ListEntitiesUseCase($entities);
+        $useCase = new ListEntitiesUseCase($entities, new UtcClock());
 
         $output = $useCase->execute(new ListEntitiesInput(
             criteria: new EntityListCriteria(hasPermalink: true),

--- a/tests/Entity/PdoEntityRepositoryTest.php
+++ b/tests/Entity/PdoEntityRepositoryTest.php
@@ -8,6 +8,7 @@ use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Entity\Entity;
 use NeNeRecords\Entity\EntityListCriteria;
 use NeNeRecords\Entity\PdoEntityRepository;
@@ -90,7 +91,7 @@ final class PdoEntityRepositoryTest extends TestCase
 
         $this->executor->execute('INSERT INTO entities (entity_type_id) VALUES (?)', [$typeId]);
 
-        $repository = new PdoEntityRepository($this->executor, $this->orgId);
+        $repository = new PdoEntityRepository($this->executor, $this->orgId, new UtcClock());
         $entity = $repository->findById(1);
 
         self::assertNotNull($entity);
@@ -104,7 +105,7 @@ final class PdoEntityRepositoryTest extends TestCase
         $typeId = $this->insertEntityTypeId();
         $this->executor->execute('INSERT INTO entities (entity_type_id) VALUES (?)', [$typeId]);
 
-        $repository = new PdoEntityRepository($this->executor, $this->orgId);
+        $repository = new PdoEntityRepository($this->executor, $this->orgId, new UtcClock());
         $repository->softDelete(1);
 
         self::assertNull($repository->findById(1));
@@ -115,7 +116,7 @@ final class PdoEntityRepositoryTest extends TestCase
         $typeId = $this->insertEntityTypeId();
         $this->executor->execute('INSERT INTO entities (entity_type_id) VALUES (?)', [$typeId]);
 
-        $repository = new PdoEntityRepository($this->executor, $this->orgId);
+        $repository = new PdoEntityRepository($this->executor, $this->orgId, new UtcClock());
         $repository->softDelete(1);
 
         $row = $this->executor->fetchOne(
@@ -131,7 +132,7 @@ final class PdoEntityRepositoryTest extends TestCase
     {
         $typeId = $this->insertEntityTypeId();
 
-        $repository = new PdoEntityRepository($this->executor, $this->orgId);
+        $repository = new PdoEntityRepository($this->executor, $this->orgId, new UtcClock());
         $id = $repository->save(new Entity(id: null, entityTypeId: $typeId));
 
         self::assertSame(1, $id);
@@ -141,7 +142,7 @@ final class PdoEntityRepositoryTest extends TestCase
     {
         $typeId = $this->insertEntityTypeId();
 
-        $repository = new PdoEntityRepository($this->executor, $this->orgId);
+        $repository = new PdoEntityRepository($this->executor, $this->orgId, new UtcClock());
         $id = $repository->save(new Entity(id: null, entityTypeId: $typeId));
         $entity = $repository->findById($id);
 
@@ -153,7 +154,7 @@ final class PdoEntityRepositoryTest extends TestCase
     {
         $typeId = $this->insertEntityTypeId();
 
-        $repository = new PdoEntityRepository($this->executor, $this->orgId);
+        $repository = new PdoEntityRepository($this->executor, $this->orgId, new UtcClock());
         $a = $repository->save(new Entity(id: null, entityTypeId: $typeId));
         $repository->save(new Entity(id: null, entityTypeId: $typeId));
 
@@ -169,7 +170,7 @@ final class PdoEntityRepositoryTest extends TestCase
     {
         $typeId = $this->insertEntityTypeId();
 
-        $repository = new PdoEntityRepository($this->executor, $this->orgId);
+        $repository = new PdoEntityRepository($this->executor, $this->orgId, new UtcClock());
 
         for ($i = 0; $i < 5; $i++) {
             $repository->save(new Entity(id: null, entityTypeId: $typeId));
@@ -189,7 +190,7 @@ final class PdoEntityRepositoryTest extends TestCase
         $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('Other', 'other')");
         $typeB = 2;
 
-        $repository = new PdoEntityRepository($this->executor, $this->orgId);
+        $repository = new PdoEntityRepository($this->executor, $this->orgId, new UtcClock());
         $repository->save(new Entity(id: null, entityTypeId: $typeA));
         $repository->save(new Entity(id: null, entityTypeId: $typeB));
 
@@ -203,7 +204,7 @@ final class PdoEntityRepositoryTest extends TestCase
     public function testFindByCriteriaFiltersByPublishedDateRange(): void
     {
         $typeId = $this->insertEntityTypeId();
-        $repository = new PdoEntityRepository($this->executor, $this->orgId);
+        $repository = new PdoEntityRepository($this->executor, $this->orgId, new UtcClock());
 
         $may = $repository->save(new Entity(
             id: null,
@@ -232,7 +233,7 @@ final class PdoEntityRepositoryTest extends TestCase
     {
         $typeId = $this->insertEntityTypeId();
 
-        $repository = new PdoEntityRepository($this->executor, $this->orgId);
+        $repository = new PdoEntityRepository($this->executor, $this->orgId, new UtcClock());
         $entityA = $repository->save(new Entity(id: null, entityTypeId: $typeId));
         $entityB = $repository->save(new Entity(id: null, entityTypeId: $typeId));
         $repository->save(new Entity(id: null, entityTypeId: $typeId));
@@ -253,7 +254,7 @@ final class PdoEntityRepositoryTest extends TestCase
     {
         $typeId = $this->insertEntityTypeId();
 
-        $repository = new PdoEntityRepository($this->executor, $this->orgId);
+        $repository = new PdoEntityRepository($this->executor, $this->orgId, new UtcClock());
         $entityA = $repository->save(new Entity(id: null, entityTypeId: $typeId));
         $entityB = $repository->save(new Entity(id: null, entityTypeId: $typeId));
         $repository->save(new Entity(id: null, entityTypeId: $typeId));
@@ -290,7 +291,7 @@ final class PdoEntityRepositoryTest extends TestCase
     public function testFindByCriteriaSearchBySlug(): void
     {
         $typeId = $this->insertEntityTypeId();
-        $repository = new PdoEntityRepository($this->executor, $this->orgId);
+        $repository = new PdoEntityRepository($this->executor, $this->orgId, new UtcClock());
 
         $entityA = $repository->save(new Entity(id: null, entityTypeId: $typeId, slug: 'hello-world'));
         $repository->save(new Entity(id: null, entityTypeId: $typeId, slug: 'another-post'));
@@ -305,7 +306,7 @@ final class PdoEntityRepositoryTest extends TestCase
     public function testFindByCriteriaSearchByTextField(): void
     {
         $typeId = $this->insertEntityTypeId();
-        $repository = new PdoEntityRepository($this->executor, $this->orgId);
+        $repository = new PdoEntityRepository($this->executor, $this->orgId, new UtcClock());
 
         $entityA = $repository->save(new Entity(id: null, entityTypeId: $typeId));
         $entityB = $repository->save(new Entity(id: null, entityTypeId: $typeId));
@@ -329,7 +330,7 @@ final class PdoEntityRepositoryTest extends TestCase
     public function testFindByCriteriaSearchReturnsEmptyWhenNoMatch(): void
     {
         $typeId = $this->insertEntityTypeId();
-        $repository = new PdoEntityRepository($this->executor, $this->orgId);
+        $repository = new PdoEntityRepository($this->executor, $this->orgId, new UtcClock());
 
         $repository->save(new Entity(id: null, entityTypeId: $typeId, slug: 'hello-world'));
 
@@ -345,7 +346,7 @@ final class PdoEntityRepositoryTest extends TestCase
         $this->executor->execute("INSERT INTO entity_types (name, slug) VALUES ('Other', 'other')");
         $otherTypeId = $this->executor->lastInsertId();
 
-        $repository = new PdoEntityRepository($this->executor, $this->orgId);
+        $repository = new PdoEntityRepository($this->executor, $this->orgId, new UtcClock());
         $entityA = $repository->save(new Entity(id: null, entityTypeId: $typeId, slug: 'hello-world'));
         $repository->save(new Entity(id: null, entityTypeId: $otherTypeId, slug: 'hello-other'));
 

--- a/tests/Entity/ScheduledPublishHttpTest.php
+++ b/tests/Entity/ScheduledPublishHttpTest.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Entity\CreateEntityHandler;
 use NeNeRecords\Entity\CreateEntityUseCase;
 use NeNeRecords\Entity\DeleteEntityHandler;
@@ -62,16 +63,16 @@ final class ScheduledPublishHttpTest extends TestCase
         $registrar = new EntityRouteRegistrar(
             new GetEntityByIdHandler(new GetEntityByIdUseCase($this->entities), $jsonResponse),
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
-            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
+            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes, new UtcClock()), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities, new UtcClock()), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),
-            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),
+            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities, new UtcClock()), $jsonResponse),
             new UnscheduleEntityHandler(new UnscheduleEntityUseCase($this->entities), $this->factory),
-            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities), $jsonResponse),
+            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities, new UtcClock()), $jsonResponse),
         );
 
         $this->application = (new RuntimeApplicationFactory(

--- a/tests/Entity/UpdateEntityUseCaseTest.php
+++ b/tests/Entity/UpdateEntityUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Tests\Entity;
 
+use Nene2\Http\UtcClock;
 use NeNeRecords\Entity\DuplicateEntityPermalinkException;
 use NeNeRecords\Entity\Entity;
 use NeNeRecords\Entity\EntityStatus;
@@ -24,7 +25,7 @@ final class UpdateEntityUseCaseTest extends TestCase
             new Entity(id: 1, entityTypeId: $typeId, permalink: '/company/about/team', status: EntityStatus::Published),
         ]);
         $redirects = new InMemoryUrlRedirectRepository();
-        $useCase = new UpdateEntityUseCase($entities, $entityTypes, null, $redirects);
+        $useCase = new UpdateEntityUseCase($entities, $entityTypes, new UtcClock(), null, $redirects);
 
         $useCase->execute(new UpdateEntityInput(
             id: 1,
@@ -45,7 +46,7 @@ final class UpdateEntityUseCaseTest extends TestCase
             new Entity(id: 5, entityTypeId: $typeId, status: EntityStatus::Published),
         ]);
         $redirects = new InMemoryUrlRedirectRepository();
-        $useCase = new UpdateEntityUseCase($entities, $entityTypes, null, $redirects);
+        $useCase = new UpdateEntityUseCase($entities, $entityTypes, new UtcClock(), null, $redirects);
 
         $useCase->execute(new UpdateEntityInput(
             id: 5,
@@ -66,7 +67,7 @@ final class UpdateEntityUseCaseTest extends TestCase
             new Entity(id: 1, entityTypeId: $typeId, slug: 'a', permalink: '/keep', status: EntityStatus::Published),
         ]);
         $redirects = new InMemoryUrlRedirectRepository();
-        $useCase = new UpdateEntityUseCase($entities, $entityTypes, null, $redirects);
+        $useCase = new UpdateEntityUseCase($entities, $entityTypes, new UtcClock(), null, $redirects);
 
         $useCase->execute(new UpdateEntityInput(
             id: 1,
@@ -87,7 +88,7 @@ final class UpdateEntityUseCaseTest extends TestCase
             new Entity(id: 1, entityTypeId: $typeId, permalink: '/taken'),
             new Entity(id: 2, entityTypeId: $typeId),
         ]);
-        $useCase = new UpdateEntityUseCase($entities, $entityTypes, null, new InMemoryUrlRedirectRepository());
+        $useCase = new UpdateEntityUseCase($entities, $entityTypes, new UtcClock(), null, new InMemoryUrlRedirectRepository());
 
         $this->expectException(DuplicateEntityPermalinkException::class);
         $useCase->execute(new UpdateEntityInput(

--- a/tests/EnumField/EnumFieldHttpTest.php
+++ b/tests/EnumField/EnumFieldHttpTest.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Tests\EnumField;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Entity\CreateEntityHandler;
 use NeNeRecords\Entity\CreateEntityUseCase;
 use NeNeRecords\Entity\DeleteEntityHandler;
@@ -81,16 +82,16 @@ final class EnumFieldHttpTest extends TestCase
         $entityRegistrar = new EntityRouteRegistrar(
             new GetEntityByIdHandler(new GetEntityByIdUseCase($this->entities), $jsonResponse),
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
-            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
+            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes, new UtcClock()), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities, new UtcClock()), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),
-            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),
+            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities, new UtcClock()), $jsonResponse),
             new UnscheduleEntityHandler(new UnscheduleEntityUseCase($this->entities), $this->factory),
-            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities), $jsonResponse),
+            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities, new UtcClock()), $jsonResponse),
         );
 
         $enumFieldRegistrar = new EnumFieldRouteRegistrar(

--- a/tests/IntField/IntFieldHttpTest.php
+++ b/tests/IntField/IntFieldHttpTest.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Tests\IntField;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Entity\CreateEntityHandler;
 use NeNeRecords\Entity\CreateEntityUseCase;
 use NeNeRecords\Entity\DeleteEntityHandler;
@@ -81,16 +82,16 @@ final class IntFieldHttpTest extends TestCase
         $entityRegistrar = new EntityRouteRegistrar(
             new GetEntityByIdHandler(new GetEntityByIdUseCase($this->entities), $jsonResponse),
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
-            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
+            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes, new UtcClock()), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities, new UtcClock()), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, new InMemoryTextFieldRepository(), $this->factory),
-            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),
+            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities, new UtcClock()), $jsonResponse),
             new UnscheduleEntityHandler(new UnscheduleEntityUseCase($this->entities), $this->factory),
-            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities), $jsonResponse),
+            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities, new UtcClock()), $jsonResponse),
         );
 
         $intFieldRegistrar = new IntFieldRouteRegistrar(

--- a/tests/Media/MediaHttpTest.php
+++ b/tests/Media/MediaHttpTest.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Tests\Media;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Media\DeleteMediaHandler;
 use NeNeRecords\Media\DeleteMediaUseCase;
 use NeNeRecords\Media\FindMediaUsagesUseCase;
@@ -74,7 +75,7 @@ final class MediaHttpTest extends TestCase
 
         $registrar = new MediaRouteRegistrar(
             new UploadMediaHandler(
-                new UploadMediaUseCase($this->repository, $this->storage),
+                new UploadMediaUseCase($this->repository, $this->storage, new UtcClock()),
                 $jsonResponse,
             ),
             new ListMediaHandler(
@@ -165,7 +166,7 @@ final class MediaHttpTest extends TestCase
         $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
 
         $registrar = new MediaRouteRegistrar(
-            new UploadMediaHandler(new UploadMediaUseCase($emptyRepo, $this->storage), $jsonResponse),
+            new UploadMediaHandler(new UploadMediaUseCase($emptyRepo, $this->storage, new UtcClock()), $jsonResponse),
             new ListMediaHandler(new ListMediaUseCase($emptyRepo), $jsonResponse),
             new DeleteMediaHandler(new DeleteMediaUseCase($emptyRepo, $this->storage), $this->factory),
             new ServeMediaHandler($this->storage, $this->factory, $this->factory),

--- a/tests/Media/MediaUseCaseTest.php
+++ b/tests/Media/MediaUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Tests\Media;
 
+use Nene2\Http\UtcClock;
 use NeNeRecords\Media\DeleteMediaInput;
 use NeNeRecords\Media\DeleteMediaUseCase;
 use NeNeRecords\Media\LocalStorage;
@@ -26,7 +27,7 @@ final class MediaUseCaseTest extends TestCase
         file_put_contents($tmpFile, 'fake image content');
 
         $mediaRepo = new InMemoryMediaRepository();
-        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot));
+        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot), new UtcClock());
 
         $input = new UploadMediaInput(
             tmpPath: $tmpFile,
@@ -62,7 +63,7 @@ final class MediaUseCaseTest extends TestCase
         file_put_contents($tmpFile, $png);
 
         $mediaRepo = new InMemoryMediaRepository();
-        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot));
+        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot), new UtcClock());
 
         $output = $useCase->execute(new UploadMediaInput(
             tmpPath: $tmpFile,
@@ -88,7 +89,7 @@ final class MediaUseCaseTest extends TestCase
     {
         $storageRoot = sys_get_temp_dir() . '/nene_media_test_' . uniqid('', true);
         $mediaRepo = new InMemoryMediaRepository();
-        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot));
+        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot), new UtcClock());
 
         $input = new UploadMediaInput(
             tmpPath: '/tmp/irrelevant',
@@ -106,7 +107,7 @@ final class MediaUseCaseTest extends TestCase
     {
         $storageRoot = sys_get_temp_dir() . '/nene_media_test_' . uniqid('', true);
         $mediaRepo = new InMemoryMediaRepository();
-        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot));
+        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot), new UtcClock());
 
         $tenMibPlusOne = 10 * 1024 * 1024 + 1;
 
@@ -134,7 +135,7 @@ final class MediaUseCaseTest extends TestCase
         );
 
         $mediaRepo = new InMemoryMediaRepository();
-        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot));
+        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot), new UtcClock());
 
         $output = $useCase->execute(new UploadMediaInput(
             tmpPath: $tmpFile,
@@ -167,7 +168,7 @@ final class MediaUseCaseTest extends TestCase
         file_put_contents($tmpFile, '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>');
 
         $mediaRepo = new InMemoryMediaRepository();
-        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot));
+        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot), new UtcClock());
 
         // Declared as PNG to try to dodge the SVG path — content sniff must catch it.
         $output = $useCase->execute(new UploadMediaInput(
@@ -199,7 +200,7 @@ final class MediaUseCaseTest extends TestCase
         file_put_contents($tmpFile, '<svg xmlns="http://www.w3.org/2000/svg">' . $padding . '</svg>');
 
         $mediaRepo = new InMemoryMediaRepository();
-        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot));
+        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot), new UtcClock());
 
         $this->expectException(MediaTooLargeException::class);
 
@@ -224,7 +225,7 @@ final class MediaUseCaseTest extends TestCase
         file_put_contents($tmpFile, '<svg xmlns="http://www.w3.org/2000/svg"><rect'); // truncated / unparseable
 
         $mediaRepo = new InMemoryMediaRepository();
-        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot));
+        $useCase = new UploadMediaUseCase($mediaRepo, new LocalStorage($storageRoot), new UtcClock());
 
         $this->expectException(MediaInvalidTypeException::class);
 

--- a/tests/Menu/PdoMenuRepositoryTest.php
+++ b/tests/Menu/PdoMenuRepositoryTest.php
@@ -8,6 +8,7 @@ use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Menu\Menu;
 use NeNeRecords\Menu\PdoMenuRepository;
 use PHPUnit\Framework\TestCase;
@@ -54,7 +55,7 @@ final class PdoMenuRepositoryTest extends TestCase
 
     public function testSaveAndFindById(): void
     {
-        $repository = new PdoMenuRepository($this->executor, $this->orgId);
+        $repository = new PdoMenuRepository($this->executor, $this->orgId, new UtcClock());
         $id = $repository->save(new Menu(null, 'Main nav', 'main-nav', 'header', '', ''));
 
         $found = $repository->findById($id);
@@ -66,7 +67,7 @@ final class PdoMenuRepositoryTest extends TestCase
 
     public function testFindByIdSupportsNullLocation(): void
     {
-        $repository = new PdoMenuRepository($this->executor, $this->orgId);
+        $repository = new PdoMenuRepository($this->executor, $this->orgId, new UtcClock());
         $id = $repository->save(new Menu(null, 'Categories', 'categories', null, '', ''));
 
         $found = $repository->findById($id);
@@ -76,7 +77,7 @@ final class PdoMenuRepositoryTest extends TestCase
 
     public function testExistsBySlug(): void
     {
-        $repository = new PdoMenuRepository($this->executor, $this->orgId);
+        $repository = new PdoMenuRepository($this->executor, $this->orgId, new UtcClock());
         $id = $repository->save(new Menu(null, 'Footer', 'footer', 'footer', '', ''));
 
         self::assertTrue($repository->existsBySlug('footer'));
@@ -86,7 +87,7 @@ final class PdoMenuRepositoryTest extends TestCase
 
     public function testUpdateChangesFields(): void
     {
-        $repository = new PdoMenuRepository($this->executor, $this->orgId);
+        $repository = new PdoMenuRepository($this->executor, $this->orgId, new UtcClock());
         $id = $repository->save(new Menu(null, 'Old', 'old', null, '', ''));
         $existing = $repository->findById($id);
         self::assertNotNull($existing);
@@ -101,7 +102,7 @@ final class PdoMenuRepositoryTest extends TestCase
 
     public function testDeleteRemovesMenu(): void
     {
-        $repository = new PdoMenuRepository($this->executor, $this->orgId);
+        $repository = new PdoMenuRepository($this->executor, $this->orgId, new UtcClock());
         $id = $repository->save(new Menu(null, 'Temp', 'temp', null, '', ''));
 
         $repository->delete($id);

--- a/tests/NavigationItem/PdoNavigationItemRepositoryTest.php
+++ b/tests/NavigationItem/PdoNavigationItemRepositoryTest.php
@@ -8,6 +8,7 @@ use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\UtcClock;
 use NeNeRecords\NavigationItem\NavigationItem;
 use NeNeRecords\NavigationItem\PdoNavigationItemRepository;
 use PHPUnit\Framework\TestCase;
@@ -65,13 +66,13 @@ final class PdoNavigationItemRepositoryTest extends TestCase
 
     public function testFindAllReturnsEmptyInitially(): void
     {
-        $repository = new PdoNavigationItemRepository($this->executor, $this->orgId);
+        $repository = new PdoNavigationItemRepository($this->executor, $this->orgId, new UtcClock());
         self::assertSame([], $repository->findAll());
     }
 
     public function testSaveAndFindById(): void
     {
-        $repository = new PdoNavigationItemRepository($this->executor, $this->orgId);
+        $repository = new PdoNavigationItemRepository($this->executor, $this->orgId, new UtcClock());
         $item = new NavigationItem(
             id: null,
             label: 'Home',
@@ -94,7 +95,7 @@ final class PdoNavigationItemRepositoryTest extends TestCase
 
     public function testFindAllReturnsSortedByDisplayOrder(): void
     {
-        $repository = new PdoNavigationItemRepository($this->executor, $this->orgId);
+        $repository = new PdoNavigationItemRepository($this->executor, $this->orgId, new UtcClock());
 
         foreach ([
             ['About', '/about', 2],
@@ -111,7 +112,7 @@ final class PdoNavigationItemRepositoryTest extends TestCase
 
     public function testUpdateChangesFields(): void
     {
-        $repository = new PdoNavigationItemRepository($this->executor, $this->orgId);
+        $repository = new PdoNavigationItemRepository($this->executor, $this->orgId, new UtcClock());
         $id = $repository->save(new NavigationItem(null, 'Home', '/', 0, '', ''));
 
         $found = $repository->findById($id);
@@ -135,7 +136,7 @@ final class PdoNavigationItemRepositoryTest extends TestCase
 
     public function testDeleteRemovesItem(): void
     {
-        $repository = new PdoNavigationItemRepository($this->executor, $this->orgId);
+        $repository = new PdoNavigationItemRepository($this->executor, $this->orgId, new UtcClock());
         $id = $repository->save(new NavigationItem(null, 'To Delete', '/delete', 0, '', ''));
 
         $repository->delete($id);
@@ -146,7 +147,7 @@ final class PdoNavigationItemRepositoryTest extends TestCase
 
     public function testFindByIdReturnsNullForMissing(): void
     {
-        $repository = new PdoNavigationItemRepository($this->executor, $this->orgId);
+        $repository = new PdoNavigationItemRepository($this->executor, $this->orgId, new UtcClock());
         self::assertNull($repository->findById(9999));
     }
 }

--- a/tests/Notification/NotificationChannelHttpTest.php
+++ b/tests/Notification/NotificationChannelHttpTest.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Tests\Notification;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Mail\MailerInterface;
 use NeNeRecords\Notification\Channel\ChatWorkChannel;
 use NeNeRecords\Notification\Channel\DiscordChannel;
@@ -49,7 +50,7 @@ final class NotificationChannelHttpTest extends TestCase
         $slackChannel = new SlackChannel();
         $discordChannel = new DiscordChannel();
         $chatWorkChannel = new ChatWorkChannel();
-        $webhookChannel = new WebhookChannel();
+        $webhookChannel = new WebhookChannel(new UtcClock());
         $emailStub = new EmailChannel($this->createStub(MailerInterface::class));
 
         $registrar = new NotificationRouteRegistrar(

--- a/tests/Notification/NotificationChannelUseCaseTest.php
+++ b/tests/Notification/NotificationChannelUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Tests\Notification;
 
+use Nene2\Http\UtcClock;
 use NeNeRecords\Mail\MailerInterface;
 use NeNeRecords\Notification\Channel\ChatWorkChannel;
 use NeNeRecords\Notification\Channel\DiscordChannel;
@@ -188,7 +189,7 @@ final class NotificationChannelUseCaseTest extends TestCase
             slackChannel: new SlackChannel(),
             discordChannel: new DiscordChannel(),
             chatWorkChannel: new ChatWorkChannel(),
-            webhookChannel: new WebhookChannel(),
+            webhookChannel: new WebhookChannel(new UtcClock()),
         );
 
         $this->expectException(NotificationChannelNotFoundException::class);
@@ -209,7 +210,7 @@ final class NotificationChannelUseCaseTest extends TestCase
             slackChannel: new SlackChannel(),
             discordChannel: new DiscordChannel(),
             chatWorkChannel: new ChatWorkChannel(),
-            webhookChannel: new WebhookChannel(),
+            webhookChannel: new WebhookChannel(new UtcClock()),
         );
 
         // No exception should be thrown
@@ -234,7 +235,7 @@ final class NotificationChannelUseCaseTest extends TestCase
             slackChannel: new SlackChannel(),
             discordChannel: new DiscordChannel(),
             chatWorkChannel: new ChatWorkChannel(),
-            webhookChannel: new WebhookChannel(),
+            webhookChannel: new WebhookChannel(new UtcClock()),
         );
 
         $notifier->notify(new NotificationMessage(
@@ -258,7 +259,7 @@ final class NotificationChannelUseCaseTest extends TestCase
             slackChannel: new SlackChannel(),
             discordChannel: new DiscordChannel(),
             chatWorkChannel: new ChatWorkChannel(),
-            webhookChannel: new WebhookChannel(),
+            webhookChannel: new WebhookChannel(new UtcClock()),
         );
 
         // Should not throw
@@ -318,7 +319,7 @@ final class NotificationChannelUseCaseTest extends TestCase
             slackChannel: new SlackChannel(),
             discordChannel: new DiscordChannel(),
             chatWorkChannel: new ChatWorkChannel(),
-            webhookChannel: new WebhookChannel(),
+            webhookChannel: new WebhookChannel(new UtcClock()),
         );
 
         // Should NOT propagate the repository exception (fire-and-forget contract)

--- a/tests/PreviewToken/PreviewTokenHttpTest.php
+++ b/tests/PreviewToken/PreviewTokenHttpTest.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Entity\Entity;
 use NeNeRecords\Entity\EntityNotFoundExceptionHandler;
 use NeNeRecords\Entity\EntityStatus;
@@ -73,7 +74,7 @@ final class PreviewTokenHttpTest extends TestCase
         $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
         $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
 
-        $generateUseCase = new GeneratePreviewTokenUseCase($this->entities, $this->previewTokens);
+        $generateUseCase = new GeneratePreviewTokenUseCase($this->entities, $this->previewTokens, new UtcClock());
         $revokeUseCase = new RevokePreviewTokenUseCase($this->entities, $this->previewTokens);
         $getPreviewUseCase = new GetPreviewRecordViewUseCase(
             $this->previewTokens,
@@ -88,6 +89,7 @@ final class PreviewTokenHttpTest extends TestCase
             new InMemoryEntityRelationRepository(),
             $publicSettings,
             new \NeNeRecords\PublicRecord\PublicRecordHierarchyBuilder($this->entities, $textFields),
+            new UtcClock(),
         );
 
         $registrar = new PreviewTokenRouteRegistrar(

--- a/tests/PreviewToken/PreviewTokenUseCaseTest.php
+++ b/tests/PreviewToken/PreviewTokenUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Tests\PreviewToken;
 
+use Nene2\Http\UtcClock;
 use NeNeRecords\Entity\Entity;
 use NeNeRecords\Entity\EntityNotFoundException;
 use NeNeRecords\PreviewToken\GeneratePreviewTokenInput;
@@ -21,7 +22,7 @@ final class PreviewTokenUseCaseTest extends TestCase
         $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
 
         $previewTokens = new InMemoryEntityPreviewTokenRepository();
-        $useCase = new GeneratePreviewTokenUseCase($entities, $previewTokens);
+        $useCase = new GeneratePreviewTokenUseCase($entities, $previewTokens, new UtcClock());
 
         $output = $useCase->execute(new GeneratePreviewTokenInput(entityId: $entityId));
 
@@ -34,7 +35,7 @@ final class PreviewTokenUseCaseTest extends TestCase
     {
         $entities = new InMemoryEntityRepository([]);
         $previewTokens = new InMemoryEntityPreviewTokenRepository();
-        $useCase = new GeneratePreviewTokenUseCase($entities, $previewTokens);
+        $useCase = new GeneratePreviewTokenUseCase($entities, $previewTokens, new UtcClock());
 
         $this->expectException(EntityNotFoundException::class);
 
@@ -48,7 +49,7 @@ final class PreviewTokenUseCaseTest extends TestCase
         $entities->softDelete($entityId);
 
         $previewTokens = new InMemoryEntityPreviewTokenRepository();
-        $useCase = new GeneratePreviewTokenUseCase($entities, $previewTokens);
+        $useCase = new GeneratePreviewTokenUseCase($entities, $previewTokens, new UtcClock());
 
         $this->expectException(EntityNotFoundException::class);
 
@@ -61,7 +62,7 @@ final class PreviewTokenUseCaseTest extends TestCase
         $entityId = $entities->save(new Entity(id: null, entityTypeId: 1));
 
         $previewTokens = new InMemoryEntityPreviewTokenRepository();
-        $useCase = new GeneratePreviewTokenUseCase($entities, $previewTokens);
+        $useCase = new GeneratePreviewTokenUseCase($entities, $previewTokens, new UtcClock());
 
         $first = $useCase->execute(new GeneratePreviewTokenInput(entityId: $entityId));
         $second = $useCase->execute(new GeneratePreviewTokenInput(entityId: $entityId));
@@ -80,7 +81,7 @@ final class PreviewTokenUseCaseTest extends TestCase
 
         $previewTokens = new InMemoryEntityPreviewTokenRepository();
 
-        $generate = new GeneratePreviewTokenUseCase($entities, $previewTokens);
+        $generate = new GeneratePreviewTokenUseCase($entities, $previewTokens, new UtcClock());
         $generated = $generate->execute(new GeneratePreviewTokenInput(entityId: $entityId));
 
         self::assertNotNull($previewTokens->findByToken($generated->token));

--- a/tests/Setting/PdoSettingRepositoryTest.php
+++ b/tests/Setting/PdoSettingRepositoryTest.php
@@ -8,6 +8,7 @@ use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Setting\PdoSettingRepository;
 use NeNeRecords\Setting\SettingRevisionAction;
 use PHPUnit\Framework\TestCase;
@@ -72,7 +73,7 @@ final class PdoSettingRepositoryTest extends TestCase
 
     public function testApplyValueCreatesRevisionAndStoredValue(): void
     {
-        $repository = new PdoSettingRepository($this->executor, $this->orgId);
+        $repository = new PdoSettingRepository($this->executor, $this->orgId, new UtcClock());
         $stored = $repository->applyValue('site_name', 'Updated Site', null);
 
         self::assertSame('Updated Site', $stored->value);

--- a/tests/Setting/UpdateSettingFrontPageValidationTest.php
+++ b/tests/Setting/UpdateSettingFrontPageValidationTest.php
@@ -6,6 +6,7 @@ namespace NeNeRecords\Tests\Setting;
 
 use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Entity\Entity;
 use NeNeRecords\Entity\EntityStatus;
 use NeNeRecords\PublicRecord\FrontPageSetting;
@@ -77,7 +78,7 @@ final class UpdateSettingFrontPageValidationTest extends TestCase
             new InMemorySettingRepository(),
             new InMemoryEntityRepository($entities),
             new InMemoryEntityTypeRepository(),
-        ));
+        ), new UtcClock());
     }
 
     private function page(int $id, EntityStatus $status): Entity

--- a/tests/Signup/ConfirmEmailUseCaseTest.php
+++ b/tests/Signup/ConfirmEmailUseCaseTest.php
@@ -8,6 +8,7 @@ use Nene2\Http\SecureTokenHelper;
 use NeNeRecords\Organization\Organization;
 use NeNeRecords\Signup\ConfirmEmailUseCase;
 use NeNeRecords\Tests\Organization\InMemoryOrganizationRepository;
+use NeNeRecords\Tests\Support\FixedClock;
 use NeNeRecords\Tests\User\InMemoryUserRepository;
 use NeNeRecords\User\CreateUserInput;
 use NeNeRecords\User\CreateUserUseCase;
@@ -21,10 +22,12 @@ final class ConfirmEmailUseCaseTest extends TestCase
     /** @var array{0: string, 1: string} */
     private array $token;
     private int $orgId;
+    private FixedClock $clock;
 
     protected function setUp(): void
     {
         parent::setUp();
+        $this->clock = new FixedClock('2026-06-01T10:00:00+00:00');
         $this->token = SecureTokenHelper::generateWithHash();
         $this->orgs = new InMemoryOrganizationRepository();
         $this->orgId = $this->orgs->save(new Organization('My Org', 'myorg', 'free', true));
@@ -38,9 +41,9 @@ final class ConfirmEmailUseCaseTest extends TestCase
         );
         $user = $this->users->findByEmail('a@b.test');
         self::assertNotNull($user);
-        $this->users->storeEmailVerification($user->id, 'a@b.test', $this->token[1], time() + $expiresInSeconds);
+        $this->users->storeEmailVerification($user->id, 'a@b.test', $this->token[1], $this->clock->now()->getTimestamp() + $expiresInSeconds);
 
-        return new ConfirmEmailUseCase($this->users, $this->orgs);
+        return new ConfirmEmailUseCase($this->users, $this->orgs, $this->clock);
     }
 
     public function testConfirmsValidTokenAndReturnsSlug(): void

--- a/tests/Signup/PublicSignupHandlerTest.php
+++ b/tests/Signup/PublicSignupHandlerTest.php
@@ -9,6 +9,7 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Middleware\InMemoryRateLimitStorage;
 use Nene2\Validation\ValidationException;
 use NeNeRecords\Signup\PublicSignupHandler;
+use NeNeRecords\Tests\Support\FixedClock;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
@@ -32,6 +33,7 @@ final class PublicSignupHandlerTest extends TestCase
             new JsonResponseFactory($this->factory, $this->factory),
             new ProblemDetailsResponseFactory($this->factory, $this->factory),
             new InMemoryRateLimitStorage(),
+            new FixedClock(),
             maxSignupsPerWindow: 2,
             rateLimitWindowSeconds: 3600,
         );

--- a/tests/Signup/PublicSignupUseCaseTest.php
+++ b/tests/Signup/PublicSignupUseCaseTest.php
@@ -15,6 +15,7 @@ use NeNeRecords\Tests\Mail\RecordingMailer;
 use NeNeRecords\Tests\Organization\InMemoryOrganizationRepository;
 use NeNeRecords\Tests\Organization\RecordingDefaultContentTypeSeeder;
 use NeNeRecords\Tests\Organization\RecordingDefaultSettingDefsSeeder;
+use NeNeRecords\Tests\Support\FixedClock;
 use NeNeRecords\Tests\User\InMemoryUserRepository;
 use NeNeRecords\User\CreateUserUseCase;
 use PHPUnit\Framework\TestCase;
@@ -47,10 +48,11 @@ final class PublicSignupUseCaseTest extends TestCase
         return new PublicSignupUseCase(
             new CreateOrganizationUseCase($this->orgs, $this->seeder, new RecordingDefaultSettingDefsSeeder()),
             new CreateUserUseCase($this->users),
-            new LoginUseCase($this->users, $tokenIssuer),
+            new LoginUseCase($this->users, $tokenIssuer, new FixedClock()),
             $holder,
             $this->users,
             $this->mailer,
+            new FixedClock(),
         );
     }
 

--- a/tests/Support/FixedClock.php
+++ b/tests/Support/FixedClock.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Support;
+
+use DateTimeImmutable;
+use Nene2\Http\ClockInterface;
+
+/**
+ * Test {@see ClockInterface} that always returns a fixed instant, so time-boundary
+ * behaviour (token TTL/exp, scheduled publish, rate-limit windows) is deterministic.
+ */
+final readonly class FixedClock implements ClockInterface
+{
+    public function __construct(private string $instant = '2026-06-01T10:00:00+00:00')
+    {
+    }
+
+    public function now(): DateTimeImmutable
+    {
+        return new DateTimeImmutable($this->instant);
+    }
+}

--- a/tests/TextField/TextFieldHttpTest.php
+++ b/tests/TextField/TextFieldHttpTest.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Tests\TextField;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Entity\CreateEntityHandler;
 use NeNeRecords\Entity\CreateEntityUseCase;
 use NeNeRecords\Entity\DeleteEntityHandler;
@@ -80,16 +81,16 @@ final class TextFieldHttpTest extends TestCase
         $entityRegistrar = new EntityRouteRegistrar(
             new GetEntityByIdHandler(new GetEntityByIdUseCase($this->entities), $jsonResponse),
             new CreateEntityHandler(new CreateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
-            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes), $jsonResponse),
+            new UpdateEntityHandler(new UpdateEntityUseCase($this->entities, $this->entityTypes, new UtcClock()), $jsonResponse),
             new DeleteEntityHandler(new DeleteEntityUseCase($this->entities), $this->factory),
             new \NeNeRecords\Entity\MoveEntityHandler(new \NeNeRecords\Entity\MoveEntitySubtreeUseCase($this->entities), $jsonResponse),
             new \NeNeRecords\Entity\ReorderEntitiesHandler(new \NeNeRecords\Entity\ReorderEntitiesUseCase($this->entities), $jsonResponse),
-            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
+            new ListEntitiesHandler(new ListEntitiesUseCase($this->entities, new UtcClock()), $jsonResponse, new ExcerptResolver(new InMemoryTextFieldRepository(), new InMemorySettingRepository())),
             new ListEntityRevisionsHandler(new ListEntityRevisionsUseCase($this->entities), $jsonResponse),
             new ExportEntitiesHandler($this->entities, $this->textFields, $this->factory),
-            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities), $jsonResponse),
+            new ScheduleEntityHandler(new ScheduleEntityUseCase($this->entities, new UtcClock()), $jsonResponse),
             new UnscheduleEntityHandler(new UnscheduleEntityUseCase($this->entities), $this->factory),
-            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities), $jsonResponse),
+            new ProcessScheduledPublishHandler(new ProcessScheduledPublishUseCase($this->entities, new UtcClock()), $jsonResponse),
         );
 
         $textFieldRegistrar = new TextFieldRouteRegistrar(

--- a/tests/User/UserHttpTest.php
+++ b/tests/User/UserHttpTest.php
@@ -8,6 +8,7 @@ use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Http\SecureTokenHelper;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Auth\User;
 use NeNeRecords\Tests\UserInvite\NullMailer;
 use NeNeRecords\User\CannotDeleteSelfExceptionHandler;
@@ -83,8 +84,8 @@ final class UserHttpTest extends TestCase
             new ResetUserPasswordHandler(new ResetUserPasswordUseCase($this->repository), $this->factory),
             new DeleteUserHandler(new DeleteUserUseCase($this->repository), $this->factory),
             new ChangePasswordHandler(new ChangePasswordUseCase($this->repository), $this->factory),
-            new ChangeEmailHandler(new ChangeEmailUseCase($this->repository, $this->mailer), $this->factory),
-            new VerifyEmailChangeHandler(new VerifyEmailChangeUseCase($this->repository), $this->factory),
+            new ChangeEmailHandler(new ChangeEmailUseCase($this->repository, $this->mailer, new UtcClock()), $this->factory),
+            new VerifyEmailChangeHandler(new VerifyEmailChangeUseCase($this->repository, new UtcClock()), $this->factory),
             new UpdateUserProfileHandler(new UpdateUserProfileUseCase($this->repository, $this->profiles), $jsonResponse),
         );
 

--- a/tests/UserInvite/InviteUserMultitenancyTest.php
+++ b/tests/UserInvite/InviteUserMultitenancyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Tests\UserInvite;
 
+use Nene2\Http\UtcClock;
 use NeNeRecords\Tests\User\InMemoryUserRepository;
 use NeNeRecords\UserInvite\InviteUserInput;
 use NeNeRecords\UserInvite\InviteUserUseCase;
@@ -24,7 +25,7 @@ final class InviteUserMultitenancyTest extends TestCase
     {
         $users = new InMemoryUserRepository([]);
         $mailer = new NullMailer();
-        $useCase = new InviteUserUseCase($users, $mailer);
+        $useCase = new InviteUserUseCase($users, $mailer, new UtcClock());
 
         $useCase->execute(new InviteUserInput(
             email: 'invite@org.example.com',
@@ -45,7 +46,7 @@ final class InviteUserMultitenancyTest extends TestCase
     {
         $users = new InMemoryUserRepository([]);
         $mailer = new NullMailer();
-        $useCase = new InviteUserUseCase($users, $mailer);
+        $useCase = new InviteUserUseCase($users, $mailer, new UtcClock());
 
         $useCase->execute(new InviteUserInput(
             email: 'editor@org.example.com',
@@ -66,7 +67,7 @@ final class InviteUserMultitenancyTest extends TestCase
     {
         $users = new InMemoryUserRepository([]);
         $mailer = new NullMailer();
-        $useCase = new InviteUserUseCase($users, $mailer);
+        $useCase = new InviteUserUseCase($users, $mailer, new UtcClock());
 
         $useCase->execute(new InviteUserInput(
             email: 'lead@org.example.com',
@@ -88,7 +89,7 @@ final class InviteUserMultitenancyTest extends TestCase
     {
         $users = new InMemoryUserRepository([]);
         $mailer = new NullMailer();
-        $useCase = new InviteUserUseCase($users, $mailer);
+        $useCase = new InviteUserUseCase($users, $mailer, new UtcClock());
 
         $output = $useCase->execute(new InviteUserInput(
             email: 'pending@org.example.com',
@@ -111,7 +112,7 @@ final class InviteUserMultitenancyTest extends TestCase
     {
         $users = new InMemoryUserRepository([]);
         $mailer = new NullMailer();
-        $useCase = new InviteUserUseCase($users, $mailer);
+        $useCase = new InviteUserUseCase($users, $mailer, new UtcClock());
 
         $useCase->execute(new InviteUserInput(
             email: 'newmember@org.example.com',
@@ -132,7 +133,7 @@ final class InviteUserMultitenancyTest extends TestCase
     {
         $users = new InMemoryUserRepository([]);
         $mailer = new NullMailer();
-        $useCase = new InviteUserUseCase($users, $mailer);
+        $useCase = new InviteUserUseCase($users, $mailer, new UtcClock());
 
         $useCase->execute(new InviteUserInput(
             email: 'org3member@example.com',

--- a/tests/UserInvite/UserInviteHttpTest.php
+++ b/tests/UserInvite/UserInviteHttpTest.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Tests\UserInvite;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Auth\User;
 use NeNeRecords\Tests\User\InMemoryUserRepository;
 use NeNeRecords\User\InvalidUserRoleExceptionHandler;
@@ -56,10 +57,10 @@ final class UserInviteHttpTest extends TestCase
         $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
 
         $registrar = new UserInviteRouteRegistrar(
-            new InviteUserHandler(new InviteUserUseCase($this->repository, $this->mailer), $jsonResponse),
-            new AcceptInviteHandler(new AcceptInviteUseCase($this->repository), $this->factory),
-            new RequestPasswordResetHandler(new RequestPasswordResetUseCase($this->repository, $this->mailer), $this->factory),
-            new ConfirmPasswordResetHandler(new ConfirmPasswordResetUseCase($this->repository), $this->factory),
+            new InviteUserHandler(new InviteUserUseCase($this->repository, $this->mailer, new UtcClock()), $jsonResponse),
+            new AcceptInviteHandler(new AcceptInviteUseCase($this->repository, new UtcClock()), $this->factory),
+            new RequestPasswordResetHandler(new RequestPasswordResetUseCase($this->repository, $this->mailer, new UtcClock()), $this->factory),
+            new ConfirmPasswordResetHandler(new ConfirmPasswordResetUseCase($this->repository, new UtcClock()), $this->factory),
         );
 
         $this->application = (new RuntimeApplicationFactory(

--- a/tests/UserInvite/UserInviteUseCaseTest.php
+++ b/tests/UserInvite/UserInviteUseCaseTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Tests\UserInvite;
 
 use Nene2\Http\SecureTokenHelper;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Auth\User;
 use NeNeRecords\Tests\User\InMemoryUserRepository;
 use NeNeRecords\User\InvalidUserRoleException;
@@ -31,7 +32,7 @@ final class UserInviteUseCaseTest extends TestCase
     {
         $users = new InMemoryUserRepository([]);
         $mailer = new NullMailer();
-        $useCase = new InviteUserUseCase($users, $mailer);
+        $useCase = new InviteUserUseCase($users, $mailer, new UtcClock());
 
         $email = 'new-editor@example.com';
         $output = $useCase->execute(new InviteUserInput(
@@ -60,7 +61,7 @@ final class UserInviteUseCaseTest extends TestCase
     {
         $users = new InMemoryUserRepository([]);
         $mailer = new NullMailer();
-        $useCase = new InviteUserUseCase($users, $mailer);
+        $useCase = new InviteUserUseCase($users, $mailer, new UtcClock());
 
         $this->expectException(InvalidUserRoleException::class);
 
@@ -78,7 +79,7 @@ final class UserInviteUseCaseTest extends TestCase
             new User(id: 1, email: 'taken@example.com', passwordHash: $hash, role: 'admin'),
         ]);
         $mailer = new NullMailer();
-        $useCase = new InviteUserUseCase($users, $mailer);
+        $useCase = new InviteUserUseCase($users, $mailer, new UtcClock());
 
         $this->expectException(UserEmailConflictException::class);
 
@@ -102,7 +103,7 @@ final class UserInviteUseCaseTest extends TestCase
         [$rawToken, $tokenHash] = SecureTokenHelper::generateWithHash();
         $users->storeInviteToken($user->id, $tokenHash, time() + 3600);
 
-        $useCase = new AcceptInviteUseCase($users);
+        $useCase = new AcceptInviteUseCase($users, new UtcClock());
         $useCase->execute(new AcceptInviteInput(
             token: $rawToken,
             password: 'my-new-secure-password',
@@ -118,7 +119,7 @@ final class UserInviteUseCaseTest extends TestCase
     public function testAcceptInviteThrowsInvalidInviteTokenExceptionForInvalidToken(): void
     {
         $users = new InMemoryUserRepository([]);
-        $useCase = new AcceptInviteUseCase($users);
+        $useCase = new AcceptInviteUseCase($users, new UtcClock());
 
         $this->expectException(InvalidInviteTokenException::class);
 
@@ -138,7 +139,7 @@ final class UserInviteUseCaseTest extends TestCase
         // Store with an already-past expiry
         $users->storeInviteToken($user->id, $tokenHash, time() - 1);
 
-        $useCase = new AcceptInviteUseCase($users);
+        $useCase = new AcceptInviteUseCase($users, new UtcClock());
 
         $this->expectException(InvalidInviteTokenException::class);
 
@@ -161,7 +162,7 @@ final class UserInviteUseCaseTest extends TestCase
         [$rawToken, $tokenHash] = SecureTokenHelper::generateWithHash();
         $users->storePasswordResetToken($user->id, $tokenHash, time() + 3600);
 
-        $useCase = new ConfirmPasswordResetUseCase($users);
+        $useCase = new ConfirmPasswordResetUseCase($users, new UtcClock());
         $useCase->execute(new ConfirmPasswordResetInput(
             token: $rawToken,
             newPassword: 'brand-new-password',
@@ -177,7 +178,7 @@ final class UserInviteUseCaseTest extends TestCase
     public function testConfirmPasswordResetThrowsInvalidPasswordResetTokenExceptionForInvalidToken(): void
     {
         $users = new InMemoryUserRepository([]);
-        $useCase = new ConfirmPasswordResetUseCase($users);
+        $useCase = new ConfirmPasswordResetUseCase($users, new UtcClock());
 
         $this->expectException(InvalidPasswordResetTokenException::class);
 
@@ -197,7 +198,7 @@ final class UserInviteUseCaseTest extends TestCase
         // Store with an already-past expiry
         $users->storePasswordResetToken($user->id, $tokenHash, time() - 1);
 
-        $useCase = new ConfirmPasswordResetUseCase($users);
+        $useCase = new ConfirmPasswordResetUseCase($users, new UtcClock());
 
         $this->expectException(InvalidPasswordResetTokenException::class);
 
@@ -218,7 +219,7 @@ final class UserInviteUseCaseTest extends TestCase
             new User(id: 1, email: 'known@example.com', passwordHash: $hash, role: 'editor'),
         ]);
         $mailer = new NullMailer();
-        $useCase = new RequestPasswordResetUseCase($users, $mailer);
+        $useCase = new RequestPasswordResetUseCase($users, $mailer, new UtcClock());
 
         $useCase->execute(new RequestPasswordResetInput(
             email: 'known@example.com',
@@ -233,7 +234,7 @@ final class UserInviteUseCaseTest extends TestCase
     {
         $users = new InMemoryUserRepository([]);
         $mailer = new NullMailer();
-        $useCase = new RequestPasswordResetUseCase($users, $mailer);
+        $useCase = new RequestPasswordResetUseCase($users, $mailer, new UtcClock());
 
         // Must not throw — silently succeeds to prevent email enumeration
         $useCase->execute(new RequestPasswordResetInput(

--- a/tests/Webhook/ProcessWebhookDeliveriesHandlerTest.php
+++ b/tests/Webhook/ProcessWebhookDeliveriesHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Tests\Webhook;
 
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Webhook\ProcessWebhookDeliveriesHandler;
 use NeNeRecords\Webhook\WebhookDeliveryProcessor;
 use NeNeRecords\Webhook\WebhookSendResult;
@@ -42,7 +43,7 @@ final class ProcessWebhookDeliveriesHandlerTest extends TestCase
     private function handler(WebhookSendResult $result): ProcessWebhookDeliveriesHandler
     {
         return new ProcessWebhookDeliveriesHandler(
-            new WebhookDeliveryProcessor($this->deliveries, new FakeWebhookSender($result)),
+            new WebhookDeliveryProcessor($this->deliveries, new FakeWebhookSender($result), new UtcClock()),
             new JsonResponseFactory($this->factory, $this->factory),
         );
     }

--- a/tests/Webhook/QueueingWebhookDispatcherTest.php
+++ b/tests/Webhook/QueueingWebhookDispatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Tests\Webhook;
 
+use Nene2\Http\UtcClock;
 use NeNeRecords\Webhook\QueueingWebhookDispatcher;
 use NeNeRecords\Webhook\Webhook;
 use PHPUnit\Framework\TestCase;
@@ -20,7 +21,7 @@ final class QueueingWebhookDispatcherTest extends TestCase
 
         $this->webhooks = new InMemoryWebhookRepository();
         $this->deliveries = new InMemoryWebhookDeliveryRepository();
-        $this->dispatcher = new QueueingWebhookDispatcher($this->webhooks, $this->deliveries);
+        $this->dispatcher = new QueueingWebhookDispatcher($this->webhooks, $this->deliveries, new UtcClock());
     }
 
     private function seedWebhook(string $url, string $event, ?int $entityTypeId, ?string $secret = null): void

--- a/tests/Webhook/WebhookDeliveryProcessorTest.php
+++ b/tests/Webhook/WebhookDeliveryProcessorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Tests\Webhook;
 
+use Nene2\Http\UtcClock;
 use NeNeRecords\Webhook\WebhookDeliveryProcessor;
 use NeNeRecords\Webhook\WebhookSendResult;
 use PHPUnit\Framework\TestCase;
@@ -37,7 +38,7 @@ final class WebhookDeliveryProcessorTest extends TestCase
     {
         $id = $this->enqueue();
         $sender = new FakeWebhookSender(WebhookSendResult::ok(200));
-        $processor = new WebhookDeliveryProcessor($this->deliveries, $sender);
+        $processor = new WebhookDeliveryProcessor($this->deliveries, $sender, new UtcClock());
 
         $summary = $processor->process(50, 2000);
 
@@ -52,7 +53,7 @@ final class WebhookDeliveryProcessorTest extends TestCase
     {
         $id = $this->enqueue(maxAttempts: 5);
         $sender = new FakeWebhookSender(WebhookSendResult::failure('timeout'));
-        $processor = new WebhookDeliveryProcessor($this->deliveries, $sender);
+        $processor = new WebhookDeliveryProcessor($this->deliveries, $sender, new UtcClock());
 
         $now = 2000;
         $summary = $processor->process(50, $now);
@@ -72,7 +73,7 @@ final class WebhookDeliveryProcessorTest extends TestCase
         // maxAttempts=1 → the first failure exhausts the budget.
         $id = $this->enqueue(maxAttempts: 1);
         $sender = new FakeWebhookSender(WebhookSendResult::failure('connection refused'));
-        $processor = new WebhookDeliveryProcessor($this->deliveries, $sender);
+        $processor = new WebhookDeliveryProcessor($this->deliveries, $sender, new UtcClock());
 
         $summary = $processor->process(50, 2000);
 
@@ -86,7 +87,7 @@ final class WebhookDeliveryProcessorTest extends TestCase
     {
         $this->enqueue(nextAttemptAt: 5000);
         $sender = new FakeWebhookSender(WebhookSendResult::ok(200));
-        $processor = new WebhookDeliveryProcessor($this->deliveries, $sender);
+        $processor = new WebhookDeliveryProcessor($this->deliveries, $sender, new UtcClock());
 
         $summary = $processor->process(50, 2000);
 

--- a/tests/Webhook/WebhookHttpTest.php
+++ b/tests/Webhook/WebhookHttpTest.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\Tests\Webhook;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use NeNeRecords\Webhook\CreateWebhookHandler;
 use NeNeRecords\Webhook\CreateWebhookUseCase;
 use NeNeRecords\Webhook\DeleteWebhookHandler;
@@ -44,13 +45,13 @@ final class WebhookHttpTest extends TestCase
         $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
 
         $deliveries = new InMemoryWebhookDeliveryRepository();
-        $processor = new WebhookDeliveryProcessor($deliveries, new FakeWebhookSender(WebhookSendResult::ok(200)));
+        $processor = new WebhookDeliveryProcessor($deliveries, new FakeWebhookSender(WebhookSendResult::ok(200)), new UtcClock());
 
         $registrar = new WebhookRouteRegistrar(
             new ListWebhooksHandler(new ListWebhooksUseCase($this->webhooks), $jsonResponse),
             new GetWebhookByIdHandler(new GetWebhookByIdUseCase($this->webhooks), $jsonResponse),
-            new CreateWebhookHandler(new CreateWebhookUseCase($this->webhooks), $jsonResponse),
-            new UpdateWebhookHandler(new UpdateWebhookUseCase($this->webhooks), $jsonResponse),
+            new CreateWebhookHandler(new CreateWebhookUseCase($this->webhooks, new UtcClock()), $jsonResponse),
+            new UpdateWebhookHandler(new UpdateWebhookUseCase($this->webhooks, new UtcClock()), $jsonResponse),
             new DeleteWebhookHandler(new DeleteWebhookUseCase($this->webhooks), $jsonResponse),
             new ProcessWebhookDeliveriesHandler($processor, $jsonResponse),
         );

--- a/tests/Webhook/WebhookUseCaseTest.php
+++ b/tests/Webhook/WebhookUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Tests\Webhook;
 
+use Nene2\Http\UtcClock;
 use NeNeRecords\Webhook\CreateWebhookInput;
 use NeNeRecords\Webhook\CreateWebhookUseCase;
 use NeNeRecords\Webhook\DeleteWebhookInput;
@@ -20,7 +21,7 @@ final class CreateWebhookUseCaseTest extends TestCase
     public function testCreatesWebhookAndReturnsCorrectOutput(): void
     {
         $webhooks = new InMemoryWebhookRepository();
-        $useCase = new CreateWebhookUseCase($webhooks);
+        $useCase = new CreateWebhookUseCase($webhooks, new UtcClock());
 
         $output = $useCase->execute(new CreateWebhookInput(
             url: 'https://example.com/hook',
@@ -43,7 +44,7 @@ final class CreateWebhookUseCaseTest extends TestCase
     public function testCreatesWebhookWithNullableFields(): void
     {
         $webhooks = new InMemoryWebhookRepository();
-        $useCase = new CreateWebhookUseCase($webhooks);
+        $useCase = new CreateWebhookUseCase($webhooks, new UtcClock());
 
         $output = $useCase->execute(new CreateWebhookInput(
             url: 'https://example.com/hook',
@@ -62,7 +63,7 @@ final class CreateWebhookUseCaseTest extends TestCase
     public function testAssignsSequentialIds(): void
     {
         $webhooks = new InMemoryWebhookRepository();
-        $useCase = new CreateWebhookUseCase($webhooks);
+        $useCase = new CreateWebhookUseCase($webhooks, new UtcClock());
 
         $first = $useCase->execute(new CreateWebhookInput(
             url: 'https://example.com/hook1',
@@ -89,7 +90,7 @@ final class UpdateWebhookUseCaseTest extends TestCase
     public function testUpdatesWebhookAndReturnsOutput(): void
     {
         $webhooks = new InMemoryWebhookRepository();
-        $createUseCase = new CreateWebhookUseCase($webhooks);
+        $createUseCase = new CreateWebhookUseCase($webhooks, new UtcClock());
         $createUseCase->execute(new CreateWebhookInput(
             url: 'https://example.com/hook',
             events: ['entity.created'],
@@ -98,7 +99,7 @@ final class UpdateWebhookUseCaseTest extends TestCase
             isActive: true,
         ));
 
-        $updateUseCase = new UpdateWebhookUseCase($webhooks);
+        $updateUseCase = new UpdateWebhookUseCase($webhooks, new UtcClock());
         $output = $updateUseCase->execute(new UpdateWebhookInput(
             id: 1,
             url: 'https://example.com/hook-updated',
@@ -119,7 +120,7 @@ final class UpdateWebhookUseCaseTest extends TestCase
     public function testThrowsWebhookNotFoundExceptionIfNotFound(): void
     {
         $webhooks = new InMemoryWebhookRepository();
-        $useCase = new UpdateWebhookUseCase($webhooks);
+        $useCase = new UpdateWebhookUseCase($webhooks, new UtcClock());
 
         $this->expectException(WebhookNotFoundException::class);
 
@@ -139,7 +140,7 @@ final class DeleteWebhookUseCaseTest extends TestCase
     public function testDeletesWebhook(): void
     {
         $webhooks = new InMemoryWebhookRepository();
-        $createUseCase = new CreateWebhookUseCase($webhooks);
+        $createUseCase = new CreateWebhookUseCase($webhooks, new UtcClock());
         $createUseCase->execute(new CreateWebhookInput(
             url: 'https://example.com/hook',
             events: [],
@@ -170,7 +171,7 @@ final class GetWebhookByIdUseCaseTest extends TestCase
     public function testReturnsWebhook(): void
     {
         $webhooks = new InMemoryWebhookRepository();
-        $createUseCase = new CreateWebhookUseCase($webhooks);
+        $createUseCase = new CreateWebhookUseCase($webhooks, new UtcClock());
         $createUseCase->execute(new CreateWebhookInput(
             url: 'https://example.com/hook',
             events: ['entity.created'],


### PR DESCRIPTION
## 目的

検品 C（NENE2 上流化 準拠 sweep）の **Clock** 分。records の業務コードが現在時刻を生の time API（`time()` / 単一引数 `date()` / `new DateTimeImmutable('now')`）で直書きしており、NENE2 `Nene2\Http\ClockInterface` 未採用だった。時刻依存ロジック（トークン TTL・exp/nbf 判定・スケジュール公開・レート制限窓・created_at/updated_at）が実クロックに縛られ、テストを決定論化できなかった。

設計: `_work/reports/2026-07-06/upstream-design/06-clock-v-config-sweep.md`（Recipe A）。参照実装は sibling **nene-clear**（Clock 採用済み・生時刻残存ゼロ）。独自 Clock は作らず、NENE2 の `ClockInterface`/`UtcClock` に厳密準拠。

## 変更内容

- **DI 束縛**: `RuntimeServiceProvider` に `ClockInterface -> UtcClock` を 1 箇所束縛。既定は `UtcClock` ＝**本番挙動不変**（`UtcClock::now()->getTimestamp() === time()`、UTC/Unix 秒）。
- **注入**: 現在時刻を読む UseCase / Handler / Service / Pdo リポジトリに `ClockInterface` をコンストラクタ注入し、生 time API を `$this->clock->now()` 由来へ置換。NENE2 conformance ルール **D4 (RawClockRule)** が検出する `src/` 全域のサイト（実測 66 箇所 / 約40ファイル）を網羅。
- **テスト**: 新設 `NeNeRecords\Tests\Support\FixedClock` を注入して時刻依存テストを決定論化。代表として `LoginUseCaseTest::testTokenClaimsAreDeterministicWithFixedClock` で iat/exp/expiresAt が固定時刻に厳密一致することを実証。挙動不変が要点の箇所（トークン失効テスト等）は `UtcClock` を注入し生 `time()` と完全同値を維持。

## 対象外（意図的）

- 表示整形の `date($fmt, $ts)`（明示タイムスタンプ付き＝現在時刻読みではない）。
- `PdoAccessLogRepository::52` の `mktime(0,0,0,$month,1,$year)`（明示 `$month/$year` 引数。D4 の粗いトークン検出による**偽陽性**。clock 化すると挙動が壊れるため据え置き）。
- **Validation V / ConfigLoader**（設計で defer 確定）。

## 検証

- `composer test` 緑（**1197 tests, 3340 assertions**）
- `composer analyse`（PHPStan level 8）エラー 0 — 全 `new X(...)` の引数整合を静的に担保
- `composer cs`（CS-Fixer）クリーン（0 fixable）
- D4 finding: **68 → 1**（残 1 は上記 mktime 偽陽性）
- 実コンテナ（`RuntimeContainerFactory`）で `ClockInterface → UtcClock` 解決、`getTimestamp() === time()` を確認。clock 注入済み全サービス（Entity / Webhook / Analytics / Dashboard / OrgExport / EntityArchive / Media / PreviewToken / Auth / Signup / UserInvite / User / Setting / Notification / RateLimit）が正しく wire することを実解決で確認。

## 本番不変の担保

既定 `UtcClock` は `time()` と同一の Unix 秒（UTC）を返すため、時刻挙動は現行と完全同値。optional でない位置に注入したコンストラクタ引数は全 DI 経路・全テストで更新済み。

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)