### PR TITLE
build(conformance): 準拠リンタを composer check に組み込む (#735)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "cs": "php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php",
         "cs:fix": "php-cs-fixer fix --config=.php-cs-fixer.php",
         "openapi": "php tools/validate-openapi.php",
+        "conformance": "php vendor/hideyukimori/nene2/tools/conformance.php --root=.",
         "mcp": "php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php --root=.",
         "mcp:generate": "php tools/generate-mcp-tools.php",
         "migrations:new": "php tools/migration-new.php",
@@ -51,6 +52,7 @@
             "@analyse",
             "@cs",
             "@openapi",
+            "@conformance",
             "@mcp"
         ]
     },

--- a/conformance.baseline.json
+++ b/conformance.baseline.json
@@ -1,0 +1,11 @@
+{
+    "version": 1,
+    "allow": [
+        {
+            "rule": "D4",
+            "file": "src/Analytics/PdoAccessLogRepository.php",
+            "reason": "False positive: mktime(0, 0, 0, $month, 1, $year) in countByYearMonth() builds a timestamp from explicit year/month arguments to derive the month's last day via date('t', ...). It never reads the wall clock, so ClockInterface is not applicable."
+        }
+    ],
+    "ignore": []
+}


### PR DESCRIPTION
## 目的

上流化 設計提案 04（検品C・`_work/reports/2026-07-06/upstream-design/04-conformance-linter.md`）で NENE2 v1.8.2 に追加された準拠リンタ（error 4ルール D1–D4）を NeNe Records へ横展開し、`composer check` に自己組込みする。

## 変更点

- `composer.json`
  - `scripts.conformance` = `php vendor/hideyukimori/nene2/tools/conformance.php --root=.` を配線
  - `scripts.check` に `@conformance` を追加（D3「check 未組込」を自己充足）
- `conformance.baseline.json` を新規追加（既存ドリフトの逃がし弁 / phpstan baseline 同型）

NENE2 は path-repo `@dev`（`../NENE2` への symlink）で **v1.8.2** を参照するため、`composer.lock` の更新は不要。

## 検出内訳

| ルール | 内容 | 結果 |
|---|---|---|
| D1 | JWT 既定secretリテラル | 該当なし |
| D2 | 依存ブランチ固定 | 該当なし |
| D3 | check 未組込 | 配線で解消 |
| D4 | 生 time API | 1件（#734 Clock sweep 済） |

D4 の 1件（`src/Analytics/PdoAccessLogRepository.php` の `mktime()`）は **真の偽陽性**。`countByYearMonth()` が明示引数 `$month`/`$year` から `date('t', mktime(0,0,0,$month,1,$year))` で月末日を算出する処理で、壁時計を読まないため `ClockInterface` は適用外。baseline の `allow`（理由必須）で許容した。

## 検証結果

- `composer conformance` → exit 0（`Conformance OK — no error findings (1 suppressed by baseline/ignore)`）
- `composer check` → 緑（1197 tests / 3340 assertions・PHPStan L8 clean・CS clean・OpenAPI valid・conformance OK・MCP valid・exit 0）
- ゲート実効確認: `src/` に新規 `time()` を仕込むと exit 1 で赤化、baseline の FP は引き続き抑制されることを確認 → 撤去済み

## Self-review

Self-review: backend-api, release-ci

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)