### PR TITLE
fix(media): AVIF エンコーダ不在の GD で派生画像が 500 になるのを修正する (#737)

### DIFF
--- a/src/Media/GdImageProcessor.php
+++ b/src/Media/GdImageProcessor.php
@@ -29,6 +29,18 @@ final readonly class GdImageProcessor implements ImageProcessorInterface
         return in_array($mimeType, self::SUPPORTED_SOURCES, true);
     }
 
+    public function supportsOutput(string $format): bool
+    {
+        // GD の encoder はビルドフラグ依存（共有ホスティングでは AVIF 無しが普通にある）。
+        return match ($format) {
+            self::FORMAT_WEBP => function_exists('imagewebp'),
+            self::FORMAT_AVIF => function_exists('imageavif'),
+            self::FORMAT_JPEG => function_exists('imagejpeg'),
+            self::FORMAT_PNG => function_exists('imagepng'),
+            default => false,
+        };
+    }
+
     public function resize(string $sourceBytes, int $maxWidth, string $format): string
     {
         $src = @imagecreatefromstring($sourceBytes);

--- a/src/Media/ImageProcessorInterface.php
+++ b/src/Media/ImageProcessorInterface.php
@@ -20,6 +20,14 @@ interface ImageProcessorInterface
     public function supportsSource(string $mimeType): bool;
 
     /**
+     * Whether this processor can encode the given output format (one of the
+     * FORMAT_* constants). Encoder availability depends on how the underlying
+     * library was built (e.g. GD without --with-avif has no imageavif()), so
+     * format negotiation must consult this before selecting a format.
+     */
+    public function supportsOutput(string $format): bool;
+
+    /**
      * Resize $sourceBytes to fit within $maxWidth (never upscaling) and encode as
      * $format (one of the FORMAT_* constants). Returns the encoded image bytes.
      *

--- a/src/Media/ServeDerivativeHandler.php
+++ b/src/Media/ServeDerivativeHandler.php
@@ -106,24 +106,34 @@ final readonly class ServeDerivativeHandler
             ImageProcessorInterface::FORMAT_PNG,
         ];
 
-        if ($fm !== null && in_array($fm, $allowed, true)) {
+        // encoder はビルドフラグ依存（GD の AVIF 無しビルド等）。processor が出力
+        // できない形式を選ぶと encode 時に fatal になるため、交渉は常に能力込みで行う。
+        if ($fm !== null && in_array($fm, $allowed, true) && $this->processor->supportsOutput($fm)) {
             return $fm;
         }
 
-        if (str_contains($accept, 'image/avif')) {
+        if (str_contains($accept, 'image/avif') && $this->processor->supportsOutput(ImageProcessorInterface::FORMAT_AVIF)) {
             return ImageProcessorInterface::FORMAT_AVIF;
         }
 
-        if (str_contains($accept, 'image/webp')) {
+        if (str_contains($accept, 'image/webp') && $this->processor->supportsOutput(ImageProcessorInterface::FORMAT_WEBP)) {
             return ImageProcessorInterface::FORMAT_WEBP;
         }
 
-        return match ($sourceMime) {
+        $sourceFormat = match ($sourceMime) {
             'image/png' => ImageProcessorInterface::FORMAT_PNG,
             'image/webp' => ImageProcessorInterface::FORMAT_WEBP,
             'image/avif' => ImageProcessorInterface::FORMAT_AVIF,
             default => ImageProcessorInterface::FORMAT_JPEG,
         };
+
+        if ($this->processor->supportsOutput($sourceFormat)) {
+            return $sourceFormat;
+        }
+
+        return $this->processor->supportsOutput(ImageProcessorInterface::FORMAT_PNG)
+            ? ImageProcessorInterface::FORMAT_PNG
+            : ImageProcessorInterface::FORMAT_JPEG;
     }
 
     /** @return array{0: string, 1: string} [mime, extension] */

--- a/tests/Media/GdImageProcessorTest.php
+++ b/tests/Media/GdImageProcessorTest.php
@@ -73,4 +73,17 @@ final class GdImageProcessorTest extends TestCase
         self::assertFalse($processor->supportsSource('application/pdf'));
         self::assertFalse($processor->supportsSource('image/svg+xml'));
     }
+
+    public function testSupportsOutputReflectsAvailableEncoders(): void
+    {
+        $processor = new GdImageProcessor();
+
+        // PNG/JPEG/WebP は GD の標準構成で常に有効。AVIF はビルドフラグ依存なので
+        // 環境の実状（imageavif の有無）と一致することだけを検証する。
+        self::assertTrue($processor->supportsOutput(ImageProcessorInterface::FORMAT_PNG));
+        self::assertTrue($processor->supportsOutput(ImageProcessorInterface::FORMAT_JPEG));
+        self::assertTrue($processor->supportsOutput(ImageProcessorInterface::FORMAT_WEBP));
+        self::assertSame(function_exists('imageavif'), $processor->supportsOutput(ImageProcessorInterface::FORMAT_AVIF));
+        self::assertFalse($processor->supportsOutput('tiff'));
+    }
 }

--- a/tests/Media/MediaHttpTest.php
+++ b/tests/Media/MediaHttpTest.php
@@ -8,10 +8,12 @@ use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Http\UtcClock;
+use Nene2\Routing\Router;
 use NeNeRecords\Media\DeleteMediaHandler;
 use NeNeRecords\Media\DeleteMediaUseCase;
 use NeNeRecords\Media\FindMediaUsagesUseCase;
 use NeNeRecords\Media\GdImageProcessor;
+use NeNeRecords\Media\ImageProcessorInterface;
 use NeNeRecords\Media\ListMediaHandler;
 use NeNeRecords\Media\ListMediaUsagesHandler;
 use NeNeRecords\Media\ListMediaUseCase;
@@ -472,6 +474,33 @@ final class MediaHttpTest extends TestCase
         self::assertSame(404, $response->getStatusCode());
     }
 
+    public function testDerivativeFallsBackToWebpWhenAvifEncoderIsUnavailable(): void
+    {
+        // GD の AVIF 無しビルド（共有ホスティングで実在）では、Accept: image/avif を
+        // 受けても encode 可能な形式へフォールバックしなければならない（#737）。
+        $this->seedStorageImage('2026/05/pic.png', 200, 200);
+
+        $response = $this->avifLessDerivativeHandler()->handle(
+            $this->derivativeRequest('thumb', 'pic.png')
+                ->withHeader('Accept', 'image/avif,image/webp,image/*'),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('image/webp', $response->getHeaderLine('Content-Type'));
+    }
+
+    public function testDerivativeWithUnsupportedFormatOverrideFallsBack(): void
+    {
+        $this->seedStorageImage('2026/05/pic.png', 200, 200);
+
+        $response = $this->avifLessDerivativeHandler()->handle(
+            $this->derivativeRequest('thumb', 'pic.png', '?fm=avif'),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('image/png', $response->getHeaderLine('Content-Type'), 'fm=avif が使えない場合はソース形式へ');
+    }
+
     public function testDerivativeForUndecodableSourceReturns404(): void
     {
         // A file with an image extension but non-image bytes must not 500.
@@ -484,6 +513,53 @@ final class MediaHttpTest extends TestCase
         );
 
         self::assertSame(404, $response->getStatusCode());
+    }
+
+    /** AVIF encoder を持たない環境を模した ServeDerivativeHandler（#737 回帰用）。 */
+    private function avifLessDerivativeHandler(): ServeDerivativeHandler
+    {
+        $processor = new class () implements ImageProcessorInterface {
+            private GdImageProcessor $inner;
+
+            public function __construct()
+            {
+                $this->inner = new GdImageProcessor();
+            }
+
+            public function supportsSource(string $mimeType): bool
+            {
+                return $this->inner->supportsSource($mimeType);
+            }
+
+            public function supportsOutput(string $format): bool
+            {
+                return $format !== self::FORMAT_AVIF && $this->inner->supportsOutput($format);
+            }
+
+            public function resize(string $sourceBytes, int $maxWidth, string $format): string
+            {
+                if ($format === self::FORMAT_AVIF) {
+                    throw new \Error('Call to undefined function imageavif()');
+                }
+
+                return $this->inner->resize($sourceBytes, $maxWidth, $format);
+            }
+        };
+
+        return new ServeDerivativeHandler($this->storage, $processor, $this->factory, $this->factory);
+    }
+
+    private function derivativeRequest(string $preset, string $filename, string $query = ''): \Psr\Http\Message\ServerRequestInterface
+    {
+        return $this->factory
+            ->createServerRequest('GET', "https://example.test/media/{$preset}/2026/05/{$filename}{$query}")
+            ->withQueryParams($query === '' ? [] : ['fm' => substr($query, strlen('?fm='))])
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, [
+                'preset' => $preset,
+                'year' => '2026',
+                'month' => '05',
+                'filename' => $filename,
+            ]);
     }
 
     /**


### PR DESCRIPTION
## 目的

Tier A 設置リハーサル（AYANE レーン・2026-07-09）で発見したバグの修正。
GD が AVIF 無しビルドの環境（共有ホスティングで実在・php:8.4 公式イメージも該当）では、
Chrome/Edge が送る `Accept: image/avif` に対し `imageavif()` 未定義の PHP Error で
**派生画像リクエストが全て 500** になる。

## 変更

- `ImageProcessorInterface` に `supportsOutput(string $format): bool` を追加
- `GdImageProcessor::supportsOutput()` — `function_exists()` で encoder 実在を判定
- `ServeDerivativeHandler::negotiateFormat()` — 交渉を能力込みに変更。
  AVIF 不可なら webp → ソース形式 → PNG へフォールバック。`?fm=` 明示指定が
  未対応形式でも 500 にしない
- 回帰テスト: AVIF-less processor で `Accept: image/avif` → 200 `image/webp`、
  `?fm=avif` → 200 ソース形式。`GdImageProcessor::supportsOutput()` の契約テスト

## 検証

- `composer check` 全緑（PHPUnit 1200 tests / PHPStan level 8 0 errors / CS / OpenAPI / MCP / conformance）
- 共有ホスティング相当ハーネス（php:8.4-apache 公式・GD AVIF 無し・docroot=public_html・
  `/blog` サブディレクトリ設置）で v0.5.1 zip に本パッチを当て、
  `Accept: image/avif` 500 → **200 image/webp** を実機確認
- Docker 本番（`--with-avif` ビルド）は挙動不変（AVIF 対応環境では従来どおり AVIF を返す）

## チェックリスト

- [x] Issue driven（#737）
- [x] Conventional Commits
- [x] composer check 全緑

Closes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)