### PR TITLE
fix(org-export): export/import API がルートパラメータを読めず常に 404 になるのを修正する (#739)

### DIFF
--- a/src/OrgExport/ExportOrganizationHandler.php
+++ b/src/OrgExport/ExportOrganizationHandler.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\OrgExport;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
 use NeNeRecords\Organization\OrganizationRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -30,7 +31,7 @@ final readonly class ExportOrganizationHandler implements RequestHandlerInterfac
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $id  = (int) ($request->getAttribute('id') ?? 0);
+        $id  = (int) Router::param($request, 'id');
         $org = $this->orgs->findById($id);
 
         if ($org === null) {

--- a/src/OrgExport/ImportOrganizationHandler.php
+++ b/src/OrgExport/ImportOrganizationHandler.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\OrgExport;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
 use NeNeRecords\Organization\OrganizationRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -33,7 +34,7 @@ final readonly class ImportOrganizationHandler implements RequestHandlerInterfac
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $id  = (int) ($request->getAttribute('id') ?? 0);
+        $id  = (int) Router::param($request, 'id');
         $org = $this->orgs->findById($id);
 
         if ($org === null) {

--- a/tests/OrgExport/OrgExportHttpTest.php
+++ b/tests/OrgExport/OrgExportHttpTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\OrgExport;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Organization\Organization;
+use NeNeRecords\OrgExport\ExportOrganizationHandler;
+use NeNeRecords\OrgExport\ImportOrganizationHandler;
+use NeNeRecords\OrgExport\OrgExportRepositoryInterface;
+use NeNeRecords\OrgExport\OrgExportRouteRegistrar;
+use NeNeRecords\OrgExport\OrgImportRepositoryInterface;
+use NeNeRecords\Tests\Organization\InMemoryOrganizationRepository;
+use NeNeRecords\Tests\Support\FixedClock;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * 実 Router 配線での export/import HTTP テスト。
+ *
+ * ルートパラメータは Router::PARAMETERS_ATTRIBUTE 経由でしか渡らないため、
+ * ハンドラ単体に attribute を手置きするテストでは #739（{id} が常に 0 に落ちて
+ * 404）の退行を検知できない。必ずアプリケーション（実 Router）越しに叩く。
+ */
+final class OrgExportHttpTest extends TestCase
+{
+    private Psr17Factory $factory;
+    private InMemoryOrganizationRepository $orgs;
+    private RecordingOrgImportRepository $importRepository;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        $this->factory = new Psr17Factory();
+        $this->orgs    = new InMemoryOrganizationRepository();
+        $this->orgs->save(new Organization(name: 'Acme', slug: 'acme', plan: 'free', isActive: true));
+
+        $exportRepository       = new StubOrgExportRepository();
+        $this->importRepository = new RecordingOrgImportRepository();
+
+        $jsonResponse   = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+
+        $registrar = new OrgExportRouteRegistrar(
+            new ExportOrganizationHandler($exportRepository, $this->orgs, $jsonResponse, $problemDetails, new FixedClock()),
+            new ImportOrganizationHandler($this->importRepository, $this->orgs, $jsonResponse, $problemDetails),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            routeRegistrars: [$registrar],
+        ))->create();
+    }
+
+    public function testExportResolvesRouteIdAndReturnsPayload(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/superadmin/organizations/1/export'),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertSame(1, $payload['meta']['organization_id']);
+        self::assertSame([['id' => 1, 'slug' => 'posts']], $payload['entity_types']);
+    }
+
+    public function testExportForUnknownOrgReturns404(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/superadmin/organizations/99/export'),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testImportResolvesRouteIdAndDelegatesPayload(): void
+    {
+        $body = $this->factory->createStream((string) json_encode([
+            'meta'         => ['exported_at' => '2026-06-01T10:00:00+00:00', 'organization_id' => 5],
+            'entity_types' => [['id' => 5, 'slug' => 'posts']],
+        ]));
+
+        $response = $this->application->handle(
+            $this->factory
+                ->createServerRequest('POST', 'https://example.test/api/v1/superadmin/organizations/1/import')
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($body),
+        );
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame(1, $this->importRepository->lastTargetOrgId);
+
+        $result = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($result);
+        self::assertSame(1, $result['organization_id']);
+        self::assertSame(['entity_types' => 1], $result['imported']);
+    }
+
+    public function testImportWithoutMetaReturns422(): void
+    {
+        $body = $this->factory->createStream((string) json_encode(['entity_types' => []]));
+
+        $response = $this->application->handle(
+            $this->factory
+                ->createServerRequest('POST', 'https://example.test/api/v1/superadmin/organizations/1/import')
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($body),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+}
+
+final class StubOrgExportRepository implements OrgExportRepositoryInterface
+{
+    /** @return list<array<string, mixed>> */
+    public function findAllEntityTypes(int $orgId): array
+    {
+        return [['id' => 1, 'slug' => 'posts']];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllEntities(int $orgId): array
+    {
+        return [];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllFieldDefs(int $orgId): array
+    {
+        return [];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllTextFields(int $orgId): array
+    {
+        return [];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllIntFields(int $orgId): array
+    {
+        return [];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllEnumFields(int $orgId): array
+    {
+        return [];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllBoolFields(int $orgId): array
+    {
+        return [];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllDatetimeFields(int $orgId): array
+    {
+        return [];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllTags(int $orgId): array
+    {
+        return [];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllEntityTags(int $orgId): array
+    {
+        return [];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllNavigationItems(int $orgId): array
+    {
+        return [];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllSettingDefs(int $orgId): array
+    {
+        return [];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllSettingValues(int $orgId): array
+    {
+        return [];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllMedia(int $orgId): array
+    {
+        return [];
+    }
+}
+
+final class RecordingOrgImportRepository implements OrgImportRepositoryInterface
+{
+    public ?int $lastTargetOrgId = null;
+
+    /** @var array<string, mixed> */
+    public array $lastPayload = [];
+
+    public function import(int $targetOrgId, array $payload): array
+    {
+        $this->lastTargetOrgId = $targetOrgId;
+        $this->lastPayload     = $payload;
+
+        return ['entity_types' => count((array) ($payload['entity_types'] ?? []))];
+    }
+}


### PR DESCRIPTION
## 目的

AYANE Tier A 移送リハーサルで発見: superadmin の org export/import API（M8 #215）が
ルートパラメータ `{id}` を読めず**常に 404** で、HTTP 経由では一度も機能していなかった。

## 変更

- 両ハンドラの `$request->getAttribute('id')` を `Router::param($request, 'id')` へ（他の全ハンドラと同じ契約）
- `tests/OrgExport/OrgExportHttpTest.php` 新設 — **実 Router 配線**で export 200 / 未知 org 404 /
  import 201（target org id の解決を検証）/ meta 欠落 422。OrgExport にはテストが皆無で、
  ハンドラ単体に attribute を手置きする形式ではこの退行を検知できないため、アプリ越しに叩く

## 検証

- `composer check` 全緑（PHPUnit 1204 / PHPStan level 8 / CS / OpenAPI / MCP / conformance）
- Tier A 設置インスタンス（v0.5.1 zip・共有ホスティング相当ハーネス）で同等パッチにより
  404 → 200 & export ペイロード取得を実機確認

## 備考

これは移送経路の入口の修正のみ。import 自体は fresh 設置の seed（posts/pages・設定17定義）と
unique 衝突して即 500 になる等の本質ギャップが別にあり、#741で扱う。

## チェックリスト

- [x] Issue driven（#739）
- [x] Conventional Commits
- [x] composer check 全緑

Closes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)