### PR TITLE
fix(docker): PHP ベースイメージを 8.4.23 に固定する（CVE-2026-12184 / CVE-2026-14355）(#744)

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,4 +1,5 @@
-FROM php:8.4-apache
+# CVE-2026-12184 / CVE-2026-14355 対応で patch level を固定（8.4.23 以上を維持・#744）
+FROM php:8.4.23-apache
 
 ENV COMPOSER_ALLOW_SUPERUSER=1
 

--- a/docker/php/Dockerfile.prod
+++ b/docker/php/Dockerfile.prod
@@ -17,7 +17,8 @@ COPY frontend/ ./
 RUN npm run build
 
 # ── Stage 2: PHP runtime (single-origin Apache) ──
-FROM php:8.4-apache AS runtime
+# CVE-2026-12184 / CVE-2026-14355 対応で patch level を固定（8.4.23 以上を維持・#744）
+FROM php:8.4.23-apache AS runtime
 
 ENV COMPOSER_ALLOW_SUPERUSER=1
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer


### PR DESCRIPTION
## 目的

PHP CVE-2026-12184（FPM DoS・High）/ CVE-2026-14355 の修正版（8.4.23 以上）へ
dev/prod イメージを確実に乗せる（横断 board 課題 #39・本番再ビルドは本日デプロイに同乗）。

## 変更

- `docker/php/Dockerfile` / `docker/php/Dockerfile.prod`: `php:8.4-apache` → `php:8.4.23-apache`（ピン）

## 検証

- `docker manifest inspect php:8.4.23-apache` でタグ実在を確認済み
- 本番デプロイ後にコンテナ内 `php -v` ≥ 8.4.23 を確認（デプロイ手順に含む）

## チェックリスト

- [x] Issue driven（#744）
- [x] Conventional Commits

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)