### PR TITLE
fix(public): パターンURLレコードの固定ページで SPA トップが notFound になるのを修正する (#748)

### DIFF
--- a/frontend/src/pages/consumer/PublicRecordDetailPage.test.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.test.tsx
@@ -1,7 +1,10 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { cleanup, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
-import { PublicRecordDetailPage } from '@/pages/consumer/PublicRecordDetailPage'
+import {
+  PublicRecordByPermalink,
+  PublicRecordDetailPage,
+} from '@/pages/consumer/PublicRecordDetailPage'
 import { resetBoolFieldStore, seedBoolFields } from '@tests/msw/handlers/bool-field'
 import { resetEntityStore, seedEntities } from '@tests/msw/handlers/entity'
 import { resetEntityRelationStore, seedEntityRelations } from '@tests/msw/handlers/entity-relation'
@@ -192,6 +195,64 @@ describe('PublicRecordDetailPage', () => {
     renderDetailPage('unknown', 1)
 
     expect(await screen.findByText('Record not found')).toBeInTheDocument()
+  })
+
+  it('front-page fallback: renders an id-pattern URL the resolver does not know (#748)', async () => {
+    // front_page が返す正規パスはパターン由来 URL（例 /article/1）でもよいが、
+    // resolve API はカスタム permalink 専用で found:false（MSW 既定）を返す。
+    // その場合でもパターン解釈で本文を描画し、notFound にしないこと。
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    seedEntities([{ id: 1, entity_type_id: 1, is_deleted: false, deleted_at: null }])
+    seedFieldDefs([{ id: 1, entity_type_id: 1, field_key: 'title', data_type: 'text' }])
+    seedTextFields([{ id: 1, entity_id: 1, field_key: 'title', value: 'Pinned pattern home' }])
+
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route element={<PublicSiteTestProvider site={{ frontPagePath: '/article/1' }} />}>
+            <Route path="/" element={<PublicRecordByPermalink path="/article/1" isFrontPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: 'Pinned pattern home' }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Record not found')).not.toBeInTheDocument()
+  })
+
+  it('front-page fallback: renders a slug-pattern URL the resolver does not know (#748)', async () => {
+    seedEntityTypes([{ id: 1, name: 'Work', slug: 'work', permalink_pattern: '/{type}/{slug}' }])
+    seedEntities([
+      {
+        id: 7,
+        entity_type_id: 1,
+        slug: 'company',
+        status: 'published',
+        is_deleted: false,
+        deleted_at: null,
+      },
+    ])
+    seedFieldDefs([{ id: 1, entity_type_id: 1, field_key: 'title', data_type: 'text' }])
+    seedTextFields([{ id: 1, entity_id: 7, field_key: 'title', value: 'Slug pattern home' }])
+
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route element={<PublicSiteTestProvider site={{ frontPagePath: '/work/company' }} />}>
+            <Route
+              path="/"
+              element={<PublicRecordByPermalink path="/work/company" isFrontPage />}
+            />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: 'Slug pattern home' }),
+    ).toBeInTheDocument()
   })
 
   it('renders the derived chapter nav and hides series/chapter_no/chapter_total', async () => {

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
@@ -497,6 +497,7 @@ function PublicRecordDetailBySlug({
   previousPattern,
   splat,
   entityTypeDefaultLayout,
+  isFrontPage = false,
 }: {
   entityTypeSlug: string
   entityTypeName: string
@@ -508,6 +509,7 @@ function PublicRecordDetailBySlug({
   previousPattern: string | null | undefined
   splat: string
   entityTypeDefaultLayout: PublicLayoutKey
+  isFrontPage?: boolean
 }) {
   const { t } = useTranslation()
   const site = usePublicSite()
@@ -550,6 +552,7 @@ function PublicRecordDetailBySlug({
       entityTypePatternById={entityTypePatternById}
       currentPattern={currentPattern}
       entityTypeDefaultLayout={entityTypeDefaultLayout}
+      isFrontPage={isFrontPage}
     />
   )
 }
@@ -649,6 +652,50 @@ export function PublicRecordByPermalink({
       : undefined
 
   if (resolved === null || type === undefined) {
+    // resolve API はカスタム permalink 専用。front_page 設定などから渡るパターン由来
+    // URL（例 `/pages/1118`）はここに落ちるため、catch-all ルートと同じ機構で
+    // 「タイプ slug ＋パターン」として解釈してから notFound に倒す（#748）。
+    // サーバ側の解決順序（カスタム permalink 優先→パターン URL）と対称。
+    const [patternTypeSlug = '', ...restSegments] = path.split('/').filter(Boolean)
+    const patternType = findEntityTypeBySlug(entityTypeQuery.data?.items ?? [], patternTypeSlug)
+
+    if (patternType !== undefined && restSegments.length > 0) {
+      const splat = restSegments.join('/')
+      const key = extractEntityKeyFromSplat(patternType.permalinkPattern, splat)
+
+      if (key.kind === 'id') {
+        return (
+          <PublicRecordDetailById
+            entityTypeSlug={patternType.slug}
+            entityTypeName={patternType.name}
+            entityTypeId={Number(patternType.id)}
+            entityId={key.id}
+            entityTypeSlugById={entityTypeSlugById}
+            entityTypePatternById={entityTypePatternById}
+            currentPattern={patternType.permalinkPattern}
+            entityTypeDefaultLayout={patternType.defaultLayout}
+            isFrontPage={isFrontPage}
+          />
+        )
+      }
+
+      return (
+        <PublicRecordDetailBySlug
+          entityTypeSlug={patternType.slug}
+          entityTypeName={patternType.name}
+          entityTypeId={Number(patternType.id)}
+          entitySlug={key.slug}
+          entityTypeSlugById={entityTypeSlugById}
+          entityTypePatternById={entityTypePatternById}
+          currentPattern={patternType.permalinkPattern}
+          previousPattern={patternType.previousPermalinkPattern}
+          splat={splat}
+          entityTypeDefaultLayout={patternType.defaultLayout}
+          isFrontPage={isFrontPage}
+        />
+      )
+    }
+
     return (
       <RecordShellMessage
         site={site}


### PR DESCRIPTION
## 目的

本番 `ayane.nene-records.com` で発生: カスタム permalink を持たないページを固定ページ（#701）に
設定すると、`/` の SSR は正常なのに **SPA がマウント後に「レコードが見つかりません」で上書き**する。

## 原因

`front_page`（record id 保存）→ 公開設定 API が正規パスへ変換（`/pages/1118`）→
SPA の `PublicRecordByPermalink` は `/api/v1/public/records/resolve`（**カスタム permalink 専用**）
しか引かず `{found:false}`（本番実測）→ notFound ビュー。

## 変更

- `PublicRecordByPermalink`: resolve が外れたら **パターン URL 解釈へフォールバック**
  （catch-all ルートと同じ `findEntityTypeBySlug` + `extractEntityKeyFromSplat`。
  id パターン→ById / slug パターン→BySlug）。サーバの解決順序（custom 優先→パターン）と対称
- `PublicRecordDetailBySlug` に `isFrontPage` を配線（`PublicRecordDetailContent` へ転送）
- 回帰テスト2本: id パターン（ayane の実ケース・MSW 既定 resolve=found:false のまま本文描画）／
  slug パターン

## 検証

- `npm run check --prefix frontend` 全段グリーン（type-check / lint / prettier / test / storybook）
- 対象テストファイル 8/8 pass（既存 6＋新規 2）

## チェックリスト

- [x] Issue driven（#748）
- [x] Conventional Commits

Closes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)