### PR TITLE
feat(appearance): サイトタイトル専用のフォントノブと Roboto を追加する (#750)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "@fontsource/oswald": "^5.2.8",
         "@fontsource/playfair-display": "^5.2.8",
         "@fontsource/poiret-one": "^5.2.8",
+        "@fontsource/roboto": "^5.2.10",
         "@fontsource/rye": "^5.2.7",
         "@fontsource/saira-condensed": "^5.2.8",
         "@fontsource/saira-semi-condensed": "^5.2.7",
@@ -1297,6 +1298,15 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource/poiret-one/-/poiret-one-5.2.8.tgz",
       "integrity": "sha512-w/sOQ0ctiIx730UdG+AChxtIqfOnORQUbFbyy+ALNh6YXCBAmLW2LmGMLCyg5F897bTrAGZoLvvkxXZ4IXopnQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/roboto": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.2.10.tgz",
+      "integrity": "sha512-8HlA5FtSfz//oFSr2eL7GFXAiE7eIkcGOtx7tjsLKq+as702x9+GU7K95iDeWFapHC4M2hv9RrpXKRTGGBI8Zg==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,6 +52,7 @@
     "@fontsource/oswald": "^5.2.8",
     "@fontsource/playfair-display": "^5.2.8",
     "@fontsource/poiret-one": "^5.2.8",
+    "@fontsource/roboto": "^5.2.10",
     "@fontsource/rye": "^5.2.7",
     "@fontsource/saira-condensed": "^5.2.8",
     "@fontsource/saira-semi-condensed": "^5.2.7",

--- a/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
+++ b/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, useMemo, useState } from 'react'
 import { useMediaList } from '@/entities/media'
 import { useTranslation } from '@/shared/i18n'
 import {
+  BRAND_FONT_OPTIONS,
   DENSITY_OPTIONS,
   DISPLAY_FONT_OPTIONS,
   FLAG_DEFS,
@@ -294,6 +295,16 @@ export function ThemeCustomizeView({
               placeholder={themePlaceholder}
               onChange={(v) => {
                 setKnob('fontMono', v)
+              }}
+            />
+          </Field>
+          <Field label={t('admin.themeCustomize.fontBrand')}>
+            <Select
+              value={draft.fontBrand}
+              options={BRAND_FONT_OPTIONS}
+              placeholder={themePlaceholder}
+              onChange={(v) => {
+                setKnob('fontBrand', v)
               }}
             />
           </Field>

--- a/frontend/src/pages/consumer/public-fonts.ts
+++ b/frontend/src/pages/consumer/public-fonts.ts
@@ -9,6 +9,10 @@
  *   / Fredoka(funk) / Nunito(coastal) / Nunito Sans(japandi)。
  * Inter / Saira / Space Grotesk / JetBrains は admin の fonts.ts 経由で読まれる。
  */
+// Roboto: body/display/brand の汎用 sans（#750・AYANE ブランド語の実需）
+import '@fontsource/roboto/latin-400.css'
+import '@fontsource/roboto/latin-500.css'
+import '@fontsource/roboto/latin-700.css'
 import '@fontsource/source-serif-4/latin-400.css'
 import '@fontsource/source-serif-4/latin-400-italic.css'
 import '@fontsource/source-serif-4/latin-600.css'

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -188,7 +188,9 @@
   line-height: 1.05;
 }
 .nene-public .brand__name {
-  font-family: var(--font-display);
+  /* Brand wordmark voice: its own token (customizer #750), falling back to the
+     display face so themes without a brand override are unaffected. */
+  font-family: var(--font-brand, var(--font-display));
   font-weight: var(--weight-bold);
   font-size: 1.25rem;
   letter-spacing: -0.01em;

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -105,6 +105,7 @@ export const de: Partial<MessageCatalog> = {
   'admin.themeCustomize.font': 'Fließtext-Schrift',
   'admin.themeCustomize.fontDisplay': 'Display-Schrift',
   'admin.themeCustomize.fontMono': 'Monospace-Schrift',
+  'admin.themeCustomize.fontBrand': 'Schriftart des Seitentitels',
   'admin.themeCustomize.width': 'Inhaltsbreite',
   'admin.themeCustomize.gutter': 'Seitenrand',
   'admin.themeCustomize.radius': 'Ecken',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -112,6 +112,7 @@ export const en = {
   'admin.themeCustomize.font': 'Body font',
   'admin.themeCustomize.fontDisplay': 'Display font',
   'admin.themeCustomize.fontMono': 'Mono font',
+  'admin.themeCustomize.fontBrand': 'Site title font',
   'admin.themeCustomize.width': 'Content width',
   'admin.themeCustomize.gutter': 'Side margin',
   'admin.themeCustomize.radius': 'Corners',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -108,6 +108,7 @@ export const fr: Partial<MessageCatalog> = {
   'admin.themeCustomize.font': 'Police du corps',
   'admin.themeCustomize.fontDisplay': "Police d'affichage",
   'admin.themeCustomize.fontMono': 'Police à chasse fixe',
+  'admin.themeCustomize.fontBrand': 'Police du titre du site',
   'admin.themeCustomize.width': 'Largeur du contenu',
   'admin.themeCustomize.gutter': 'Marge latérale',
   'admin.themeCustomize.radius': 'Coins',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -105,6 +105,7 @@ export const ja: Partial<MessageCatalog> = {
   'admin.themeCustomize.font': '本文フォント',
   'admin.themeCustomize.fontDisplay': '見出しフォント',
   'admin.themeCustomize.fontMono': 'モノスペースフォント',
+  'admin.themeCustomize.fontBrand': 'サイトタイトルのフォント',
   'admin.themeCustomize.width': 'コンテンツ幅',
   'admin.themeCustomize.gutter': '左右余白',
   'admin.themeCustomize.radius': '角丸',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -106,6 +106,7 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.themeCustomize.font': 'Fonte do corpo',
   'admin.themeCustomize.fontDisplay': 'Fonte de títulos',
   'admin.themeCustomize.fontMono': 'Fonte monoespaçada',
+  'admin.themeCustomize.fontBrand': 'Fonte do título do site',
   'admin.themeCustomize.width': 'Largura do conteúdo',
   'admin.themeCustomize.gutter': 'Margem lateral',
   'admin.themeCustomize.radius': 'Cantos',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -105,6 +105,7 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.themeCustomize.font': '正文字体',
   'admin.themeCustomize.fontDisplay': '标题字体',
   'admin.themeCustomize.fontMono': '等宽字体',
+  'admin.themeCustomize.fontBrand': '站点标题字体',
   'admin.themeCustomize.width': '内容宽度',
   'admin.themeCustomize.gutter': '两侧边距',
   'admin.themeCustomize.radius': '圆角',

--- a/frontend/src/shared/lib/theme-customization.test.ts
+++ b/frontend/src/shared/lib/theme-customization.test.ts
@@ -39,6 +39,20 @@ describe('resolveOverrideStyle', () => {
     expect(style['--font-mono']).toBeUndefined()
   })
 
+  it('emits the brand font variable for a valid key and omits it when unset (#750)', () => {
+    // ブランド語ノブ: 設定時のみ --font-brand を発行（未設定＝CSS 側で
+    // var(--font-brand, var(--font-display)) にフォールバック＝テーマ既定）。
+    expect(resolveOverrideStyle({ fontBrand: 'roboto' })['--font-brand']).toContain('Roboto')
+    expect(resolveOverrideStyle({})['--font-brand']).toBeUndefined()
+    expect(resolveOverrideStyle({ fontBrand: 'evil-font' })['--font-brand']).toBeUndefined()
+  })
+
+  it('emits Roboto for body and display knobs (#750)', () => {
+    const style = resolveOverrideStyle({ fontBody: 'roboto', fontDisplay: 'roboto' })
+    expect(style['--font-sans']).toContain('Roboto')
+    expect(style['--font-display']).toContain('Roboto')
+  })
+
   it('ignores invalid / unknown values (no injection)', () => {
     const style = resolveOverrideStyle({
       accent: 'red; } body { display:none',

--- a/frontend/src/shared/lib/theme-customization.ts
+++ b/frontend/src/shared/lib/theme-customization.ts
@@ -25,6 +25,11 @@ export interface ThemeOverrides {
   fontDisplay?: string
   /** Mono/eyebrow font key (see MONO_FONT_OPTIONS). Maps to `--font-mono`. */
   fontMono?: string
+  /**
+   * Site-title (brand wordmark) font key (see BRAND_FONT_OPTIONS). Maps to
+   * `--font-brand`; unset = theme default = follows `--font-display` (#750).
+   */
+  fontBrand?: string
   /** Content width preset key (see WIDTH_OPTIONS). Maps to `--content-w`. */
   contentWidth?: string
   /** Gutter preset key (see GUTTER_OPTIONS). Maps to `--gutter`. */
@@ -256,6 +261,7 @@ export interface KnobOption {
 /** Body font allowlist (all self-hosted via @fontsource). */
 export const FONT_OPTIONS: readonly KnobOption[] = [
   { value: 'inter', label: 'Inter (sans)' },
+  { value: 'roboto', label: 'Roboto (sans)' },
   { value: 'source-serif', label: 'Source Serif 4 (serif)' },
   { value: 'saira', label: 'Saira Semi Condensed' },
   { value: 'space-grotesk', label: 'Space Grotesk' },
@@ -264,6 +270,7 @@ export const FONT_OPTIONS: readonly KnobOption[] = [
 
 const FONT_STACKS: Record<string, string> = {
   inter: "'Inter', 'Noto Sans JP', ui-sans-serif, system-ui, sans-serif",
+  roboto: "'Roboto', 'Noto Sans JP', ui-sans-serif, system-ui, sans-serif",
   'source-serif': "'Source Serif 4', 'Noto Serif JP', Georgia, 'Times New Roman', serif",
   saira: "'Saira Semi Condensed', 'Noto Sans JP', sans-serif",
   'space-grotesk': "'Space Grotesk', 'Noto Sans JP', sans-serif",
@@ -276,6 +283,7 @@ export const DISPLAY_FONT_OPTIONS: readonly KnobOption[] = [
   { value: 'bricolage', label: 'Bricolage Grotesque' },
   { value: 'archivo', label: 'Archivo' },
   { value: 'oswald', label: 'Oswald' },
+  { value: 'roboto', label: 'Roboto (sans)' },
   { value: 'source-serif', label: 'Source Serif 4 (serif)' },
   { value: 'system', label: 'System sans' },
 ]
@@ -285,7 +293,40 @@ const DISPLAY_FONT_STACKS: Record<string, string> = {
   bricolage: "'Bricolage Grotesque', 'Noto Sans JP', system-ui, sans-serif",
   archivo: "'Archivo', 'Arial Narrow', system-ui, sans-serif",
   oswald: "'Oswald', 'Noto Sans JP', system-ui, sans-serif",
+  roboto: "'Roboto', 'Noto Sans JP', system-ui, sans-serif",
   'source-serif': "'Source Serif 4', 'Noto Serif JP', Georgia, serif",
+  system: 'ui-sans-serif, system-ui, sans-serif',
+}
+
+/**
+ * Site-title (brand wordmark) allowlist (→ `--font-brand`). The union of the body
+ * and display faces: the brand voice may legitimately want either kind. Unset =
+ * theme default (the CSS falls back to `--font-display`), so there is no
+ * explicit "inherit" entry (#750).
+ */
+export const BRAND_FONT_OPTIONS: readonly KnobOption[] = [
+  { value: 'roboto', label: 'Roboto (sans)' },
+  { value: 'inter', label: 'Inter (sans)' },
+  { value: 'playfair', label: 'Playfair Display (serif)' },
+  { value: 'bricolage', label: 'Bricolage Grotesque' },
+  { value: 'archivo', label: 'Archivo' },
+  { value: 'oswald', label: 'Oswald' },
+  { value: 'source-serif', label: 'Source Serif 4 (serif)' },
+  { value: 'saira', label: 'Saira Semi Condensed' },
+  { value: 'space-grotesk', label: 'Space Grotesk' },
+  { value: 'system', label: 'System sans' },
+]
+
+const BRAND_FONT_STACKS: Record<string, string> = {
+  roboto: "'Roboto', 'Noto Sans JP', ui-sans-serif, system-ui, sans-serif",
+  inter: "'Inter', 'Noto Sans JP', ui-sans-serif, system-ui, sans-serif",
+  playfair: "'Playfair Display', Georgia, 'Times New Roman', serif",
+  bricolage: "'Bricolage Grotesque', 'Noto Sans JP', system-ui, sans-serif",
+  archivo: "'Archivo', 'Arial Narrow', system-ui, sans-serif",
+  oswald: "'Oswald', 'Noto Sans JP', system-ui, sans-serif",
+  'source-serif': "'Source Serif 4', 'Noto Serif JP', Georgia, serif",
+  saira: "'Saira Semi Condensed', 'Noto Sans JP', sans-serif",
+  'space-grotesk': "'Space Grotesk', 'Noto Sans JP', sans-serif",
   system: 'ui-sans-serif, system-ui, sans-serif',
 }
 
@@ -408,6 +449,10 @@ export function resolveOverrideStyle(overrides: ThemeOverrides): Record<string, 
   if (isOption(MONO_FONT_OPTIONS, overrides.fontMono)) {
     const stack = MONO_FONT_STACKS[overrides.fontMono]
     if (stack !== undefined) style['--font-mono'] = stack
+  }
+  if (isOption(BRAND_FONT_OPTIONS, overrides.fontBrand)) {
+    const stack = BRAND_FONT_STACKS[overrides.fontBrand]
+    if (stack !== undefined) style['--font-brand'] = stack
   }
   if (isOption(WIDTH_OPTIONS, overrides.contentWidth)) {
     const width = WIDTH_VALUES[overrides.contentWidth]

--- a/src/Theme/ThemeAuthoringGuide.php
+++ b/src/Theme/ThemeAuthoringGuide.php
@@ -119,6 +119,7 @@ final class ThemeAuthoringGuide
         'font-display' => ['fontFamily', 'Font stack for display/headings.'],
         'font-sans' => ['fontFamily', 'Font stack for body text.'],
         'font-mono' => ['fontFamily', 'Font stack for monospace.'],
+        'font-brand' => ['fontFamily', 'Font stack for the site title (brand wordmark). Optional; falls back to font-display.'],
         // Type sizes
         'text-display' => ['fontSize', 'Hero/display size.'],
         'text-h1' => ['fontSize', 'H1 size.'],
@@ -169,6 +170,7 @@ final class ThemeAuthoringGuide
      * @var list<array{family: string, slug: string, kind: string}>
      */
     private const AVAILABLE_FONTS = [
+        ['family' => 'Roboto', 'slug' => 'roboto', 'kind' => 'sans'],
         ['family' => 'Bricolage Grotesque', 'slug' => 'bricolage-grotesque', 'kind' => 'display'],
         ['family' => 'Archivo', 'slug' => 'archivo', 'kind' => 'display'],
         ['family' => 'Oswald', 'slug' => 'oswald', 'kind' => 'display'],


### PR DESCRIPTION
## 目的

AYANE 移行で出た実需（ayane.co.jp のロゴ = Roboto）＋WP 定番ノブ（Site Title Typography）への対応。
テキストロゴ運用でブランド語だけ書体を変えられるようにする。**per-element タイポグラフィには
滑らせず「ブランド語専用の 1 トークン」に限定**（テーマ思想＝型付きノブの厳選を維持）。

## 変更

- **`--font-brand` トークン新設**: `.brand__name`（ヘッダー/フッターのサイトタイトル共通コンポーネント）で
  `var(--font-brand, var(--font-display))`。未設定＝従来どおり見出しに追従＝**既存テーマ・既存サイトは挙動不変**
- **カスタマイザ「サイトタイトルのフォント」ノブ**（`fontBrand`・i18n 6ロケール・未選択＝テーマ既定）。
  `resolveOverrideStyle` 経由なので「テーマとして保存」(#454)・ライブプレビューにも自動で乗る
- **Roboto をセルフホスト同梱**（`@fontsource/roboto` latin 400/500/700・約100KB・外部リクエストなし）。
  body / display / brand の各 allowlist と `ThemeAuthoringGuide::AVAILABLE_FONTS` に追加
- テーマ manifest からも `font-brand` トークンで指定可（validator はトークン key のパターン許可のため無変更）

## 検証

- ユニットテスト追加: fontBrand → `--font-brand` 発行／未設定・不正キーは無発行／Roboto の body/display 発行
- `ThemeAuthoringGuideTest`（AVAILABLE_FONTS ↔ public-fonts.ts import 整合）グリーン
- `composer check` / `npm run check` 全段グリーン（locales 6ロケール完全性テスト含む）

## チェックリスト

- [x] Issue driven（#750）
- [x] Conventional Commits

Closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)