### PR TITLE
fix(public): ロゴ未設定時に NeNe Records マークをテナントサイトへ表示しない (#752)

### DIFF
--- a/frontend/src/pages/consumer/PublicSiteShell.test.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.test.tsx
@@ -106,4 +106,23 @@ describe('PublicSiteShell header reflection', () => {
 
     expect(screen.queryByRole('link', { name: 'Bad' })).toBeNull()
   })
+
+  it('renders no brand mark when the tenant has no logo (#752)', () => {
+    // ロゴ未設定時にプラットフォームのマーク（NeneMark）をフォールバック表示しない。
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    const { container } = renderShell(makeSite())
+
+    expect(container.querySelector('.brand__mark')).toBeNull()
+    expect(screen.getAllByText('Test Site').length).toBeGreaterThan(0)
+  })
+
+  it('renders the logo image in the brand mark when a logo is set', () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    const { container } = renderShell(makeSite({ logo: '/media/2026/07/logo.png' }))
+
+    expect(container.querySelector('.brand__mark')).not.toBeNull()
+    const img = container.querySelector('.brand__logo')
+    expect(img).not.toBeNull()
+    expect(img?.getAttribute('src')).toBe('/media/2026/07/logo.png')
+  })
 })

--- a/frontend/src/pages/consumer/PublicSiteShell.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.tsx
@@ -7,7 +7,6 @@ import { LOCALES, SUPPORTED_LOCALE_IDS, type SupportedLocale, useTranslation } f
 import { hasCta, hasTopbarContent, safeHref } from '@/shared/lib/header-config'
 import { useHeaderShrink } from '@/shared/lib/motion/use-header-shrink'
 import { useScrollReveal } from '@/shared/lib/motion/use-scroll-reveal'
-import { NeneMark } from '@/shared/ui'
 import { IconMenu, IconMoon, IconSearch, IconSun, IconX } from '@/shared/ui/icons/Icons'
 import { IconAuto } from '@/shared/ui/icons/magazine-icons'
 import './public-site.css'
@@ -135,15 +134,15 @@ function HeaderCtaButton({ cta }: { cta: HeaderCta }) {
 }
 
 function Brand({ siteName, tagline, logo }: { siteName: string; tagline?: string; logo?: string }) {
+  // ロゴ未設定時はマーク枠ごと描画しない（サイト名のみ）。テナントのサイトに
+  // プラットフォームのブランド（NeneMark）をフォールバック表示しない (#752)。
   return (
     <Link className="brand" to="/">
-      <span className="brand__mark">
-        {logo !== undefined && logo !== '' ? (
+      {logo !== undefined && logo !== '' ? (
+        <span className="brand__mark">
           <img className="brand__logo" src={logo} alt={siteName} />
-        ) : (
-          <NeneMark size={22} />
-        )}
-      </span>
+        </span>
+      ) : null}
       <span className="brand__text">
         <span className="brand__name">{siteName}</span>
         {tagline !== undefined && tagline !== '' ? (


### PR DESCRIPTION
## 目的

テナント公開サイトのブランド枠（ヘッダー/フッター）が、ロゴ未設定時に **NeNe Records の
プロダクトマークをフォールバック表示**し、非表示手段が無かった。利用者のサイトに
プラットフォームブランドを掲出しない既定へ修正する。

## 変更

- `Brand`（PublicSiteShell）: ロゴ未設定時は `.brand__mark` ごと非描画（サイト名テキストのみ）。
  **トグルは追加しない**（ノブ最小の思想・WP のサイトアイコン慣行と同じ既定）
- ロゴ設定済みテナントは挙動不変。apex LP／ログイン等の NeNe Records 自身の面は別コンポーネントで対象外
- 回帰テスト2本（ロゴ無し→マーク無し／ロゴ有り→img 描画）

## 検証

- `npm run check --prefix frontend` 全段グリーン

## チェックリスト

- [x] Issue driven（#752）
- [x] Conventional Commits

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)