### PR TITLE
feat(appearance): サイトタイトルのサイズノブ（--brand-size・プリセット式）を追加する (#754)

### DIFF
--- a/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
+++ b/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
@@ -3,6 +3,7 @@ import { useMediaList } from '@/entities/media'
 import { useTranslation } from '@/shared/i18n'
 import {
   BRAND_FONT_OPTIONS,
+  BRAND_SIZE_OPTIONS,
   DENSITY_OPTIONS,
   DISPLAY_FONT_OPTIONS,
   FLAG_DEFS,
@@ -305,6 +306,16 @@ export function ThemeCustomizeView({
               placeholder={themePlaceholder}
               onChange={(v) => {
                 setKnob('fontBrand', v)
+              }}
+            />
+          </Field>
+          <Field label={t('admin.themeCustomize.brandSize')}>
+            <Select
+              value={draft.brandSize}
+              options={BRAND_SIZE_OPTIONS}
+              placeholder={themePlaceholder}
+              onChange={(v) => {
+                setKnob('brandSize', v)
               }}
             />
           </Field>

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -192,7 +192,8 @@
      display face so themes without a brand override are unaffected. */
   font-family: var(--font-brand, var(--font-display));
   font-weight: var(--weight-bold);
-  font-size: 1.25rem;
+  /* Size preset knob (#754); unset = the historical fixed size. */
+  font-size: var(--brand-size, 1.25rem);
   letter-spacing: -0.01em;
   white-space: nowrap;
   overflow: hidden;

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -106,6 +106,7 @@ export const de: Partial<MessageCatalog> = {
   'admin.themeCustomize.fontDisplay': 'Display-Schrift',
   'admin.themeCustomize.fontMono': 'Monospace-Schrift',
   'admin.themeCustomize.fontBrand': 'Schriftart des Seitentitels',
+  'admin.themeCustomize.brandSize': 'Größe des Seitentitels',
   'admin.themeCustomize.width': 'Inhaltsbreite',
   'admin.themeCustomize.gutter': 'Seitenrand',
   'admin.themeCustomize.radius': 'Ecken',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -113,6 +113,7 @@ export const en = {
   'admin.themeCustomize.fontDisplay': 'Display font',
   'admin.themeCustomize.fontMono': 'Mono font',
   'admin.themeCustomize.fontBrand': 'Site title font',
+  'admin.themeCustomize.brandSize': 'Site title size',
   'admin.themeCustomize.width': 'Content width',
   'admin.themeCustomize.gutter': 'Side margin',
   'admin.themeCustomize.radius': 'Corners',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -109,6 +109,7 @@ export const fr: Partial<MessageCatalog> = {
   'admin.themeCustomize.fontDisplay': "Police d'affichage",
   'admin.themeCustomize.fontMono': 'Police à chasse fixe',
   'admin.themeCustomize.fontBrand': 'Police du titre du site',
+  'admin.themeCustomize.brandSize': 'Taille du titre du site',
   'admin.themeCustomize.width': 'Largeur du contenu',
   'admin.themeCustomize.gutter': 'Marge latérale',
   'admin.themeCustomize.radius': 'Coins',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -106,6 +106,7 @@ export const ja: Partial<MessageCatalog> = {
   'admin.themeCustomize.fontDisplay': '見出しフォント',
   'admin.themeCustomize.fontMono': 'モノスペースフォント',
   'admin.themeCustomize.fontBrand': 'サイトタイトルのフォント',
+  'admin.themeCustomize.brandSize': 'サイトタイトルのサイズ',
   'admin.themeCustomize.width': 'コンテンツ幅',
   'admin.themeCustomize.gutter': '左右余白',
   'admin.themeCustomize.radius': '角丸',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -107,6 +107,7 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.themeCustomize.fontDisplay': 'Fonte de títulos',
   'admin.themeCustomize.fontMono': 'Fonte monoespaçada',
   'admin.themeCustomize.fontBrand': 'Fonte do título do site',
+  'admin.themeCustomize.brandSize': 'Tamanho do título do site',
   'admin.themeCustomize.width': 'Largura do conteúdo',
   'admin.themeCustomize.gutter': 'Margem lateral',
   'admin.themeCustomize.radius': 'Cantos',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -106,6 +106,7 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.themeCustomize.fontDisplay': '标题字体',
   'admin.themeCustomize.fontMono': '等宽字体',
   'admin.themeCustomize.fontBrand': '站点标题字体',
+  'admin.themeCustomize.brandSize': '站点标题字号',
   'admin.themeCustomize.width': '内容宽度',
   'admin.themeCustomize.gutter': '两侧边距',
   'admin.themeCustomize.radius': '圆角',

--- a/frontend/src/shared/lib/theme-customization.test.ts
+++ b/frontend/src/shared/lib/theme-customization.test.ts
@@ -53,6 +53,13 @@ describe('resolveOverrideStyle', () => {
     expect(style['--font-display']).toContain('Roboto')
   })
 
+  it('emits the brand size for a valid preset and omits it when unset/unknown (#754)', () => {
+    expect(resolveOverrideStyle({ brandSize: 'xl' })['--brand-size']).toBe('2rem')
+    expect(resolveOverrideStyle({ brandSize: 'comfort' })['--brand-size']).toBe('1.5rem')
+    expect(resolveOverrideStyle({})['--brand-size']).toBeUndefined()
+    expect(resolveOverrideStyle({ brandSize: '999px' })['--brand-size']).toBeUndefined()
+  })
+
   it('ignores invalid / unknown values (no injection)', () => {
     const style = resolveOverrideStyle({
       accent: 'red; } body { display:none',

--- a/frontend/src/shared/lib/theme-customization.ts
+++ b/frontend/src/shared/lib/theme-customization.ts
@@ -30,6 +30,11 @@ export interface ThemeOverrides {
    * `--font-brand`; unset = theme default = follows `--font-display` (#750).
    */
   fontBrand?: string
+  /**
+   * Site-title size preset (see BRAND_SIZE_OPTIONS). Maps to `--brand-size`;
+   * unset = theme default (1.25rem) (#754).
+   */
+  brandSize?: string
   /** Content width preset key (see WIDTH_OPTIONS). Maps to `--content-w`. */
   contentWidth?: string
   /** Gutter preset key (see GUTTER_OPTIONS). Maps to `--gutter`. */
@@ -317,6 +322,24 @@ export const BRAND_FONT_OPTIONS: readonly KnobOption[] = [
   { value: 'system', label: 'System sans' },
 ]
 
+/**
+ * Site-title size presets (→ `--brand-size`). Fixed steps, no free input; the
+ * header fit-probe (#697) absorbs any nav overflow a larger wordmark causes.
+ */
+export const BRAND_SIZE_OPTIONS: readonly KnobOption[] = [
+  { value: 'default', label: 'Default' },
+  { value: 'comfort', label: 'Comfort' },
+  { value: 'large', label: 'Large' },
+  { value: 'xl', label: 'XL' },
+]
+
+const BRAND_SIZE_VALUES: Record<string, string> = {
+  default: '1.25rem',
+  comfort: '1.5rem',
+  large: '1.75rem',
+  xl: '2rem',
+}
+
 const BRAND_FONT_STACKS: Record<string, string> = {
   roboto: "'Roboto', 'Noto Sans JP', ui-sans-serif, system-ui, sans-serif",
   inter: "'Inter', 'Noto Sans JP', ui-sans-serif, system-ui, sans-serif",
@@ -453,6 +476,10 @@ export function resolveOverrideStyle(overrides: ThemeOverrides): Record<string, 
   if (isOption(BRAND_FONT_OPTIONS, overrides.fontBrand)) {
     const stack = BRAND_FONT_STACKS[overrides.fontBrand]
     if (stack !== undefined) style['--font-brand'] = stack
+  }
+  if (isOption(BRAND_SIZE_OPTIONS, overrides.brandSize)) {
+    const size = BRAND_SIZE_VALUES[overrides.brandSize]
+    if (size !== undefined) style['--brand-size'] = size
   }
   if (isOption(WIDTH_OPTIONS, overrides.contentWidth)) {
     const width = WIDTH_VALUES[overrides.contentWidth]

--- a/src/Theme/ThemeAuthoringGuide.php
+++ b/src/Theme/ThemeAuthoringGuide.php
@@ -120,6 +120,7 @@ final class ThemeAuthoringGuide
         'font-sans' => ['fontFamily', 'Font stack for body text.'],
         'font-mono' => ['fontFamily', 'Font stack for monospace.'],
         'font-brand' => ['fontFamily', 'Font stack for the site title (brand wordmark). Optional; falls back to font-display.'],
+        'brand-size' => ['fontSize', 'Site title (brand wordmark) size. Optional; defaults to 1.25rem.'],
         // Type sizes
         'text-display' => ['fontSize', 'Hero/display size.'],
         'text-h1' => ['fontSize', 'H1 size.'],


### PR DESCRIPTION
## 目的

タグラインを外した際にサイトタイトル（1.25rem 固定）が控えめすぎる — AYANE 実制作の指摘。
#750（サイトタイトルのフォント）と対になるサイズ制御を、型付きプリセットで追加する。

## 変更

- `--brand-size` トークン新設: `.brand__name` は `font-size: var(--brand-size, 1.25rem)`（未設定＝挙動不変）
- カスタマイザ「サイトタイトルのサイズ」ノブ: **Default (1.25) / Comfort (1.5) / Large (1.75) / XL (2rem)**。
  任意 px 入力はさせない（ノブ最小の思想）。`resolveOverrideStyle` 経由＝ライブプレビュー・
  「テーマとして保存」(#454)・manifest 指定に自動対応
- 大サイズによるヘッダー溢れは既存 fit-probe（#697）が実測でドロワーへ畳むため構造的に安全
- i18n 6ロケール・authoring guide トークン表に `brand-size` 記載

## 検証

- ユニットテスト: プリセット→`--brand-size` 発行／未設定・不正値は無発行
- `npm run check` / `ThemeAuthoringGuideTest` グリーン

## チェックリスト

- [x] Issue driven（#754）
- [x] Conventional Commits

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)