### PR TITLE
fix(public): header 領域のメニューウィジェットを公開ヘッダーのナビに配線する (#756)

### DIFF
--- a/frontend/src/pages/consumer/PublicSiteShell.test.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.test.tsx
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
-import { cleanup, screen } from '@testing-library/react'
+import { cleanup, screen, within } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
 import { MemoryRouter } from 'react-router-dom'
 import { PublicSiteShell } from '@/pages/consumer/PublicSiteShell'
 import type { PublicSite } from '@/pages/consumer/public-site-context'
@@ -114,6 +115,57 @@ describe('PublicSiteShell header reflection', () => {
 
     expect(container.querySelector('.brand__mark')).toBeNull()
     expect(screen.getAllByText('Test Site').length).toBeGreaterThan(0)
+  })
+
+  it('renders the header-region menu widget items as the primary nav (#756)', async () => {
+    // レイアウトビルダーで header 領域に置いたメニューウィジェットが公開ナビを駆動する。
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    mswServer.use(
+      http.get('/api/v1/public/widgets', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: 4,
+              widget_type: 'menu',
+              region: 'header',
+              display_order: 0,
+              title: null,
+              settings: { menuId: 1 },
+              created_at: '2026-07-09 00:00:00',
+              updated_at: '2026-07-09 00:00:00',
+            },
+          ],
+        }),
+      ),
+    )
+
+    renderShell(
+      makeSite({
+        navItems: [
+          { id: 1, url: '/', label: 'HOME', menuId: 1 },
+          { id: 2, url: '/services', label: 'SERVICES', menuId: 1 },
+          { id: 3, url: '/other', label: 'OTHER', menuId: 2 },
+        ],
+      }),
+    )
+
+    // widgets 取得後に primary nav がメニュー項目へ置き換わる。
+    expect((await screen.findAllByText('HOME')).length).toBeGreaterThan(0)
+    const nav = screen.getByRole('navigation', { name: 'Primary' })
+    expect(within(nav).getByText('HOME')).toBeInTheDocument()
+    expect(within(nav).getByText('SERVICES')).toBeInTheDocument()
+    // 他メニュー所属の項目・従来のフォールバックナビは primary nav に出ない
+    //（Latest はフッターには正当に存在するため nav スコープで確認する）。
+    expect(within(nav).queryByText('OTHER')).toBeNull()
+    expect(within(nav).queryByText('Latest')).toBeNull()
+  })
+
+  it('keeps the default nav when no header menu widget exists', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    renderShell(makeSite())
+
+    const nav = screen.getByRole('navigation', { name: 'Primary' })
+    expect(await within(nav).findByText('Latest')).toBeInTheDocument()
   })
 
   it('renders the logo image in the brand mark when a logo is set', () => {

--- a/frontend/src/pages/consumer/PublicSiteShell.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.tsx
@@ -49,6 +49,35 @@ interface ShellNavLink {
   current: boolean
 }
 
+/**
+ * A primary-nav entry. Menu items (#756) may point at external URLs — those
+ * render as plain anchors (scheme-checked by `safeHref`); site paths use the
+ * SPA router.
+ */
+function NavLinkItem({ link, onClick }: { link: ShellNavLink; onClick?: () => void }) {
+  if (!link.to.startsWith('/')) {
+    const href = safeHref(link.to)
+    if (href === '') {
+      return null
+    }
+    return (
+      <a className="navlink" href={href} onClick={onClick}>
+        {link.label}
+      </a>
+    )
+  }
+  return (
+    <Link
+      className="navlink"
+      to={link.to}
+      aria-current={link.current ? 'page' : undefined}
+      onClick={onClick}
+    >
+      {link.label}
+    </Link>
+  )
+}
+
 function ThemeSwitch({ mode, onMode }: { mode: ThemeMode; onMode: (mode: ThemeMode) => void }) {
   const options: Array<{ key: ThemeMode; label: string; icon: ReactNode }> = [
     { key: 'light', label: 'Light theme', icon: <IconSun size={16} /> },
@@ -252,15 +281,31 @@ export function PublicSiteShell({
     [entityTypeQuery.data?.items],
   )
 
-  const navLinks: ShellNavLink[] = [
-    { label: 'Latest', to: '/', current: isHome },
-    ...types.slice(0, 3).map((type) => ({
-      label: type.name,
-      to: type.href,
-      current: !isHome && type.slug === activeTypeSlug,
-    })),
-    { label: 'Search', to: '/search', current: false },
-  ]
+  // Header-region menu widgets (#756): a menu widget placed in the `header`
+  // region (layout builder) drives the primary nav with its named menu's items.
+  // Without one, fall back to the historical default nav (Latest + types + Search).
+  const menuNavLinks: ShellNavLink[] = widgets
+    .filter((widget) => widget.region === 'header' && widget.widgetType === 'menu')
+    .sort((a, b) => a.displayOrder - b.displayOrder)
+    .flatMap((widget) => {
+      const menuId = widget.settings['menuId']
+      if (typeof menuId !== 'number') return []
+      return site.navItems.filter((item) => item.menuId === menuId)
+    })
+    .map((item) => ({ label: item.label, to: item.url, current: pathname === item.url }))
+
+  const navLinks: ShellNavLink[] =
+    menuNavLinks.length > 0
+      ? menuNavLinks
+      : [
+          { label: 'Latest', to: '/', current: isHome },
+          ...types.slice(0, 3).map((type) => ({
+            label: type.name,
+            to: type.href,
+            current: !isHome && type.slug === activeTypeSlug,
+          })),
+          { label: 'Search', to: '/search', current: false },
+        ]
 
   // Fit-probe (#695): fold the inline nav into the drawer the instant it would
   // overflow, so a long / many-item nav never overflows or clips the row ABOVE
@@ -311,14 +356,7 @@ export function PublicSiteShell({
           <Brand siteName={site.siteName} tagline={site.tagline} logo={effectiveLogo} />
           <nav className="hd__nav" aria-label="Primary">
             {navLinks.map((link) => (
-              <Link
-                key={`${link.label}-${link.to}`}
-                className="navlink"
-                to={link.to}
-                aria-current={link.current ? 'page' : undefined}
-              >
-                {link.label}
-              </Link>
+              <NavLinkItem key={`${link.label}-${link.to}`} link={link} />
             ))}
           </nav>
           <div className="hd__actions">
@@ -422,17 +460,13 @@ export function PublicSiteShell({
             </button>
           </div>
           {navLinks.map((link) => (
-            <Link
+            <NavLinkItem
               key={`drawer-${link.label}-${link.to}`}
-              className="navlink"
-              to={link.to}
-              aria-current={link.current ? 'page' : undefined}
+              link={link}
               onClick={() => {
                 setDrawerOpen(false)
               }}
-            >
-              {link.label}
-            </Link>
+            />
           ))}
           <div className="drawer__prefs">
             <div className="drawer__pref">

--- a/frontend/src/pages/consumer/public-site-context.ts
+++ b/frontend/src/pages/consumer/public-site-context.ts
@@ -7,6 +7,8 @@ export interface PublicSiteNavItem {
   id: number
   url: string
   label: string
+  /** Named-menu membership (#347); drives the header-region menu widget (#756). */
+  menuId: number | null
 }
 
 /**


### PR DESCRIPTION
## 目的

本番 ayane で発覚: 外観→メニューでメニューを作り、レイアウトビルダーで **header 領域に
メニューウィジェットを配置**しても公開ヘッダーに反映されない。データは正しく保存されている
（menu id=1・widget region=header/menuId=1 を API で確認）のに、公開シェルの `navLinks` が
ハードコードでウィジェットを読んでいなかった。

## 変更

- header 領域の menu widget（display_order 順）の `settings.menuId` から、その名前付きメニューの
  項目（`site.navItems` を menuId でフィルタ）で primary nav を構築
- menu widget が無い場合は従来の既定ナビ（Latest＋タイプ3件＋Search）へフォールバック＝既存サイト挙動不変
- モバイルドロワーは同じ `navLinks` を共有しているため自動追従
- 外部 URL の項目は `safeHref` 検証つき `<a>`、内部パスは `<Link>`（`NavLinkItem` に共通化）
- 回帰テスト: menu widget あり→メニュー項目が primary nav に出る（他メニュー項目・既定ナビは出ない）／
  無し→既定ナビ維持

## 検証

- `npm run check` 全段グリーン（対象ファイル 7/7 pass）
- マージ後に本番デプロイし ayane 実ブラウザで HOME/SERVICES の表示を確認予定

## チェックリスト

- [x] Issue driven（#756）
- [x] Conventional Commits

Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)