### PR TITLE
fix(public): footer 領域のメニューウィジェットを公開フッターの列に配線する (#758)

### DIFF
--- a/frontend/src/pages/consumer/PublicSiteShell.test.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.test.tsx
@@ -160,6 +160,61 @@ describe('PublicSiteShell header reflection', () => {
     expect(within(nav).queryByText('Latest')).toBeNull()
   })
 
+  it('renders footer-region menu widgets as footer columns (#758)', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    mswServer.use(
+      http.get('/api/v1/public/widgets', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: 9,
+              widget_type: 'menu',
+              region: 'footer',
+              display_order: 0,
+              title: 'サイトマップ',
+              settings: { menuId: 1 },
+              created_at: '2026-07-09 00:00:00',
+              updated_at: '2026-07-09 00:00:00',
+            },
+          ],
+        }),
+      ),
+      http.get('/api/v1/public/menus', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: 1,
+              name: 'FOOTER MENU',
+              slug: 'footer-menu',
+              location: null,
+              created_at: '2026-07-09 00:00:00',
+              updated_at: '2026-07-09 00:00:00',
+            },
+          ],
+        }),
+      ),
+    )
+
+    renderShell(
+      makeSite({
+        navItems: [{ id: 1, url: '/company', label: 'COMPANY', menuId: 1 }],
+      }),
+    )
+
+    // widget title が列見出しになり、メニュー項目が列に並ぶ。既定の Browse 列は出ない。
+    expect(await screen.findByText('サイトマップ')).toBeInTheDocument()
+    expect(screen.getByText('COMPANY')).toBeInTheDocument()
+    expect(screen.queryByText('Browse')).toBeNull()
+  })
+
+  it('keeps the default footer columns when no footer menu widget exists', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    renderShell(makeSite())
+
+    expect(await screen.findByText('Browse')).toBeInTheDocument()
+    expect(screen.getByText('Content')).toBeInTheDocument()
+  })
+
   it('keeps the default nav when no header menu widget exists', async () => {
     seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
     renderShell(makeSite())

--- a/frontend/src/pages/consumer/PublicSiteShell.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useLocation, useSearchParams } from 'react-router-dom'
 import { useEntityTypeList } from '@/entities/entity-type'
+import { usePublicMenus } from '@/entities/menu'
 import { usePublicWidgets } from '@/entities/widget'
 import { SiteWidgets } from '@/features/render-widgets'
 import { LOCALES, SUPPORTED_LOCALE_IDS, type SupportedLocale, useTranslation } from '@/shared/i18n'
@@ -307,6 +308,24 @@ export function PublicSiteShell({
           { label: 'Search', to: '/search', current: false },
         ]
 
+  // Footer-region menu widgets (#758): like the header (#756), menu widgets
+  // placed into the `footer` region replace the default Content/Browse columns —
+  // one column per widget, titled by the widget title (falling back to the menu
+  // name). Without any, the historical default columns render unchanged.
+  const menusQuery = usePublicMenus()
+  const menus = menusQuery.data?.items ?? []
+  const footerMenuColumns = widgets
+    .filter((widget) => widget.region === 'footer' && widget.widgetType === 'menu')
+    .sort((a, b) => a.displayOrder - b.displayOrder)
+    .flatMap((widget) => {
+      const menuId = widget.settings['menuId']
+      if (typeof menuId !== 'number') return []
+      const items = site.navItems.filter((item) => item.menuId === menuId)
+      if (items.length === 0) return []
+      const title = widget.title ?? menus.find((menu) => menu.id === menuId)?.name ?? ''
+      return [{ key: widget.id, title, items }]
+    })
+
   // Fit-probe (#695): fold the inline nav into the drawer the instant it would
   // overflow, so a long / many-item nav never overflows or clips the row ABOVE
   // the 900px width floor (the CSS handles ≤900 on its own, no JS). `.hd__nav`
@@ -405,29 +424,55 @@ export function PublicSiteShell({
             <Brand siteName={site.siteName} logo={effectiveLogo} />
             {site.footerMarkdown !== '' ? <p className="ft__free">{site.footerMarkdown}</p> : null}
           </div>
-          <div className="ft__col">
-            <h4>Content</h4>
-            <ul>
-              <li>
-                <Link to="/">Latest</Link>
-              </li>
-              {footerTypeLinks.map((type) => (
-                <li key={type.slug}>
-                  <Link to={type.href}>{type.name}</Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div className="ft__col">
-            <h4>Browse</h4>
-            <ul>
-              <li>
-                <Link to="/search">
-                  <IconSearch size={14} /> Search
-                </Link>
-              </li>
-            </ul>
-          </div>
+          {footerMenuColumns.length > 0 ? (
+            footerMenuColumns.map((column) => (
+              <div className="ft__col" key={`ft-menu-${String(column.key)}`}>
+                {column.title !== '' ? <h4>{column.title}</h4> : null}
+                <ul>
+                  {column.items.map((item) => {
+                    const external = !item.url.startsWith('/')
+                    const href = external ? safeHref(item.url) : item.url
+                    if (href === '') return null
+                    return (
+                      <li key={item.id}>
+                        {external ? (
+                          <a href={href}>{item.label}</a>
+                        ) : (
+                          <Link to={item.url}>{item.label}</Link>
+                        )}
+                      </li>
+                    )
+                  })}
+                </ul>
+              </div>
+            ))
+          ) : (
+            <>
+              <div className="ft__col">
+                <h4>Content</h4>
+                <ul>
+                  <li>
+                    <Link to="/">Latest</Link>
+                  </li>
+                  {footerTypeLinks.map((type) => (
+                    <li key={type.slug}>
+                      <Link to={type.href}>{type.name}</Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div className="ft__col">
+                <h4>Browse</h4>
+                <ul>
+                  <li>
+                    <Link to="/search">
+                      <IconSearch size={14} /> Search
+                    </Link>
+                  </li>
+                </ul>
+              </div>
+            </>
+          )}
         </div>
         <div className="wrap ft__bar">
           <small>{renderCopyright(site.copyrightText, site.siteName)}</small>


### PR DESCRIPTION
## 目的

#756（ヘッダー配線）と同根の footer 版。レイアウトビルダーで footer 領域に置いた
メニューウィジェットが公開フッターに反映されない（列がハードコード）。

## 変更

- footer 領域の menu widget（display_order 順）→ **1ウィジェット＝1列（ft__col）**。
  見出し＝widget title（fallback: メニュー名）・項目＝メニューの navigation items
- 無ければ従来の Content / Browse 列へフォールバック（既存サイト挙動不変）
- 外部 URL は safeHref 検証つき `<a>`・内部パスは `<Link>`
- 回帰テスト2本（footer menu widget あり→列描画・既定列なし／なし→従来列）
- menu 以外のウィジェット型の footer 描画は範囲外（要デザイン判断・必要時に別 Issue）

## 検証

- `npm run check` 全段グリーン（対象ファイル 9/9 pass）
- マージ後に本番デプロイ→ ayane 実ブラウザ確認

## チェックリスト

- [x] Issue driven（#758）
- [x] Conventional Commits

Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)