### PR TITLE
feat(appearance): メニュー文字サイズのトークンと最小ノブを追加する (#760)

### DIFF
--- a/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
+++ b/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
@@ -5,6 +5,7 @@ import {
   BRAND_FONT_OPTIONS,
   BRAND_SIZE_OPTIONS,
   DENSITY_OPTIONS,
+  MENU_SIZE_OPTIONS,
   DISPLAY_FONT_OPTIONS,
   FLAG_DEFS,
   FONT_OPTIONS,
@@ -316,6 +317,16 @@ export function ThemeCustomizeView({
               placeholder={themePlaceholder}
               onChange={(v) => {
                 setKnob('brandSize', v)
+              }}
+            />
+          </Field>
+          <Field label={t('admin.themeCustomize.menuSize')}>
+            <Select
+              value={draft.menuSize}
+              options={MENU_SIZE_OPTIONS}
+              placeholder={themePlaceholder}
+              onChange={(v) => {
+                setKnob('menuSize', v)
               }}
             />
           </Field>

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -257,7 +257,8 @@
   color: var(--color-text-primary);
 }
 .nene-public .navlink {
-  font-size: var(--text-body-sm);
+  /* Menu size token (#760): themes may set --nav-size; default follows the type scale. */
+  font-size: var(--nav-size, var(--text-body-sm));
   font-weight: var(--weight-medium);
   color: var(--color-text-muted);
   padding: 6px 2px;
@@ -1088,7 +1089,8 @@
   gap: var(--space-xs);
 }
 .nene-public .ft__col a {
-  font-size: var(--text-body-sm);
+  /* Menu size token (#760): themes may set --footer-size; default follows the type scale. */
+  font-size: var(--footer-size, var(--text-body-sm));
   color: var(--color-text-primary);
   display: inline-flex;
   align-items: center;

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -107,6 +107,7 @@ export const de: Partial<MessageCatalog> = {
   'admin.themeCustomize.fontMono': 'Monospace-Schrift',
   'admin.themeCustomize.fontBrand': 'Schriftart des Seitentitels',
   'admin.themeCustomize.brandSize': 'Größe des Seitentitels',
+  'admin.themeCustomize.menuSize': 'Schriftgröße des Menüs',
   'admin.themeCustomize.width': 'Inhaltsbreite',
   'admin.themeCustomize.gutter': 'Seitenrand',
   'admin.themeCustomize.radius': 'Ecken',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -114,6 +114,7 @@ export const en = {
   'admin.themeCustomize.fontMono': 'Mono font',
   'admin.themeCustomize.fontBrand': 'Site title font',
   'admin.themeCustomize.brandSize': 'Site title size',
+  'admin.themeCustomize.menuSize': 'Menu font size',
   'admin.themeCustomize.width': 'Content width',
   'admin.themeCustomize.gutter': 'Side margin',
   'admin.themeCustomize.radius': 'Corners',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -110,6 +110,7 @@ export const fr: Partial<MessageCatalog> = {
   'admin.themeCustomize.fontMono': 'Police à chasse fixe',
   'admin.themeCustomize.fontBrand': 'Police du titre du site',
   'admin.themeCustomize.brandSize': 'Taille du titre du site',
+  'admin.themeCustomize.menuSize': 'Taille de police du menu',
   'admin.themeCustomize.width': 'Largeur du contenu',
   'admin.themeCustomize.gutter': 'Marge latérale',
   'admin.themeCustomize.radius': 'Coins',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -107,6 +107,7 @@ export const ja: Partial<MessageCatalog> = {
   'admin.themeCustomize.fontMono': 'モノスペースフォント',
   'admin.themeCustomize.fontBrand': 'サイトタイトルのフォント',
   'admin.themeCustomize.brandSize': 'サイトタイトルのサイズ',
+  'admin.themeCustomize.menuSize': 'メニューの文字サイズ',
   'admin.themeCustomize.width': 'コンテンツ幅',
   'admin.themeCustomize.gutter': '左右余白',
   'admin.themeCustomize.radius': '角丸',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -108,6 +108,7 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.themeCustomize.fontMono': 'Fonte monoespaçada',
   'admin.themeCustomize.fontBrand': 'Fonte do título do site',
   'admin.themeCustomize.brandSize': 'Tamanho do título do site',
+  'admin.themeCustomize.menuSize': 'Tamanho da fonte do menu',
   'admin.themeCustomize.width': 'Largura do conteúdo',
   'admin.themeCustomize.gutter': 'Margem lateral',
   'admin.themeCustomize.radius': 'Cantos',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -107,6 +107,7 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.themeCustomize.fontMono': '等宽字体',
   'admin.themeCustomize.fontBrand': '站点标题字体',
   'admin.themeCustomize.brandSize': '站点标题字号',
+  'admin.themeCustomize.menuSize': '菜单字号',
   'admin.themeCustomize.width': '内容宽度',
   'admin.themeCustomize.gutter': '两侧边距',
   'admin.themeCustomize.radius': '圆角',

--- a/frontend/src/shared/lib/theme-customization.test.ts
+++ b/frontend/src/shared/lib/theme-customization.test.ts
@@ -60,6 +60,14 @@ describe('resolveOverrideStyle', () => {
     expect(resolveOverrideStyle({ brandSize: '999px' })['--brand-size']).toBeUndefined()
   })
 
+  it('emits nav + footer sizes from the menu size preset (#760)', () => {
+    const style = resolveOverrideStyle({ menuSize: 'compact' })
+    expect(style['--nav-size']).toBe('0.8125rem')
+    expect(style['--footer-size']).toBe('0.8125rem')
+    expect(resolveOverrideStyle({})['--nav-size']).toBeUndefined()
+    expect(resolveOverrideStyle({ menuSize: 'huge' })['--nav-size']).toBeUndefined()
+  })
+
   it('ignores invalid / unknown values (no injection)', () => {
     const style = resolveOverrideStyle({
       accent: 'red; } body { display:none',

--- a/frontend/src/shared/lib/theme-customization.ts
+++ b/frontend/src/shared/lib/theme-customization.ts
@@ -35,6 +35,12 @@ export interface ThemeOverrides {
    * unset = theme default (1.25rem) (#754).
    */
   brandSize?: string
+  /**
+   * Header/footer menu font-size preset (see MENU_SIZE_OPTIONS). Maps to both
+   * `--nav-size` and `--footer-size`; unset = theme default = follows the type
+   * scale (`--text-body-sm`). Themes may set the two tokens independently (#760).
+   */
+  menuSize?: string
   /** Content width preset key (see WIDTH_OPTIONS). Maps to `--content-w`. */
   contentWidth?: string
   /** Gutter preset key (see GUTTER_OPTIONS). Maps to `--gutter`. */
@@ -340,6 +346,23 @@ const BRAND_SIZE_VALUES: Record<string, string> = {
   xl: '2rem',
 }
 
+/**
+ * Header/footer menu font-size presets (→ `--nav-size` + `--footer-size`, one
+ * coarse knob for both). Finer per-region control is the theme layer's job —
+ * a manifest can set the two tokens independently (#760).
+ */
+export const MENU_SIZE_OPTIONS: readonly KnobOption[] = [
+  { value: 'compact', label: 'Compact' },
+  { value: 'default', label: 'Default' },
+  { value: 'large', label: 'Large' },
+]
+
+const MENU_SIZE_VALUES: Record<string, string> = {
+  compact: '0.8125rem',
+  default: '0.9375rem',
+  large: '1.0625rem',
+}
+
 const BRAND_FONT_STACKS: Record<string, string> = {
   roboto: "'Roboto', 'Noto Sans JP', ui-sans-serif, system-ui, sans-serif",
   inter: "'Inter', 'Noto Sans JP', ui-sans-serif, system-ui, sans-serif",
@@ -480,6 +503,13 @@ export function resolveOverrideStyle(overrides: ThemeOverrides): Record<string, 
   if (isOption(BRAND_SIZE_OPTIONS, overrides.brandSize)) {
     const size = BRAND_SIZE_VALUES[overrides.brandSize]
     if (size !== undefined) style['--brand-size'] = size
+  }
+  if (isOption(MENU_SIZE_OPTIONS, overrides.menuSize)) {
+    const size = MENU_SIZE_VALUES[overrides.menuSize]
+    if (size !== undefined) {
+      style['--nav-size'] = size
+      style['--footer-size'] = size
+    }
   }
   if (isOption(WIDTH_OPTIONS, overrides.contentWidth)) {
     const width = WIDTH_VALUES[overrides.contentWidth]

--- a/src/Theme/ThemeAuthoringGuide.php
+++ b/src/Theme/ThemeAuthoringGuide.php
@@ -121,6 +121,8 @@ final class ThemeAuthoringGuide
         'font-mono' => ['fontFamily', 'Font stack for monospace.'],
         'font-brand' => ['fontFamily', 'Font stack for the site title (brand wordmark). Optional; falls back to font-display.'],
         'brand-size' => ['fontSize', 'Site title (brand wordmark) size. Optional; defaults to 1.25rem.'],
+        'nav-size' => ['fontSize', 'Header menu link size. Optional; defaults to text-body-sm.'],
+        'footer-size' => ['fontSize', 'Footer menu/link size. Optional; defaults to text-body-sm.'],
         // Type sizes
         'text-display' => ['fontSize', 'Hero/display size.'],
         'text-h1' => ['fontSize', 'H1 size.'],


### PR DESCRIPTION
## 目的

ayane のヘッダー/フッターメニューの文字サイズを下げたい（実需）。メニューは型スケール
（`--text-body-sm`）追従のため単独調整の手段が無かった。方針どおり**テーマ層のトークンを正規ルート**
とし、管理 UI から操作できる最小の入口ノブを 1 個だけ設ける。

## 変更

- `--nav-size` / `--footer-size` トークン新設（fallback = `--text-body-sm`＝既存サイト挙動不変。
  テーマ manifest からは個別指定可・authoring guide 記載）
- カスタマイザ「メニューの文字サイズ」: **Compact (0.8125rem) / Default (0.9375rem) / Large (1.0625rem)**。
  header/footer 連動の粗い1ノブ（要素別の乱立はしない）・未設定＝テーマ既定・i18n 6ロケール
- 回帰テスト（プリセット→2トークン発行／未設定・不正値は無発行）

## 検証

- `npm run check` / `ThemeAuthoringGuideTest` 全緑
- マージ後デプロイ→ ayane で Compact を実機確認

## チェックリスト

- [x] Issue driven（#760）
- [x] Conventional Commits

Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)