### PR TITLE
docs(release): リリース手順にプロフィール README 同期ステップを追記する (#763)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,13 @@ composer migrations:migrate   # apply pending
 composer migrations:rollback  # rollback last batch
 ```
 
+## Release
+
+1. `VERSION` をバンプする（版の単一ソース。`/machine/health` も同じ値を報告する・#586）。
+2. `bash tools/build-release.sh <version>` で配布 zip を作る（→ `dist/nene-records-<version>.zip`。詳細は `docs/install-tier-a.md`）。
+3. zip と `.sha256` を GitHub Release に添付して公開する（Latest・target=main）。
+4. Release 公開後、プロフィール README（github.com/hideyukiMORI/hideyukiMORI）の版数・状況表を同期する（At a glance / Platform products / What shipped recently の該当行）。
+
 ## OpenAPI → TypeScript types
 
 The frontend types for API responses are **auto-generated** from `docs/openapi/openapi.yaml`.


### PR DESCRIPTION
## 目的

プロフィール README（github.com/hideyukiMORI/hideyukiMORI）が約1ヶ月遅れで陳腐化していた（本日 hideyukiMORI/hideyukiMORI#7 で同期済み）再発防止として、リリース手順に「Release 公開後にプロフィール README を同期する」ステップを組み込む。

## 変更内容

- `CLAUDE.md` に `## Release` 節を新設（docs 変更のみ）:
  - 既存の v0.5.0 / v0.5.2 リリースで実施した流れ（`VERSION` バンプ → `tools/build-release.sh` → zip + `.sha256` を Release 公開・Latest）を明文化
  - 末尾ステップとして「Release 公開後、プロフィール README（github.com/hideyukiMORI/hideyukiMORI）の版数・状況表を同期する（At a glance / Platform products / What shipped recently の該当行）」を追加
- 配置の判断: リリース runbook は docs/ 配下に存在せず（`tools/build-release.sh` の利用手順は設置者向けガイド `docs/install-tier-a.md` のみ）、CLAUDE.md のリリース節を正本とした。

## 検証

- docs のみの変更（コード変更なし）。Markdown 目視確認。
- 手順内容は `tools/build-release.sh` ヘッダーコメント・`docs/todo/current.md` の v0.5.0/v0.5.2 リリース記録と突き合わせ済み。

## 残リスク / フォローアップ

- なし（手順の運用は次回リリース時に実地確認）。

Closes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)