### PR TITLE
fix(public): footer_markdown を Markdown として描画する (#762)

### DIFF
--- a/frontend/src/pages/consumer/PublicSiteShell.test.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.test.tsx
@@ -207,6 +207,16 @@ describe('PublicSiteShell header reflection', () => {
     expect(screen.queryByText('Browse')).toBeNull()
   })
 
+  it('renders footer_markdown as markdown (links work) (#762)', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    renderShell(
+      makeSite({ footerMarkdown: '運営: AYANE — [免責事項](/disclaimer) をご確認ください。' }),
+    )
+
+    const link = await screen.findByRole('link', { name: '免責事項' })
+    expect(link).toHaveAttribute('href', '/disclaimer')
+  })
+
   it('keeps the default footer columns when no footer menu widget exists', async () => {
     seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
     renderShell(makeSite())

--- a/frontend/src/pages/consumer/PublicSiteShell.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.tsx
@@ -10,6 +10,7 @@ import { useHeaderShrink } from '@/shared/lib/motion/use-header-shrink'
 import { useScrollReveal } from '@/shared/lib/motion/use-scroll-reveal'
 import { IconMenu, IconMoon, IconSearch, IconSun, IconX } from '@/shared/ui/icons/Icons'
 import { IconAuto } from '@/shared/ui/icons/magazine-icons'
+import { PublicMarkdownContent } from '@/shared/ui/markdown'
 import './public-site.css'
 import type { HeaderCta, HeaderTopbar } from '@/shared/lib/header-config'
 import { useConsumerMotion } from './use-consumer-motion'
@@ -422,7 +423,11 @@ export function PublicSiteShell({
         <div className="wrap ft__grid">
           <div className="ft__brand">
             <Brand siteName={site.siteName} logo={effectiveLogo} />
-            {site.footerMarkdown !== '' ? <p className="ft__free">{site.footerMarkdown}</p> : null}
+            {site.footerMarkdown !== '' ? (
+              <div className="ft__free">
+                <PublicMarkdownContent markdown={site.footerMarkdown} />
+              </div>
+            ) : null}
           </div>
           {footerMenuColumns.length > 0 ? (
             footerMenuColumns.map((column) => (

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -1070,7 +1070,32 @@
   font-size: var(--text-body-sm);
   color: var(--color-text-muted);
   line-height: 1.6;
-  white-space: pre-line;
+}
+/* footer_markdown は Markdown 描画（#762）。フッター文脈では見出し級を作らず、
+   全て周囲のサイズに畳む（免責・注釈・運営者情報などの短文用途）。 */
+.nene-public .ft__free .markdown-body,
+.nene-public .ft__free .markdown-body p,
+.nene-public .ft__free .markdown-body li,
+.nene-public .ft__free .markdown-body h1,
+.nene-public .ft__free .markdown-body h2,
+.nene-public .ft__free .markdown-body h3,
+.nene-public .ft__free .markdown-body h4 {
+  font-size: inherit;
+  color: inherit;
+  line-height: inherit;
+  margin: 0 0 var(--space-2xs);
+}
+.nene-public .ft__free .markdown-body a {
+  color: var(--color-text-primary);
+  text-decoration: underline;
+}
+.nene-public .ft__free .markdown-body a:hover {
+  color: var(--color-accent);
+}
+.nene-public .ft__free .markdown-body ul,
+.nene-public .ft__free .markdown-body ol {
+  margin: 0 0 var(--space-2xs);
+  padding-left: 1.2em;
 }
 .nene-public .ft__col h4 {
   font-family: var(--font-mono);


### PR DESCRIPTION
## 目的

フッター検証レポート（2026-07-09）Phase 1。`footer_markdown` がプレーンテキスト描画で
リンク・強調が書けなかったのを、既存の `PublicMarkdownContent` 資産で Markdown 描画にする。

## 変更

- `ft__free` を PublicMarkdownContent で描画（script/style/iframe 遮断は既存のまま）
- フッター文脈 CSS: 見出し級を inherit に畳む・リンクは下線＋hover accent
- 回帰テスト: `[免責事項](/disclaimer)` がリンクとして描画される

## 検証

- `npm run check` 全段グリーン（対象ファイル 10/10 pass）

Closes #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)