### PR TITLE
fix(settings): footer_config を設定一覧から隠す（専用 UI 済みキーの非表示漏れ）(#768)

### DIFF
--- a/frontend/src/features/manage-settings/hooks/useManageSiteSettingsPage.test.ts
+++ b/frontend/src/features/manage-settings/hooks/useManageSiteSettingsPage.test.ts
@@ -19,6 +19,7 @@ vi.mock('@/entities/setting', () => {
     'tagline',
     'theme_overrides',
     'header_config',
+    'footer_config',
     'home_hero',
     'layout_config',
     'active_theme',
@@ -51,6 +52,7 @@ describe('useManageSiteSettingsPage', () => {
     for (const dedicated of [
       'theme_overrides',
       'header_config',
+      'footer_config',
       'home_hero',
       'layout_config',
       'active_theme',

--- a/frontend/src/features/manage-settings/hooks/useManageSiteSettingsPage.ts
+++ b/frontend/src/features/manage-settings/hooks/useManageSiteSettingsPage.ts
@@ -19,6 +19,7 @@ const DEDICATED_UI_KEYS = new Set([
   'front_page',
   'theme_overrides',
   'header_config',
+  'footer_config',
   'home_hero',
   'layout_config',
   'active_theme',


### PR DESCRIPTION
## 目的

#766 のフォローアップ。専用エディタを持つ `footer_config` が汎用設定一覧に生 JSON で二重露出していたのを非表示に（#722 の方針どおり）。

## 変更

- `DEDICATED_UI_KEYS` に `footer_config` を追加＋テスト拡張

## 検証

- `npm run check` 全段グリーン

Closes #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)