### PR TITLE
feat(public): フッター列のモバイルアコーディオンと非 menu ウィジェットの footer 描画 (#772)

### DIFF
--- a/frontend/src/features/render-widgets/index.ts
+++ b/frontend/src/features/render-widgets/index.ts
@@ -1,2 +1,2 @@
-export { SiteWidgets } from './ui/SiteWidgets'
+export { SiteWidgetBody, SiteWidgets } from './ui/SiteWidgets'
 export { PageContentContext, usePageContent } from './page-content-context'

--- a/frontend/src/features/render-widgets/ui/SiteWidgets.tsx
+++ b/frontend/src/features/render-widgets/ui/SiteWidgets.tsx
@@ -36,6 +36,20 @@ function orientationForRegion(region: WidgetRegion): WidgetOrientation {
   return region === 'header' || region === 'footer' ? 'horizontal' : 'vertical'
 }
 
+/**
+ * Renders a single widget's body without the section/title chrome — for hosts
+ * that provide their own heading (footer columns, #772).
+ */
+export function SiteWidgetBody({
+  widget,
+  orientation = 'vertical',
+}: {
+  widget: Widget
+  orientation?: WidgetOrientation
+}) {
+  return <>{WIDGET_REGISTRY[widget.widgetType](widget, orientation)}</>
+}
+
 /** Renders all site widgets placed into a given region, in order. */
 export function SiteWidgets({ region }: SiteWidgetsProps) {
   const { data } = usePublicWidgets()

--- a/frontend/src/pages/consumer/PublicSiteShell.test.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.test.tsx
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { cleanup, screen, within } from '@testing-library/react'
 import { http, HttpResponse } from 'msw'
 import { MemoryRouter } from 'react-router-dom'
@@ -315,6 +315,60 @@ describe('PublicSiteShell header reflection', () => {
 
     expect(screen.getByText(/Powered by NENE2/)).toBeInTheDocument()
     expect(document.querySelector('.ft__social')).toBeNull()
+  })
+
+  it('renders a non-menu footer widget as a titled column (#772)', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    mswServer.use(
+      http.get('/api/v1/public/widgets', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: 11,
+              widget_type: 'search',
+              region: 'footer',
+              display_order: 0,
+              title: 'サイト内検索',
+              settings: {},
+              created_at: '2026-07-10 00:00:00',
+              updated_at: '2026-07-10 00:00:00',
+            },
+          ],
+        }),
+      ),
+    )
+
+    renderShell(makeSite())
+
+    expect(await screen.findByText('サイト内検索')).toBeInTheDocument()
+    // search ウィジェット本体（role=search のフォーム）が列内に描画される
+    expect(screen.getByRole('search')).toBeInTheDocument()
+    expect(screen.queryByText('Browse')).toBeNull()
+  })
+
+  it('turns footer column headings into accordions on narrow viewports (#772)', async () => {
+    // matchMedia を「常にマッチ」にスタブ → モバイル分岐（既定 閉）を検証。
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    const mql = {
+      matches: true,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }
+    vi.stubGlobal('matchMedia', () => mql)
+
+    try {
+      renderShell(makeSite())
+
+      const toggle = await screen.findByRole('button', { name: /Content/ })
+      expect(toggle).toHaveAttribute('aria-expanded', 'false')
+      // 閉じている間はフッター列の中身（Latest リンク）が描画されない
+      //（ヘッダー nav の Latest とは別物なのでフッタースコープで確認）。
+      const grid = document.querySelector('.ft__grid')
+      expect(grid).not.toBeNull()
+      expect(within(grid as HTMLElement).queryByRole('link', { name: 'Latest' })).toBeNull()
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 
   it('keeps the default footer columns when no footer menu widget exists', async () => {

--- a/frontend/src/pages/consumer/PublicSiteShell.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.tsx
@@ -2,12 +2,13 @@ import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useLocation, useSearchParams } from 'react-router-dom'
 import { useEntityTypeList } from '@/entities/entity-type'
 import { usePublicMenus } from '@/entities/menu'
-import { usePublicWidgets } from '@/entities/widget'
-import { SiteWidgets } from '@/features/render-widgets'
+import { usePublicWidgets, type Widget } from '@/entities/widget'
+import { SiteWidgetBody, SiteWidgets } from '@/features/render-widgets'
 import { LOCALES, SUPPORTED_LOCALE_IDS, type SupportedLocale, useTranslation } from '@/shared/i18n'
 import { hasFooterCta } from '@/shared/lib/footer-config'
 import { hasCta, hasTopbarContent, safeHref } from '@/shared/lib/header-config'
 import { useHeaderShrink } from '@/shared/lib/motion/use-header-shrink'
+import { useMediaQuery } from '@/shared/lib/use-media-query'
 import { useScrollReveal } from '@/shared/lib/motion/use-scroll-reveal'
 import { IconMenu, IconMoon, IconSearch, IconSun, IconX } from '@/shared/ui/icons/Icons'
 import { IconAuto } from '@/shared/ui/icons/magazine-icons'
@@ -16,7 +17,7 @@ import { PublicMarkdownContent } from '@/shared/ui/markdown'
 import './public-site.css'
 import type { HeaderCta, HeaderTopbar } from '@/shared/lib/header-config'
 import { useConsumerMotion } from './use-consumer-motion'
-import type { PublicSite } from './public-site-context'
+import type { PublicSite, PublicSiteNavItem } from './public-site-context'
 import { type ThemeMode, useConsumerTheme } from './use-consumer-theme'
 import { useThemePreviewBridge } from './use-theme-preview-bridge'
 
@@ -186,6 +187,50 @@ function Brand({ siteName, tagline, logo }: { siteName: string; tagline?: string
   )
 }
 
+/** One footer column: a named menu's links or a widget body (#758 / #772). */
+type FooterColumnModel =
+  | { kind: 'menu'; key: number; title: string; items: PublicSiteNavItem[] }
+  | { kind: 'widget'; key: number; title: string; widget: Widget }
+
+/**
+ * A footer column that collapses into an accordion on narrow viewports (#772):
+ * ≤680px the heading becomes an `aria-expanded` toggle (default closed) so tall
+ * multi-column footers stay compact on mobile. Desktop renders statically.
+ */
+function FooterColumn({ title, children }: { title: string; children: ReactNode }) {
+  const compact = useMediaQuery('(max-width: 680px)')
+  const [open, setOpen] = useState(false)
+
+  if (!compact || title === '') {
+    return (
+      <div className="ft__col">
+        {title !== '' ? <h4>{title}</h4> : null}
+        {children}
+      </div>
+    )
+  }
+
+  return (
+    <div className="ft__col ft__col--acc">
+      <h4>
+        <button
+          type="button"
+          aria-expanded={open}
+          onClick={() => {
+            setOpen((prev) => !prev)
+          }}
+        >
+          {title}
+          <span className="ft__acc-mark" aria-hidden="true">
+            {open ? '−' : '+'}
+          </span>
+        </button>
+      </h4>
+      {open ? children : null}
+    </div>
+  )
+}
+
 /** Footer copyright: substitute `{year}`/`{site}` tokens, fall back to a default. */
 function renderCopyright(template: string, siteName: string): string {
   const year = String(new Date().getFullYear())
@@ -311,22 +356,26 @@ export function PublicSiteShell({
           { label: 'Search', to: '/search', current: false },
         ]
 
-  // Footer-region menu widgets (#758): like the header (#756), menu widgets
-  // placed into the `footer` region replace the default Content/Browse columns —
-  // one column per widget, titled by the widget title (falling back to the menu
-  // name). Without any, the historical default columns render unchanged.
+  // Footer-region widgets (#758 / #772): widgets placed into the `footer` region
+  // replace the default Content/Browse columns — one column per widget. Menu
+  // widgets render their named menu's items (title falls back to the menu name);
+  // every other widget type renders via the widget registry under its title.
+  // Without any footer widgets, the historical default columns render unchanged.
   const menusQuery = usePublicMenus()
   const menus = menusQuery.data?.items ?? []
-  const footerMenuColumns = widgets
-    .filter((widget) => widget.region === 'footer' && widget.widgetType === 'menu')
+  const footerColumns: FooterColumnModel[] = widgets
+    .filter((widget) => widget.region === 'footer')
     .sort((a, b) => a.displayOrder - b.displayOrder)
-    .flatMap((widget) => {
-      const menuId = widget.settings['menuId']
-      if (typeof menuId !== 'number') return []
-      const items = site.navItems.filter((item) => item.menuId === menuId)
-      if (items.length === 0) return []
-      const title = widget.title ?? menus.find((menu) => menu.id === menuId)?.name ?? ''
-      return [{ key: widget.id, title, items }]
+    .flatMap((widget): FooterColumnModel[] => {
+      if (widget.widgetType === 'menu') {
+        const menuId = widget.settings['menuId']
+        if (typeof menuId !== 'number') return []
+        const items = site.navItems.filter((item) => item.menuId === menuId)
+        if (items.length === 0) return []
+        const title = widget.title ?? menus.find((menu) => menu.id === menuId)?.name ?? ''
+        return [{ kind: 'menu', key: widget.id, title, items }]
+      }
+      return [{ kind: 'widget', key: widget.id, title: widget.title ?? '', widget }]
     })
 
   // Fit-probe (#695): fold the inline nav into the drawer the instant it would
@@ -446,32 +495,34 @@ export function PublicSiteShell({
               </div>
             ) : null}
           </div>
-          {footerMenuColumns.length > 0 ? (
-            footerMenuColumns.map((column) => (
-              <div className="ft__col" key={`ft-menu-${String(column.key)}`}>
-                {column.title !== '' ? <h4>{column.title}</h4> : null}
-                <ul>
-                  {column.items.map((item) => {
-                    const external = !item.url.startsWith('/')
-                    const href = external ? safeHref(item.url) : item.url
-                    if (href === '') return null
-                    return (
-                      <li key={item.id}>
-                        {external ? (
-                          <a href={href}>{item.label}</a>
-                        ) : (
-                          <Link to={item.url}>{item.label}</Link>
-                        )}
-                      </li>
-                    )
-                  })}
-                </ul>
-              </div>
+          {footerColumns.length > 0 ? (
+            footerColumns.map((column) => (
+              <FooterColumn key={`ft-${column.kind}-${String(column.key)}`} title={column.title}>
+                {column.kind === 'menu' ? (
+                  <ul>
+                    {column.items.map((item) => {
+                      const external = !item.url.startsWith('/')
+                      const href = external ? safeHref(item.url) : item.url
+                      if (href === '') return null
+                      return (
+                        <li key={item.id}>
+                          {external ? (
+                            <a href={href}>{item.label}</a>
+                          ) : (
+                            <Link to={item.url}>{item.label}</Link>
+                          )}
+                        </li>
+                      )
+                    })}
+                  </ul>
+                ) : (
+                  <SiteWidgetBody widget={column.widget} />
+                )}
+              </FooterColumn>
             ))
           ) : (
             <>
-              <div className="ft__col">
-                <h4>Content</h4>
+              <FooterColumn title="Content">
                 <ul>
                   <li>
                     <Link to="/">Latest</Link>
@@ -482,9 +533,8 @@ export function PublicSiteShell({
                     </li>
                   ))}
                 </ul>
-              </div>
-              <div className="ft__col">
-                <h4>Browse</h4>
+              </FooterColumn>
+              <FooterColumn title="Browse">
                 <ul>
                   <li>
                     <Link to="/search">
@@ -492,7 +542,7 @@ export function PublicSiteShell({
                     </Link>
                   </li>
                 </ul>
-              </div>
+              </FooterColumn>
             </>
           )}
         </div>

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -1128,6 +1128,29 @@
   width: 14px;
   height: 14px;
 }
+/* フッター列のモバイルアコーディオン（#772・≤680px で JS が有効化）。 */
+.nene-public .ft__col--acc h4 button {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  font: inherit;
+  color: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+}
+.nene-public .ft__col--acc h4 button:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+.nene-public .ft__acc-mark {
+  font-size: 1rem;
+  line-height: 1;
+  color: var(--color-text-muted);
+}
+
 /* Above-footer CTA 行（#770）: 列グリッドの上の締めの訴求。 */
 .nene-public .ft-cta {
   border-bottom: 1px solid var(--color-border);


### PR DESCRIPTION
## 目的

フッター検証レポート P3 ③④: モバイルでの列アコーディオン化（文献定番の省スペース策）と、
レイアウトビルダーで footer に置ける全ウィジェット型の公開描画（#758 の申し送り解消）。

## 変更

- `FooterColumn`: ≤680px で見出しを `aria-expanded` ボタン化（既定 閉・focus-visible リング付き）。
  デスクトップ・見出し無し列は静的（挙動不変）
- footer 領域の非 menu ウィジェットを ft__col として WIDGET_REGISTRY で描画
  （`SiteWidgetBody` を render-widgets から export — 列が見出しを持つため chrome 無し版）
- 回帰テスト: search ウィジェット列の描画／matchMedia スタブでアコーディオン既定 閉＋中身非描画

## 検証

- `npm run check` 全段グリーン（対象 16/16 pass）
- マージ後デプロイ→実機（375px 幅）確認

## チェックリスト

- [x] Issue driven（#772）
- [x] Conventional Commits

Closes #772

🤖 Generated with [Claude Code](https://claude.com/claude-code)