### PR TITLE
fix(public): SSR bootstrap の entity に show_comments/show_related を載せる（#778）

### DIFF
--- a/src/PublicRecord/PublicRecordViewHttpMapper.php
+++ b/src/PublicRecord/PublicRecordViewHttpMapper.php
@@ -73,6 +73,10 @@ final readonly class PublicRecordViewHttpMapper
                 'deleted_at' => $entity->deletedAt?->format(\DateTimeInterface::ATOM),
                 'meta_title' => $entity->metaTitle,
                 'meta_description' => $entity->metaDescription,
+                // The SPA hydrates useEntity from this payload and never refetches,
+                // so the tri-state visibility overrides must ride along (#778).
+                'show_comments' => $entity->showComments,
+                'show_related' => $entity->showRelated,
             ],
             'fieldDefs' => [
                 'items' => array_map(

--- a/tests/PublicRecord/GetPublicRecordViewUseCaseTest.php
+++ b/tests/PublicRecord/GetPublicRecordViewUseCaseTest.php
@@ -72,6 +72,45 @@ final class GetPublicRecordViewUseCaseTest extends TestCase
         self::assertSame('Hello', $output->bootstrap['textFields']['items'][0]['value']);
         self::assertSame(42, $output->bootstrap['intFields']['items'][0]['value']);
         self::assertArrayHasKey('publicSettings', $output->bootstrap);
+        // The SPA hydrates useEntity from this payload without refetching (#778).
+        self::assertNull($output->bootstrap['entity']['show_comments']);
+        self::assertNull($output->bootstrap['entity']['show_related']);
+    }
+
+    public function testBootstrapEntityCarriesVisibilityOverrides(): void
+    {
+        $entityTypes = new InMemoryEntityTypeRepository([
+            new EntityType(name: 'Article', slug: 'article', id: 1),
+        ]);
+        $entities = new InMemoryEntityRepository([
+            new Entity(
+                id: 10,
+                entityTypeId: 1,
+                slug: 'hello-world',
+                status: EntityStatus::Published,
+                showComments: false,
+                showRelated: false,
+            ),
+        ]);
+
+        $useCase = new GetPublicRecordViewUseCase(
+            $entityTypes,
+            $entities,
+            new InMemoryFieldDefRepository(),
+            new InMemoryTextFieldRepository([], $entities),
+            new InMemoryIntFieldRepository(),
+            new InMemoryEnumFieldRepository(),
+            new InMemoryBoolFieldRepository(),
+            new InMemoryDateTimeFieldRepository(),
+            new InMemoryEntityRelationRepository(),
+            new ListPublicSettingsUseCase(new InMemorySettingRepository(), new InMemoryMediaRepository(), new \NeNeRecords\PublicRecord\FrontPageSetting(new InMemorySettingRepository(), new InMemoryEntityRepository(), new InMemoryEntityTypeRepository())),
+            new PublicRecordHierarchyBuilder(new InMemoryEntityRepository(), new InMemoryTextFieldRepository()),
+        );
+
+        $output = $useCase->execute(new GetPublicRecordViewInput('article', 'hello-world'));
+
+        self::assertFalse($output->bootstrap['entity']['show_comments']);
+        self::assertFalse($output->bootstrap['entity']['show_related']);
     }
 
     public function testThrowsWhenEntityTypeMissing(): void


### PR DESCRIPTION
## 目的

#775 の表示制御が SSR 経由ページ（front page 含む）で効かないバグの修正。`Closes #778`

## 原因と修正

SSR ページは `PublicRecordViewHttpMapper::toBootstrap` のペイロードで SPA の React Query を事前ハイドレートし（`seed-public-record-view-cache.ts` → `entityKeys.detail`）、SPA は `/api/v1/entities/{id}` を再フェッチしない。bootstrap の `entity` に `show_comments` / `show_related` が無かったため、SPA 側で常に null（サイト既定に従う）になっていた。public / preview 両 UseCase 共用の `toBootstrap` に 2 フィールドを追加。

## 検証

- `composer check` ✅
- 回帰テスト追加: bootstrap entity に tri-state が載ること（null / false 両ケース）
- 本番診断の経緯: API 単体は正しく false を返す・配信バンドルに条件分岐あり・Playwright で `entities/{id}` リクエストが発生しないことを確認済み（詳細は #778）

## 備考

bootstrap の `entity` は `layout` / `slug` / `status` 等も欠く「部分 entity」で、per-record layout override 等も同経路では SPA に届かない可能性がある（今回はスコープ外・必要なら別 Issue で棚卸し）。

Closes #778

🤖 Generated with [Claude Code](https://claude.com/claude-code)