### PR TITLE
fix(entity): full-replace 更新の echo 漏れで layout・permalink が消えるのを修正（#776）

### DIFF
--- a/frontend/src/features/manage-entity-status/hooks/useEntitySeoPanel.test.ts
+++ b/frontend/src/features/manage-entity-status/hooks/useEntitySeoPanel.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { act, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { useEntitySeoPanel } from './useEntitySeoPanel'
+import { toEntityId, type Entity } from '@/entities/entity'
+import { mswServer } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+
+function makeEntity(overrides: Partial<Entity> = {}): Entity {
+  return {
+    id: toEntityId(7),
+    entityTypeId: 1,
+    slug: 'hello',
+    permalink: null,
+    layout: null,
+    showComments: null,
+    showRelated: null,
+    status: 'draft',
+    publishedAt: null,
+    scheduledAt: null,
+    isDeleted: false,
+    deletedAt: null,
+    metaTitle: null,
+    metaDescription: null,
+    menuOrder: 0,
+    createdAt: null,
+    updatedAt: null,
+    ...overrides,
+  }
+}
+
+/** Install a PUT handler that records each update body and echoes a valid EntityDto. */
+function captureUpdates(): Array<Record<string, unknown>> {
+  const bodies: Array<Record<string, unknown>> = []
+  mswServer.use(
+    http.put('/api/v1/entities/:id', async ({ request, params }) => {
+      const body = (await request.json()) as Record<string, unknown>
+      bodies.push(body)
+      return HttpResponse.json({
+        id: Number(params.id),
+        entity_type_id: body.entity_type_id ?? 1,
+        slug: body.slug ?? null,
+        permalink: body.permalink ?? null,
+        layout: body.layout ?? null,
+        status: body.status ?? 'draft',
+        published_at: null,
+        scheduled_at: null,
+        is_deleted: false,
+        deleted_at: null,
+        meta_title: body.meta_title ?? null,
+        meta_description: body.meta_description ?? null,
+        created_at: null,
+        updated_at: null,
+      })
+    }),
+  )
+  return bodies
+}
+
+describe('useEntitySeoPanel — preserves untouched fields on full-replace update', () => {
+  beforeAll(() => {
+    mswServer.listen()
+  })
+  afterEach(() => {
+    mswServer.resetHandlers()
+  })
+  afterAll(() => {
+    mswServer.close()
+  })
+
+  it('onSave echoes the custom permalink / layout / visibility overrides (#776)', async () => {
+    const bodies = captureUpdates()
+    const { result } = renderHookWithProviders(() =>
+      useEntitySeoPanel(
+        makeEntity({
+          permalink: '/company/about',
+          layout: 'two-col',
+          showComments: false,
+          showRelated: false,
+        }),
+      ),
+    )
+
+    act(() => {
+      result.current.onMetaTitleChange('New title')
+    })
+    act(() => {
+      result.current.onSave()
+    })
+
+    await waitFor(() => {
+      expect(bodies).toHaveLength(1)
+    })
+    expect(bodies[0]).toMatchObject({
+      meta_title: 'New title',
+      permalink: '/company/about',
+      layout: 'two-col',
+      show_comments: false,
+      show_related: false,
+    })
+  })
+})

--- a/frontend/src/features/manage-entity-status/hooks/useEntitySeoPanel.ts
+++ b/frontend/src/features/manage-entity-status/hooks/useEntitySeoPanel.ts
@@ -31,10 +31,12 @@ export function useEntitySeoPanel(entity: Entity): EntitySeoPanelState {
         id: Number(entity.id),
         entityTypeId: entity.entityTypeId,
         slug: entity.slug,
+        // Preserve the custom permalink / layout / visibility flags: the update
+        // endpoint is full-replace, so omitting them clears them (#776).
+        permalink: entity.permalink,
         status: entity.status,
         metaTitle: metaTitle !== '' ? metaTitle : null,
         metaDescription: metaDescription !== '' ? metaDescription : null,
-        // Preserve layout / visibility flags: the update endpoint is full-replace.
         layout: entity.layout,
         showComments: entity.showComments,
         showRelated: entity.showRelated,

--- a/src/Entity/ProcessScheduledPublishUseCase.php
+++ b/src/Entity/ProcessScheduledPublishUseCase.php
@@ -28,10 +28,14 @@ final readonly class ProcessScheduledPublishUseCase implements ProcessScheduledP
                 throw new LogicException('Scheduled entity missing id.');
             }
 
+            // repository::update() is full-replace: every column it writes must be
+            // carried from the loaded entity or it is silently nulled (#776).
             $updated = new Entity(
                 id: $entityId,
                 entityTypeId: $entity->entityTypeId,
                 slug: $entity->slug,
+                permalink: $entity->permalink,
+                layout: $entity->layout,
                 status: EntityStatus::Published,
                 publishedAt: $entity->publishedAt ?? $now,
                 isDeleted: $entity->isDeleted,

--- a/src/Entity/ScheduleEntityUseCase.php
+++ b/src/Entity/ScheduleEntityUseCase.php
@@ -35,10 +35,14 @@ final readonly class ScheduleEntityUseCase implements ScheduleEntityUseCaseInter
             throw new InvalidArgumentException('scheduled_at must be in the future.');
         }
 
+        // repository::update() is full-replace: every column it writes must be
+        // carried from $existing or it is silently nulled (#776).
         $updated = new Entity(
             id: $entityId,
             entityTypeId: $existing->entityTypeId,
             slug: $existing->slug,
+            permalink: $existing->permalink,
+            layout: $existing->layout,
             status: EntityStatus::Scheduled,
             publishedAt: $existing->publishedAt,
             isDeleted: $existing->isDeleted,

--- a/src/Entity/UnscheduleEntityUseCase.php
+++ b/src/Entity/UnscheduleEntityUseCase.php
@@ -27,10 +27,14 @@ final readonly class UnscheduleEntityUseCase implements UnscheduleEntityUseCaseI
             throw new LogicException('Loaded entity missing id.');
         }
 
+        // repository::update() is full-replace: every column it writes must be
+        // carried from $existing or it is silently nulled (#776).
         $updated = new Entity(
             id: $id,
             entityTypeId: $existing->entityTypeId,
             slug: $existing->slug,
+            permalink: $existing->permalink,
+            layout: $existing->layout,
             status: EntityStatus::Draft,
             publishedAt: $existing->publishedAt,
             isDeleted: $existing->isDeleted,

--- a/tests/Entity/EntityScheduleUseCaseTest.php
+++ b/tests/Entity/EntityScheduleUseCaseTest.php
@@ -46,6 +46,31 @@ final class EntityScheduleUseCaseTest extends TestCase
         );
     }
 
+    public function testSchedulePreservesPermalinkLayoutAndVisibilityOverrides(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(
+            id: null,
+            entityTypeId: 1,
+            slug: 'about',
+            permalink: '/company/about',
+            layout: 'two-col',
+            showComments: false,
+            showRelated: false,
+        ));
+
+        $useCase = new ScheduleEntityUseCase($entities, new UtcClock());
+        $useCase->execute(new ScheduleEntityInput(id: $entityId, scheduledAt: new DateTimeImmutable('+1 hour')));
+
+        // repository::update() is full-replace — scheduling must not wipe these (#776).
+        $updated = $entities->findById($entityId);
+        self::assertNotNull($updated);
+        self::assertSame('/company/about', $updated->permalink);
+        self::assertSame('two-col', $updated->layout);
+        self::assertFalse($updated->showComments);
+        self::assertFalse($updated->showRelated);
+    }
+
     public function testScheduleEntityThrowsEntityNotFoundExceptionWhenEntityMissing(): void
     {
         $entities = new InMemoryEntityRepository([]);
@@ -88,6 +113,28 @@ final class EntityScheduleUseCaseTest extends TestCase
         self::assertNotNull($updated);
         self::assertSame(EntityStatus::Draft, $updated->status);
         self::assertNull($updated->scheduledAt);
+    }
+
+    public function testUnschedulePreservesPermalinkAndLayout(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(
+            id: null,
+            entityTypeId: 1,
+            slug: 'about',
+            permalink: '/company/about',
+            layout: 'bare',
+            status: EntityStatus::Scheduled,
+            scheduledAt: new DateTimeImmutable('+1 day'),
+        ));
+
+        (new UnscheduleEntityUseCase($entities))->execute(new UnscheduleEntityInput(entityId: $entityId));
+
+        // Full-replace update — cancelling a schedule must not wipe these (#776).
+        $updated = $entities->findById($entityId);
+        self::assertNotNull($updated);
+        self::assertSame('/company/about', $updated->permalink);
+        self::assertSame('bare', $updated->layout);
     }
 
     public function testUnscheduleEntityThrowsEntityNotFoundExceptionWhenEntityMissing(): void
@@ -146,6 +193,28 @@ final class EntityScheduleUseCaseTest extends TestCase
         self::assertNotNull($published);
         self::assertSame(EntityStatus::Published, $published->status);
         self::assertNull($published->scheduledAt);
+    }
+
+    public function testProcessScheduledPublishPreservesPermalinkAndLayout(): void
+    {
+        $entities = new InMemoryEntityRepository([]);
+        $entityId = $entities->save(new Entity(
+            id: null,
+            entityTypeId: 1,
+            slug: 'about',
+            permalink: '/company/about',
+            layout: 'full',
+            status: EntityStatus::Scheduled,
+            scheduledAt: new DateTimeImmutable('-1 minute'),
+        ));
+
+        (new ProcessScheduledPublishUseCase($entities, new UtcClock()))->execute();
+
+        // Full-replace update — the cron auto-publish must not wipe these (#776).
+        $published = $entities->findById($entityId);
+        self::assertNotNull($published);
+        self::assertSame('/company/about', $published->permalink);
+        self::assertSame('full', $published->layout);
     }
 
     public function testProcessScheduledPublishReturnsEmptyListWhenNoDueEntities(): void


### PR DESCRIPTION
## 目的

`entities` の UPDATE は full-replace（渡さないフィールドは NULL 上書き）だが、既存値を引き継がずに `Entity` を再構築して更新する経路があり、`layout` と `permalink` が黙って消えていた。`Closes #776`

## 変更内容

- **backend**: `ScheduleEntityUseCase` / `UnscheduleEntityUseCase` / `ProcessScheduledPublishUseCase` が `$existing` から `permalink` / `layout` を引き継ぐように修正（#775 の `show_comments` / `show_related` は実装時に引き継ぎ済み）
- **frontend**: SEO パネル保存（`useEntitySeoPanel`）が `permalink` を echo するように修正（従来はカスタム permalink 持ちページで SEO を保存すると permalink が外れ、301 リダイレクトまで記録された）

## 検証

- `composer check` / `npm run check --prefix frontend` ✅
- 回帰テスト追加: 予約公開・予約解除・cron 自動公開が permalink / layout / 表示フラグを保持すること（backend 3本）、SEO 保存の PUT body に permalink / layout / 表示フラグが載ること（frontend 1本）

## 再現手順（修正前）

カスタム permalink＋layout 指定のあるレコードを「予約公開」→ DB の `layout` / `permalink` が NULL になる。

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)