### PR TITLE
feat(theme): footer_markdown の文字サイズトークン --footer-free-size（#781）

### DIFF
--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -1067,7 +1067,9 @@
   max-width: 34ch;
 }
 .nene-public .ft__free {
-  font-size: var(--text-body-sm);
+  /* Free-text size token (#781): themes may set --footer-free-size; default
+     follows the type scale (independent of --footer-size = menu links). */
+  font-size: var(--footer-free-size, var(--text-body-sm));
   color: var(--color-text-muted);
   line-height: 1.6;
 }

--- a/src/Theme/ThemeAuthoringGuide.php
+++ b/src/Theme/ThemeAuthoringGuide.php
@@ -123,6 +123,7 @@ final class ThemeAuthoringGuide
         'brand-size' => ['fontSize', 'Site title (brand wordmark) size. Optional; defaults to 1.25rem.'],
         'nav-size' => ['fontSize', 'Header menu link size. Optional; defaults to text-body-sm.'],
         'footer-size' => ['fontSize', 'Footer menu/link size. Optional; defaults to text-body-sm.'],
+        'footer-free-size' => ['fontSize', 'Footer free-text (footer_markdown) size. Optional; defaults to text-body-sm.'],
         // Type sizes
         'text-display' => ['fontSize', 'Hero/display size.'],
         'text-h1' => ['fontSize', 'H1 size.'],


### PR DESCRIPTION
## 目的

フッターのフリー Markdown（`footer_markdown`）の文字サイズを、テーマから調整可能にする。`Closes #781`

## 変更内容

- `.ft__free` の font-size を `var(--footer-free-size, var(--text-body-sm))` に（**既定の見た目は不変**・メニューリンク用の `--footer-size` とは独立）
- `ThemeAuthoringGuide` の OPTIONAL_TOKENS に `footer-free-size` を追記（`nav-size` / `footer-size` の並び）

#760 の「要素別 UI ノブは打ち止め・細粒度はテーマトークンで」方針に従い、管理 UI ノブは追加しない。runtime テーマ manifest はトークン名 allowlist を持たないため、この2点で ClaudeDesign / manifest から設定可能になる。

## 検証

- `composer check` / `npm run check --prefix frontend` ✅

Closes #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)