### PR TITLE
feat(appearance): カスタマイザに汎用「詳細トークン設定」— MCP/API なしで optional トークンを上書き（#785）

### DIFF
--- a/frontend/src/entities/theme/api-types.ts
+++ b/frontend/src/entities/theme/api-types.ts
@@ -3,3 +3,4 @@ import type { components } from '@/shared/api/schema.gen'
 export type ThemeDto = components['schemas']['ThemeResponse']
 export type ThemeListDto = components['schemas']['ThemeListResponse']
 export type ThemeManifestDto = components['schemas']['ThemeManifest']
+export type ThemeAuthoringGuideDto = components['schemas']['ThemeAuthoringGuideResponse']

--- a/frontend/src/entities/theme/index.ts
+++ b/frontend/src/entities/theme/index.ts
@@ -1,3 +1,3 @@
-export { usePublicThemes, useThemes } from './queries'
+export { usePublicThemes, useThemeAuthoringGuide, useThemes } from './queries'
 export { useCreateTheme, useDeleteTheme, useUpdateTheme } from './mutations'
 export type { ThemeDto, ThemeListDto, ThemeManifestDto } from './api-types'

--- a/frontend/src/entities/theme/queries.ts
+++ b/frontend/src/entities/theme/queries.ts
@@ -1,6 +1,6 @@
 import { useQuery, type UseQueryResult } from '@tanstack/react-query'
 import { apiClient, type AppError } from '@/shared/api/client'
-import type { ThemeListDto } from './api-types'
+import type { ThemeAuthoringGuideDto, ThemeListDto } from './api-types'
 import { themeKeys } from './query-keys'
 
 /**
@@ -19,5 +19,19 @@ export function useThemes(): UseQueryResult<ThemeListDto, AppError> {
   return useQuery({
     queryKey: themeKeys.adminList(),
     queryFn: async ({ signal }) => apiClient.get<ThemeListDto>('/api/v1/themes', signal),
+  })
+}
+
+/**
+ * The theme authoring guide — the customizer's advanced token section reads its
+ * `renderModel.optionalTokens` catalog (#785), so the documented engine tokens
+ * drive the UI without a hand-maintained copy.
+ */
+export function useThemeAuthoringGuide(): UseQueryResult<ThemeAuthoringGuideDto, AppError> {
+  return useQuery({
+    queryKey: themeKeys.authoringGuide(),
+    queryFn: async ({ signal }) =>
+      apiClient.get<ThemeAuthoringGuideDto>('/api/v1/themes/authoring-guide', signal),
+    staleTime: Infinity,
   })
 }

--- a/frontend/src/entities/theme/query-keys.ts
+++ b/frontend/src/entities/theme/query-keys.ts
@@ -8,4 +8,5 @@ export const themeKeys = {
   all: ['themes'] as const,
   publicList: () => [...themeKeys.all, 'public'] as const,
   adminList: () => [...themeKeys.all, 'admin'] as const,
+  authoringGuide: () => [...themeKeys.all, 'authoring-guide'] as const,
 }

--- a/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
+++ b/frontend/src/features/manage-appearance/ui/ThemeCustomizeView.tsx
@@ -1,6 +1,8 @@
 import { type ReactNode, useMemo, useState } from 'react'
 import { useMediaList } from '@/entities/media'
+import { useThemeAuthoringGuide } from '@/entities/theme'
 import { useTranslation } from '@/shared/i18n'
+import { isSafeTokenValue, TOKEN_KEY } from '@/shared/lib/runtime-themes'
 import {
   BRAND_FONT_OPTIONS,
   BRAND_SIZE_OPTIONS,
@@ -92,6 +94,146 @@ function Select({
         </option>
       ))}
     </select>
+  )
+}
+
+/** One documented optional engine token from the authoring guide. */
+interface TokenCatalogEntry {
+  token: string
+  group: string
+  drives: string
+}
+
+/**
+ * Advanced token overrides (#785): the escape hatch that makes the documented
+ * optional engine tokens reachable from the UI (no MCP/API). The catalog is the
+ * authoring guide's `optionalTokens` — adding an engine token there makes it
+ * appear here with no UI work. Values are re-validated at emission; an unsafe
+ * value is highlighted and simply never emitted.
+ */
+function TokenOverridesEditor({
+  tokens,
+  disabled,
+  onChange,
+}: {
+  tokens: Record<string, string> | undefined
+  disabled: boolean
+  onChange: (next: Record<string, string> | undefined) => void
+}) {
+  const { t } = useTranslation()
+  const guideQuery = useThemeAuthoringGuide()
+  const [pendingToken, setPendingToken] = useState('')
+
+  const catalog = useMemo((): TokenCatalogEntry[] => {
+    const raw = guideQuery.data?.renderModel['optionalTokens']
+    if (typeof raw !== 'object' || raw === null) {
+      return []
+    }
+    return Object.entries(raw as Record<string, unknown>).flatMap(
+      ([token, doc]): TokenCatalogEntry[] => {
+        if (!TOKEN_KEY.test(token)) return []
+        const detail =
+          typeof doc === 'object' && doc !== null ? (doc as Record<string, unknown>) : {}
+        return [
+          {
+            token,
+            group: typeof detail['group'] === 'string' ? detail['group'] : '',
+            drives: typeof detail['drives'] === 'string' ? detail['drives'] : '',
+          },
+        ]
+      },
+    )
+  }, [guideQuery.data])
+
+  const current = tokens ?? {}
+  const entries = Object.entries(current)
+  const availableByGroup = useMemo(() => {
+    const used = tokens ?? {}
+    const groups = new Map<string, TokenCatalogEntry[]>()
+    for (const entry of catalog) {
+      if (entry.token in used) continue
+      const list = groups.get(entry.group) ?? []
+      list.push(entry)
+      groups.set(entry.group, list)
+    }
+    return groups
+  }, [catalog, tokens])
+
+  const emit = (next: Record<string, string>): void => {
+    onChange(Object.keys(next).length > 0 ? next : undefined)
+  }
+
+  return (
+    <Stack gap="xs" className="border-t border-border pt-stack-sm">
+      <Text muted variant="caption">
+        {t('admin.themeCustomize.tokens.help')}
+      </Text>
+      {entries.map(([token, value]) => {
+        const safe = isSafeTokenValue(value)
+        return (
+          <div key={token} className="flex items-center gap-inline-sm">
+            <span className="w-44 shrink-0 truncate font-mono text-caption text-text-primary">
+              --{token}
+            </span>
+            <input
+              type="text"
+              className={`min-w-0 flex-1 rounded-sm border bg-surface px-inline-sm py-stack-xs font-mono text-body-sm text-text-primary ${safe ? 'border-border' : 'border-danger'}`}
+              value={value}
+              disabled={disabled}
+              aria-label={`--${token}`}
+              aria-invalid={!safe}
+              title={safe ? undefined : t('admin.themeCustomize.tokens.invalid')}
+              onChange={(event) => {
+                emit({ ...current, [token]: event.target.value })
+              }}
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={disabled}
+              onClick={() => {
+                emit(Object.fromEntries(entries.filter(([key]) => key !== token)))
+              }}
+            >
+              {t('admin.themeCustomize.tokens.remove')}
+            </Button>
+          </div>
+        )
+      })}
+      <div className="flex items-center gap-inline-sm">
+        <select
+          className="rounded-sm border border-border bg-surface px-inline-sm py-stack-xs font-sans text-body text-text-primary"
+          value={pendingToken}
+          disabled={disabled}
+          aria-label={t('admin.themeCustomize.tokens.placeholder')}
+          onChange={(event) => {
+            setPendingToken(event.target.value)
+          }}
+        >
+          <option value="">{t('admin.themeCustomize.tokens.placeholder')}</option>
+          {[...availableByGroup.entries()].map(([group, list]) => (
+            <optgroup key={group} label={group}>
+              {list.map((entry) => (
+                <option key={entry.token} value={entry.token} title={entry.drives}>
+                  --{entry.token}
+                </option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={disabled || pendingToken === ''}
+          onClick={() => {
+            emit({ ...current, [pendingToken]: '' })
+            setPendingToken('')
+          }}
+        >
+          {t('admin.themeCustomize.tokens.add')}
+        </Button>
+      </div>
+    </Stack>
   )
 }
 
@@ -611,6 +753,14 @@ export function ThemeCustomizeView({
                 }}
               />
             </Field>
+            {/* Documented engine tokens, editable without MCP/API (#785). */}
+            <TokenOverridesEditor
+              tokens={draft.tokens}
+              disabled={disabled}
+              onChange={(next) => {
+                setKnob('tokens', next)
+              }}
+            />
           </Stack>
         </details>
 

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -178,6 +178,12 @@ export const de: Partial<MessageCatalog> = {
   'admin.footerContent.bannerAlt': 'Alternativtext',
   'admin.themeCustomize.basic': 'Grundlagen',
   'admin.themeCustomize.advanced': 'Erweitert',
+  'admin.themeCustomize.tokens.help':
+    'Token-Überschreibungen (erweitert): dokumentierte Engine-Tokens direkt setzen — z. B. footer-free-size für den Footer-Freitext. Unsichere Werte werden ignoriert.',
+  'admin.themeCustomize.tokens.placeholder': 'Token auswählen…',
+  'admin.themeCustomize.tokens.add': 'Hinzufügen',
+  'admin.themeCustomize.tokens.remove': 'Entfernen',
+  'admin.themeCustomize.tokens.invalid': 'Dieser Wert ist unsicher und wird ignoriert.',
   'admin.themeCustomize.saved': 'Anpassung gespeichert',
   'admin.themeCustomize.saveError': 'Anpassung konnte nicht gespeichert werden',
   'admin.themeCustomize.save': 'Speichern',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -185,6 +185,12 @@ export const en = {
   'admin.footerContent.bannerAlt': 'Alt text',
   'admin.themeCustomize.basic': 'Basics',
   'admin.themeCustomize.advanced': 'Advanced',
+  'admin.themeCustomize.tokens.help':
+    'Token overrides (advanced): set a documented engine token directly — e.g. footer-free-size for the footer free text. Unsafe values are ignored.',
+  'admin.themeCustomize.tokens.placeholder': 'Select a token…',
+  'admin.themeCustomize.tokens.add': 'Add',
+  'admin.themeCustomize.tokens.remove': 'Remove',
+  'admin.themeCustomize.tokens.invalid': 'This value is unsafe and will be ignored.',
   'admin.themeCustomize.saved': 'Customization saved',
   'admin.themeCustomize.saveError': 'Could not save customization',
   'admin.themeCustomize.save': 'Save',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -181,6 +181,12 @@ export const fr: Partial<MessageCatalog> = {
   'admin.footerContent.bannerAlt': 'Texte alternatif',
   'admin.themeCustomize.basic': 'Bases',
   'admin.themeCustomize.advanced': 'Avancé',
+  'admin.themeCustomize.tokens.help':
+    'Surcharges de tokens (avancé) : définissez directement un token documenté du moteur — p. ex. footer-free-size pour le texte libre du pied de page. Les valeurs non sûres sont ignorées.',
+  'admin.themeCustomize.tokens.placeholder': 'Choisir un token…',
+  'admin.themeCustomize.tokens.add': 'Ajouter',
+  'admin.themeCustomize.tokens.remove': 'Retirer',
+  'admin.themeCustomize.tokens.invalid': 'Cette valeur n’est pas sûre et sera ignorée.',
   'admin.themeCustomize.saved': 'Personnalisation enregistrée',
   'admin.themeCustomize.saveError': "Impossible d'enregistrer la personnalisation",
   'admin.themeCustomize.save': 'Enregistrer',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -178,6 +178,12 @@ export const ja: Partial<MessageCatalog> = {
   'admin.footerContent.bannerAlt': '代替テキスト',
   'admin.themeCustomize.basic': '基本',
   'admin.themeCustomize.advanced': '詳細設定',
+  'admin.themeCustomize.tokens.help':
+    'トークン上書き（上級者向け）: 文書化済みのエンジントークンを直接設定できます — 例: フッターのフリーテキストは footer-free-size。安全でない値は無視されます。',
+  'admin.themeCustomize.tokens.placeholder': 'トークンを選択…',
+  'admin.themeCustomize.tokens.add': '追加',
+  'admin.themeCustomize.tokens.remove': '削除',
+  'admin.themeCustomize.tokens.invalid': 'この値は安全でないため無視されます。',
   'admin.themeCustomize.saved': 'カスタマイズを保存しました',
   'admin.themeCustomize.saveError': 'カスタマイズを保存できませんでした',
   'admin.themeCustomize.save': '保存',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -179,6 +179,12 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.footerContent.bannerAlt': 'Texto alternativo',
   'admin.themeCustomize.basic': 'Básico',
   'admin.themeCustomize.advanced': 'Avançado',
+  'admin.themeCustomize.tokens.help':
+    'Substituições de tokens (avançado): defina diretamente um token documentado do motor — p. ex. footer-free-size para o texto livre do rodapé. Valores inseguros são ignorados.',
+  'admin.themeCustomize.tokens.placeholder': 'Selecionar um token…',
+  'admin.themeCustomize.tokens.add': 'Adicionar',
+  'admin.themeCustomize.tokens.remove': 'Remover',
+  'admin.themeCustomize.tokens.invalid': 'Este valor é inseguro e será ignorado.',
   'admin.themeCustomize.saved': 'Personalização salva',
   'admin.themeCustomize.saveError': 'Não foi possível salvar a personalização',
   'admin.themeCustomize.save': 'Salvar',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -177,6 +177,12 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.footerContent.bannerAlt': '替代文本',
   'admin.themeCustomize.basic': '基础',
   'admin.themeCustomize.advanced': '高级',
+  'admin.themeCustomize.tokens.help':
+    '令牌覆盖（高级）：直接设置文档化的引擎令牌 — 例如页脚自由文本用 footer-free-size。不安全的值将被忽略。',
+  'admin.themeCustomize.tokens.placeholder': '选择令牌…',
+  'admin.themeCustomize.tokens.add': '添加',
+  'admin.themeCustomize.tokens.remove': '移除',
+  'admin.themeCustomize.tokens.invalid': '该值不安全，将被忽略。',
   'admin.themeCustomize.saved': '已保存自定义设置',
   'admin.themeCustomize.saveError': '无法保存自定义设置',
   'admin.themeCustomize.save': '保存',

--- a/frontend/src/shared/lib/runtime-themes.ts
+++ b/frontend/src/shared/lib/runtime-themes.ts
@@ -34,7 +34,8 @@ export interface RuntimeTheme {
 }
 
 const THEME_KEY = /^[a-z][a-z0-9-]{1,40}$/
-const TOKEN_KEY = /^[a-z][a-z0-9-]*$/
+/** Valid token key shape — shared with the customizer's advanced overrides (#785). */
+export const TOKEN_KEY = /^[a-z][a-z0-9-]*$/
 const BREAKOUT = /[;{}<>\\`]/
 const UNSAFE_SUBSTRINGS = ['url(', '@import', 'expression(', 'javascript:', '/*', '*/']
 

--- a/frontend/src/shared/lib/theme-customization.test.ts
+++ b/frontend/src/shared/lib/theme-customization.test.ts
@@ -68,6 +68,30 @@ describe('resolveOverrideStyle', () => {
     expect(resolveOverrideStyle({ menuSize: 'huge' })['--nav-size']).toBeUndefined()
   })
 
+  it('emits advanced token overrides with runtime-theme safety rules (#785)', () => {
+    const style = resolveOverrideStyle({
+      tokens: {
+        'footer-free-size': '0.75rem',
+        'Bad Key': '1rem',
+        'nav-size': 'url(https://evil.example/x)',
+        empty: '   ',
+      },
+    })
+    expect(style['--footer-free-size']).toBe('0.75rem')
+    expect(style['--Bad Key']).toBeUndefined()
+    expect(style['--nav-size']).toBeUndefined()
+    expect(style['--empty']).toBeUndefined()
+  })
+
+  it('advanced token overrides win over knob-derived values of the same name (#785)', () => {
+    const style = resolveOverrideStyle({
+      menuSize: 'compact',
+      tokens: { 'footer-size': '1.25rem' },
+    })
+    expect(style['--nav-size']).toBe('0.8125rem')
+    expect(style['--footer-size']).toBe('1.25rem')
+  })
+
   it('ignores invalid / unknown values (no injection)', () => {
     const style = resolveOverrideStyle({
       accent: 'red; } body { display:none',

--- a/frontend/src/shared/lib/theme-customization.ts
+++ b/frontend/src/shared/lib/theme-customization.ts
@@ -14,6 +14,7 @@
  */
 
 import { mediaDerivativeUrl } from './media-derivatives'
+import { isSafeTokenValue, TOKEN_KEY } from './runtime-themes'
 
 /** Per-theme override values as stored (one entry per theme id). */
 export interface ThemeOverrides {
@@ -61,6 +62,14 @@ export interface ThemeOverrides {
   flags?: ThemeFlags
   /** Image slots (logo / hero / background), per mode. See ThemeImages. */
   images?: ThemeImages
+  /**
+   * Advanced raw token overrides (#785) — the customizer's escape hatch for the
+   * documented optional engine tokens (authoring-guide `optionalTokens`), so
+   * they are reachable without MCP/API. Keys/values are re-validated at emission
+   * with the same rules as runtime-theme manifests; they are emitted LAST so an
+   * explicit token wins over a knob-derived value of the same name.
+   */
+  tokens?: Record<string, string>
 }
 
 /** A colour value per light/dark mode (hex). */
@@ -551,6 +560,16 @@ export function resolveOverrideStyle(overrides: ThemeOverrides): Record<string, 
     if (factor !== undefined) {
       for (const [name, value] of SPACE_SCALE) {
         style[`--space-${name}`] = rem(value * factor)
+      }
+    }
+  }
+
+  // Advanced token overrides (#785): validated like runtime-theme manifest
+  // tokens, emitted last so they beat knob-derived values of the same name.
+  if (overrides.tokens !== undefined) {
+    for (const [key, value] of Object.entries(overrides.tokens)) {
+      if (TOKEN_KEY.test(key) && typeof value === 'string' && isSafeTokenValue(value)) {
+        style[`--${key}`] = value
       }
     }
   }


### PR DESCRIPTION
## 目的

#781 の `--footer-free-size` などテーマトークンが ClaudeDesign(MCP)/API 経由でしか触れず、組み込みテーマ＋カスタマイザ運用の非技術ユーザーに届かない問題への回答。要素別ノブは増やさず（#760 方針堅持）、**汎用のトークン上書きセクションを1つ**追加する。`Closes #785`

## 変更内容

- **`ThemeOverrides.tokens`**（`Record<string,string>`）を追加。`resolveOverrideStyle` が runtime テーマ manifest と同一の安全検証（キー形状 `TOKEN_KEY` + `isSafeTokenValue`）で**ノブの後に** emit — 明示トークンがノブ由来値（例: menuSize→`--footer-size`）に勝つ
- **カタログはデータ駆動**: 既存 `GET /api/v1/themes/authoring-guide` の `renderModel.optionalTokens`（グループ・説明付き）から描画。エンジンに新トークンを足すと（ガイド同期はテスト強制）**UI 工事なしで自動的に選択肢へ**
- **UI**: 外観 → テーマ → カスタマイズ → 「詳細設定」内の末尾に、トークン選択（optgroup でグループ分け・説明は title）＋値入力＋追加/削除。不正値は赤枠表示＆emission で無視。ライブプレビュー（#538）は override CSS 再導出に乗るので自動追従
- **save-as-theme**: `buildThemeManifestFromCustomization` は `resolveOverrideStyle` を使うため、トークンは新テーマの manifest にも自動で焼き込まれる
- **backend**: 変更なし（guide エンドポイント既存・`theme_overrides` は設定 JSON）
- i18n 全 6 ロケール

## 検証

- `composer check` / `npm run check --prefix frontend` ✅
- テスト追加: 安全検証（不正キー/url()/空値の排除）・ノブとの優先順位（明示トークンが勝つ）

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)