### PR TITLE
feat(appearance): テーマ/レイアウトタブ表示中は admin サイドバーをレール化（#789）

### DIFF
--- a/frontend/src/features/manage-widgets/ui/ManageWidgetsView.tsx
+++ b/frontend/src/features/manage-widgets/ui/ManageWidgetsView.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useUpdateSetting, useSettingList } from '@/entities/setting'
 import { useTranslation } from '@/shared/i18n'
-import { setChromeRail } from '@/shared/lib/chrome-rail'
 import {
   allActiveSideRegions,
   parseLayoutConfig,
@@ -77,14 +76,6 @@ export function ManageWidgetsView({ page }: ManageWidgetsViewProps) {
   }
   const pageLabel =
     layoutPage === 'home' ? t('admin.layout.previewHome') : t('admin.layout.previewRecord')
-
-  // Preview mode collapses the app sidebar into an icon rail (desktop only).
-  useEffect(() => {
-    setChromeRail(mode === 'preview')
-    return () => {
-      setChromeRail(false)
-    }
-  }, [mode])
 
   const segBtn = (on: boolean): string =>
     [

--- a/frontend/src/pages/appearance/AppearanceLayoutPage.tsx
+++ b/frontend/src/pages/appearance/AppearanceLayoutPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link, Navigate, useParams } from 'react-router-dom'
 import { currentUserHasCapability } from '@/entities/auth'
 import { useMenuList } from '@/entities/menu'
@@ -18,6 +18,7 @@ import {
   useManageWidgetsPage,
 } from '@/features/manage-widgets'
 import { useTranslation } from '@/shared/i18n'
+import { setChromeRail } from '@/shared/lib/chrome-rail'
 import { useUnsavedChangesGuard } from '@/shared/lib/use-unsaved-changes-guard'
 import { Button, ConfirmDialog, Stack, Text } from '@/shared/ui'
 
@@ -80,6 +81,18 @@ export function AppearanceLayoutPage() {
   const [help, setHelp] = useState(false)
   const [tourOn, setTourOn] = useState(() => localStorage.getItem(TOUR_LS_KEY) === null)
 
+  const active: AppearanceTab = tab === 'menus' ? 'menus' : tab === 'theme' ? 'theme' : 'layout'
+
+  // The theme workspace (#787) and the layout builder are wide multi-pane
+  // surfaces: collapse the app sidebar into an icon rail while they are shown
+  // (#789). Desktop-only gating lives in AppShell; menus stays full-width nav.
+  useEffect(() => {
+    setChromeRail(active === 'theme' || active === 'layout')
+    return () => {
+      setChromeRail(false)
+    }
+  }, [active])
+
   if (!currentUserHasCapability('manage_settings')) {
     return <Navigate to="/forbidden" replace />
   }
@@ -88,8 +101,6 @@ export function AppearanceLayoutPage() {
     setTourOn(false)
     localStorage.setItem(TOUR_LS_KEY, '1')
   }
-
-  const active: AppearanceTab = tab === 'menus' ? 'menus' : tab === 'theme' ? 'theme' : 'layout'
 
   const tabTitle: Record<AppearanceTab, string> = {
     layout: t('admin.appearance.layoutTab'),


### PR DESCRIPTION
## 目的

3ペイン化（#787）したテーマページとレイアウトビルダーで作業幅を確保するため、両タブ表示中は admin サイドバーをアイコンレールに畳む。`Closes #789`

## 変更内容

- レール化機構（chrome-rail・#360）の発火元を一本化: `ManageWidgetsView` の「プレビューモード連動」トグルを撤去し、`AppearanceLayoutPage` が **タブ（theme / layout）表示中つねに** `setChromeRail` を制御（アンマウント/タブ離脱で解除）
- menus タブ・他ページは従来どおり通常幅。デスクトップ限定ガード（≥lg・モバイルドロワー不干渉）は AppShell 側の既存実装のまま
- hooks ルール順守のため effect は権限ガードの早期 return より前に配置

## 検証

- `composer check` / `npm run check --prefix frontend` ✅
- 実ブラウザ（Playwright・実ログイン）: サイドバー実測幅 posts/menus/settings=240px、**theme/layout=64px（レール）**、離脱で復帰

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)