### PR TITLE
docs(daily): 2026-07-11 の日報を追加する

### DIFF
--- a/docs/daily/2026-07-11.md
+++ b/docs/daily/2026-07-11.md
@@ -1,0 +1,58 @@
+# 日報 — 2026-07-11（NeNe Records）
+
+> 前報（07-05）以降、07-09〜10 前半はフッター体系（P1〜P3・#762〜#773）と AYANE レーンのデプロイ群。本報は **07-10 夜〜07-11** の連続セッション: 公開ページの表示制御 → その本番バグ根治 → フッター微調整 → カスタマイザのトークン開放 → **テーマページ IA 再設計（ClaudeDesign 往復）** → レール化 → 全機能ブラウザ監査まで、**8 Issue / 8 PR を実装〜本番反映（第20〜25回デプロイ）**。
+
+## ヘッドライン
+**テーマページを ClaudeDesign 納品の 3ペインワークスペースへ全面再設計（#787）**。左ナビがそのまま「保存モデルの地図」（即時反映 / 1つの保存単位 / 各独立保存）になり、theme_overrides の保存は常設保存バー1本に集約、ライブプレビューは常時表示化。あわせて **SSR bootstrap が SPA の useEntity を事前ハイドレートし再フェッチしない**という重要な設計事実を本番バグ（#778）から特定し根治。再設計後は実ブラウザで **31 チェック全機能・境界値監査 → 全パス（#791）**。
+
+---
+
+## 本日の成果（時系列）
+
+### A. コメント/関連レコードの表示制御（#775 / PR #777）
+- front page 固定ページでコメント欄と「Keep reading」を消せない問題に、**2層カスケード**（layout と同型）で対応: サイト共通 `record_page_config`（設定・専用セクション UI・汎用一覧から隠す）＋レコード個別 `entities.show_comments` / `show_related`（tri-state・公開ステータスパネル）。
+- migration 2本（版番は date-skew 対策の手動採番 20260718/20260719）・seeder＋backfill で**本番 7 org 反映**。full-replace 更新のため既存の全 update 呼び出し（status/slug/permalink/layout/SEO/schedule系）で echo を追加。
+
+### B. 「反映されない」の根治 — SSR bootstrap の穴（#778 / PR #779）
+- 施主報告「ayane トップで消えない」を診断: DB は設定済み・API も正しい・バンドルにも条件分岐あり、なのに表示。ネットワーク傍受で **SPA が `entities/{id}` を一度もフェッチしていない**ことが決め手 —— SSR の bootstrap ペイロードが React Query を事前ハイドレートし、その `entity` に新フィールドが無かった。
+- `PublicRecordViewHttpMapper::toBootstrap`（public/preview 共用）に 2 フィールド追加で根治。**教訓: entities に新カラムを足して SPA で読むなら bootstrap にも必ず載せる**（bootstrap の entity は layout/slug 等も欠く「部分 entity」のまま＝棚卸し候補として注記）。
+
+### C. full-replace echo 漏れの既存バグ修正（#776 / PR #780）
+- A の実装中に発見: **予約公開・予約解除・cron 自動公開が `permalink` / `layout` を黙って NULL 化**、SEO パネル保存も permalink を落として 301 まで記録。3 UseCase の引き継ぎ＋SEO パネルの echo を修正、回帰テスト4本。
+
+### D. フッター微調整 2本（#781 / PR #783・#782 / PR #784）
+- `--footer-free-size` トークン新設（footer_markdown の文字サイズ・#760「ノブ打ち止め」方針どおり管理 UI ノブは増やさずテーマトークンで）。
+- footer menu ウィジェットに `layout: 縦積み/横並び` 設定（inline は折返し行フロー・モバイルはアコーディオンに畳まない・インスペクタは footer 配置時のみ表示）。
+
+### E. カスタマイザ「詳細トークン設定」（#785 / PR #786）
+- 施主指摘「**MCP/API を使えない人はトークンに触れない**」への回答。要素別ノブ再開ではなく**汎用エスケープハッチ1つ**: `ThemeOverrides.tokens` ＋ authoring-guide の `optionalTokens` カタログを**データ駆動**で描画（エンジンにトークンを足すと UI 工事なしで選択肢に出る）。値は runtime テーマと同一の安全検証・ノブ由来値より明示トークンが勝つ・save-as-theme にも自動流入。
+
+### F. テーマページ IA 再設計（handoff → #787 / PR #788）
+- 情報過多（5大セクション・80+コントロール縦積み）を ClaudeDesign に相談するため、**単体動作のモック HTML＋詳細 SPEC＋REQUEST を zip 化**（`design-export/theme-page-handoff/`・Playwright でモック検証済み）。
+- 納品（`NeNe Records Design System (29).zip`）を React 移植: **3ペイン**（保存モデルの地図ナビ＋パネル切替＋常設プレビュー iframe）・**常設保存バー**・**ヘッダー統合**（内容=header_config / 配置・見た目=theme_overrides を保存先タグで明示）・**セグメントコントロール**（スライドサムネイル・折返し行追従）。旧 ThemeCustomizeView は解体。
+- **prototype からの意図的乖離**: 到達性の補完（fontSize ノブ・スタイル4フラグ・画像スロット復元）＋ **breakpoints を admin サイドバー分シフト**（prototype は単独ページ前提で、1280px 実機でプレビューが中央カラムに重なりクリック不能 —— Playwright 検証で検出し 1420/1280/1000/460 に補正）。
+
+### G. サイドバーのレール化（#789 / PR #790）
+- chrome-rail（#360）の発火を「レイアウトビルダーの preview モード連動」から **AppearanceLayoutPage のタブ制御（theme/layout 表示中は常時）**へ一本化。実測: posts/menus/settings=240px・theme/layout=64px。
+
+### H. 再設計後の全機能・境界値ブラウザ監査（#791・クローズ済み）
+- ローカル dev に実ログインした Playwright で **31 チェック**（保存単位の分離・既定クリア・不正トークン値・未保存ガード・テーマ適用ラウンドトリップ・**1281/1280px 境界ちょうど**・FAB/バックドロップ・1000/460/375px・ja ロケール・キーボード操作）。**全パス・実バグ 0・JS 例外 0**。レポートは #791 コメントに恒久化。
+
+---
+
+## 意思決定
+- 表示制御は **2層カスケード**（サイト共通 default ＋レコード tri-state）。タイプ既定の3層目は必要になってから。
+- **ノブ打ち止め方針（#760）の運用形が確立**: 細粒度=テーマトークン（#781）、非技術ユーザーへの開放=汎用トークン UI 1つ（#785）。要素別ノブは今後も増やさない。
+- ClaudeDesign 協働の新しい教訓: **prototype は「単独ページ」前提で来る** — admin シェル内に置く場合は breakpoints をシェルの chrome 幅分シフトして検証する。
+
+## 現在の状態
+- `main` 先頭 = **`c44d081`**（#790）。作業ツリー clean・全ゲート/CI グリーン。
+- **本番（apex/ayane/aozora）= 第20〜25回デプロイ済み・health 3面 200**。ayane トップのコメント/関連ブロックは施主設定どおり非表示を実機確認済み。
+- open だった今回分の Issue はすべてクローズ（#775/#776/#778/#781/#782/#785/#787/#789/#791）。
+
+## 残課題 / 次の一手
+1. **bootstrap「部分 entity」の棚卸し**（#778 で注記）: layout/slug/status 等も bootstrap に無い — per-record layout override が SSR 経由で効いていない可能性の検証は未実施（要 Issue 化判断）。
+2. テーマページの正式 E2E 化: #791 の一時スクリプト知見（レール化でテキストリンク消失・locale キー等）を `tests/e2e` に昇華するか。
+3. 持ち越し: フッター newsletter 実体（#774・ESP 判断待ち）・#647 Aozora 章モード調整ほか既存バックログ。
+
+> 詳細: PR #777/#779/#780/#783/#784/#786/#788/#790・テストレポート=#791 コメント・handoff=`design-export/theme-page-handoff/`（非追跡）・会話メモリ `records-live-deployment`（第20〜25回）反映済み。


### PR DESCRIPTION
07-10 夜〜07-11 のセッション日報（8 Issue / 8 PR・本番デプロイ第20〜25回）。

- 表示制御 #775 → SSR bootstrap 根治 #778 → full-replace echo 修正 #776
- フッター微調整 #781/#782 → カスタマイザ詳細トークン #785
- テーマページ IA 再設計 #787（ClaudeDesign 往復）→ レール化 #789 → 全機能監査 #791（31チェック全パス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)