### PR TITLE
feat(public-record): bare レイアウトで単一 html 本文を素直に描画する (#799)

### DIFF
--- a/frontend/src/features/public-view-entity-record/ui/PublicRecordFieldList.tsx
+++ b/frontend/src/features/public-view-entity-record/ui/PublicRecordFieldList.tsx
@@ -53,6 +53,18 @@ export function PublicRecordFieldList({
           )
         }
 
+        // Rich HTML (a `html` field) is body prose, not a labelled attribute:
+        // render it as the article's reading column with no field-key label,
+        // so a `bare`/custom page whose body is a single sanitized-HTML field
+        // fills the content host cleanly (parity with markdown/blocks above).
+        if (row.dataType === 'html') {
+          return (
+            <div key={row.fieldKey} className="prose">
+              <SanitizedHtml html={row.displayValue === '—' ? '' : row.displayValue} />
+            </div>
+          )
+        }
+
         // Typed post blocks (#486) render as the article body via first-party,
         // theme-following block renderers — no field-key label.
         if (row.dataType === 'blocks') {
@@ -86,15 +98,9 @@ export function PublicRecordFieldList({
             <Text as="dt" variant="heading-sm">
               {row.fieldKey}
             </Text>
-            {row.dataType === 'html' ? (
-              <dd>
-                <SanitizedHtml html={row.displayValue === '—' ? '' : row.displayValue} />
-              </dd>
-            ) : (
-              <Text as="dd" muted>
-                {row.displayValue}
-              </Text>
-            )}
+            <Text as="dd" muted>
+              {row.displayValue}
+            </Text>
           </div>
         )
       })}

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.test.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.test.tsx
@@ -103,6 +103,32 @@ describe('PublicRecordDetailPage', () => {
     expect(screen.getByText('Yes')).toBeInTheDocument()
   })
 
+  it('renders an html body field as prose without a field-key label', async () => {
+    seedEntityTypes([{ id: 1, name: 'Article', slug: 'article' }])
+    seedEntities([{ id: 1, entity_type_id: 1, is_deleted: false, deleted_at: null }])
+    seedFieldDefs([
+      { id: 1, entity_type_id: 1, field_key: 'title', data_type: 'text' },
+      { id: 2, entity_type_id: 1, field_key: 'content', data_type: 'html' },
+    ])
+    seedTextFields([
+      { id: 1, entity_id: 1, field_key: 'title', value: 'My article' },
+      {
+        id: 2,
+        entity_id: 1,
+        field_key: 'content',
+        value: '<p>本文の<strong>段落</strong>です。</p>',
+      },
+    ])
+
+    renderDetailPage()
+
+    await screen.findByRole('heading', { level: 1, name: 'My article' })
+    // The rich html renders as the body...
+    expect(screen.getByText('段落')).toBeInTheDocument()
+    // ...but its field key is not surfaced as a label (parity with markdown body).
+    expect(screen.queryByText('content')).not.toBeInTheDocument()
+  })
+
   // ── Comments / related visibility (#775) ─────────────────────────────────
   // Per-record tri-state (show_comments / show_related) wins; null falls back
   // to the site-wide record_page_config default.

--- a/src/PublicRecord/PublicHtmlSanitizer.php
+++ b/src/PublicRecord/PublicHtmlSanitizer.php
@@ -26,7 +26,13 @@ final readonly class PublicHtmlSanitizer
             ->allowElement('img', ['src', 'alt', 'title', 'width', 'height'])
             ->allowRelativeLinks()
             ->allowRelativeMedias()
-            ->allowAttribute('style', '*');
+            ->allowAttribute('style', '*')
+            // A full custom page body (a `bare`/custom page authored as one html
+            // field) routinely exceeds Symfony's 20 KB default, which would
+            // silently truncate the crawlable SSR mid-page. Raise the cap to a
+            // generous-but-bounded ceiling so the whole body is sanitized and
+            // server-rendered, while still guarding against pathological input.
+            ->withMaxInputLength(5_000_000);
 
         $this->sanitizer = new HtmlSanitizer($config);
     }

--- a/src/PublicRecord/PublicRecordViewHttpMapper.php
+++ b/src/PublicRecord/PublicRecordViewHttpMapper.php
@@ -77,6 +77,11 @@ final readonly class PublicRecordViewHttpMapper
                 // so the tri-state visibility overrides must ride along (#778).
                 'show_comments' => $entity->showComments,
                 'show_related' => $entity->showRelated,
+                // Per-record layout must ride along too: the SPA resolves the
+                // page chrome (standard / full / two-col / bare / custom) from
+                // entity.layout, so a `bare`/`custom` custom page can only drop
+                // the shell if this payload carries the value it hydrates from.
+                'layout' => $entity->layout,
             ],
             'fieldDefs' => [
                 'items' => array_map(

--- a/tests/PublicRecord/GetPublicRecordViewUseCaseTest.php
+++ b/tests/PublicRecord/GetPublicRecordViewUseCaseTest.php
@@ -75,6 +75,45 @@ final class GetPublicRecordViewUseCaseTest extends TestCase
         // The SPA hydrates useEntity from this payload without refetching (#778).
         self::assertNull($output->bootstrap['entity']['show_comments']);
         self::assertNull($output->bootstrap['entity']['show_related']);
+        // Pin: a record with no explicit layout carries layout=null, so the SPA
+        // resolves it to the type default (standard chrome) exactly as before —
+        // existing orgs' pages are unaffected by exposing layout in the payload.
+        self::assertNull($output->bootstrap['entity']['layout']);
+    }
+
+    public function testBootstrapEntityCarriesLayoutForCustomPages(): void
+    {
+        $entityTypes = new InMemoryEntityTypeRepository([
+            new EntityType(name: 'Article', slug: 'article', id: 1),
+        ]);
+        $entities = new InMemoryEntityRepository([
+            new Entity(
+                id: 10,
+                entityTypeId: 1,
+                slug: 'hello-world',
+                status: EntityStatus::Published,
+                layout: 'bare',
+            ),
+        ]);
+
+        $useCase = new GetPublicRecordViewUseCase(
+            $entityTypes,
+            $entities,
+            new InMemoryFieldDefRepository(),
+            new InMemoryTextFieldRepository([], $entities),
+            new InMemoryIntFieldRepository(),
+            new InMemoryEnumFieldRepository(),
+            new InMemoryBoolFieldRepository(),
+            new InMemoryDateTimeFieldRepository(),
+            new InMemoryEntityRelationRepository(),
+            new ListPublicSettingsUseCase(new InMemorySettingRepository(), new InMemoryMediaRepository(), new \NeNeRecords\PublicRecord\FrontPageSetting(new InMemorySettingRepository(), new InMemoryEntityRepository(), new InMemoryEntityTypeRepository())),
+            new PublicRecordHierarchyBuilder(new InMemoryEntityRepository(), new InMemoryTextFieldRepository()),
+        );
+
+        $output = $useCase->execute(new GetPublicRecordViewInput('article', 'hello-world'));
+
+        // A `bare`/custom page rides its layout to the SPA so it can drop the shell.
+        self::assertSame('bare', $output->bootstrap['entity']['layout']);
     }
 
     public function testBootstrapEntityCarriesVisibilityOverrides(): void

--- a/tests/PublicRecord/PublicHtmlSanitizerTest.php
+++ b/tests/PublicRecord/PublicHtmlSanitizerTest.php
@@ -58,4 +58,19 @@ final class PublicHtmlSanitizerTest extends TestCase
         self::assertStringNotContainsString('<style', $clean);
         self::assertStringContainsString('style="color:red"', $clean);
     }
+
+    public function testKeepsLongCustomPageBodyPastSymfonyDefaultLimit(): void
+    {
+        // A full `bare`/custom page body easily exceeds Symfony's 20 KB default
+        // maxInputLength; raising the cap keeps the whole body crawlable in the
+        // SSR instead of silently truncating it mid-page.
+        $filler = str_repeat('<p style="margin:0">段落テキスト。</p>', 4000);
+        $html = $filler . '<footer id="page-end">末尾</footer>';
+        self::assertGreaterThan(20_000, \strlen($html));
+
+        $clean = $this->sanitizer->sanitize($html);
+
+        self::assertStringContainsString('id="page-end"', $clean);
+        self::assertStringContainsString('末尾', $clean);
+    }
 }


### PR DESCRIPTION
## 目的

公開カスタムページ（#311 の `bare`/`custom`）が **単一の `html` フィールドを本文**として、同一オリジンのクロール可能ページとして素直に描画できるよう、公開レコードビューの配線ギャップを3点修正する。Closes #799。

## 変更

1. **`PublicRecordViewHttpMapper`** — bootstrap の `entity` payload に `layout` を追加。SPA は `useEntity` をこの payload から hydrate し refetch しないため、`layout` を載せないと `bare`/`custom` を尊重できずサイト chrome が二重に出る（#778 の `show_comments`/`show_related` と同型の対応）。
2. **`PublicRecordFieldList.tsx`** — `html` フィールドをラベルなし `prose` として描画（`markdown`/`blocks` と同扱い）。リッチ html は「本文」であってラベル付き属性行ではない。
3. **`PublicHtmlSanitizer`** — `withMaxInputLength(5_000_000)`。Symfony 既定 20KB を超えるカスタムページ本文が SSR で無言のうちに截断されるのを防ぐ。

## テスト（pin）

- `GetPublicRecordViewUseCaseTest`: layout 未設定 → payload `layout=null`（既存ページは従来どおり型デフォルト＝standard chrome）／`bare` は載る。
- `PublicHtmlSanitizerTest`: 20KB 超本文が末尾まで残る。
- `PublicRecordDetailPage.test`: `html` 本文がラベルなしで prose 描画される。

## レビュー留意点

- **サニタイズコスト**: 上限引き上げが効くのは **管理者入力の `html` フィールドのみ**（公開閲覧者の入力経路ではない）。sanitize コストは入力長にほぼ線形で、5MB は長い本文に十分な余裕を持たせつつ病的入力へのガードは維持（無制限 -1 にはしない）。
- **既存データへの影響**: 本番で `html` フィールドを持つ公開コンテンツは無し（`default` org の1定義のみ）。`aozora` に `layout=full` を明示設定した2レコードがあり、従来は SPA が無視していたが本修正で **意図どおり full 幅（chrome は維持）** で描画されるようになる（バグ修正・破壊ではない）。デプロイ後に aozora の SSR/描画回帰を確認する。

## 検証

- `composer check` 緑（PHPUnit 1217 / PHPStan L8 / CS-Fixer / OpenAPI / MCP）。
- `npm run check` 緑（type-check / lint / prettier / test / storybook）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)