### PR TITLE
feat(csp): 信頼済み埋め込みオリジンの allowlist（Phase 1・#802）

### DIFF
--- a/src/Http/EmbedAllowlist.php
+++ b/src/Http/EmbedAllowlist.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Http;
+
+/**
+ * The per-org allowlist of trusted external origins that a public page may embed
+ * (e.g. a first-party form widget hosted on one of the operator's own
+ * subdomains). Sourced from the org's `embed_allowlist` public setting and
+ * consumed by {@see PublicHtmlCsp::build()} to widen `script-src` / `connect-src`
+ * / `frame-src` — and *only* those — by the exact origins listed.
+ *
+ * Trust model (see #802 / tiered-trust): the allowlist is admin-configured and
+ * MUST only contain **self-owned, self-operated origins** (the operator's own
+ * subdomains), never arbitrary third-party hosts. The relaxation is safe because
+ * such an origin is effectively the same operator; this mechanism is not a
+ * general third-party-JS host. Third-party embeds require a different, sandboxed
+ * trust tier — do not repurpose this one.
+ *
+ * The read side here is the security boundary: every origin is re-validated and
+ * anything malformed is dropped, so the CSP only ever receives well-formed
+ * `https://host[:port]` origins (no scheme other than https, no wildcard, no
+ * path/query/fragment/userinfo).
+ */
+final readonly class EmbedAllowlist
+{
+    /** Defensive cap so a misconfigured setting can't bloat the header. */
+    private const MAX_ORIGINS = 10;
+
+    /** `https://` + dotted host (labels a-z0-9, hyphen-internal) + optional port. */
+    private const ORIGIN_PATTERN =
+        '#^https://[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+(:\d{1,5})?$#';
+
+    /** @param list<string> $origins already-validated `https://host[:port]` origins */
+    private function __construct(private array $origins)
+    {
+    }
+
+    public static function empty(): self
+    {
+        return new self([]);
+    }
+
+    /**
+     * Build from a flat `settingKey => effectiveValue` map (public settings).
+     * The `embed_allowlist` value is a JSON array of origin strings. Invalid or
+     * duplicate entries are silently dropped (the write path / admin UI is where
+     * bad input is surfaced; the read path stays fail-safe).
+     *
+     * @param array<string, string> $settings
+     */
+    public static function fromSettings(array $settings): self
+    {
+        $raw = trim($settings['embed_allowlist'] ?? '');
+        if ($raw === '') {
+            return self::empty();
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            return self::empty();
+        }
+
+        $origins = [];
+        foreach ($decoded as $entry) {
+            if (!is_string($entry)) {
+                continue;
+            }
+            $origin = strtolower(trim($entry));
+            if (preg_match(self::ORIGIN_PATTERN, $origin) !== 1) {
+                continue;
+            }
+            if (!in_array($origin, $origins, true)) {
+                $origins[] = $origin;
+            }
+            if (count($origins) >= self::MAX_ORIGINS) {
+                break;
+            }
+        }
+
+        return new self($origins);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->origins === [];
+    }
+
+    /** @return list<string> validated `https://host[:port]` origins */
+    public function origins(): array
+    {
+        return $this->origins;
+    }
+}

--- a/src/Http/PublicHtmlCsp.php
+++ b/src/Http/PublicHtmlCsp.php
@@ -19,6 +19,13 @@ namespace NeNeRecords\Http;
  * `https://www.googletagmanager.com` on `script-src`, and the Google Analytics
  * endpoints on `connect-src` / `img-src`. With no analytics configured the policy
  * is byte-for-byte {@see POLICY} (scripts stay `'self'`, no nonce, no third party).
+ *
+ * When the org has configured a trusted-embed allowlist ({@see EmbedAllowlist}, #802),
+ * the listed origins are added to `script-src` / `connect-src` / `frame-src` — and
+ * only those directives — so a first-party embed hosted on a self-owned subdomain can
+ * load, call its API, and (if it opens one) frame itself. An **empty** allowlist leaves
+ * the policy byte-for-byte identical to the analytics-only result (the embed path is a
+ * pure add-on): the existing return values are reached by the unchanged code below.
  */
 final class PublicHtmlCsp
 {
@@ -34,25 +41,67 @@ final class PublicHtmlCsp
     /**
      * Policy for an analytics-aware public HTML response. Returns the strict
      * {@see POLICY} unchanged when analytics is disabled; otherwise allows the
-     * nonce'd inline tag and the Google Analytics / Tag Manager hosts.
+     * nonce'd inline tag and the Google Analytics / Tag Manager hosts. A non-empty
+     * trusted-embed allowlist adds those origins to script/connect/frame-src.
      */
-    public static function build(WebAnalyticsConfig $analytics, ?string $scriptNonce = null): string
-    {
-        if (!$analytics->isEnabled()) {
-            return self::POLICY;
+    public static function build(
+        WebAnalyticsConfig $analytics,
+        ?string $scriptNonce = null,
+        ?EmbedAllowlist $embeds = null,
+    ): string {
+        $embedOrigins = $embeds?->origins() ?? [];
+
+        // ── Fast path: no embeds ⇒ existing behaviour, byte-for-byte unchanged ──
+        // (This block is intentionally identical to the pre-#802 implementation so
+        // adding the allowlist parameter cannot regress any analytics/nonce output.)
+        if ($embedOrigins === []) {
+            if (!$analytics->isEnabled()) {
+                return self::POLICY;
+            }
+
+            $scriptSrc = "'self'";
+            if ($scriptNonce !== null && $scriptNonce !== '') {
+                $scriptSrc .= " 'nonce-{$scriptNonce}'";
+            }
+            $scriptSrc .= ' https://www.googletagmanager.com';
+
+            return "default-src 'self'; "
+                . "script-src {$scriptSrc}; "
+                . "style-src 'self' 'unsafe-inline'; "
+                . "font-src 'self' data:; "
+                . "img-src 'self' data: https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com; "
+                . "connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com";
         }
 
-        $scriptSrc = "'self'";
-        if ($scriptNonce !== null && $scriptNonce !== '') {
-            $scriptSrc .= " 'nonce-{$scriptNonce}'";
+        // ── Embed path: compose 'self' + (analytics, if any) + embed origins ──
+        $embedList = implode(' ', $embedOrigins);
+
+        $script = "'self'";
+        if ($analytics->isEnabled() && $scriptNonce !== null && $scriptNonce !== '') {
+            $script .= " 'nonce-{$scriptNonce}'";
         }
-        $scriptSrc .= ' https://www.googletagmanager.com';
+        if ($analytics->isEnabled()) {
+            $script .= ' https://www.googletagmanager.com';
+        }
+        $script .= " {$embedList}";
+
+        $img = "'self' data:";
+        if ($analytics->isEnabled()) {
+            $img .= ' https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com';
+        }
+
+        $connect = "'self'";
+        if ($analytics->isEnabled()) {
+            $connect .= ' https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com';
+        }
+        $connect .= " {$embedList}";
 
         return "default-src 'self'; "
-            . "script-src {$scriptSrc}; "
+            . "script-src {$script}; "
             . "style-src 'self' 'unsafe-inline'; "
             . "font-src 'self' data:; "
-            . "img-src 'self' data: https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com; "
-            . "connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com";
+            . "img-src {$img}; "
+            . "connect-src {$connect}; "
+            . "frame-src 'self' {$embedList}";
     }
 }

--- a/src/Http/SpaShellFallback.php
+++ b/src/Http/SpaShellFallback.php
@@ -85,7 +85,9 @@ final readonly class SpaShellFallback
         $html = $this->injectBasePath($html, $request);
         $html = $this->injectApexFlag($html, $request);
 
-        $analytics = $this->resolveAnalytics($path);
+        $settings = $this->resolveSettingsMap($path);
+        $analytics = $settings === null ? WebAnalyticsConfig::disabled() : WebAnalyticsConfig::fromSettings($settings);
+        $embeds = $settings === null ? EmbedAllowlist::empty() : EmbedAllowlist::fromSettings($settings);
         $nonce = $analytics->isEnabled() ? bin2hex(random_bytes(16)) : '';
 
         if ($analytics->isEnabled()) {
@@ -94,19 +96,22 @@ final readonly class SpaShellFallback
 
         return $this->responseFactory->createResponse(200)
             ->withHeader('Content-Type', 'text/html; charset=utf-8')
-            ->withHeader('Content-Security-Policy', PublicHtmlCsp::build($analytics, $nonce !== '' ? $nonce : null))
+            ->withHeader('Content-Security-Policy', PublicHtmlCsp::build($analytics, $nonce !== '' ? $nonce : null, $embeds))
             ->withBody($this->streamFactory->createStream($html));
     }
 
     /**
-     * Best-effort analytics resolution for the shell. Disabled on admin / auth
-     * paths and whenever settings can't be read (org-scoped lookup throws when no
-     * org is resolved — same resilience contract as the 301 redirect layer).
+     * Best-effort public-settings resolution for the shell. Returns null on admin /
+     * auth paths and whenever settings can't be read (org-scoped lookup throws when
+     * no org is resolved — same resilience contract as the 301 redirect layer), so
+     * both analytics and the trusted-embed allowlist stay disabled there.
+     *
+     * @return array<string, string>|null
      */
-    private function resolveAnalytics(string $path): WebAnalyticsConfig
+    private function resolveSettingsMap(string $path): ?array
     {
         if ($this->publicSettings === null || preg_match(self::ANALYTICS_SKIP, $path) === 1) {
-            return WebAnalyticsConfig::disabled();
+            return null;
         }
 
         try {
@@ -115,9 +120,9 @@ final readonly class SpaShellFallback
                 $map[$entry->def->settingKey] = $entry->effectiveValue;
             }
 
-            return WebAnalyticsConfig::fromSettings($map);
+            return $map;
         } catch (\Throwable) {
-            return WebAnalyticsConfig::disabled();
+            return null;
         }
     }
 

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -9,6 +9,7 @@ use Nene2\Routing\Router;
 use Nene2\View\HtmlResponseFactory;
 use NeNeRecords\BundleField\BundleDocumentValidator;
 use NeNeRecords\Http\BasePath;
+use NeNeRecords\Http\EmbedAllowlist;
 use NeNeRecords\Http\PublicHtmlCsp;
 use NeNeRecords\Http\WebAnalyticsConfig;
 use NeNeRecords\Http\WebAnalyticsHeadSnippet;
@@ -221,7 +222,11 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
             'renderBundleSeo' => static fn (string $raw): string => PublicMarkdownRenderer::toSafeHtml(BundleDocumentValidator::seoTextOf($raw)),
         ])->withHeader(
             'Content-Security-Policy',
-            PublicHtmlCsp::build($analytics, $analyticsNonce !== '' ? $analyticsNonce : null),
+            PublicHtmlCsp::build(
+                $analytics,
+                $analyticsNonce !== '' ? $analyticsNonce : null,
+                EmbedAllowlist::fromSettings($settings),
+            ),
         );
     }
 

--- a/src/Setting/PdoDefaultSettingDefsSeeder.php
+++ b/src/Setting/PdoDefaultSettingDefsSeeder.php
@@ -42,6 +42,9 @@ final readonly class PdoDefaultSettingDefsSeeder implements DefaultSettingDefsSe
         ['setting_key' => 'header_config', 'data_type' => 'text', 'default_value' => '{"topbar":{"enabled":false,"phone":"","email":"","infoText":""},"cta":{"enabled":false,"label":"","url":""}}', 'is_public' => 1, 'label' => 'Header'],
         ['setting_key' => 'footer_config', 'data_type' => 'text', 'default_value' => '{"social":[],"legalLinks":[],"showPoweredBy":true}', 'is_public' => 1, 'label' => 'Footer content'],
         ['setting_key' => 'home_hero', 'data_type' => 'text', 'default_value' => '[]', 'is_public' => 1, 'label' => 'Home hero'],
+        // Trusted-embed allowlist (#802): JSON array of self-owned https origins a
+        // public page may embed. Read server-side into the CSP; empty by default.
+        ['setting_key' => 'embed_allowlist', 'data_type' => 'text', 'default_value' => '[]', 'is_public' => 1, 'label' => 'Trusted embed origins'],
         ['setting_key' => 'analytics_gtm_id', 'data_type' => 'text', 'default_value' => '', 'is_public' => 1, 'label' => 'Google Tag Manager container ID'],
         ['setting_key' => 'analytics_ga4_id', 'data_type' => 'text', 'default_value' => '', 'is_public' => 1, 'label' => 'Google Analytics 4 measurement ID'],
         ['setting_key' => 'analytics_consent_default', 'data_type' => 'text', 'default_value' => 'denied', 'is_public' => 1, 'label' => 'Analytics consent default (denied/granted)'],

--- a/tests/Http/EmbedAllowlistTest.php
+++ b/tests/Http/EmbedAllowlistTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Http;
+
+use NeNeRecords\Http\EmbedAllowlist;
+use PHPUnit\Framework\TestCase;
+
+final class EmbedAllowlistTest extends TestCase
+{
+    /** @param list<string> $origins */
+    private static function fromOrigins(array $origins): EmbedAllowlist
+    {
+        return EmbedAllowlist::fromSettings(['embed_allowlist' => (string) json_encode($origins)]);
+    }
+
+    public function testEmptyWhenSettingAbsentOrBlank(): void
+    {
+        self::assertTrue(EmbedAllowlist::fromSettings([])->isEmpty());
+        self::assertTrue(EmbedAllowlist::fromSettings(['embed_allowlist' => ''])->isEmpty());
+        self::assertSame([], EmbedAllowlist::empty()->origins());
+    }
+
+    public function testAcceptsHttpsOriginsIncludingPort(): void
+    {
+        $list = self::fromOrigins(['https://contact.example.com', 'https://forms.example.co.jp:8443']);
+
+        self::assertSame(
+            ['https://contact.example.com', 'https://forms.example.co.jp:8443'],
+            $list->origins(),
+        );
+        self::assertFalse($list->isEmpty());
+    }
+
+    public function testNormalisesCaseAndTrims(): void
+    {
+        $list = self::fromOrigins(['  HTTPS://Contact.Example.COM  ']);
+
+        self::assertSame(['https://contact.example.com'], $list->origins());
+    }
+
+    public function testDropsInvalidOrigins(): void
+    {
+        $list = self::fromOrigins([
+            'http://insecure.example.com',          // not https
+            'https://*.example.com',                // wildcard
+            'https://example.com/path',             // has a path
+            'https://example.com?q=1',              // has a query
+            'https://user:pw@example.com',          // userinfo
+            'javascript:alert(1)',                  // scheme abuse
+            'https://localhost',                    // no dot (not a domain)
+            'not a url',
+            'https://ok.example.com',               // the one good entry
+        ]);
+
+        self::assertSame(['https://ok.example.com'], $list->origins());
+    }
+
+    public function testDeduplicates(): void
+    {
+        $list = self::fromOrigins(['https://a.example.com', 'https://a.example.com', 'https://b.example.com']);
+
+        self::assertSame(['https://a.example.com', 'https://b.example.com'], $list->origins());
+    }
+
+    public function testCapsTheNumberOfOrigins(): void
+    {
+        $many = [];
+        for ($i = 0; $i < 25; $i++) {
+            $many[] = "https://h{$i}.example.com";
+        }
+
+        self::assertLessThanOrEqual(10, count(self::fromOrigins($many)->origins()));
+    }
+
+    public function testIgnoresNonArrayOrNonStringEntries(): void
+    {
+        self::assertTrue(EmbedAllowlist::fromSettings(['embed_allowlist' => '"just a string"'])->isEmpty());
+        self::assertTrue(EmbedAllowlist::fromSettings(['embed_allowlist' => 'not json'])->isEmpty());
+        self::assertSame(
+            ['https://ok.example.com'],
+            EmbedAllowlist::fromSettings(['embed_allowlist' => (string) json_encode([42, null, 'https://ok.example.com'])])->origins(),
+        );
+    }
+}

--- a/tests/Http/PublicHtmlCspTest.php
+++ b/tests/Http/PublicHtmlCspTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Tests\Http;
 
+use NeNeRecords\Http\EmbedAllowlist;
 use NeNeRecords\Http\PublicHtmlCsp;
 use NeNeRecords\Http\WebAnalyticsConfig;
 use PHPUnit\Framework\TestCase;
@@ -55,5 +56,74 @@ final class PublicHtmlCspTest extends TestCase
         self::assertStringContainsString("style-src 'self' 'unsafe-inline'", PublicHtmlCsp::POLICY);
         self::assertStringContainsString("font-src 'self' data:", PublicHtmlCsp::POLICY);
         self::assertStringNotContainsString("'unsafe-inline'", explode('style-src', PublicHtmlCsp::POLICY)[0]);
+    }
+
+    // ── Trusted-embed allowlist (#802) ────────────────────────────────────────
+
+    /** @param list<string> $origins */
+    private static function embeds(array $origins): EmbedAllowlist
+    {
+        return EmbedAllowlist::fromSettings(['embed_allowlist' => (string) json_encode($origins)]);
+    }
+
+    public function testEmptyAllowlistIsByteForByteIdenticalWhenAnalyticsDisabled(): void
+    {
+        // The whole guarantee of the feature: an empty allowlist changes nothing.
+        self::assertSame(
+            PublicHtmlCsp::POLICY,
+            PublicHtmlCsp::build(WebAnalyticsConfig::disabled(), 'nonce', self::embeds([])),
+        );
+        self::assertSame(
+            PublicHtmlCsp::build(WebAnalyticsConfig::disabled(), 'nonce'),
+            PublicHtmlCsp::build(WebAnalyticsConfig::disabled(), 'nonce', self::embeds([])),
+        );
+    }
+
+    public function testEmptyAllowlistIsByteForByteIdenticalWhenAnalyticsEnabled(): void
+    {
+        $analytics = new WebAnalyticsConfig('GTM-ABC1234', 'G-XYZ987', 'granted');
+
+        self::assertSame(
+            PublicHtmlCsp::build($analytics, 'nn'),
+            PublicHtmlCsp::build($analytics, 'nn', self::embeds([])),
+        );
+        // A null EmbedAllowlist (default arg) is also a no-op.
+        self::assertSame(
+            PublicHtmlCsp::build($analytics, 'nn'),
+            PublicHtmlCsp::build($analytics, 'nn', null),
+        );
+    }
+
+    public function testAllowlistAddsOriginsToScriptConnectFrameOnly(): void
+    {
+        $csp = PublicHtmlCsp::build(
+            WebAnalyticsConfig::disabled(),
+            null,
+            self::embeds(['https://contact.example.com']),
+        );
+
+        self::assertStringContainsString("script-src 'self' https://contact.example.com", $csp);
+        self::assertStringContainsString("connect-src 'self' https://contact.example.com", $csp);
+        self::assertStringContainsString("frame-src 'self' https://contact.example.com", $csp);
+        // Not widened where an embed has no business: style/font/img/default stay strict.
+        self::assertStringContainsString("default-src 'self';", $csp);
+        self::assertStringContainsString("style-src 'self' 'unsafe-inline'", $csp);
+        self::assertStringNotContainsString('contact.example.com', explode('script-src', $csp)[0]);
+    }
+
+    public function testAllowlistComposesWithAnalytics(): void
+    {
+        $csp = PublicHtmlCsp::build(
+            new WebAnalyticsConfig(null, 'G-XYZ987', 'denied'),
+            'abc',
+            self::embeds(['https://contact.example.com']),
+        );
+
+        // Both the GA host and the embed origin ride script-src / connect-src.
+        self::assertStringContainsString('https://www.googletagmanager.com', $csp);
+        self::assertStringContainsString("'nonce-abc'", $csp);
+        self::assertStringContainsString('https://contact.example.com', explode('script-src', $csp)[1]);
+        self::assertStringContainsString('https://*.analytics.google.com', $csp);
+        self::assertStringContainsString('frame-src', $csp);
     }
 }


### PR DESCRIPTION
#802 の **Phase 1**。trusted-embed の土台として per-org の CSP 埋め込み allowlist を導入する（widget 本体・描画は Phase 2、media 永続化は Phase 3）。

## 内容
- **`EmbedAllowlist`**（`src/Http/`）: `embed_allowlist` 設定（自己保有 https オリジンの JSON 配列）を読み、**https・明示ホスト・ワイルドカード/パス/ユーザ情報不可**で検証してフィルタ。空/不正は drop（read 側が安全境界）。dedup＋件数上限。
- **`PublicHtmlCsp::build()`** に `?EmbedAllowlist` を追加。非空なら **`script-src` / `connect-src` / `frame-src` のみ**に当該オリジンを追加。**空 allowlist は現行と byte-for-byte 同一**（既存コードパスをそのまま残し、analytics/nonce 出力を一切回帰させない）。設計は既存の `WebAnalyticsConfig` GA allowlist と同型。
- 公開レコード SSR（`RenderPublicRecordViewHandler`）と SPA シェル（`SpaShellFallback`）の両 CSP 生成点で、per-org 公開設定から解決。
- 設定 def `embed_allowlist`（public・既定 `[]`）を seeder に追加。
- **content サニタイザは不変**（ユーザ入力からの `<script>` 混入は従来どおり不可）。

## テスト（pin 中心）
- `PublicHtmlCspTest`: **空 allowlist = 現行と byte-for-byte 同一**（analytics 有/無・null 引数）を pin／非空は script/connect/frame-src にのみ追加（default/style/font は不変）／analytics と合成。
- `EmbedAllowlistTest`: 有効 https を受理（ポート可）・小文字化/trim・http/ワイルドカード/パス/userinfo/`javascript:`/ドット無しを drop・dedup・件数上限・非配列/非文字列を無視。

## 信頼モデル（#802）
allowlist に載せてよいのは**自己保有・自己運用のオリジンのみ**（第三者 JS の汎用受け入れ機構に流用しない）。cookie は HttpOnly、content サニタイザ不変。

## 検証
`composer check` 緑（PHPUnit 1228 / PHPStan L8 / CS-Fixer / OpenAPI / Conformance / MCP）。frontend 変更なし（Phase 2 で SPA 描画）。

> ⚠️ 本 PR は **Phase 1 のみ**。本番デプロイは Phase 2/3 が揃った後に**別 GO**（指揮精査→施主 GO）。マージ即デプロイはしない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)