### PR TITLE
docs(daily): 2026-07-12 の日報を追加する

### DIFF
--- a/docs/daily/2026-07-12.md
+++ b/docs/daily/2026-07-12.md
@@ -1,0 +1,56 @@
+# 日報 — 2026-07-12（NeNe Records）
+
+> 前報（07-11）の残課題 #1「bootstrap の部分 entity 棚卸し（per-record layout が SSR 経由で効いていない可能性）」を起点に、**公開カスタムページ（bare/custom）を同一オリジンでクロール可能に描画する配線ギャップを 3 点根治 → 本番反映（#799 / PR #800）**。続けて、公開ページへ**信頼済み外部埋め込み**を一級で載せる機構を EPIC 化（#802）し、**Phase 1（per-org CSP 埋め込み allowlist）を実装〜マージ（#803・未デプロイ）**。移送系の穴 2 件（org import の entity 参照非再マップ #801・prod media 永続化ギャップ）も起票/記録。
+
+## ヘッドライン
+**`bare`/`custom` レイアウトのカスタムページが「単一の `html` 本文フィールド」を同一オリジンのクロール可能ページとして素直に描画できるよう、公開レコードビューの 3 つの配線ギャップを根治（#799 / PR #800・本番反映）。** ①公開レコード payload に `entity.layout` を載せ（07-11 残課題 #1 に直接回答＝SPA が bootstrap から hydrate する #778 と同型）②`html` フィールドをラベルなし `prose` 描画（`markdown`/`blocks` と同扱い）③`PublicHtmlSanitizer` の `maxInputLength` を 20KB→5MB（長い本文の SSR 無言截断を回避）。あわせて **公開ページの信頼済み埋め込み**を EPIC #802 として計画化し、**Phase 1 = CSP 埋め込み allowlist（空なら現行と byte-for-byte 同一を pin）を実装〜マージ**。
+
+---
+
+## 本日の成果（時系列）
+
+### A. カスタムページ描画の配線ギャップ 3 点根治（#799 / PR #800・本番反映）
+`bare`/`custom`（#311）は「レコードがページそのもの」を意図するが、公開レコードビューに 3 つの穴があり、単一 `html` 本文のカスタムページがクロール可能ページとして出せなかった。
+- **payload に `layout`**：`PublicRecordViewHttpMapper` の bootstrap `entity` に `layout` を追加。SPA は `useEntity` を bootstrap から hydrate し refetch しないため、`layout` を載せないと `bare`/`custom` を尊重できずサイト chrome が二重に出る（#778 の `show_comments`/`show_related` と同じ轍）。**07-11 残課題 #1 の解消**。
+- **`html` をラベルなし prose 描画**：`PublicRecordFieldList` が `html` を `<dt>fieldKey</dt>` 付きの定義行にしていたのを、`markdown`/`blocks` と同じくラベルなし `.prose` に。リッチ html は「本文」であって属性行ではない。
+- **サニタイザ上限 20KB→5MB**：`PublicHtmlSanitizer` が Symfony 既定の 20KB のままで、20KB 超の本文が SSR で途中截断されクロール不能になっていた。`withMaxInputLength(5_000_000)`（管理側入力のみ・DoS ガードは維持）。
+- pin テスト：`layout` 未設定 → payload `null`（既存ページは従来どおり型デフォルト＝chrome 維持）／`bare` は載る／20KB 超本文が末尾まで残る／`html` 本文がラベルなしで描画。BE 1217→（後述で 1228）・FE ともにグリーン。
+
+### B. org import の entity 参照設定が非再マップ（#801 起票）
+`tools/import-org.php` は entity 等の id を新採番に再マップするが、**`front_page` のように「値がエンティティ id」の設定は再マップされない**（`logo_media_id` は media マップ経由で再マップ済み）。→ org 移送後にトップページが解決できず手当てが要る。恒久対応（既知の entity 参照設定を id マップで書換）か手順書化かを issue で判断。別インスタンス設置（Tier A）でも毎回効く穴。
+
+### C. 公開ページの信頼済み埋め込みを EPIC 化（#802）
+公開ページに任意 3rd-party JS を通さないのは意図的な境界（CSP `default-src 'self'` ＋ content サニタイザが `<script>`/`<iframe>` を除去・tiered-trust）。一方で「**自社が保有・運用するサブドメインにホストした第一者ウィジェット**（フォーム等）」を一級で埋め込む道が無い。→ 設計 issue を起票：(A) per-org 埋め込み allowlist ＋ CSP 拡張、(B) 一級 trusted-embed プリミティブ（サニタイザ迂回でなく第一者テンプレートが SRI 付き script を出力）、(C) media 永続化の同乗。設計/変更半径/tiered-trust 影響/リスク緩和/段階分割/テスト計画を明記。
+- 申し送り 2 点をコメント追記：**(N1)** SRI ↔ 埋め込みアセットのバージョン連動を runbook 化（アセットのリビルドで content-hash が変われば SRI 不一致で無言破損 → 更新を lockstep に＋staging スモークで検知）。**(N2)** 信頼するのは「自己資産（自社サブドメイン）」前提の歯止め（cookie/same-origin の緩和が成立するのは第三者でないから・任意の第三者 JS 汎用機構に流用しない）。
+
+### D. Phase 1 — per-org CSP 埋め込み allowlist（#803・main マージ・未デプロイ）
+- **`EmbedAllowlist`**（`src/Http/`）：`embed_allowlist` 設定（自己保有 https オリジンの JSON 配列）を **https・明示ホスト・ワイルドカード/パス/userinfo 不可**で検証しフィルタ（read 側が安全境界）。dedup ＋件数上限。
+- **`PublicHtmlCsp::build()`** に `?EmbedAllowlist` を追加。非空なら **`script-src`/`connect-src`/`frame-src` のみ**に当該オリジンを追加。**空 allowlist は現行と byte-for-byte 同一**（既存コードパスを不変のまま残し、analytics/nonce 出力を一切回帰させない）。設計は既存 `WebAnalyticsConfig`（GA allowlist）と同型。
+- 公開レコード SSR（`RenderPublicRecordViewHandler`）と SPA シェル（`SpaShellFallback`）の両 CSP 生成点で per-org 設定から解決（シェル側は設定 map を 1 回だけ解決するよう整理）。設定 def `embed_allowlist`（public・既定 `[]`）を seeder に追加。**content サニタイザは不変**。
+- テストは pin 中心（空＝現行同一／非空は 3 指令のみ拡張／validation の drop 群）。`composer check` グリーン（PHPUnit **1228**・PHPStan L8・CS-Fixer・OpenAPI・Conformance・MCP）。frontend 変更なし。
+
+### E. prod media 永続化ギャップの発見（Phase 3 で対応予定）
+prod は `MEDIA_STORAGE_DRIVER` 未設定＝local `var/media`、かつ **永続ボリューム無し** → `docker compose build && up` の再作成で **runtime アップロードの media が消える**。安定運用には prod compose に `var/media` の volume 追加（小 ops）or `MEDIA_S3_*` 設定が要る。EPIC #802 の Phase 3 に同乗。
+
+### F. 本番デプロイ（#800 系）
+07-09 と同じ runbook（rsync→build→up→migrate）で **#799/#800 ＋ org-export Phase 2・import CLI（#741/#793/#794）を本番反映**。回帰確認：apex/aozora/ayane の `/health` 3 面 200・フロント/実レコード SSR 正常・`entity.layout` が公開 payload に載ることを実データで確認（値 null＝従来描画）。
+
+---
+
+## 意思決定
+- **同一オリジンの bespoke カスタムページ**は「content サニタイザは緩めず、`html` を第一級の body prose として扱う」方針で描画（ブロックは SSR 非描画・サニタイザは script 除去のまま）。
+- **trusted-embed は多段で慎重に**：Phase 1（CSP 拡張・空 allowlist=現行同一を pin）→ Phase 2（trusted-embed プリミティブ描画・SSR/SPA parity）→ Phase 3（media 永続化・同乗）。**信頼するのは自己保有オリジンのみ**（第三者 JS 汎用機構に流用しない）。
+- **本番デプロイは各フェーズが揃った後の別 GO**（レビュー精査 → 施主承認 → デプロイ）。マージ即デプロイはしない。
+
+## 現在の状態
+- `main` 先頭 = **`d4eaa33`**（#803）。作業ツリー clean・全ゲート/CI グリーン。
+- **本番（apex/aozora/ayane）= #800 系デプロイ済み・health 3 面 200・回帰なし**。#803（Phase 1）は **main マージ済み・未デプロイ**（EPIC 完了後の別 GO 待ち）。
+- open：**#802**（EPIC・Phase 2/3 残）／**#801**（follow-up）。クローズ：#799（→ PR #800）。
+
+## 残課題 / 次の一手
+1. **#802 Phase 2**：trusted-embed プリミティブの描画。査読観点＝SRI 必須・origin×allowlist 照合で不一致は描画拒否・**非 allowlist は SSR 段階で drop**・**SSR/SPA parity**。器は `bundle` 型（SSR seoText twin ＋ SPA 描画の前例）に倣うのが有力。
+2. **#802 Phase 3**：media 永続化（`var/media` volume or S3）を Phase 2 と揃えて。
+3. 微修正（Phase 2 折込・任意）：`EmbedAllowlist` のポート正規表現が 65535 超を通す点の範囲チェック。
+4. **公開レコードの SPA canonical URL**：bootstrap `entity` payload が `slug`/`permalink` を持たないため、明示 permalink のカスタムページでも **クライアント遷移後に `/{type}/{id}` へフォールバック**する（SSR canonical/og:url/sitemap は clean permalink で SEO 正常）。#799 で `layout` は解消したが、bootstrap「部分 entity」の残りとして `slug`/`permalink` 追加が候補（07-11 残課題 #1 の続き）。
+
+> 詳細：PR #800／#803・EPIC #802（コメントに N1/N2）・follow-up #801・会話メモリ `records-live-deployment` 反映済み。


### PR DESCRIPTION
2026-07-12 の日報。製品目線のみ（社内情報は _work 側）。

- カスタムページ（bare/custom）描画の配線ギャップ 3 点根治（#799 / PR #800・本番反映）— payload に `entity.layout`／`html` をラベルなし prose／サニタイザ `maxInputLength` 20KB→5MB。07-11 残課題 #1 に回答。
- org import が `front_page` 等 entity 参照設定を非再マップ（#801 起票）。
- 公開ページの信頼済み外部埋め込み EPIC（#802）＋ Phase 1 = per-org CSP 埋め込み allowlist（#803・main マージ・未デプロイ・空 allowlist=現行 byte 一致を pin）。
- prod media 永続化ギャップ（`var/media` volume 無し）を記録（Phase 3 対応）。
- 本番デプロイ回帰（apex/aozora/ayane health 3 面 200）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)