### PR TITLE
fix(auth): superadmin コンソールを superadmin 専用に閉じる（#797）

### DIFF
--- a/src/Auth/AdminApiAuthMiddleware.php
+++ b/src/Auth/AdminApiAuthMiddleware.php
@@ -50,6 +50,11 @@ final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
         '/api/v1/users',
         '/api/v1/admin/comments',
         '/api/v1/organizations',
+        // Superadmin console (export/import, data-migration, system-config). Must
+        // be authenticated for ALL methods — the GET export is not a "non-GET"
+        // mutation, so without this prefix its read of every tenant's data would
+        // be unauthenticated. Role is then enforced by CapabilityMiddleware. See #797.
+        '/api/v1/superadmin/',
         '/api/v1/themes',
         '/api/v1/migration',
         '/api/v1/account',

--- a/src/Auth/CapabilityResolver.php
+++ b/src/Auth/CapabilityResolver.php
@@ -20,6 +20,15 @@ final class CapabilityResolver
     {
         $method = strtoupper($method);
 
+        // Superadmin console: every /api/v1/superadmin/** route is superadmin-only
+        // (org export/import, data-migration, system-config). ManageOrganizations is
+        // granted to superadmin alone (see Role::hasCapability), so it doubles as the
+        // "superadmin required" gate — for all methods, GET included. Checked first so
+        // no narrower rule below can widen these routes. See #797.
+        if (str_starts_with($path, '/api/v1/superadmin/')) {
+            return Capability::ManageOrganizations;
+        }
+
         // Organization management: superadmin only
         if (str_starts_with($path, '/api/v1/organizations')) {
             return Capability::ManageOrganizations;

--- a/tests/Auth/AdminApiAuthMiddlewareTest.php
+++ b/tests/Auth/AdminApiAuthMiddlewareTest.php
@@ -113,6 +113,22 @@ final class AdminApiAuthMiddlewareTest extends TestCase
         self::assertSame(401, $this->middleware->process($request, $this->passThrough())->getStatusCode());
     }
 
+    public function testSuperadminExportGetRequiresAuth(): void
+    {
+        // GET export reads every tenant's data; it is not a "non-GET" mutation,
+        // so it must be gated by the admin-only prefix, not left open. See #797.
+        $request = $this->factory->createServerRequest('GET', 'https://example.test/api/v1/superadmin/organizations/1/export');
+
+        self::assertSame(401, $this->middleware->process($request, $this->passThrough())->getStatusCode());
+    }
+
+    public function testSuperadminSystemConfigGetRequiresAuth(): void
+    {
+        $request = $this->factory->createServerRequest('GET', 'https://example.test/api/v1/superadmin/system-config');
+
+        self::assertSame(401, $this->middleware->process($request, $this->passThrough())->getStatusCode());
+    }
+
     public function testInvalidTokenReturns401(): void
     {
         $request = $this->factory

--- a/tests/Auth/CapabilityMiddlewareTest.php
+++ b/tests/Auth/CapabilityMiddlewareTest.php
@@ -8,6 +8,7 @@ use Nene2\Error\ProblemDetailsResponseFactory;
 use NeNeRecords\Auth\CapabilityMiddleware;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\Response;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -90,6 +91,61 @@ final class CapabilityMiddlewareTest extends TestCase
         $response = $this->middleware->process($request, $this->createPassThroughHandler());
 
         self::assertSame(204, $response->getStatusCode());
+    }
+
+    // ── Superadmin console (export/import, data-migration, system-config) ────────
+
+    /**
+     * 非 superadmin（admin）が org export を叩くと 403。認証は通っても
+     * ManageOrganizations を持たないため拒否される（#797）。
+     */
+    public function testAdminExportingOrganizationReturns403(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('GET', 'https://example.test/api/v1/superadmin/organizations/1/export')
+            ->withAttribute('nene2.auth.claims', ['role' => 'admin', 'sub' => 'admin@example.com', 'org_id' => 1]);
+
+        $response = $this->middleware->process($request, $this->createPassThroughHandler());
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    /**
+     * editor が org import を叩くと 403。
+     */
+    public function testEditorImportingOrganizationReturns403(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('POST', 'https://example.test/api/v1/superadmin/organizations/1/import')
+            ->withAttribute('nene2.auth.claims', ['role' => 'editor', 'sub' => 'editor@example.com', 'org_id' => 1]);
+
+        $response = $this->middleware->process($request, $this->createPassThroughHandler());
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    /**
+     * superadmin は従来どおり通過する（export/data-migration/system-config）。
+     */
+    #[DataProvider('provideSuperadminConsoleRequests')]
+    public function testSuperadminPassesThroughConsoleRoutes(string $method, string $path): void
+    {
+        $request = $this->factory
+            ->createServerRequest($method, 'https://example.test' . $path)
+            ->withAttribute('nene2.auth.claims', ['role' => 'superadmin', 'sub' => 'sa@example.com', 'org_id' => null]);
+
+        $response = $this->middleware->process($request, $this->createPassThroughHandler());
+
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function provideSuperadminConsoleRequests(): iterable
+    {
+        yield 'org export'         => ['GET', '/api/v1/superadmin/organizations/1/export'];
+        yield 'org import'         => ['POST', '/api/v1/superadmin/organizations/1/import'];
+        yield 'data-migration'     => ['POST', '/api/v1/superadmin/data-migration/assign-org'];
+        yield 'system-config PATCH' => ['PATCH', '/api/v1/superadmin/system-config'];
     }
 
     // ── Organization scope checks ────────────────────────────────────────────────

--- a/tests/Auth/CapabilityResolverTest.php
+++ b/tests/Auth/CapabilityResolverTest.php
@@ -29,6 +29,26 @@ final class CapabilityResolverTest extends TestCase
         yield 'delete'     => ['/api/v1/organizations/1', 'DELETE'];
     }
 
+    // ── Superadmin console ────────────────────────────────────────────────────
+
+    #[DataProvider('provideSuperadminPaths')]
+    public function testSuperadminPathsRequireManageOrganizations(string $path, string $method): void
+    {
+        self::assertSame(Capability::ManageOrganizations, CapabilityResolver::resolve($path, $method));
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function provideSuperadminPaths(): iterable
+    {
+        // GET export must be gated too — it reads every tenant's data. See #797.
+        yield 'org export GET'         => ['/api/v1/superadmin/organizations/1/export', 'GET'];
+        yield 'org import POST'        => ['/api/v1/superadmin/organizations/1/import', 'POST'];
+        yield 'data-migration status'  => ['/api/v1/superadmin/data-migration/status', 'GET'];
+        yield 'data-migration assign'  => ['/api/v1/superadmin/data-migration/assign-org', 'POST'];
+        yield 'system-config GET'      => ['/api/v1/superadmin/system-config', 'GET'];
+        yield 'system-config PATCH'    => ['/api/v1/superadmin/system-config', 'PATCH'];
+    }
+
     // ── Account ─────────────────────────────────────────────────────────────────
 
     public function testAccountRequiresManageAccount(): void


### PR DESCRIPTION
## 目的

`/api/v1/superadmin/**` が capability 未マッピングで、認証を通れば非 superadmin（admin/editor）でも org export/import・data-migration・system-config を実行できた。GET export に至っては `ADMIN_ONLY_PREFIXES` 外のため**未認証で全テナントのデータを読める**状態だった（テナント越境・情報漏えい）。

## 変更

- **`CapabilityResolver`**: `/api/v1/superadmin/` prefix → `Capability::ManageOrganizations`（superadmin のみ保有）を最優先で返す。GET を含む全メソッドを gate。
- **`AdminApiAuthMiddleware`**: `ADMIN_ONLY_PREFIXES` に `/api/v1/superadmin/` を追加し、GET export も全メソッド要認証に。
- 影響ルート: `OrgExportRouteRegistrar`（export/import）・`DataMigrationRouteRegistrar`（status/assign-org）・`SystemConfigRouteRegistrar`（GET/PATCH）を一括で被覆。

## 検証

- `composer test` … 1242 tests OK（新規テスト: 401 未認証 / 403 非 superadmin / 200 superadmin・6 経路の capability 解決）
- `composer analyse`（PHPStan L8）… clean
- CS-Fixer … clean

テストは脆弱性の在処である middleware seam（`CapabilityResolver` / `CapabilityMiddleware` / `AdminApiAuthMiddleware`）で enforcement を検証。{id} 解決の実 Router テストは既存 `OrgExportHttpTest`（#739 由来）が担保済み。

## チェックリスト
- [x] composer check 相当（test / analyse / cs）緑
- [x] 非 superadmin=403 / 未認証=401 / superadmin=従来どおり のテスト追加

Closes #797