### PR TITLE
feat(org-export): 移送時に front_page のエンティティ id を再マップする（#801）

### DIFF
--- a/src/OrgExport/PdoOrgImportRepository.php
+++ b/src/OrgExport/PdoOrgImportRepository.php
@@ -515,10 +515,14 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
         $counts['setting_defs'] = $settingDefCount;
 
         // ── setting_values (merge on org+setting_key, source-wins) ─────────
-        // logo_media_id points at a media row id — remap it via the media map so
-        // the logo survives transport. Other settings that embed media URLs or
-        // entity references inside JSON blobs (home_hero, footer_config, …) are
-        // NOT rewritten here (see #741 Phase 2 design note / follow-up issue).
+        // Scalar id-valued settings are remapped so the reference survives transport:
+        //   - logo_media_id → media row id (via mediaMap)
+        //   - front_page    → published record's entity id (via entityMap, #701 /
+        //                     FrontPageSetting) — otherwise the pinned front page can't
+        //                     resolve on the target and needs a manual post-fix on every
+        //                     move (#801).
+        // Settings that embed media URLs or entity references INSIDE JSON blobs
+        // (home_hero, footer_config, …) are NOT rewritten here (see #795).
         $settingValueCount = 0;
         foreach ((array) ($payload['setting_values'] ?? []) as $row) {
             $now       = $this->clock->now()->format('Y-m-d H:i:s');
@@ -526,6 +530,9 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
             $value      = isset($row['value']) ? (string) $row['value'] : null;
             if ($settingKey === 'logo_media_id' && $value !== null && $value !== '' && ctype_digit($value)) {
                 $value = isset($mediaMap[(int) $value]) ? (string) $mediaMap[(int) $value] : $value;
+            }
+            if ($settingKey === 'front_page' && $value !== null && $value !== '' && ctype_digit($value)) {
+                $value = isset($entityMap[(int) $value]) ? (string) $entityMap[(int) $value] : $value;
             }
             $existing = $query->fetchOne(
                 'SELECT id FROM setting_values WHERE organization_id = ? AND setting_key = ?',

--- a/tests/OrgExport/PdoOrgImportRepositoryTest.php
+++ b/tests/OrgExport/PdoOrgImportRepositoryTest.php
@@ -185,6 +185,12 @@ final class PdoOrgImportRepositoryTest extends TestCase
         self::assertNotNull($logo);
         self::assertSame((string) (int) $media['id'], $logo['value']);
 
+        // front_page setting value remapped onto the imported entity row (#801) —
+        // it pinned source id 30, which must now point at the new hello-world id.
+        $frontPage = $this->executor->fetchOne("SELECT value FROM setting_values WHERE organization_id = 1 AND setting_key = 'front_page'");
+        self::assertNotNull($frontPage);
+        self::assertSame((string) (int) $entity['id'], $frontPage['value']);
+
         self::assertSame(1, $counts['menus']);
         self::assertSame(1, $counts['widgets']);
         self::assertSame(1, $counts['entity_relations']);
@@ -296,9 +302,12 @@ final class PdoOrgImportRepositoryTest extends TestCase
             'url_redirects'    => [['id' => 120, 'source_path' => '/old', 'target_path' => '/new']],
             'setting_defs'     => [
                 ['id' => 130, 'setting_key' => 'logo_media_id', 'data_type' => 'media', 'default_value' => '', 'is_public' => 1, 'label' => 'Logo'],
+                ['id' => 131, 'setting_key' => 'front_page', 'data_type' => 'int', 'default_value' => '', 'is_public' => 1, 'label' => 'Front page'],
             ],
             'setting_values'   => [
                 ['id' => 140, 'setting_key' => 'logo_media_id', 'value' => '60', 'is_deleted' => 0],
+                // front_page pins source entity 30 → must be remapped onto the new id.
+                ['id' => 141, 'setting_key' => 'front_page', 'value' => '30', 'is_deleted' => 0],
             ],
         ];
     }


### PR DESCRIPTION
## 目的

`front_page`（トップに固定する公開レコードの**エンティティ id**・#701 / `FrontPageSetting`）は org インポート時に再マップされず、移送元インスタンスの id のまま残る。移送先ではレコード id が新採番されるため、**インポート後にトップページが解決できない**（`resolvePublished()` が対象を見つけられず）状態になり、Tier A 設置のたびに手作業の post-fix（`front_page` を新 id へ UPDATE）が必要だった。

## 変更

- `PdoOrgImportRepository` の `setting_values` 取り込みで、`front_page` の値を `entityMap`（old→new）経由で再マップ。既存の `logo_media_id`（mediaMap）と同じ「スカラ id 値の設定を再マップ」パターン。
- round-trip テスト（`testImportsPhase2TablesWithIdRemap`）に `front_page` setting を追加し、移送先で新 entity id を指すことを検証。

## スコープ外（#795 で対応）

JSON blob 内（`home_hero` / `footer_config` 等）に埋め込まれた media URL・entity 参照の書き換えは本 PR の対象外。#795 で扱う。

## 検証

- `composer test`（該当スイート 3 tests / 101 assertions OK・全体は CI）
- `composer analyse`（PHPStan L8）clean / CS-Fixer clean

Closes #801