### PR TITLE
fix(deploy): 本番 compose に var/media 永続ボリュームを追加する（#807）

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -63,7 +63,12 @@ services:
       timeout: 5s
       retries: 3
       start_period: 40s
-    # No volumes: code, vendor and built assets are baked into the image.
+    volumes:
+      # Uploaded media (originals + on-demand derivatives) is written at runtime to
+      # var/media. Code/vendor/assets are baked into the image, so WITHOUT this
+      # volume every `up --build` starts from an empty var/media and destroys all
+      # uploaded files. Persist just that directory. See #807.
+      - media-prod-data:/var/www/html/var/media
     # No command: the image CMD is docker/app/entrypoint.prod.sh (migrate + serve).
 
   mysql:
@@ -97,3 +102,4 @@ services:
 
 volumes:
   mysql-prod-data:
+  media-prod-data:


### PR DESCRIPTION
## 目的

`compose.prod.yaml` の app は image 焼き込み設計で **volume を持たない**。アップロードメディアは実行時に `/var/www/html/var/media` へ書かれるため、`up -d --build` のたびに空の新コンテナになり**アップロード済みファイルが消える**（次デプロイで本番 PDF 等が失われる実害）。

## 変更

- app に名前付きボリューム `media-prod-data:/var/www/html/var/media` を追加。
- トップレベル `volumes:` に `media-prod-data` を宣言。

DB（`mysql-prod-data`）と同じ「データだけ named volume で永続・コードは image」の形に揃えた。

## 検証

- YAML 構文・構造を確認（app.volumes / top volumes に反映）。docker 実行はこの環境に無いため未実施。
- **本番反映（デプロイ）は施主 GO 案件**。初回デプロイ前に既存コンテナ内 `var/media` をホスト退避 → 新ボリュームへ配置する運用手順が必要（runbook・trusted-embed デプロイと同乗が理想）。

## チェックリスト
- [x] app に media 永続ボリューム
- [x] 本番反映は別 GO と明記

Closes #807