### PR TITLE
feat(org-export): 移送時にブロック本文・home_hero の media 参照を書き換える（#795）

### DIFF
--- a/src/OrgExport/BlocksMediaRewriter.php
+++ b/src/OrgExport/BlocksMediaRewriter.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgExport;
+
+/**
+ * Rewrites the media references embedded in a blocks document during org transport
+ * (#795). Two settings/fields carry the exact same block-document shape — a
+ * `blocks_fields.value` and the `home_hero` setting (see
+ * {@see \NeNeRecords\BlocksField\BlocksDocumentValidator} for the canonical shape).
+ *
+ * Media-bearing blocks:
+ *  - hero:    data.media   = {mediaId, url, alt}
+ *  - gallery: data.items[] = {mediaId, url, alt, caption}
+ * and containers nest leaf blocks: group → data.children[], columns → data.columns[].children[].
+ *
+ * On each media reference:
+ *  - `mediaId` (a numeric string) is remapped through the media id map so it points
+ *    at the imported media row.
+ *  - `url` is RELATIVIZED: an absolute same-origin `/media/...` URL loses its
+ *    scheme+host and becomes a bare `/media/...` path. Transport is domain-agnostic
+ *    (the CLI import does not know the final public domain; Tier A switches DNS
+ *    later), and the media file keeps its storage_key, so the relative path resolves
+ *    on the target. External images (non-/media paths or other hosts) are left as-is.
+ *
+ * Blocks carry no numeric entity-id references (internal links are permalink-based
+ * and permalinks are preserved; relations live in entity_relations, remapped
+ * separately), so only media is rewritten here.
+ *
+ * A document with no rewritten reference is returned byte-for-byte verbatim (no
+ * reformatting churn), and any string that is not a blocks document is left verbatim
+ * (defensive: never corrupt an unexpected shape).
+ */
+final class BlocksMediaRewriter
+{
+    /**
+     * @param array<int, int> $mediaMap old media id → new media id
+     */
+    public static function rewrite(string $json, array $mediaMap): string
+    {
+        if ($json === '' || $mediaMap === []) {
+            return $json;
+        }
+
+        $decoded = json_decode($json, true);
+        if (!is_array($decoded) || !array_is_list($decoded)) {
+            // A blocks document is a JSON array of blocks; anything else is left verbatim.
+            return $json;
+        }
+
+        $rewritten = array_map(
+            static fn (mixed $block): mixed => self::rewriteBlock($block, $mediaMap),
+            $decoded,
+        );
+
+        $flags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+        $after = json_encode($rewritten, $flags);
+        if ($after === false) {
+            return $json;
+        }
+
+        // Re-encode the original the same way: equal output ⇒ nothing was rewritten,
+        // so return the untouched body (avoids reformatting a verbatim document).
+        return $after === json_encode($decoded, $flags) ? $json : $after;
+    }
+
+    /**
+     * @param array<int, int> $mediaMap
+     */
+    private static function rewriteBlock(mixed $block, array $mediaMap): mixed
+    {
+        if (!is_array($block)) {
+            return $block;
+        }
+
+        $type = $block['type'] ?? null;
+        $data = $block['data'] ?? null;
+        if (!is_array($data)) {
+            return $block;
+        }
+
+        if ($type === 'hero' && isset($data['media']) && is_array($data['media'])) {
+            $data['media'] = self::rewriteMedia($data['media'], $mediaMap);
+        } elseif ($type === 'gallery' && isset($data['items']) && is_array($data['items'])) {
+            $data['items'] = array_map(
+                static fn (mixed $item): mixed => is_array($item) ? self::rewriteMedia($item, $mediaMap) : $item,
+                $data['items'],
+            );
+        } elseif ($type === 'group' && isset($data['children']) && is_array($data['children'])) {
+            $data['children'] = array_map(
+                static fn (mixed $child): mixed => self::rewriteBlock($child, $mediaMap),
+                $data['children'],
+            );
+        } elseif ($type === 'columns' && isset($data['columns']) && is_array($data['columns'])) {
+            $data['columns'] = array_map(
+                static function (mixed $column) use ($mediaMap): mixed {
+                    if (is_array($column) && isset($column['children']) && is_array($column['children'])) {
+                        $column['children'] = array_map(
+                            static fn (mixed $child): mixed => self::rewriteBlock($child, $mediaMap),
+                            $column['children'],
+                        );
+                    }
+
+                    return $column;
+                },
+                $data['columns'],
+            );
+        }
+
+        $block['data'] = $data;
+
+        return $block;
+    }
+
+    /**
+     * Rewrite a single {mediaId, url, …} media object (hero media or gallery item).
+     *
+     * @param array<array-key, mixed> $media
+     * @param array<int, int>         $mediaMap
+     * @return array<array-key, mixed>
+     */
+    private static function rewriteMedia(array $media, array $mediaMap): array
+    {
+        $mediaId = $media['mediaId'] ?? null;
+        if (is_string($mediaId) && $mediaId !== '' && ctype_digit($mediaId)) {
+            $new = $mediaMap[(int) $mediaId] ?? null;
+            if ($new !== null) {
+                $media['mediaId'] = (string) $new;
+            }
+        }
+
+        $url = $media['url'] ?? null;
+        if (is_string($url) && $url !== '') {
+            $media['url'] = self::relativizeMediaUrl($url);
+        }
+
+        return $media;
+    }
+
+    /**
+     * Strip scheme+host from an absolute same-origin `/media/...` URL. A relative
+     * URL, or an absolute URL whose path is not under /media/, is returned unchanged.
+     */
+    private static function relativizeMediaUrl(string $url): string
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+        if (!is_string($host) || $host === '') {
+            return $url; // already relative
+        }
+
+        $path = parse_url($url, PHP_URL_PATH);
+        if (!is_string($path) || !str_starts_with($path, '/media/')) {
+            return $url; // external (non-media) absolute URL — leave verbatim
+        }
+
+        $query = parse_url($url, PHP_URL_QUERY);
+
+        return is_string($query) && $query !== '' ? $path . '?' . $query : $path;
+    }
+}

--- a/src/OrgExport/PdoOrgImportRepository.php
+++ b/src/OrgExport/PdoOrgImportRepository.php
@@ -411,10 +411,11 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
         $counts['themes'] = $themeCount;
 
         // ── blocks_fields (append; entity_id remapped) (#486) ──────────────
-        // NOTE: the block body may embed media URLs / entity references. Those
-        // are NOT rewritten here (see #741 Phase 2 design note / follow-up issue);
-        // the body is imported verbatim so block content survives, and relative
-        // media URLs resolve because Tier A serves media from the same paths.
+        // The block body embeds media references (hero/gallery mediaId + url). They
+        // are rewritten via the media map + relativized so images survive transport
+        // (#795). Block bodies carry no numeric entity-id references (internal links
+        // are permalink-based; relations live in entity_relations), so only media is
+        // rewritten; everything else is preserved verbatim.
         $blocksCount = 0;
         foreach ((array) ($payload['blocks_fields'] ?? []) as $row) {
             $newEntityId = $entityMap[(int) $row['entity_id']] ?? null;
@@ -429,7 +430,7 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
                     $newEntityId,
                     (string) $row['field_key'],
                     isset($row['locale']) ? (string) $row['locale'] : null,
-                    (string) $row['value'],
+                    BlocksMediaRewriter::rewrite((string) $row['value'], $mediaMap),
                     (int) ($row['is_deleted'] ?? 0),
                     isset($row['deleted_at']) ? (string) $row['deleted_at'] : null,
                 ],
@@ -521,8 +522,10 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
         //                     FrontPageSetting) — otherwise the pinned front page can't
         //                     resolve on the target and needs a manual post-fix on every
         //                     move (#801).
-        // Settings that embed media URLs or entity references INSIDE JSON blobs
-        // (home_hero, footer_config, …) are NOT rewritten here (see #795).
+        //   - home_hero     → a blocks document; its embedded media (hero/gallery) is
+        //                     remapped + relativized like blocks_fields (#795).
+        // footer_config / header_config hold only external {label,url} links (no media
+        // or entity ids), so they are imported verbatim.
         $settingValueCount = 0;
         foreach ((array) ($payload['setting_values'] ?? []) as $row) {
             $now       = $this->clock->now()->format('Y-m-d H:i:s');
@@ -533,6 +536,9 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
             }
             if ($settingKey === 'front_page' && $value !== null && $value !== '' && ctype_digit($value)) {
                 $value = isset($entityMap[(int) $value]) ? (string) $entityMap[(int) $value] : $value;
+            }
+            if ($settingKey === 'home_hero' && $value !== null && $value !== '') {
+                $value = BlocksMediaRewriter::rewrite($value, $mediaMap);
             }
             $existing = $query->fetchOne(
                 'SELECT id FROM setting_values WHERE organization_id = ? AND setting_key = ?',

--- a/tests/OrgExport/BlocksMediaRewriterTest.php
+++ b/tests/OrgExport/BlocksMediaRewriterTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\OrgExport;
+
+use NeNeRecords\OrgExport\BlocksMediaRewriter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #795: rewriting media references embedded in a blocks document on org transport.
+ * mediaId is remapped via the media map; absolute same-origin /media URLs are
+ * relativized; everything else is preserved verbatim.
+ */
+final class BlocksMediaRewriterTest extends TestCase
+{
+    /** @var array<int, int> */
+    private const MEDIA_MAP = [60 => 900, 61 => 901];
+
+    public function testRemapsHeroMediaIdAndRelativizesAbsoluteUrl(): void
+    {
+        $doc = json_encode([[
+            'id'   => 'b1',
+            'type' => 'hero',
+            'data' => [
+                'variant' => 'center',
+                'heading' => 'Hi',
+                'media'   => ['mediaId' => '60', 'url' => 'https://source.nene-records.com/media/2026/x.png', 'alt' => 'x'],
+            ],
+        ]], JSON_UNESCAPED_SLASHES);
+
+        $out = json_decode(BlocksMediaRewriter::rewrite((string) $doc, self::MEDIA_MAP), true);
+
+        self::assertSame('900', $out[0]['data']['media']['mediaId']);
+        self::assertSame('/media/2026/x.png', $out[0]['data']['media']['url']);
+        self::assertSame('x', $out[0]['data']['media']['alt']); // untouched
+    }
+
+    public function testRemapsGalleryItems(): void
+    {
+        $doc = json_encode([[
+            'id'   => 'g1',
+            'type' => 'gallery',
+            'data' => [
+                'layout' => 'grid',
+                'items'  => [
+                    ['mediaId' => '60', 'url' => '/media/a.png', 'alt' => 'a'],
+                    ['mediaId' => '61', 'url' => 'https://old-host.example/media/b.png', 'alt' => 'b'],
+                ],
+            ],
+        ]], JSON_UNESCAPED_SLASHES);
+
+        $out   = json_decode(BlocksMediaRewriter::rewrite((string) $doc, self::MEDIA_MAP), true);
+        $items = $out[0]['data']['items'];
+
+        self::assertSame('900', $items[0]['mediaId']);
+        self::assertSame('/media/a.png', $items[0]['url']); // already relative
+        self::assertSame('901', $items[1]['mediaId']);
+        self::assertSame('/media/b.png', $items[1]['url']); // relativized
+    }
+
+    public function testRemapsMediaNestedInsideColumnsAndGroup(): void
+    {
+        $doc = json_encode([
+            [
+                'id'   => 'c1',
+                'type' => 'columns',
+                'data' => ['columns' => [
+                    ['children' => [[
+                        'id'   => 'h1',
+                        'type' => 'hero',
+                        'data' => ['media' => ['mediaId' => '60', 'url' => '/media/x.png']],
+                    ]]],
+                ]],
+            ],
+            [
+                'id'   => 'grp',
+                'type' => 'group',
+                'data' => ['tone' => 'muted', 'children' => [[
+                    'id'   => 'gal',
+                    'type' => 'gallery',
+                    'data' => ['items' => [['mediaId' => '61', 'url' => '/media/y.png']]],
+                ]]],
+            ],
+        ], JSON_UNESCAPED_SLASHES);
+
+        $out = json_decode(BlocksMediaRewriter::rewrite((string) $doc, self::MEDIA_MAP), true);
+
+        self::assertSame('900', $out[0]['data']['columns'][0]['children'][0]['data']['media']['mediaId']);
+        self::assertSame('901', $out[1]['data']['children'][0]['data']['items'][0]['mediaId']);
+    }
+
+    public function testLeavesExternalNonMediaUrlUntouched(): void
+    {
+        $doc = json_encode([[
+            'id'   => 'h',
+            'type' => 'hero',
+            'data' => ['media' => ['mediaId' => '999', 'url' => 'https://cdn.example.com/images/x.png']],
+        ]], JSON_UNESCAPED_SLASHES);
+
+        $out = json_decode(BlocksMediaRewriter::rewrite((string) $doc, self::MEDIA_MAP), true);
+
+        // mediaId 999 not in the map → kept; external non-/media URL → kept.
+        self::assertSame('999', $out[0]['data']['media']['mediaId']);
+        self::assertSame('https://cdn.example.com/images/x.png', $out[0]['data']['media']['url']);
+    }
+
+    public function testReturnsBodyVerbatimWhenNothingChanges(): void
+    {
+        // A text block with no media, and pretty-printed JSON: the exact bytes must
+        // come back so an untouched document is not reformatted.
+        $doc = "[\n  {\"id\": \"t1\", \"type\": \"text\", \"data\": {\"markdown\": \"hello\"}}\n]";
+
+        self::assertSame($doc, BlocksMediaRewriter::rewrite($doc, self::MEDIA_MAP));
+    }
+
+    public function testLeavesNonBlocksDocumentVerbatim(): void
+    {
+        // footer_config-shaped object (not a JSON array of blocks) → untouched.
+        $obj = '{"social":[],"legalLinks":[],"showPoweredBy":true}';
+        self::assertSame($obj, BlocksMediaRewriter::rewrite($obj, self::MEDIA_MAP));
+        self::assertSame('[]', BlocksMediaRewriter::rewrite('[]', self::MEDIA_MAP));
+        self::assertSame('not json', BlocksMediaRewriter::rewrite('not json', self::MEDIA_MAP));
+    }
+
+    public function testEmptyMediaMapIsNoOp(): void
+    {
+        $doc = json_encode([[
+            'id'   => 'h',
+            'type' => 'hero',
+            'data' => ['media' => ['mediaId' => '60', 'url' => 'https://source/media/x.png']],
+        ]], JSON_UNESCAPED_SLASHES);
+
+        self::assertSame((string) $doc, BlocksMediaRewriter::rewrite((string) $doc, []));
+    }
+}

--- a/tests/OrgExport/PdoOrgImportRepositoryTest.php
+++ b/tests/OrgExport/PdoOrgImportRepositoryTest.php
@@ -191,6 +191,20 @@ final class PdoOrgImportRepositoryTest extends TestCase
         self::assertNotNull($frontPage);
         self::assertSame((string) (int) $entity['id'], $frontPage['value']);
 
+        // #795: the hero block's media reference was remapped onto the new media id
+        // and its absolute URL relativized — both in the blocks_fields body and in
+        // the home_hero setting (same block-document shape).
+        $newMediaId = (string) (int) $media['id'];
+        $blockMedia = json_decode((string) $block['value'], true);
+        self::assertSame($newMediaId, $blockMedia[1]['data']['media']['mediaId']);
+        self::assertSame('/media/logo.png', $blockMedia[1]['data']['media']['url']);
+
+        $homeHero = $this->executor->fetchOne("SELECT value FROM setting_values WHERE organization_id = 1 AND setting_key = 'home_hero'");
+        self::assertNotNull($homeHero);
+        $hero = json_decode((string) $homeHero['value'], true);
+        self::assertSame($newMediaId, $hero[0]['data']['media']['mediaId']);
+        self::assertSame('/media/logo.png', $hero[0]['data']['media']['url']);
+
         self::assertSame(1, $counts['menus']);
         self::assertSame(1, $counts['widgets']);
         self::assertSame(1, $counts['entity_relations']);
@@ -294,7 +308,10 @@ final class PdoOrgImportRepositoryTest extends TestCase
                 ['id' => 90, 'theme_key' => 'custom', 'name' => 'Custom', 'version' => '1.0.0', 'source' => 'runtime', 'manifest' => '{"brand":"#ff0000"}'],
             ],
             'blocks_fields'    => [
-                ['id' => 100, 'entity_id' => 30, 'field_key' => 'blocks', 'value' => '[{"type":"paragraph","text":"hi"}]', 'is_deleted' => 0],
+                // A paragraph (no media, preserved verbatim) plus a hero block whose
+                // media references source id 60 via an absolute same-origin URL — the
+                // mediaId must be remapped and the URL relativized on import (#795).
+                ['id' => 100, 'entity_id' => 30, 'field_key' => 'blocks', 'value' => '[{"type":"paragraph","text":"hi"},{"id":"h","type":"hero","data":{"media":{"mediaId":"60","url":"https://source.example/media/logo.png"}}}]', 'is_deleted' => 0],
             ],
             'entity_relations' => [
                 ['id' => 110, 'source_entity_id' => 30, 'target_entity_id' => 31, 'field_key' => 'related'],
@@ -303,11 +320,15 @@ final class PdoOrgImportRepositoryTest extends TestCase
             'setting_defs'     => [
                 ['id' => 130, 'setting_key' => 'logo_media_id', 'data_type' => 'media', 'default_value' => '', 'is_public' => 1, 'label' => 'Logo'],
                 ['id' => 131, 'setting_key' => 'front_page', 'data_type' => 'int', 'default_value' => '', 'is_public' => 1, 'label' => 'Front page'],
+                ['id' => 132, 'setting_key' => 'home_hero', 'data_type' => 'text', 'default_value' => '[]', 'is_public' => 1, 'label' => 'Home hero'],
             ],
             'setting_values'   => [
                 ['id' => 140, 'setting_key' => 'logo_media_id', 'value' => '60', 'is_deleted' => 0],
                 // front_page pins source entity 30 → must be remapped onto the new id.
                 ['id' => 141, 'setting_key' => 'front_page', 'value' => '30', 'is_deleted' => 0],
+                // home_hero is a blocks document → its hero media (id 60) is remapped
+                // + the absolute URL relativized on import (#795).
+                ['id' => 142, 'setting_key' => 'home_hero', 'value' => '[{"id":"hh","type":"hero","data":{"media":{"mediaId":"60","url":"https://source.example/media/logo.png"}}}]', 'is_deleted' => 0],
             ],
         ];
     }


### PR DESCRIPTION
## 目的

#741 Phase 2 で org export/import に blocks_fields・settings を含めたが、JSON blob に埋め込まれた media 参照は verbatim 取り込みだった。移送先では media id が再採番されるため、ブロックの画像（hero/gallery）が古い id・古いドメインの絶対 URL を指し画像切れを起こす。

## 変更

- **`BlocksMediaRewriter`（新規）**: ブロックドキュメントを走査し、`hero.data.media` / `gallery.data.items[]` の `mediaId` を mediaMap で再マップ、絶対**同一オリジン `/media` URL** を相対化（scheme+host を落とす）。`group.children` / `columns[].children` も再帰。変更が無ければ本文を byte-for-byte verbatim 返却（非ブロックドキュメント文字列も verbatim）。
- **`PdoOrgImportRepository`**: `blocks_fields` 取り込みと `home_hero` 設定（同じブロックドキュメント形式）に適用。

## スコープ判断

- **絶対 URL 方針＝「同一オリジンに相対化」**（施主裁定・CLI import は最終公開ドメインを知らず Tier A は後で DNS 切替のため）。外部（非 /media）画像は verbatim。
- ブロックに数値 entity-id 参照は無い（内部リンクは permalink 由来・リレーションは `entity_relations` で別途再マップ済み）。`footer_config`/`header_config` は外部 `{label,url}` リンクのみで対象外。

## 検証

- `composer test` … 新規 `BlocksMediaRewriterTest` 8＋round-trip（blocks 本文・home_hero の再マップ＆相対化）／PHPStan L8・CS-Fixer clean

（旧 PR #811 は base ブランチ削除で自動クローズされたため、main ベースで再作成。#801 は #806 で先行マージ済み。）

Closes #795