### PR TITLE
fix(public): 明示permalinkのbareページが直リンクで /pages/{id} へ落ちるのを修正（#816）

### DIFF
--- a/src/PublicRecord/PublicRecordViewHttpMapper.php
+++ b/src/PublicRecord/PublicRecordViewHttpMapper.php
@@ -77,6 +77,14 @@ final readonly class PublicRecordViewHttpMapper
                 // so the tri-state visibility overrides must ride along (#778).
                 'show_comments' => $entity->showComments,
                 'show_related' => $entity->showRelated,
+                // Canonical URL identity must ride along too (#816): the SPA's
+                // useCanonicalRedirect derives the record's URL from entity.permalink
+                // (falling back to /{type}/{id} when absent). Without it, a direct
+                // load of an explicit-permalink page (e.g. /company/ip, which does
+                // not match the type's /{slug} pattern) bounces to /pages/{id} on
+                // mount. slug rides along for the title/humanize fallbacks (#657).
+                'slug' => $entity->slug,
+                'permalink' => $entity->permalink,
                 // Per-record layout must ride along too: the SPA resolves the
                 // page chrome (standard / full / two-col / bare / custom) from
                 // entity.layout, so a `bare`/`custom` custom page can only drop

--- a/tests/PublicRecord/GetPublicRecordViewUseCaseTest.php
+++ b/tests/PublicRecord/GetPublicRecordViewUseCaseTest.php
@@ -91,6 +91,7 @@ final class GetPublicRecordViewUseCaseTest extends TestCase
                 id: 10,
                 entityTypeId: 1,
                 slug: 'hello-world',
+                permalink: '/company/ip',
                 status: EntityStatus::Published,
                 layout: 'bare',
             ),
@@ -114,6 +115,11 @@ final class GetPublicRecordViewUseCaseTest extends TestCase
 
         // A `bare`/custom page rides its layout to the SPA so it can drop the shell.
         self::assertSame('bare', $output->bootstrap['entity']['layout']);
+        // The canonical URL identity rides along (#816): without permalink in the
+        // bootstrap, a direct load of an explicit-permalink page bounces to
+        // /pages/{id} on mount (useCanonicalRedirect falls back to /{type}/{id}).
+        self::assertSame('/company/ip', $output->bootstrap['entity']['permalink']);
+        self::assertSame('hello-world', $output->bootstrap['entity']['slug']);
     }
 
     public function testBootstrapEntityCarriesVisibilityOverrides(): void


### PR DESCRIPTION
## 症状
`/company/ip`（明示 permalink・pages型 `/{slug}` に不一致・layout=bare）を**直リンクで開く**と、SSR は正しく `/company/ip` を描画するのに **SPA マウント後に URL が `/pages/{id}` へ遷移**（AYANE で実観測）。クライアントナビ（リンク遷移）では正常。

## 原因
- SPA `useCanonicalRedirect`：`canonical = entity.permalink ?? resolvePermalink(pattern ?? DEFAULT, …)`。`DEFAULT_PERMALINK_PATTERN='/{type}/{id}'` → permalink 欠落時 `/pages/{id}`。
- 直リンク時の entity は **SSR bootstrap（`toBootstrap`）が seed する partial entity**で、`layout`/`show_comments` はあるが **`permalink`/`slug` が無い** → fallback。
- クライアントナビは `GET /api/v1/entities/{id}`（permalink を返す）で正常＝直リンクのみ再現。

## 修正
`PublicRecordViewHttpMapper::toBootstrap` の entity payload に **`permalink`・`slug` を追加**（#778 の show_comments、#799 の layout と同型＝bootstrap に読む列を足す）。`bootstrap.entity` は OpenAPI 上 `EntityResponse` 参照で、permalink/slug は元々宣言済みの列＝**欠けていた宣言列を補う**修正。フロントは既に `entity.permalink` を読み型も持つため変更なし。

## 検証
- `composer test` … 1266 OK（`GetPublicRecordViewUseCaseTest` に `bootstrap['entity']['permalink']='/company/ip'`・`['slug']` の assert 追加）
- PHPStan L8 / CS-Fixer clean / `composer openapi` valid
- ※ライブ反映は本番デプロイ後（bootstrap はサーバ生成・フロント再ビルド不要）。反映後 `/company/ip` 等の明示 permalink ページが直リンクでも留まる。

Closes #816