### PR TITLE
fix(auth): 未認証の管理API読取とクロステナント越境を塞ぐ（自己診断 #824）

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -14,6 +14,9 @@ RUN apt-get update \
     && a2enmod rewrite headers \
     && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n\n# Single-origin: serve the built SPA assets (Vite /assets/*) directly from the\n# frontend build so the PHP-rendered pages can mount the production SPA.\n# Vite copies frontend/public/* to the dist ROOT (not dist/assets), so every\n# public/ passthrough directory the app references needs its own Alias here\n# (theme-thumbnails = built-in theme picker images, #705).\nAlias /assets /var/www/html/frontend/dist/assets\n<Directory /var/www/html/frontend/dist/assets>\n    Require all granted\n</Directory>\nAlias /theme-thumbnails /var/www/html/frontend/dist/theme-thumbnails\n<Directory /var/www/html/frontend/dist/theme-thumbnails>\n    Require all granted\n</Directory>\n' > /etc/apache2/conf-available/nene-records.conf \
     && a2enconf nene-records \
+    && printf 'ServerTokens Prod\nServerSignature Off\nHeader always unset X-Powered-By\n' > /etc/apache2/conf-available/zz-hardening.conf \
+    && a2enconf zz-hardening \
+    && printf 'expose_php = Off\n' > /usr/local/etc/php/conf.d/zz-security.ini \
     && sed -ri -e 's!/var/www/html!/var/www/html/public_html!g' /etc/apache2/sites-available/*.conf \
     && sed -ri -e 's!/var/www/!/var/www/html/public_html!g' /etc/apache2/apache2.conf
 

--- a/docker/php/Dockerfile.prod
+++ b/docker/php/Dockerfile.prod
@@ -32,6 +32,9 @@ RUN apt-get update \
     && a2enmod rewrite headers \
     && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n\n# Single-origin: serve the built SPA assets (Vite /assets/*) directly.\n# Vite copies frontend/public/* to the dist ROOT (not dist/assets), so every\n# public/ passthrough directory the app references needs its own Alias here\n# (theme-thumbnails = built-in theme picker images, #705).\nAlias /assets /var/www/html/frontend/dist/assets\n<Directory /var/www/html/frontend/dist/assets>\n    Require all granted\n</Directory>\nAlias /theme-thumbnails /var/www/html/frontend/dist/theme-thumbnails\n<Directory /var/www/html/frontend/dist/theme-thumbnails>\n    Require all granted\n</Directory>\n' > /etc/apache2/conf-available/nene-records.conf \
     && a2enconf nene-records \
+    && printf 'ServerTokens Prod\nServerSignature Off\nHeader always unset X-Powered-By\n' > /etc/apache2/conf-available/zz-hardening.conf \
+    && a2enconf zz-hardening \
+    && printf 'expose_php = Off\n' > /usr/local/etc/php/conf.d/zz-security.ini \
     && sed -ri -e 's!/var/www/html!/var/www/html/public_html!g' /etc/apache2/sites-available/*.conf \
     && sed -ri -e 's!/var/www/!/var/www/html/public_html!g' /etc/apache2/apache2.conf
 

--- a/docs/security/2026-07-13-assessment.md
+++ b/docs/security/2026-07-13-assessment.md
@@ -1,0 +1,140 @@
+# Security Assessment — NeNe Records (2026-07-13)
+
+**Type:** Authorized self / maintainer-run assessment — black-box live attack (ATK) + white-box code review.
+**This is not a third-party penetration test.**
+**App version at test:** `VERSION` 0.5.2, branch `sec/824-assessment-2026-07` (off `main` `1562814`).
+**Scope:** NeNe Records application (`src/`, HTTP API + public SSR), exercised as a running service.
+**Target:** disposable Docker stack (`php:8.4.23-apache` + mysql:8.4), isolated project `nene-records-sectest`
+on non-production ports — never run against production data or `*.nene-records.com` / `*.ayane.co.jp`.
+Reproduction: [`harness/`](harness/). Issue: #824.
+
+---
+
+## Result
+
+Pre-remediation: **1 Critical, 1 Medium, 1 Low `EXPOSED`.** All three were remediated in this branch and
+re-verified live (**post-fix: 0 `EXPOSED`**). Every other attack category was already blocked.
+
+| # | Severity | Finding | Status |
+|---|----------|---------|--------|
+| F-01 | **Critical** | Unauthenticated read of the entire admin API (incl. webhook signing secrets, draft/unpublished records, full export, field values) | Fixed + regression-verified |
+| F-02 | **Medium** | Cross-tenant read via JWT replay — org binding enforced only on capability-mapped routes | Fixed + regression-verified |
+| F-03 | **Low** | Version disclosure via `Server` / `X-Powered-By` response headers | Fixed + regression-verified |
+
+---
+
+## Methodology
+
+- **Black-box live attack (ATK):** the app was booted in a throwaway Docker stack, migrated, seeded with
+  two organizations (`default` #1, `ayane` #2) and an admin each, then attacked over HTTP with a cracker
+  mindset — malicious inputs aimed at breaking authentication, tenant isolation, injecting SQL, and leaking
+  data. Source was not modified during attack; the containers and volumes were destroyed afterwards.
+- **White-box review:** `AdminApiAuthMiddleware`, `CapabilityMiddleware` / `CapabilityResolver`,
+  `OrgResolverMiddleware`, `SessionCookie`, and the OpenAPI route inventory were read to find the root cause
+  of each observed behaviour.
+- **Regression verification:** each `EXPOSED` finding was re-exercised after its fix with the exact input
+  that previously triggered it, and the full `composer check` suite (1271 tests / 3609 assertions, PHPStan
+  level 8, CS-Fixer, OpenAPI, conformance, MCP) was run green.
+
+---
+
+## Findings
+
+### F-01 — Unauthenticated read of the admin API (Critical) — FIXED
+
+**Observed.** With no credentials whatsoever:
+
+```
+GET /api/v1/webhooks              → 200, body includes "secret":"whsec_…"   (webhook signing secret)
+GET /api/v1/entities?status=draft → 200, returns draft / unpublished records
+GET /api/v1/entities/export       → 200, full export
+GET /api/v1/text-fields           → 200, field content (incl. draft bodies)
+GET /api/v1/notification-channels → 200
+GET /api/v1/field-defs, /entity-types, /tags, /dashboard, /analytics/*  → 200
+```
+
+31 GET routes under `/api/v1/` were reachable unauthenticated. On the multi-tenant production
+(`<tenant>.nene-records.com`), this exposed **each tenant's webhook signing secret** (enabling forged,
+correctly-signed webhook payloads), all **draft/unpublished content**, and a **full data export** — to any
+anonymous visitor.
+
+**Root cause.** `AdminApiAuthMiddleware` protected only *non-GET* methods for `/api/v1/*` routes not listed
+in `ADMIN_ONLY_PREFIXES` (rule 3). Any admin resource whose prefix was never added to that list leaked its
+GET response. The intended design is that public reads go through the dedicated `/api/v1/public/*` surface
+(and server-side SSR); admin APIs require auth.
+
+**Remediation.** `AdminApiAuthMiddleware` now requires authentication for **every** method on `/api/v1/*`
+except the CORS-preflight `OPTIONS` — GET/HEAD included (fail-closed). `ALWAYS_OPEN_PREFIXES`
+(`/health`, `/api/v1/auth/*`, `/api/v1/public/*`, cron batch endpoints) are unchanged, so the public site and
+login are unaffected. A newly added admin route is now protected by default instead of leaking its GET.
+
+**Regression (live).** All the routes above now return **401**; the webhook secret is no longer reachable
+unauthenticated; authenticated admin reads still return 200; `/health` and `/api/v1/public/*` stay open;
+`OPTIONS` passes through. Unit regression in `tests/Auth/AdminApiAuthMiddlewareTest.php`.
+
+**Defense-in-depth (recommendation, not blocking).** `WebhookHttpMapper` returns the `secret` field in
+read responses. Consider a write-only secret (return a masked/last-4 value on read) so the signing secret is
+never echoed back even to authenticated admins. Tracked as a follow-up.
+
+### F-02 — Cross-tenant read via JWT replay (Medium) — FIXED
+
+**Observed.** An authenticated user of org A, replaying their session JWT as an `Authorization: Bearer`
+token against org B's host (or, before F-01's fix, any cross-org cookie), could read org B's data on routes
+that `CapabilityResolver` does not map:
+
+```
+admin(org=1) cookie/bearer → GET /api/v1/webhooks on ayane(org=2) host → 200, returned org 2's webhook + secret
+```
+
+**Root cause.** `CapabilityMiddleware` enforced "JWT `org_id` must equal the resolved org id" **only after**
+`CapabilityResolver::resolve()` returned a required capability. For routes with no capability mapping
+(e.g. `GET /api/v1/webhooks`), the middleware returned early and skipped the org-scope check entirely.
+Session cookies are host-only (a browser will not send them cross-subdomain), but a user can copy their JWT
+and replay it manually as a bearer token, bypassing that mitigation.
+
+**Remediation.** The organization-scope check now runs **unconditionally** for every authenticated,
+org-scoped request (non-superadmin, where `OrgResolverMiddleware` resolved `nene2.org.id`), independent of
+whether a capability is mapped. Superadmin (cross-org by design) and org-agnostic bypass routes
+(`/superadmin/*`, `/organizations`, `/auth/*`) are unaffected because they never set `nene2.org.id`.
+
+**Regression (live).** Cross-org cookie **and** bearer-replay now return **403** `org-access-denied`;
+same-org admin access still returns 200; superadmin console gating (#797) still holds
+(non-superadmin → 403, unauthenticated → 401). Unit regression in `tests/Auth/CapabilityMiddlewareTest.php`.
+
+### F-03 — Version disclosure headers (Low) — FIXED
+
+**Observed.** `Server: Apache/2.4.67 (Debian)` and `X-Powered-By: PHP/8.4.23` were returned on every
+response, disclosing exact component versions.
+
+**Remediation.** `ServerTokens Prod` + `ServerSignature Off` (in a `zz-hardening.conf` that loads after
+Debian's `security.conf`) and `expose_php = Off` added to both `docker/php/Dockerfile` and
+`docker/php/Dockerfile.prod`. **Live re-test:** `Server: Apache`, `X-Powered-By` absent. Takes effect in
+production on the next image rebuild/deploy.
+
+---
+
+## Verified robust (no finding)
+
+| Category | Test | Result |
+|----------|------|--------|
+| CSRF | Cookie-auth `POST` without `X-Requested-With` | **403**; with header → passes |
+| Superadmin authz (#797) | Non-superadmin → `/api/v1/superadmin/*`; unauth → same | **403** / **401** |
+| JWT algorithm confusion | `alg:none` forged token; malformed bearer | **401** |
+| SQL injection | `' OR '1'='1`, time-based `SLEEP(3)`, path-param SQLi (authenticated) | **200**, ≤35 ms, no SQL error — parameterized |
+| Error info leak | Force 404/500 with `APP_DEBUG=false` | RFC 9457 Problem Details; no stack trace / SQL / path |
+| Response headers | Baseline | `CSP: default-src 'self'`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy: strict-origin-when-cross-origin` present |
+| Session cookie | `nene_session` flags | `HttpOnly`, `SameSite=Lax`, `Path=/`, host-only (no `Domain`), `Secure` over HTTPS |
+| HTML/SVG sanitization | Unit coverage | `PublicHtmlSanitizer` (6 tests), `SvgSanitizer` (17 tests) |
+
+---
+
+## Coverage & known limits (honest)
+
+- Tested against the **dev container** image; production runs `Dockerfile.prod` (multi-stage). F-03's
+  hardening was applied to both, but a prod-image rebuild should re-confirm the headers on deploy.
+- **Not exhaustively fuzzed:** stored-XSS through `PublicHtmlSanitizer` on live SSR (relied on unit
+  coverage + one spot check), media on-demand-derivative SSRF / path traversal, and webhook delivery SSRF.
+  Recommended as the next round's focus.
+- **Out of scope this round:** rate-limiting / DoS (destructive), Playwright E2E, dependency-CVE scanning,
+  and the private-vulnerability-reporting flow.
+- All numbers/behaviour are point-in-time for the version above and will drift as the code changes.

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,28 @@
+# Security
+
+Security posture, policy, and assessment records for NeNe Records.
+
+The vulnerability-reporting policy (how to report, response timelines, scope) lives in
+[`/SECURITY.md`](../../SECURITY.md).
+
+## Assessments
+
+Point-in-time **authorized self / maintainer-run** assessments — black-box live attack (ATK) against a
+running instance plus code review. Each is a snapshot of the version tested. **These are not third-party
+penetration tests.**
+
+| Date | Version | Report | Result |
+|------|---------|--------|--------|
+| 2026-07-13 | 0.5.2 | [Assessment](2026-07-13-assessment.md) | 1 Critical + 1 Medium + 1 Low found, all fixed & regression-verified (post-fix 0 EXPOSED) |
+
+## Methodology
+
+Assessments follow the pattern documented in the NENE2 framework
+([`live-penetration-testing.md`](https://github.com/hideyukiMORI/NENE2/blob/main/docs/howto/live-penetration-testing.md),
+[`docs/security/`](https://github.com/hideyukiMORI/NENE2/tree/main/docs/security)): boot the app in a
+disposable container on a dedicated port, attack it with a cracker mindset, never touch production data or
+credentials, and destroy the container afterwards. Reproduction tooling is in [`harness/`](harness/).
+
+## Reporting a vulnerability
+
+See [`/SECURITY.md`](../../SECURITY.md) — use GitHub Private Vulnerability Reporting.

--- a/docs/security/harness/.gitignore
+++ b/docs/security/harness/.gitignore
@@ -1,0 +1,8 @@
+# Never commit secrets, captured tokens, or attack output.
+*.cookie
+*.cookies
+cook*.txt
+*.jwt
+out/
+*.log
+.env.app

--- a/docs/security/harness/README.md
+++ b/docs/security/harness/README.md
@@ -1,0 +1,34 @@
+# Security assessment harness
+
+Reproduces the live-attack environment used for the assessments in the parent directory. It boots an
+**isolated, disposable** NeNe Records instance from the repo's own `compose.yaml` under a dedicated Compose
+project (`nene-records-sectest`) on non-production ports, so it never collides with the dev stack and never
+touches production.
+
+> ⚠️ For your own, authorized, isolated instance only. Never point this at production
+> (`*.nene-records.com`, `*.ayane.co.jp`) or any third-party system.
+
+## Run
+
+```bash
+cd <repo root>
+bash docs/security/harness/probe.sh
+```
+
+`probe.sh`:
+
+1. Boots `app` + `mysql` under project `nene-records-sectest` (app on :18092, mysql on :13318) with a
+   throwaway JWT secret and `APP_DEBUG=false` (production-like error handling).
+2. Installs two orgs (`default`, `ayane`) each with an admin, logs in, and seeds a webhook (with a secret)
+   and a draft entity.
+3. Runs the attack battery and asserts the expected result for each case:
+   - unauthenticated GET on admin routes → **401** (F-01)
+   - cross-tenant cookie / JWT-bearer replay → **403** (F-02)
+   - CSRF (cookie mutation without `X-Requested-With`) → **403**
+   - superadmin route as non-superadmin → **403**, unauthenticated → **401** (#797)
+   - JWT `alg:none` / malformed → **401**
+   - version-disclosure headers absent (F-03)
+4. Tears everything down with `docker compose -p nene-records-sectest down -v` (destroys the DB volume).
+
+Captured cookies / tokens / output are git-ignored (see `.gitignore`). The throwaway JWT secret in the
+script is a test value with no production meaning.

--- a/docs/security/harness/probe.sh
+++ b/docs/security/harness/probe.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# NeNe Records — security assessment harness (authorized, isolated instances only).
+# Boots a throwaway instance, seeds data, runs the attack battery, asserts results, tears down.
+# Never run against production (*.nene-records.com / *.ayane.co.jp).
+set -uo pipefail
+
+PROJECT=nene-records-sectest
+APP_PORT=18092
+DB_PORT=13318
+B="http://localhost:${APP_PORT}"
+JWT='sectest-jwt-secret-32chars-minimum!!'   # throwaway test secret — no production meaning
+PW='SecTest-Passw0rd-2026!'
+WORK="$(mktemp -d)"
+pass=0; fail=0
+
+repo_root() { git rev-parse --show-toplevel 2>/dev/null || pwd; }
+cd "$(repo_root)" || exit 1
+
+cleanup() { docker compose -p "$PROJECT" down -v >/dev/null 2>&1; rm -rf "$WORK"; }
+trap cleanup EXIT
+
+check() { # name expected actual
+  if [ "$2" = "$3" ]; then echo "  ✅ $1 ($3)"; pass=$((pass+1));
+  else echo "  ❌ $1 (expected $2, got $3)"; fail=$((fail+1)); fi
+}
+code() { curl -s -o /dev/null -w '%{http_code}' "$@"; }
+
+echo "== boot isolated instance =="
+NENE_RECORDS_PORT=$APP_PORT NENE_RECORDS_MYSQL_PORT=$DB_PORT APP_DEBUG=false \
+  NENE2_LOCAL_JWT_SECRET="$JWT" NENE2_MACHINE_API_KEY='sectest-machine-key' \
+  docker compose -p "$PROJECT" up -d --build app mysql >/dev/null 2>&1
+for i in $(seq 1 40); do [ "$(code "$B/health")" = "200" ] && break; sleep 3; done
+
+echo "== seed orgs / admins / data =="
+for slug in default ayane; do
+  docker compose -p "$PROJECT" exec -T \
+    -e NENE_INSTALL_ADMIN_EMAIL="admin-${slug}@sectest.local" -e NENE_INSTALL_ADMIN_PASSWORD="$PW" \
+    -e NENE_INSTALL_ORG_SLUG="$slug" app php tools/install.php >/dev/null 2>&1
+done
+# resolved org is driven by ORG_SLUG from the repo .env (compose auto-loads it).
+RESOLVED=$(docker compose -p "$PROJECT" exec -T app sh -c 'echo $ORG_SLUG' | tr -d '\r')
+curl -s -c "$WORK/match.txt"  -o /dev/null -X POST "$B/api/v1/auth/login" -H 'Content-Type: application/json' -H 'X-Requested-With: 1' -d "{\"email\":\"admin-${RESOLVED}@sectest.local\",\"password\":\"$PW\"}"
+OTHER=default; [ "$RESOLVED" = default ] && OTHER=ayane
+curl -s -c "$WORK/other.txt" -o /dev/null -X POST "$B/api/v1/auth/login" -H 'Content-Type: application/json' -H 'X-Requested-With: 1' -d "{\"email\":\"admin-${OTHER}@sectest.local\",\"password\":\"$PW\"}"
+curl -s -b "$WORK/match.txt" -o /dev/null -X POST "$B/api/v1/webhooks" -H 'Content-Type: application/json' -H 'X-Requested-With: 1' \
+  -d '{"url":"https://x.example/h","events":["entity.created"],"secret":"whsec_TEST","is_active":true}'
+
+echo "== F-01: unauthenticated admin GET must be 401 =="
+for p in /api/v1/webhooks /api/v1/entities /api/v1/entities/export /api/v1/text-fields /api/v1/notification-channels; do
+  check "unauth GET $p" 401 "$(code "$B$p")"
+done
+check "public GET /api/v1/public/settings stays open" 200 "$(code "$B/api/v1/public/settings")"
+check "GET /health stays open" 200 "$(code "$B/health")"
+
+echo "== F-02: cross-tenant must be 403 =="
+check "other-org cookie -> resolved org webhooks" 403 "$(code -b "$WORK/other.txt" "$B/api/v1/webhooks")"
+JWT_OTHER=$(grep -oE 'nene_session[[:space:]]+ey[A-Za-z0-9._-]+' "$WORK/other.txt" | awk '{print $2}')
+check "other-org JWT bearer replay" 403 "$(code -H "Authorization: Bearer $JWT_OTHER" "$B/api/v1/webhooks")"
+check "same-org admin still works" 200 "$(code -b "$WORK/match.txt" "$B/api/v1/webhooks")"
+
+echo "== CSRF / superadmin / JWT =="
+check "cookie POST w/o X-Requested-With" 403 "$(code -b "$WORK/match.txt" -X POST "$B/api/v1/webhooks" -H 'Content-Type: application/json' -d '{}')"
+check "non-superadmin -> superadmin route" 403 "$(code -b "$WORK/match.txt" "$B/api/v1/superadmin/organizations")"
+check "unauth -> superadmin route" 401 "$(code "$B/api/v1/superadmin/organizations")"
+NONE="$(printf '{"typ":"JWT","alg":"none"}' | base64 -w0 | tr '+/' '-_' | tr -d '=').$(printf '{"sub":"a","exp":9999999999}' | base64 -w0 | tr '+/' '-_' | tr -d '=')."
+check "JWT alg:none" 401 "$(code -H "Authorization: Bearer $NONE" "$B/api/v1/webhooks")"
+
+echo "== F-03: version-disclosure headers absent =="
+hdr=$(curl -s -D - -o /dev/null "$B/health")
+echo "$hdr" | grep -qi '^X-Powered-By:' && { echo "  ❌ X-Powered-By present"; fail=$((fail+1)); } || { echo "  ✅ X-Powered-By absent"; pass=$((pass+1)); }
+echo "$hdr" | grep -qiE '^Server: Apache/[0-9]' && { echo "  ❌ Server discloses version"; fail=$((fail+1)); } || { echo "  ✅ Server version suppressed"; pass=$((pass+1)); }
+
+echo
+echo "== RESULT: $pass passed, $fail failed =="
+[ "$fail" -eq 0 ]

--- a/src/Auth/AdminApiAuthMiddleware.php
+++ b/src/Auth/AdminApiAuthMiddleware.php
@@ -18,8 +18,9 @@ use Psr\Http\Server\RequestHandlerInterface;
  * Protection rules (first match wins):
  *  1. Always open: /health, /api/v1/auth/*, /api/v1/public/*, and the
  *     cron-triggered batch endpoints (process-scheduled / process-deliveries)
- *  2. Always protected (all HTTP methods): paths starting with /api/v1/settings
- *  3. Protected for non-GET methods: all other /api/v1/ paths
+ *  2. Always protected (all HTTP methods incl. OPTIONS): the ADMIN_ONLY_PREFIXES
+ *  3. Protected for every method except OPTIONS (CORS preflight): all other
+ *     /api/v1/ paths — GET and HEAD included. Fail-closed by default.
  *  4. Everything else: open (static assets, public HTML pages)
  */
 final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
@@ -151,9 +152,16 @@ final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
             }
         }
 
-        // 3. All /api/v1/* paths: protect non-GET methods
+        // 3. All other /api/v1/* paths: protect EVERY method except the CORS
+        //    preflight OPTIONS. GET/HEAD are protected too — admin reads must be
+        //    authenticated. The only unauthenticated reads are the dedicated
+        //    /api/v1/public/* surface and /api/v1/auth/* (both ALWAYS_OPEN above)
+        //    plus the cron batch endpoints. Fail-closed: a newly added admin
+        //    route is protected by default instead of leaking its GET response
+        //    (incl. drafts, webhook secrets, exports) until someone remembers to
+        //    add a prefix. See security assessment #824.
         if (str_starts_with($path, '/api/v1/')) {
-            return $method !== 'GET' && $method !== 'HEAD' && $method !== 'OPTIONS';
+            return $method !== 'OPTIONS';
         }
 
         // 4. Everything else: open (HTML pages, static assets)

--- a/src/Auth/CapabilityMiddleware.php
+++ b/src/Auth/CapabilityMiddleware.php
@@ -36,26 +36,17 @@ final readonly class CapabilityMiddleware implements MiddlewareInterface
         }
 
         $path = $request->getUri()->getPath() ?: '/';
-        $required = CapabilityResolver::resolve($path, $request->getMethod());
-
-        if ($required === null) {
-            return $handler->handle($request);
-        }
-
         $role = Role::tryFrom((string) ($claims['role'] ?? ''));
 
-        if ($role === null || !$role->hasCapability($required)) {
-            return $this->problemDetails->create(
-                $request,
-                'forbidden',
-                'Forbidden',
-                403,
-                'You do not have permission to perform this action.',
-            );
-        }
-
-        // Organization scope check: skip for superadmin and routes where org is not resolved.
-        // OrgResolverMiddleware sets nene2.org.id (an int) only for org-scoped routes.
+        // Organization scope check — runs for EVERY authenticated org-scoped request,
+        // BEFORE (and independent of) capability resolution. OrgResolverMiddleware sets
+        // the nene2.org.id attribute (an int) only for org-scoped routes; bypass routes
+        // (superadmin / organizations / auth) leave it unset and are skipped here.
+        //
+        // This must NOT be gated behind a mapped capability: a route CapabilityResolver
+        // does not map (e.g. GET /api/v1/webhooks) would otherwise skip the org check
+        // entirely, letting a user of org A read org B's data by replaying their JWT as
+        // a Bearer token against org B's host. Fail-closed by default. See #824.
         if ($role !== Role::Superadmin) {
             $resolvedOrgId = $request->getAttribute('nene2.org.id');
 
@@ -74,6 +65,22 @@ final readonly class CapabilityMiddleware implements MiddlewareInterface
                     );
                 }
             }
+        }
+
+        $required = CapabilityResolver::resolve($path, $request->getMethod());
+
+        if ($required === null) {
+            return $handler->handle($request);
+        }
+
+        if ($role === null || !$role->hasCapability($required)) {
+            return $this->problemDetails->create(
+                $request,
+                'forbidden',
+                'Forbidden',
+                403,
+                'You do not have permission to perform this action.',
+            );
         }
 
         return $handler->handle($request);

--- a/tests/Auth/AdminApiAuthMiddlewareTest.php
+++ b/tests/Auth/AdminApiAuthMiddlewareTest.php
@@ -139,6 +139,38 @@ final class AdminApiAuthMiddlewareTest extends TestCase
         self::assertSame(401, $this->middleware->process($request, $this->passThrough())->getStatusCode());
     }
 
+    public function testUnauthenticatedGetOnUnmappedApiRouteIsRejected(): void
+    {
+        // Fail-closed regression (#824): a GET on an admin resource that is NOT in
+        // ADMIN_ONLY_PREFIXES must still require auth. Before the fix these leaked
+        // their response unauthenticated (drafts, webhook secrets, exports, field
+        // values). GET is no longer exempt.
+        foreach (['/api/v1/webhooks', '/api/v1/entities', '/api/v1/entities/export', '/api/v1/text-fields'] as $path) {
+            $request = $this->factory->createServerRequest('GET', 'https://example.test' . $path);
+            self::assertSame(
+                401,
+                $this->middleware->process($request, $this->passThrough())->getStatusCode(),
+                sprintf('Unauthenticated GET %s must be 401', $path),
+            );
+        }
+    }
+
+    public function testPublicApiGetRemainsOpen(): void
+    {
+        // The dedicated public surface (/api/v1/public/*) stays unauthenticated.
+        $request = $this->factory->createServerRequest('GET', 'https://example.test/api/v1/public/settings');
+
+        self::assertSame(204, $this->middleware->process($request, $this->passThrough())->getStatusCode());
+    }
+
+    public function testCorsPreflightOptionsIsOpen(): void
+    {
+        // OPTIONS carries no credentials (CORS preflight) and must pass through.
+        $request = $this->factory->createServerRequest('OPTIONS', 'https://example.test/api/v1/entities');
+
+        self::assertSame(204, $this->middleware->process($request, $this->passThrough())->getStatusCode());
+    }
+
     private function passThrough(): RequestHandlerInterface
     {
         return new class () implements RequestHandlerInterface {

--- a/tests/Auth/CapabilityMiddlewareTest.php
+++ b/tests/Auth/CapabilityMiddlewareTest.php
@@ -38,6 +38,32 @@ final class CapabilityMiddlewareTest extends TestCase
         self::assertSame(204, $response->getStatusCode());
     }
 
+    /**
+     * クロステナント遮断（#824）: CapabilityResolver が capability をマップしない
+     * org-scoped ルート（例 GET /api/v1/webhooks）でも、JWT org_id と解決済み
+     * org_id が食い違えば 403。以前は capability 未マップだと org チェックごと
+     * スキップされ、JWT を別 org のホストへ Bearer で使い回すと越境読取できた。
+     */
+    public function testUnmappedOrgScopedRouteWithMismatchedOrgIdReturns403(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('GET', 'https://example.test/api/v1/webhooks')
+            ->withAttribute('nene2.auth.claims', ['role' => 'admin', 'sub' => 'a@example.com', 'org_id' => 1])
+            ->withAttribute('nene2.org.id', 2);
+
+        self::assertSame(403, $this->middleware->process($request, $this->createPassThroughHandler())->getStatusCode());
+    }
+
+    public function testUnmappedOrgScopedRouteWithMatchingOrgIdPassesThrough(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('GET', 'https://example.test/api/v1/webhooks')
+            ->withAttribute('nene2.auth.claims', ['role' => 'admin', 'sub' => 'a@example.com', 'org_id' => 2])
+            ->withAttribute('nene2.org.id', 2);
+
+        self::assertSame(204, $this->middleware->process($request, $this->createPassThroughHandler())->getStatusCode());
+    }
+
     public function testEditorDeletingEntityTypeReturns403(): void
     {
         $request = $this->factory


### PR DESCRIPTION
## 目的

nene-records の**認可された自己セキュリティ診断**（black-box live ATK＋コードレビュー・指示書 P0）を実施し、確認した脆弱性を修正し、診断記録を `docs/security/` に整備する。指示書=`_work/handoff-security-assessment-2026-07-13-work-order.md`。

## 発見と修正（すべて回帰検証済み）

| 深刻度 | 内容 | 修正 |
|---|---|---|
| 🔴 Critical | `/api/v1/*` の GET が `ADMIN_ONLY_PREFIXES` 未登録だと**未認証で読めた**（webhook 署名 secret・下書き・全 export・フィールド値が漏洩）。本番では `<tenant>.nene-records.com` で各テナントの secret / 下書きが匿名公開状態 | `AdminApiAuthMiddleware` を fail-closed 化（OPTIONS 以外の全メソッドを認証必須。公開読取は従来どおり `/api/v1/public/*`） |
| 🟠 Medium | `CapabilityMiddleware` の org 一致チェックが capability マップ済みルートでしか走らず、**JWT を別 org のホストへ Bearer で使い回すと越境読取**できた | org スコープチェックを capability に依らず**常時実行**（fail-closed） |
| 🟢 Low | `Server` / `X-Powered-By` のバージョン開示 | `ServerTokens Prod` / `ServerSignature Off` / `expose_php Off`（dev/prod Dockerfile 両方） |

## 堅牢だった項目（所見なし）

CSRF（`X-Requested-With`）・superadmin capability（#797）・JWT alg 混同/不正・SQLi（parameterized）・エラー情報漏洩（debug off で Problem Details）・CSP/セキュリティヘッダ・セッション cookie（HttpOnly/SameSite=Lax/host-only）。

## 検証

- 使い捨て Docker（`nene-records-sectest`・非本番ポート・本番へは未実施）で実弾 → 修正 → 回帰。
- 該当ルートは **401**、越境は **403**、正規アクセスは **200**、公開/health は開放。
- `composer check` 緑（**1271 tests / 3609 assertions**・PHPStan L8・CS-Fixer・OpenAPI・conformance・MCP）。
- 再現ハーネス `docs/security/harness/probe.sh` = **16/16 pass**（teardown で volume 破棄）。

## 成果物

- `docs/security/2026-07-13-assessment.md`（レポート・Crit/Med/Low・手法・回帰・カバレッジ限界を正直に記載）
- `docs/security/README.md`（診断履歴）
- `docs/security/harness/`（再現ハーネス・秘密は `.gitignore`）

## 申し送り（follow-up）

`WebhookHttpMapper` が read 応答で `secret` を返す点は defense-in-depth（write-only 化）を別途推奨。

> ⚠️ これは**認可された自己/maintainer-run 診断**であり、第三者機関の pentest ではない。

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)