### PR TITLE
fix(auth): 公開サイトの login バウンス回帰を直す（#824 の GET 保護を絞る・#826）

### DIFF
--- a/docs/security/2026-07-13-assessment.md
+++ b/docs/security/2026-07-13-assessment.md
@@ -76,6 +76,19 @@ unauthenticated; authenticated admin reads still return 200; `/health` and `/api
 read responses. Consider a write-only secret (return a masked/last-4 value on read) so the signing secret is
 never echoed back even to authenticated admins. Tracked as a follow-up.
 
+> **Revision 2026-07-14 (#826).** The original F-01 fix ("require auth for every
+> `/api/v1/*` GET") was **too broad** and broke the public consumer site: `PublicSiteShell`
+> and the public feature hooks read content (entity-types, entities, text-fields, tags,
+> analytics-popular) unauthenticated to render public pages, so a global 401→`/login`
+> interceptor bounced every visitor to the login page. Refined remediation: the sensitive
+> reads that actually caused the leak — `/api/v1/webhooks` (signing secrets),
+> `/api/v1/notification-channels`, `/api/v1/entities/export`, `/api/v1/dashboard` — are
+> now in `ADMIN_ONLY_PREFIXES` (auth required for all methods), while the content-read
+> surface stays open. **The Critical (webhook-secret disclosure) remains closed.**
+> **Known residual (High, follow-up #826):** anonymous content reads can still surface
+> unpublished records via `?status`; to be tightened to published-only for anonymous
+> callers (not by blanket-locking the read surface).
+
 ### F-02 — Cross-tenant read via JWT replay (Medium) — FIXED
 
 **Observed.** An authenticated user of org A, replaying their session JWT as an `Authorization: Bearer`

--- a/src/Auth/AdminApiAuthMiddleware.php
+++ b/src/Auth/AdminApiAuthMiddleware.php
@@ -19,8 +19,9 @@ use Psr\Http\Server\RequestHandlerInterface;
  *  1. Always open: /health, /api/v1/auth/*, /api/v1/public/*, and the
  *     cron-triggered batch endpoints (process-scheduled / process-deliveries)
  *  2. Always protected (all HTTP methods incl. OPTIONS): the ADMIN_ONLY_PREFIXES
- *  3. Protected for every method except OPTIONS (CORS preflight): all other
- *     /api/v1/ paths — GET and HEAD included. Fail-closed by default.
+ *     (includes sensitive reads: webhooks / notification-channels / export / dashboard)
+ *  3. Protected for non-GET methods: all other /api/v1/ paths. GET/HEAD are the
+ *     public content-read surface (the consumer site reads them unauthenticated).
  *  4. Everything else: open (static assets, public HTML pages)
  */
 final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
@@ -59,6 +60,18 @@ final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
         '/api/v1/themes',
         '/api/v1/migration',
         '/api/v1/account',
+        // Sensitive reads that must never be anonymous, even though the rest of the
+        // content API (entity-types / entities / text-fields / tags / analytics-
+        // popular) stays readable for the public consumer site. Webhooks expose
+        // signing secrets, notification-channels expose delivery configs, export is
+        // a bulk dump, dashboard is org business metrics. None are used by the public
+        // site. See security assessment #824 and public-site regression #826.
+        // (`/api/v1/webhooks/process-deliveries` stays open via ALWAYS_OPEN above,
+        // which is matched first.)
+        '/api/v1/webhooks',
+        '/api/v1/notification-channels',
+        '/api/v1/entities/export',
+        '/api/v1/dashboard',
     ];
 
     public function __construct(
@@ -152,16 +165,17 @@ final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
             }
         }
 
-        // 3. All other /api/v1/* paths: protect EVERY method except the CORS
-        //    preflight OPTIONS. GET/HEAD are protected too — admin reads must be
-        //    authenticated. The only unauthenticated reads are the dedicated
-        //    /api/v1/public/* surface and /api/v1/auth/* (both ALWAYS_OPEN above)
-        //    plus the cron batch endpoints. Fail-closed: a newly added admin
-        //    route is protected by default instead of leaking its GET response
-        //    (incl. drafts, webhook secrets, exports) until someone remembers to
-        //    add a prefix. See security assessment #824.
+        // 3. All other /api/v1/* paths: protect non-GET methods. GET/HEAD are the
+        //    public content-read surface the consumer site depends on (entity-types,
+        //    entities, text-fields, tags, analytics-popular — all read unauthenticated
+        //    to render public pages). Genuinely sensitive GETs are enumerated in
+        //    ADMIN_ONLY_PREFIXES above. See #824 (secret/export lockdown) and #826
+        //    (public-site regression: over-broad GET lockdown broke the consumer site).
+        //    KNOWN RESIDUAL: anonymous content reads can still surface unpublished
+        //    records via `?status` — to be tightened to published-only for anonymous
+        //    callers (#826 follow-up), not by blanket-protecting the read surface.
         if (str_starts_with($path, '/api/v1/')) {
-            return $method !== 'OPTIONS';
+            return $method !== 'GET' && $method !== 'HEAD' && $method !== 'OPTIONS';
         }
 
         // 4. Everything else: open (HTML pages, static assets)

--- a/tests/Auth/AdminApiAuthMiddlewareTest.php
+++ b/tests/Auth/AdminApiAuthMiddlewareTest.php
@@ -139,18 +139,31 @@ final class AdminApiAuthMiddlewareTest extends TestCase
         self::assertSame(401, $this->middleware->process($request, $this->passThrough())->getStatusCode());
     }
 
-    public function testUnauthenticatedGetOnUnmappedApiRouteIsRejected(): void
+    public function testSensitiveUnauthenticatedGetIsRejected(): void
     {
-        // Fail-closed regression (#824): a GET on an admin resource that is NOT in
-        // ADMIN_ONLY_PREFIXES must still require auth. Before the fix these leaked
-        // their response unauthenticated (drafts, webhook secrets, exports, field
-        // values). GET is no longer exempt.
-        foreach (['/api/v1/webhooks', '/api/v1/entities', '/api/v1/entities/export', '/api/v1/text-fields'] as $path) {
+        // #824: sensitive reads (webhook signing secrets, notification-channel
+        // configs, bulk export, org dashboard metrics) must require auth even for
+        // GET — they are in ADMIN_ONLY_PREFIXES.
+        foreach (['/api/v1/webhooks', '/api/v1/notification-channels', '/api/v1/entities/export', '/api/v1/dashboard'] as $path) {
             $request = $this->factory->createServerRequest('GET', 'https://example.test' . $path);
             self::assertSame(
                 401,
                 $this->middleware->process($request, $this->passThrough())->getStatusCode(),
                 sprintf('Unauthenticated GET %s must be 401', $path),
+            );
+        }
+    }
+
+    public function testPublicContentGetSurfaceStaysOpen(): void
+    {
+        // #826: the consumer site reads content unauthenticated to render public
+        // pages — these GETs must stay open (protecting them broke the public site).
+        foreach (['/api/v1/entities', '/api/v1/text-fields', '/api/v1/entity-types', '/api/v1/tags', '/api/v1/analytics/popular-entities'] as $path) {
+            $request = $this->factory->createServerRequest('GET', 'https://example.test' . $path);
+            self::assertSame(
+                204,
+                $this->middleware->process($request, $this->passThrough())->getStatusCode(),
+                sprintf('Unauthenticated GET %s must stay open (public content read)', $path),
             );
         }
     }


### PR DESCRIPTION
## 事象（本番障害）

#824/#825 デプロイ後、**公開サイトが login に飛ばされる**（`<tenant>.nene-records.com/`・ayane/aozora 等 PublicSiteShell を使う全サイト）。

## 原因

#824 の「`/api/v1/*` の GET を一律認証必須（fail-closed）」が過剰だった。**公開サイトは entity-types / entities / text-fields / tags / analytics-popular を未認証で読んでレンダリングしている**（`PublicSiteShell` ＋ public 系フック 40+ 箇所）。これらが 401 になり、`shared/api/client.ts` の 401→`/login` インターセプタで全訪問者が login へ。

## 修正（surgical）

- **本当に機密な read だけ**を `ADMIN_ONLY_PREFIXES` に追加: `/api/v1/webhooks`（署名secret）・`/api/v1/notification-channels`・`/api/v1/entities/export`・`/api/v1/dashboard`。→ **Critical（webhook secret 漏洩）は引き続き封鎖**。
- rule 3 を GET 開放（非GETのみ保護）に戻し、公開コンテンツ read サーフェスを復旧。
- `CapabilityMiddleware` の org バインディング（#824 F-02 越境防止）とヘッダ堅牢化は**維持**。

## 検証

- 公開コンテンツ GET（entity-types/entities/text-fields/tags/analytics-popular）= **200 開放**。
- 機密 GET（webhooks/notification-channels/entities-export/dashboard）= **401**。webhook secret 到達不可。
- `composer check` 緑（PHPStan L8・37 middleware tests 含む）。

## 既知の残（follow-up・High）

未認証の content read が `?status` で下書きを返しうる。→ 匿名は **published-only** に絞る（read サーフェスの一律封鎖ではなく）。別途対応。assessment doc に追記済み。

Closes #826
Refs #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)