### PR TITLE
sec: 匿名の content read を published-only に絞る（#824/#826 の残 High・#828）

### DIFF
--- a/src/Auth/AdminApiAuthMiddleware.php
+++ b/src/Auth/AdminApiAuthMiddleware.php
@@ -82,16 +82,23 @@ final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        if (!$this->requiresAuthentication($request)) {
-            return $handler->handle($request);
-        }
+        // Whether this route ENFORCES auth (401 without a valid token). Open routes
+        // still authenticate *opportunistically*: if a valid token is present we
+        // attach the claims so downstream handlers (e.g. the open public content-read
+        // surface) can distinguish an authenticated admin from an anonymous visitor
+        // and widen what they return (drafts, all statuses). See #828.
+        $requiresAuth = $this->requiresAuthentication($request);
 
         $authorization = $request->getHeaderLine('Authorization');
         $credentialType = 'bearer';
 
         if ($authorization !== '') {
             if (!str_starts_with($authorization, 'Bearer ')) {
-                return $this->unauthorized($request, 'invalid_token', 'Authorization header must use the Bearer scheme.');
+                if ($requiresAuth) {
+                    return $this->unauthorized($request, 'invalid_token', 'Authorization header must use the Bearer scheme.');
+                }
+
+                return $handler->handle($request);
             }
 
             $token = substr($authorization, 7);
@@ -103,7 +110,11 @@ final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
                 : '';
 
             if ($cookieToken === '') {
-                return $this->unauthorized($request, 'missing_token', 'No session token was provided.');
+                if ($requiresAuth) {
+                    return $this->unauthorized($request, 'missing_token', 'No session token was provided.');
+                }
+
+                return $handler->handle($request);
             }
 
             $token = $cookieToken;
@@ -125,7 +136,12 @@ final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
         try {
             $claims = $this->verifier->verify($token);
         } catch (TokenVerificationException $e) {
-            return $this->unauthorized($request, 'invalid_token', $e->getMessage());
+            if ($requiresAuth) {
+                return $this->unauthorized($request, 'invalid_token', $e->getMessage());
+            }
+
+            // Open route with an invalid/expired token → serve as anonymous.
+            return $handler->handle($request);
         }
 
         return $handler->handle(

--- a/src/Entity/EntityListCriteria.php
+++ b/src/Entity/EntityListCriteria.php
@@ -25,6 +25,12 @@ final readonly class EntityListCriteria
         public ?string $publishedToExclusive = null,
         /** When true, restrict to records carrying a non-empty custom permalink (#682). */
         public bool $hasPermalink = false,
+        /**
+         * When true, force published-only regardless of the `status` filter. Set for
+         * unauthenticated (anonymous) callers so the open content-read surface can
+         * never surface drafts/scheduled records via `?status`. See #828.
+         */
+        public bool $publishedOnly = false,
     ) {
     }
 }

--- a/src/Entity/GetEntityByIdHandler.php
+++ b/src/Entity/GetEntityByIdHandler.php
@@ -28,6 +28,13 @@ final readonly class GetEntityByIdHandler
 
         $output = $this->useCase->execute(new GetEntityByIdInput($id));
 
+        // Unauthenticated callers may only read published records — a draft/scheduled
+        // record is indistinguishable from a non-existent one (no metadata leak). See #828.
+        $isAnonymous = !is_array($request->getAttribute('nene2.auth.claims'));
+        if ($isAnonymous && $output->status !== EntityStatus::Published->value) {
+            throw new EntityNotFoundException($id);
+        }
+
         return $this->response->create([
             'id' => $output->id,
             'entity_type_id' => $output->entityTypeId,

--- a/src/Entity/ListEntitiesHandler.php
+++ b/src/Entity/ListEntitiesHandler.php
@@ -78,6 +78,9 @@ final readonly class ListEntitiesHandler
                 publishedFrom: $publishedFrom,
                 publishedToExclusive: $publishedToExclusive,
                 hasPermalink: $hasPermalink,
+                // Unauthenticated callers (the open public content-read surface) may
+                // only see published records — never drafts/scheduled. See #828.
+                publishedOnly: !is_array($request->getAttribute('nene2.auth.claims')),
             ),
             includeViews: $wantViews,
         ));

--- a/src/Entity/PdoEntityRepository.php
+++ b/src/Entity/PdoEntityRepository.php
@@ -265,7 +265,12 @@ final readonly class PdoEntityRepository implements EntityRepositoryInterface
             $conditions[] = "(e.permalink IS NOT NULL AND e.permalink != '')";
         }
 
-        if ($criteria->status !== null) {
+        if ($criteria->publishedOnly) {
+            // Anonymous callers: force published-only and ignore any client `status`
+            // filter (so `?status=draft` cannot surface unpublished records). See #828.
+            $conditions[] = 'e.status = ?';
+            $params[] = EntityStatus::Published->value;
+        } elseif ($criteria->status !== null) {
             $conditions[] = 'e.status = ?';
             $params[] = $criteria->status->value;
         }

--- a/src/TextField/ListTextFieldsHandler.php
+++ b/src/TextField/ListTextFieldsHandler.php
@@ -50,6 +50,8 @@ final readonly class ListTextFieldsHandler
             limit: $pagination->limit,
             offset: $pagination->offset,
             locale: $locale,
+            // Anonymous callers may only read fields of published records. See #828.
+            publishedOnly: !is_array($request->getAttribute('nene2.auth.claims')),
         ));
 
         return $this->response->create(

--- a/src/TextField/ListTextFieldsInput.php
+++ b/src/TextField/ListTextFieldsInput.php
@@ -12,6 +12,8 @@ final readonly class ListTextFieldsInput
         public int $limit = 20,
         public int $offset = 0,
         public ?string $locale = null,
+        /** Anonymous callers: restrict to fields whose parent entity is published. #828. */
+        public bool $publishedOnly = false,
     ) {
     }
 }

--- a/src/TextField/ListTextFieldsUseCase.php
+++ b/src/TextField/ListTextFieldsUseCase.php
@@ -19,14 +19,16 @@ final readonly class ListTextFieldsUseCase implements ListTextFieldsUseCaseInter
                 $input->limit,
                 $input->offset,
                 $input->locale,
+                $input->publishedOnly,
             ),
             $input->entityTypeId !== null => $this->textFields->findByEntityTypeId(
                 $input->entityTypeId,
                 $input->limit,
                 $input->offset,
                 $input->locale,
+                $input->publishedOnly,
             ),
-            default => $this->textFields->findAll($input->limit, $input->offset, $input->locale),
+            default => $this->textFields->findAll($input->limit, $input->offset, $input->locale, $input->publishedOnly),
         };
 
         $items = array_map(

--- a/src/TextField/PdoTextFieldRepository.php
+++ b/src/TextField/PdoTextFieldRepository.php
@@ -41,17 +41,28 @@ final readonly class PdoTextFieldRepository implements TextFieldRepositoryInterf
         return $this->mapRow($row);
     }
 
+    /**
+     * SQL fragment gating an unaliased `text_fields` query to fields whose parent
+     * entity is published. Appended for anonymous callers so the open content-read
+     * surface can never return draft/scheduled bodies (`?entity_id`/`findAll`). #828.
+     */
+    private const PUBLISHED_PARENT_GATE =
+        ' AND EXISTS (SELECT 1 FROM entities e WHERE e.id = text_fields.entity_id'
+        . " AND e.status = 'published' AND e.is_deleted = 0)";
+
     /** @return list<TextField> */
-    public function findAll(int $limit, int $offset, ?string $locale = null): array
+    public function findAll(int $limit, int $offset, ?string $locale = null, bool $publishedOnly = false): array
     {
+        $gate = $publishedOnly ? self::PUBLISHED_PARENT_GATE : '';
+
         if ($locale !== null) {
             $rows = $this->query->fetchAll(
-                'SELECT id, entity_id, field_key, locale, value FROM text_fields WHERE is_deleted = 0 AND locale = ? AND organization_id = ? ORDER BY id ASC LIMIT ? OFFSET ?',
+                "SELECT id, entity_id, field_key, locale, value FROM text_fields WHERE is_deleted = 0 AND locale = ? AND organization_id = ?{$gate} ORDER BY id ASC LIMIT ? OFFSET ?",
                 [$locale, $this->orgId->get(), $limit, $offset],
             );
         } else {
             $rows = $this->query->fetchAll(
-                'SELECT id, entity_id, field_key, locale, value FROM text_fields WHERE is_deleted = 0 AND organization_id = ? ORDER BY id ASC LIMIT ? OFFSET ?',
+                "SELECT id, entity_id, field_key, locale, value FROM text_fields WHERE is_deleted = 0 AND organization_id = ?{$gate} ORDER BY id ASC LIMIT ? OFFSET ?",
                 [$this->orgId->get(), $limit, $offset],
             );
         }
@@ -60,16 +71,18 @@ final readonly class PdoTextFieldRepository implements TextFieldRepositoryInterf
     }
 
     /** @return list<TextField> */
-    public function findByEntityId(int $entityId, int $limit, int $offset, ?string $locale = null): array
+    public function findByEntityId(int $entityId, int $limit, int $offset, ?string $locale = null, bool $publishedOnly = false): array
     {
+        $gate = $publishedOnly ? self::PUBLISHED_PARENT_GATE : '';
+
         if ($locale !== null) {
             $rows = $this->query->fetchAll(
-                'SELECT id, entity_id, field_key, locale, value FROM text_fields WHERE entity_id = ? AND locale = ? AND is_deleted = 0 AND organization_id = ? ORDER BY id ASC LIMIT ? OFFSET ?',
+                "SELECT id, entity_id, field_key, locale, value FROM text_fields WHERE entity_id = ? AND locale = ? AND is_deleted = 0 AND organization_id = ?{$gate} ORDER BY id ASC LIMIT ? OFFSET ?",
                 [$entityId, $locale, $this->orgId->get(), $limit, $offset],
             );
         } else {
             $rows = $this->query->fetchAll(
-                'SELECT id, entity_id, field_key, locale, value FROM text_fields WHERE entity_id = ? AND is_deleted = 0 AND organization_id = ? ORDER BY id ASC LIMIT ? OFFSET ?',
+                "SELECT id, entity_id, field_key, locale, value FROM text_fields WHERE entity_id = ? AND is_deleted = 0 AND organization_id = ?{$gate} ORDER BY id ASC LIMIT ? OFFSET ?",
                 [$entityId, $this->orgId->get(), $limit, $offset],
             );
         }
@@ -78,37 +91,36 @@ final readonly class PdoTextFieldRepository implements TextFieldRepositoryInterf
     }
 
     /** @return list<TextField> */
-    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset, ?string $locale = null): array
+    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset, ?string $locale = null, bool $publishedOnly = false): array
     {
+        // findByEntityTypeId already joins `entities e`, so gate on the alias directly.
+        $gate = $publishedOnly ? "\n                  AND e.status = 'published'" : '';
+
         if ($locale !== null) {
             $rows = $this->query->fetchAll(
-                <<<'SQL'
-                SELECT tf.id, tf.entity_id, tf.field_key, tf.locale, tf.value
+                "SELECT tf.id, tf.entity_id, tf.field_key, tf.locale, tf.value
                 FROM text_fields tf
                 INNER JOIN entities e ON e.id = tf.entity_id
                 WHERE tf.is_deleted = 0
                   AND e.is_deleted = 0
                   AND e.entity_type_id = ?
                   AND tf.locale = ?
-                  AND tf.organization_id = ?
+                  AND tf.organization_id = ?{$gate}
                 ORDER BY tf.id ASC
-                LIMIT ? OFFSET ?
-                SQL,
+                LIMIT ? OFFSET ?",
                 [$entityTypeId, $locale, $this->orgId->get(), $limit, $offset],
             );
         } else {
             $rows = $this->query->fetchAll(
-                <<<'SQL'
-                SELECT tf.id, tf.entity_id, tf.field_key, tf.locale, tf.value
+                "SELECT tf.id, tf.entity_id, tf.field_key, tf.locale, tf.value
                 FROM text_fields tf
                 INNER JOIN entities e ON e.id = tf.entity_id
                 WHERE tf.is_deleted = 0
                   AND e.is_deleted = 0
                   AND e.entity_type_id = ?
-                  AND tf.organization_id = ?
+                  AND tf.organization_id = ?{$gate}
                 ORDER BY tf.id ASC
-                LIMIT ? OFFSET ?
-                SQL,
+                LIMIT ? OFFSET ?",
                 [$entityTypeId, $this->orgId->get(), $limit, $offset],
             );
         }

--- a/src/TextField/TextFieldRepositoryInterface.php
+++ b/src/TextField/TextFieldRepositoryInterface.php
@@ -14,7 +14,7 @@ interface TextFieldRepositoryInterface
      *
      * @return list<TextField>
      */
-    public function findAll(int $limit, int $offset, ?string $locale = null): array;
+    public function findAll(int $limit, int $offset, ?string $locale = null, bool $publishedOnly = false): array;
 
     /**
      * Active (non-soft-deleted) rows for the given entity only.
@@ -22,7 +22,7 @@ interface TextFieldRepositoryInterface
      *
      * @return list<TextField>
      */
-    public function findByEntityId(int $entityId, int $limit, int $offset, ?string $locale = null): array;
+    public function findByEntityId(int $entityId, int $limit, int $offset, ?string $locale = null, bool $publishedOnly = false): array;
 
     /**
      * Active (non-soft-deleted) rows for entities belonging to the given entity type.
@@ -30,7 +30,7 @@ interface TextFieldRepositoryInterface
      *
      * @return list<TextField>
      */
-    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset, ?string $locale = null): array;
+    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset, ?string $locale = null, bool $publishedOnly = false): array;
 
     /**
      * Active (non-soft-deleted) rows for a batch of entity ids (no limit).

--- a/tests/Auth/AdminApiAuthMiddlewareTest.php
+++ b/tests/Auth/AdminApiAuthMiddlewareTest.php
@@ -184,6 +184,57 @@ final class AdminApiAuthMiddlewareTest extends TestCase
         self::assertSame(204, $this->middleware->process($request, $this->passThrough())->getStatusCode());
     }
 
+    public function testOpenGetRouteAttachesClaimsForValidToken(): void
+    {
+        // #828: on an open content-read route, a valid token must still attach claims
+        // so downstream handlers can widen results for an authenticated admin.
+        $capture = new class () implements RequestHandlerInterface {
+            /** @var array<string, mixed>|null */
+            public ?array $claims = null;
+
+            public function handle(ServerRequestInterface $request): \Psr\Http\Message\ResponseInterface
+            {
+                $claims = $request->getAttribute('nene2.auth.claims');
+                $this->claims = is_array($claims) ? $claims : null;
+
+                return new Response(204);
+            }
+        };
+
+        $request = $this->factory
+            ->createServerRequest('GET', 'https://example.test/api/v1/entities')
+            ->withHeader('Authorization', 'Bearer good');
+
+        self::assertSame(204, $this->middleware->process($request, $capture)->getStatusCode());
+        self::assertIsArray($capture->claims);
+        self::assertSame('admin', $capture->claims['role'] ?? null);
+    }
+
+    public function testOpenGetRouteWithInvalidTokenServesAnonymously(): void
+    {
+        // Invalid/expired token on an open route → no 401, no claims (anonymous).
+        $capture = new class () implements RequestHandlerInterface {
+            public bool $handled = false;
+            public mixed $claims = 'unset';
+
+            public function handle(ServerRequestInterface $request): \Psr\Http\Message\ResponseInterface
+            {
+                $this->handled = true;
+                $this->claims = $request->getAttribute('nene2.auth.claims');
+
+                return new Response(204);
+            }
+        };
+
+        $request = $this->factory
+            ->createServerRequest('GET', 'https://example.test/api/v1/entities')
+            ->withHeader('Authorization', 'Bearer bad');
+
+        self::assertSame(204, $this->middleware->process($request, $capture)->getStatusCode());
+        self::assertTrue($capture->handled);
+        self::assertNull($capture->claims);
+    }
+
     private function passThrough(): RequestHandlerInterface
     {
         return new class () implements RequestHandlerInterface {

--- a/tests/Entity/EntityFilterHttpTest.php
+++ b/tests/Entity/EntityFilterHttpTest.php
@@ -96,7 +96,8 @@ final class EntityFilterHttpTest extends TestCase
     public function testListEntitiesFilteredByEntityTypeId(): void
     {
         $response = $this->application->handle(
-            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/entities?entity_type_id=2'),
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/entities?entity_type_id=2')
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
         );
         $payload = $this->decodeJson($response);
 
@@ -109,7 +110,8 @@ final class EntityFilterHttpTest extends TestCase
     public function testListEntitiesFilteredByTagSlugsUsesOrSemantics(): void
     {
         $response = $this->application->handle(
-            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/entities?tags=featured,draft'),
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/entities?tags=featured,draft')
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
         );
         $payload = $this->decodeJson($response);
 
@@ -121,7 +123,8 @@ final class EntityFilterHttpTest extends TestCase
     public function testListEntitiesMergesTagAndTagsQueryParameters(): void
     {
         $response = $this->application->handle(
-            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/entities?tag=draft&tags=featured'),
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/entities?tag=draft&tags=featured')
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
         );
         $payload = $this->decodeJson($response);
 
@@ -131,7 +134,8 @@ final class EntityFilterHttpTest extends TestCase
     public function testListEntitiesFilteredByRelationFieldKey(): void
     {
         $response = $this->application->handle(
-            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/entities?relation.author=10'),
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/entities?relation.author=10')
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
         );
         $payload = $this->decodeJson($response);
 
@@ -146,7 +150,7 @@ final class EntityFilterHttpTest extends TestCase
             $this->factory->createServerRequest(
                 'GET',
                 'https://example.test/api/v1/entities?relation.author=10&relation.category=20',
-            ),
+            )->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
         );
         $payload = $this->decodeJson($response);
 

--- a/tests/Entity/EntityHttpTest.php
+++ b/tests/Entity/EntityHttpTest.php
@@ -120,7 +120,8 @@ final class EntityHttpTest extends TestCase
         self::assertSame('bare', $payload['layout']);
 
         $get = $this->application->handle(
-            $this->factory->createServerRequest('GET', "https://example.test/api/v1/entities/{$payload['id']}"),
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/entities/{$payload['id']}")
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
         );
         self::assertSame('bare', $this->decodeJson($get)['layout']);
     }
@@ -159,7 +160,8 @@ final class EntityHttpTest extends TestCase
         self::assertTrue($payload['show_related']);
 
         $get = $this->decodeJson($this->application->handle(
-            $this->factory->createServerRequest('GET', "https://example.test/api/v1/entities/{$payload['id']}"),
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/entities/{$payload['id']}")
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
         ));
         self::assertFalse($get['show_comments']);
         self::assertTrue($get['show_related']);
@@ -320,7 +322,8 @@ final class EntityHttpTest extends TestCase
         self::assertSame(201, $createResponse->getStatusCode());
 
         $getBefore = $this->application->handle(
-            $this->factory->createServerRequest('GET', "https://example.test/api/v1/entities/{$id}"),
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/entities/{$id}")
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
         );
         self::assertSame(200, $getBefore->getStatusCode());
 
@@ -336,6 +339,54 @@ final class EntityHttpTest extends TestCase
 
         self::assertSame(404, $getAfter->getStatusCode());
         self::assertStringEndsWith('not-found', (string) $payload['type']);
+    }
+
+    public function testAnonymousReadsAreScopedToPublishedRecords(): void
+    {
+        // #828: the open content-read surface must never surface drafts to anonymous
+        // callers — the list hides them (even under ?status=draft) and get-by-id is
+        // 404 — while an authenticated admin still sees everything.
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Doc', slug: 'doc'));
+
+        $draftId = (int) $this->decodeJson($this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody(
+                $this->factory->createStream(json_encode(['entity_type_id' => $typeId, 'slug' => 'secret-draft'], JSON_THROW_ON_ERROR)),
+            ),
+        ))['id'];
+
+        $publishedId = (int) $this->decodeJson($this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/entities')->withBody(
+                $this->factory->createStream(json_encode(['entity_type_id' => $typeId, 'slug' => 'public-post', 'status' => 'published'], JSON_THROW_ON_ERROR)),
+            ),
+        ))['id'];
+
+        $anonList = $this->decodeJson($this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/entities'),
+        ));
+        $anonIds = array_map(static fn (array $row): int => (int) $row['id'], $anonList['items']);
+        self::assertContains($publishedId, $anonIds);
+        self::assertNotContains($draftId, $anonIds);
+
+        // `?status=draft` cannot bypass the anonymous published-only gate: the draft
+        // never appears (published-only overrides the requested status filter).
+        $anonDraftList = $this->decodeJson($this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/entities?status=draft'),
+        ));
+        $anonDraftIds = array_map(static fn (array $row): int => (int) $row['id'], $anonDraftList['items']);
+        self::assertNotContains($draftId, $anonDraftIds);
+
+        self::assertSame(200, $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/entities/{$publishedId}"),
+        )->getStatusCode());
+        self::assertSame(404, $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/entities/{$draftId}"),
+        )->getStatusCode());
+
+        // Authenticated admin still sees the draft by id.
+        self::assertSame(200, $this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/entities/{$draftId}")
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
+        )->getStatusCode());
     }
 
     /**

--- a/tests/Entity/InMemoryEntityRepository.php
+++ b/tests/Entity/InMemoryEntityRepository.php
@@ -272,7 +272,11 @@ final class InMemoryEntityRepository implements EntityRepositoryInterface
                 continue;
             }
 
-            if ($criteria->status !== null && $entity->status !== $criteria->status) {
+            if ($criteria->publishedOnly) {
+                if ($entity->status !== \NeNeRecords\Entity\EntityStatus::Published) {
+                    continue;
+                }
+            } elseif ($criteria->status !== null && $entity->status !== $criteria->status) {
                 continue;
             }
 

--- a/tests/Entity/ScheduledPublishHttpTest.php
+++ b/tests/Entity/ScheduledPublishHttpTest.php
@@ -230,7 +230,8 @@ final class ScheduledPublishHttpTest extends TestCase
             scheduledAt: $scheduledAt,
         ));
 
-        $request = $this->factory->createServerRequest('GET', "https://example.test/api/v1/entities/{$entityId}");
+        $request = $this->factory->createServerRequest('GET', "https://example.test/api/v1/entities/{$entityId}")
+            ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']);
         $response = $this->application->handle($request);
 
         self::assertSame(200, $response->getStatusCode());

--- a/tests/TextField/InMemoryTextFieldRepository.php
+++ b/tests/TextField/InMemoryTextFieldRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Tests\TextField;
 
 use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\Entity\EntityStatus;
 use NeNeRecords\TextField\TextField;
 use NeNeRecords\TextField\TextFieldNotFoundException;
 use NeNeRecords\TextField\TextFieldRepositoryInterface;
@@ -49,13 +50,17 @@ final class InMemoryTextFieldRepository implements TextFieldRepositoryInterface
     }
 
     /** @return list<TextField> */
-    public function findAll(int $limit, int $offset, ?string $locale = null): array
+    public function findAll(int $limit, int $offset, ?string $locale = null, bool $publishedOnly = false): array
     {
         $active = [];
 
         foreach ($this->fields as $id => $textField) {
             if (!isset($this->deletedIds[$id])) {
                 if ($locale !== null && $textField->locale !== $locale) {
+                    continue;
+                }
+
+                if ($publishedOnly && !$this->isPublishedParent($textField->entityId)) {
                     continue;
                 }
 
@@ -69,8 +74,12 @@ final class InMemoryTextFieldRepository implements TextFieldRepositoryInterface
     }
 
     /** @return list<TextField> */
-    public function findByEntityId(int $entityId, int $limit, int $offset, ?string $locale = null): array
+    public function findByEntityId(int $entityId, int $limit, int $offset, ?string $locale = null, bool $publishedOnly = false): array
     {
+        if ($publishedOnly && !$this->isPublishedParent($entityId)) {
+            return [];
+        }
+
         $active = [];
 
         foreach ($this->fields as $id => $textField) {
@@ -89,7 +98,7 @@ final class InMemoryTextFieldRepository implements TextFieldRepositoryInterface
     }
 
     /** @return list<TextField> */
-    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset, ?string $locale = null): array
+    public function findByEntityTypeId(int $entityTypeId, int $limit, int $offset, ?string $locale = null, bool $publishedOnly = false): array
     {
         $active = [];
 
@@ -109,6 +118,10 @@ final class InMemoryTextFieldRepository implements TextFieldRepositoryInterface
                     continue;
                 }
 
+                if ($publishedOnly && $entity->status !== EntityStatus::Published) {
+                    continue;
+                }
+
                 $active[] = $textField;
             }
         }
@@ -116,6 +129,17 @@ final class InMemoryTextFieldRepository implements TextFieldRepositoryInterface
         usort($active, static fn (TextField $a, TextField $b): int => ($a->id ?? 0) <=> ($b->id ?? 0));
 
         return array_slice($active, $offset, $limit);
+    }
+
+    private function isPublishedParent(int $entityId): bool
+    {
+        if ($this->entities === null) {
+            return false;
+        }
+
+        $entity = $this->entities->findById($entityId);
+
+        return $entity !== null && $entity->status === EntityStatus::Published;
     }
 
     /**

--- a/tests/TextField/TextFieldHttpTest.php
+++ b/tests/TextField/TextFieldHttpTest.php
@@ -281,7 +281,8 @@ final class TextFieldHttpTest extends TestCase
         );
 
         $response = $this->application->handle(
-            $this->factory->createServerRequest('GET', "https://example.test/api/v1/text-fields?entity_id={$entityAId}"),
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/text-fields?entity_id={$entityAId}")
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
         );
         $payload = $this->decodeJson($response);
 
@@ -306,7 +307,8 @@ final class TextFieldHttpTest extends TestCase
         $this->createTextField($entityBId, 'title', 'Type B title');
 
         $response = $this->application->handle(
-            $this->factory->createServerRequest('GET', "https://example.test/api/v1/text-fields?entity_type_id={$typeAId}"),
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/text-fields?entity_type_id={$typeAId}")
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
         );
         $payload = $this->decodeJson($response);
 
@@ -359,7 +361,8 @@ final class TextFieldHttpTest extends TestCase
 
         // Filter by locale=ja → should return only the Japanese version
         $response = $this->application->handle(
-            $this->factory->createServerRequest('GET', "https://example.test/api/v1/text-fields?entity_id={$entityId}&locale=ja"),
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/text-fields?entity_id={$entityId}&locale=ja")
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
         );
         $payload = $this->decodeJson($response);
 
@@ -389,6 +392,28 @@ final class TextFieldHttpTest extends TestCase
         self::assertSame(201, $response->getStatusCode());
         self::assertArrayHasKey('locale', $payload);
         self::assertNull($payload['locale']);
+    }
+
+    public function testAnonymousTextFieldsExcludeDraftParents(): void
+    {
+        // #828: anonymous callers may not read the body of an unpublished record,
+        // even by guessing its entity id. Authenticated admins still can.
+        $typeId = $this->entityTypes->save(new EntityType(name: 'Doc', slug: 'doc'));
+        $this->fieldDefs->save(new FieldDef(entityTypeId: $typeId, fieldKey: 'title', dataType: 'text'));
+
+        $draftId = $this->createEntity($typeId); // default status = draft
+        $this->createTextField($draftId, 'title', 'Secret draft body');
+
+        $anon = $this->decodeJson($this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/text-fields?entity_id={$draftId}"),
+        ));
+        self::assertSame([], $anon['items']);
+
+        $authed = $this->decodeJson($this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/text-fields?entity_id={$draftId}")
+                ->withAttribute('nene2.auth.claims', ['sub' => 'admin@example.test']),
+        ));
+        self::assertCount(1, $authed['items']);
     }
 
     private function createEntity(int $entityTypeId): int


### PR DESCRIPTION
## 目的

#824 のセキュリティ診断で見つかった残 High を閉じる。#826 で公開サイト回帰回避のため content GET（entities/text-fields 等）を匿名開放に戻したが、**未認証で下書き（unpublished）が読める**状態が残っていた。read サーフェスを一律封鎖せず（公開サイトが依存）、**匿名アクセスを published-only に絞る**。

## 変更

- **匿名は published-only**（判定＝`nene2.auth.claims` の有無）:
  - entities list: published のみ（`?status=draft` でバイパス不可）
  - 単一 entity: 非公開なら 404（存在秘匿）
  - text-fields: published 親エンティティのみ（`?entity_id` 総当たりでも本文非漏洩）
- **AdminApiAuthMiddleware を opportunistic 認証化**: 開放ルートでも有効トークンがあれば claims を付与。従来は保護ルートのみ set していたため、開放 GET で **admin が匿名扱いになり下書きが見えなくなる回帰**が起きる（＝admin UI が壊れる）ので防止。401 強制は従来どおり保護ルートのみ。
- 認証済み admin/editor は全 status 参照可。

## 検証

- **実 MySQL**（隔離スタック）で: 匿名 → published のみ / 下書き list・by-id・text-fields すべて不可視、admin → 全 status 可視。
- unit 回帰: EntityHttp/TextFieldHttp（匿名 published-only ＋ authed 可視）、AdminApiAuthMiddleware（opportunistic 認証）。
- `composer check` 緑（**1276 tests**・PHPStan L8・CS-Fixer・OpenAPI・conformance・MCP）。
- 公開サイト（published のみ表示）は不変＝#826 の回帰を再発させない。

## 効果

これで #824 assessment の F-01 残（下書き露出）まで解消。Critical（webhook secret）＋ Medium（越境）＋ Low（ヘッダ）＋ 残 High（下書き）すべて閉じた。

Closes #828
Refs #824 #826

🤖 Generated with [Claude Code](https://claude.com/claude-code)