### PR TITLE
docs(daily): 2026-07-14 の日報を追加する

### DIFF
--- a/docs/daily/2026-07-14.md
+++ b/docs/daily/2026-07-14.md
@@ -1,0 +1,58 @@
+# 日報 — 2026-07-14（NeNe Records）
+
+> **セキュリティ集中日**。`nene-records` へ**認可された自己 red-team 診断**（black-box live ATK）を実施し、実在の脆弱性 **Critical / Medium / Low を発見 → 修正 → 本番反映**（#824 / PR #825）。反映後に**公開サイトが login へバウンスする回帰**を検知し、GET 保護を surgical に絞って復旧（#826 / PR #827）。最後に残 High（未認証での下書き露出）を **匿名 published-only ＋ opportunistic 認証**で根治（#828 / PR #829）。診断記録・再現ハーネスを `docs/security/` に整備。あわせて午前中にガバナンス文書の鮮度同期（#820 / PR #821）。**本番デプロイ 3 回（00:04 / 00:50 / 01:33）**・health 3 面 200・公開サイト描画正常。
+
+## ヘッドライン
+**`nene-records` のセキュリティ自己診断で「未認証で管理 API GET が読める（webhook 署名 secret / 下書き / export 漏洩）」Critical をはじめ 3 件を発見し、修正・本番反映まで完走（#824 → #825/#827/#829）。** #824 assessment の指摘は残らず**すべてクローズ**：Critical（未認証管理 API read）・Medium（JWT 越境）・Low（バージョンヘッダ）・公開サイト回帰・残 High（下書き露出）。診断は **認可された自己 / maintainer-run**（第三者 pentest ではない）と明記し、再現ハーネス（`docs/security/harness/probe.sh`・16/16 pass）ごと `docs/security/` に公開。
+
+---
+
+## 本日の成果（時系列）
+
+### A. ガバナンス文書の鮮度同期（#820 / PR #821・本番反映不要）
+`docs/todo/current.md` ほかが 07-11 以前で止まり、移送仕上げ（#795/#801）・公開堅牢化（#797/#802/#813/#816/#818）・**本番が既に最新 main で稼働している実態**（07-13 05:28 ビルド）から乖離していたのを同期。`current.md` / `CHANGELOG` / `README` / `CLAUDE.md` / `roadmap` を 07-13 実測へ整合。「未デプロイ判断は git・サーバ実測で確認する」旨も明記（据え置き文書に引きずられない）。
+
+### B. セキュリティ自己診断 → Critical/Medium/Low を修正・本番反映（#824 / PR #825）
+使い捨て Docker（隔離・非本番ポート・**本番へは未実施**）で実アプリを起動し、cracker mindset で実弾。OpenAPI から全ルートを列挙し、認可行列で総当たり検証。
+
+- **🔴 F-01 Critical — 未認証で管理 API GET が読める**：`AdminApiAuthMiddleware` は `/api/v1/*` の **非 GET だけ**を保護し、`ADMIN_ONLY_PREFIXES` 未登録のリソースは GET が匿名開放だった。`GET /api/v1/webhooks` が **webhook 署名 secret（`whsec_…`）を平文返却**、`/api/v1/entities?status=draft`・`/entities/export`・`/text-fields` から**下書き / 全 export / 本文**が匿名で読めた。マルチテナント本番では `<tenant>.nene-records.com` 単位で各テナントの secret / 下書きが露出。
+- **🟠 F-02 Medium — JWT 越境 read**：`CapabilityMiddleware` の org 一致チェックが **capability マップ済みルートでしか走らず**、未マップルートは org 拘束をスキップ。JWT を別 org のホストへ Bearer で使い回すと越境 read できた（host-only cookie で一部緩和されるが手動 replay で回避可）。
+- **🟢 F-03 Low — バージョン露出**：`Server: Apache/2.4.67 (Debian)` / `X-Powered-By: PHP/8.4.23`。
+- **堅牢（所見なし）**：CSRF（`X-Requested-With`）・superadmin capability（#797）・JWT alg 混同・SQLi（parameterized）・エラー情報漏洩（debug off の Problem Details）・CSP/セキュリティヘッダ・cookie（HttpOnly/SameSite=Lax/host-only）。
+- **修正**：`AdminApiAuthMiddleware` を fail-closed（OPTIONS 以外の全メソッド認証必須）／`CapabilityMiddleware` の org スコープチェックを capability に依らず常時実行／`ServerTokens Prod`・`expose_php Off`（dev/prod Dockerfile）。
+- **成果物**：`docs/security/2026-07-13-assessment.md`（レポート・カバレッジ限界も正直に記載）／`docs/security/README.md`（履歴）／`docs/security/harness/`（再現ハーネス・秘密は `.gitignore`）。`composer check` 緑（1271 tests / PHPStan L8）。
+- **本番反映 00:04**：デプロイ前に本番で該当 GET が **200（脆弱）**、反映後 **401（解消）** を code-only で実証（secret 本体は取得しない）。
+
+### C. 公開サイト login バウンス回帰の検知と surgical 修正（#826 / PR #827）
+B の反映後、**公開サイトが login に飛ぶ**（PublicSiteShell を使う全サイト＝ayane / aozora）と施主報告。原因＝**公開サイトは content（entity-types / entities / text-fields / tags / analytics-popular）を未認証で読んでレンダリング**しており（`useEntityTypeList` 等 40+ 箇所）、F-01 の「GET 一律保護」で 401 → `shared/api/client.ts` の 401→`/login` インターセプタが全訪問者をバウンス。#824 の一律保護が**公開サイトの実アーキと非互換**だった。
+- **修正**：本当に機密な read だけ（`webhooks` / `notification-channels` / `entities/export` / `dashboard`）を `ADMIN_ONLY_PREFIXES` 化し、GET 開放を復旧。**Critical（webhook secret）は封鎖維持**。org バインディング・ヘッダ堅牢化は維持。
+- **本番反映 00:50**：公開サイト描画復帰・機密 401 維持を確認。assessment doc に「Revision（#826）」として過剰だった点と残 High を正直に追記。
+
+### D. 残 High（下書き露出）を根治（#828 / PR #829）
+C は content GET を匿名開放に戻したため「未認証で下書きが読める」High が残存。read サーフェスを塞がず（公開サイトが依存）、**匿名アクセスを published-only に絞る**方針で根治。
+- **匿名は published-only**（判定＝`nene2.auth.claims` の有無）：entities list は published のみ（`?status=draft` でバイパス不可）／単一 entity は非公開なら 404（存在秘匿）／text-fields は **published 親エンティティのみ**（`?entity_id` 総当たりでも本文非漏洩）。
+- **`AdminApiAuthMiddleware` を opportunistic 認証化**：従来は保護ルートのみ claims を付与していたため、開放 GET で **admin が匿名扱いになり下書きが見えなくなる回帰**（＝admin UI 破壊）が起きる。開放ルートでも有効トークンがあれば claims を付与するよう修正（401 強制は保護ルートのみ）。**ライブ検証で発見した要修正点**。
+- **検証**：実 MySQL で 匿名＝published のみ / admin＝全 status を確認。unit 回帰追加（匿名 published-only ＋ authed 可視 ＋ opportunistic 認証）。`composer check` 緑（**1276 tests** / PHPStan L8）。
+- **本番反映 01:33**：公開サイト（ayane homepage・aozora SSR record）**200 で正常描画**＝#826 回帰なし。anon content read は開放（published-only）、sensitive は 401 維持。
+
+---
+
+## 意思決定
+- **公開サイトのデータ供給は "admin GET を匿名で読む" 現状アーキを尊重しつつ安全化**：read サーフェスを一律封鎖する（fail-closed 全面）と公開サイトが壊れるため、①機密 read だけ認証必須 ②匿名は published-only、の二段で締める。理想（公開は `/api/v1/public/*` 専用）へのフロント全面移行は別途。
+- **セキュリティ診断は "認可された自己 / maintainer-run" と必ず明記**し、第三者機関 pentest とは称さない。
+- **緊急でも Critical は封鎖を維持**：回帰対応（#826）でロールバックせず forward-fix を選択（ロールバックは Critical を再露出するため）。
+- **エビデンスの正直さ**：assessment doc に「テスト済み / 未実施」を明記（フロント SPA 診断・media SSRF は未実施）。
+
+## 現在の状態
+- `main` 先頭 = **`824af03`**（#829）。作業ツリー clean・全ゲート/CI グリーン（1276 tests）。
+- **本番（apex/aozora/ayane）**：#825 → #827 → #829 を反映済み（最終ビルド 01:33）。health 3 面 200・公開サイト描画正常・機密 GET 401・匿名 content は published-only。
+- `docs/security/` 新設（assessment ＋ README ＋ harness）。#824 assessment の指摘は**全クローズ**。
+
+## 残課題 / 次の一手
+1. **`WebhookHttpMapper` の `secret` を read で write-only 化**（defense-in-depth・#824 申し送り・急がない）。
+2. **フロントエンド SPA 診断**（全製品で未実施・assessment に明記）。将来ラウンドの主対象。
+3. **公開フロントの `/api/v1/public/*` 専用化**（理想アーキ・大きめ）：現状は admin GET を匿名で読む依存が 40+ 箇所。段階移行を検討。
+4. **record-detail の id ベース fallback**（`useEntity`→`/api/v1/entities/{id}`）等、稀な公開フォールバックの published-only 徹底（#829 でハンドラは 404 化済みだが総点検）。
+
+> 横断コンテキスト（詳細は `_work/`）：本日は vault（#198/199）・deal（#123/124）の red-team 診断結果を統合リナ側で取り込み（records の Critical/Medium 同型は両者に**不在**）、AYANE エビデンス（marketing repo の evidence doc §3.5）を「全 AYANE 関連製品 診断済み・EXPOSED 0」へ更新。
+> 参照：PR #825 / #827 / #829・`docs/security/`・会話メモリ `records-live-deployment`。


### PR DESCRIPTION
2026-07-14（セキュリティ集中日）の日報。

- ガバナンス文書の鮮度同期（#820/#821）
- 自己 red-team 診断で Critical（未認証管理API read/webhook secret）・Medium（JWT越境）・Low（ヘッダ）を発見→修正→本番反映（#824/#825）
- 公開サイト login バウンス回帰を surgical 修正（#826/#827）
- 残 High（下書き露出）を匿名 published-only＋opportunistic 認証で根治（#828/#829）
- `docs/security/` に診断記録・再現ハーネス整備

ドキュメントのみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)