### PR TITLE
fix(saas): reserve www.<base> for subdomain SaaS mode

### DIFF
--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -46,6 +46,7 @@ use NeNeRecords\Organization\Resolution\OrgResolverMiddleware;
 use NeNeRecords\Organization\Resolution\PathPrefixResolutionStrategy;
 use NeNeRecords\Organization\Resolution\SubdomainOrCustomDomainResolutionStrategy;
 use NeNeRecords\Organization\Resolution\SubdomainResolutionStrategy;
+use NeNeRecords\Organization\Resolution\WwwRedirectMiddleware;
 use NeNeRecords\RateLimit\RateLimitServiceProvider;
 use NeNeRecords\Setting\SettingRepositoryInterface;
 use NeNeRecords\SystemConfig\SystemConfigRepositoryInterface;
@@ -353,6 +354,14 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         'path'      => new PathPrefixResolutionStrategy(),
                         default     => new EnvResolutionStrategy($resolvedSlug),
                     };
+
+                    // Reserved `www.<base>` host (#832): 301 to the apex ahead of org
+                    // resolution. `localhost` is the "unconfigured" sentinel (same as
+                    // $resolvedDomain's own fallback above) — normalize it to '' so the
+                    // middleware no-ops for single/path mode deployers that never set
+                    // BASE_DOMAIN, matching SingleOriginServiceProvider's SpaShellFallback wiring.
+                    $wwwBaseDomain = $resolvedDomain === 'localhost' ? '' : $resolvedDomain;
+                    $authMiddleware[] = new WwwRedirectMiddleware($responseFactory, $wwwBaseDomain);
 
                     $authMiddleware[] = new OrgResolverMiddleware($orgIdHolder, $orgRepo, $problemDetails, $strategy);
 

--- a/src/Organization/Resolution/WwwRedirectMiddleware.php
+++ b/src/Organization/Resolution/WwwRedirectMiddleware.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Organization\Resolution;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Reserved `www.<base-domain>` host (subdomain SaaS mode): 301s to the apex
+ * instead of falling into org resolution.
+ *
+ * `www` is the near-universal DNS default, so a subdomain-mode deployer's own
+ * promotional domain lands here first — and it is not an org slug, so
+ * {@see OrgResolverMiddleware} would 404 it (and, one layer below, on-demand
+ * TLS issuance for it would be refused by
+ * {@see \NeNeRecords\Organization\TlsCheckHandler} were this host not also
+ * allow-listed there, #832). This middleware runs ahead of OrgResolverMiddleware
+ * in the auth pipeline so the redirect happens before any tenant lookup / 404.
+ *
+ * No-op when `$baseDomain` is empty — single/path mode deployers, where the SaaS
+ * base domain isn't configured, are never affected.
+ */
+final readonly class WwwRedirectMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private ResponseFactoryInterface $responseFactory,
+        /** Subdomain SaaS base domain, e.g. `nene-records.com`; '' disables this middleware. */
+        private string $baseDomain = '',
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if ($this->baseDomain === '' || !$this->isWwwHost($request)) {
+            return $handler->handle($request);
+        }
+
+        $uri = $request->getUri();
+        $target = $uri->getPath() . ($uri->getQuery() !== '' ? '?' . $uri->getQuery() : '');
+
+        return $this->responseFactory->createResponse(301)
+            ->withHeader('Location', 'https://' . $this->baseDomain . $target);
+    }
+
+    private function isWwwHost(ServerRequestInterface $request): bool
+    {
+        $host = $request->getUri()->getHost();
+        $host = str_contains($host, ':') ? explode(':', $host)[0] : $host;
+
+        return $host === 'www.' . $this->baseDomain;
+    }
+}

--- a/src/Organization/TlsCheckHandler.php
+++ b/src/Organization/TlsCheckHandler.php
@@ -50,6 +50,14 @@ final readonly class TlsCheckHandler
             return $this->decide(true);
         }
 
+        // Reserved `www` host: not an org slug, but `www.<base>` is the near-universal
+        // DNS default a subdomain-mode deployer's own promotional domain lands on. Allow
+        // the on-demand cert so the TLS handshake succeeds — WwwRedirectMiddleware then
+        // 301s it to the apex at the application layer (#832).
+        if ($domain === 'www.' . $this->baseDomain) {
+            return $this->decide(true);
+        }
+
         $baseParts = explode('.', $this->baseDomain);
         $hostParts = explode('.', $domain);
 

--- a/tests/Organization/Resolution/WwwRedirectMiddlewareTest.php
+++ b/tests/Organization/Resolution/WwwRedirectMiddlewareTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Organization\Resolution;
+
+use NeNeRecords\Organization\Resolution\WwwRedirectMiddleware;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class WwwRedirectMiddlewareTest extends TestCase
+{
+    private function passthroughHandler(): RequestHandlerInterface
+    {
+        return new readonly class (new Psr17Factory()) implements RequestHandlerInterface {
+            public function __construct(private Psr17Factory $factory)
+            {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->factory->createResponse(200);
+            }
+        };
+    }
+
+    /**
+     * `www.<base>` must 301 to the apex, preserving path + query. Regression for #832.
+     */
+    public function testWwwHostRedirectsToApex(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new WwwRedirectMiddleware($factory, 'nene-records.com');
+
+        $response = $middleware->process(
+            $factory->createServerRequest('GET', 'https://www.nene-records.com/posts/1?ref=x'),
+            $this->passthroughHandler(),
+        );
+
+        self::assertSame(301, $response->getStatusCode());
+        self::assertSame('https://nene-records.com/posts/1?ref=x', $response->getHeaderLine('Location'));
+    }
+
+    public function testWwwHostWithPortRedirects(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new WwwRedirectMiddleware($factory, 'nene-records.com');
+
+        $response = $middleware->process(
+            $factory->createServerRequest('GET', 'https://www.nene-records.com:443/'),
+            $this->passthroughHandler(),
+        );
+
+        self::assertSame(301, $response->getStatusCode());
+        self::assertSame('https://nene-records.com/', $response->getHeaderLine('Location'));
+    }
+
+    public function testApexHostPassesThrough(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new WwwRedirectMiddleware($factory, 'nene-records.com');
+
+        $response = $middleware->process(
+            $factory->createServerRequest('GET', 'https://nene-records.com/'),
+            $this->passthroughHandler(),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testTenantSubdomainPassesThrough(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new WwwRedirectMiddleware($factory, 'nene-records.com');
+
+        $response = $middleware->process(
+            $factory->createServerRequest('GET', 'https://shop.nene-records.com/'),
+            $this->passthroughHandler(),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    /**
+     * Single/path mode: baseDomain unset/empty → no-op, even for a `www` host.
+     */
+    public function testEmptyBaseDomainIsNoOp(): void
+    {
+        $factory = new Psr17Factory();
+        $middleware = new WwwRedirectMiddleware($factory, '');
+
+        $response = $middleware->process(
+            $factory->createServerRequest('GET', 'https://www.example.com/'),
+            $this->passthroughHandler(),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+}

--- a/tests/Organization/TlsCheckHandlerTest.php
+++ b/tests/Organization/TlsCheckHandlerTest.php
@@ -41,6 +41,17 @@ final class TlsCheckHandlerTest extends TestCase
         self::assertSame(200, $this->statusFor('shop.nene-records.com:443'));
     }
 
+    /**
+     * `www.<base>` is a reserved host, not an org slug: allow the on-demand cert so
+     * the TLS handshake succeeds (WwwRedirectMiddleware 301s it to the apex at the
+     * application layer). Regression for #832.
+     */
+    public function testReservedWwwHostIsAllowed(): void
+    {
+        self::assertSame(200, $this->statusFor('www.nene-records.com'));
+        self::assertSame(200, $this->statusFor('www.nene-records.com:443'));
+    }
+
     public function testUnknownSubdomainIsDenied(): void
     {
         self::assertSame(403, $this->statusFor('nope.nene-records.com'));


### PR DESCRIPTION
## Summary

- `www.<base-domain>` (subdomain SaaS mode) currently trips over two independent bugs at once: `TlsCheckHandler` refuses on-demand TLS issuance for it (not an org slug), and even with a certificate, `OrgResolverMiddleware` doesn't treat it as apex so it 404s. Since `www` is the near-universal DNS default, every subdomain-mode deployer's own promotional domain hits this trap.
- `TlsCheckHandler`: allow `www.<base>` alongside the apex so the on-demand cert issuance succeeds.
- New `WwwRedirectMiddleware`, spliced into the auth pipeline ahead of `OrgResolverMiddleware`: 301s `www.<base>` → `https://<base>{path}{?query}` before org resolution runs. No-op when `baseDomain` is unset (`localhost` sentinel, same convention as `SpaShellFallback`/`SingleOriginServiceProvider`), so single/path mode deployers are unaffected.

Closes #832

## Test plan

- [x] `composer test` — 1282 tests green, including new `TlsCheckHandlerTest::testReservedWwwHostIsAllowed` and new `WwwRedirectMiddlewareTest` (www→301 with path+query preserved, port stripped, apex/tenant/empty-baseDomain unaffected).
- [x] `composer analyse` (PHPStan) — no errors.
- [x] `composer cs` — no diffs.
- [x] `composer check` (full gate incl. OpenAPI/MCP/conformance) — all green.
- [ ] After merge/deploy: verify production (`curl -sI https://www.nene-records.com/` → expect `301` with `Location: https://nene-records.com/`), then remove the temporary explicit `www` redirect block from the production Caddyfile (`/home/deploy/stacks/caddy/Caddyfile`, backed up as `.bak-2026-07-14-www`) — this app-level fix now owns both the on-demand cert allow and the redirect, so the Caddy-level workaround becomes redundant (and would otherwise short-circuit the on-demand TLS `ask` path for `www`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)