### PR TITLE
fix(saas): www→apex 301 を SPA シェルに飲まれないようにする（#834）

### DIFF
--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -361,7 +361,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     // middleware no-ops for single/path mode deployers that never set
                     // BASE_DOMAIN, matching SingleOriginServiceProvider's SpaShellFallback wiring.
                     $wwwBaseDomain = $resolvedDomain === 'localhost' ? '' : $resolvedDomain;
-                    $authMiddleware[] = new WwwRedirectMiddleware($responseFactory, $wwwBaseDomain);
+                    $authMiddleware[] = new WwwRedirectMiddleware($responseFactory, $orgIdHolder, $wwwBaseDomain);
 
                     $authMiddleware[] = new OrgResolverMiddleware($orgIdHolder, $orgRepo, $problemDetails, $strategy);
 

--- a/src/Http/SpaShellFallback.php
+++ b/src/Http/SpaShellFallback.php
@@ -53,8 +53,12 @@ final readonly class SpaShellFallback
         // for `/` + text/html even though the framework answered 200 (not 404).
         // EXCEPT when an upstream handler already produced an HTML page for `/` (the
         // front-page SSR, #701): that response is the real page, so let it pass through.
+        // Only the 200 framework JSON qualifies: a non-200 at `/` (e.g. the bare
+        // www→apex 301 from WwwRedirectMiddleware, #834) is a deliberate answer and
+        // must never be swallowed by the shell.
         $alreadyHtml = str_contains($response->getHeaderLine('Content-Type'), 'text/html');
-        $isHtmlHome = $isGet && $wantsHtml && $path === '/' && !$alreadyHtml;
+        $isHtmlHome = $isGet && $wantsHtml && $path === '/' && !$alreadyHtml
+            && $response->getStatusCode() === 200;
 
         if ($response->getStatusCode() !== 404 && !$isHtmlHome) {
             return $response;

--- a/src/Organization/Resolution/WwwRedirectMiddleware.php
+++ b/src/Organization/Resolution/WwwRedirectMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Organization\Resolution;
 
+use Nene2\Http\RequestScopedHolder;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -27,8 +28,12 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final readonly class WwwRedirectMiddleware implements MiddlewareInterface
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId
+     */
     public function __construct(
         private ResponseFactoryInterface $responseFactory,
+        private RequestScopedHolder $orgId,
         /** Subdomain SaaS base domain, e.g. `nene-records.com`; '' disables this middleware. */
         private string $baseDomain = '',
     ) {
@@ -39,6 +44,12 @@ final readonly class WwwRedirectMiddleware implements MiddlewareInterface
         if ($this->baseDomain === '' || !$this->isWwwHost($request)) {
             return $handler->handle($request);
         }
+
+        // Short-circuiting ahead of OrgResolverMiddleware means downstream
+        // request-scoped readers (the access-log writer wraps this middleware)
+        // never see the holder populated — seed the no-org sentinel, same as
+        // OrgResolver's own bypass branch (#528, #834).
+        $this->orgId->set(0);
 
         $uri = $request->getUri();
         $target = $uri->getPath() . ($uri->getQuery() !== '' ? '?' . $uri->getQuery() : '');

--- a/tests/Http/SpaShellFallbackTest.php
+++ b/tests/Http/SpaShellFallbackTest.php
@@ -137,6 +137,21 @@ final class SpaShellFallbackTest extends TestCase
         self::assertStringContainsString('<div id="root">', (string) $result->getBody());
     }
 
+    public function testLeavesRedirectAtHomeUntouched(): void
+    {
+        // The www→apex 301 (WwwRedirectMiddleware) is a bare redirect with no
+        // Content-Type; the HTML-home carve-out must not swallow it into the shell
+        // for browser navigations (GET + text/html). Regression for #834.
+        $redirect = $this->factory->createResponse(301)
+            ->withHeader('Location', 'https://nene-records.com/');
+
+        $result = $this->fallback->apply($this->request('GET', '/'), $redirect);
+
+        self::assertSame(301, $result->getStatusCode());
+        self::assertSame('https://nene-records.com/', $result->getHeaderLine('Location'));
+        self::assertSame('', (string) $result->getBody());
+    }
+
     public function testLeavesJsonHomeForApiClients(): void
     {
         // No text/html Accept → the framework JSON passes through untouched.

--- a/tests/Organization/Resolution/WwwRedirectMiddlewareTest.php
+++ b/tests/Organization/Resolution/WwwRedirectMiddlewareTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Tests\Organization\Resolution;
 
+use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\Organization\Resolution\WwwRedirectMiddleware;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
@@ -13,6 +14,20 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 final class WwwRedirectMiddlewareTest extends TestCase
 {
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->orgId = new RequestScopedHolder();
+    }
+
+    private function middleware(string $baseDomain): WwwRedirectMiddleware
+    {
+        return new WwwRedirectMiddleware(new Psr17Factory(), $this->orgId, $baseDomain);
+    }
+
     private function passthroughHandler(): RequestHandlerInterface
     {
         return new readonly class (new Psr17Factory()) implements RequestHandlerInterface {
@@ -33,9 +48,8 @@ final class WwwRedirectMiddlewareTest extends TestCase
     public function testWwwHostRedirectsToApex(): void
     {
         $factory = new Psr17Factory();
-        $middleware = new WwwRedirectMiddleware($factory, 'nene-records.com');
 
-        $response = $middleware->process(
+        $response = $this->middleware('nene-records.com')->process(
             $factory->createServerRequest('GET', 'https://www.nene-records.com/posts/1?ref=x'),
             $this->passthroughHandler(),
         );
@@ -44,12 +58,28 @@ final class WwwRedirectMiddlewareTest extends TestCase
         self::assertSame('https://nene-records.com/posts/1?ref=x', $response->getHeaderLine('Location'));
     }
 
+    /**
+     * The redirect short-circuits ahead of OrgResolverMiddleware, so the org holder
+     * must be seeded with the no-org sentinel here or the access-log writer that
+     * wraps this middleware faults on every www request (#528 pattern, #834).
+     */
+    public function testWwwRedirectSeedsNoOrgSentinel(): void
+    {
+        $factory = new Psr17Factory();
+
+        $this->middleware('nene-records.com')->process(
+            $factory->createServerRequest('GET', 'https://www.nene-records.com/'),
+            $this->passthroughHandler(),
+        );
+
+        self::assertSame(0, $this->orgId->get());
+    }
+
     public function testWwwHostWithPortRedirects(): void
     {
         $factory = new Psr17Factory();
-        $middleware = new WwwRedirectMiddleware($factory, 'nene-records.com');
 
-        $response = $middleware->process(
+        $response = $this->middleware('nene-records.com')->process(
             $factory->createServerRequest('GET', 'https://www.nene-records.com:443/'),
             $this->passthroughHandler(),
         );
@@ -61,9 +91,8 @@ final class WwwRedirectMiddlewareTest extends TestCase
     public function testApexHostPassesThrough(): void
     {
         $factory = new Psr17Factory();
-        $middleware = new WwwRedirectMiddleware($factory, 'nene-records.com');
 
-        $response = $middleware->process(
+        $response = $this->middleware('nene-records.com')->process(
             $factory->createServerRequest('GET', 'https://nene-records.com/'),
             $this->passthroughHandler(),
         );
@@ -74,9 +103,8 @@ final class WwwRedirectMiddlewareTest extends TestCase
     public function testTenantSubdomainPassesThrough(): void
     {
         $factory = new Psr17Factory();
-        $middleware = new WwwRedirectMiddleware($factory, 'nene-records.com');
 
-        $response = $middleware->process(
+        $response = $this->middleware('nene-records.com')->process(
             $factory->createServerRequest('GET', 'https://shop.nene-records.com/'),
             $this->passthroughHandler(),
         );
@@ -90,9 +118,8 @@ final class WwwRedirectMiddlewareTest extends TestCase
     public function testEmptyBaseDomainIsNoOp(): void
     {
         $factory = new Psr17Factory();
-        $middleware = new WwwRedirectMiddleware($factory, '');
 
-        $response = $middleware->process(
+        $response = $this->middleware('')->process(
             $factory->createServerRequest('GET', 'https://www.example.com/'),
             $this->passthroughHandler(),
         );


### PR DESCRIPTION
## 目的

#833（www.<base> 予約・www→apex 301）の本番デプロイ直後に実測で発見した実害バグの修正。**GET + `Accept: text/html`（＝実ブラウザのナビゲーション）で `https://www.nene-records.com/` が 301 されず SPA シェル 200 が返っていた**（curl 素 / HEAD / bot は 301 で正常だったため #833 のテスト・検証はすり抜けた）。

## 原因

`SpaShellFallback` の HTML ホーム特例（#701: `/` の GET+text/html は 404 でなくてもシェル差し替え）がレスポンスステータスを見ておらず、`WwwRedirectMiddleware` の素の 301（Content-Type 無し → `$alreadyHtml=false`）を飲み込んでいた。

## 変更

- `SpaShellFallback`: HTML ホーム差し替えの対象を **status 200 に限定**（3xx/4xx/5xx は意図された応答として素通し）
- `WwwRedirectMiddleware`: 301 を返す前に orgId holder へ **no-org sentinel (0) を seed**（OrgResolver 前の short-circuit で access-log writer が www 全リクエストで非致命 ERROR を出していた・#528 と同型）
- `RuntimeServiceProvider`: holder 注入の配線
- 回帰テスト: `/`+text/html への 301 素通し（SpaShellFallbackTest）・holder seed（WwwRedirectMiddlewareTest）

## 検証

- `composer check` 全緑（PHPUnit **1284** tests / 3648 assertions・PHPStan level 8・CS・OpenAPI・conformance）
- 本番は本 PR マージ後に再デプロイし、`curl -s -H 'Accept: text/html' -D - https://www.nene-records.com/` → 301 を実測確認予定

## チェックリスト

- [x] Issue 起票済み（#834）
- [x] Conventional Commits
- [x] テスト追加
- [x] composer check 緑

Closes #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)