### PR TITLE
feat(settings): メンテナンスモードの管理 UI トグルを追加する（#814）

### DIFF
--- a/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.test.tsx
+++ b/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.test.tsx
@@ -68,3 +68,44 @@ describe('ManageSiteSettingsView · analytics_consent_default', () => {
     expect(input.tagName).toBe('INPUT')
   })
 })
+
+const maintenanceItem: SettingItem = {
+  settingKey: 'maintenance_mode',
+  label: 'Maintenance mode',
+  dataType: 'bool',
+  defaultValue: 'false',
+  isPublic: false,
+  value: 'false',
+  updatedAt: null,
+}
+
+describe('ManageSiteSettingsView · maintenance_mode', () => {
+  it('renders an off switch with no warning when maintenance is disabled', () => {
+    renderView(maintenanceItem)
+
+    const toggle = screen.getByRole<HTMLInputElement>('switch')
+    expect(toggle.checked).toBe(false)
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('turns maintenance on and shows the visitor warning', () => {
+    const { onSave } = renderView(maintenanceItem)
+
+    fireEvent.click(screen.getByRole('switch'))
+
+    expect(onSave).toHaveBeenCalledWith('maintenance_mode', 'true')
+    expect(screen.getByRole('status')).toBeTruthy()
+  })
+
+  it('reflects the on state and turns maintenance off on toggle', () => {
+    const { onSave } = renderView({ ...maintenanceItem, value: 'true' })
+
+    const toggle = screen.getByRole<HTMLInputElement>('switch')
+    expect(toggle.checked).toBe(true)
+    expect(screen.getByRole('status')).toBeTruthy()
+
+    fireEvent.click(toggle)
+
+    expect(onSave).toHaveBeenCalledWith('maintenance_mode', 'false')
+  })
+})

--- a/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.tsx
+++ b/frontend/src/features/manage-settings/ui/ManageSiteSettingsView.tsx
@@ -160,6 +160,68 @@ function ConsentDefaultField({
   )
 }
 
+// ── Maintenance-mode setting field (immediate toggle) ────────────────────────
+
+interface MaintenanceModeFieldProps {
+  item: SettingItem
+  inputId: string
+  isSaving: boolean
+  canManageSettings: boolean
+  onSave: (settingKey: string, value: string) => Promise<void>
+}
+
+/**
+ * `maintenance_mode` (bool, admin-only) gates the public site (#813). A plain
+ * "true"/"false" text box is a footgun for non-technical operators, so this is a
+ * switch that saves immediately on toggle. When on, a notice spells out that
+ * visitors see the maintenance page while signed-in staff keep the normal site.
+ */
+function MaintenanceModeField({
+  item,
+  inputId,
+  isSaving,
+  canManageSettings,
+  onSave,
+}: MaintenanceModeFieldProps) {
+  const { t } = useTranslation()
+  // Optimistic local state; the card remounts on save (keyed by updatedAt), so
+  // it re-syncs to the server value after the mutation settles.
+  const [on, setOn] = useState(item.value === 'true')
+
+  return (
+    <div className="flex flex-col gap-stack-sm">
+      <div className="flex items-center gap-inline-sm">
+        <input
+          id={inputId}
+          type="checkbox"
+          role="switch"
+          checked={on}
+          disabled={isSaving || !canManageSettings}
+          onChange={(e) => {
+            const next = e.target.checked
+            setOn(next)
+            void onSave(item.settingKey, next ? 'true' : 'false')
+          }}
+          className="h-4 w-4 shrink-0 accent-accent disabled:cursor-not-allowed disabled:opacity-50"
+        />
+        <Text variant="caption" className="font-medium">
+          {on ? t('admin.settings.maintenance.stateOn') : t('admin.settings.maintenance.stateOff')}
+        </Text>
+      </div>
+      {on ? (
+        <div
+          role="status"
+          className="rounded-md border border-warning bg-warning-weak px-inline-sm py-stack-xs"
+        >
+          <Text variant="caption" className="text-warning">
+            {t('admin.settings.maintenance.warning')}
+          </Text>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
 // ── Setting card (local form state only) ─────────────────────────────────────
 
 interface SettingCardProps {
@@ -247,6 +309,14 @@ function SettingCard({
             </div>
           ) : null}
         </div>
+      ) : item.settingKey === 'maintenance_mode' ? (
+        <MaintenanceModeField
+          item={item}
+          inputId={inputId}
+          isSaving={isSaving}
+          canManageSettings={canManageSettings}
+          onSave={onSave}
+        />
       ) : item.settingKey === 'analytics_consent_default' ? (
         <ConsentDefaultField
           item={item}

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -1403,6 +1403,10 @@ export const de: Partial<MessageCatalog> = {
   // ── Admin · settings · analytics consent default ──────────────────────────
   'admin.settings.consentDefault.denied': 'Abgelehnt (EU-sicherer Standard)',
   'admin.settings.consentDefault.granted': 'Zugelassen',
+  'admin.settings.maintenance.stateOn': 'Ein',
+  'admin.settings.maintenance.stateOff': 'Aus',
+  'admin.settings.maintenance.warning':
+    'Solange der Wartungsmodus aktiv ist, sehen Besucher der öffentlichen Website eine „Wartungs“-Seite. Angemeldete Mitarbeitende sehen die Website weiterhin normal.',
 
   // ── Public · cookie consent ───────────────────────────────────────────────
   'public.consent.label': 'Cookie-Einwilligung',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -1410,6 +1410,10 @@ export const en = {
   // ── Admin · settings · analytics consent default ──────────────────────────
   'admin.settings.consentDefault.denied': 'Denied (EU-safe default)',
   'admin.settings.consentDefault.granted': 'Granted',
+  'admin.settings.maintenance.stateOn': 'On',
+  'admin.settings.maintenance.stateOff': 'Off',
+  'admin.settings.maintenance.warning':
+    'While maintenance mode is on, visitors to the public site see an “Under maintenance” page. Signed-in staff still see the site normally.',
 
   // ── Public · cookie consent ───────────────────────────────────────────────
   'public.consent.label': 'Cookie consent',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -1438,6 +1438,10 @@ export const fr: Partial<MessageCatalog> = {
   // ── Admin · settings · analytics consent default ──────────────────────────
   'admin.settings.consentDefault.denied': 'Refusé (valeur par défaut sûre pour l’UE)',
   'admin.settings.consentDefault.granted': 'Autorisé',
+  'admin.settings.maintenance.stateOn': 'Activé',
+  'admin.settings.maintenance.stateOff': 'Désactivé',
+  'admin.settings.maintenance.warning':
+    'Lorsque le mode maintenance est activé, les visiteurs du site public voient une page « En maintenance ». Le personnel connecté continue de voir le site normalement.',
 
   // ── Public · cookie consent ───────────────────────────────────────────────
   'public.consent.label': 'Consentement aux cookies',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -1413,6 +1413,10 @@ export const ja: Partial<MessageCatalog> = {
   // ── Admin · settings · analytics consent default ──────────────────────────
   'admin.settings.consentDefault.denied': '拒否（EU 安全側の既定）',
   'admin.settings.consentDefault.granted': '許可',
+  'admin.settings.maintenance.stateOn': 'オン',
+  'admin.settings.maintenance.stateOff': 'オフ',
+  'admin.settings.maintenance.warning':
+    'メンテナンスモードがオンの間、公開サイトの来訪者には「メンテナンス中」ページが表示されます。ログイン中のスタッフには通常どおり表示されます。',
 
   // ── Public · cookie consent ───────────────────────────────────────────────
   'public.consent.label': 'Cookie の同意',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -1424,6 +1424,10 @@ export const ptBR: Partial<MessageCatalog> = {
   // ── Admin · settings · analytics consent default ──────────────────────────
   'admin.settings.consentDefault.denied': 'Negado (padrão seguro na UE)',
   'admin.settings.consentDefault.granted': 'Concedido',
+  'admin.settings.maintenance.stateOn': 'Ativado',
+  'admin.settings.maintenance.stateOff': 'Desativado',
+  'admin.settings.maintenance.warning':
+    'Enquanto o modo de manutenção está ativado, os visitantes do site público veem uma página “Em manutenção”. A equipe conectada continua vendo o site normalmente.',
 
   // ── Public · cookie consent ───────────────────────────────────────────────
   'public.consent.label': 'Consentimento de cookies',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -1363,6 +1363,10 @@ export const zhHans: Partial<MessageCatalog> = {
   // ── Admin · settings · analytics consent default ──────────────────────────
   'admin.settings.consentDefault.denied': '拒绝（欧盟安全默认）',
   'admin.settings.consentDefault.granted': '允许',
+  'admin.settings.maintenance.stateOn': '开启',
+  'admin.settings.maintenance.stateOff': '关闭',
+  'admin.settings.maintenance.warning':
+    '维护模式开启期间，公开站点的访客会看到“维护中”页面。已登录的员工仍可正常查看站点。',
 
   // ── Public · cookie consent ───────────────────────────────────────────────
   'public.consent.label': 'Cookie 同意',


### PR DESCRIPTION
## 目的
#813 で backend（`maintenance_mode` 設定＋`MaintenanceMiddleware`）は実装済みだが、トグルは設定 API（`PUT /api/v1/settings/maintenance_mode` = `"true"`/`"false"`）でしか操作できなかった。非技術オペレータが管理画面から ON/OFF できるよう、UI トグルを追加する。

## 変更点
- **配置**: 一般設定ページ（Site settings＝`ManageSiteSettingsView`）に `maintenance_mode` 専用フィールドを追加。既存の `analytics_consent_default` と同じく settingKey で分岐する。`maintenance_mode` は bool・is_public 0 で、そのまま generic 経路に落ちると `"true"`/`"false"` の生テキスト入力になり footgun のため、専用トグルにした。
- **トグル**: `role="switch"` のスイッチ。操作で即座に既存の設定 read/write API（`PUT /api/v1/settings/maintenance_mode`）へ `"true"`/`"false"` を保存する（新規エンドポイントなし）。カードは `updatedAt` を key に持つため保存後に remount → サーバ値へ再同期。
- **注意表示**: ON 時に `role="status"` の警告（warn トークン）を表示 —「公開サイトの来訪者には『メンテナンス中』が表示され、ログイン中のスタッフには通常表示される」。
- **i18n**: 6 ロケール完備（`stateOn` / `stateOff` / `warning`）。
- **FE テスト**: 3 件（OFF 表示・no warning／ON 化で `onSave('maintenance_mode','true')` ＋注意表示／ON 反映と OFF 化で `onSave('maintenance_mode','false')`）。

## 検証
- `npm run check --prefix frontend` → 全緑（type-check / lint / format / test / validate:themes / knip / build-storybook）。
- backend は不変更（`composer check` 対象外）。
- 対象テスト: `ManageSiteSettingsView.test.tsx`・`locales.test.ts` 緑。

## チェックリスト
- [x] Issue 駆動（#814）
- [x] Conventional Commits（type/scope 英語・description 日本語・`（#814）`）
- [x] i18n 6 ロケール
- [x] strict TS / vitest cleanup 順守
- [x] secrets 未混入

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)