### PR TITLE
feat(org-export): comments/webhooks/notification_channels/user_profiles を移送対象化（#796）

### DIFF
--- a/database/schema/comments.sql
+++ b/database/schema/comments.sql
@@ -1,0 +1,13 @@
+CREATE TABLE comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    organization_id INTEGER NOT NULL DEFAULT 0,
+    entity_id INTEGER NOT NULL,
+    author_name VARCHAR(100) NOT NULL,
+    author_email VARCHAR(255) NOT NULL,
+    body TEXT NOT NULL,
+    is_approved INTEGER NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL,
+    FOREIGN KEY (entity_id) REFERENCES entities (id) ON DELETE CASCADE ON UPDATE NO ACTION
+);
+CREATE INDEX comments_org ON comments (organization_id);
+CREATE INDEX comments_entity_approved ON comments (entity_id, is_approved);

--- a/database/schema/notification_channels.sql
+++ b/database/schema/notification_channels.sql
@@ -1,0 +1,12 @@
+CREATE TABLE notification_channels (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    organization_id INTEGER NOT NULL DEFAULT 0,
+    channel_type VARCHAR(16) NOT NULL,
+    label VARCHAR(100) NOT NULL,
+    is_enabled INTEGER NOT NULL DEFAULT 1,
+    config_json TEXT NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+);
+CREATE INDEX notification_channels_org_enabled ON notification_channels (organization_id, is_enabled);
+CREATE INDEX notification_channels_org_type ON notification_channels (organization_id, channel_type);

--- a/database/schema/user_profiles.sql
+++ b/database/schema/user_profiles.sql
@@ -1,0 +1,11 @@
+CREATE TABLE user_profiles (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    display_name VARCHAR(100) NULL DEFAULT NULL,
+    full_name VARCHAR(200) NULL DEFAULT NULL,
+    job_title VARCHAR(100) NULL DEFAULT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE ON UPDATE NO ACTION
+);
+CREATE UNIQUE INDEX user_profiles_user_id ON user_profiles (user_id);

--- a/database/schema/webhook_deliveries.sql
+++ b/database/schema/webhook_deliveries.sql
@@ -1,0 +1,21 @@
+CREATE TABLE webhook_deliveries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    webhook_id INTEGER NOT NULL,
+    event VARCHAR(64) NOT NULL,
+    entity_type_id INTEGER NOT NULL,
+    entity_id INTEGER NOT NULL,
+    target_url VARCHAR(2048) NOT NULL,
+    secret VARCHAR(255) NULL DEFAULT NULL,
+    payload TEXT NOT NULL,
+    status VARCHAR(16) NOT NULL DEFAULT 'pending',
+    attempts INTEGER NOT NULL DEFAULT 0,
+    max_attempts INTEGER NOT NULL DEFAULT 5,
+    next_attempt_at DATETIME NOT NULL,
+    last_error TEXT NULL DEFAULT NULL,
+    response_status INTEGER NULL DEFAULT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    delivered_at DATETIME NULL DEFAULT NULL
+);
+CREATE INDEX webhook_deliveries_due ON webhook_deliveries (status, next_attempt_at);
+CREATE INDEX webhook_deliveries_webhook ON webhook_deliveries (webhook_id);

--- a/database/schema/webhooks.sql
+++ b/database/schema/webhooks.sql
@@ -1,0 +1,12 @@
+CREATE TABLE webhooks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    organization_id INTEGER NOT NULL DEFAULT 0,
+    url VARCHAR(2048) NOT NULL,
+    events TEXT NOT NULL,
+    entity_type_id INTEGER NULL DEFAULT NULL,
+    secret VARCHAR(255) NULL DEFAULT NULL,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+);
+CREATE INDEX webhooks_org ON webhooks (organization_id);

--- a/src/OrgExport/ExportOrganizationHandler.php
+++ b/src/OrgExport/ExportOrganizationHandler.php
@@ -71,6 +71,11 @@ final readonly class ExportOrganizationHandler implements RequestHandlerInterfac
             'blocks_fields'    => $this->repository->findAllBlocksFields($id),
             'entity_relations' => $this->repository->findAllEntityRelations($id),
             'url_redirects'    => $this->repository->findAllUrlRedirects($id),
+            'comments'         => $this->repository->findAllComments($id),
+            'webhooks'         => $this->repository->findAllWebhooks($id),
+            'webhook_deliveries' => $this->repository->findAllWebhookDeliveries($id),
+            'notification_channels' => $this->repository->findAllNotificationChannels($id),
+            'user_profiles'    => $this->repository->findAllUserProfiles($id),
         ];
 
         return $this->json->create($payload);

--- a/src/OrgExport/OrgExportRepositoryInterface.php
+++ b/src/OrgExport/OrgExportRepositoryInterface.php
@@ -65,4 +65,35 @@ interface OrgExportRepositoryInterface
 
     /** @return list<array<string, mixed>> */
     public function findAllUrlRedirects(int $orgId): array;
+
+    /** @return list<array<string, mixed>> */
+    public function findAllComments(int $orgId): array;
+
+    /**
+     * Webhook config rows. The HMAC signing `secret` column is intentionally
+     * omitted from the payload — it is re-provisioned on the target (#836).
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function findAllWebhooks(int $orgId): array;
+
+    /**
+     * Webhook delivery-queue rows, scoped through the parent webhook. The
+     * per-delivery `secret` snapshot is omitted (see findAllWebhooks).
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function findAllWebhookDeliveries(int $orgId): array;
+
+    /** @return list<array<string, mixed>> */
+    public function findAllNotificationChannels(int $orgId): array;
+
+    /**
+     * User profiles, scoped through the owning user. Each row carries the
+     * owner's `user_email` so the target can re-attach it to a same-email user
+     * (users themselves are never exported — see PdoOrgImportRepository).
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function findAllUserProfiles(int $orgId): array;
 }

--- a/src/OrgExport/PdoOrgExportRepository.php
+++ b/src/OrgExport/PdoOrgExportRepository.php
@@ -205,4 +205,76 @@ final readonly class PdoOrgExportRepository implements OrgExportRepositoryInterf
             [$orgId],
         );
     }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllComments(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT * FROM comments WHERE organization_id = ? ORDER BY id',
+            [$orgId],
+        );
+    }
+
+    /**
+     * The `secret` column is deliberately excluded — HMAC secrets are not moved
+     * between instances (re-provisioned on the target, #836).
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function findAllWebhooks(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT id, organization_id, url, events, entity_type_id, is_active, created_at, updated_at
+             FROM webhooks WHERE organization_id = ? ORDER BY id',
+            [$orgId],
+        );
+    }
+
+    /**
+     * webhook_deliveries has no organization_id — scope through the parent webhook.
+     * The per-delivery `secret` snapshot is excluded like findAllWebhooks.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function findAllWebhookDeliveries(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT d.id, d.webhook_id, d.event, d.entity_type_id, d.entity_id, d.target_url,
+                    d.payload, d.status, d.attempts, d.max_attempts, d.next_attempt_at,
+                    d.last_error, d.response_status, d.created_at, d.updated_at, d.delivered_at
+             FROM webhook_deliveries d
+             JOIN webhooks w ON w.id = d.webhook_id
+             WHERE w.organization_id = ?
+             ORDER BY d.id',
+            [$orgId],
+        );
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllNotificationChannels(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT * FROM notification_channels WHERE organization_id = ? ORDER BY id',
+            [$orgId],
+        );
+    }
+
+    /**
+     * user_profiles has no organization_id — scope through the owning user and
+     * carry the user's email so the target can re-attach the profile by email.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function findAllUserProfiles(int $orgId): array
+    {
+        return $this->query->fetchAll(
+            'SELECT p.id, p.user_id, p.display_name, p.full_name, p.job_title,
+                    p.created_at, p.updated_at, u.email AS user_email
+             FROM user_profiles p
+             JOIN users u ON u.id = p.user_id
+             WHERE u.organization_id = ?
+             ORDER BY p.id',
+            [$orgId],
+        );
+    }
 }

--- a/src/OrgExport/PdoOrgImportRepository.php
+++ b/src/OrgExport/PdoOrgImportRepository.php
@@ -575,6 +575,184 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
         }
         $counts['setting_values'] = $settingValueCount;
 
+        // ── comments (append; entity_id remapped) (#625/#796) ──────────────
+        // comments has no user reference — only author_name/author_email are held,
+        // so nothing to scrub. Rows whose entity is missing on the target are skipped.
+        $commentCount = 0;
+        foreach ((array) ($payload['comments'] ?? []) as $row) {
+            $newEntityId = $entityMap[(int) $row['entity_id']] ?? null;
+            if ($newEntityId === null) {
+                continue;
+            }
+            $now = $this->clock->now()->format('Y-m-d H:i:s');
+            $query->insert(
+                'INSERT INTO comments
+                    (organization_id, entity_id, author_name, author_email, body, is_approved, created_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)',
+                [
+                    $targetOrgId,
+                    $newEntityId,
+                    (string) $row['author_name'],
+                    (string) $row['author_email'],
+                    (string) $row['body'],
+                    (int) ($row['is_approved'] ?? 0),
+                    (string) ($row['created_at'] ?? $now),
+                ],
+            );
+            $commentCount++;
+        }
+        $counts['comments'] = $commentCount;
+
+        // ── webhooks (append; entity_type_id remapped, secret re-provisioned) (#285/#796) ─
+        // The HMAC `secret` is never transported — it is inserted NULL so the operator
+        // regenerates it on the target (#836 write-only). webhookMap feeds deliveries below.
+        /** @var array<int, int> $webhookMap  old_id → new_id */
+        $webhookMap  = [];
+        $webhookCount = 0;
+        foreach ((array) ($payload['webhooks'] ?? []) as $row) {
+            $oldId = (int) $row['id'];
+            $now   = $this->clock->now()->format('Y-m-d H:i:s');
+            $newEntityTypeId = isset($row['entity_type_id'])
+                ? ($entityTypeMap[(int) $row['entity_type_id']] ?? null)
+                : null;
+            $newId = $query->insert(
+                'INSERT INTO webhooks
+                    (organization_id, url, events, entity_type_id, secret, is_active, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, NULL, ?, ?, ?)',
+                [
+                    $targetOrgId,
+                    (string) $row['url'],
+                    (string) $row['events'],
+                    $newEntityTypeId,
+                    (int) ($row['is_active'] ?? 1),
+                    (string) ($row['created_at'] ?? $now),
+                    (string) ($row['updated_at'] ?? $now),
+                ],
+            );
+            $webhookMap[$oldId] = $newId;
+            $webhookCount++;
+        }
+        $counts['webhooks'] = $webhookCount;
+
+        // ── webhook_deliveries (append; webhook_id/entity/entity_type remapped) (#285/#796) ─
+        // The delivery-queue snapshot rides along so in-flight/failed history survives a move.
+        // secret is NULL (re-provisioned like webhooks). Rows whose parent webhook or
+        // referenced entity/entity_type is missing on the target are skipped (all NOT NULL).
+        $deliveryCount = 0;
+        foreach ((array) ($payload['webhook_deliveries'] ?? []) as $row) {
+            $newWebhookId    = $webhookMap[(int) $row['webhook_id']] ?? null;
+            $newEntityTypeId = $entityTypeMap[(int) $row['entity_type_id']] ?? null;
+            $newEntityId     = $entityMap[(int) $row['entity_id']] ?? null;
+            if ($newWebhookId === null || $newEntityTypeId === null || $newEntityId === null) {
+                continue;
+            }
+            $now = $this->clock->now()->format('Y-m-d H:i:s');
+            $query->insert(
+                'INSERT INTO webhook_deliveries
+                    (webhook_id, event, entity_type_id, entity_id, target_url, secret, payload, status,
+                     attempts, max_attempts, next_attempt_at, last_error, response_status,
+                     created_at, updated_at, delivered_at)
+                 VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                [
+                    $newWebhookId,
+                    (string) $row['event'],
+                    $newEntityTypeId,
+                    $newEntityId,
+                    (string) $row['target_url'],
+                    (string) $row['payload'],
+                    (string) ($row['status'] ?? 'pending'),
+                    (int) ($row['attempts'] ?? 0),
+                    (int) ($row['max_attempts'] ?? 5),
+                    (string) ($row['next_attempt_at'] ?? $now),
+                    isset($row['last_error']) ? (string) $row['last_error'] : null,
+                    isset($row['response_status']) ? (int) $row['response_status'] : null,
+                    (string) ($row['created_at'] ?? $now),
+                    (string) ($row['updated_at'] ?? $now),
+                    isset($row['delivered_at']) ? (string) $row['delivered_at'] : null,
+                ],
+            );
+            $deliveryCount++;
+        }
+        $counts['webhook_deliveries'] = $deliveryCount;
+
+        // ── notification_channels (append; org stamped) (#796) ─────────────
+        // config_json is the owner's own destination config (Slack/Discord/webhook URLs)
+        // and is transported verbatim so notifications keep working on the target.
+        $channelCount = 0;
+        foreach ((array) ($payload['notification_channels'] ?? []) as $row) {
+            $now = $this->clock->now()->format('Y-m-d H:i:s');
+            $query->insert(
+                'INSERT INTO notification_channels
+                    (organization_id, channel_type, label, is_enabled, config_json, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)',
+                [
+                    $targetOrgId,
+                    (string) $row['channel_type'],
+                    (string) $row['label'],
+                    (int) ($row['is_enabled'] ?? 1),
+                    (string) $row['config_json'],
+                    (string) ($row['created_at'] ?? $now),
+                    (string) ($row['updated_at'] ?? $now),
+                ],
+            );
+            $channelCount++;
+        }
+        $counts['notification_channels'] = $channelCount;
+
+        // ── user_profiles (re-attach by email; users are never exported) (#704/#796) ─
+        // Users carry password hashes + roles, so they are not transported. A profile is
+        // re-attached only when the target org already has a user with the same email;
+        // otherwise it is skipped and reported (user_profiles_skipped). user_id is UNIQUE,
+        // so an existing profile for that user is updated rather than duplicated.
+        $profileCount   = 0;
+        $profileSkipped = 0;
+        foreach ((array) ($payload['user_profiles'] ?? []) as $row) {
+            $email = isset($row['user_email']) ? (string) $row['user_email'] : '';
+            if ($email === '') {
+                $profileSkipped++;
+                continue;
+            }
+            $user = $query->fetchOne(
+                'SELECT id FROM users WHERE email = ? AND organization_id = ?',
+                [$email, $targetOrgId],
+            );
+            if ($user === null) {
+                $profileSkipped++;
+                continue;
+            }
+            $newUserId = (int) $user['id'];
+            $now       = $this->clock->now()->format('Y-m-d H:i:s');
+            $existing  = $query->fetchOne('SELECT id FROM user_profiles WHERE user_id = ?', [$newUserId]);
+            if ($existing !== null) {
+                $query->execute(
+                    'UPDATE user_profiles SET display_name = ?, full_name = ?, job_title = ?, updated_at = ? WHERE id = ?',
+                    [
+                        isset($row['display_name']) ? (string) $row['display_name'] : null,
+                        isset($row['full_name']) ? (string) $row['full_name'] : null,
+                        isset($row['job_title']) ? (string) $row['job_title'] : null,
+                        $now,
+                        (int) $existing['id'],
+                    ],
+                );
+            } else {
+                $query->insert(
+                    'INSERT INTO user_profiles (user_id, display_name, full_name, job_title, created_at, updated_at)
+                     VALUES (?, ?, ?, ?, ?, ?)',
+                    [
+                        $newUserId,
+                        isset($row['display_name']) ? (string) $row['display_name'] : null,
+                        isset($row['full_name']) ? (string) $row['full_name'] : null,
+                        isset($row['job_title']) ? (string) $row['job_title'] : null,
+                        (string) ($row['created_at'] ?? $now),
+                        (string) ($row['updated_at'] ?? $now),
+                    ],
+                );
+            }
+            $profileCount++;
+        }
+        $counts['user_profiles']         = $profileCount;
+        $counts['user_profiles_skipped'] = $profileSkipped;
+
         return $counts;
     }
 

--- a/tests/OrgExport/OrgExportHttpTest.php
+++ b/tests/OrgExport/OrgExportHttpTest.php
@@ -239,6 +239,36 @@ final class StubOrgExportRepository implements OrgExportRepositoryInterface
     {
         return [];
     }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllComments(int $orgId): array
+    {
+        return [];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllWebhooks(int $orgId): array
+    {
+        return [];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllWebhookDeliveries(int $orgId): array
+    {
+        return [];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllNotificationChannels(int $orgId): array
+    {
+        return [];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function findAllUserProfiles(int $orgId): array
+    {
+        return [];
+    }
 }
 
 final class RecordingOrgImportRepository implements OrgImportRepositoryInterface

--- a/tests/OrgExport/PdoOrgImportRepositoryTest.php
+++ b/tests/OrgExport/PdoOrgImportRepositoryTest.php
@@ -210,6 +210,62 @@ final class PdoOrgImportRepositoryTest extends TestCase
         self::assertSame(1, $counts['entity_relations']);
     }
 
+    public function testImportsPhase3TablesWithIdRemapAndSecretScrub(): void
+    {
+        $repository = new PdoOrgImportRepository(
+            new PdoDatabaseTransactionManager($this->factory),
+            new FixedClock(),
+        );
+
+        $counts = $repository->import(1, $this->phase3Payload());
+
+        $entity   = $this->executor->fetchOne("SELECT id FROM entities WHERE slug = 'hello-world'");
+        self::assertNotNull($entity);
+        $newEntityId = (int) $entity['id'];
+        $postsType   = $this->executor->fetchOne("SELECT id FROM entity_types WHERE organization_id = 1 AND slug = 'posts'");
+        self::assertNotNull($postsType);
+        $newTypeId = (int) $postsType['id'];
+
+        // comments: valid one imported + org-stamped; the one for a missing entity skipped.
+        $comment = $this->executor->fetchOne("SELECT * FROM comments WHERE author_email = 'jane@example.test'");
+        self::assertNotNull($comment);
+        self::assertSame($newEntityId, (int) $comment['entity_id']);
+        self::assertSame(1, (int) $comment['organization_id']);
+        self::assertSame('Nice post', $comment['body']);
+        self::assertSame(1, $counts['comments']);
+
+        // webhooks: secret dropped (NULL), entity_type_id remapped, org-stamped.
+        $webhook = $this->executor->fetchOne('SELECT * FROM webhooks WHERE organization_id = 1');
+        self::assertNotNull($webhook);
+        self::assertNull($webhook['secret']);
+        self::assertSame($newTypeId, (int) $webhook['entity_type_id']);
+        $newWebhookId = (int) $webhook['id'];
+
+        // webhook_deliveries: parent + entity remapped, secret dropped; orphan skipped.
+        $delivery = $this->executor->fetchOne("SELECT * FROM webhook_deliveries WHERE event = 'entity.created'");
+        self::assertNotNull($delivery);
+        self::assertNull($delivery['secret']);
+        self::assertSame($newWebhookId, (int) $delivery['webhook_id']);
+        self::assertSame($newEntityId, (int) $delivery['entity_id']);
+        self::assertSame($newTypeId, (int) $delivery['entity_type_id']);
+        self::assertSame(1, $counts['webhook_deliveries']);
+
+        // notification_channels: org-stamped, config preserved.
+        $channel = $this->executor->fetchOne('SELECT * FROM notification_channels WHERE organization_id = 1');
+        self::assertNotNull($channel);
+        self::assertSame('slack', $channel['channel_type']);
+        self::assertStringContainsString('hooks.slack', (string) $channel['config_json']);
+
+        // user_profiles: attached to the same-email target user; the ghost user is skipped + reported.
+        $targetUser = $this->executor->fetchOne("SELECT id FROM users WHERE email = 'admin@target.test'");
+        self::assertNotNull($targetUser);
+        $profile = $this->executor->fetchOne('SELECT * FROM user_profiles WHERE user_id = ?', [(int) $targetUser['id']]);
+        self::assertNotNull($profile);
+        self::assertSame('Rina', $profile['display_name']);
+        self::assertSame(1, $counts['user_profiles']);
+        self::assertSame(1, $counts['user_profiles_skipped']);
+    }
+
     public function testFailedImportRollsBackEntireOrg(): void
     {
         $repository = new PdoOrgImportRepository(
@@ -333,6 +389,41 @@ final class PdoOrgImportRepositoryTest extends TestCase
         ];
     }
 
+    /** @return array<string, mixed> */
+    private function phase3Payload(): array
+    {
+        return [
+            'meta'         => ['organization_id' => 77],
+            'entity_types' => [['id' => 10, 'name' => 'Posts', 'slug' => 'posts', 'is_pinned' => 1]],
+            'entities'     => [
+                ['id' => 30, 'entity_type_id' => 10, 'slug' => 'hello-world', 'status' => 'published'],
+            ],
+            'comments'     => [
+                ['id' => 200, 'entity_id' => 30, 'author_name' => 'Jane', 'author_email' => 'jane@example.test', 'body' => 'Nice post', 'is_approved' => 1, 'created_at' => '2026-05-01 00:00:00'],
+                // references a missing entity → skipped.
+                ['id' => 201, 'entity_id' => 999, 'author_name' => 'Ghost', 'author_email' => 'ghost@example.test', 'body' => 'orphan', 'is_approved' => 0],
+            ],
+            'webhooks'     => [
+                // secret is present in the source row but must be dropped on import.
+                ['id' => 300, 'url' => 'https://hook.test/x', 'events' => '["entity.created"]', 'entity_type_id' => 10, 'secret' => 'top-secret', 'is_active' => 1],
+            ],
+            'webhook_deliveries' => [
+                ['id' => 400, 'webhook_id' => 300, 'event' => 'entity.created', 'entity_type_id' => 10, 'entity_id' => 30, 'target_url' => 'https://hook.test/x', 'secret' => 'top-secret', 'payload' => '{}', 'status' => 'pending', 'attempts' => 0, 'max_attempts' => 5, 'next_attempt_at' => '2026-05-01 00:00:00', 'created_at' => '2026-05-01 00:00:00', 'updated_at' => '2026-05-01 00:00:00'],
+                // parent webhook missing → skipped.
+                ['id' => 401, 'webhook_id' => 999, 'event' => 'entity.updated', 'entity_type_id' => 10, 'entity_id' => 30, 'target_url' => 'https://hook.test/y', 'payload' => '{}', 'status' => 'failed', 'attempts' => 5, 'max_attempts' => 5, 'next_attempt_at' => '2026-05-01 00:00:00', 'created_at' => '2026-05-01 00:00:00', 'updated_at' => '2026-05-01 00:00:00'],
+            ],
+            'notification_channels' => [
+                ['id' => 500, 'channel_type' => 'slack', 'label' => 'Ops', 'is_enabled' => 1, 'config_json' => '{"webhook_url":"https://hooks.slack.test/abc"}', 'created_at' => '2026-05-01 00:00:00', 'updated_at' => '2026-05-01 00:00:00'],
+            ],
+            'user_profiles' => [
+                // same email as the seeded target admin → re-attached.
+                ['id' => 600, 'user_id' => 42, 'user_email' => 'admin@target.test', 'display_name' => 'Rina', 'full_name' => 'Rina R.', 'job_title' => 'Engineer', 'created_at' => '2026-05-01 00:00:00', 'updated_at' => '2026-05-01 00:00:00'],
+                // no such user on the target → skipped + reported.
+                ['id' => 601, 'user_id' => 43, 'user_email' => 'ghost@source.test', 'display_name' => 'Ghost'],
+            ],
+        ];
+    }
+
     private function seedFreshOrg(int $orgId): void
     {
         // Mirror the fresh-install seed: posts type + title/body field_defs, and one setting_def.
@@ -351,6 +442,12 @@ final class PdoOrgImportRepositoryTest extends TestCase
         $this->executor->execute(
             "INSERT INTO setting_defs (organization_id, setting_key, data_type, default_value, is_public, label, created_at, updated_at)
              VALUES (?, 'site_name', 'text', 'NeNe Records', 1, 'Site name', '2026-01-01 00:00:00', '2026-01-01 00:00:00')",
+            [$orgId],
+        );
+        // A target-org admin so an imported user_profile can be re-attached by email (#796).
+        $this->executor->execute(
+            "INSERT INTO users (email, password_hash, role, organization_id, org_role, created_at, updated_at)
+             VALUES ('admin@target.test', 'x', 'admin', ?, 'admin', '2026-01-01 00:00:00', '2026-01-01 00:00:00')",
             [$orgId],
         );
     }
@@ -379,9 +476,29 @@ final class PdoOrgImportRepositoryTest extends TestCase
             $projectRoot . '/database/schema/entity_relations.sql',
             $projectRoot . '/database/schema/url_redirects.sql',
             $projectRoot . '/database/schema/settings.sql',
+            $projectRoot . '/database/schema/comments.sql',
+            $projectRoot . '/database/schema/webhooks.sql',
+            $projectRoot . '/database/schema/webhook_deliveries.sql',
+            $projectRoot . '/database/schema/notification_channels.sql',
+            $projectRoot . '/database/schema/user_profiles.sql',
         ];
 
-        $statements = [];
+        // users.sql uses MySQL ENUM syntax SQLite cannot parse; user_profiles only
+        // needs id/email/organization_id here, so a minimal SQLite users table is
+        // created first (before user_profiles.sql, which carries the FK).
+        $statements = [
+            'CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email VARCHAR(255) NOT NULL,
+                password_hash VARCHAR(255) NOT NULL DEFAULT \'\',
+                role VARCHAR(32) NOT NULL DEFAULT \'admin\',
+                organization_id INTEGER NULL DEFAULT NULL,
+                org_role VARCHAR(32) NULL DEFAULT NULL,
+                created_at DATETIME NOT NULL DEFAULT \'2026-01-01 00:00:00\',
+                updated_at DATETIME NOT NULL DEFAULT \'2026-01-01 00:00:00\'
+            )',
+            'CREATE UNIQUE INDEX users_email ON users (email)',
+        ];
         foreach ($paths as $path) {
             self::assertFileExists($path);
             $raw = trim((string) file_get_contents($path));


### PR DESCRIPTION
## 目的

#741 の org export/import は AYANE 移送に必要なテーブルまでで、org 全体の完全移送・バックアップ用途では以下が欠落していた（Phase 1/2 のスコープ外残置）:

- comments（#625）
- webhooks / webhook_deliveries（#285）
- notification_channels
- user_profiles（#704）

本 PR でこの4系統を export/import 対象に加える。

## 設計判断（PR に明記）

- **users は export しない**: パスワードハッシュ・ロールをインスタンス間で移送するのは tenancy/セキュリティ上不可。よって user 参照は以下で扱う:
  - **comments**: スキーマ上 `user_id` を持たず、`author_name` / `author_email` のみ保持するため参照スクラブは不要。`entity_id` を entityMap で再マップ（欠落行は skip）し `organization_id` を刻印。
  - **user_profiles**: `user_id` が本質。export 時に所有ユーザの `email` を同梱し、**移送先に同一 email（かつ同一 org）のユーザが居れば再アタッチ、居なければ skip**。skip 件数を import 結果に `user_profiles_skipped` として報告する。`user_id` は UNIQUE のため既存プロファイルは UPDATE（重複しない）。
- **secret は移送しない**: `webhooks.secret`（HMAC 署名鍵）と `webhook_deliveries.secret`（スナップショット）は export の SELECT から除外し、import では `NULL` で挿入する（移送先で再設定・#836 の write-only 方針と整合）。
- **notification_channels.config_json は維持**: Slack/Discord/webhook の宛先設定は所有者自身が同一 org を移送するものなので、通知が引き続き機能するよう verbatim で移送する（外向き宛先であり本システムへのアクセス鍵ではない）。
- **webhook_deliveries は同梱**: 配送キュー/履歴を移送先に持ち込む。`webhook_id`/`entity_id`/`entity_type_id`（すべて NOT NULL）を再マップし、親や参照エンティティが欠落する行は skip。pending 行は移送先ワーカが再送しうる点に留意（in-flight 継続の意図）。

## ID リマップ / org 刻印

- comments.entity_id → entityMap、org 刻印。
- webhooks.entity_type_id → entityTypeMap、org 刻印、webhookMap 構築。
- webhook_deliveries.webhook_id → webhookMap、entity_id → entityMap、entity_type_id → entityTypeMap。
- notification_channels: org 刻印。
- user_profiles.user_id → email 突合による target user。
- 全 org スコープ行に `organization_id` を刻印（stop-gate 不変条件を維持）。

## 変更点

- `OrgExportRepositoryInterface` / `PdoOrgExportRepository`: `findAllComments` / `findAllWebhooks` / `findAllWebhookDeliveries` / `findAllNotificationChannels` / `findAllUserProfiles` を追加（secret 除外・親経由スコープ・email 同梱）。
- `ExportOrganizationHandler`: payload キー5つを追加。
- `PdoOrgImportRepository::doImport`: 4系統の insert + ID リマップ + secret スクラブ + skip 報告を追加。
- `database/schema/*.sql`: SQLite ラウンドトリップテスト用に comments / webhooks / webhook_deliveries / notification_channels / user_profiles を追加。

## 検証

- `composer check` 全緑（PHPUnit 1285 tests / PHPStan level 8 / CS-Fixer / OpenAPI / MCP）。既存の risky 1件は `ModuleRegistryTest`（本 PR と無関係の既存）。
- 追加テスト `testImportsPhase3TablesWithIdRemapAndSecretScrub`: 復元・ID リマップ・secret 除去（NULL）・orphan skip・user_profiles email 再アタッチ / skip 報告を実証。

## チェックリスト

- [x] Issue-driven（#796）
- [x] main から `feat/796-...` ブランチ
- [x] Conventional Commits（type/scope 英語・description 日本語・`（#796）`）
- [x] secrets 非コミット
- [x] `composer check` 全緑

Refs #741
Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)