### PR TITLE
sec(webhook): webhook secret を read 側で write-only 化する（#836）

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -7281,6 +7281,7 @@ components:
         - id
         - url
         - events
+        - has_secret
         - is_active
         - created_at
         - updated_at
@@ -7302,9 +7303,11 @@ components:
           type: integer
           format: int64
           nullable: true
-        secret:
-          type: string
-          nullable: true
+        has_secret:
+          type: boolean
+          description: >-
+            Whether a signing secret is configured. The secret itself is
+            write-only and is never returned on read (defense-in-depth).
         is_active:
           type: boolean
         created_at:
@@ -7351,6 +7354,9 @@ components:
         secret:
           type: string
           nullable: true
+          description: >-
+            Write-only HMAC-SHA256 signing secret. Never returned on read; use
+            `has_secret` on the response to tell whether one is configured.
         is_active:
           type: boolean
           default: true
@@ -7382,6 +7388,10 @@ components:
         secret:
           type: string
           nullable: true
+          description: >-
+            Write-only HMAC-SHA256 signing secret. Omit (or send null) to keep
+            the existing secret; send a new value to replace it. Never returned
+            on read.
         is_active:
           type: boolean
       additionalProperties: false

--- a/frontend/src/entities/webhook/api-types.ts
+++ b/frontend/src/entities/webhook/api-types.ts
@@ -3,7 +3,8 @@ export interface WebhookDto {
   url: string
   events: string[]
   entity_type_id: number | null
-  secret: string | null
+  /** Write-only secret: never returned on read; only whether one is configured. */
+  has_secret: boolean
   is_active: boolean
   created_at: string
   updated_at: string

--- a/frontend/src/entities/webhook/mapper.ts
+++ b/frontend/src/entities/webhook/mapper.ts
@@ -7,7 +7,7 @@ export function mapWebhookDtoToModel(dto: WebhookDto): Webhook {
     url: dto.url,
     events: dto.events as WebhookEvent[],
     entityTypeId: dto.entity_type_id,
-    secret: dto.secret,
+    hasSecret: dto.has_secret,
     isActive: dto.is_active,
     createdAt: dto.created_at,
     updatedAt: dto.updated_at,

--- a/frontend/src/entities/webhook/model.ts
+++ b/frontend/src/entities/webhook/model.ts
@@ -7,7 +7,8 @@ export interface Webhook {
   url: string
   events: WebhookEvent[]
   entityTypeId: number | null
-  secret: string | null
+  /** Write-only: the secret value is never read back, only whether one is set. */
+  hasSecret: boolean
   isActive: boolean
   createdAt: string
   updatedAt: string

--- a/frontend/src/features/manage-webhooks/ui/ManageWebhooksView.tsx
+++ b/frontend/src/features/manage-webhooks/ui/ManageWebhooksView.tsx
@@ -97,9 +97,11 @@ export function ManageWebhooksView({
                   url: webhook.url,
                   events: webhook.events,
                   entityTypeId: webhook.entityTypeId,
-                  secret: webhook.secret ?? '',
+                  // Secret is write-only: never pre-filled. Blank keeps the existing one.
+                  secret: '',
                   isActive: webhook.isActive,
                 }}
+                secretConfigured={webhook.hasSecret}
                 isSubmitting={isUpdating}
                 serverErrorTitle={updateError}
                 submitLabel={t('common.actions.save')}

--- a/frontend/src/features/manage-webhooks/ui/WebhookForm.tsx
+++ b/frontend/src/features/manage-webhooks/ui/WebhookForm.tsx
@@ -6,6 +6,8 @@ import { Button, Card, Stack, Text } from '@/shared/ui'
 
 export interface WebhookFormProps {
   defaultValues?: Partial<CreateWebhookInput>
+  /** Whether a signing secret is already configured (write-only: value is never loaded). */
+  secretConfigured?: boolean
   isSubmitting: boolean
   serverErrorTitle: string | null
   submitLabel: string
@@ -15,6 +17,7 @@ export interface WebhookFormProps {
 
 export function WebhookForm({
   defaultValues,
+  secretConfigured = false,
   isSubmitting,
   serverErrorTitle,
   submitLabel,
@@ -129,7 +132,8 @@ export function WebhookForm({
           </label>
           <input
             id={`${fieldId}-secret`}
-            type="text"
+            type="password"
+            autoComplete="new-password"
             value={secret}
             disabled={isSubmitting}
             placeholder={t('admin.webhooks.form.secretPlaceholder')}
@@ -138,6 +142,11 @@ export function WebhookForm({
             }}
             className="rounded-md border border-border bg-surface px-3 py-2 font-sans text-body text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent disabled:opacity-50"
           />
+          <span className="font-sans text-caption text-text-muted">
+            {secretConfigured
+              ? t('admin.webhooks.form.secretConfiguredHint')
+              : t('admin.webhooks.form.secretHint')}
+          </span>
         </div>
 
         {/* Is active */}

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -2929,7 +2929,8 @@ export interface components {
             events: ("entity.created" | "entity.updated" | "entity.deleted")[];
             /** Format: int64 */
             entity_type_id?: number | null;
-            secret?: string | null;
+            /** @description Whether a signing secret is configured. The secret itself is write-only and is never returned on read (defense-in-depth). */
+            has_secret: boolean;
             is_active: boolean;
             /** Format: date-time */
             created_at: string;
@@ -2945,6 +2946,7 @@ export interface components {
             events: ("entity.created" | "entity.updated" | "entity.deleted")[];
             /** Format: int64 */
             entity_type_id?: number | null;
+            /** @description Write-only HMAC-SHA256 signing secret. Never returned on read; use `has_secret` on the response to tell whether one is configured. */
             secret?: string | null;
             /** @default true */
             is_active: boolean;
@@ -2955,6 +2957,7 @@ export interface components {
             events: ("entity.created" | "entity.updated" | "entity.deleted")[];
             /** Format: int64 */
             entity_type_id?: number | null;
+            /** @description Write-only HMAC-SHA256 signing secret. Omit (or send null) to keep the existing secret; send a new value to replace it. Never returned on read. */
             secret?: string | null;
             is_active?: boolean;
         };

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -1174,6 +1174,10 @@ export const de: Partial<MessageCatalog> = {
   'admin.webhooks.form.secretLabel': 'Signatur-Secret (optional)',
   'admin.webhooks.form.secretPlaceholder':
     'Wird für den HMAC-SHA256-Header X-NeNe-Signature verwendet',
+  'admin.webhooks.form.secretHint':
+    'Wird schreibgeschützt gespeichert und nach dem Speichern nicht mehr angezeigt.',
+  'admin.webhooks.form.secretConfiguredHint':
+    'Ein Signatur-Secret ist konfiguriert. Leer lassen, um es beizubehalten, oder einen neuen Wert eingeben, um es zu ersetzen.',
   'admin.webhooks.form.isActiveLabel': 'Aktiv',
   // ── Notification channels ────────────────────────────────────────────────
   'admin.notifications.title': 'Benachrichtigungskanäle',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -1182,6 +1182,9 @@ export const en = {
   'admin.webhooks.form.entityTypeIdPlaceholder': 'All entity types',
   'admin.webhooks.form.secretLabel': 'Signing secret (optional)',
   'admin.webhooks.form.secretPlaceholder': 'Used for HMAC-SHA256 X-NeNe-Signature header',
+  'admin.webhooks.form.secretHint': 'Stored write-only and never shown again after saving.',
+  'admin.webhooks.form.secretConfiguredHint':
+    'A signing secret is configured. Leave blank to keep it, or enter a new value to replace it.',
   'admin.webhooks.form.isActiveLabel': 'Active',
 
   // ── Notification channels ────────────────────────────────────────────────

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -1202,6 +1202,10 @@ export const fr: Partial<MessageCatalog> = {
   'admin.webhooks.form.entityTypeIdPlaceholder': "Tous les types d'entité",
   'admin.webhooks.form.secretLabel': 'Secret de signature (facultatif)',
   'admin.webhooks.form.secretPlaceholder': "Utilisé pour l'en-tête HMAC-SHA256 X-NeNe-Signature",
+  'admin.webhooks.form.secretHint':
+    "Enregistré en écriture seule et jamais réaffiché après l'enregistrement.",
+  'admin.webhooks.form.secretConfiguredHint':
+    'Un secret de signature est configuré. Laissez vide pour le conserver, ou saisissez une nouvelle valeur pour le remplacer.',
   'admin.webhooks.form.isActiveLabel': 'Actif',
 
   // ── Notification channels ────────────────────────────────────────────────

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -1182,6 +1182,9 @@ export const ja: Partial<MessageCatalog> = {
   'admin.webhooks.form.entityTypeIdPlaceholder': '全エンティティタイプ',
   'admin.webhooks.form.secretLabel': '署名シークレット（省略可）',
   'admin.webhooks.form.secretPlaceholder': 'HMAC-SHA256 X-NeNe-Signature ヘッダーに使用',
+  'admin.webhooks.form.secretHint': '書き込み専用で保存され、保存後は再表示されません。',
+  'admin.webhooks.form.secretConfiguredHint':
+    '署名シークレットは設定済みです。空欄のままにすると保持し、新しい値を入力すると置き換えます。',
   'admin.webhooks.form.isActiveLabel': '有効',
 
   // ── Notification channels ────────────────────────────────────────────────

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -1193,6 +1193,10 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.webhooks.form.entityTypeIdPlaceholder': 'Todos os tipos de entidade',
   'admin.webhooks.form.secretLabel': 'Segredo de assinatura (opcional)',
   'admin.webhooks.form.secretPlaceholder': 'Usado no cabeçalho HMAC-SHA256 X-NeNe-Signature',
+  'admin.webhooks.form.secretHint':
+    'Armazenado como somente gravação e nunca exibido novamente após salvar.',
+  'admin.webhooks.form.secretConfiguredHint':
+    'Um secret de assinatura está configurado. Deixe em branco para mantê-lo ou insira um novo valor para substituí-lo.',
   'admin.webhooks.form.isActiveLabel': 'Ativo',
 
   // ── Notification channels ────────────────────────────────────────────────

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -1141,6 +1141,8 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.webhooks.form.entityTypeIdPlaceholder': '所有实体类型',
   'admin.webhooks.form.secretLabel': '签名密钥（可选）',
   'admin.webhooks.form.secretPlaceholder': '用于 HMAC-SHA256 X-NeNe-Signature 标头',
+  'admin.webhooks.form.secretHint': '以只写方式存储，保存后不再显示。',
+  'admin.webhooks.form.secretConfiguredHint': '已配置签名密钥。留空以保留，或输入新值以替换。',
   'admin.webhooks.form.isActiveLabel': '已启用',
 
   // ── Notification channels ────────────────────────────────────────────────

--- a/src/Webhook/CreateWebhookHandler.php
+++ b/src/Webhook/CreateWebhookHandler.php
@@ -50,16 +50,18 @@ final readonly class CreateWebhookHandler
             isActive: $isActive,
         ));
 
-        return $this->response->create([
-            'id' => $output->id,
-            'url' => $output->url,
-            'events' => $output->events,
-            'entity_type_id' => $output->entityTypeId,
-            'secret' => $output->secret,
-            'is_active' => $output->isActive,
-            'created_at' => $output->createdAt,
-            'updated_at' => $output->updatedAt,
-        ], 201)->withHeader('Location', '/api/v1/webhooks/' . $output->id);
+        // Response is write-only for the secret: return `has_secret`, not the
+        // secret itself (#836). Reuse the shared read mapper for a single shape.
+        return $this->response->create(WebhookHttpMapper::toArray(new Webhook(
+            id: $output->id,
+            url: $output->url,
+            events: $output->events,
+            entityTypeId: $output->entityTypeId,
+            secret: $output->secret,
+            isActive: $output->isActive,
+            createdAt: $output->createdAt,
+            updatedAt: $output->updatedAt,
+        )), 201)->withHeader('Location', '/api/v1/webhooks/' . $output->id);
     }
 
     /**

--- a/src/Webhook/UpdateWebhookHandler.php
+++ b/src/Webhook/UpdateWebhookHandler.php
@@ -54,16 +54,18 @@ final readonly class UpdateWebhookHandler
             isActive: $isActive,
         ));
 
-        return $this->response->create([
-            'id' => $output->id,
-            'url' => $output->url,
-            'events' => $output->events,
-            'entity_type_id' => $output->entityTypeId,
-            'secret' => $output->secret,
-            'is_active' => $output->isActive,
-            'created_at' => $output->createdAt,
-            'updated_at' => $output->updatedAt,
-        ]);
+        // Response is write-only for the secret: return `has_secret`, not the
+        // secret itself (#836). Reuse the shared read mapper for a single shape.
+        return $this->response->create(WebhookHttpMapper::toArray(new Webhook(
+            id: $output->id,
+            url: $output->url,
+            events: $output->events,
+            entityTypeId: $output->entityTypeId,
+            secret: $output->secret,
+            isActive: $output->isActive,
+            createdAt: $output->createdAt,
+            updatedAt: $output->updatedAt,
+        )));
     }
 
     /**

--- a/src/Webhook/UpdateWebhookUseCase.php
+++ b/src/Webhook/UpdateWebhookUseCase.php
@@ -24,12 +24,17 @@ final readonly class UpdateWebhookUseCase implements UpdateWebhookUseCaseInterfa
 
         $now = $this->clock->now()->format('Y-m-d H:i:s');
 
+        // Write-only secret (#836): an omitted secret (null) keeps the existing
+        // value so the write-only read contract does not break the update flow.
+        // A non-null secret replaces it.
+        $secret = $input->secret ?? $existing->secret;
+
         $updated = new Webhook(
             id: $input->id,
             url: $input->url,
             events: $input->events,
             entityTypeId: $input->entityTypeId,
-            secret: $input->secret,
+            secret: $secret,
             isActive: $input->isActive,
             createdAt: $existing->createdAt,
             updatedAt: $now,
@@ -42,7 +47,7 @@ final readonly class UpdateWebhookUseCase implements UpdateWebhookUseCaseInterfa
             url: $input->url,
             events: $input->events,
             entityTypeId: $input->entityTypeId,
-            secret: $input->secret,
+            secret: $secret,
             isActive: $input->isActive,
             createdAt: $existing->createdAt,
             updatedAt: $now,

--- a/src/Webhook/WebhookHttpMapper.php
+++ b/src/Webhook/WebhookHttpMapper.php
@@ -11,12 +11,15 @@ final class WebhookHttpMapper
      */
     public static function toArray(Webhook $webhook): array
     {
+        // The signing secret is write-only: it is never echoed back on read
+        // (defense-in-depth, #836 / #824). Callers only learn whether one is
+        // configured via `has_secret`.
         return [
             'id' => $webhook->id,
             'url' => $webhook->url,
             'events' => $webhook->events,
             'entity_type_id' => $webhook->entityTypeId,
-            'secret' => $webhook->secret,
+            'has_secret' => $webhook->secret !== null && $webhook->secret !== '',
             'is_active' => $webhook->isActive,
             'created_at' => $webhook->createdAt,
             'updated_at' => $webhook->updatedAt,

--- a/tests/Webhook/WebhookHttpTest.php
+++ b/tests/Webhook/WebhookHttpTest.php
@@ -95,7 +95,9 @@ final class WebhookHttpTest extends TestCase
         self::assertSame('https://example.com/hook', $payload['url']);
         self::assertSame(['entity.created', 'entity.updated'], $payload['events']);
         self::assertNull($payload['entity_type_id']);
-        self::assertNull($payload['secret']);
+        // Write-only secret (#836): never echoed; has_secret reports absence.
+        self::assertArrayNotHasKey('secret', $payload);
+        self::assertFalse($payload['has_secret']);
         self::assertTrue($payload['is_active']);
     }
 
@@ -116,8 +118,69 @@ final class WebhookHttpTest extends TestCase
 
         self::assertSame(201, $response->getStatusCode());
         self::assertSame(5, $payload['entity_type_id']);
-        self::assertSame('my-secret', $payload['secret']);
+        // Write-only secret (#836): a configured secret is reported but not echoed.
+        self::assertArrayNotHasKey('secret', $payload);
+        self::assertTrue($payload['has_secret']);
         self::assertFalse($payload['is_active']);
+    }
+
+    public function testGetAndListNeverExposeSecret(): void
+    {
+        $created = $this->createWebhookWithSecret('https://example.com/hook', ['entity.created'], 'top-secret');
+
+        $get = $this->decodeJson($this->application->handle(
+            $this->factory->createServerRequest('GET', "https://example.test/api/v1/webhooks/{$created['id']}"),
+        ));
+        self::assertArrayNotHasKey('secret', $get);
+        self::assertTrue($get['has_secret']);
+
+        $list = $this->decodeJson($this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/webhooks'),
+        ));
+        self::assertIsArray($list['items']);
+        foreach ($list['items'] as $item) {
+            self::assertIsArray($item);
+            self::assertArrayNotHasKey('secret', $item);
+        }
+        self::assertTrue($list['items'][0]['has_secret']);
+    }
+
+    public function testPutWithoutSecretKeepsExistingSecret(): void
+    {
+        $created = $this->createWebhookWithSecret('https://example.com/hook', ['entity.created'], 'keep-me');
+
+        $body = $this->factory->createStream(json_encode([
+            'url' => 'https://updated.example.com/hook',
+            'events' => ['entity.updated'],
+        ], JSON_THROW_ON_ERROR));
+
+        $payload = $this->decodeJson($this->application->handle(
+            $this->factory->createServerRequest('PUT', "https://example.test/api/v1/webhooks/{$created['id']}")->withBody($body),
+        ));
+
+        // Response stays write-only, but the stored secret must survive.
+        self::assertArrayNotHasKey('secret', $payload);
+        self::assertTrue($payload['has_secret']);
+        self::assertSame('keep-me', $this->webhooks->findById($created['id'])?->secret);
+    }
+
+    public function testPutWithSecretReplacesExistingSecret(): void
+    {
+        $created = $this->createWebhookWithSecret('https://example.com/hook', ['entity.created'], 'old-secret');
+
+        $body = $this->factory->createStream(json_encode([
+            'url' => 'https://example.com/hook',
+            'events' => ['entity.created'],
+            'secret' => 'new-secret',
+        ], JSON_THROW_ON_ERROR));
+
+        $payload = $this->decodeJson($this->application->handle(
+            $this->factory->createServerRequest('PUT', "https://example.test/api/v1/webhooks/{$created['id']}")->withBody($body),
+        ));
+
+        self::assertArrayNotHasKey('secret', $payload);
+        self::assertTrue($payload['has_secret']);
+        self::assertSame('new-secret', $this->webhooks->findById($created['id'])?->secret);
     }
 
     public function testPostWithMissingUrlReturns422(): void
@@ -257,6 +320,24 @@ final class WebhookHttpTest extends TestCase
     {
         $body = $this->factory->createStream(json_encode(
             compact('url', 'events'),
+            JSON_THROW_ON_ERROR,
+        ));
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('POST', 'https://example.test/api/v1/webhooks')->withBody($body),
+        );
+
+        return $this->decodeJson($response);
+    }
+
+    /**
+     * @param list<string> $events
+     * @return array<string, mixed>
+     */
+    private function createWebhookWithSecret(string $url, array $events, string $secret): array
+    {
+        $body = $this->factory->createStream(json_encode(
+            compact('url', 'events', 'secret'),
             JSON_THROW_ON_ERROR,
         ));
 

--- a/tests/Webhook/WebhookUseCaseTest.php
+++ b/tests/Webhook/WebhookUseCaseTest.php
@@ -117,6 +117,59 @@ final class UpdateWebhookUseCaseTest extends TestCase
         self::assertSame(false, $output->isActive);
     }
 
+    public function testNullSecretKeepsExistingSecret(): void
+    {
+        $webhooks = new InMemoryWebhookRepository();
+        $createUseCase = new CreateWebhookUseCase($webhooks, new UtcClock());
+        $createUseCase->execute(new CreateWebhookInput(
+            url: 'https://example.com/hook',
+            events: ['entity.created'],
+            entityTypeId: null,
+            secret: 'existing-secret',
+            isActive: true,
+        ));
+
+        $updateUseCase = new UpdateWebhookUseCase($webhooks, new UtcClock());
+        $output = $updateUseCase->execute(new UpdateWebhookInput(
+            id: 1,
+            url: 'https://example.com/hook-updated',
+            events: ['entity.updated'],
+            entityTypeId: null,
+            secret: null,
+            isActive: true,
+        ));
+
+        // Write-only update (#836): an omitted secret keeps the stored value.
+        self::assertSame('existing-secret', $output->secret);
+        self::assertSame('existing-secret', $webhooks->findById(1)?->secret);
+    }
+
+    public function testNonNullSecretReplacesExistingSecret(): void
+    {
+        $webhooks = new InMemoryWebhookRepository();
+        $createUseCase = new CreateWebhookUseCase($webhooks, new UtcClock());
+        $createUseCase->execute(new CreateWebhookInput(
+            url: 'https://example.com/hook',
+            events: ['entity.created'],
+            entityTypeId: null,
+            secret: 'old-secret',
+            isActive: true,
+        ));
+
+        $updateUseCase = new UpdateWebhookUseCase($webhooks, new UtcClock());
+        $output = $updateUseCase->execute(new UpdateWebhookInput(
+            id: 1,
+            url: 'https://example.com/hook',
+            events: ['entity.created'],
+            entityTypeId: null,
+            secret: 'new-secret',
+            isActive: true,
+        ));
+
+        self::assertSame('new-secret', $output->secret);
+        self::assertSame('new-secret', $webhooks->findById(1)?->secret);
+    }
+
     public function testThrowsWebhookNotFoundExceptionIfNotFound(): void
     {
         $webhooks = new InMemoryWebhookRepository();


### PR DESCRIPTION
## 目的

セキュリティ自己診断 #824 の申し送り（defense-in-depth）。webhook の署名シークレット（HMAC 鍵）が管理 API の read 経路（get/list のレスポンス）にそのまま載っていた。認可済み管理者しか読めないが、画面表示・ログ・ブラウザ拡張などへの露出面を減らすため、secret を **write-only** 化する。

## 変更点

**設計判断: 完全除去 ＋ 派生 `has_secret: bool`**（マスク表示より露出面が小さく、issue 推奨。「設定済みか」の UX と write-only 編集を両立）。

### backend
- `WebhookHttpMapper`: `secret` を落とし `has_secret`（`secret !== null && !== ''`）を返す。
- `CreateWebhookHandler` / `UpdateWebhookHandler`: レスポンスを同マッパー経由に統一（secret を echo しない）。
- `UpdateWebhookUseCase`: secret 未指定（null）なら**既存値を維持**、指定時は差し替え（write-only 化で更新フローを壊さない）。
- HMAC 署名（webhook delivery）は repository から読む実 secret を使うため**不変**（`CurlWebhookSender` は無変更）。

### API 契約
- `docs/openapi/openapi.yaml` の `WebhookResponse` から `secret` を削除し `has_secret`（required）を追加。request スキーマの `secret` に write-only の説明を追記。
- `npm run codegen` で `schema.gen.ts` 再生成。

### frontend
- `WebhookDto`/`Webhook` を `has_secret`/`hasSecret` 化、mapper 追随。
- 編集フォームは write-only UX: 現在値は非表示（常に空欄）、空欄なら既存 secret を保持、新値入力で差し替え。`secretConfigured` に応じたヒント文言を **6 ロケール**追加。secret 入力を `type=password` + `autocomplete=new-password` に。

## 検証

- `composer check`: PHPUnit 1287 tests green（Risky 1 件は既存の `ModuleRegistryTest`・本 PR 無関係）/ PHPStan level 8 No errors / CS-Fixer clean / OpenAPI valid / MCP valid。
- `npm run check --prefix frontend`: type-check / lint / prettier / test / themes / knip / storybook すべて green。
- 追加した回帰テスト:
  - read（get/list/create/update）に `secret` が載らず `has_secret` が正しい。
  - PUT で secret 省略 → 既存 secret を維持。
  - PUT で secret 指定 → 差し替え。
  - use-case レベルでも null=維持 / 非null=差し替えを担保。

## チェックリスト
- Issue 駆動（#836）/ ブランチ `sec/836-webhook-secret-write-only`
- Conventional Commits / secrets 未混入

Refs #824
Closes #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)