### PR TITLE
feat(install): 配布 ZIP のフォントをオンデマンド化して base を約14MB に削減する（#709）

### DIFF
--- a/docs/install-tier-a.md
+++ b/docs/install-tier-a.md
@@ -18,10 +18,18 @@ NeNe Records を「zip をアップロードして install ページを開くだ
 
    ```bash
    bash tools/build-release.sh <version>
-   # → dist/nene-records-<version>.zip（Packagist の NENE2 を解決した自己完結 zip）
+   # → dist/nene-records-<version>.zip        本体（Packagist の NENE2 を解決した自己完結 zip・約11MB）
+   # → dist/nene-records-fonts-<version>.zip   フォントパック（オンデマンドの追加フォント・約55MB）
    ```
 
-2. **アップロード**: ZIP を展開した中身一式をサーバーへアップロードする
+   本体 ZIP は「設置直後から見た目が破綻しない最小フォントセット」（管理画面フォント＋
+   既定テーマ＋日本語見出し）だけを同梱し、テーマのフォントピッカーで選べる残りの
+   フォント（CJK の Noto Sans JP/SC・Shippori Mincho ほか）は **フォントパック** に
+   分離している（#709）。GitHub Release には **本体・フォントパック両方の ZIP と各
+   `.sha256`** を添付する（Latest・target=main）。フォントパックは任意導入なので、まず
+   本体だけで設置を完了できる。詳細は後述の「フォントパック（任意）」を参照。
+
+2. **アップロード**: 本体 ZIP を展開した中身一式をサーバーへアップロードする
    （例: `~/web/nene-records/` 配下に `src/ vendor/ public_html/ …` が並ぶ形）。
 
 3. **公開フォルダを `public_html/` に向ける**: ホスティングの管理画面で、サイトの
@@ -40,6 +48,41 @@ NeNe Records を「zip をアップロードして install ページを開くだ
 
 5. **後片付け（推奨）**: サーバー上の `public_html/install/` ディレクトリを削除する。
    削除しなくても `var/.installed` マーカーと DB 検査により再実行は 403 で遮断される。
+
+## フォントパック（任意）
+
+本体 ZIP は配布サイズを抑えるため（66MB → 約11MB・#709）、フォントを最小セットだけ
+同梱している。**同梱済み**なのは次の用途:
+
+- 管理画面の UI フォント（Inter / Saira Semi Condensed / Space Grotesk / JetBrains Mono）
+- 既定の公開テーマ「consumer」の見出しフォント（Bricolage Grotesque）
+- 公開サイトの日本語見出し・本文（Zen Kaku Gothic New サブセット）と mono ラベル（IBM Plex Mono）
+
+これ以外の、テーマのフォントピッカーで選べるフォント（Playfair Display・Oswald・
+Source Serif 4・Roboto、および CJK 全域の Noto Sans JP/SC・Shippori Mincho など）は
+**フォントパック** に分離している。フォントパック未導入でも、選ばれたフォントは CSS の
+フォールバック（システムフォント）で描画されるため見た目は破綻しない。管理画面
+「外観 > カスタマイズ」のフォント選択では、未導入フォントに「（フォントパック）」の
+注記が付き、上部に導入を促すヒントが表示される。
+
+### フォントパックの導入（FTP）
+
+shell の無い共有ホスティングでも導入できる手動手順（正）:
+
+1. `dist/nene-records-fonts-<version>.zip` をローカルで展開する。
+2. 中身の `public_html/assets/` 配下の `*.woff2` / `*.woff` を、本体を設置したのと
+   **同じ階層**（`public_html/` がある場所）へ、フォルダ構成ごと **上書き** アップロード
+   する。既存ファイルとは衝突しない（ハッシュ名なので純粋に増えるだけ）。
+3. 反映確認は管理画面「外観 > カスタマイズ」のフォント選択で、追加フォントの
+   「（フォントパック）」注記が消えることで分かる。
+
+> **バージョン整合**: 必ず本体 ZIP と同じ `<version>` のフォントパックを使うこと。
+> Vite の出力ファイル名は版ごとにハッシュが変わるため、版がズレると CSS の参照先と
+> 一致せず反映されない。
+
+> **将来**: 管理画面／インストーラからフォントパックを HTTP 取得して自動展開する導線は
+> follow-up（PHP `ZipArchive` ＋ `allow_url_fopen`/curl 検出、失敗時は上記 FTP へ誘導）
+> として検討中。現時点では上記の FTP 手動導入が唯一の手段。
 
 ## サブディレクトリ設置
 

--- a/frontend/src/features/manage-appearance/ui/workspace/CustomizePanels.tsx
+++ b/frontend/src/features/manage-appearance/ui/workspace/CustomizePanels.tsx
@@ -1,5 +1,6 @@
-import { type ReactNode, useState } from 'react'
+import { type ReactNode, useEffect, useState } from 'react'
 import { useTranslation, type MessageKey } from '@/shared/i18n'
+import { isBaseBundledFontValue, probeFontPackInstalled } from '@/shared/lib/font-availability'
 import {
   BRAND_FONT_OPTIONS,
   BRAND_SIZE_OPTIONS,
@@ -223,16 +224,37 @@ function FlagSegment({
   )
 }
 
+/**
+ * Whether the on-demand font pack (#709) is installed. `null` while probing —
+ * treated as installed so a full/Docker install never flashes a nag. Only
+ * flips to `false` on a Tier A base-only install where the pack woff2 404s.
+ */
+function useFontPackInstalled(): boolean | null {
+  const [installed, setInstalled] = useState<boolean | null>(null)
+  useEffect(() => {
+    let active = true
+    void probeFontPackInstalled().then((result) => {
+      if (active) setInstalled(result)
+    })
+    return () => {
+      active = false
+    }
+  }, [])
+  return installed
+}
+
 /** Font select (many options — the one control kept as a dropdown). */
 function FontSelect({
   customize,
   knob,
   label,
+  fontPackInstalled,
   options,
 }: {
   customize: ThemeCustomizePageState
   knob: 'fontBody' | 'fontDisplay' | 'fontMono' | 'fontBrand'
   label: string
+  fontPackInstalled: boolean | null
   options: readonly KnobOption[]
 }) {
   const { t } = useTranslation()
@@ -248,11 +270,18 @@ function FontSelect({
         }}
       >
         <option value="">{t('admin.themeCustomize.themeDefault')}</option>
-        {options.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
+        {options.map((option) => {
+          // On a Tier A base-only install, fonts not in the base ZIP need the
+          // font pack; flag them so the picker never silently falls back.
+          const needsPack = fontPackInstalled === false && !isBaseBundledFontValue(option.value)
+          return (
+            <option key={option.value} value={option.value}>
+              {needsPack
+                ? `${option.label} · ${t('admin.themeCustomize.fontPackRequired')}`
+                : option.label}
+            </option>
+          )
+        })}
       </select>
     </FieldRow>
   )
@@ -383,6 +412,7 @@ export function BrandPanel({
 
 export function TypographyPanel({ customize }: { customize: ThemeCustomizePageState }) {
   const { t } = useTranslation()
+  const fontPackInstalled = useFontPackInstalled()
   return (
     <div>
       <PanelHead title={t('admin.themeWs.navType')} desc={t('admin.themeWs.descType')} />
@@ -392,28 +422,37 @@ export function TypographyPanel({ customize }: { customize: ThemeCustomizePageSt
         noteKey="admin.themeWs.scopeOverridesNote"
       />
       <WsCard title={t('admin.themeWs.cardFonts')}>
+        {fontPackInstalled === false && (
+          <Text muted variant="caption" className="mb-2 block">
+            {t('admin.themeCustomize.fontPackHint')}
+          </Text>
+        )}
         <FontSelect
           customize={customize}
           knob="fontBody"
           label={t('admin.themeCustomize.font')}
+          fontPackInstalled={fontPackInstalled}
           options={FONT_OPTIONS}
         />
         <FontSelect
           customize={customize}
           knob="fontDisplay"
           label={t('admin.themeCustomize.fontDisplay')}
+          fontPackInstalled={fontPackInstalled}
           options={DISPLAY_FONT_OPTIONS}
         />
         <FontSelect
           customize={customize}
           knob="fontMono"
           label={t('admin.themeCustomize.fontMono')}
+          fontPackInstalled={fontPackInstalled}
           options={MONO_FONT_OPTIONS}
         />
         <FontSelect
           customize={customize}
           knob="fontBrand"
           label={t('admin.themeCustomize.fontBrand')}
+          fontPackInstalled={fontPackInstalled}
           options={BRAND_FONT_OPTIONS}
         />
       </WsCard>

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -106,6 +106,9 @@ export const de: Partial<MessageCatalog> = {
   'admin.themeCustomize.fontDisplay': 'Display-Schrift',
   'admin.themeCustomize.fontMono': 'Monospace-Schrift',
   'admin.themeCustomize.fontBrand': 'Schriftart des Seitentitels',
+  'admin.themeCustomize.fontPackRequired': 'Schriftpaket',
+  'admin.themeCustomize.fontPackHint':
+    'Einige Schriftarten sind noch nicht installiert. Laden Sie das Schriftpaket-ZIP hoch, um alle Optionen zu aktivieren.',
   'admin.themeCustomize.brandSize': 'Größe des Seitentitels',
   'admin.themeCustomize.menuSize': 'Schriftgröße des Menüs',
   'admin.themeCustomize.width': 'Inhaltsbreite',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -113,6 +113,9 @@ export const en = {
   'admin.themeCustomize.fontDisplay': 'Display font',
   'admin.themeCustomize.fontMono': 'Mono font',
   'admin.themeCustomize.fontBrand': 'Site title font',
+  'admin.themeCustomize.fontPackRequired': 'font pack',
+  'admin.themeCustomize.fontPackHint':
+    'Some fonts are not installed yet. Upload the font pack ZIP to enable every option.',
   'admin.themeCustomize.brandSize': 'Site title size',
   'admin.themeCustomize.menuSize': 'Menu font size',
   'admin.themeCustomize.width': 'Content width',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -109,6 +109,9 @@ export const fr: Partial<MessageCatalog> = {
   'admin.themeCustomize.fontDisplay': "Police d'affichage",
   'admin.themeCustomize.fontMono': 'Police à chasse fixe',
   'admin.themeCustomize.fontBrand': 'Police du titre du site',
+  'admin.themeCustomize.fontPackRequired': 'pack de polices',
+  'admin.themeCustomize.fontPackHint':
+    'Certaines polices ne sont pas encore installées. Téléversez le ZIP du pack de polices pour activer toutes les options.',
   'admin.themeCustomize.brandSize': 'Taille du titre du site',
   'admin.themeCustomize.menuSize': 'Taille de police du menu',
   'admin.themeCustomize.width': 'Largeur du contenu',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -106,6 +106,9 @@ export const ja: Partial<MessageCatalog> = {
   'admin.themeCustomize.fontDisplay': '見出しフォント',
   'admin.themeCustomize.fontMono': 'モノスペースフォント',
   'admin.themeCustomize.fontBrand': 'サイトタイトルのフォント',
+  'admin.themeCustomize.fontPackRequired': 'フォントパック',
+  'admin.themeCustomize.fontPackHint':
+    '一部のフォントは未導入です。フォントパック ZIP をアップロードすると全ての選択肢が使えます。',
   'admin.themeCustomize.brandSize': 'サイトタイトルのサイズ',
   'admin.themeCustomize.menuSize': 'メニューの文字サイズ',
   'admin.themeCustomize.width': 'コンテンツ幅',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -107,6 +107,9 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.themeCustomize.fontDisplay': 'Fonte de títulos',
   'admin.themeCustomize.fontMono': 'Fonte monoespaçada',
   'admin.themeCustomize.fontBrand': 'Fonte do título do site',
+  'admin.themeCustomize.fontPackRequired': 'pacote de fontes',
+  'admin.themeCustomize.fontPackHint':
+    'Algumas fontes ainda não estão instaladas. Envie o ZIP do pacote de fontes para habilitar todas as opções.',
   'admin.themeCustomize.brandSize': 'Tamanho do título do site',
   'admin.themeCustomize.menuSize': 'Tamanho da fonte do menu',
   'admin.themeCustomize.width': 'Largura do conteúdo',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -106,6 +106,8 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.themeCustomize.fontDisplay': '标题字体',
   'admin.themeCustomize.fontMono': '等宽字体',
   'admin.themeCustomize.fontBrand': '站点标题字体',
+  'admin.themeCustomize.fontPackRequired': '字体包',
+  'admin.themeCustomize.fontPackHint': '部分字体尚未安装。上传字体包 ZIP 即可启用全部选项。',
   'admin.themeCustomize.brandSize': '站点标题字号',
   'admin.themeCustomize.menuSize': '菜单字号',
   'admin.themeCustomize.width': '内容宽度',

--- a/frontend/src/shared/lib/font-availability.test.ts
+++ b/frontend/src/shared/lib/font-availability.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   BASE_BUNDLED_FONT_FAMILIES,
   FONT_VALUE_TO_FAMILY,
@@ -37,8 +38,35 @@ describe('isBaseBundledFontValue', () => {
 })
 
 describe('probeFontPackInstalled', () => {
-  it('assumes installed when the Font Loading API is unavailable (SSR / jsdom)', async () => {
-    // jsdom provides no document.fonts, so the probe must not nag.
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function stubFetch(impl: () => Promise<Response>): void {
+    vi.stubGlobal('fetch', vi.fn(impl))
+  }
+
+  function jsonResponse(body: unknown, status = 200): Promise<Response> {
+    return Promise.resolve(new Response(JSON.stringify(body), { status }))
+  }
+
+  it('reports not-installed only when the marker says complete:false (Tier A base)', async () => {
+    stubFetch(() => jsonResponse({ complete: false }))
+    await expect(probeFontPackInstalled()).resolves.toBe(false)
+  })
+
+  it('reports installed when the marker says complete:true (base + pack)', async () => {
+    stubFetch(() => jsonResponse({ complete: true }))
+    await expect(probeFontPackInstalled()).resolves.toBe(true)
+  })
+
+  it('assumes installed when the marker is absent (Docker / production / dev → 404)', async () => {
+    stubFetch(() => Promise.resolve(new Response('Not found', { status: 404 })))
+    await expect(probeFontPackInstalled()).resolves.toBe(true)
+  })
+
+  it('assumes installed when the fetch fails (offline / SSR / tests)', async () => {
+    stubFetch(() => Promise.reject(new Error('network down')))
     await expect(probeFontPackInstalled()).resolves.toBe(true)
   })
 })

--- a/frontend/src/shared/lib/font-availability.test.ts
+++ b/frontend/src/shared/lib/font-availability.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BASE_BUNDLED_FONT_FAMILIES,
+  FONT_VALUE_TO_FAMILY,
+  isBaseBundledFontValue,
+  probeFontPackInstalled,
+} from './font-availability'
+
+describe('isBaseBundledFontValue', () => {
+  it('treats theme-default (undefined / empty) and system as always available', () => {
+    expect(isBaseBundledFontValue(undefined)).toBe(true)
+    expect(isBaseBundledFontValue('')).toBe(true)
+    expect(isBaseBundledFontValue('system')).toBe(true)
+  })
+
+  it('marks admin + default-theme + #818 fonts as base-bundled', () => {
+    for (const value of ['inter', 'saira', 'space-grotesk', 'bricolage']) {
+      expect(isBaseBundledFontValue(value)).toBe(true)
+    }
+  })
+
+  it('marks pack-only picker fonts as not base-bundled', () => {
+    for (const value of ['roboto', 'source-serif', 'playfair', 'archivo', 'oswald', 'space-mono']) {
+      expect(isBaseBundledFontValue(value)).toBe(false)
+    }
+  })
+
+  it('keeps every mapped family either base-bundled or explicitly pack-only', () => {
+    for (const family of Object.values(FONT_VALUE_TO_FAMILY)) {
+      expect(typeof family).toBe('string')
+    }
+    // The base set is a strict subset of the mapped families.
+    for (const family of BASE_BUNDLED_FONT_FAMILIES) {
+      expect(family.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('probeFontPackInstalled', () => {
+  it('assumes installed when the Font Loading API is unavailable (SSR / jsdom)', async () => {
+    // jsdom provides no document.fonts, so the probe must not nag.
+    await expect(probeFontPackInstalled()).resolves.toBe(true)
+  })
+})

--- a/frontend/src/shared/lib/font-availability.ts
+++ b/frontend/src/shared/lib/font-availability.ts
@@ -1,0 +1,85 @@
+/**
+ * On-demand font availability (#709).
+ *
+ * The Tier A release ZIP ships only a minimal font set; the rest travels in a
+ * separate "font pack" ZIP that a self-host installer may or may not have applied
+ * yet (see `tools/build-release.sh` step 3b). Docker/production builds bundle
+ * every font, so this module must degrade to "everything available" whenever the
+ * runtime probe cannot prove otherwise — never nag on a full install.
+ *
+ * `BASE_BUNDLED_FONT_FAMILIES` MUST stay in sync with `KEEP_FONT_FAMILIES` in
+ * `tools/build-release.sh` (the split allowlist).
+ */
+
+/**
+ * @font-face families guaranteed to ship inside the base release ZIP: the admin
+ * UI faces (see `src/fonts.ts`), the default public theme `consumer`
+ * (Bricolage Grotesque), and the #818 public-site faces. Family names here match
+ * the CSS `font-family` used by @fontsource / the #818 subset.
+ */
+export const BASE_BUNDLED_FONT_FAMILIES: ReadonlySet<string> = new Set([
+  'Inter',
+  'Saira Semi Condensed',
+  'Space Grotesk',
+  'JetBrains Mono',
+  'Bricolage Grotesque',
+  'Zen Kaku Gothic New',
+  'IBM Plex Mono',
+])
+
+/**
+ * Map a font-picker option `value` (see `theme-customization.ts`) to its primary
+ * @font-face family. `system` (and any unlisted value) resolves to `undefined` =
+ * no webfont required, so it is always considered available.
+ */
+export const FONT_VALUE_TO_FAMILY: Readonly<Record<string, string>> = {
+  inter: 'Inter',
+  roboto: 'Roboto',
+  'source-serif': 'Source Serif 4',
+  saira: 'Saira Semi Condensed',
+  'space-grotesk': 'Space Grotesk',
+  playfair: 'Playfair Display',
+  bricolage: 'Bricolage Grotesque',
+  archivo: 'Archivo',
+  oswald: 'Oswald',
+  'space-mono': 'Space Mono',
+}
+
+/**
+ * True when a picker option is guaranteed present in the base ZIP (or needs no
+ * webfont at all). Options for which this is false require the on-demand font
+ * pack on a Tier A install.
+ */
+export function isBaseBundledFontValue(value: string | undefined): boolean {
+  if (value === undefined || value === '') return true
+  const family = FONT_VALUE_TO_FAMILY[value]
+  return family === undefined || BASE_BUNDLED_FONT_FAMILIES.has(family)
+}
+
+/**
+ * Representative pack-only family. The font pack is applied atomically (one ZIP),
+ * so probing a single non-base family is enough to decide whether the whole pack
+ * is present. Playfair Display is a common display pick and pack-only.
+ */
+const PACK_PROBE_FAMILY = 'Playfair Display'
+
+/**
+ * Probe whether the on-demand font pack is installed. Attempts to load a
+ * representative pack-only face: on a full install the woff2 exists and the load
+ * resolves; on a base-only Tier A install the file 404s and the load rejects.
+ *
+ * Returns `true` (assume installed → do not nag) whenever the CSS Font Loading
+ * API is unavailable (SSR, jsdom) so tests and server render never flag fonts.
+ */
+export async function probeFontPackInstalled(): Promise<boolean> {
+  if (typeof document === 'undefined' || !('fonts' in document)) return true
+  try {
+    // `document.fonts.load` fetches the matching @font-face; a missing woff2
+    // rejects → pack absent. A resolved load (with or without matched faces)
+    // means the file is reachable → pack present.
+    await document.fonts.load(`16px "${PACK_PROBE_FAMILY}"`)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/frontend/src/shared/lib/font-availability.ts
+++ b/frontend/src/shared/lib/font-availability.ts
@@ -57,29 +57,40 @@ export function isBaseBundledFontValue(value: string | undefined): boolean {
 }
 
 /**
- * Representative pack-only family. The font pack is applied atomically (one ZIP),
- * so probing a single non-base family is enough to decide whether the whole pack
- * is present. Playfair Display is a common display pick and pack-only.
+ * Static marker the Tier A base ZIP drops at the app docroot (`font-pack.json`).
+ * `build-release.sh` writes `{"complete": false}` into the base ZIP and
+ * `{"complete": true}` into the font pack, which overwrites it on install.
+ * Resolved relative to `document.baseURI` so subdirectory installs work.
  */
-const PACK_PROBE_FAMILY = 'Playfair Display'
+const FONT_PACK_MARKER = 'font-pack.json'
 
 /**
- * Probe whether the on-demand font pack is installed. Attempts to load a
- * representative pack-only face: on a full install the woff2 exists and the load
- * resolves; on a base-only Tier A install the file 404s and the load rejects.
+ * Probe whether the on-demand font pack is installed. The admin font picker does
+ * not itself load the public/theme @font-face rules (those live in the public
+ * shell / preview iframe), so a Font Loading API check would be blind here.
+ * Instead we fetch the docroot marker that `build-release.sh` ships:
  *
- * Returns `true` (assume installed → do not nag) whenever the CSS Font Loading
- * API is unavailable (SSR, jsdom) so tests and server render never flag fonts.
+ * - Tier A base-only install → marker served with `complete: false` → not installed.
+ * - Tier A base + font pack   → pack overwrote the marker to `complete: true`.
+ * - Docker / production / dev → no marker file (front controller 404s) → treated
+ *   as installed, so a full build never nags.
+ *
+ * Any fetch/parse failure resolves to `true` (assume installed) so SSR, tests,
+ * and non-Tier-A installs never flag fonts.
  */
 export async function probeFontPackInstalled(): Promise<boolean> {
-  if (typeof document === 'undefined' || !('fonts' in document)) return true
+  if (typeof fetch === 'undefined' || typeof document === 'undefined') return true
   try {
-    // `document.fonts.load` fetches the matching @font-face; a missing woff2
-    // rejects → pack absent. A resolved load (with or without matched faces)
-    // means the file is reachable → pack present.
-    await document.fonts.load(`16px "${PACK_PROBE_FAMILY}"`)
+    const response = await fetch(new URL(FONT_PACK_MARKER, document.baseURI), {
+      headers: { Accept: 'application/json' },
+    })
+    if (!response.ok) return true
+    const data: unknown = await response.json()
+    if (data !== null && typeof data === 'object' && 'complete' in data) {
+      return (data as { complete?: unknown }).complete !== false
+    }
     return true
   } catch {
-    return false
+    return true
   }
 }

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -72,6 +72,84 @@ cp -r "$ROOT/frontend/dist/assets" "$STAGE/public_html/assets"
 cp -r "$ROOT/frontend/dist/theme-thumbnails" "$STAGE/public_html/theme-thumbnails"
 
 # ----------------------------------------
+# 3b. フォントのオンデマンド分離（#709）
+# ----------------------------------------
+# 配布 ZIP の 8 割超は @fontsource の woff/woff2（特に CJK: Shippori Mincho /
+# Noto Sans JP / Noto Sans SC で ~48MB）。共有ホスティング勢が 66MB を FTP で
+# 上げるのは重いので、base zip には「設置直後に見た目が破綻しない最小セット」だけ
+# を残し、残りは別アーティファクト nene-records-fonts-<version>.zip として切り出す。
+# 両者は同一ビルドの成果物なので woff2 のハッシュ名（＝CSS が参照するパス）は完全
+# 一致し、フォントパックを FTP で上書き展開すれば全フォントが揃う。
+#
+# base 同梱（keep）= 管理 UI フォント（fonts.ts の Inter/Saira/Space Grotesk/
+# JetBrains）＋既定公開テーマ consumer の表示フォント Bricolage Grotesque ＋
+# #818 の公開サイトフォント（Zen Kaku Gothic New subset / IBM Plex Mono）。
+# それ以外（フォントピッカーの選択肢・テーマ固有フォント・CJK 大物）はパックへ。
+#
+# Docker/本番ビルド（docker/php/Dockerfile.prod）はこのスクリプトを通らないので
+# 影響しない（全部入りのまま）。keep 一覧を変える場合は frontend 側の
+# BASE_BUNDLED_FONT_FAMILIES（src/shared/lib/font-availability.ts）と揃えること。
+KEEP_FONT_FAMILIES=(
+    inter                          # 管理 UI body（--font-sans 既定）
+    saira-semi-condensed           # 管理 UI display（--font-display 既定）
+    space-grotesk                  # 管理 UI chrome（--font-chrome 既定）
+    jetbrains-mono                 # 管理 UI mono（--font-mono 既定）
+    bricolage-grotesque            # 既定公開テーマ consumer の display/chrome
+    zen-kaku-gothic-new-jp-subset  # #818 公開サイト日本語見出し/本文（subset 同梱）
+    ibm-plex-mono                  # #818 公開サイト mono ラベル/数字
+)
+FONTS_STAGE="$DIST/build/fonts-stage"
+mkdir -p "$FONTS_STAGE/public_html/assets"
+echo "→ splitting fonts (base keep-set vs on-demand pack)..."
+kept_fonts=0
+moved_fonts=0
+shopt -s nullglob
+for font in "$STAGE/public_html/assets/"*.woff "$STAGE/public_html/assets/"*.woff2; do
+    base_name="$(basename "$font")"
+    keep=0
+    for family in "${KEEP_FONT_FAMILIES[@]}"; do
+        # 末尾 '-' 境界で照合し saira-semi-condensed と saira-condensed 等の前方
+        # 一致衝突を防ぐ（Vite 出力は <family>-<subset>-<weight>-<hash>.woff2）。
+        case "$base_name" in
+            "$family"-*)
+                keep=1
+                break
+                ;;
+        esac
+    done
+    if [ "$keep" -eq 1 ]; then
+        kept_fonts=$((kept_fonts + 1))
+    else
+        mv "$font" "$FONTS_STAGE/public_html/assets/"
+        moved_fonts=$((moved_fonts + 1))
+    fi
+done
+shopt -u nullglob
+echo "  fonts: base に $kept_fonts 件 / フォントパックへ $moved_fonts 件"
+
+# フォントパックの設置手順（shell 無しの共有ホスティング前提）を同梱する。
+cat > "$FONTS_STAGE/READ-ME-FIRST.txt" <<'FONTPACK_README'
+NeNe Records — フォントパック / Font Pack
+========================================
+
+この ZIP は本体（nene-records-<version>.zip）から切り出した追加フォントです。
+本体だけでも管理画面・既定テーマ・日本語見出しは正しく表示されますが、テーマの
+フォントピッカーで選べる全フォント（Playfair Display・Oswald・Source Serif 4・
+CJK の Noto Sans JP/SC・Shippori Mincho など）を使うにはこのパックが必要です。
+
+導入方法（FTP）:
+  1. 本体と同じインストール先（public_html/ がある階層）に、この ZIP の中身を
+     フォルダ構成ごと **上書き** アップロードします。
+  2. public_html/assets/ に woff2/woff が追加されれば完了です（本体側の同名
+     ファイルとは衝突しません。ハッシュ名なので純粋に増えるだけです）。
+  3. 反映確認は管理画面「外観 > カスタマイズ」のフォント選択で、追加フォントの
+     「（フォントパック）」注記が消えることで分かります。
+
+バージョンは必ず本体 ZIP と同じ <version> のフォントパックを使ってください
+（ハッシュ名がビルドごとに変わるため、版がズレると反映されません）。
+FONTPACK_README
+
+# ----------------------------------------
 # 4. var/（空・書き込み先）
 # ----------------------------------------
 mkdir -p "$STAGE/var"
@@ -115,18 +193,29 @@ mkdir -p "$DIST"
 rm -f "$DIST/$ZIP_NAME"
 (cd "$STAGE" && zip -qr "$DIST/$ZIP_NAME" . -x "*.DS_Store")
 
+# フォントパック（#709）— base から切り出した残りフォントを別 ZIP に。
+FONTS_ZIP_NAME="nene-records-fonts-${VERSION}.zip"
+echo "→ zip: dist/${FONTS_ZIP_NAME}..."
+rm -f "$DIST/$FONTS_ZIP_NAME"
+(cd "$FONTS_STAGE" && zip -qr "$DIST/$FONTS_ZIP_NAME" . -x "*.DS_Store")
+
 # ----------------------------------------
 # 8. サイズ実測報告（受入④）
 # ----------------------------------------
 RAW_SIZE="$(du -sh "$STAGE" | cut -f1)"
 ZIP_SIZE="$(du -sh "$DIST/$ZIP_NAME" | cut -f1)"
-FONT_SIZE="$(du -ch "$STAGE/public_html/assets/"*.woff* 2>/dev/null | tail -1 | cut -f1)"
+FONTS_ZIP_SIZE="$(du -sh "$DIST/$FONTS_ZIP_NAME" | cut -f1)"
+BASE_FONT_SIZE="$(du -ch "$STAGE/public_html/assets/"*.woff* 2>/dev/null | tail -1 | cut -f1)"
 
 rm -rf "$DIST/build"
 
 echo ""
-echo "✓ ビルド完了: dist/${ZIP_NAME}"
+echo "✓ ビルド完了"
+echo "  本体:         dist/${ZIP_NAME}"
+echo "  フォントパック: dist/${FONTS_ZIP_NAME}"
 echo "  nene2:        ${NENE2_RESOLVED}"
 echo "  raw:          ${RAW_SIZE}"
-echo "  zip:          ${ZIP_SIZE}"
-echo "  内フォント:   ${FONT_SIZE}（woff/woff2・削減は別 Issue）"
+echo "  base zip:     ${ZIP_SIZE}（内フォント ${BASE_FONT_SIZE} / keep ${kept_fonts} 件）"
+echo "  fonts zip:    ${FONTS_ZIP_SIZE}（オンデマンド ${moved_fonts} 件）"
+echo ""
+echo "  → GitHub Release には両 ZIP と各 .sha256 を添付する（docs/install-tier-a.md）。"

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -127,6 +127,16 @@ done
 shopt -u nullglob
 echo "  fonts: base に $kept_fonts 件 / フォントパックへ $moved_fonts 件"
 
+# フォントパック導入検出用マーカー（#709）。管理画面はフォントピッカーの @font-face を
+# 読み込まない（公開フォントは公開シェル/プレビュー iframe 側）ため、フォントの load
+# 試行では pack 有無を判定できない。そこで docroot 直下に静的マーカーを置き、frontend は
+# これを fetch して判定する（public_html/.htaccess は実在ファイルを素通しするので、
+# 存在すれば Apache がそのまま JSON を返す）。base は complete:false、フォントパックが
+# 同名ファイルで上書きして complete:true にする。Docker/本番/dev はこのファイルを持た
+# ない（front controller が 404 を返す）ので frontend は「完備」とみなし何も表示しない。
+printf '{"complete":false,"version":"%s"}\n' "$VERSION" > "$STAGE/public_html/font-pack.json"
+printf '{"complete":true,"version":"%s"}\n' "$VERSION" > "$FONTS_STAGE/public_html/font-pack.json"
+
 # フォントパックの設置手順（shell 無しの共有ホスティング前提）を同梱する。
 cat > "$FONTS_STAGE/READ-ME-FIRST.txt" <<'FONTPACK_README'
 NeNe Records — フォントパック / Font Pack


### PR DESCRIPTION
## 目的

Tier A 配布 ZIP（#707）は 66MB で、うち約53MB が @fontsource の woff/woff2
（特に CJK: Shippori Mincho / Noto Sans JP / Noto Sans SC で ~48MB）。共有
ホスティング勢が 66MB を FTP で上げるのは重い。base ZIP をフォント最小セットに
絞り、残りを別アーティファクト「フォントパック」に分離してオンデマンド化する。

Closes #709

## 変更点

- **`tools/build-release.sh`**: ビルド後、`public_html/assets/` の woff/woff2 を
  keep 一覧で分割する。
  - keep（base 同梱）= 管理 UI フォント（Inter / Saira Semi Condensed /
    Space Grotesk / JetBrains Mono）＋既定公開テーマ **consumer** の表示フォント
    Bricolage Grotesque ＋ #818 公開サイトフォント（Zen Kaku Gothic New subset /
    IBM Plex Mono）。
  - 残りは `dist/nene-records-fonts-<version>.zip`（フォントパック）へ。導入手順
    `READ-ME-FIRST.txt` を同梱。
  - 両 ZIP は同一ビルドの成果物なので **woff2 のハッシュ名（＝CSS 参照パス）が完全
    一致**。フォントパックを FTP で上書き展開すれば全フォントが揃う（パス整合）。
  - **Docker/本番ビルド（`docker/php/Dockerfile.prod`）はこのスクリプトを通らない
    ので影響なし**（全部入りのまま）。
  - 導入検出用マーカー `public_html/font-pack.json` を出力（base=`complete:false`・
    フォントパックが同名で上書きして `complete:true`）。
- **frontend（未取得フォントの安全側 UX）**:
  - `src/shared/lib/font-availability.ts` — base 同梱一覧 `BASE_BUNDLED_FONT_FAMILIES`
    （ビルド script の keep と対応）と、フォントパック導入有無の runtime 検出
    `probeFontPackInstalled`。
  - **検出方式＝docroot マーカー fetch**。管理画面のフォントピッカーは公開/テーマの
    `@font-face` を読み込まない（公開フォントは公開シェル/プレビュー iframe 側）ため、
    Font Loading API では admin 文脈で判定できない。そこで `document.baseURI` 起点で
    `font-pack.json` を fetch し、`complete:false` のときだけ未導入と判定する。
    404・失敗・マーカー不在（Docker/本番/dev）は「導入済み」とみなし誤検知しない。
  - 外観 > カスタマイズのフォント選択で、pack 未導入時のみ未導入フォントに
    「（フォントパック）」注記＋上部に導入ヒントを表示。フォールバックは元々 CSS
    スタックで graceful（未導入フォント選択時はシステムフォント描画で破綻しない）。
  - i18n キー 2 件を 6 ロケール全てに追加。
- **`docs/install-tier-a.md`**: 両 ZIP の Release 添付運用と、shell 無し共有
  ホスティング向けの FTP フォントパック導入手順（正）を明記。
- **(b) HTTP 自動取得は分離**: 管理画面/インストーラからの HTTP ダウンロード＋
  `ZipArchive` 展開はバックエンド＋フロント＋OpenAPI＋テストにまたがり PR が
  大きくなりすぎるため、follow-up #840 に分離した（#709 方針どおり）。

## 検証

`bash tools/build-release.sh 0.5.2-test` で実ビルドした実測（nene2 v1.10.0 解決）:

| アーティファクト | before（#709 前・全部入り） | after |
| --- | --- | --- |
| 本体 base ZIP | 66MB | **14MB**（内フォント 2.0MB / keep 51 woff2） |
| フォントパック ZIP | —（存在せず） | **52MB**（オンデマンド 482 woff2） |
| 合計 | 66MB | 66MB（不変・欠落なし） |

- base ZIP の非フォント下限が約12MB のため base は約14MB（Issue の「約11MB」は
  font-less 概算）。フォント自体は 53MB → 2.0MB に圧縮。
- **分割整合を実測で確認**: base(51 woff2) と fonts(482 woff2) は woff2 では重複ゼロ。
  base 展開 → fonts を上書き展開すると woff2 が 51 → **533 に復元**し、フルビルドの
  `frontend/dist/assets` の woff2 セットと **完全一致**。マーカー `font-pack.json` の
  み両 ZIP に存在し pack が base を上書きする設計。
- base ZIP に既定テーマ（Bricolage Grotesque）・#818（Zen Kaku Gothic New /
  IBM Plex Mono）・管理 UI フォントの woff2 が残存することを確認。
- `npm run check --prefix frontend` 全緑（type-check / lint / prettier / test
  ＋新規 `font-availability.test.ts` 8 件 / validate:themes / knip / storybook）。
- backend（PHP）は不変のため `composer check` 対象外。

## チェックリスト

Verified by: **nene-records リポ担当リナ**

- [x] Issue-driven（#709）
- [x] 品質ゲート（frontend check 全緑）
- [x] ビルド産物（dist/）はコミットしない
- [x] follow-up #840 起票

🤖 Generated with [Claude Code](https://claude.com/claude-code)