### PR TITLE
feat(org-export): メディア実ファイルを zip 同梱で移送する（#798）

### DIFF
--- a/docs/install-tier-a.md
+++ b/docs/install-tier-a.md
@@ -65,12 +65,35 @@ cron を設定しない場合、即時公開・閲覧などの基本機能は動
 
 SaaS 側（例 `ayane.nene-records.com`）で制作したサイトを、この Tier A 設置へ丸ごと移す手順。
 コンテンツ（entity/フィールド/ブロック本文/リレーション）・タグ・ナビ/メニュー・ウィジェット・
-テーマ・設定（テーマ選択/レイアウト/フロントページ/カスタム permalink 等）・メディア DB 行・
-301 リダイレクトが移送対象。
+テーマ・設定（テーマ選択/レイアウト/フロントページ/カスタム permalink 等）・メディア（DB 行＋
+実ファイル）・301 リダイレクト・コメント・Webhook・通知チャンネル・ユーザプロフィールが移送対象。
 
-### 1. 移送元で JSON を書き出す
+### 推奨: zip 一括移送（DB＋メディア実ファイルを 1 ファイルで）（#798）
 
-SaaS 側の superadmin で org export API を叩き、JSON を 1 ファイルに保存する:
+`tools/export-org.php` は DB payload（`export.json`）とメディア原本（`var/media/` を
+`storage_key` の相対パスのまま同梱）を含む単一 zip を書き出す。`tools/import-org.php` が
+その zip を展開し、原本を `var/media/` へ配置してから DB 行を取り込むので、画像入りサイトが
+1 操作で移送先に表示される。派生画像（サムネイル等）は移送先で **オンデマンド再生成** される
+ため同梱しない（原本のみ）。**ローカルディスク保存（`MEDIA_STORAGE_DRIVER=local`）専用**。
+
+```
+# 1) 移送元で zip を書き出す（SSH シェルから）
+php tools/export-org.php --org=<id|slug> --out=org-export.zip
+#   docker: docker compose exec -T app php tools/export-org.php --org=aozora --out=/tmp/aozora.zip
+
+# 2) zip を移送先へ転送する（scp/rsync/FTP どれでも 1 ファイル）
+scp org-export.zip user@あなたのホスト:/path/to/app/
+
+# 3) 移送先で取り込む（DB 行＋メディア原本が同時に入る）
+php tools/import-org.php --file=org-export.zip --org=<id|slug>
+```
+
+### 代替: JSON export ＋ メディア実ファイル別送（rsync/FTP）
+
+zip が使えない場合（S3 ストレージ利用時・巨大メディアを個別転送したい場合など）は、従来どおり
+JSON export とメディアを別々に転送する。
+
+**1. 移送元で JSON を書き出す** — superadmin で org export API を叩く（media は DB 行のみ）:
 
 ```
 curl -fsS -H "Authorization: Bearer <superadmin-token>" \
@@ -78,33 +101,38 @@ curl -fsS -H "Authorization: Bearer <superadmin-token>" \
   -o org-export.json
 ```
 
-### 2. メディア実ファイルを転送する
-
-export JSON には media の **DB 行のみ** が入る。実ファイル（原本＋派生画像）は別送する。
-移送元の `var/media/` を、この設置の `var/media/` へ丸ごとコピーする（相対パス＝`storage_key`
-を保つこと。URL も相対で解決されるためブロック本文中の画像もそのまま表示される）:
+**2. メディア実ファイルを転送する** — 移送元の `var/media/` を、この設置の `var/media/` へ
+丸ごとコピーする（相対パス＝`storage_key` を保つこと。URL も相対で解決されるためブロック本文中の
+画像もそのまま表示される）:
 
 ```
 # SSH がある場合（HETEML 等）
 rsync -avz ./var/media/ user@あなたのホスト:/path/to/app/var/media/
 
 # FTP/SFTP しか無い場合: var/media/ 配下を同じ階層のままアップロード
-#   var/media/originals/... と var/media/derivatives/... を保持する
 ```
 
-### 3. この設置で JSON を取り込む（CLI）
-
-Tier A の installer は org admin しか作らず、export/import API は superadmin 専用のため、
-取り込みは同梱の CLI ツールで行う（SSH シェルから実行）:
+**3. この設置で JSON を取り込む（CLI）** — export/import API は superadmin 専用で Tier A の
+installer は org admin しか作らないため、取り込みは同梱の CLI ツールで行う:
 
 ```
 php tools/import-org.php --file=org-export.json --org=<id|slug>
 # 例: php tools/import-org.php --file=org-export.json --org=default
 ```
 
+### 取り込みの挙動（zip / JSON 共通）
+
 取り込みは 1 トランザクションで走り、失敗時は org 無傷（部分取り込みなし）。設置時に
 シード済みのコンテンツタイプ（posts/pages）・設定定義は **マージ**される（重複しない・
 移送元の値で更新）。取り込み後、公開ページの見た目と URL が移送元と一致することを確認する。
+
+- **Webhook の secret は移送されない**（移送先で再設定する。`webhooks` / `webhook_deliveries`
+  の secret はエクスポートに含めない）。
+- **ユーザ本体（パスワードハッシュ・ロール）は移送されない**。`user_profiles` は移送先に
+  同一 email のユーザが居れば再アタッチ、居なければ skip し件数を報告する。
+- **S3 ストレージ（`MEDIA_STORAGE_DRIVER=s3`）では zip 移送は使えない**（原本がバケットにあり
+  `var/media/` に無いため、export/import 双方が明示エラーで停止する）。バケットを別途複製し、
+  JSON export を使うこと。
 
 > **注意（現行の制限）**: ブロック本文や一部設定（`home_hero` / `footer_config` 等）の JSON に
 > 埋め込まれた **media URL・entity 参照は書き換えられない**（`logo_media_id` と

--- a/src/OrgExport/ExportOrganizationHandler.php
+++ b/src/OrgExport/ExportOrganizationHandler.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace NeNeRecords\OrgExport;
 
 use Nene2\Error\ProblemDetailsResponseFactory;
-use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
 use NeNeRecords\Organization\OrganizationRepositoryInterface;
@@ -17,15 +16,18 @@ use Psr\Http\Server\RequestHandlerInterface;
  * Exports all tenant-scoped data for a given organization as a JSON payload.
  *
  * GET /api/v1/superadmin/organizations/{id}/export
+ *
+ * This endpoint returns DB rows only. Media originals are transported by the CLI
+ * zip flow (tools/export-org.php → tools/import-org.php, #798), which reuses the
+ * same {@see OrgExportPayloadBuilder} for the DB half.
  */
 final readonly class ExportOrganizationHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private OrgExportRepositoryInterface $repository,
+        private OrgExportPayloadBuilder $payloadBuilder,
         private OrganizationRepositoryInterface $orgs,
         private JsonResponseFactory $json,
         private ProblemDetailsResponseFactory $problemDetails,
-        private ClockInterface $clock,
     ) {
     }
 
@@ -44,40 +46,6 @@ final readonly class ExportOrganizationHandler implements RequestHandlerInterfac
             );
         }
 
-        $now = $this->clock->now()->format('c');
-
-        $payload = [
-            'meta'             => [
-                'exported_at'     => $now,
-                'organization_id' => $id,
-            ],
-            'entity_types'     => $this->repository->findAllEntityTypes($id),
-            'entities'         => $this->repository->findAllEntities($id),
-            'field_defs'       => $this->repository->findAllFieldDefs($id),
-            'text_fields'      => $this->repository->findAllTextFields($id),
-            'int_fields'       => $this->repository->findAllIntFields($id),
-            'enum_fields'      => $this->repository->findAllEnumFields($id),
-            'bool_fields'      => $this->repository->findAllBoolFields($id),
-            'datetime_fields'  => $this->repository->findAllDatetimeFields($id),
-            'tags'             => $this->repository->findAllTags($id),
-            'entity_tags'      => $this->repository->findAllEntityTags($id),
-            'navigation_items' => $this->repository->findAllNavigationItems($id),
-            'setting_defs'     => $this->repository->findAllSettingDefs($id),
-            'setting_values'   => $this->repository->findAllSettingValues($id),
-            'media'            => $this->repository->findAllMedia($id),
-            'menus'            => $this->repository->findAllMenus($id),
-            'widgets'          => $this->repository->findAllWidgets($id),
-            'themes'           => $this->repository->findAllThemes($id),
-            'blocks_fields'    => $this->repository->findAllBlocksFields($id),
-            'entity_relations' => $this->repository->findAllEntityRelations($id),
-            'url_redirects'    => $this->repository->findAllUrlRedirects($id),
-            'comments'         => $this->repository->findAllComments($id),
-            'webhooks'         => $this->repository->findAllWebhooks($id),
-            'webhook_deliveries' => $this->repository->findAllWebhookDeliveries($id),
-            'notification_channels' => $this->repository->findAllNotificationChannels($id),
-            'user_profiles'    => $this->repository->findAllUserProfiles($id),
-        ];
-
-        return $this->json->create($payload);
+        return $this->json->create($this->payloadBuilder->build($id));
     }
 }

--- a/src/OrgExport/OrgExportPayloadBuilder.php
+++ b/src/OrgExport/OrgExportPayloadBuilder.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgExport;
+
+use Nene2\Http\ClockInterface;
+
+/**
+ * Builds the tenant-scoped export payload for one organization.
+ *
+ * Single source of truth for the payload shape, shared by the HTTP
+ * {@see ExportOrganizationHandler} and the CLI tools/export-org.php so a new
+ * table is only ever added in one place.
+ */
+final readonly class OrgExportPayloadBuilder
+{
+    public function __construct(
+        private OrgExportRepositoryInterface $repository,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    /** @return array<string, mixed> */
+    public function build(int $orgId): array
+    {
+        return [
+            'meta'                  => [
+                'exported_at'     => $this->clock->now()->format('c'),
+                'organization_id' => $orgId,
+            ],
+            'entity_types'          => $this->repository->findAllEntityTypes($orgId),
+            'entities'              => $this->repository->findAllEntities($orgId),
+            'field_defs'            => $this->repository->findAllFieldDefs($orgId),
+            'text_fields'           => $this->repository->findAllTextFields($orgId),
+            'int_fields'            => $this->repository->findAllIntFields($orgId),
+            'enum_fields'           => $this->repository->findAllEnumFields($orgId),
+            'bool_fields'           => $this->repository->findAllBoolFields($orgId),
+            'datetime_fields'       => $this->repository->findAllDatetimeFields($orgId),
+            'tags'                  => $this->repository->findAllTags($orgId),
+            'entity_tags'           => $this->repository->findAllEntityTags($orgId),
+            'navigation_items'      => $this->repository->findAllNavigationItems($orgId),
+            'setting_defs'          => $this->repository->findAllSettingDefs($orgId),
+            'setting_values'        => $this->repository->findAllSettingValues($orgId),
+            'media'                 => $this->repository->findAllMedia($orgId),
+            'menus'                 => $this->repository->findAllMenus($orgId),
+            'widgets'               => $this->repository->findAllWidgets($orgId),
+            'themes'                => $this->repository->findAllThemes($orgId),
+            'blocks_fields'         => $this->repository->findAllBlocksFields($orgId),
+            'entity_relations'      => $this->repository->findAllEntityRelations($orgId),
+            'url_redirects'         => $this->repository->findAllUrlRedirects($orgId),
+            'comments'              => $this->repository->findAllComments($orgId),
+            'webhooks'              => $this->repository->findAllWebhooks($orgId),
+            'webhook_deliveries'    => $this->repository->findAllWebhookDeliveries($orgId),
+            'notification_channels' => $this->repository->findAllNotificationChannels($orgId),
+            'user_profiles'         => $this->repository->findAllUserProfiles($orgId),
+        ];
+    }
+}

--- a/src/OrgExport/OrgExportServiceProvider.php
+++ b/src/OrgExport/OrgExportServiceProvider.php
@@ -48,24 +48,37 @@ final readonly class OrgExportServiceProvider implements ServiceProviderInterfac
                 },
             )
             ->set(
+                OrgExportPayloadBuilder::class,
+                static function (ContainerInterface $c): OrgExportPayloadBuilder {
+                    $repo  = $c->get(OrgExportRepositoryInterface::class);
+                    $clock = $c->get(ClockInterface::class);
+                    if (
+                        !$repo instanceof OrgExportRepositoryInterface
+                        || !$clock instanceof ClockInterface
+                    ) {
+                        throw new LogicException('OrgExportPayloadBuilder dependencies are invalid.');
+                    }
+
+                    return new OrgExportPayloadBuilder($repo, $clock);
+                },
+            )
+            ->set(
                 ExportOrganizationHandler::class,
                 static function (ContainerInterface $c): ExportOrganizationHandler {
-                    $repo    = $c->get(OrgExportRepositoryInterface::class);
+                    $builder = $c->get(OrgExportPayloadBuilder::class);
                     $orgs    = $c->get(OrganizationRepositoryInterface::class);
                     $json    = $c->get(JsonResponseFactory::class);
                     $problem = $c->get(ProblemDetailsResponseFactory::class);
-                    $clock   = $c->get(ClockInterface::class);
                     if (
-                        !$repo instanceof OrgExportRepositoryInterface
+                        !$builder instanceof OrgExportPayloadBuilder
                         || !$orgs instanceof OrganizationRepositoryInterface
                         || !$json instanceof JsonResponseFactory
                         || !$problem instanceof ProblemDetailsResponseFactory
-                        || !$clock instanceof ClockInterface
                     ) {
                         throw new LogicException('ExportOrganizationHandler dependencies are invalid.');
                     }
 
-                    return new ExportOrganizationHandler($repo, $orgs, $json, $problem, $clock);
+                    return new ExportOrganizationHandler($builder, $orgs, $json, $problem);
                 },
             )
             ->set(

--- a/src/OrgExport/OrgExportZip.php
+++ b/src/OrgExport/OrgExportZip.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgExport;
+
+use RuntimeException;
+use ZipArchive;
+
+/**
+ * Single-file org transport archive (#798).
+ *
+ * Layout:
+ *   export.json          the DB payload ({@see OrgExportPayloadBuilder})
+ *   media/<storage_key>  each media original, at its storage-relative path
+ *
+ * Only originals are bundled — image derivatives are regenerated on demand by
+ * {@see \NeNeRecords\Media\ServeDerivativeHandler} on the target, so they never
+ * need to travel. Originals are added with ZipArchive::addFile (streamed from
+ * disk) and extracted through the zip:// stream wrapper (streamed to disk), so a
+ * large media library is never held in memory in full. Local-disk storage only:
+ * with the S3 driver the originals do not live under $mediaRoot and the caller
+ * must refuse the zip flow (see tools/export-org.php / tools/import-org.php).
+ */
+final class OrgExportZip
+{
+    private const PAYLOAD_ENTRY = 'export.json';
+    private const MEDIA_PREFIX  = 'media/';
+
+    /**
+     * Write $payload plus its media originals to a new zip at $zipPath.
+     *
+     * @param  array<string, mixed>                        $payload    export payload (must contain "media")
+     * @param  string                                      $mediaRoot  absolute path to var/media
+     * @return array{added: int, missing: list<string>}                originals bundled / storage keys not found on disk
+     */
+    public static function create(string $zipPath, array $payload, string $mediaRoot): array
+    {
+        $zip = new ZipArchive();
+        if ($zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+            throw new RuntimeException('Failed to create archive: ' . $zipPath);
+        }
+
+        $json = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if ($json === false) {
+            $zip->close();
+            throw new RuntimeException('Failed to encode export payload as JSON.');
+        }
+        if (!$zip->addFromString(self::PAYLOAD_ENTRY, $json)) {
+            $zip->close();
+            throw new RuntimeException('Failed to add export.json to the archive.');
+        }
+
+        $root    = rtrim($mediaRoot, '/');
+        $added   = 0;
+        $missing = [];
+        foreach (self::storageKeys($payload) as $key) {
+            $src = self::safePath($root, $key);
+            if ($src === null || !is_file($src)) {
+                $missing[] = $key;
+                continue;
+            }
+            if (!$zip->addFile($src, self::MEDIA_PREFIX . $key)) {
+                $zip->close();
+                throw new RuntimeException('Failed to add media file to the archive: ' . $key);
+            }
+            $added++;
+        }
+
+        if ($zip->close() !== true) {
+            throw new RuntimeException('Failed to finalize archive: ' . $zipPath);
+        }
+
+        return ['added' => $added, 'missing' => $missing];
+    }
+
+    /**
+     * Read $zipPath: decode its payload and place each media original under
+     * $mediaRoot, preserving the storage_key relative path.
+     *
+     * @param  string                                                        $mediaRoot  absolute path to var/media
+     * @return array{payload: array<string, mixed>, placed: int, missing: list<string>}
+     */
+    public static function open(string $zipPath, string $mediaRoot): array
+    {
+        $zip = new ZipArchive();
+        if ($zip->open($zipPath) !== true) {
+            throw new RuntimeException('Failed to open archive: ' . $zipPath);
+        }
+
+        $raw = $zip->getFromName(self::PAYLOAD_ENTRY);
+        if ($raw === false) {
+            $zip->close();
+            throw new RuntimeException('Archive does not contain export.json — not an org-export zip.');
+        }
+        $zip->close();
+
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new RuntimeException('export.json is not valid JSON: ' . $e->getMessage(), 0, $e);
+        }
+        if (!is_array($decoded) || !isset($decoded['meta'])) {
+            throw new RuntimeException('export.json is not an org-export payload (missing "meta").');
+        }
+        /** @var array<string, mixed> $payload */
+        $payload = $decoded;
+
+        $root    = rtrim($mediaRoot, '/');
+        $placed  = 0;
+        $missing = [];
+        foreach (self::storageKeys($payload) as $key) {
+            $entry = self::MEDIA_PREFIX . $key;
+            $dest  = self::safePath($root, $key);
+            if ($dest === null) {
+                $missing[] = $key;
+                continue;
+            }
+
+            $stream = @fopen('zip://' . $zipPath . '#' . $entry, 'rb');
+            if ($stream === false) {
+                $missing[] = $key;
+                continue;
+            }
+
+            $dir = dirname($dest);
+            if (!is_dir($dir) && !mkdir($dir, 0755, true) && !is_dir($dir)) {
+                fclose($stream);
+                throw new RuntimeException('Failed to create media directory: ' . $dir);
+            }
+
+            $out = @fopen($dest, 'wb');
+            if ($out === false) {
+                fclose($stream);
+                throw new RuntimeException('Failed to write media file: ' . $dest);
+            }
+            stream_copy_to_stream($stream, $out);
+            fclose($stream);
+            fclose($out);
+            $placed++;
+        }
+
+        return ['payload' => $payload, 'placed' => $placed, 'missing' => $missing];
+    }
+
+    /**
+     * Distinct, non-empty storage keys referenced by the payload's media rows.
+     *
+     * @param  array<string, mixed> $payload
+     * @return list<string>
+     */
+    private static function storageKeys(array $payload): array
+    {
+        $keys = [];
+        foreach ((array) ($payload['media'] ?? []) as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+            $key = isset($row['storage_key']) ? ltrim((string) $row['storage_key'], '/') : '';
+            if ($key !== '') {
+                $keys[$key] = true;
+            }
+        }
+
+        return array_keys($keys);
+    }
+
+    /**
+     * Resolve $key under $root, rejecting traversal. Returns null for unsafe keys.
+     */
+    private static function safePath(string $root, string $key): ?string
+    {
+        $key = ltrim($key, '/');
+        if ($key === '' || str_contains($key, '..') || str_contains($key, "\0")) {
+            return null;
+        }
+
+        return $root . '/' . $key;
+    }
+}

--- a/tests/OrgExport/OrgExportHttpTest.php
+++ b/tests/OrgExport/OrgExportHttpTest.php
@@ -10,6 +10,7 @@ use Nene2\Http\RuntimeApplicationFactory;
 use NeNeRecords\Organization\Organization;
 use NeNeRecords\OrgExport\ExportOrganizationHandler;
 use NeNeRecords\OrgExport\ImportOrganizationHandler;
+use NeNeRecords\OrgExport\OrgExportPayloadBuilder;
 use NeNeRecords\OrgExport\OrgExportRepositoryInterface;
 use NeNeRecords\OrgExport\OrgExportRouteRegistrar;
 use NeNeRecords\OrgExport\OrgImportRepositoryInterface;
@@ -46,7 +47,7 @@ final class OrgExportHttpTest extends TestCase
         $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
 
         $registrar = new OrgExportRouteRegistrar(
-            new ExportOrganizationHandler($exportRepository, $this->orgs, $jsonResponse, $problemDetails, new FixedClock()),
+            new ExportOrganizationHandler(new OrgExportPayloadBuilder($exportRepository, new FixedClock()), $this->orgs, $jsonResponse, $problemDetails),
             new ImportOrganizationHandler($this->importRepository, $this->orgs, $jsonResponse, $problemDetails),
         );
 

--- a/tests/OrgExport/OrgExportZipTest.php
+++ b/tests/OrgExport/OrgExportZipTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\OrgExport;
+
+use NeNeRecords\OrgExport\OrgExportZip;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Media transport archive round-trip (#798): originals are bundled at their
+ * storage_key path and restored byte-for-byte on the target, missing/unsafe keys
+ * are reported not fatal, and the DB payload survives the trip.
+ */
+final class OrgExportZipTest extends TestCase
+{
+    private string $workDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $base = tempnam(sys_get_temp_dir(), 'nene-zip-') ?: throw new \RuntimeException('tempnam failed');
+        @unlink($base);
+        @mkdir($base, 0755, true);
+        $this->workDir = $base;
+    }
+
+    protected function tearDown(): void
+    {
+        self::rrmdir($this->workDir);
+        parent::tearDown();
+    }
+
+    public function testCreateThenOpenRestoresOriginalsAndPayload(): void
+    {
+        $srcRoot = $this->workDir . '/src-media';
+        $this->writeFile($srcRoot . '/2026/06/logo.png', 'PNG-BYTES-1');
+        $this->writeFile($srcRoot . '/2026/06/hero.jpg', 'JPG-BYTES-2');
+
+        $payload = [
+            'meta'  => ['organization_id' => 5, 'exported_at' => '2026-07-14T00:00:00+00:00'],
+            'media' => [
+                ['id' => 1, 'storage_key' => '2026/06/logo.png'],
+                ['id' => 2, 'storage_key' => '2026/06/hero.jpg'],
+                // referenced in the DB but absent on disk → reported missing, not fatal.
+                ['id' => 3, 'storage_key' => '2026/06/gone.gif'],
+            ],
+        ];
+
+        $zipPath = $this->workDir . '/export.zip';
+        $created = OrgExportZip::create($zipPath, $payload, $srcRoot);
+
+        self::assertSame(2, $created['added']);
+        self::assertSame(['2026/06/gone.gif'], $created['missing']);
+        self::assertFileExists($zipPath);
+
+        // Extract into a fresh media root, as the target instance would.
+        $destRoot = $this->workDir . '/dest-media';
+        $opened   = OrgExportZip::open($zipPath, $destRoot);
+
+        self::assertSame(5, $opened['payload']['meta']['organization_id']);
+        self::assertSame(2, $opened['placed']);
+        self::assertSame(['2026/06/gone.gif'], $opened['missing']);
+
+        // Originals restored byte-for-byte at their storage_key path.
+        self::assertSame('PNG-BYTES-1', file_get_contents($destRoot . '/2026/06/logo.png'));
+        self::assertSame('JPG-BYTES-2', file_get_contents($destRoot . '/2026/06/hero.jpg'));
+        self::assertFileDoesNotExist($destRoot . '/2026/06/gone.gif');
+    }
+
+    public function testUnsafeStorageKeyIsSkipped(): void
+    {
+        $srcRoot = $this->workDir . '/src2';
+        $this->writeFile($srcRoot . '/ok.png', 'OK');
+
+        $payload = [
+            'meta'  => ['organization_id' => 1],
+            'media' => [
+                ['id' => 1, 'storage_key' => '../escape.png'],
+                ['id' => 2, 'storage_key' => 'ok.png'],
+            ],
+        ];
+
+        $zipPath = $this->workDir . '/unsafe.zip';
+        $created = OrgExportZip::create($zipPath, $payload, $srcRoot);
+
+        // The traversal key is treated as missing (never resolved under the root).
+        self::assertContains('../escape.png', $created['missing']);
+        self::assertSame(1, $created['added']);
+    }
+
+    public function testOpenRejectsNonExportZip(): void
+    {
+        $zipPath = $this->workDir . '/plain.zip';
+        $zip     = new \ZipArchive();
+        self::assertTrue($zip->open($zipPath, \ZipArchive::CREATE) === true);
+        $zip->addFromString('readme.txt', 'not an export');
+        $zip->close();
+
+        $this->expectException(\RuntimeException::class);
+        OrgExportZip::open($zipPath, $this->workDir . '/out');
+    }
+
+    private function writeFile(string $path, string $contents): void
+    {
+        $dir = dirname($path);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+        file_put_contents($path, $contents);
+    }
+
+    private static function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir) ?: [];
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            is_dir($path) ? self::rrmdir($path) : @unlink($path);
+        }
+        @rmdir($dir);
+    }
+}

--- a/tools/export-org.php
+++ b/tools/export-org.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * CLI org export for Tier A transport (#741 / #798).
+ *
+ * Produces a single self-contained zip — the DB payload (export.json) plus every
+ * media original at its storage_key path — so a whole org, images included, moves
+ * in one file. The counterpart tools/import-org.php extracts it on the target.
+ *
+ * The HTTP export endpoint (GET /api/v1/superadmin/organizations/{id}/export)
+ * returns DB rows only; media originals live on the server filesystem, so bundling
+ * them is an operator task with shell access, exactly like tools/install.php.
+ *
+ * Local-disk storage only: with MEDIA_STORAGE_DRIVER=s3 the originals live in the
+ * bucket (not under var/media), so this tool refuses to run — replicate the bucket
+ * to the target instead, or use the JSON-only HTTP export. Image derivatives are
+ * regenerated on demand on the target, so only originals are bundled.
+ *
+ * Usage:
+ *   php tools/export-org.php --org=<id|slug> --out=export.zip
+ *   docker compose exec -T app php tools/export-org.php --org=aozora --out=/tmp/aozora.zip
+ *
+ * Options:
+ *   --org=REF     (required) source organization: numeric id or slug
+ *   --out=PATH    (required) destination zip path
+ */
+
+use NeNeRecords\Http\RuntimeContainerFactory;
+use NeNeRecords\Organization\OrganizationRepositoryInterface;
+use NeNeRecords\OrgExport\OrgExportPayloadBuilder;
+use NeNeRecords\OrgExport\OrgExportZip;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+/** @param non-empty-string $name */
+function exportOption(string $name): ?string
+{
+    foreach ($GLOBALS['argv'] as $arg) {
+        if (str_starts_with((string) $arg, "--{$name}=")) {
+            return substr((string) $arg, strlen($name) + 3);
+        }
+    }
+
+    return null;
+}
+
+$org = exportOption('org');
+$out = exportOption('out');
+
+if ($org === null || $org === '' || $out === null || $out === '') {
+    fwrite(STDERR, "ERROR: both --org=<id|slug> and --out=PATH are required.\n");
+    fwrite(STDERR, "Usage: php tools/export-org.php --org=<id|slug> --out=export.zip\n");
+    exit(1);
+}
+
+$driver = getenv('MEDIA_STORAGE_DRIVER') ?: 'local';
+if ($driver !== 'local') {
+    fwrite(STDERR, "ERROR: the zip export bundles media originals from local disk (var/media),\n");
+    fwrite(STDERR, "but MEDIA_STORAGE_DRIVER is '{$driver}'. Replicate the object store separately,\n");
+    fwrite(STDERR, "or use the JSON-only HTTP export endpoint. See docs/install-tier-a.md.\n");
+    exit(1);
+}
+
+$projectRoot = dirname(__DIR__);
+$mediaRoot   = $projectRoot . '/var/media';
+
+$container = (new RuntimeContainerFactory($projectRoot))->create();
+
+$organizations = $container->get(OrganizationRepositoryInterface::class);
+$builder       = $container->get(OrgExportPayloadBuilder::class);
+
+if (
+    !$organizations instanceof OrganizationRepositoryInterface
+    || !$builder instanceof OrgExportPayloadBuilder
+) {
+    fwrite(STDERR, "ERROR: the application container is misconfigured.\n");
+    exit(1);
+}
+
+$organization = ctype_digit($org)
+    ? $organizations->findById((int) $org)
+    : $organizations->findBySlug($org);
+
+if ($organization === null || $organization->id === null) {
+    fwrite(STDERR, "ERROR: no organization found for '{$org}'.\n");
+    exit(1);
+}
+
+$sourceOrgId = $organization->id;
+
+fwrite(STDOUT, sprintf("→ Exporting organization '%s' (#%d)...\n", $organization->slug, $sourceOrgId));
+
+$payload    = $builder->build($sourceOrgId);
+$mediaRows  = is_array($payload['media'] ?? null) ? count((array) $payload['media']) : 0;
+
+try {
+    $result = OrgExportZip::create($out, $payload, $mediaRoot);
+} catch (\Throwable $e) {
+    fwrite(STDERR, 'ERROR: failed to build the archive: ' . $e->getMessage() . "\n");
+    exit(1);
+}
+
+fwrite(STDOUT, sprintf("    media rows            %d\n", $mediaRows));
+fwrite(STDOUT, sprintf("    media files bundled   %d\n", $result['added']));
+
+if ($result['missing'] !== []) {
+    fwrite(STDERR, sprintf("⚠ %d media original(s) referenced in the DB were not found on disk:\n", count($result['missing'])));
+    foreach ($result['missing'] as $key) {
+        fwrite(STDERR, "    - {$key}\n");
+    }
+}
+
+fwrite(STDOUT, sprintf("✓ Wrote %s (%d bytes).\n", $out, (int) @filesize($out)));
+fwrite(STDOUT, sprintf("  Import on the target with:\n    php tools/import-org.php --file=%s --org=<id|slug>\n", basename($out)));
+
+exit(0);

--- a/tools/import-org.php
+++ b/tools/import-org.php
@@ -17,17 +17,25 @@ declare(strict_types=1);
  * (default content types / setting defs) are merged, not duplicated, and the whole
  * import runs in one transaction (a failure leaves the org untouched).
  *
+ * The --file may be either a JSON payload or a transport zip produced by
+ * tools/export-org.php. A zip additionally carries the media originals; they are
+ * placed under var/media/ at their storage_key before the DB rows are imported, so
+ * an image-bearing site moves in one file (#798). Zip transport is local-disk only
+ * (MEDIA_STORAGE_DRIVER=local); image derivatives regenerate on demand on import.
+ *
  * Usage:
  *   php tools/import-org.php --file=export.json --org=<id|slug>
- *   docker compose exec -T app php tools/import-org.php --file=export.json --org=default
+ *   php tools/import-org.php --file=export.zip  --org=<id|slug>
+ *   docker compose exec -T app php tools/import-org.php --file=export.zip --org=default
  *
  * Options:
- *   --file=PATH   (required) path to an org-export JSON payload (must contain "meta")
+ *   --file=PATH   (required) an org-export JSON payload or transport zip (must contain "meta")
  *   --org=REF     (required) target organization: numeric id or slug
  */
 
 use NeNeRecords\Http\RuntimeContainerFactory;
 use NeNeRecords\Organization\OrganizationRepositoryInterface;
+use NeNeRecords\OrgExport\OrgExportZip;
 use NeNeRecords\OrgExport\OrgImportRepositoryInterface;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
@@ -58,24 +66,56 @@ if (!is_file($file) || !is_readable($file)) {
     exit(1);
 }
 
-$raw = (string) file_get_contents($file);
+$projectRoot = dirname(__DIR__);
 
-try {
-    $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
-} catch (JsonException $e) {
-    fwrite(STDERR, "ERROR: export file is not valid JSON: {$e->getMessage()}\n");
-    exit(1);
-}
-
-if (!is_array($decoded) || !isset($decoded['meta'])) {
-    fwrite(STDERR, "ERROR: not an org-export payload (missing \"meta\" key).\n");
-    exit(1);
-}
+// A transport zip starts with the PK local-file / end-of-central-directory magic.
+$magic = (string) file_get_contents($file, false, null, 0, 4);
+$isZip = str_starts_with($magic, "PK\x03\x04") || str_starts_with($magic, "PK\x05\x06");
 
 /** @var array<string, mixed> $payload */
-$payload = $decoded;
+$payload      = [];
+$mediaPlaced  = null;
+$mediaMissing = [];
 
-$container = (new RuntimeContainerFactory(dirname(__DIR__)))->create();
+if ($isZip) {
+    $driver = getenv('MEDIA_STORAGE_DRIVER') ?: 'local';
+    if ($driver !== 'local') {
+        fwrite(STDERR, "ERROR: this archive places media originals under local disk (var/media),\n");
+        fwrite(STDERR, "but MEDIA_STORAGE_DRIVER is '{$driver}'. Import the JSON-only payload and\n");
+        fwrite(STDERR, "replicate the object store separately. See docs/install-tier-a.md.\n");
+        exit(1);
+    }
+
+    try {
+        $archive = OrgExportZip::open($file, $projectRoot . '/var/media');
+    } catch (\Throwable $e) {
+        fwrite(STDERR, 'ERROR: ' . $e->getMessage() . "\n");
+        exit(1);
+    }
+
+    $payload      = $archive['payload'];
+    $mediaPlaced  = $archive['placed'];
+    $mediaMissing = $archive['missing'];
+} else {
+    $raw = (string) file_get_contents($file);
+
+    try {
+        $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+    } catch (JsonException $e) {
+        fwrite(STDERR, "ERROR: export file is not valid JSON: {$e->getMessage()}\n");
+        exit(1);
+    }
+
+    if (!is_array($decoded) || !isset($decoded['meta'])) {
+        fwrite(STDERR, "ERROR: not an org-export payload (missing \"meta\" key).\n");
+        exit(1);
+    }
+
+    /** @var array<string, mixed> $payload */
+    $payload = $decoded;
+}
+
+$container = (new RuntimeContainerFactory($projectRoot))->create();
 
 $organizations = $container->get(OrganizationRepositoryInterface::class);
 $importer      = $container->get(OrgImportRepositoryInterface::class);
@@ -109,7 +149,20 @@ foreach ($counts as $table => $count) {
 }
 
 fwrite(STDOUT, sprintf("✓ Imported %d rows into '%s' (#%d).\n", $total, $organization->slug, $targetOrgId));
-fwrite(STDOUT, "\nNote: media DB rows were imported, but the actual files under var/media/ must be\n");
-fwrite(STDOUT, "transferred separately (rsync/FTP). See docs/install-tier-a.md.\n");
+
+if ($isZip) {
+    fwrite(STDOUT, sprintf("\n✓ Placed %d media original(s) under var/media/ from the archive.\n", (int) $mediaPlaced));
+    if ($mediaMissing !== []) {
+        fwrite(STDERR, sprintf("⚠ %d media file(s) referenced in the DB were not present in the archive:\n", count($mediaMissing)));
+        foreach ($mediaMissing as $key) {
+            fwrite(STDERR, "    - {$key}\n");
+        }
+    }
+    fwrite(STDOUT, "  Image derivatives are regenerated on demand on first request.\n");
+} else {
+    fwrite(STDOUT, "\nNote: media DB rows were imported, but the actual files under var/media/ must be\n");
+    fwrite(STDOUT, "transferred separately (rsync/FTP), or use a transport zip from tools/export-org.php.\n");
+    fwrite(STDOUT, "See docs/install-tier-a.md.\n");
+}
 
 exit(0);


### PR DESCRIPTION
> **Stacked PR**: この PR は #838（#796）の上に積んでいます。**#838 を先にマージ**してください。base は `feat/796-org-export-coverage`。#838 マージ後に base は自動で `main` に切り替わります。

## 目的

#741 の org export は media の **DB 行のみ** を JSON 化し、実ファイル（`var/media/` の原本）は rsync/FTP で別送が必要だった。本 PR は export を「DB payload ＋ メディア原本」を含む **単一 zip** にし、`tools/import-org.php` が展開して `var/media/` に配置することで、画像入りサイトを **1 操作**で移送できるようにする。

## 設計判断（PR に明記）

- **既存 JSON export は互換維持**: HTTP エンドポイント `GET /api/v1/superadmin/organizations/{id}/export` は DB 行のみを返す挙動のまま。zip は **CLI 専用の別系統**（`tools/export-org.php`）で、既存呼び出しを壊さない。新しい superadmin ルートは足していない（capability 追加も不要）。
- **payload の単一ソース化**: `OrgExportPayloadBuilder` を新設し、HTTP handler と CLI export tool が同じ builder を共有。テーブル追加時に片方だけ追従漏れする事故を防ぐ。`ExportOrganizationHandler` は builder 利用にリファクタ（挙動不変、既存 HTTP テストは緑）。
- **ストリーミング（大容量対策）**: メディア原本は `ZipArchive::addFile` でディスクから直接同梱（全体をメモリに載せない）。取り込み側は `zip://` ストリームラッパ＋`stream_copy_to_stream` でストリーム展開する。
- **派生画像は同梱しない**: サムネイル等の derivative は移送先で `ServeDerivativeHandler` によりオンデマンド再生成されるため、**原本のみ**同梱すれば十分（コード確認済み）。
- **S3 は対象外**: `MEDIA_STORAGE_DRIVER=s3` のとき原本はバケットにあり `var/media/` に無いため、export/import 双方が **明示エラーで停止**する（バケット複製＋JSON export を使うよう案内）。
- **安全性**: `storage_key` のパストラバーサル（`..`・NULL バイト）は解決せず skip。DB に在るが disk に無い原本は fatal にせず「missing」として報告。

## zip レイアウト

```
export.json          DB payload（OrgExportPayloadBuilder）
media/<storage_key>  各メディア原本（storage 相対パスのまま）
```

## 変更点

- `src/OrgExport/OrgExportPayloadBuilder.php`（新規）: payload 構築の単一ソース。
- `src/OrgExport/OrgExportZip.php`（新規）: `create()`（zip 生成）/`open()`（展開＋原本配置）。ストリーミング・トラバーサル防御・missing 報告。
- `src/OrgExport/ExportOrganizationHandler.php` / `OrgExportServiceProvider.php`: builder 利用へ配線変更。
- `tools/export-org.php`（新規）: `--org=<id|slug> --out=export.zip`。local ドライバ専用チェック付き。
- `tools/import-org.php`: `--file` が zip（PK マジック検知）なら原本を `var/media/` へ配置してから DB を取り込む。JSON 入力は従来どおり。
- `docs/install-tier-a.md`: 移送節を zip 一括手順に更新（rsync/FTP は代替として残置）。

## 検証

- `composer check` 全緑（PHPUnit 1288 tests / PHPStan level 8 / CS-Fixer / OpenAPI / MCP）。risky 1件は既存の `ModuleRegistryTest`（無関係）。
- 追加テスト `OrgExportZipTest`: create→open のラウンドトリップで、テンポラリディレクトリの実ファイルが移送先に **バイト一致**で復元されること、欠落キー/不正キーが報告され fatal にならないこと、非 export zip が拒否されることを実証。
- 両 CLI ツールは `php -l` 構文チェック済み。

## チェックリスト

- [x] Issue-driven（#798）
- [x] `feat/796-...` から `feat/798-...` ブランチ（stacked）
- [x] Conventional Commits（type/scope 英語・description 日本語・`（#798）`）
- [x] secrets 非コミット
- [x] `composer check` 全緑

Refs #741
Closes #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)