### PR TITLE
sec(notification): 通知チャネル config の機微キーを read で write-only 化する（#845）

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -7606,6 +7606,13 @@ components:
           type: boolean
         config:
           type: object
+          description: >-
+            Channel-specific settings. Capability secrets (Slack/Discord
+            `webhook_url`, ChatWork `api_token`, generic webhook `url` /
+            `headers_json`) are write-only: they are never returned on read.
+            Instead a `has_<key>` boolean (e.g. `has_webhook_url`) reports
+            whether one is configured (defense-in-depth, #845). Non-sensitive
+            keys are returned verbatim.
           additionalProperties: true
         created_at:
           type: string
@@ -7641,6 +7648,9 @@ components:
           default: true
         config:
           type: object
+          description: >-
+            Channel-specific settings including capability secrets (write-only;
+            never returned on read — see NotificationChannelResponse.config).
           additionalProperties: true
       additionalProperties: false
     UpdateNotificationChannelRequest:
@@ -7655,5 +7665,9 @@ components:
           type: boolean
         config:
           type: object
+          description: >-
+            Channel-specific settings. Omit (or send an empty/null value for) a
+            capability secret to keep the stored one; send a new value to
+            replace it. Write-only: never returned on read (#845).
           additionalProperties: true
       additionalProperties: false

--- a/frontend/src/features/manage-notification-channels/ui/NotificationChannelForm.test.tsx
+++ b/frontend/src/features/manage-notification-channels/ui/NotificationChannelForm.test.tsx
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@tests/render/render-with-providers'
 import { NotificationChannelForm } from './NotificationChannelForm'
+import type {
+  NotificationChannel,
+  UpdateNotificationChannelInput,
+} from '@/entities/notification-channel'
 
 afterEach(cleanup)
 
@@ -11,6 +16,18 @@ const baseProps = {
   submitLabel: 'Save',
   onSubmit: vi.fn(() => Promise.resolve()),
   onCancel: vi.fn(),
+}
+
+// A Slack channel whose webhook_url is already stored: the read payload carries
+// only the `has_webhook_url` flag, never the secret itself (#845).
+const slackWithConfiguredSecret: NotificationChannel = {
+  id: 1,
+  channelType: 'slack',
+  label: 'Slack Alerts',
+  isEnabled: true,
+  config: { has_webhook_url: true },
+  createdAt: '2026-07-01T00:00:00Z',
+  updatedAt: '2026-07-01T00:00:00Z',
 }
 
 describe('NotificationChannelForm', () => {
@@ -31,5 +48,38 @@ describe('NotificationChannelForm', () => {
     expect(boxes).toHaveLength(2)
     expect(boxes[0]?.id).toBeTruthy()
     expect(boxes[0]?.id).not.toBe(boxes[1]?.id)
+  })
+
+  it('never prefills a write-only secret and marks it password + configured', () => {
+    renderWithProviders(
+      <NotificationChannelForm {...baseProps} defaultValues={slackWithConfiguredSecret} />,
+    )
+    const input = screen.getByPlaceholderText('https://hooks.slack.com/services/...')
+    expect(input).toHaveProperty('type', 'password')
+    expect(input).toHaveProperty('value', '')
+    // Hint reflects that a secret is already configured.
+    expect(screen.getByText(/already configured/i)).toBeTruthy()
+  })
+
+  it('submits without re-entering the secret and omits it from the payload', async () => {
+    const onSubmit = vi.fn((input: UpdateNotificationChannelInput) => {
+      void input
+      return Promise.resolve()
+    })
+    renderWithProviders(
+      <NotificationChannelForm
+        {...baseProps}
+        onSubmit={onSubmit}
+        defaultValues={slackWithConfiguredSecret}
+      />,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    const payload = onSubmit.mock.calls[0]?.[0]
+    // Blank secret is not sent (backend keeps the stored one); no has_* echo.
+    expect(payload?.config).not.toHaveProperty('webhook_url')
+    expect(payload?.config).not.toHaveProperty('has_webhook_url')
   })
 })

--- a/frontend/src/features/manage-notification-channels/ui/NotificationChannelForm.tsx
+++ b/frontend/src/features/manage-notification-channels/ui/NotificationChannelForm.tsx
@@ -27,13 +27,17 @@ type NotificationChannelFormProps =
       onCancel: () => void
     }
 
-function getConfigFields(channelType: NotificationChannelType): Array<{
+interface ConfigField {
   key: string
   label: string
   placeholder: string
   required: boolean
   multiline?: boolean
-}> {
+  /** Capability secret: write-only — never prefilled, blank keeps the stored value (#845). */
+  sensitive?: boolean
+}
+
+function getConfigFields(channelType: NotificationChannelType): ConfigField[] {
   switch (channelType) {
     case 'email':
       return [
@@ -51,6 +55,7 @@ function getConfigFields(channelType: NotificationChannelType): Array<{
           label: 'Webhook URL',
           placeholder: 'https://hooks.slack.com/services/...',
           required: true,
+          sensitive: true,
         },
       ]
     case 'discord':
@@ -60,11 +65,18 @@ function getConfigFields(channelType: NotificationChannelType): Array<{
           label: 'Webhook URL',
           placeholder: 'https://discord.com/api/webhooks/...',
           required: true,
+          sensitive: true,
         },
       ]
     case 'chatwork':
       return [
-        { key: 'api_token', label: 'API token', placeholder: 'ChatWork API token', required: true },
+        {
+          key: 'api_token',
+          label: 'API token',
+          placeholder: 'ChatWork API token',
+          required: true,
+          sensitive: true,
+        },
         { key: 'room_id', label: 'Room ID', placeholder: '123456', required: true },
       ]
     case 'webhook':
@@ -74,6 +86,7 @@ function getConfigFields(channelType: NotificationChannelType): Array<{
           label: 'Endpoint URL',
           placeholder: 'https://example.com/hook',
           required: true,
+          sensitive: true,
         },
         {
           key: 'headers_json',
@@ -81,6 +94,7 @@ function getConfigFields(channelType: NotificationChannelType): Array<{
           placeholder: '{"X-Token": "secret"}',
           required: false,
           multiline: true,
+          sensitive: true,
         },
       ]
   }
@@ -106,17 +120,27 @@ export function NotificationChannelForm({
   const [config, setConfig] = useState<Record<string, string>>(() => {
     if (defaultValues?.config == null) return {}
     return Object.fromEntries(
-      Object.entries(defaultValues.config).map(([k, v]) => [
-        k,
-        typeof v === 'string'
-          ? v
-          : typeof v === 'number' || typeof v === 'boolean'
-            ? String(v)
-            : '',
-      ]),
+      Object.entries(defaultValues.config)
+        // Capability secrets are write-only: the read payload never carries
+        // their values, only `has_<key>` flags — never prefill either (#845).
+        .filter(([k]) => !k.startsWith('has_'))
+        .map(([k, v]) => [
+          k,
+          typeof v === 'string'
+            ? v
+            : typeof v === 'number' || typeof v === 'boolean'
+              ? String(v)
+              : '',
+        ]),
     )
   })
   const [errors, setErrors] = useState<Record<string, string>>({})
+
+  // Whether a capability secret is already stored (from the read `has_<key>`
+  // flag). A configured secret may be left blank on edit to keep it.
+  function isSecretConfigured(key: string): boolean {
+    return defaultValues?.config[`has_${key}`] === true
+  }
 
   function setConfigField(key: string, value: string) {
     setConfig((prev) => ({ ...prev, [key]: value }))
@@ -128,6 +152,8 @@ export function NotificationChannelForm({
       next['label'] = t('admin.notifications.form.labelRequired')
     }
     for (const field of getConfigFields(channelType)) {
+      // A configured write-only secret may be left blank to keep the stored one.
+      if (field.sensitive === true && isSecretConfigured(field.key)) continue
       if (field.required && !config[field.key]?.trim()) {
         next[field.key] = t('admin.notifications.form.fieldRequired', { field: field.label })
       }
@@ -235,7 +261,8 @@ export function NotificationChannelForm({
               />
             ) : (
               <input
-                type={field.key === 'api_token' ? 'password' : 'text'}
+                type={field.sensitive === true ? 'password' : 'text'}
+                autoComplete={field.sensitive === true ? 'new-password' : undefined}
                 value={config[field.key] ?? ''}
                 onChange={(e) => {
                   setConfigField(field.key, e.target.value)
@@ -243,6 +270,13 @@ export function NotificationChannelForm({
                 placeholder={field.placeholder}
                 className="w-full rounded-md border border-border bg-surface px-3 py-2 font-sans text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-accent"
               />
+            )}
+            {field.sensitive === true && (
+              <p className="mt-1 font-sans text-xs text-text-muted">
+                {isSecretConfigured(field.key)
+                  ? t('admin.notifications.form.secretConfiguredHint')
+                  : t('admin.notifications.form.secretHint')}
+              </p>
             )}
             {errors[field.key] !== undefined && (
               <p className="mt-1 font-sans text-xs text-danger">{errors[field.key]}</p>

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -3036,6 +3036,7 @@ export interface components {
             channel_type: "email" | "slack" | "discord" | "chatwork" | "webhook";
             label: string;
             is_enabled: boolean;
+            /** @description Channel-specific settings. Capability secrets (Slack/Discord `webhook_url`, ChatWork `api_token`, generic webhook `url` / `headers_json`) are write-only: they are never returned on read. Instead a `has_<key>` boolean (e.g. `has_webhook_url`) reports whether one is configured (defense-in-depth, #845). Non-sensitive keys are returned verbatim. */
             config: {
                 [key: string]: unknown;
             };
@@ -3053,6 +3054,7 @@ export interface components {
             label: string;
             /** @default true */
             is_enabled: boolean;
+            /** @description Channel-specific settings including capability secrets (write-only; never returned on read — see NotificationChannelResponse.config). */
             config?: {
                 [key: string]: unknown;
             };
@@ -3060,6 +3062,7 @@ export interface components {
         UpdateNotificationChannelRequest: {
             label: string;
             is_enabled?: boolean;
+            /** @description Channel-specific settings. Omit (or send an empty/null value for) a capability secret to keep the stored one; send a new value to replace it. Write-only: never returned on read (#845). */
             config?: {
                 [key: string]: unknown;
             };

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -1217,6 +1217,10 @@ export const de: Partial<MessageCatalog> = {
   'admin.notifications.form.isEnabledLabel': 'Aktiviert',
   'admin.notifications.form.labelRequired': 'Die Beschriftung ist erforderlich.',
   'admin.notifications.form.fieldRequired': '{field} ist erforderlich.',
+  'admin.notifications.form.secretHint':
+    'Wird schreibgeschützt gespeichert und nach dem Speichern nicht mehr angezeigt.',
+  'admin.notifications.form.secretConfiguredHint':
+    'Es ist bereits ein Wert konfiguriert. Leer lassen, um ihn beizubehalten, oder einen neuen Wert eingeben, um ihn zu ersetzen.',
   // ── Media library ───────────────────────────────────────────────────────
   'admin.nav.media': 'Medien',
   'admin.media.pageTitle': 'Medienbibliothek',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -1225,6 +1225,9 @@ export const en = {
   'admin.notifications.form.isEnabledLabel': 'Enabled',
   'admin.notifications.form.labelRequired': 'Label is required.',
   'admin.notifications.form.fieldRequired': '{field} is required.',
+  'admin.notifications.form.secretHint': 'Stored write-only and never shown again after saving.',
+  'admin.notifications.form.secretConfiguredHint':
+    'A value is already configured. Leave blank to keep it, or enter a new value to replace it.',
 
   // ── Media library ───────────────────────────────────────────────────────
   'admin.nav.media': 'Media',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -1246,6 +1246,10 @@ export const fr: Partial<MessageCatalog> = {
   'admin.notifications.form.isEnabledLabel': 'Activé',
   'admin.notifications.form.labelRequired': 'Le libellé est requis.',
   'admin.notifications.form.fieldRequired': '{field} est requis.',
+  'admin.notifications.form.secretHint':
+    "Enregistré en écriture seule et jamais réaffiché après l'enregistrement.",
+  'admin.notifications.form.secretConfiguredHint':
+    'Une valeur est déjà configurée. Laissez vide pour la conserver, ou saisissez une nouvelle valeur pour la remplacer.',
 
   // ── Media library ───────────────────────────────────────────────────────
   'admin.nav.media': 'Médias',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -1225,6 +1225,9 @@ export const ja: Partial<MessageCatalog> = {
   'admin.notifications.form.isEnabledLabel': '有効',
   'admin.notifications.form.labelRequired': 'ラベルは必須です。',
   'admin.notifications.form.fieldRequired': '{field} は必須です。',
+  'admin.notifications.form.secretHint': '書き込み専用で保存され、保存後は再表示されません。',
+  'admin.notifications.form.secretConfiguredHint':
+    '値は設定済みです。空欄のままにすると保持し、新しい値を入力すると置き換えます。',
 
   // ── Media library ───────────────────────────────────────────────────────
   'admin.nav.media': 'メディア',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -1237,6 +1237,10 @@ export const ptBR: Partial<MessageCatalog> = {
   'admin.notifications.form.isEnabledLabel': 'Ativado',
   'admin.notifications.form.labelRequired': 'O rótulo é obrigatório.',
   'admin.notifications.form.fieldRequired': '{field} é obrigatório.',
+  'admin.notifications.form.secretHint':
+    'Armazenado como somente gravação e nunca exibido novamente após salvar.',
+  'admin.notifications.form.secretConfiguredHint':
+    'Um valor já está configurado. Deixe em branco para mantê-lo ou insira um novo valor para substituí-lo.',
 
   // ── Media library ───────────────────────────────────────────────────────
   'admin.nav.media': 'Mídia',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -1181,6 +1181,8 @@ export const zhHans: Partial<MessageCatalog> = {
   'admin.notifications.form.isEnabledLabel': '已启用',
   'admin.notifications.form.labelRequired': '标签为必填项。',
   'admin.notifications.form.fieldRequired': '{field} 为必填项。',
+  'admin.notifications.form.secretHint': '以只写方式存储，保存后不再显示。',
+  'admin.notifications.form.secretConfiguredHint': '已配置该值。留空以保留，或输入新值以替换。',
 
   // ── Media library ───────────────────────────────────────────────────────
   'admin.nav.media': '媒体',

--- a/src/Notification/CreateNotificationChannelHandler.php
+++ b/src/Notification/CreateNotificationChannelHandler.php
@@ -52,20 +52,8 @@ final readonly class CreateNotificationChannelHandler
             config: $config,
         ));
 
-        return $this->response->create($this->serialize($channel), 201);
-    }
-
-    /** @return array<string,mixed> */
-    private function serialize(NotificationChannel $ch): array
-    {
-        return [
-            'id'           => $ch->id,
-            'channel_type' => $ch->channelType,
-            'label'        => $ch->label,
-            'is_enabled'   => $ch->isEnabled,
-            'config'       => $ch->config,
-            'created_at'   => $ch->createdAt,
-            'updated_at'   => $ch->updatedAt,
-        ];
+        // config capability secrets are write-only on read (#845): reuse the
+        // shared mapper so create/list/update share one redacted shape.
+        return $this->response->create(NotificationChannelHttpMapper::toArray($channel), 201);
     }
 }

--- a/src/Notification/ListNotificationChannelsHandler.php
+++ b/src/Notification/ListNotificationChannelsHandler.php
@@ -20,16 +20,10 @@ final readonly class ListNotificationChannelsHandler
     {
         $output = $this->useCase->execute();
 
+        // config capability secrets are write-only on read (#845): the mapper
+        // strips them and exposes `has_<key>` flags instead.
         $items = array_map(
-            static fn (NotificationChannel $ch): array => [
-                'id'           => $ch->id,
-                'channel_type' => $ch->channelType,
-                'label'        => $ch->label,
-                'is_enabled'   => $ch->isEnabled,
-                'config'       => $ch->config,
-                'created_at'   => $ch->createdAt,
-                'updated_at'   => $ch->updatedAt,
-            ],
+            static fn (NotificationChannel $ch): array => NotificationChannelHttpMapper::toArray($ch),
             $output->items,
         );
 

--- a/src/Notification/NotificationChannelHttpMapper.php
+++ b/src/Notification/NotificationChannelHttpMapper.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Notification;
+
+/**
+ * Serialises a {@see NotificationChannel} for read responses while keeping the
+ * capability secrets inside `config` write-only (#845, same contract as the
+ * webhook signing secret in #836 / #824).
+ *
+ * A channel's `config` carries per-type settings. Some of those keys are
+ * capability secrets — a Slack/Discord Incoming Webhook URL can post to the
+ * workspace on its own, a ChatWork API token can act as the account, a generic
+ * webhook URL / extra headers can carry bearer credentials. Those keys are
+ * never echoed on read; the response only advertises whether one is configured
+ * via a `has_<key>` boolean placed inside `config`. Non-sensitive keys
+ * (recipient address, room id, …) are returned verbatim.
+ */
+final class NotificationChannelHttpMapper
+{
+    /**
+     * Capability-secret config keys per channel type. Only these are stripped
+     * from read responses and preserved on omitted updates.
+     *
+     * @var array<string, list<string>>
+     */
+    private const SENSITIVE_KEYS = [
+        'email' => [],
+        'slack' => ['webhook_url'],
+        'discord' => ['webhook_url'],
+        'chatwork' => ['api_token'],
+        'webhook' => ['url', 'headers_json'],
+    ];
+
+    /**
+     * @return list<string>
+     */
+    public static function sensitiveKeys(string $channelType): array
+    {
+        return self::SENSITIVE_KEYS[$channelType] ?? [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function toArray(NotificationChannel $channel): array
+    {
+        return [
+            'id'           => $channel->id,
+            'channel_type' => $channel->channelType,
+            'label'        => $channel->label,
+            'is_enabled'   => $channel->isEnabled,
+            'config'       => self::redactConfig($channel->channelType, $channel->config),
+            'created_at'   => $channel->createdAt,
+            'updated_at'   => $channel->updatedAt,
+        ];
+    }
+
+    /**
+     * Strip capability secrets from a config for read exposure and add a
+     * `has_<key>` flag for each so callers can tell whether one is configured.
+     *
+     * @param array<string, mixed> $config
+     * @return array<string, mixed>
+     */
+    public static function redactConfig(string $channelType, array $config): array
+    {
+        $sensitive = self::sensitiveKeys($channelType);
+
+        $result = [];
+        foreach ($config as $key => $value) {
+            if (in_array($key, $sensitive, true)) {
+                continue; // never echo the secret itself
+            }
+            $result[$key] = $value;
+        }
+
+        foreach ($sensitive as $key) {
+            // isset() already treats a null value as absent.
+            $result['has_' . $key] = isset($config[$key]) && $config[$key] !== '';
+        }
+
+        return $result;
+    }
+
+    /**
+     * Merge an incoming (write) config with the stored one so that an omitted
+     * (missing / null / empty) capability secret keeps its existing value and a
+     * provided one replaces it. Any `has_<key>` mirror keys the client echoed
+     * back are dropped so they never get persisted.
+     *
+     * @param array<string, mixed> $existing
+     * @param array<string, mixed> $incoming
+     * @return array<string, mixed>
+     */
+    public static function mergeConfigForUpdate(string $channelType, array $existing, array $incoming): array
+    {
+        $sensitive = self::sensitiveKeys($channelType);
+
+        $result = [];
+        foreach ($incoming as $key => $value) {
+            if (str_starts_with($key, 'has_')) {
+                continue; // read-only mirror flag, never stored
+            }
+            $result[$key] = $value;
+        }
+
+        foreach ($sensitive as $key) {
+            $provided = array_key_exists($key, $incoming)
+                && $incoming[$key] !== null
+                && $incoming[$key] !== '';
+
+            if ($provided) {
+                $result[$key] = $incoming[$key];
+            } elseif (array_key_exists($key, $existing)) {
+                $result[$key] = $existing[$key]; // keep existing secret
+            } else {
+                unset($result[$key]); // no value anywhere: drop any empty echo
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Notification/UpdateNotificationChannelUseCase.php
+++ b/src/Notification/UpdateNotificationChannelUseCase.php
@@ -17,6 +17,15 @@ final readonly class UpdateNotificationChannelUseCase implements UpdateNotificat
             throw new NotificationChannelNotFoundException($input->id);
         }
 
-        $this->channels->update($input->id, $input->label, $input->isEnabled, $input->config);
+        // Write-only capability secrets (#845): an omitted sensitive config key
+        // keeps its stored value so the write-only read contract does not wipe
+        // the secret on an unrelated edit; a provided one replaces it.
+        $config = NotificationChannelHttpMapper::mergeConfigForUpdate(
+            $channel->channelType,
+            $channel->config,
+            $input->config,
+        );
+
+        $this->channels->update($input->id, $input->label, $input->isEnabled, $config);
     }
 }

--- a/tests/Notification/NotificationChannelHttpMapperTest.php
+++ b/tests/Notification/NotificationChannelHttpMapperTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Notification;
+
+use NeNeRecords\Notification\NotificationChannel;
+use NeNeRecords\Notification\NotificationChannelHttpMapper;
+use PHPUnit\Framework\TestCase;
+
+final class NotificationChannelHttpMapperTest extends TestCase
+{
+    public function testSensitiveKeysPerChannelType(): void
+    {
+        self::assertSame([], NotificationChannelHttpMapper::sensitiveKeys('email'));
+        self::assertSame(['webhook_url'], NotificationChannelHttpMapper::sensitiveKeys('slack'));
+        self::assertSame(['webhook_url'], NotificationChannelHttpMapper::sensitiveKeys('discord'));
+        self::assertSame(['api_token'], NotificationChannelHttpMapper::sensitiveKeys('chatwork'));
+        self::assertSame(['url', 'headers_json'], NotificationChannelHttpMapper::sensitiveKeys('webhook'));
+        self::assertSame([], NotificationChannelHttpMapper::sensitiveKeys('unknown'));
+    }
+
+    public function testRedactStripsSecretsAndAddsHasFlags(): void
+    {
+        $redacted = NotificationChannelHttpMapper::redactConfig('webhook', [
+            'url' => 'https://example.com/hook',
+            'headers_json' => '{"Authorization":"Bearer x"}',
+        ]);
+
+        self::assertArrayNotHasKey('url', $redacted);
+        self::assertArrayNotHasKey('headers_json', $redacted);
+        self::assertTrue($redacted['has_url']);
+        self::assertTrue($redacted['has_headers_json']);
+    }
+
+    public function testRedactKeepsNonSensitiveKeys(): void
+    {
+        $redacted = NotificationChannelHttpMapper::redactConfig('chatwork', [
+            'api_token' => 'tok',
+            'room_id' => '42',
+        ]);
+
+        self::assertArrayNotHasKey('api_token', $redacted);
+        self::assertTrue($redacted['has_api_token']);
+        self::assertSame('42', $redacted['room_id']);
+    }
+
+    public function testRedactReportsMissingAndEmptySecretsAsAbsent(): void
+    {
+        self::assertFalse(NotificationChannelHttpMapper::redactConfig('slack', [])['has_webhook_url']);
+        self::assertFalse(NotificationChannelHttpMapper::redactConfig('slack', ['webhook_url' => ''])['has_webhook_url']);
+        self::assertFalse(NotificationChannelHttpMapper::redactConfig('slack', ['webhook_url' => null])['has_webhook_url']);
+    }
+
+    public function testToArrayRedactsConfig(): void
+    {
+        $channel = new NotificationChannel(
+            id: 7,
+            organizationId: 1,
+            channelType: 'slack',
+            label: 'Slack',
+            isEnabled: true,
+            config: ['webhook_url' => 'https://hooks.slack.com/secret'],
+            createdAt: '2026-07-01 00:00:00',
+            updatedAt: '2026-07-01 00:00:00',
+        );
+
+        $array = NotificationChannelHttpMapper::toArray($channel);
+
+        self::assertSame(7, $array['id']);
+        self::assertSame('slack', $array['channel_type']);
+        self::assertIsArray($array['config']);
+        self::assertArrayNotHasKey('webhook_url', $array['config']);
+        self::assertTrue($array['config']['has_webhook_url']);
+    }
+
+    public function testMergeKeepsExistingSecretWhenOmitted(): void
+    {
+        $merged = NotificationChannelHttpMapper::mergeConfigForUpdate(
+            'slack',
+            ['webhook_url' => 'https://hooks.slack.com/keep'],
+            [],
+        );
+
+        self::assertSame('https://hooks.slack.com/keep', $merged['webhook_url']);
+    }
+
+    public function testMergeReplacesSecretWhenProvided(): void
+    {
+        $merged = NotificationChannelHttpMapper::mergeConfigForUpdate(
+            'slack',
+            ['webhook_url' => 'https://hooks.slack.com/old'],
+            ['webhook_url' => 'https://hooks.slack.com/new'],
+        );
+
+        self::assertSame('https://hooks.slack.com/new', $merged['webhook_url']);
+    }
+
+    public function testMergeTreatsEmptySecretAsOmitted(): void
+    {
+        $merged = NotificationChannelHttpMapper::mergeConfigForUpdate(
+            'slack',
+            ['webhook_url' => 'https://hooks.slack.com/keep'],
+            ['webhook_url' => ''],
+        );
+
+        self::assertSame('https://hooks.slack.com/keep', $merged['webhook_url']);
+    }
+
+    public function testMergeDropsEchoedHasFlag(): void
+    {
+        $merged = NotificationChannelHttpMapper::mergeConfigForUpdate(
+            'slack',
+            ['webhook_url' => 'https://hooks.slack.com/keep'],
+            ['has_webhook_url' => true],
+        );
+
+        self::assertArrayNotHasKey('has_webhook_url', $merged);
+        self::assertSame('https://hooks.slack.com/keep', $merged['webhook_url']);
+    }
+
+    public function testMergeReplacesNonSensitiveKeysWholesale(): void
+    {
+        $merged = NotificationChannelHttpMapper::mergeConfigForUpdate(
+            'chatwork',
+            ['api_token' => 'tok', 'room_id' => '1'],
+            ['room_id' => '2'],
+        );
+
+        // Non-sensitive keys come from the incoming payload; the omitted token
+        // is preserved from the stored config.
+        self::assertSame('2', $merged['room_id']);
+        self::assertSame('tok', $merged['api_token']);
+    }
+}

--- a/tests/Notification/NotificationChannelHttpTest.php
+++ b/tests/Notification/NotificationChannelHttpTest.php
@@ -138,6 +138,102 @@ final class NotificationChannelHttpTest extends TestCase
         self::assertTrue($body['is_enabled']);
     }
 
+    public function testCreateRedactsSensitiveConfigButReportsPresence(): void
+    {
+        $response = $this->request('POST', '/api/v1/notification-channels', [
+            'channel_type' => 'slack',
+            'label'        => 'Slack Alerts',
+            'config'       => ['webhook_url' => 'https://hooks.slack.com/services/secret'],
+        ]);
+
+        self::assertSame(201, $response->getStatusCode());
+        $config = $this->json($response)['config'];
+        self::assertIsArray($config);
+        // Write-only (#845): the capability secret is never echoed on read.
+        self::assertArrayNotHasKey('webhook_url', $config);
+        self::assertTrue($config['has_webhook_url']);
+    }
+
+    public function testListNeverExposesSensitiveConfig(): void
+    {
+        $this->repository->create('slack', 'Slack', true, ['webhook_url' => 'https://hooks.slack.com/xxx']);
+        $this->repository->create('chatwork', 'ChatWork', true, ['api_token' => 'tok-123', 'room_id' => '42']);
+        $this->repository->create('webhook', 'Webhook', true, [
+            'url' => 'https://example.com/hook',
+            'headers_json' => '{"Authorization":"Bearer abc"}',
+        ]);
+        $this->repository->create('email', 'Email', true, ['to_address' => 'admin@example.com']);
+
+        $body = $this->json($this->request('GET', '/api/v1/notification-channels'));
+        self::assertCount(4, $body['items']);
+
+        [$slack, $chatwork, $webhook, $email] = $body['items'];
+
+        self::assertArrayNotHasKey('webhook_url', $slack['config']);
+        self::assertTrue($slack['config']['has_webhook_url']);
+
+        // Non-sensitive keys survive; only the token is redacted.
+        self::assertArrayNotHasKey('api_token', $chatwork['config']);
+        self::assertTrue($chatwork['config']['has_api_token']);
+        self::assertSame('42', $chatwork['config']['room_id']);
+
+        self::assertArrayNotHasKey('url', $webhook['config']);
+        self::assertArrayNotHasKey('headers_json', $webhook['config']);
+        self::assertTrue($webhook['config']['has_url']);
+        self::assertTrue($webhook['config']['has_headers_json']);
+
+        // Email has no capability secret: to_address stays visible.
+        self::assertSame('admin@example.com', $email['config']['to_address']);
+    }
+
+    public function testUpdateWithoutSecretKeepsStoredSecret(): void
+    {
+        $created = $this->repository->create('slack', 'Slack', true, ['webhook_url' => 'https://hooks.slack.com/keep']);
+
+        $response = $this->request('PATCH', "/api/v1/notification-channels/{$created->id}", [
+            'label'  => 'Renamed',
+            'config' => [], // secret omitted → must be preserved
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $updated = $this->repository->findById($created->id);
+        self::assertNotNull($updated);
+        self::assertSame('Renamed', $updated->label);
+        self::assertSame('https://hooks.slack.com/keep', $updated->config['webhook_url']);
+    }
+
+    public function testUpdateWithSecretReplacesStoredSecret(): void
+    {
+        $created = $this->repository->create('slack', 'Slack', true, ['webhook_url' => 'https://hooks.slack.com/old']);
+
+        $response = $this->request('PATCH', "/api/v1/notification-channels/{$created->id}", [
+            'label'  => 'Slack',
+            'config' => ['webhook_url' => 'https://hooks.slack.com/new'],
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $updated = $this->repository->findById($created->id);
+        self::assertNotNull($updated);
+        self::assertSame('https://hooks.slack.com/new', $updated->config['webhook_url']);
+    }
+
+    public function testUpdateIgnoresEchoedHasFlag(): void
+    {
+        $created = $this->repository->create('slack', 'Slack', true, ['webhook_url' => 'https://hooks.slack.com/keep']);
+
+        // Client echoes the read shape back (has_webhook_url, no secret).
+        $this->request('PATCH', "/api/v1/notification-channels/{$created->id}", [
+            'label'  => 'Slack',
+            'config' => ['has_webhook_url' => true],
+        ]);
+
+        $updated = $this->repository->findById($created->id);
+        self::assertNotNull($updated);
+        // The mirror flag is not stored; the real secret is kept.
+        self::assertArrayNotHasKey('has_webhook_url', $updated->config);
+        self::assertSame('https://hooks.slack.com/keep', $updated->config['webhook_url']);
+    }
+
     public function testCreateWithoutChannelTypeReturns422(): void
     {
         $response = $this->request('POST', '/api/v1/notification-channels', [

--- a/tests/Notification/NotificationChannelUseCaseTest.php
+++ b/tests/Notification/NotificationChannelUseCaseTest.php
@@ -140,6 +140,44 @@ final class NotificationChannelUseCaseTest extends TestCase
         self::assertSame('new@example.com', $updated->config['to_address']);
     }
 
+    public function testUpdateKeepsSensitiveConfigWhenOmitted(): void
+    {
+        $repo = new InMemoryNotificationChannelRepository();
+        $created = $repo->create('slack', 'Slack', true, ['webhook_url' => 'https://hooks.slack.com/keep']);
+
+        // Write-only contract (#845): an omitted capability secret is preserved,
+        // so the notify path (which reads the stored config) still has it.
+        (new UpdateNotificationChannelUseCase($repo))->execute(new UpdateNotificationChannelInput(
+            id: $created->id,
+            label: 'Renamed',
+            isEnabled: true,
+            config: [],
+        ));
+
+        $updated = $repo->findById($created->id);
+        self::assertNotNull($updated);
+        self::assertSame('Renamed', $updated->label);
+        self::assertSame('https://hooks.slack.com/keep', $updated->config['webhook_url']);
+    }
+
+    public function testUpdateReplacesSensitiveConfigWhenProvided(): void
+    {
+        $repo = new InMemoryNotificationChannelRepository();
+        $created = $repo->create('chatwork', 'ChatWork', true, ['api_token' => 'old-tok', 'room_id' => '1']);
+
+        (new UpdateNotificationChannelUseCase($repo))->execute(new UpdateNotificationChannelInput(
+            id: $created->id,
+            label: 'ChatWork',
+            isEnabled: true,
+            config: ['api_token' => 'new-tok', 'room_id' => '2'],
+        ));
+
+        $updated = $repo->findById($created->id);
+        self::assertNotNull($updated);
+        self::assertSame('new-tok', $updated->config['api_token']);
+        self::assertSame('2', $updated->config['room_id']);
+    }
+
     public function testUpdateNonExistentChannelThrows(): void
     {
         $repo = new InMemoryNotificationChannelRepository();


### PR DESCRIPTION
## 目的

通知チャネルの read 経路（`ListNotificationChannelsHandler` / Create レスポンス）が `config` を丸ごと返しており、Slack/Discord の `webhook_url`・ChatWork の `api_token`・汎用 webhook の `url` / `headers_json` といった「それ自体で投稿できる capability secret」が admin-only とはいえ露出していた。#836（webhook signing secret の write-only 化・PR #839）と同型の defense-in-depth を通知チャネルにも適用する。

## 変更点

- **`NotificationChannelHttpMapper` 新設**（read serialize / config redact / update merge を集約）。
  - チャネル型ごとの機微キー定義: `slack`/`discord` → `webhook_url`、`chatwork` → `api_token`、`webhook` → `url` + `headers_json`、`email` → なし。
  - read では機微キーを除去し `config` 内に `has_<key>`（例 `has_webhook_url`）boolean で置換。`label`/`channel_type`/`is_enabled`/非機微キー（`room_id`・`to_address` 等）は従来どおり返す。
- **更新の write-only 契約**: 機微キー未指定（欠落 / null / 空文字）なら既存値を維持、指定時のみ差し替え。クライアントが read 形（`has_*`）をそのまま送り返しても保存しない。
- **送信経路は不変**: `CompositeNotifier` / 各 Notifier / 疎通テストは repository の実 config を読むため挙動不変。省略更新で実値が保持されることを回帰テストで担保。
- **OpenAPI** に write-only 契約を明記 → `npm run codegen` 反映（`schema.gen.ts`）。
- **frontend** 編集フォームを write-only UX に追随: 機微フィールドを `type=password` + `autoComplete=new-password`・未プリフィル・設定済みなら「空欄で維持」ヒント・required バリデーション緩和。i18n は 6 ロケール（en/ja/de/fr/pt-BR/zh-Hans）追加。
- **org-export（#796 / PR #838）の `config_json` verbatim 移送は不変**（issue の整理どおり別レイヤーとして維持）。

## 検証

- `composer check` 緑（PHPUnit 1327 / PHPStan lv8 / CS-Fixer / OpenAPI / MCP）。Risky:1 は既存の `ModuleRegistryTest`（本 PR 無関係）。
- `npm run check --prefix frontend` 緑（type-check / lint / format / test / validate:themes / knip / storybook build）。
- 追加テスト: read（list/create）に機微値が載らず `has_*` が正しい／省略更新で既存値維持・指定更新で差し替え／echo された `has_*` を保存しない／mapper 単体（型ごとの redact・merge・空値扱い）／frontend フォーム（未プリフィル・password・省略送信）。

Closes #845
Refs #836 #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)