### PR TITLE
fix(admin): 一覧のレコードラベル導出をタグ除去＋120字キャップに正規化する（#849）

### DIFF
--- a/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
+++ b/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
@@ -133,7 +133,8 @@ export function useManageEntitiesPage(entityTypeId: number) {
         (f) => f.entityId === Number(entity.id) && f.fieldKey === 'body',
       )
       if (bodyField !== undefined && bodyField.value.trim() !== '') {
-        result[String(entity.id)] = bodyField.value.trim()
+        // One truncated preview line in the UI — never mount a huge body verbatim (#849).
+        result[String(entity.id)] = bodyField.value.trim().slice(0, 200)
       }
     }
     return result

--- a/frontend/src/features/manage-entities/ui/EntityListPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityListPanel.tsx
@@ -101,12 +101,12 @@ export function EntityListPanel({
 
             {/* 中央カラム: タイトル・ステータス・body・日時 */}
             <div className="min-w-0 flex-1">
-              {/* 行1: タイトル + ステータスバッジ */}
-              <div className="flex flex-wrap items-center gap-x-inline-sm gap-y-0.5">
-                <Text as="span" variant="heading-sm">
+              {/* 行1: タイトル + ステータスバッジ（タイトルは 1 行 truncate・#849） */}
+              <div className="flex items-center gap-x-inline-sm gap-y-0.5">
+                <Text as="span" variant="heading-sm" className="min-w-0 truncate">
                   {label}
                 </Text>
-                <StatusBadge status={item.status}>
+                <StatusBadge status={item.status} className="shrink-0">
                   {t(`admin.entityStatus.status.${item.status}`)}
                 </StatusBadge>
               </div>

--- a/frontend/src/shared/lib/get-record-display-label.test.ts
+++ b/frontend/src/shared/lib/get-record-display-label.test.ts
@@ -55,3 +55,28 @@ describe('getRecordDisplayLabel', () => {
     })
   })
 })
+
+describe('derived (non-title) fallback normalization (#849)', () => {
+  it('strips markup and collapses whitespace', () => {
+    const html = '<header style="position:sticky"><a href="/">AYANE</a>\n  Home</header>'
+    expect(getRecordDisplayLabel(1, [tf(1, 'content', html)], 'fb')).toBe('AYANE Home')
+  })
+
+  it('caps a long derived label at 120 chars with an ellipsis', () => {
+    const long = 'word '.repeat(100)
+    const label = getRecordDisplayLabel(1, [tf(1, 'content', long)], 'fb')
+    expect(label.length).toBeLessThanOrEqual(121)
+    expect(label.endsWith('…')).toBe(true)
+  })
+
+  it('falls back when the field is markup only', () => {
+    expect(getRecordDisplayLabel(1, [tf(1, 'content', '<div><span></span></div>')], 'fb')).toBe(
+      'fb',
+    )
+  })
+
+  it('never normalizes an explicit title field', () => {
+    const title = 'A <b>literal</b> title kept as-is'
+    expect(getRecordDisplayLabel(1, [tf(1, 'title', title)], 'fb')).toBe(title)
+  })
+})

--- a/frontend/src/shared/lib/get-record-display-label.ts
+++ b/frontend/src/shared/lib/get-record-display-label.ts
@@ -8,7 +8,26 @@ import type { TextField } from '@/entities/text-field'
  * the locale-agnostic (null) row, then the first — so listings show titles in the
  * visitor's language and fall back gracefully. With no `locale` the behavior is
  * unchanged (first match), so admin callers are unaffected.
+ *
+ * The non-title fallback is a *derived* label, so it is normalized for display:
+ * markup is stripped and the text capped (#849). A bespoke page whose only field
+ * is a full html document (bare layout, #799) must not dump its source into
+ * listings. An explicit `title` field is trusted as-is.
  */
+const FALLBACK_LABEL_MAX = 120
+
+/** Strip markup, collapse whitespace, and cap for use as a derived label. */
+export function toDerivedLabel(value: string): string {
+  const text = value
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (text.length <= FALLBACK_LABEL_MAX) {
+    return text
+  }
+  return text.slice(0, FALLBACK_LABEL_MAX).trimEnd() + '…'
+}
+
 export function getRecordDisplayLabel(
   entityId: number,
   textFields: TextField[],
@@ -40,7 +59,10 @@ export function getRecordDisplayLabel(
 
   const first = pick(forEntity)
   if (first !== undefined) {
-    return first.value.trim()
+    const derived = toDerivedLabel(first.value)
+    if (derived !== '') {
+      return derived
+    }
   }
 
   return fallback


### PR DESCRIPTION
## 目的
title フィールドを持たないレコード（bare レイアウトの bespoke ページ＝#799 の AYANE 型）で、最初のテキストフィールドの**生 html 全文**が一覧のタイトルとして描画され、`/admin/pages` が縦 41,121px（1アイテム最大 11,732px・描画テキスト約249,000字）に爆発する問題を修正する。

## 変更点
- `get-record-display-label.ts`: 非 title フォールバックを新設 `toDerivedLabel`（タグ除去→空白正規化→**120字キャップ＋…**）に通す。除去後に空なら従来の id フォールバック。**明示 title フィールドは従来どおり無加工**。共有先（recent-posts ウィジェット・削除ダイアログ等）も一括で直る。
- `EntityListPanel.tsx`: タイトル行を 1 行 truncate（防御層）。StatusBadge は `shrink-0` で潰れないように。
- `use-manage-entities-page.ts`: `recordBodyMap` の値を 200 字にキャップ（UI は truncate 済みだが巨大文字列を DOM に載せない）。

## 検証
- ローカル ayane org 実データ（bare 10ページ・最大78KB html）＋headless Chromium で実測: **scrollHeight 41,121px → 1,137px**・全行均一 57px・ラベルは「AYANE サービスと料金 SERVICES…」に truncate。コンソールエラーなし。
- lib テスト4件追加（タグ除去・120字キャップ・markup-only は fallback・title 無加工）。
- `npm run check --prefix frontend` 全緑。

## 補足（スコープ外・必要なら別 issue）
- ラベル品質: bespoke ページは全行が nav テキスト由来の似た表示になる。`meta_title` を derived フォールバックより優先する案は挙動変更が広いので今回は見送り。
- 一覧がタイプ全 text_fields をフェッチする転送量問題（issue 記載のスコープ外項目）。

Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)