### PR TITLE
feat(admin): 一覧のレコードラベルで meta_title を導出抜粋より優先する（#853）

### DIFF
--- a/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
+++ b/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
@@ -120,6 +120,8 @@ export function useManageEntitiesPage(entityTypeId: number) {
           Number(entity.id),
           textFields,
           t('admin.entityRecord.id', { id: entity.id }),
+          null,
+          entity.metaTitle,
         ),
       ]),
     )

--- a/frontend/src/shared/lib/get-record-display-label.test.ts
+++ b/frontend/src/shared/lib/get-record-display-label.test.ts
@@ -80,3 +80,23 @@ describe('derived (non-title) fallback normalization (#849)', () => {
     expect(getRecordDisplayLabel(1, [tf(1, 'title', title)], 'fb')).toBe(title)
   })
 })
+
+describe('metaTitle priority (#853)', () => {
+  it('prefers metaTitle over the derived excerpt when there is no title field', () => {
+    const html = '<header><a href="/">AYANE</a> Home</header>'
+    expect(getRecordDisplayLabel(1, [tf(1, 'content', html)], 'fb', null, '会社案内｜AYANE')).toBe(
+      '会社案内｜AYANE',
+    )
+  })
+
+  it('never beats an explicit title field', () => {
+    expect(getRecordDisplayLabel(1, [tf(1, 'title', 'Hello')], 'fb', null, 'Meta')).toBe('Hello')
+  })
+
+  it('ignores empty or whitespace-only metaTitle', () => {
+    expect(getRecordDisplayLabel(1, [tf(1, 'body', 'Body text')], 'fb', null, '  ')).toBe(
+      'Body text',
+    )
+    expect(getRecordDisplayLabel(1, [], 'fb', null, null)).toBe('fb')
+  })
+})

--- a/frontend/src/shared/lib/get-record-display-label.ts
+++ b/frontend/src/shared/lib/get-record-display-label.ts
@@ -1,8 +1,9 @@
 import type { TextField } from '@/entities/text-field'
 
 /**
- * Resolve a record's display label from its text fields: the `title` field if
- * present, else the first non-empty field, else the fallback.
+ * Resolve a record's display label: the `title` field if present, else the
+ * entity's SEO `metaTitle` when the caller provides one (#853), else the first
+ * non-empty field, else the fallback.
  *
  * When `locale` is given (public i18n, #540) each step prefers that locale, then
  * the locale-agnostic (null) row, then the first — so listings show titles in the
@@ -33,6 +34,7 @@ export function getRecordDisplayLabel(
   textFields: TextField[],
   fallback: string,
   locale: string | null = null,
+  metaTitle: string | null = null,
 ): string {
   const forEntity = textFields.filter(
     (item) => item.entityId === entityId && item.value.trim() !== '',
@@ -55,6 +57,12 @@ export function getRecordDisplayLabel(
   const title = pick(forEntity.filter((item) => item.fieldKey === 'title'))
   if (title !== undefined) {
     return title.value.trim()
+  }
+
+  // SEO meta_title beats the derived excerpt: bespoke pages sharing one html
+  // field would otherwise all show the same stripped header/nav text (#853).
+  if (metaTitle !== null && metaTitle.trim() !== '') {
+    return metaTitle.trim()
   }
 
   const first = pick(forEntity)


### PR DESCRIPTION
## 目的
#850 の導出抜粋ラベルは、自由 html 1本の bespoke ページだと**全行が同じヘッダー/ナビ文字列**になり一覧で区別できない（施主レビュー 2026-07-14）。SEO meta_title を優先して各ページを識別可能にする。

## 変更点
- `get-record-display-label.ts`: 優先順位を **title フィールド → `metaTitle`（新規・optional param）→ 導出抜粋（#850）→ id** に。空/空白の metaTitle は無視。
- `use-manage-entities-page.ts`: 一覧ラベルに `entity.metaTitle` を配線。
- 他の共有先（recent-posts 等）は param 省略＝挙動不変。

## 検証
- AYANE 実データ＋headless Chromium で全10行が「サイトをリニューアルしました｜株式会社AYANE」等の meta_title 表示になることをスクリーンショット確認（行高・truncate は #850 のまま維持）。
- lib テスト3件追加（metaTitle 優先・title には勝たない・空白 metaTitle 無視）。
- `npm run check --prefix frontend` 全緑。

Closes #853 / Refs #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)