### PR TITLE
docs(daily): bundle 配信の技術調査（#857/#858）を 07-14 日報に追記する（#860）

### DIFF
--- a/docs/daily/2026-07-14.md
+++ b/docs/daily/2026-07-14.md
@@ -128,3 +128,29 @@ recent-posts ウィジェット等も一括で直る）＋タイトル 1 行 tru
 **title フィールド → meta_title → 導出抜粋 → id** に変更（PR #854・AYANE 実データで
 「会社案内｜株式会社AYANE」等の表示を headless Chromium 実測確認）。同日夜に**第30回デプロイ**で
 本番反映（施主 GO・migration 無し・healthy / 3面 200 / www 301 維持 / エラーログ 0）。
+
+---
+
+## 追補4（同夜〜深夜）— bundle 配信の技術調査（#857 / #858・方針は保留）
+
+Custom Page の `bundle` フィールドと trusted-embed で任意 JS（three.js 等）を動かせるかの問いを起点に、
+bundle 配信の技術制約を調査し issue 2件を起票。**実装は起こさず保留**（実需要が出てから着手）。設計は #858 に確定記録。
+
+### #857（bug）— bundle の JS が本番CSP下で実行されない
+`SandboxedBundle` が `srcDoc` iframe のため**親ページの CSP（本番 `default-src 'self'`）を継承**し、
+bundle 内の inline `<script>` が CSP 違反で実行拒否される。`sandbox="allow-scripts"` でも srcdoc は親CSP継承なので効かない。
+本番相当CSPを再現した headless Chromium で `SCRIPT_BLOCKED`（`Executing inline script violates 'script-src 'self''`）を実測。
+dev は CSP が緩く露見しない。根本解は「別レスポンスを iframe `src=` で読む実URL配信」で、#858 の配信モデルに収束。
+
+### #858（epic）— LP バンドル配信（実URL・トークンレス公開オリジン）
+AI 製の自己完結バンドルを「トークンレスな公開配信オリジン」から実URLで配信する方針の実装トラッカー。
+3観点でコード裏取り:
+- **routing**: ホスト→org 解決は `RuntimeServiceProvider` の strategy（single/subdomain/path）。「公開配信ホストでログインさせない」規律は**現状どのモードでも未実装**（`/api/v1/auth/login` が全ホストで通る）→ `OriginGuardMiddleware` 新設が起点。
+- **CSP/bundle**: `PublicHtmlCsp::build` の呼び出しは SSR/SPAシェルの2点。bundle は text_fields の単一JSON（`{html, seoText}`）。**最小修正案（別オリジン不要）= `srcDoc` を実URL `/bundle/…` の iframe `src` 配信に変え、その配信レスポンスに bundle専用CSP（`connect-src 'none'` で多層防御）を付ける**。iframe が別レスポンスを読むので親CSPを継承せず、隔離は既存の opaque origin（`allow-scripts` のみ）維持。
+- **インフラ**: 独自ドメイン + on-demand TLS ask は #618/#600 で実装済み（`TlsCheckHandler`）。配信は単一オリジン。専用サブオリジン新設（アプリ4点改修+Caddy/DNS）vs 既存テナントサブドメイン流用（アプリ改修ほぼ0・隔離は論理依存）の2案。
+
+### 技術核 PoC（ローカル実測・全て緑）
+three.js r152 を含む自己完結バンドルを2オリジンで対比配信し headless Chromium で実測:
+① 別ホストには host-only の認証 cookie が**乗らない** ② **実HTML**が返り索引可能（iframe でない）
+③ トークンレス配信オリジン相当CSPで **three.js（WebGL）が描画成功**／対比で現行公開CSP（`default-src 'self'`）では実行拒否。
+→「別トークンレス公開オリジンなら任意JSが動き・cookie が乗らず・実HTMLで索引可能」が技術的に成立することを確認。


### PR DESCRIPTION
## 目的
bundle（Custom Page）の JS が本番CSP下で動かない件（#857）と、LP バンドル配信エピック（#858）の技術調査結果を 07-14 日報に記録する。

## 変更点
- `docs/daily/2026-07-14.md` に追補4: #857 の CSP 制約（srcdoc iframe が親CSP継承）・#858 の3観点裏取りと最小修正案・技術核 PoC の実測結果。方針は保留（設計は #858 に確定記録）。

## 検証
- docs のみ。issue/PR 番号・file 参照は実データと突合済み。

Closes #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)