### PR TITLE
fix(theme): codemod 写像表 v1 の silent no-op 群を契約語彙へ是正する（W1・#863）

### DIFF
--- a/frontend/src/features/import-url-redirects/ui/ImportUrlRedirectsView.tsx
+++ b/frontend/src/features/import-url-redirects/ui/ImportUrlRedirectsView.tsx
@@ -20,7 +20,7 @@ function ErrorAlert({ message }: { message: string }) {
 
 function Stat({ label, value }: { label: string; value: number }) {
   return (
-    <div className="flex flex-col gap-stack-3xs rounded-sm border border-border-subtle px-inline-md py-stack-xs">
+    <div className="flex flex-col gap-stack-3xs rounded-sm border border-border px-inline-md py-stack-xs">
       <span className="font-chrome text-tiny uppercase tracking-wide text-text-muted">{label}</span>
       <span className="font-sans text-heading-sm font-semibold text-text-primary">{value}</span>
     </div>
@@ -51,7 +51,7 @@ function ResultCard({ result }: { result: RedirectCsvImportDto }) {
             </Text>
             <ul className="flex flex-col gap-stack-3xs">
               {result.samples.map((sample) => (
-                <li key={sample.source} className="text-caption text-text-secondary">
+                <li key={sample.source} className="text-caption text-text-muted">
                   <code className="text-text-primary">{sample.source}</code>
                   {' → '}
                   <code className="text-text-primary">{sample.target}</code>
@@ -104,7 +104,7 @@ export function ImportUrlRedirectsView() {
             <input
               type="file"
               accept=".csv,text/csv"
-              className="text-caption text-text-secondary"
+              className="text-caption text-text-muted"
               onChange={(event) => {
                 setFile(event.target.files?.[0] ?? null)
                 preview.reset()

--- a/frontend/src/features/import-wxr/ui/WxrImportView.tsx
+++ b/frontend/src/features/import-wxr/ui/WxrImportView.tsx
@@ -21,7 +21,7 @@ function ErrorAlert({ message }: { message: string }) {
 
 function Stat({ label, value }: { label: string; value: number }) {
   return (
-    <div className="flex flex-col gap-stack-3xs rounded-sm border border-border-subtle px-inline-md py-stack-xs">
+    <div className="flex flex-col gap-stack-3xs rounded-sm border border-border px-inline-md py-stack-xs">
       <span className="font-chrome text-tiny uppercase tracking-wide text-text-muted">{label}</span>
       <span className="font-sans text-heading-sm font-semibold text-text-primary">{value}</span>
     </div>
@@ -45,10 +45,7 @@ function PlanCard({ plan }: { plan: WxrImportPlanDto }) {
         {plan.planned.length > 0 ? (
           <ul className="flex flex-col gap-stack-3xs">
             {plan.planned.map((item) => (
-              <li
-                key={`${item.entity_type}/${item.slug}`}
-                className="text-caption text-text-secondary"
-              >
+              <li key={`${item.entity_type}/${item.slug}`} className="text-caption text-text-muted">
                 <span className="font-medium text-text-primary">{item.title || item.slug}</span>
                 {` — ${item.entity_type} · ${item.status}`}
                 {item.tags.length > 0 ? ` · ${item.tags.join(', ')}` : ''}
@@ -133,7 +130,7 @@ export function WxrImportView() {
             <input
               type="file"
               accept=".xml,application/xml,text/xml"
-              className="text-caption text-text-secondary"
+              className="text-caption text-text-muted"
               onChange={(event) => {
                 setFile(event.target.files?.[0] ?? null)
                 preview.reset()

--- a/frontend/src/features/manage-data-migration/ui/DataMigrationView.tsx
+++ b/frontend/src/features/manage-data-migration/ui/DataMigrationView.tsx
@@ -67,10 +67,10 @@ export function DataMigrationView({
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b border-border">
-                      <th className="pb-2 text-left font-medium text-text-secondary">
+                      <th className="pb-2 text-left font-medium text-text-muted">
                         {t('admin.dataMigration.table.name')}
                       </th>
-                      <th className="pb-2 text-right font-medium text-text-secondary">
+                      <th className="pb-2 text-right font-medium text-text-muted">
                         {t('admin.dataMigration.table.rows')}
                       </th>
                     </tr>

--- a/frontend/src/features/manage-notification-channels/ui/ManageNotificationChannelsView.tsx
+++ b/frontend/src/features/manage-notification-channels/ui/ManageNotificationChannelsView.tsx
@@ -136,7 +136,9 @@ export function ManageNotificationChannelsView({
                   >
                     {t(`admin.notifications.channelType.${channel.channelType}`)}
                   </span>
-                  <span className="font-sans text-sm font-medium text-text">{channel.label}</span>
+                  <span className="font-sans text-sm font-medium text-text-primary">
+                    {channel.label}
+                  </span>
                   <span
                     className={`inline-block rounded px-1.5 py-0.5 font-sans text-caption ${
                       channel.isEnabled

--- a/frontend/src/features/manage-notification-channels/ui/NotificationChannelForm.tsx
+++ b/frontend/src/features/manage-notification-channels/ui/NotificationChannelForm.tsx
@@ -204,7 +204,7 @@ export function NotificationChannelForm({
 
         {!isEdit && (
           <div>
-            <label className="mb-1 block font-sans text-sm font-medium text-text">
+            <label className="mb-1 block font-sans text-sm font-medium text-text-primary">
               {t('admin.notifications.form.channelTypeLabel')}
             </label>
             <select
@@ -214,7 +214,7 @@ export function NotificationChannelForm({
                 setConfig({})
                 setErrors({})
               }}
-              className="w-full rounded-md border border-border bg-surface px-3 py-2 font-sans text-sm text-text focus:outline-none focus:ring-2 focus:ring-accent"
+              className="w-full rounded-md border border-border bg-surface px-3 py-2 font-sans text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-accent"
             >
               {NOTIFICATION_CHANNEL_TYPES.map((type) => (
                 <option key={type} value={type}>
@@ -226,7 +226,7 @@ export function NotificationChannelForm({
         )}
 
         <div>
-          <label className="mb-1 block font-sans text-sm font-medium text-text">
+          <label className="mb-1 block font-sans text-sm font-medium text-text-primary">
             {t('admin.notifications.form.labelLabel')}
           </label>
           <input
@@ -236,7 +236,7 @@ export function NotificationChannelForm({
               setLabel(e.target.value)
             }}
             placeholder={t('admin.notifications.form.labelPlaceholder')}
-            className="w-full rounded-md border border-border bg-surface px-3 py-2 font-sans text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-accent"
+            className="w-full rounded-md border border-border bg-surface px-3 py-2 font-sans text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-accent"
           />
           {errors['label'] !== undefined && (
             <p className="mt-1 font-sans text-xs text-danger">{errors['label']}</p>
@@ -245,7 +245,7 @@ export function NotificationChannelForm({
 
         {configFields.map((field) => (
           <div key={field.key}>
-            <label className="mb-1 block font-sans text-sm font-medium text-text">
+            <label className="mb-1 block font-sans text-sm font-medium text-text-primary">
               {field.label}
               {field.required && <span className="ml-1 text-danger">*</span>}
             </label>
@@ -257,7 +257,7 @@ export function NotificationChannelForm({
                 }}
                 placeholder={field.placeholder}
                 rows={3}
-                className="w-full rounded-md border border-border bg-surface px-3 py-2 font-mono text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-accent"
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 font-mono text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-accent"
               />
             ) : (
               <input
@@ -268,7 +268,7 @@ export function NotificationChannelForm({
                   setConfigField(field.key, e.target.value)
                 }}
                 placeholder={field.placeholder}
-                className="w-full rounded-md border border-border bg-surface px-3 py-2 font-sans text-sm text-text placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-accent"
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 font-sans text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-accent"
               />
             )}
             {field.sensitive === true && (
@@ -294,7 +294,7 @@ export function NotificationChannelForm({
             }}
             className="h-4 w-4 rounded border-border text-accent"
           />
-          <label htmlFor={enabledId} className="font-sans text-sm text-text">
+          <label htmlFor={enabledId} className="font-sans text-sm text-text-primary">
             {t('admin.notifications.form.isEnabledLabel')}
           </label>
         </div>

--- a/frontend/src/features/manage-organizations/ui/ManageOrganizationDetailView.tsx
+++ b/frontend/src/features/manage-organizations/ui/ManageOrganizationDetailView.tsx
@@ -58,7 +58,7 @@ export function ManageOrganizationDetailView({
       <div>
         <Link
           to="/superadmin/organizations"
-          className="mb-2 flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary"
+          className="mb-2 flex items-center gap-1 text-sm text-text-muted hover:text-text-primary"
         >
           <IconChevronLeft size={14} />
           {t('admin.organizations.pageTitle')}

--- a/frontend/src/features/manage-organizations/ui/ManageOrganizationsView.tsx
+++ b/frontend/src/features/manage-organizations/ui/ManageOrganizationsView.tsx
@@ -196,22 +196,22 @@ export function ManageOrganizationsView({
           <table className="w-full text-sm">
             <thead className="border-b border-border bg-surface-raised">
               <tr>
-                <th className="px-4 py-3 text-left font-medium text-text-secondary">
+                <th className="px-4 py-3 text-left font-medium text-text-muted">
                   {t('admin.organizations.idColumn')}
                 </th>
-                <th className="px-4 py-3 text-left font-medium text-text-secondary">
+                <th className="px-4 py-3 text-left font-medium text-text-muted">
                   {t('common.field.name')}
                 </th>
-                <th className="px-4 py-3 text-left font-medium text-text-secondary">
+                <th className="px-4 py-3 text-left font-medium text-text-muted">
                   {t('common.field.slug')}
                 </th>
-                <th className="px-4 py-3 text-left font-medium text-text-secondary">
+                <th className="px-4 py-3 text-left font-medium text-text-muted">
                   {t('admin.organizations.plan')}
                 </th>
-                <th className="px-4 py-3 text-left font-medium text-text-secondary">
+                <th className="px-4 py-3 text-left font-medium text-text-muted">
                   {t('admin.organizations.status')}
                 </th>
-                <th className="px-4 py-3 text-left font-medium text-text-secondary">
+                <th className="px-4 py-3 text-left font-medium text-text-muted">
                   {t('admin.organizations.actions')}
                 </th>
               </tr>
@@ -221,7 +221,7 @@ export function ManageOrganizationsView({
                 <tr key={org.id} className="hover:bg-surface-raised/50">
                   <td className="px-4 py-3 text-text-muted">{org.id}</td>
                   <td className="px-4 py-3 font-medium text-text-primary">{org.name}</td>
-                  <td className="px-4 py-3 font-mono text-text-secondary">{org.slug}</td>
+                  <td className="px-4 py-3 font-mono text-text-muted">{org.slug}</td>
                   <td className="px-4 py-3">
                     <span className="inline-flex rounded-full bg-accent/10 px-2 py-0.5 text-xs font-medium text-accent">
                       {org.plan}

--- a/frontend/src/pages/superadmin/SuperadminShell.tsx
+++ b/frontend/src/pages/superadmin/SuperadminShell.tsx
@@ -19,7 +19,7 @@ function SuperadminNavItem({ to, icon, label }: SuperadminNavItemProps) {
           'flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors',
           isActive
             ? 'bg-accent text-white'
-            : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary',
+            : 'text-text-muted hover:bg-surface-overlay hover:text-text-primary',
         ].join(' ')
       }
     >
@@ -65,7 +65,7 @@ export function SuperadminShell() {
         <div className="absolute bottom-0 left-0 w-56 border-t border-border p-3">
           <Link
             to="/admin"
-            className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-text-secondary hover:text-text-primary"
+            className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-text-muted hover:text-text-primary"
           >
             <IconHome size={16} />
             <span>{t('admin.superadmin.backToAdmin')}</span>

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -10,6 +10,10 @@
   --color-surface: oklch(97% 0.006 75);
   --color-surface-raised: oklch(100% 0 0);
   --color-surface-overlay: oklch(94% 0.008 75);
+  /* sunken well (table stripes / empty thumbnail slots) — one step below the
+     page surface. Declared at the root @theme so `bg-surface-sunken` resolves
+     in the default theme (previously undefined here → silent no-op; #863). */
+  --color-surface-sunken: oklch(95.5% 0.006 75);
 
   /* ── Sidebar (dark even in light mode — WordPress style) ──────────────── */
   --color-sidebar-bg: oklch(19% 0.015 265);


### PR DESCRIPTION
## 目的

`@hideyukimori/nene2-tokens@1.0.0` 同梱の是正リスト `REMEDIATION_V1`（records 分）に従い、**CSS を生成せず黙って効かないクラス（silent no-op）** を契約語彙へ是正する。是正先は凍結レビュー（2026-07-14・approvedBy: hide）で承認済み。W1 是正第1波・records 分。

対象トークン（`--color-text-secondary` / `--color-surface-hover` / `--color-border-subtle` / 裸の `--color-text` / default テーマの `--color-surface-sunken`）が**未定義であることを実測確認**した上で是正した（＝現状は Tailwind がユーティリティを生成せず無効）。

## 変更（全数）

| from | to | 箇所 | 出典 |
| --- | --- | --- | --- |
| `text-text-secondary` | `text-text-muted` | 16 | R2⑥(B)/AI-7(b)・凍結③ |
| `text-text`（裸） | `text-text-primary` | 9 | R5 議題(3) |
| `border-border-subtle` | `border-border` | 2 | R5 議題(3) |
| `hover:bg-surface-hover` | `hover:bg-surface-overlay` | 1 | R5 議題(3) |
| `--color-surface-sunken` 未宣言 | default.css root `@theme` へ `oklch(95.5% 0.006 75)` 追加 | 1 | R5 訂正1 |

`text-body-sm`（typography-warning）は色系 block 対象外・oracle warning レポート対象のため本 PR のスコープ外。

## 見た目への影響（目検結果）

silent no-op の是正は原則「見た目不変」だが、**未定義→定義済みへ切り替わることで実際に描画が変わる箇所**があるため、目検で以下を確認・列挙する（いずれも綴りの意図＝正しい是正であり、"効いていなかっただけ" のケース）:

- **`text-text-secondary`→`text-text-muted`（16・要目視）**: テーブル見出し・キャプション・二次ナビの文字。現状は継承色（≒primary 相当）で描画され、是正後に muted（薄い灰）になる。**意図どおり de-emphasize されるが色は変わる**。
- **`border-border-subtle`→`border-border`（2）**: 現状 border-color が未解決で `currentColor`（濃色）に落ちていた枠が、是正後に `--color-border`（淡い灰 88%）になる。枠色が薄くなる。
- **`hover:bg-surface-hover`→`hover:bg-surface-overlay`（1・SuperadminShell）**: 現状ホバー無反応 → 是正後にホバー背景が付く（新規ホバー効果）。
- **`--color-surface-sunken` 追加（1・ManageSiteSettingsView の空サムネ枠）**: 現状は透明 → 是正後に一段沈んだ淡い面色が付く。値はビルトインテーマの surface ランプ（reading: surface97%→sunken95.5%）に倣った起草判断。
- **`text-text`→`text-text-primary`（9・通知チャンネル）**: 周辺の既定文字色が既に primary のため実質不変。

## 検証（実測）

- `npm run check` 一式緑: type-check / lint / prettier / **test 559 passed (103 files)** / validate:themes（All theme bundles valid）/ knip / build-storybook すべて PASS。

Closes #863

🤖 Generated with [Claude Code](https://claude.com/claude-code)
