### PR TITLE
chore(standards): problem-map exemplar アンカーを植栽

### DIFF
--- a/frontend/src/shared/i18n/map-problem-details.ts
+++ b/frontend/src/shared/i18n/map-problem-details.ts
@@ -9,6 +9,7 @@ import type { MessageKey } from './translate'
  * This mapping is for Admin UI error display — when you want a user-facing
  * localized description instead of the raw API title.
  */
+// [nene2-exemplar:problem-map] — fleet frontend-standards ER-2 problem→messageKey map exemplar (check:exemplars).
 export function mapProblemDetailsToMessageKey(error: AppError): MessageKey | null {
   switch (error.status) {
     case 401:


### PR DESCRIPTION
## 目的

`nene2-fleet-tooling` の `check:exemplars`（RAT-3(a)）green 化のための **exemplar アンカー植栽**。規約文書 02-data-flow ER-2 / 04-i18n §9 が指す

`[X:nene-records/frontend/src/shared/i18n/map-problem-details.ts#nene2-exemplar:problem-map]`

を実ファイル側のアンカーコメントと突合させる。

## 変更

- `frontend/src/shared/i18n/map-problem-details.ts` の関数直前に `// [nene2-exemplar:problem-map] ...` の**コメント1行のみ**を追加。ロジック不変（pre-commit の eslint/prettier 通過）。

## 検品（exemplar 実体確認）と申し送り

- 本ファイルは AppError（Problem Details）→ MessageKey の写像であり、規約が「内容の exemplar」と明記する対象に**一致**。
- ⚠️ **申し送り 2 点**（本 PR スコープ外・別 wave）:
  1. 現状は `switch (error.status)`（HTTP ステータス分岐・fallback は `null`）。規約 ER-2 の最終正準形は「slug 写像の網羅 switch ＋フォールバックキー `error.unknown`」であり、**形の寄せは別途**必要。
  2. 規約 R3 裁定で本 exemplar は将来 `shared/api/errors.ts` へ**移設**予定。その移設 PR がアンカー `[nene2-exemplar:problem-map]` を移送する（現状の `shared/i18n/` 配置は I18N-4 有限列挙上 conformance red の場所）。

## マージ方針

- **マージ禁止**（施主承認待ち）。上記申し送りの判断とあわせて扱う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)