### PR TITLE
fix(i18n): 非権威カタログを satisfies Record 型へ付け替え（AI-23・W4前倒し）

### DIFF
--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -1,7 +1,7 @@
 import type { MessageCatalog } from './en'
 
 /** German — complete CMS admin & public-site catalog. Missing keys fall back to English. */
-export const de: Partial<MessageCatalog> = {
+export const de = {
   // ── Common ──────────────────────────────────────────────────────────────
   'common.actions.edit': 'Bearbeiten',
   'common.actions.delete': 'Löschen',
@@ -1544,4 +1544,4 @@ export const de: Partial<MessageCatalog> = {
   // ── Misc (#728) ───────────────────────────────────────────────────────────
   'common.tableOfContents': 'Inhaltsverzeichnis',
   'admin.entityRecords.breadcrumbLabel': 'Brotkrümelnavigation',
-}
+} satisfies Record<keyof MessageCatalog, string>

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -1,7 +1,7 @@
 import type { MessageCatalog } from './en'
 
 /** French — complete admin and public UI catalog. Missing keys fall back to English. */
-export const fr: Partial<MessageCatalog> = {
+export const fr = {
   // ── Common ──────────────────────────────────────────────────────────────
   'common.actions.edit': 'Modifier',
   'common.actions.delete': 'Supprimer',
@@ -1582,4 +1582,4 @@ export const fr: Partial<MessageCatalog> = {
   // ── Misc (#728) ───────────────────────────────────────────────────────────
   'common.tableOfContents': 'Table des matières',
   'admin.entityRecords.breadcrumbLabel': 'Fil d’Ariane',
-}
+} satisfies Record<keyof MessageCatalog, string>

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -1,6 +1,6 @@
 import type { MessageCatalog } from './en'
 
-export const ja: Partial<MessageCatalog> = {
+export const ja = {
   // ── Common ──────────────────────────────────────────────────────────────
   'common.actions.edit': '編集',
   'common.actions.delete': '削除',
@@ -1552,4 +1552,4 @@ export const ja: Partial<MessageCatalog> = {
   // ── Misc (#728) ───────────────────────────────────────────────────────────
   'common.tableOfContents': '目次',
   'admin.entityRecords.breadcrumbLabel': 'パンくずリスト',
-}
+} satisfies Record<keyof MessageCatalog, string>

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -1,7 +1,7 @@
 import type { MessageCatalog } from './en'
 
 /** Brazilian Portuguese — complete admin/public UI catalog. Missing keys fall back to English. */
-export const ptBR: Partial<MessageCatalog> = {
+export const ptBR = {
   // ── Common ──────────────────────────────────────────────────────────────
   'common.actions.edit': 'Editar',
   'common.actions.delete': 'Excluir',
@@ -1564,4 +1564,4 @@ export const ptBR: Partial<MessageCatalog> = {
   // ── Misc (#728) ───────────────────────────────────────────────────────────
   'common.tableOfContents': 'Sumário',
   'admin.entityRecords.breadcrumbLabel': 'Trilha de navegação',
-}
+} satisfies Record<keyof MessageCatalog, string>

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -1,7 +1,7 @@
 import type { MessageCatalog } from './en'
 
 /** Simplified Chinese (简体中文) message catalog. Missing keys fall back to English. */
-export const zhHans: Partial<MessageCatalog> = {
+export const zhHans = {
   // ── Common ──────────────────────────────────────────────────────────────
   'common.actions.edit': '编辑',
   'common.actions.delete': '删除',
@@ -1493,4 +1493,4 @@ export const zhHans: Partial<MessageCatalog> = {
   // ── Misc (#728) ───────────────────────────────────────────────────────────
   'common.tableOfContents': '目录',
   'admin.entityRecords.breadcrumbLabel': '面包屑导航',
-}
+} satisfies Record<keyof MessageCatalog, string>

--- a/frontend/src/shared/i18n/translate.test.ts
+++ b/frontend/src/shared/i18n/translate.test.ts
@@ -21,7 +21,7 @@ describe('translate', () => {
 
     it('falls back to English for keys absent from ja', () => {
       // Temporarily verify a key that is NOT in ja
-      const jaWithoutKey: typeof ja = { ...ja }
+      const jaWithoutKey: Partial<typeof ja> = { ...ja }
       delete jaWithoutKey['admin.nav.home']
       expect(translate(jaWithoutKey, 'admin.nav.home')).toBe('Home')
     })


### PR DESCRIPTION
## 概要
records の非権威カタログは `Partial<MessageCatalog>` で型付けされており、**キー削除/欠落を検知しない**（⑦「satisfies Record — 欠落＝コンパイルエラー」に不適合）。議事録 R5 E18 / W4 work order (AI-23) の指示に従い型を付け替える。**records の権威は en のまま**（本 PR は反転ではない）。

## 変更（i18n 型ファイルのみ）
- `de.ts` / `fr.ts` / `ja.ts` / `pt-BR.ts` / `zh-Hans.ts`：`export const X: Partial<MessageCatalog> = {…}` → `export const X = {…} satisfies Record<keyof MessageCatalog, string>`。
- `translate.test.ts`：フォールバック検証の局所変数を `Partial<typeof ja>` に（カタログ型が optional でなくなったため `delete` を許可）。

## 安全性
- 5 ロケールとも **1,346/1,346 で完備**（実測 missing=0 / extra=0）なので `satisfies` は機械的に通過。**値は不変**。
- open PR 3本（#862 lint override・#865/#866 theme CSS）とは**触るファイルが重ならない**（実測確認）。

## 検証
- 全 `type-check`：**エラー 0**（origin/main baseline も 0）。i18n unit tests：**22 passed**。eslint / prettier：clean（pre-commit lint-staged 通過）。
- **故意 fail**：非権威 `ja.ts` からキー削除 → `ja.ts` が `TS1360 does not satisfy the expected type 'Record<…>'` で型エラー（欠落検知が有効化されたことを実証）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)