### PR TITLE
feat(http): X-Authorization フォールバック受け口を opt-in 有効化する

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,11 +20,20 @@
       runtime container (RuntimeServiceProvider -> GuardedJwtSecretResolver) can
       resolve a secret without a real NENE2_LOCAL_JWT_SECRET. APP_ENV is local
       here, so production fail-closed behaviour is unaffected. This enables the
-      injected dev secret; it does NOT disable authentication. No current test
-      boots the full container (verified: suite passes without this too), but
-      this keeps the repo ready for one that does.
+      injected dev secret; it does NOT disable authentication.
     -->
     <env name="APP_ENV" value="local"/>
     <env name="NENE2_ALLOW_DEV_SECRET" value="1"/>
+    <!--
+      DB_ADAPTER/DB_NAME: AuthorizationHeaderFallbackE2ETest boots the full runtime
+      container (RuntimeContainerFactory) and needs a working connection. SQLite
+      in-memory keeps this hermetic (no external DB in CI). The container caches
+      DatabaseQueryExecutorInterface as a singleton per boot, so the schema the test
+      creates through that same service is visible to every repository the request
+      pipeline reads from during that boot. See NENE2
+      vendor/hideyukimori/nene2/docs/development/test-database-strategy.md.
+    -->
+    <env name="DB_ADAPTER" value="sqlite"/>
+    <env name="DB_NAME" value=":memory:"/>
   </php>
 </phpunit>

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -412,6 +412,11 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                             applicationIdentity: new ApplicationIdentity(PreflightIdentity::APPLICATION_ID),
                         ),
                         databaseCandidateProfiles: CandidateProfileFactory::fromEnv($_SERVER + $_ENV),
+                        // Opt-in の X-Authorization フォールバック受け口（NENE2 #1558・ADR 0019）。
+                        // 前段 proxy が標準 Authorization を剥がす共有ホスティング（HETEML 型 Tier A）で、
+                        // nene2-js v1.1.0 が全リクエストに付与する `X-Authorization: Bearer` ミラーを
+                        // Authorization 不在/空のときのみ採用する。標準ヘッダが届く環境ではバイト不変。
+                        enableAuthorizationHeaderFallback: true,
                     );
                 },
             )

--- a/tests/Http/AuthorizationHeaderFallbackE2ETest.php
+++ b/tests/Http/AuthorizationHeaderFallbackE2ETest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Http;
+
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeNeRecords\Http\RuntimeContainerFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * End-to-end proof that the opt-in X-Authorization fallback receiver (NENE2 #1558 /
+ * ADR 0019) is wired into this product's runtime pipeline.
+ *
+ * Front-end fleet clients (`@hideyukimori/nene2-client` v1.1.0) mirror every bearer
+ * token into `X-Authorization: Bearer <token>` so that shared hosting (HETEML-type
+ * Tier A) — where an upstream proxy strips the standard `Authorization` header before
+ * PHP sees it — can still authenticate. `RuntimeServiceProvider` enables the receiver
+ * via `enableAuthorizationHeaderFallback: true`, so the framework's
+ * AuthorizationHeaderFallbackMiddleware restores `Authorization` from the mirror
+ * (only when `Authorization` is absent/empty) at the head of the auth stage, before
+ * `AdminApiAuthMiddleware` (this product's own bearer/cookie auth middleware) runs.
+ *
+ * `GET /api/v1/organizations` is bearer-protected for all methods
+ * ({@see \NeNeRecords\Auth\AdminApiAuthMiddleware::ADMIN_ONLY_PREFIXES}) and is one of
+ * the `OrgResolverMiddleware` bypass prefixes
+ * ({@see \NeNeRecords\Organization\Resolution\OrgResolverMiddleware::BYPASS_PREFIXES}),
+ * so these assertions isolate the credential-restoration behaviour with no seeded
+ * tenant — the same shape as nene-field's `/organizations` pick.
+ *
+ * `AdminApiAuthMiddleware` is the only middleware in this product's pipeline that ever
+ * sets `WWW-Authenticate`, so its absence proves the request cleared the bearer-auth
+ * stage — regardless of what a downstream stage (org/role authorization) does with it
+ * afterwards. With minimal claims (`sub`, `exp`, no `role`), an authenticated request
+ * to this superadmin-only route is rejected by `CapabilityMiddleware` with a plain 403
+ * (no `WWW-Authenticate` — that middleware never sets it), which is why the "passes
+ * authentication" cases below assert 403, not 200: the org list handler requires a
+ * `role` claim that these tests intentionally omit, since only the transport-level
+ * mirror behaviour is in scope here.
+ *
+ * The tests fail if the opt-in flag is removed from RuntimeServiceProvider: a
+ * mirror-only request would then never restore `Authorization` and would be
+ * rejected as `missing_token`.
+ */
+final class AuthorizationHeaderFallbackE2ETest extends TestCase
+{
+    private const PROTECTED_PATH = '/api/v1/organizations';
+
+    private RequestHandlerInterface $app;
+    private TokenIssuerInterface $issuer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $container = (new RuntimeContainerFactory(dirname(__DIR__, 2)))->create();
+
+        // The runtime boots against SQLite `:memory:` (phpunit.xml.dist). Every
+        // request through this path touches `system_config` (tenant-resolution mode
+        // lookup, RuntimeServiceProvider — unconditional) and `access_logs`
+        // (AccessLogMiddleware — fail-open on error, but created here so the test
+        // exercises the real path instead of masking failures behind its catch).
+        // `rate_limits` (ThrottleMiddleware) sits after auth+capability and is out
+        // of reach for every case below (401/403), but is created too so a future
+        // capability change doesn't reintroduce a missing-table failure. Created
+        // through the container's own DatabaseQueryExecutorInterface (a per-boot
+        // singleton) so the same in-memory connection that RuntimeApplicationFactory's
+        // services read from sees them — a fresh PDO connection to `:memory:` would
+        // be a distinct, empty database.
+        $query = $container->get(DatabaseQueryExecutorInterface::class);
+        self::assertInstanceOf(DatabaseQueryExecutorInterface::class, $query);
+        $query->execute('CREATE TABLE system_config (`key` TEXT PRIMARY KEY, `value` TEXT, updated_at TEXT)');
+        $query->execute('CREATE TABLE rate_limits (key_hash TEXT PRIMARY KEY, count INTEGER, reset_at INTEGER)');
+        $query->execute(
+            'CREATE TABLE access_logs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                organization_id INTEGER,
+                request_id TEXT,
+                method TEXT,
+                path TEXT,
+                status_code INTEGER,
+                duration_ms INTEGER,
+                accessed_at TEXT,
+                access_date TEXT
+            )',
+        );
+
+        $app = $container->get(RequestHandlerInterface::class);
+        self::assertInstanceOf(RequestHandlerInterface::class, $app);
+        $this->app = $app;
+
+        $issuer = $container->get(TokenIssuerInterface::class);
+        self::assertInstanceOf(TokenIssuerInterface::class, $issuer);
+        $this->issuer = $issuer;
+    }
+
+    /**
+     * The mirror end-to-end proof: a valid bearer token supplied ONLY in the
+     * `X-Authorization` header (no standard `Authorization`) is restored by the
+     * fallback receiver and accepted by `AdminApiAuthMiddleware` — the request clears
+     * the bearer-auth stage (no `WWW-Authenticate` challenge).
+     */
+    public function testValidTokenInMirrorOnlyPassesAuthentication(): void
+    {
+        $token = $this->issuer->issue(['sub' => 'admin-e2e', 'exp' => time() + 3600]);
+
+        $request = (new Psr17Factory())
+            ->createServerRequest('GET', self::PROTECTED_PATH)
+            ->withHeader('X-Authorization', 'Bearer ' . $token);
+
+        $response = $this->app->handle($request);
+
+        self::assertSame(
+            '',
+            $response->getHeaderLine('WWW-Authenticate'),
+            'A valid token mirrored only into X-Authorization must clear the bearer auth stage (no challenge issued).',
+        );
+    }
+
+    /**
+     * The auth stage actually receives the mirrored credential: an INVALID token
+     * in `X-Authorization` only is rejected as `invalid_token` (AdminApiAuthMiddleware
+     * saw a token and rejected it), NOT `missing_token` — which is only possible if
+     * the fallback receiver restored `Authorization` from the mirror before auth ran.
+     */
+    public function testInvalidTokenInMirrorOnlyReachesBearerStageAsInvalidNotMissing(): void
+    {
+        $request = (new Psr17Factory())
+            ->createServerRequest('GET', self::PROTECTED_PATH)
+            ->withHeader('X-Authorization', 'Bearer not-a-real-token');
+
+        $response = $this->app->handle($request);
+
+        self::assertSame(401, $response->getStatusCode());
+        $wwwAuth = $response->getHeaderLine('WWW-Authenticate');
+        self::assertStringContainsString('error="invalid_token"', $wwwAuth);
+        self::assertStringNotContainsString('error="missing_token"', $wwwAuth);
+    }
+
+    /**
+     * Baseline / control: with NO credential in either header, the auth stage
+     * reports `missing_token`. This is the response a mirror-only request would get
+     * if the opt-in fallback were disabled.
+     */
+    public function testNoCredentialYieldsMissingToken(): void
+    {
+        $request = (new Psr17Factory())->createServerRequest('GET', self::PROTECTED_PATH);
+
+        $response = $this->app->handle($request);
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertStringContainsString(
+            'error="missing_token"',
+            $response->getHeaderLine('WWW-Authenticate'),
+        );
+    }
+
+    /**
+     * The standard header still wins when both are present (byte-for-byte behaviour
+     * unchanged on hosting that delivers `Authorization`): a valid standard token
+     * clears the bearer stage even when an invalid mirror is also sent. If the
+     * receiver wrongly preferred the mirror, AdminApiAuthMiddleware would reject the
+     * invalid token with an `invalid_token` challenge; its absence proves
+     * standard-header precedence.
+     */
+    public function testStandardAuthorizationHeaderTakesPrecedenceOverMirror(): void
+    {
+        $token = $this->issuer->issue(['sub' => 'admin-e2e', 'exp' => time() + 3600]);
+
+        $request = (new Psr17Factory())
+            ->createServerRequest('GET', self::PROTECTED_PATH)
+            ->withHeader('Authorization', 'Bearer ' . $token)
+            ->withHeader('X-Authorization', 'Bearer not-a-real-token');
+
+        $response = $this->app->handle($request);
+
+        self::assertSame('', $response->getHeaderLine('WWW-Authenticate'));
+    }
+}


### PR DESCRIPTION
## 目的

NENE2 #1558（`Nene2\Middleware\AuthorizationHeaderFallbackMiddleware`＋`RuntimeApplicationFactory` の opt-in フラグ `enableAuthorizationHeaderFallback`・ADR 0019）を本製品で有効化し、X-Auth ミラーを **E2E で実証**する（BE 配線波・nene-field #98 に続く展開）。

前段 proxy が標準 `Authorization` を PHP に渡す前に剥がす共有ホスティング（HETEML 型 Tier A）向けの受け口。FE は `@hideyukimori/nene2-client` v1.1.0 が全リクエストに `X-Authorization: Bearer <token>` ミラーを送出済み。BE がこの受け口を有効化して初めてミラーが E2E で効く。

## 変更点

- `src/Http/RuntimeServiceProvider.php` — `RuntimeApplicationFactory` 構築に `enableAuthorizationHeaderFallback: true` を追加（opt-in 有効化、field と同じ4行コメント付き）
- `tests/Http/AuthorizationHeaderFallbackE2ETest.php` — E2E 実証テスト（実 runtime を起動）。`GET /api/v1/organizations`（`AdminApiAuthMiddleware::ADMIN_ONLY_PREFIXES` で全メソッド bearer 保護・`OrgResolverMiddleware::BYPASS_PREFIXES` で org 解決 bypass 対象）を使い、seed した tenant 無しでミラー挙動を isolate する:
  - **有効な token を X-Authorization だけに載せる** → 認証ステージを通過（`AdminApiAuthMiddleware` が challenge を出さない＝`WWW-Authenticate` 不在。この製品では `CapabilityMiddleware` が同ルートを superadmin 限定にしているため、role claim なしの本テストは 403 で応答するが、`WWW-Authenticate` を発行するミドルウェアは `AdminApiAuthMiddleware` だけなので、その不在＝bearer 認証通過の証明として成立する）
  - **無効な token を X-Authorization だけに載せる** → `error="invalid_token"`（ステージが token を**受け取った**証拠）であって `missing_token` ではない ← ミラーが Authorization を復元した E2E 証明
  - credential 無し → `error="missing_token"`（baseline）
  - 標準 Authorization ＋無効ミラー併存 → 標準優先（challenge 不在）
- `phpunit.xml.dist` — 上記テストがフル DI コンテナ（`RuntimeContainerFactory`）を起動できるよう `DB_ADAPTER=sqlite` / `DB_NAME=:memory:` を追加。コンテナ内で `DatabaseQueryExecutorInterface` はシングルトンなので、テストの `setUp()` がそこを通して作るスキーマ（`system_config` / `access_logs` / `rate_limits`）がそのままリクエストパイプラインから見える。

## composer.json / composer.lock — 変更なし（field との差分）

nene-field は `hideyukimori/nene2` を Packagist 経由 semver 制約（`^1.8.2` → `^1.11`）で要求するが、**nene-records は `@dev` ＋ `repositories: [{type: path, url: ../NENE2}]`** で NENE2 を sibling checkout から直接読む構成（field とここが本質的に異なる）。このため:

- opt-in パラメータが解決できるか実際に検証: sibling `../NENE2` を NENE2 の `origin/main`（opt-in フラグ実装済み・#1558 マージ済み・v1.11.0 タグ済み）に向けた環境で `composer update hideyukimori/nene2` を実行 → `dev-<NENE2-main-HEAD> ... Symlinking from ../NENE2` で解決し、`vendor/hideyukimori/nene2/src/Http/RuntimeApplicationFactory.php` に `enableAuthorizationHeaderFallback` パラメータの存在を確認。**version 制約の bump は不要**（そもそも semver 制約がない）。
- composer.lock は**意図的に変更していない**。path パッケージの `reference` はメタ情報でしかなく、`composer install`（`update` ではなく）を実行しても実体は常に `../NENE2` ディレクトリの現在の中身をそのまま symlink する（lock の reference と実際にチェックアウトされているコミットが食い違っていても再解決・再検証はされない — 実機で確認済み）。この扱いは本リポの既存コミット #623/#624 の記録（「lock は nene2 の @dev が sibling 現状へ再解決／path パッケージのため lock は情報的・無害」）と一致する。
- CI（`.github/workflows/backend-ci.yml`）は毎回 `git clone --depth=1 https://github.com/hideyukiMORI/NENE2.git ../NENE2` で NENE2 の **default branch（main）を都度新規取得**してから `composer install` する。したがって NENE2 の main に #1558 がマージ済みである今、composer.json/lock に手を加えなくても CI は自動的に opt-in パラメータが使える NENE2 を使う。

## 検証結果（実測・2026-07-15）

サンドボックス環境（NENE2 の別 worktree を `origin/main` に向けて `../NENE2` として配置）で実施:

- `composer update hideyukimori/nene2` → 解決成功（`enableAuthorizationHeaderFallback` パラメータの存在を vendor 側で確認）
- 追加 E2E テスト単体: `vendor/bin/phpunit tests/Http/AuthorizationHeaderFallbackE2ETest.php` → **OK (4 tests, 19 assertions)**
- **フェイルクローズ確認**: `enableAuthorizationHeaderFallback` を一時的に `false` に戻して同テストを再実行 → ミラーのみ2ケースが `missing_token` に落ちて **FAILURES (2 failures)** を確認（フラグを外すとテストが落ちることを実測。フラグは true に戻し済み）
- 全 phpunit スイート: `composer test` → **OK, but there were issues!(Tests: 1331, Assertions: 3863, Risky: 1)** — risky 1件（`ModuleRegistryTest::testDefaultCandidatesYieldOnlyModuleInstances`）は本PR無関係の既存事項（`git log` で本PRの変更行より前のコミット #623/#624 由来と確認済み）
- php-cs-fixer: `vendor/bin/php-cs-fixer fix --dry-run --diff` → **0 files to fix**
- openapi / conformance / mcp: それぞれ green（`composer openapi` / `composer conformance` / `composer mcp`）
- PHPStan: `composer analyse`（並列ワーカー・level 8）は本サンドボックス特有の症状として `class.notFound` が多発したが、`vendor/bin/phpstan analyse --debug`（並列を無効化した単一プロセス実行）では **[OK] No errors**。並列ワーカーでのみ失敗し単一プロセスでは通ることから、`../NENE2` を git worktree のシンボリックリンクとして配置した本検証環境特有の並列ワーカー間のシンボリックリンク解決の問題と判断（実 CI は `git clone` で普通のディレクトリを使うため再現しないと想定）。CI で赤が出た場合は追って確認する。

## スコープ外

- records の widget は「公認差異」扱いでフロント adopt 第1波の対象外だが、本PRは BE の受け口を開けるだけのレイヤーで、標準ヘッダが届く環境ではバイト不変。widget の公認差異とは独立。

🤖 Generated with [Claude Code](https://claude.com/claude-code)