### PR TITLE
refactor(i18n): 型権威を en から ja へ反転する（規約 04 I18N-8・#870）

### DIFF
--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -814,16 +814,22 @@ The browser is **hostile context**. Treat all rendered user content and all clie
 
 ### Locales
 
-6 locales matching the NENE2 docs locale set: `en` (default), `ja`, `fr`, `zh-Hans`, `pt-BR`, `de`.
+6 locales matching the NENE2 docs locale set: `ja` (**authority**), `en` (default, runtime fallback), `fr`, `zh-Hans`, `pt-BR`, `de`.
 Locale ID mapping to NENE2 docs is tracked in `shared/i18n/locales.ts`.
+
+**Authority: `ja`** (Frontend Standard 04, I18N-8). Message keys are authored in
+Japanese first and every other catalog — `en` included — mirrors that key set.
+`en` remains the default locale and the runtime fallback: authority (who owns
+the key set) and fallback (who answers at runtime) are separate concerns.
 
 ### Infrastructure
 
 | Module | Purpose |
 | --- | --- |
 | `shared/i18n/locales.ts` | `SupportedLocale` union + `LocaleMeta` (label, dir) |
-| `shared/i18n/messages/en.ts` | `MessageCatalog` type + complete English catalog (source of truth) |
-| `shared/i18n/messages/{locale}.ts` | `Partial<MessageCatalog>` — missing keys fall back to `en` |
+| `shared/i18n/messages/ja.ts` | Complete Japanese catalog (**authority**) + `MessageKey` / `MessageCatalog` types derived from it |
+| `shared/i18n/messages/en.ts` | Complete English catalog — reference locale and runtime fallback; re-exports the catalog types |
+| `shared/i18n/messages/{locale}.ts` | `satisfies Record<MessageKey, string>` — full parity with `ja` enforced at compile time |
 | `shared/i18n/i18n-context.tsx` | `I18nProvider` — locale detection, persistence, context |
 | `shared/i18n/use-translation.ts` | `useTranslation()` hook |
 | `shared/i18n/translate.ts` | Pure `translate()` function + `MessageKey` type |
@@ -834,8 +840,9 @@ Locale ID mapping to NENE2 docs is tracked in `shared/i18n/locales.ts`.
 
 - **No hardcoded user-facing strings** in Admin UI components → `t('admin.nav.home')`.
 - Key naming: `admin.{feature}.{element}` or `common.{element}`.
-- `en.ts` is the authoritative source; add new keys there first.
-- Other locales use `Partial<MessageCatalog>` — missing keys display English at runtime.
+- `ja.ts` is the authority catalog; add new keys there first, then translate into the other five in the same PR.
+- Every non-authority catalog (`en` included) is `satisfies Record<MessageKey, string>` — a missing or extra key is a compile error (Frontend Standard 04, I18N-9). `Partial` is not permitted.
+- `en` stays the runtime fallback: a key is displayed in English only when a catalog is bypassed at runtime, not because a key is optional.
 - Locale detection order: `localStorage['nene-locale']` → `navigator.language` → `en`.
 - Locale selector lives in `AppShell` header.
 

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -1,12 +1,19 @@
+import type { MessageCatalog, MessageKey } from './ja'
+
 /**
- * English message catalog — source of truth.
+ * English message catalog — the reference locale and runtime fallback.
+ *
+ * Authority note (Frontend Standard 04, I18N-8): the message key set is owned
+ * by `ja.ts` (`MessageKey = keyof typeof ja`). This catalog is checked against
+ * `Record<MessageKey, string>` (I18N-9), so it must mirror `ja` exactly — a key
+ * added to or removed from `ja` becomes a compile error here.
+ *
+ * `en` remains `DEFAULT_LOCALE` and the runtime fallback for every other
+ * catalog (see `translate`); only the key-set authority moved to `ja`.
  *
  * Key naming: admin.{feature}.{element} | common.{element}
  * Param interpolation: {{paramName}}
- *
- * All other locales are `Partial<MessageCatalog>` and fall back to these values.
  */
-
 export const en = {
   // ── Common ──────────────────────────────────────────────────────────────
   'common.actions.edit': 'Edit',
@@ -1546,11 +1553,11 @@ export const en = {
   // ── Misc (#728) ───────────────────────────────────────────────────────────
   'common.tableOfContents': 'Table of contents',
   'admin.entityRecords.breadcrumbLabel': 'Breadcrumb',
-} as const
+} satisfies Record<MessageKey, string>
 
 /**
- * Complete message catalog type — keys derived from the English source of truth,
- * values widened to `string` so translated catalogs (ja/de/…) aren't checked
- * against the English string literals (which would reject every translation).
+ * Catalog types re-exported from the authority catalog (`ja`) so that the other
+ * locale catalogs, `translate.ts` and `messages/index.ts` keep importing them
+ * from `./en` unchanged.
  */
-export type MessageCatalog = Record<keyof typeof en, string>
+export type { MessageCatalog, MessageKey }

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -1,5 +1,15 @@
-import type { MessageCatalog } from './en'
-
+/**
+ * Japanese message catalog — the authority catalog (Frontend Standard 04, I18N-8).
+ *
+ * `MessageKey` is derived from these keys (`keyof typeof ja`). Every other
+ * locale — including `en` — is checked against `Record<MessageKey, string>`
+ * and therefore mirrors this catalog exactly: adding or removing a key here
+ * surfaces as a compile error in the five other catalogs. Add new keys here
+ * first, then translate.
+ *
+ * Authority (who owns the key set) and fallback (who answers at runtime) are
+ * separate concerns: `en` remains `DEFAULT_LOCALE` and the runtime fallback.
+ */
 export const ja = {
   // ── Common ──────────────────────────────────────────────────────────────
   'common.actions.edit': '編集',
@@ -1552,4 +1562,14 @@ export const ja = {
   // ── Misc (#728) ───────────────────────────────────────────────────────────
   'common.tableOfContents': '目次',
   'admin.entityRecords.breadcrumbLabel': 'パンくずリスト',
-} satisfies Record<keyof MessageCatalog, string>
+}
+
+/** Authority key set (Frontend Standard 04, I18N-8): `MessageKey` derives from `ja`. */
+export type MessageKey = keyof typeof ja
+
+/**
+ * Complete message catalog type — keys owned by the authority catalog (`ja`),
+ * values widened to `string` so translated catalogs (en/de/…) aren't checked
+ * against the Japanese string literals (which would reject every translation).
+ */
+export type MessageCatalog = Record<MessageKey, string>


### PR DESCRIPTION
## 概要

規約 04 **I18N-8**「権威カタログは **ja のみ**・en を権威とする実装は **MUST NOT**」と、records の現行実装（**en 権威** — `messages/en.ts` の `export type MessageCatalog = Record<keyof typeof en, string>`）が**正面衝突**していた。

**施主裁定（2026-07-15）: 反転（ja 権威へ統一）。** 「公認差異として登録」は不採用 — 例外ゼロで規約と実態を一致させる方を選んだ。規約 04 自身も records を**移行対象であり公認差異ではない**と名指ししている（I18N-8）。

先行実装: payout #162 / suite #382（パイロット）・serve #160（本日マージ・6ロケール級）。Closes #870

## ⚠️ 本 PR は `satisfies` 型の第1号（規約 04 I18N-9 準拠）

先行3リポ（payout/suite/serve）は parity 担保を**型注釈 `: MessageCatalog`** で着地させているが、規約 04 **I18N-9 の正例は `satisfies Record<MessageKey, string>`**（`Partial` は MUST NOT）。実効は同じだが規約と実装が乖離している。

**施主裁定（2026-07-15）: 実装を規約に合わせる。** よって本 PR の `en.ts` は**正例どおり `satisfies`** で書いた。records は最初から正しい形で入れられるため本 PR が第1号。**先行3リポは別途 board 経由で後追いで揃える予定。**

なお records は #868（AI-23）で非権威カタログを既に `satisfies Record<keyof MessageCatalog, string>` へ移行済みで、この形はリポ内既存慣行とも一致する。

## 変更（3ファイル）

| ファイル | 変更 |
| --- | --- |
| `messages/ja.ts` | `./en` への型依存を撤去し**権威カタログ**に。`MessageKey = keyof typeof ja` / `MessageCatalog = Record<MessageKey, string>` を ja 側で定義 |
| `messages/en.ts` | 非権威カタログとして `} satisfies Record<MessageKey, string>`（I18N-9 正例）。型は ja から import し **re-export** |
| `docs/development/frontend-standards.md` | i18n 節の en 権威の明文を是正（併せて #868 で解消済みの `Partial<MessageCatalog>` 記載も現物に合わせた） |

**`de` / `fr` / `pt-BR` / `zh-Hans` / `translate.ts` / `messages/index.ts` / `locales.ts` は無改変** — en.ts の型 re-export により `./en` からの import がそのまま生きる。

### 権威 ≠ フォールバック

`en` は **`DEFAULT_LOCALE` と実行時フォールバックのまま**（`translate.ts` / `locales.ts` 無改変）。移したのは**キー集合の権威のみ**。

## 「もう一つの en 権威面」の全数確認 — **無し**

serve #160 では TS カタログに加え **`LocaleCatalogs::CANONICAL='en'`（PHP）＋ CI の `composer locales:check`** という第2の en 権威面があった。records で同種の面を全数捜索した結果:

| 面 | records の実測 | 結論 |
| --- | --- | --- |
| PHP JSON カタログ | `locales/` ディレクトリ**不在**・locale JSON **0件** | 無し |
| `LocaleCatalogs::CANONICAL` 相当 | PHP の `canonical` 全ヒットは **URL 正規化**（`rel=canonical`・permalink・sitemap）で i18n 無関係 | 無し |
| CI の locale 検査 | `composer.json` に `locales:check` 系スクリプト**無し**。`.github/workflows/*.yml` に `i18n`/`locale` の**ヒット 0** | 無し |
| ADR | records の ADR は 0000–0005 で、**i18n/ロケール権威を定める ADR は存在しない**（serve の ADR 0011 に相当する物が無い） | 改訂不要・**波及 0** |

→ **records の en 権威面は TS カタログの 1 箇所のみ**。よって本 PR で規約との乖離は残らない。

## widget への波及 — **無し**

規約 04 §12.4 の widget 公認差異は **corpus / concierge**（`<html>` 非所有製品の lang/dir スコープ）の話で、records の CMS widget 機能とは別物。records の `features/manage-widgets/widget-catalog.ts` は `MessageKey` 型を**消費**するだけで、型は `@/shared/i18n` 経由のため**無改変で通る**（type-check 実測）。

## 安全性 — 値は byte-identical（翻訳していない）

**翻訳は一切していない。変わったのは宣言行・型配線・docコメントのみ。** 6ロケール全ての `key: value` 行を origin/main と sha256 で機械照合:

| ロケール | キー数 | key:value 行 |
| --- | --- | --- |
| en / ja / de / fr / pt-BR / zh-Hans | **各 1,346** | **全て IDENTICAL** |

（commit 後のツリーに対しても再照合 — pre-commit の `eslint --fix` / `prettier --write` による書き換えが無いことを確認済み）

## 検証（実行済み）

```
npm run check:fast   → exit 0
  type-check (tsc)      : エラー 0
  lint (eslint)         : clean（--max-warnings 0）
  format (prettier)     : All matched files use Prettier code style!
  test (vitest)         : 全パス（i18n 単体 2 files / 22 tests パス）
  validate:themes       : All theme bundles valid.
npm run knip         → clean（型 re-export が unused 判定されないことを確認）
```

### 故意 fail による権威の実証

`ja.ts` からキー `'common.tableOfContents'` を**1つ削除**（1,346→1,345）して `type-check`:

```
messages/en.ts(1554,3):      error TS2353: ''common.tableOfContents'' does not exist in type 'Record<…>'
messages/de.ts(1545,3):      error TS2353: 〃
messages/fr.ts(1583,3):      error TS2353: 〃
messages/pt-BR.ts(1565,3):   error TS2353: 〃
messages/zh-Hans.ts(1494,3): error TS2353: 〃
ui/markdown/TableOfContents.tsx(29,24): error TS2345: Argument of type '"common.tableOfContents"' is not assignable to parameter of type '…'
```

**非権威 5 ロケール（en 含む）＋実利用側**が同時に型エラー → **ja がキー空間の権威**になったことを実証。削除キーは復元し、byte-identity と type-check exit 0 を再確認済み。

## 注記

- `docs/development/frontend-standards.md` は `frontend/` の prettier スコープ外（`prettier --check .` は frontend 起点）。**origin/main 時点でも同ファイルは prettier 未整形**のため、本 PR では整形しない（無関係な巨大差分を避けるため）。
- 依存関係の変更は**無し**（composer / package lock 一切触れていない）。

## チェックリスト

- [x] Issue 起票済み（#870）
- [x] `main` 最新（`2070258` #869）から分岐
- [x] 値・キー不変（機械照合済み）
- [x] `npm run check:fast` パス
- [x] 故意 fail で権威を実証
- [x] `git diff origin/main` 全数目視（3ファイル・意図した変更のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)