### PR TITLE
fix(public-fonts): Zen Kaku Gothic New subset に OFL の著作権表示・条文を同梱する（#872）

### DIFF
--- a/frontend/src/pages/consumer/fonts/OFL.txt
+++ b/frontend/src/pages/consumer/fonts/OFL.txt
@@ -1,0 +1,93 @@
+Copyright 2022 The Zen Kaku Gothic Project Authors (https://github.com/googlefonts/zen-kakugothic)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/frontend/src/pages/consumer/fonts/zen-kaku-gothic-new-subset.css
+++ b/frontend/src/pages/consumer/fonts/zen-kaku-gothic-new-subset.css
@@ -1,14 +1,29 @@
 /*
+ * Zen Kaku Gothic New (subset)
+ * Copyright 2022 The Zen Kaku Gothic Project Authors (https://github.com/googlefonts/zen-kakugothic)
+ * Licensed under the SIL Open Font License, Version 1.1 — full text: ./OFL.txt
+ * (also at https://scripts.sil.org/OFL). Modified version: subset via fonttools pyftsubset.
+ * 上流は Reserved Font Name を宣言していないので family 名はそのまま維持してよい（実測・#872）。
+ *
+ * ⚠️ この著作権表示は **dist には残らない**（Vite 8/rolldown の CSS 最小化が `/*!` legal comment
+ * ごと削除することを実測で確認）。配布物側の OFL 表示は **`vite.config.ts` の
+ * `emitFontLicense()` が `assets/OFL-ZenKakuGothicNew.txt` を出力する経路が担っている**。
+ * pyftsubset がフォントの name テーブル（Copyright/License）を全削除するため、
+ * バイナリ側にもメタデータは残らない。**あの emit を外すと OFL 違反に戻る**（#872）。
+ *
  * Zen Kaku Gothic New — AYANE 公開サイト用 subset (#818)
  *
  * @fontsource の `japanese-*` サブセットは unicode-range 分割されておらず 1 ウェイト
  * ≈965KB（4 ウェイトで ≈3.9MB）と重すぎる。AYANE の全 11 ページで実際に使う文字に
  * ひらがな/カタカナ/ASCII/JP 約物/全角形を加えた ≈1,050 グリフへ subset し、
- * 1 ウェイト ≈97KB（4 ウェイト計 ≈389KB）に圧縮したものを同梱する（OFL・self-host）。
+ * 1 ウェイト ≈97KB（4 ウェイト計 ≈389KB）に圧縮したものを同梱する（self-host）。
  *
  * 生成: fonttools pyftsubset（Zen Kaku Gothic New v5.2.7 の japanese woff2 を入力）。
  * subset 文字集合を変えたい／新出漢字が増えたら再生成する（手順は #818 / redesign/DESIGN-SYSTEM.md）。
  * 欧文専用の Latin グリフは軽いので、この subset がそのまま賄う（unicode-range なし）。
+ *
+ * ⚠️ この subset は AYANE 専用（926 グリフ）。他 org が参照すると漢字が欠ける。
+ * 構造的な解決（org 単位のフォントアップロード）は #873。
  */
 @font-face {
   font-family: 'Zen Kaku Gothic New';

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,10 +1,42 @@
+import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
-import { defineConfig, loadEnv } from 'vite'
+import { defineConfig, loadEnv, type Plugin } from 'vite'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+/**
+ * Ship the OFL license text next to the Zen Kaku Gothic New subset woff2 files (#872).
+ *
+ * OFL 1.1 §2 requires every redistributed copy to carry the copyright notice and
+ * the license. Our copy satisfies none of the three allowed channels on its own:
+ * `pyftsubset` strips the font's `name` table (no machine-readable metadata), and
+ * CSS comments — including `/*!` legal comments — are dropped by the minifier
+ * (measured: the notice does not survive `npm run build`). So the license travels
+ * as a stand-alone text file emitted next to the fonts it covers.
+ *
+ * Emitting into `assets/` (rather than `public/`) is deliberate: the built font
+ * files live there, the production Apache already aliases `/assets`, and
+ * `tools/build-release.sh` copies that directory into the release ZIP verbatim —
+ * so one emit covers the served site and both distribution ZIPs with no extra
+ * wiring. The filename is unhashed so it stays quotable from docs and headers.
+ */
+function emitFontLicense(): Plugin {
+  const source = path.resolve(__dirname, 'src/pages/consumer/fonts/OFL.txt')
+  return {
+    name: 'nene-emit-font-license',
+    apply: 'build',
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'assets/OFL-ZenKakuGothicNew.txt',
+        source: readFileSync(source, 'utf8'),
+      })
+    },
+  }
+}
 
 export default defineConfig(({ mode }) => {
   // Read NENE_RECORDS_PORT from the project-root .env (one level up from frontend/).
@@ -24,7 +56,7 @@ export default defineConfig(({ mode }) => {
     // runtime (#zip-install S2). The injected `<base href>` anchors them to the
     // configured base path; internal chunk imports resolve next to the entry.
     base: './',
-    plugins: [react(), tailwindcss()],
+    plugins: [react(), tailwindcss(), emitFontLicense()],
     build: {
       // Emit dist/.vite/manifest.json so the PHP single-origin SSR can resolve
       // the hashed entry JS/CSS and mount the built SPA on server-rendered pages.

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -127,6 +127,19 @@ done
 shopt -u nullglob
 echo "  fonts: base に $kept_fonts 件 / フォントパックへ $moved_fonts 件"
 
+# OFL 表示義務のガード（#872）。Zen Kaku Gothic New subset は OFL 1.1 で、配布物は
+# 著作権表示とライセンス条文を含まなければならない。subset 化で font の name テーブルは
+# 空、CSS コメントは最小化で消えるため、frontend の vite.config.ts が assets/ へ emit する
+# この 1 ファイルだけが表示経路。ここが欠けたまま出荷するとライセンス違反になるので、
+# 静かに落ちないよう fail-loud にする（keep 判定は woff/woff2 のみを見るので通常は残る）。
+OFL_NOTICE="$STAGE/public_html/assets/OFL-ZenKakuGothicNew.txt"
+if [ ! -s "$OFL_NOTICE" ]; then
+    echo "ERROR: $(basename "$OFL_NOTICE") が base ZIP にありません（OFL 1.1 §2 違反）。" >&2
+    echo "       frontend/vite.config.ts の emitFontLicense() が生きているか確認してください（#872）。" >&2
+    exit 1
+fi
+echo "  fonts: OFL 表示 $(basename "$OFL_NOTICE") を base に同梱 ✔"
+
 # フォントパック導入検出用マーカー（#709）。管理画面はフォントピッカーの @font-face を
 # 読み込まない（公開フォントは公開シェル/プレビュー iframe 側）ため、フォントの load
 # 試行では pack 有無を判定できない。そこで docroot 直下に静的マーカーを置き、frontend は


### PR DESCRIPTION
## 目的

#818 で同梱した Zen Kaku Gothic New subset が、**OFL 1.1 §2 が要求する著作権表示と
ライセンス条文を配布物のどこにも含んでいなかった**のを是正する。

OFL が許す 3 経路すべてが空だった（実測）:

| 経路 | 状態 |
|---|---|
| 機械可読メタデータ（font の `name` テーブル） | **レコード 0 件**（pyftsubset が Copyright/License を全削除） |
| スタンドアロンのテキストファイル | **無し**（`fonts/` に OFL.txt が無い） |
| 人間可読ヘッダ | **不足**（CSS の記載は「（OFL・self-host）」の一言のみ） |

配布範囲 = 公開 GitHub リポジトリ ＋ **base 配布 ZIP**（`KEEP_FONT_FAMILIES` に含まれ全 Tier A 設置へ届く）＋ Docker/本番。

### ✅ 改名は不要（実測で確定）

上流の著作権行は `Copyright 2022 The Zen Kaku Gothic Project Authors (…)` で
**`with Reserved Font Name` 句が無い** → subset して family 名を維持すること自体は OFL 上問題ない。
本 PR は**表示義務のみ**を是正する。

## 変更

- **`fonts/OFL.txt`** … 上流の OFL 全文（著作権行込み・92行）を追加。上流と byte 一致。
- **`vite.config.ts` の `emitFontLicense()`** … `assets/OFL-ZenKakuGothicNew.txt` を出力。
  woff2 と同じ場所に置くことで、**既存の Apache `/assets` alias で配信され、
  `build-release.sh` がそのまま ZIP へ運ぶ**（配信・ZIP の両方を 1 箇所で満たす／
  `frontend/public/` を使うと Apache alias 追加が要るので避けた）。
- **`build-release.sh` の fail-loud guard** … 表示が落ちたまま出荷させない。
- **CSS ヘッダ** … 著作権表示と、表示経路がどこにあるかの説明。

### ★ 設計判断: なぜ CSS コメントではなくテキストファイルか

当初 `/*!` legal comment で表示する実装にしたが、**Vite 8/rolldown の CSS 最小化が
`/*!` ごと削除する**ことをビルド実測で確認したため撤回した（`dist/assets/*.css` に残らない）。
CSS コメントは表示経路として使えない。

## 検証

- [x] `dist/assets/OFL-ZenKakuGothicNew.txt` に**全 92 行**が出力されることを実測。
- [x] **base ZIP の `public_html/assets/` に woff2 4 本と同じ場所で同梱**されることを、
      `build-release.sh` を実走させ ZIP から取り出して実測。
- [x] **負のコントロール**: `emitFontLicense()` を外すと `build-release.sh` が
      **exit 1 で停止**することを実測（戻すと通ることも確認）。
- [x] OFL.txt が prettier 等に改変されていないこと（上流と diff 無し）を確認。
- [x] `npm run check --prefix frontend` 緑。

BE 変更なし（`composer check` 対象外）。

## チェックリスト

- [x] Issue 駆動（#872）
- [x] `main` から `fix/872-...` ブランチ
- [x] Conventional Commits（type/scope 英語・本文日本語・`(#872)`）
- [x] シークレット無し

## 残（本 PR の範囲外）

**構造的な解決は #873**（org 単位のフォントアップロード）。AYANE 専用 subset が製品コアに
焼き込まれ、全 org の公開サイトで @font-face 登録される問題（第三者が参照すると 926 グリフしか
無く静かに漢字が欠ける）は、org スコープの @font-face で消える。launch 後に着手。

Closes #872