### PR TITLE
fix(public): パンくず/子一覧のラベルを導出＋meta_title 優先に正規化する（#875）

### DIFF
--- a/src/PreviewToken/GetPreviewRecordViewUseCase.php
+++ b/src/PreviewToken/GetPreviewRecordViewUseCase.php
@@ -28,6 +28,7 @@ use NeNeRecords\PublicRecord\PublicPermalinkResolver;
 use NeNeRecords\PublicRecord\PublicRecordHierarchyBuilder;
 use NeNeRecords\PublicRecord\PublicRecordViewDisplayField;
 use NeNeRecords\PublicRecord\PublicRecordViewHttpMapper;
+use NeNeRecords\PublicRecord\RecordDisplayLabel;
 use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
 use NeNeRecords\Setting\SettingEntry;
 use NeNeRecords\Setting\SettingHttpMapper;
@@ -348,25 +349,13 @@ final readonly class GetPreviewRecordViewUseCase implements GetPreviewRecordView
     /** @param list<TextField> $textFieldRows */
     private function resolveRecordLabel(int $entityId, array $textFieldRows, ?string $permalink = null): string
     {
-        foreach ($textFieldRows as $textField) {
-            if ($textField->entityId === $entityId && $textField->fieldKey === 'title' && trim($textField->value) !== '') {
-                return $textField->value;
-            }
-        }
-
-        foreach ($textFieldRows as $textField) {
-            if ($textField->entityId === $entityId && trim($textField->value) !== '') {
-                return $textField->value;
-            }
-        }
-
         // No title field → humanize the permalink's last segment before a bare id (#657).
         $segment = PermalinkLabel::lastSegment($permalink);
-        if ($segment !== null) {
-            return PermalinkLabel::humanize($segment);
-        }
+        $fallback = $segment !== null ? PermalinkLabel::humanize($segment) : 'Record #' . $entityId;
 
-        return 'Record #' . $entityId;
+        // Derives (strips + caps) the non-title fallback so a bespoke page's whole
+        // html body cannot become a relation label / page title (#875).
+        return RecordDisplayLabel::resolve($entityId, $textFieldRows, null, $fallback);
     }
 
     /** @param list<TextField> $rows */

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -365,25 +365,13 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
     /** @param list<TextField> $textFieldRows */
     private function resolveRecordLabel(int $entityId, array $textFieldRows, ?string $permalink = null): string
     {
-        foreach ($textFieldRows as $textField) {
-            if ($textField->entityId === $entityId && $textField->fieldKey === 'title' && trim($textField->value) !== '') {
-                return $textField->value;
-            }
-        }
-
-        foreach ($textFieldRows as $textField) {
-            if ($textField->entityId === $entityId && trim($textField->value) !== '') {
-                return $textField->value;
-            }
-        }
-
         // No title field → humanize the permalink's last segment before a bare id (#657).
         $segment = PermalinkLabel::lastSegment($permalink);
-        if ($segment !== null) {
-            return PermalinkLabel::humanize($segment);
-        }
+        $fallback = $segment !== null ? PermalinkLabel::humanize($segment) : 'Record #' . $entityId;
 
-        return 'Record #' . $entityId;
+        // Derives (strips + caps) the non-title fallback so a bespoke page's whole
+        // html body cannot become a relation label / page title (#875).
+        return RecordDisplayLabel::resolve($entityId, $textFieldRows, null, $fallback);
     }
 
     /**

--- a/src/PublicRecord/PublicRecordHierarchyBuilder.php
+++ b/src/PublicRecord/PublicRecordHierarchyBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\PublicRecord;
 
+use NeNeRecords\Entity\Entity;
 use NeNeRecords\Entity\EntityRepositoryInterface;
 use NeNeRecords\Entity\EntityStatus;
 use NeNeRecords\TextField\TextFieldRepositoryInterface;
@@ -52,7 +53,7 @@ final readonly class PublicRecordHierarchyBuilder
             return PublicRecordHierarchy::empty();
         }
 
-        $title = $this->titlesByIds([$entity->id])[$entity->id]
+        $title = $this->titlesByIds([$entity])[$entity->id]
             ?? $this->humanize(basename($entity->permalink));
 
         // A custom-permalink record's canonical path is the permalink itself (#651 PR1).
@@ -78,7 +79,7 @@ final readonly class PublicRecordHierarchyBuilder
         // Resolve ancestors (every segment but the last) so crumbs use the real
         // page title and only link to segments that are actually published pages.
         $ancestorIdByPath = [];
-        $ancestorIds = [];
+        $ancestors = [];
         $cumulative = '';
         foreach ($segments as $index => $segment) {
             $cumulative .= '/' . $segment;
@@ -93,11 +94,11 @@ final readonly class PublicRecordHierarchyBuilder
                 && $ancestor->status === EntityStatus::Published
             ) {
                 $ancestorIdByPath[$cumulative] = $ancestor->id;
-                $ancestorIds[] = $ancestor->id;
+                $ancestors[] = $ancestor;
             }
         }
 
-        $titlesById = $this->titlesByIds($ancestorIds);
+        $titlesById = $this->titlesByIds($ancestors);
 
         $crumbs = [];
         $cumulative = '';
@@ -129,14 +130,7 @@ final readonly class PublicRecordHierarchyBuilder
     {
         $children = $this->entities->findDirectChildrenByPermalink($permalink, self::CHILD_LIMIT);
 
-        $ids = [];
-        foreach ($children as $child) {
-            if ($child->id !== null) {
-                $ids[] = $child->id;
-            }
-        }
-
-        $titlesById = $this->titlesByIds($ids);
+        $titlesById = $this->titlesByIds($children);
 
         $links = [];
         foreach ($children as $child) {
@@ -153,27 +147,37 @@ final readonly class PublicRecordHierarchyBuilder
     }
 
     /**
-     * @param list<int> $entityIds
-     * @return array<int, string> entityId => display title
+     * Entities (not ids) because the label needs `meta_title`, which the callers
+     * already hold — re-fetching them here would be a second query for nothing.
+     *
+     * @param list<Entity> $entities
+     * @return array<int, string> entityId => display label
      */
-    private function titlesByIds(array $entityIds): array
+    private function titlesByIds(array $entities): array
     {
-        if ($entityIds === []) {
+        $ids = [];
+        $metaTitleById = [];
+        foreach ($entities as $entity) {
+            if ($entity->id === null) {
+                continue;
+            }
+            $ids[] = $entity->id;
+            $metaTitleById[$entity->id] = $entity->metaTitle;
+        }
+
+        if ($ids === []) {
             return [];
         }
 
-        $rows = $this->textFields->findByEntityIds($entityIds);
+        $rows = $this->textFields->findByEntityIds($ids);
         $byId = [];
 
-        foreach ($rows as $row) {
-            if ($row->fieldKey === 'title' && trim($row->value) !== '' && !isset($byId[$row->entityId])) {
-                $byId[$row->entityId] = $row->value;
-            }
-        }
-
-        foreach ($rows as $row) {
-            if (!isset($byId[$row->entityId]) && trim($row->value) !== '') {
-                $byId[$row->entityId] = $row->value;
+        foreach ($ids as $id) {
+            // Empty fallback: callers already humanize the permalink segment, which
+            // is a better last resort here than a bare id.
+            $label = RecordDisplayLabel::resolve($id, $rows, $metaTitleById[$id] ?? null, '');
+            if ($label !== '') {
+                $byId[$id] = $label;
             }
         }
 

--- a/src/PublicRecord/RecordDisplayLabel.php
+++ b/src/PublicRecord/RecordDisplayLabel.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use NeNeRecords\TextField\TextField;
+
+/**
+ * Resolves the label shown for a record in a *listing* context — breadcrumbs,
+ * child-page lists, JSON-LD — where the record itself is not the page body.
+ *
+ * PHP twin of the frontend `shared/lib/get-record-display-label.ts`; the order
+ * is deliberately identical so the SSR label and the SPA label agree:
+ *
+ *   title field → entity meta_title → derived excerpt → caller fallback
+ *
+ * The excerpt step is what makes this class necessary. A bespoke page authored
+ * as one html field (bare layout, #799) has no `title` field, so a naive "first
+ * non-empty field" fallback puts the page's entire source into a link label:
+ * on the public site that dumped 57KB of markup into a breadcrumb, a child link
+ * and the JSON-LD BreadcrumbList (#875). The admin listing hit the same bug and
+ * fixed it the same way (#849 cap, #853 meta_title) — this is the public half.
+ *
+ * An explicit `title` field is trusted verbatim; only derived text is capped.
+ */
+final class RecordDisplayLabel
+{
+    /** Matches the frontend FALLBACK_LABEL_MAX so both halves cut at the same place. */
+    private const DERIVED_MAX = 120;
+
+    /** Strip markup, collapse whitespace, and cap — for use as a derived label. */
+    public static function derive(string $value): string
+    {
+        $text = trim((string) preg_replace('/\s+/u', ' ', strip_tags($value)));
+
+        if ($text === '' || mb_strlen($text) <= self::DERIVED_MAX) {
+            return $text;
+        }
+
+        return rtrim(mb_substr($text, 0, self::DERIVED_MAX)) . '…';
+    }
+
+    /**
+     * @param list<TextField> $textFieldRows rows for any entities; filtered by $entityId
+     * @param string          $fallback      used when nothing else yields text
+     */
+    public static function resolve(
+        int $entityId,
+        array $textFieldRows,
+        ?string $metaTitle,
+        string $fallback,
+    ): string {
+        foreach ($textFieldRows as $row) {
+            if ($row->entityId === $entityId && $row->fieldKey === 'title' && trim($row->value) !== '') {
+                return trim($row->value);
+            }
+        }
+
+        // The SEO title beats the derived excerpt: bespoke pages that share one
+        // html field would otherwise all show the same stripped header/nav text
+        // (#853 — the same reason the admin listing prefers it).
+        if ($metaTitle !== null && trim($metaTitle) !== '') {
+            return trim($metaTitle);
+        }
+
+        foreach ($textFieldRows as $row) {
+            if ($row->entityId === $entityId && trim($row->value) !== '') {
+                $derived = self::derive($row->value);
+                if ($derived !== '') {
+                    return $derived;
+                }
+            }
+        }
+
+        return $fallback;
+    }
+}

--- a/tests/PublicRecord/PublicRecordHierarchyBuilderTest.php
+++ b/tests/PublicRecord/PublicRecordHierarchyBuilderTest.php
@@ -122,4 +122,74 @@ final class PublicRecordHierarchyBuilderTest extends TestCase
         self::assertSame([], $hierarchy->breadcrumbs);
         self::assertSame([], $hierarchy->childPages);
     }
+
+    /**
+     * Regression (#875): a bespoke page (bare layout, one html field, no `title`)
+     * must not dump its whole source into an ancestor crumb or a child link.
+     * Production served a 57KB breadcrumb label and a 61.8KB JSON-LD BreadcrumbList
+     * this way — the public twin of the admin listing bug (#849/#853).
+     */
+    public function testTitlelessBespokeAncestorAndChildLabelsAreDerivedNotRawHtml(): void
+    {
+        $body = '<div style="background:#F6F3EC"><header>' . str_repeat('本文テキスト', 400) . '</header></div>';
+
+        $entities = new InMemoryEntityRepository([
+            new Entity(id: 1, entityTypeId: 1, slug: 'company', permalink: '/company', status: EntityStatus::Published),
+            new Entity(id: 2, entityTypeId: 1, slug: 'ceo', permalink: '/company/ceo', status: EntityStatus::Published),
+        ]);
+        $textFields = new InMemoryTextFieldRepository([
+            new TextField(entityId: 1, fieldKey: 'content', value: $body, id: 1),
+            new TextField(entityId: 2, fieldKey: 'content', value: $body, id: 2),
+        ], $entities);
+
+        $hierarchy = $this->builder($entities, $textFields)->buildById(2);
+
+        $ancestor = $hierarchy->breadcrumbs[0]->label;
+        self::assertStringNotContainsString('<div', $ancestor, 'markup must be stripped');
+        self::assertStringNotContainsString('style=', $ancestor);
+        self::assertLessThanOrEqual(121, mb_strlen($ancestor), 'derived label must stay capped');
+        self::assertStringEndsWith('…', $ancestor);
+
+        $child = $this->builder($entities, $textFields)->build('/company', '/company', 'Company')->childPages;
+        self::assertCount(1, $child);
+        self::assertStringNotContainsString('<div', $child[0]->title);
+        self::assertLessThanOrEqual(121, mb_strlen($child[0]->title));
+    }
+
+    /** #875: meta_title beats the derived excerpt, mirroring the admin listing (#853). */
+    public function testMetaTitleBeatsDerivedExcerptForTitlelessPages(): void
+    {
+        $body = '<div><nav>SERVICE PRODUCTS COMPANY</nav><h1>会社案内</h1></div>';
+
+        $entities = new InMemoryEntityRepository([
+            new Entity(id: 1, entityTypeId: 1, slug: 'company', permalink: '/company', status: EntityStatus::Published, metaTitle: '会社案内｜彩音インターナショナル株式会社'),
+            new Entity(id: 2, entityTypeId: 1, slug: 'ceo', permalink: '/company/ceo', status: EntityStatus::Published, metaTitle: '代表紹介 森 秀之'),
+        ]);
+        $textFields = new InMemoryTextFieldRepository([
+            new TextField(entityId: 1, fieldKey: 'content', value: $body, id: 1),
+            new TextField(entityId: 2, fieldKey: 'content', value: $body, id: 2),
+        ], $entities);
+
+        $hierarchy = $this->builder($entities, $textFields)->buildById(2);
+        self::assertSame('会社案内｜彩音インターナショナル株式会社', $hierarchy->breadcrumbs[0]->label);
+
+        $children = $this->builder($entities, $textFields)->build('/company', '/company', 'Company')->childPages;
+        self::assertSame('代表紹介 森 秀之', $children[0]->title);
+    }
+
+    /** #875: an explicit `title` field still wins over meta_title and is kept verbatim. */
+    public function testExplicitTitleFieldStillWinsOverMetaTitle(): void
+    {
+        $entities = new InMemoryEntityRepository([
+            new Entity(id: 1, entityTypeId: 1, slug: 'about', permalink: '/company/about', status: EntityStatus::Published, metaTitle: 'SEO Title'),
+            new Entity(id: 2, entityTypeId: 1, slug: 'team', permalink: '/company/about/team', status: EntityStatus::Published),
+        ]);
+        $textFields = new InMemoryTextFieldRepository([
+            new TextField(entityId: 1, fieldKey: 'title', value: 'About Us', id: 1),
+            new TextField(entityId: 2, fieldKey: 'title', value: 'Our Team', id: 2),
+        ], $entities);
+
+        $hierarchy = $this->builder($entities, $textFields)->buildById(2);
+        self::assertSame('About Us', $hierarchy->breadcrumbs[1]->label);
+    }
 }


### PR DESCRIPTION
## 目的

`title` フィールドを持たない bespoke ページ（bare layout・1本の html フィールド・#799）で、
**公開側のパンくず・子一覧・JSON-LD のラベルに content の生HTML全文が入っていた**のを塞ぐ。

### 本番実測（ayane・2026-07-15）

```html
<nav class="child-pages" aria-label="In this section">
  <li><a href="/company/ceo">&lt;div style="background:#F6F3EC...（57KBのHTMLソース）</a></li>
```

| | 実測 |
|---|---|
| `/company/ceo` のパンくずブロック | **60.5KB**（親 `/company` の content 全文がラベル） |
| JSON-LD `BreadcrumbList` | **61.8KB** → 検索エンジンに生HTMLを送っていた |
| bootstrap `hierarchy.breadcrumbs[].label` | 同上 → **SPA も描画＝ユーザーにも見える** |
| ページ全体 | `/company` 360KB・`/company/ceo` 298KB（content 実体は 56KB） |

## これは #849/#853 の公開側の双子

原因は #651 PR2（`c3d2fb8`・2026-06-27）で入った生フォールバック（`git log -S` で特定）。
**同じバグ class を 2026-07-14 に #849/#853 で修正済みだが、あの2本は
`frontend/src/shared/lib/get-record-display-label.ts`＝管理画面側のみ**だった
（実測: 両PRの変更ファイルは `frontend/src/**` のみ）。公開側の PHP は手つかずだった。

## 変更

- **`RecordDisplayLabel` を新設** — TS `get-record-display-label.ts` の対。
  順序も**キャップ値も TS と揃えた**（`title` → `meta_title` → 導出抜粋（タグ除去＋120字＋`…`） → fallback）。
  SSR と SPA でラベルが食い違わないことが目的。
- **`PublicRecordHierarchyBuilder::titlesByIds` を entity 受け取りに変更** —
  `meta_title` が要るため。**呼出側が既に entity を持っているので追加クエリは発生しない**。
  パンくず・子一覧・`buildById` の3経路が同じ規律を通る。
- **`GetPublicRecordViewUseCase` / `GetPreviewRecordViewUseCase` の `resolveRecordLabel`** も同ヘルパへ。
  **生フォールバックの複製3本を解消**（relation ラベル・pageTitle も同経路だった）。
  #657 の humanize フォールバックは維持。

`Analytics/GetPopularEntitiesUseCase` は `title` のみ採用で**安全**なため対象外（調査済み）。

## 検証

- [x] **回帰テスト3本追加**（生HTMLがラベルにならない／`meta_title` が導出抜粋に勝つ／
      明示 `title` は従来どおり verbatim で勝つ）。
- [x] **負のコントロール実測**: 修正を戻すと **2本が失敗**し、
      `'<div><nav>SERVICE PRODUCTS COMPANY</nav>...'` がラベルに出ることを再現。
- [x] **テスト 1330 件緑**。
- [x] CS-Fixer / OpenAPI 緑。

### ⚠️ ローカル環境要因（本変更とは無関係・CI が権威）

`AuthorizationHeaderFallbackE2ETest` 4本と PHPStan 1件（`RuntimeServiceProvider.php:419`
`Unknown parameter $enableAuthorizationHeaderFallback`）が手元で赤いが、これは
**共有クローン `../NENE2` が `feat/1555-conformance-r3-private-origin` ブランチのままで
#869 が要求する NENE2 #1558 を含まないため**（実測で確認）。#869 は main で CI 緑。
他セッションが使用中の可能性があるため NENE2 のブランチは切り替えていない。

## チェックリスト

- [x] Issue 駆動（#875）
- [x] `main` から `fix/875-...` ブランチ
- [x] Conventional Commits（type/scope 英語・本文日本語・`(#875)`）
- [x] シークレット無し

## 影響

AYANE 公開目標 2026-07-25 のブロッカー。全ページに `meta_title` が入っているため、
**反映後は `/company` の子一覧が正しいページ名になる**見込み。
本番反映は施主 GO の別手番。

Closes #875