### PR TITLE
feat(public): エンティティタイプ一覧を SSR でクロール可能にする（#877）

### DIFF
--- a/src/Http/SingleOriginKernel.php
+++ b/src/Http/SingleOriginKernel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Http;
 
 use NeNeRecords\PublicRecord\RenderPublicHomeHandler;
+use NeNeRecords\PublicRecord\RenderPublicTypeArchiveHandler;
 use NeNeRecords\UrlRedirect\UrlRedirectResolver;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -14,11 +15,15 @@ use Psr\Http\Server\RequestHandlerInterface;
  * Outer request handler for single-origin serving: runs the full NENE2
  * application pipeline, then applies the single-origin edge layers in order on a
  * 404 — first a per-record custom permalink (#651), then the per-org 301 redirect
- * map (migrated old WordPress URLs), then the built SPA shell fallback for
- * client-routed navigations.
+ * map (migrated old WordPress URLs), then an entity type's archive listing (#877),
+ * then the built SPA shell fallback for client-routed navigations.
  *
  * Custom permalinks run before the redirect map so a live record sitting at a path
  * wins over a stale 301 whose source equals that path.
+ *
+ * The type archive runs after both: a record parked at `/posts` and an admin-authored
+ * 301 are explicit content decisions, while the archive is derived from a type slug,
+ * so it may only answer a path nothing else claimed.
  *
  * Composing these as one DI-wired PSR-15 handler (rather than procedural code in
  * the front controller) keeps the ordering explicit and end-to-end testable, and
@@ -31,6 +36,7 @@ final readonly class SingleOriginKernel implements RequestHandlerInterface
         private RequestHandlerInterface $application,
         private CustomPermalinkResolver $customPermalink,
         private UrlRedirectResolver $redirects,
+        private RenderPublicTypeArchiveHandler $typeArchive,
         private RenderPublicHomeHandler $frontPage,
         private SpaShellFallback $shell,
     ) {
@@ -41,6 +47,9 @@ final readonly class SingleOriginKernel implements RequestHandlerInterface
         $response = $this->application->handle($request);
         $response = $this->customPermalink->apply($request, $response);
         $response = $this->redirects->apply($request, $response);
+        // Entity type archive SSR (#877): `/posts` etc. were SPA-only, so crawlers got
+        // the shell instead of the listing.
+        $response = $this->typeArchive->apply($request, $response);
         // Front-page SSR (#701) runs before the shell so a pinned record renders at `/`
         // (SpaShellFallback then honours the resulting text/html instead of the shell).
         $response = $this->frontPage->apply($request, $response);

--- a/src/Http/SingleOriginServiceProvider.php
+++ b/src/Http/SingleOriginServiceProvider.php
@@ -8,6 +8,7 @@ use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use NeNeRecords\PublicRecord\RenderPublicHomeHandler;
+use NeNeRecords\PublicRecord\RenderPublicTypeArchiveHandler;
 use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
 use NeNeRecords\SystemConfig\SystemConfigRepositoryInterface;
 use NeNeRecords\UrlRedirect\UrlRedirectResolver;
@@ -85,6 +86,7 @@ final readonly class SingleOriginServiceProvider implements ServiceProviderInter
                     $application = $c->get(RequestHandlerInterface::class);
                     $customPermalink = $c->get(CustomPermalinkResolver::class);
                     $redirects = $c->get(UrlRedirectResolver::class);
+                    $typeArchive = $c->get(RenderPublicTypeArchiveHandler::class);
                     $frontPage = $c->get(RenderPublicHomeHandler::class);
                     $shell = $c->get(SpaShellFallback::class);
 
@@ -97,6 +99,9 @@ final readonly class SingleOriginServiceProvider implements ServiceProviderInter
                     if (!$redirects instanceof UrlRedirectResolver) {
                         throw new LogicException('URL redirect resolver service is invalid.');
                     }
+                    if (!$typeArchive instanceof RenderPublicTypeArchiveHandler) {
+                        throw new LogicException('Type archive renderer service is invalid.');
+                    }
                     if (!$frontPage instanceof RenderPublicHomeHandler) {
                         throw new LogicException('Front page renderer service is invalid.');
                     }
@@ -104,7 +109,14 @@ final readonly class SingleOriginServiceProvider implements ServiceProviderInter
                         throw new LogicException('SPA shell fallback service is invalid.');
                     }
 
-                    return new SingleOriginKernel($application, $customPermalink, $redirects, $frontPage, $shell);
+                    return new SingleOriginKernel(
+                        $application,
+                        $customPermalink,
+                        $redirects,
+                        $typeArchive,
+                        $frontPage,
+                        $shell,
+                    );
                 },
             );
     }

--- a/src/PreviewToken/GetPreviewRecordViewUseCase.php
+++ b/src/PreviewToken/GetPreviewRecordViewUseCase.php
@@ -28,6 +28,7 @@ use NeNeRecords\PublicRecord\PublicPermalinkResolver;
 use NeNeRecords\PublicRecord\PublicRecordHierarchyBuilder;
 use NeNeRecords\PublicRecord\PublicRecordViewDisplayField;
 use NeNeRecords\PublicRecord\PublicRecordViewHttpMapper;
+use NeNeRecords\PublicRecord\RecordDisplayLabel;
 use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
 use NeNeRecords\Setting\SettingEntry;
 use NeNeRecords\Setting\SettingHttpMapper;
@@ -348,25 +349,13 @@ final readonly class GetPreviewRecordViewUseCase implements GetPreviewRecordView
     /** @param list<TextField> $textFieldRows */
     private function resolveRecordLabel(int $entityId, array $textFieldRows, ?string $permalink = null): string
     {
-        foreach ($textFieldRows as $textField) {
-            if ($textField->entityId === $entityId && $textField->fieldKey === 'title' && trim($textField->value) !== '') {
-                return $textField->value;
-            }
-        }
-
-        foreach ($textFieldRows as $textField) {
-            if ($textField->entityId === $entityId && trim($textField->value) !== '') {
-                return $textField->value;
-            }
-        }
-
         // No title field → humanize the permalink's last segment before a bare id (#657).
         $segment = PermalinkLabel::lastSegment($permalink);
-        if ($segment !== null) {
-            return PermalinkLabel::humanize($segment);
-        }
+        $fallback = $segment !== null ? PermalinkLabel::humanize($segment) : 'Record #' . $entityId;
 
-        return 'Record #' . $entityId;
+        // Derives (strips + caps) the non-title fallback so a bespoke page's whole
+        // html body cannot become a relation label / page title (#875).
+        return RecordDisplayLabel::resolve($entityId, $textFieldRows, null, $fallback);
     }
 
     /** @param list<TextField> $rows */

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -365,25 +365,13 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
     /** @param list<TextField> $textFieldRows */
     private function resolveRecordLabel(int $entityId, array $textFieldRows, ?string $permalink = null): string
     {
-        foreach ($textFieldRows as $textField) {
-            if ($textField->entityId === $entityId && $textField->fieldKey === 'title' && trim($textField->value) !== '') {
-                return $textField->value;
-            }
-        }
-
-        foreach ($textFieldRows as $textField) {
-            if ($textField->entityId === $entityId && trim($textField->value) !== '') {
-                return $textField->value;
-            }
-        }
-
         // No title field → humanize the permalink's last segment before a bare id (#657).
         $segment = PermalinkLabel::lastSegment($permalink);
-        if ($segment !== null) {
-            return PermalinkLabel::humanize($segment);
-        }
+        $fallback = $segment !== null ? PermalinkLabel::humanize($segment) : 'Record #' . $entityId;
 
-        return 'Record #' . $entityId;
+        // Derives (strips + caps) the non-title fallback so a bespoke page's whole
+        // html body cannot become a relation label / page title (#875).
+        return RecordDisplayLabel::resolve($entityId, $textFieldRows, null, $fallback);
     }
 
     /**

--- a/src/PublicRecord/GetPublicTypeArchiveOutput.php
+++ b/src/PublicRecord/GetPublicTypeArchiveOutput.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+/** An entity type's public archive page (#877). */
+final readonly class GetPublicTypeArchiveOutput
+{
+    /** @param list<PublicTypeArchiveItem> $items */
+    public function __construct(
+        public string $typeSlug,
+        public string $typeName,
+        public array $items,
+        public int $total,
+        public int $offset,
+        public int $pageSize,
+    ) {
+    }
+
+    /** Offset of the previous page, or null on the first page. */
+    public function prevOffset(): ?int
+    {
+        if ($this->offset <= 0) {
+            return null;
+        }
+
+        return max(0, $this->offset - $this->pageSize);
+    }
+
+    /** Offset of the next page, or null when this is the last one. */
+    public function nextOffset(): ?int
+    {
+        $next = $this->offset + $this->pageSize;
+
+        return $next < $this->total ? $next : null;
+    }
+}

--- a/src/PublicRecord/GetPublicTypeArchiveUseCase.php
+++ b/src/PublicRecord/GetPublicTypeArchiveUseCase.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use NeNeRecords\Entity\EntityListCriteria;
+use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\Entity\EntityStatus;
+use NeNeRecords\EntityType\EntityTypeRepositoryInterface;
+use NeNeRecords\TextField\TextFieldRepositoryInterface;
+
+/**
+ * Server-side data for an entity type's public archive (`/{typeSlug}`), so the
+ * listing is crawlable rather than SPA-only (#877).
+ *
+ * The SPA already renders this page (`PublicBrowsePage` via
+ * `usePublicBrowseEntityRecordsPage`) and replaces the SSR markup on mount, so
+ * this use case deliberately mirrors that hook's query: published only, page size
+ * {@see self::PAGE_SIZE}, and the repository's default id-descending order. If
+ * those drift apart the crawler and the visitor see different lists.
+ */
+final readonly class GetPublicTypeArchiveUseCase
+{
+    /** Mirrors the SPA's PUBLIC_BROWSE_PAGE_SIZE / DEFAULT_LIST_PARAMS.limit. */
+    public const PAGE_SIZE = 20;
+
+    public function __construct(
+        private EntityTypeRepositoryInterface $entityTypes,
+        private EntityRepositoryInterface $entities,
+        private TextFieldRepositoryInterface $textFields,
+    ) {
+    }
+
+    /** @return GetPublicTypeArchiveOutput|null null when no such type in this org */
+    public function execute(string $typeSlug, int $offset = 0): ?GetPublicTypeArchiveOutput
+    {
+        $entityType = $this->entityTypes->findBySlug($typeSlug);
+
+        if ($entityType === null || $entityType->id === null) {
+            return null;
+        }
+
+        $criteria = new EntityListCriteria(
+            entityTypeId: $entityType->id,
+            status: EntityStatus::Published,
+        );
+
+        $offset = max(0, $offset);
+        $total = $this->entities->countByCriteria($criteria);
+        $entities = $this->entities->findByCriteria($criteria, self::PAGE_SIZE, $offset);
+
+        $ids = [];
+        foreach ($entities as $entity) {
+            if ($entity->id !== null) {
+                $ids[] = $entity->id;
+            }
+        }
+
+        $rows = $ids === [] ? [] : $this->textFields->findByEntityIds($ids);
+
+        $items = [];
+        foreach ($entities as $entity) {
+            if ($entity->id === null) {
+                continue;
+            }
+            $items[] = new PublicTypeArchiveItem(
+                id: $entity->id,
+                label: RecordDisplayLabel::resolve(
+                    $entity->id,
+                    $rows,
+                    $entity->metaTitle,
+                    'Record #' . $entity->id,
+                ),
+                // The shared canonical builder, so an archive link always matches the
+                // record's own canonical/og:url/sitemap entry (custom permalink wins).
+                path: PublicPermalinkResolver::canonicalPath(
+                    $entity->permalink,
+                    $entityType->permalinkPattern,
+                    $entityType->slug,
+                    $entity->slug,
+                    $entity->id,
+                    $entity->publishedAt,
+                ),
+                publishedAt: $entity->publishedAt,
+            );
+        }
+
+        return new GetPublicTypeArchiveOutput(
+            typeSlug: $entityType->slug,
+            typeName: $entityType->name,
+            items: $items,
+            total: $total,
+            offset: $offset,
+            pageSize: self::PAGE_SIZE,
+        );
+    }
+}

--- a/src/PublicRecord/PublicRecordHierarchyBuilder.php
+++ b/src/PublicRecord/PublicRecordHierarchyBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\PublicRecord;
 
+use NeNeRecords\Entity\Entity;
 use NeNeRecords\Entity\EntityRepositoryInterface;
 use NeNeRecords\Entity\EntityStatus;
 use NeNeRecords\TextField\TextFieldRepositoryInterface;
@@ -52,7 +53,7 @@ final readonly class PublicRecordHierarchyBuilder
             return PublicRecordHierarchy::empty();
         }
 
-        $title = $this->titlesByIds([$entity->id])[$entity->id]
+        $title = $this->titlesByIds([$entity])[$entity->id]
             ?? $this->humanize(basename($entity->permalink));
 
         // A custom-permalink record's canonical path is the permalink itself (#651 PR1).
@@ -78,7 +79,7 @@ final readonly class PublicRecordHierarchyBuilder
         // Resolve ancestors (every segment but the last) so crumbs use the real
         // page title and only link to segments that are actually published pages.
         $ancestorIdByPath = [];
-        $ancestorIds = [];
+        $ancestors = [];
         $cumulative = '';
         foreach ($segments as $index => $segment) {
             $cumulative .= '/' . $segment;
@@ -93,11 +94,11 @@ final readonly class PublicRecordHierarchyBuilder
                 && $ancestor->status === EntityStatus::Published
             ) {
                 $ancestorIdByPath[$cumulative] = $ancestor->id;
-                $ancestorIds[] = $ancestor->id;
+                $ancestors[] = $ancestor;
             }
         }
 
-        $titlesById = $this->titlesByIds($ancestorIds);
+        $titlesById = $this->titlesByIds($ancestors);
 
         $crumbs = [];
         $cumulative = '';
@@ -129,14 +130,7 @@ final readonly class PublicRecordHierarchyBuilder
     {
         $children = $this->entities->findDirectChildrenByPermalink($permalink, self::CHILD_LIMIT);
 
-        $ids = [];
-        foreach ($children as $child) {
-            if ($child->id !== null) {
-                $ids[] = $child->id;
-            }
-        }
-
-        $titlesById = $this->titlesByIds($ids);
+        $titlesById = $this->titlesByIds($children);
 
         $links = [];
         foreach ($children as $child) {
@@ -153,27 +147,37 @@ final readonly class PublicRecordHierarchyBuilder
     }
 
     /**
-     * @param list<int> $entityIds
-     * @return array<int, string> entityId => display title
+     * Entities (not ids) because the label needs `meta_title`, which the callers
+     * already hold — re-fetching them here would be a second query for nothing.
+     *
+     * @param list<Entity> $entities
+     * @return array<int, string> entityId => display label
      */
-    private function titlesByIds(array $entityIds): array
+    private function titlesByIds(array $entities): array
     {
-        if ($entityIds === []) {
+        $ids = [];
+        $metaTitleById = [];
+        foreach ($entities as $entity) {
+            if ($entity->id === null) {
+                continue;
+            }
+            $ids[] = $entity->id;
+            $metaTitleById[$entity->id] = $entity->metaTitle;
+        }
+
+        if ($ids === []) {
             return [];
         }
 
-        $rows = $this->textFields->findByEntityIds($entityIds);
+        $rows = $this->textFields->findByEntityIds($ids);
         $byId = [];
 
-        foreach ($rows as $row) {
-            if ($row->fieldKey === 'title' && trim($row->value) !== '' && !isset($byId[$row->entityId])) {
-                $byId[$row->entityId] = $row->value;
-            }
-        }
-
-        foreach ($rows as $row) {
-            if (!isset($byId[$row->entityId]) && trim($row->value) !== '') {
-                $byId[$row->entityId] = $row->value;
+        foreach ($ids as $id) {
+            // Empty fallback: callers already humanize the permalink segment, which
+            // is a better last resort here than a bare id.
+            $label = RecordDisplayLabel::resolve($id, $rows, $metaTitleById[$id] ?? null, '');
+            if ($label !== '') {
+                $byId[$id] = $label;
             }
         }
 

--- a/src/PublicRecord/PublicRecordServiceProvider.php
+++ b/src/PublicRecord/PublicRecordServiceProvider.php
@@ -453,6 +453,72 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                 },
             )
             ->set(
+                GetPublicTypeArchiveUseCase::class,
+                static function (ContainerInterface $container): GetPublicTypeArchiveUseCase {
+                    $entityTypes = $container->get(EntityTypeRepositoryInterface::class);
+                    $entities = $container->get(EntityRepositoryInterface::class);
+                    $textFields = $container->get(TextFieldRepositoryInterface::class);
+
+                    if (!$entityTypes instanceof EntityTypeRepositoryInterface) {
+                        throw new LogicException('Entity type repository service is invalid.');
+                    }
+                    if (!$entities instanceof EntityRepositoryInterface) {
+                        throw new LogicException('Entity repository service is invalid.');
+                    }
+                    if (!$textFields instanceof TextFieldRepositoryInterface) {
+                        throw new LogicException('Text field repository service is invalid.');
+                    }
+
+                    return new GetPublicTypeArchiveUseCase($entityTypes, $entities, $textFields);
+                },
+            )
+            ->set(
+                PublicTypeArchiveRendererInterface::class,
+                static function (ContainerInterface $container): PublicTypeArchiveRendererInterface {
+                    $publicSettings = $container->get(ListPublicSettingsUseCaseInterface::class);
+                    $html = $container->get(HtmlResponseFactory::class);
+                    $config = $container->get(AppConfig::class);
+                    $projectRoot = $container->get(RuntimeServiceProvider::PROJECT_ROOT);
+
+                    if (!$publicSettings instanceof ListPublicSettingsUseCaseInterface) {
+                        throw new LogicException('Public settings use case service is invalid.');
+                    }
+                    if (!$html instanceof HtmlResponseFactory) {
+                        throw new LogicException('Html response factory service is invalid.');
+                    }
+                    if (!$config instanceof AppConfig) {
+                        throw new LogicException('App config service is invalid.');
+                    }
+                    if (!is_string($projectRoot) || $projectRoot === '') {
+                        throw new LogicException('Project root is not configured.');
+                    }
+
+                    return new RenderPublicTypeArchiveRenderer(
+                        $publicSettings,
+                        $html,
+                        $config,
+                        $projectRoot,
+                        \NeNeRecords\Http\BasePath::fromEnv(),
+                    );
+                },
+            )
+            ->set(
+                RenderPublicTypeArchiveHandler::class,
+                static function (ContainerInterface $container): RenderPublicTypeArchiveHandler {
+                    $useCase = $container->get(GetPublicTypeArchiveUseCase::class);
+                    $renderer = $container->get(PublicTypeArchiveRendererInterface::class);
+
+                    if (!$useCase instanceof GetPublicTypeArchiveUseCase) {
+                        throw new LogicException('Public type archive use case service is invalid.');
+                    }
+                    if (!$renderer instanceof PublicTypeArchiveRendererInterface) {
+                        throw new LogicException('Public type archive renderer service is invalid.');
+                    }
+
+                    return new RenderPublicTypeArchiveHandler($useCase, $renderer);
+                },
+            )
+            ->set(
                 RenderPublicHomeHandler::class,
                 static function (ContainerInterface $container): RenderPublicHomeHandler {
                     $frontPage = $container->get(FrontPageSetting::class);

--- a/src/PublicRecord/PublicTypeArchiveItem.php
+++ b/src/PublicRecord/PublicTypeArchiveItem.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use DateTimeImmutable;
+
+/** One row of an entity type's public archive listing (#877). */
+final readonly class PublicTypeArchiveItem
+{
+    public function __construct(
+        public int $id,
+        public string $label,
+        /** Canonical public path, e.g. "/privacy" or "/posts/42". */
+        public string $path,
+        public ?DateTimeImmutable $publishedAt,
+    ) {
+    }
+}

--- a/src/PublicRecord/PublicTypeArchiveRendererInterface.php
+++ b/src/PublicRecord/PublicTypeArchiveRendererInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Renders a resolved type archive as crawlable, SPA-hydratable HTML.
+ *
+ * Split from {@see RenderPublicTypeArchiveHandler} so the edge layer (which owns the
+ * "should this path even be an archive?" decision) can be unit-tested against a
+ * lightweight fake instead of the template stack (#877).
+ */
+interface PublicTypeArchiveRendererInterface
+{
+    public function render(GetPublicTypeArchiveOutput $archive, ServerRequestInterface $request): ResponseInterface;
+}

--- a/src/PublicRecord/RecordDisplayLabel.php
+++ b/src/PublicRecord/RecordDisplayLabel.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use NeNeRecords\TextField\TextField;
+
+/**
+ * Resolves the label shown for a record in a *listing* context — breadcrumbs,
+ * child-page lists, JSON-LD — where the record itself is not the page body.
+ *
+ * PHP twin of the frontend `shared/lib/get-record-display-label.ts`; the order
+ * is deliberately identical so the SSR label and the SPA label agree:
+ *
+ *   title field → entity meta_title → derived excerpt → caller fallback
+ *
+ * The excerpt step is what makes this class necessary. A bespoke page authored
+ * as one html field (bare layout, #799) has no `title` field, so a naive "first
+ * non-empty field" fallback puts the page's entire source into a link label:
+ * on the public site that dumped 57KB of markup into a breadcrumb, a child link
+ * and the JSON-LD BreadcrumbList (#875). The admin listing hit the same bug and
+ * fixed it the same way (#849 cap, #853 meta_title) — this is the public half.
+ *
+ * An explicit `title` field is trusted verbatim; only derived text is capped.
+ */
+final class RecordDisplayLabel
+{
+    /** Matches the frontend FALLBACK_LABEL_MAX so both halves cut at the same place. */
+    private const DERIVED_MAX = 120;
+
+    /** Strip markup, collapse whitespace, and cap — for use as a derived label. */
+    public static function derive(string $value): string
+    {
+        $text = trim((string) preg_replace('/\s+/u', ' ', strip_tags($value)));
+
+        if ($text === '' || mb_strlen($text) <= self::DERIVED_MAX) {
+            return $text;
+        }
+
+        return rtrim(mb_substr($text, 0, self::DERIVED_MAX)) . '…';
+    }
+
+    /**
+     * @param list<TextField> $textFieldRows rows for any entities; filtered by $entityId
+     * @param string          $fallback      used when nothing else yields text
+     */
+    public static function resolve(
+        int $entityId,
+        array $textFieldRows,
+        ?string $metaTitle,
+        string $fallback,
+    ): string {
+        foreach ($textFieldRows as $row) {
+            if ($row->entityId === $entityId && $row->fieldKey === 'title' && trim($row->value) !== '') {
+                return trim($row->value);
+            }
+        }
+
+        // The SEO title beats the derived excerpt: bespoke pages that share one
+        // html field would otherwise all show the same stripped header/nav text
+        // (#853 — the same reason the admin listing prefers it).
+        if ($metaTitle !== null && trim($metaTitle) !== '') {
+            return trim($metaTitle);
+        }
+
+        foreach ($textFieldRows as $row) {
+            if ($row->entityId === $entityId && trim($row->value) !== '') {
+                $derived = self::derive($row->value);
+                if ($derived !== '') {
+                    return $derived;
+                }
+            }
+        }
+
+        return $fallback;
+    }
+}

--- a/src/PublicRecord/RenderPublicTypeArchiveHandler.php
+++ b/src/PublicRecord/RenderPublicTypeArchiveHandler.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+/**
+ * Single-origin edge layer that server-renders an entity type's archive at
+ * `/{typeSlug}` (#877).
+ *
+ * The SPA already routes `:entityTypeSlug` to `PublicBrowsePage`, but the server
+ * had no such route, so the request fell through to {@see \NeNeRecords\Http\SpaShellFallback}
+ * and crawlers got a 1.6KB shell titled "NeNe Records Admin" instead of the listing.
+ * This renders the same list server-side; the SPA still replaces it on mount.
+ *
+ * Placed after {@see \NeNeRecords\Http\CustomPermalinkResolver} and the redirect map
+ * in {@see \NeNeRecords\Http\SingleOriginKernel}: a real record parked at `/posts`
+ * and an admin-authored 301 are both explicit, and must beat this derived listing.
+ * Acting only on an already-404 response keeps every fixed route (/api, /view,
+ * sitemap, robots, assets) untouched.
+ */
+final readonly class RenderPublicTypeArchiveHandler
+{
+    /** Same reserved prefixes CustomPermalinkResolver passes through. */
+    private const PASSTHROUGH = '#^/(api|media|view|assets|admin|superadmin)(/|$)#';
+
+    public function __construct(
+        private GetPublicTypeArchiveUseCase $useCase,
+        private PublicTypeArchiveRendererInterface $renderer,
+    ) {
+    }
+
+    public function apply(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        if ($response->getStatusCode() !== 404 || strtoupper($request->getMethod()) !== 'GET') {
+            return $response;
+        }
+
+        if (!str_contains($request->getHeaderLine('Accept'), 'text/html')) {
+            return $response;
+        }
+
+        $path = $request->getUri()->getPath();
+
+        if (preg_match(self::PASSTHROUGH, $path) === 1) {
+            return $response;
+        }
+
+        $slug = $this->singleSegment($path);
+
+        if ($slug === null) {
+            return $response;
+        }
+
+        try {
+            $archive = $this->useCase->execute($slug, $this->offset($request));
+        } catch (Throwable) {
+            // An archive is a nice-to-have surface: on any failure keep the original
+            // 404 so the shell fallback still answers, rather than white-screening.
+            return $response;
+        }
+
+        if ($archive === null) {
+            return $response;
+        }
+
+        try {
+            return $this->renderer->render($archive, $request);
+        } catch (Throwable) {
+            return $response;
+        }
+    }
+
+    /** "/posts" → "posts"; anything deeper, empty or dotted (files) → null. */
+    private function singleSegment(string $path): ?string
+    {
+        $trimmed = trim($path, '/');
+
+        if ($trimmed === '' || str_contains($trimmed, '/') || str_contains($trimmed, '.')) {
+            return null;
+        }
+
+        return rawurldecode($trimmed);
+    }
+
+    private function offset(ServerRequestInterface $request): int
+    {
+        $params = $request->getQueryParams();
+        $raw = $params['offset'] ?? null;
+
+        if (!is_string($raw) || !ctype_digit($raw)) {
+            return 0;
+        }
+
+        return (int) $raw;
+    }
+}

--- a/src/PublicRecord/RenderPublicTypeArchiveRenderer.php
+++ b/src/PublicRecord/RenderPublicTypeArchiveRenderer.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use Nene2\Config\AppConfig;
+use Nene2\View\HtmlResponseFactory;
+use NeNeRecords\Http\BasePath;
+use NeNeRecords\Http\PublicHtmlCsp;
+use NeNeRecords\Http\WebAnalyticsConfig;
+use NeNeRecords\Http\WebAnalyticsHeadSnippet;
+use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Renders a type archive as crawlable HTML that the SPA hydrates over (#877).
+ *
+ * Mirrors {@see RenderPublicRecordViewHandler}'s head/SPA-mount contract (base href,
+ * analytics snippet, canonical, Vite entry, CSP) so both public surfaces behave the
+ * same. It ships no bootstrap payload: unlike the record page, the SPA's
+ * `PublicBrowsePage` fetches its own list from the public API, so the SSR markup only
+ * has to be correct for crawlers and no-JS visitors until React mounts.
+ */
+final readonly class RenderPublicTypeArchiveRenderer implements PublicTypeArchiveRendererInterface
+{
+    public function __construct(
+        private ListPublicSettingsUseCaseInterface $publicSettings,
+        private HtmlResponseFactory $html,
+        private AppConfig $config,
+        private string $projectRoot,
+        /** Sub-directory install prefix (`APP_BASE_PATH`); '' = served at root. */
+        private string $basePath = '',
+    ) {
+    }
+
+    public function render(GetPublicTypeArchiveOutput $archive, ServerRequestInterface $request): ResponseInterface
+    {
+        $settings = $this->publicSettingsMap();
+        $siteName = $settings['site_name'] ?? 'NeNe Records';
+        $metaDescription = $settings['default_meta_description'] ?? '';
+
+        $analytics = WebAnalyticsConfig::fromSettings($settings);
+        $analyticsNonce = $analytics->isEnabled() ? bin2hex(random_bytes(16)) : '';
+        $analyticsHead = WebAnalyticsHeadSnippet::render($analytics, $analyticsNonce);
+
+        $effectiveBase = $this->basePath . (string) $request->getAttribute('nene2.base_prefix', '');
+        $uri = $request->getUri();
+        $baseUrl = $uri->getScheme() . '://' . $uri->getAuthority();
+        $archiveUrl = $baseUrl . BasePath::prefix($effectiveBase, '/' . $archive->typeSlug);
+
+        $prev = $archive->prevOffset();
+        $next = $archive->nextOffset();
+
+        $spaMode = 'none';
+        $spaJs = null;
+        $spaCss = [];
+        $spaPreload = [];
+
+        if ($this->config->debug) {
+            $spaMode = 'dev';
+        } else {
+            $entry = ViteManifest::resolveEntry($this->projectRoot . '/frontend/dist/.vite/manifest.json');
+            if ($entry !== null) {
+                $spaMode = 'prod';
+                $spaJs = $entry['js'];
+                $spaCss = $entry['css'];
+                $spaPreload = $entry['preload'];
+            }
+        }
+
+        $from = $archive->total === 0 ? 0 : $archive->offset + 1;
+        $to = min($archive->offset + count($archive->items), $archive->total);
+
+        return $this->html->create('public/type-archive.php', [
+            'pageTitle' => $archive->typeName,
+            'typeName' => $archive->typeName,
+            'items' => $archive->items,
+            'htmlLang' => PublicLocale::DEFAULT_LANG,
+            'basePath' => $effectiveBase,
+            'siteName' => $siteName,
+            'metaDescription' => $metaDescription,
+            'analyticsHead' => $analyticsHead,
+            // The first page is the archive's canonical address; deeper pages carry
+            // their offset so each paged view has its own stable URL.
+            'canonicalUrl' => $archive->offset === 0 ? $archiveUrl : $this->pageUrl($archiveUrl, $archive->offset),
+            'prevUrl' => $prev === null ? null : $this->pageUrl($archiveUrl, $prev),
+            'nextUrl' => $next === null ? null : $this->pageUrl($archiveUrl, $next),
+            'prevLabel' => 'Previous',
+            'nextLabel' => 'Next',
+            'countLabel' => $archive->total === 0
+                ? '0'
+                : sprintf('%d–%d / %d', $from, $to, $archive->total),
+            'emptyLabel' => 'No published records yet.',
+            'spaMode' => $spaMode,
+            'viteUrl' => rtrim($this->viteUrl(), '/'),
+            'spaJs' => $spaJs,
+            'spaCss' => $spaCss,
+            'spaPreload' => $spaPreload,
+        ])->withHeader(
+            'Content-Security-Policy',
+            PublicHtmlCsp::build($analytics, $analyticsNonce !== '' ? $analyticsNonce : null, null),
+        );
+    }
+
+    private function pageUrl(string $archiveUrl, int $offset): string
+    {
+        return $offset === 0 ? $archiveUrl : $archiveUrl . '?offset=' . $offset;
+    }
+
+    private function viteUrl(): string
+    {
+        $viteUrl = getenv('NENE_RECORDS_VITE_URL');
+
+        return is_string($viteUrl) && $viteUrl !== '' ? $viteUrl : 'http://localhost:5173';
+    }
+
+    /** @return array<string, string> */
+    private function publicSettingsMap(): array
+    {
+        $map = [];
+
+        foreach ($this->publicSettings->execute()->items as $entry) {
+            $map[$entry->def->settingKey] = $entry->effectiveValue;
+        }
+
+        return $map;
+    }
+}

--- a/templates/public/type-archive.php
+++ b/templates/public/type-archive.php
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="<?= $e($htmlLang) ?>">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <?php /* Runtime base path: anchors the SPA (router/API derive it from <base>). #zip-install S2 */ ?>
+    <base href="<?= $e($basePath . '/') ?>" />
+    <?= $analyticsHead ?>
+    <?php if ($metaDescription !== ''): ?>
+      <meta name="description" content="<?= $e($metaDescription) ?>" />
+    <?php endif; ?>
+    <title><?= $e($pageTitle) ?> — <?= $e($siteName) ?></title>
+    <link rel="canonical" href="<?= $e($canonicalUrl) ?>" />
+    <?php /* Paged archives: point crawlers along the sequence rather than at dead ends. */ ?>
+    <?php if ($prevUrl !== null): ?>
+      <link rel="prev" href="<?= $e($prevUrl) ?>" />
+    <?php endif; ?>
+    <?php if ($nextUrl !== null): ?>
+      <link rel="next" href="<?= $e($nextUrl) ?>" />
+    <?php endif; ?>
+
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="<?= $e($pageTitle) ?>" />
+    <?php if ($metaDescription !== ''): ?>
+      <meta property="og:description" content="<?= $e($metaDescription) ?>" />
+    <?php endif; ?>
+    <meta property="og:site_name" content="<?= $e($siteName) ?>" />
+    <meta property="og:url" content="<?= $e($canonicalUrl) ?>" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="<?= $e($pageTitle) ?>" />
+
+    <style>
+      .archive__list { margin: 1rem 0 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 0.75rem; }
+      .archive__item { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem 1rem; padding-bottom: 0.75rem; border-bottom: 1px solid #e5e7eb; }
+      .archive__date { color: #6b7280; font-size: 0.85rem; }
+      .archive__empty { color: #6b7280; }
+      .archive__pager { display: flex; gap: 1rem; margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid #e5e7eb; }
+      .archive__count { color: #6b7280; font-size: 0.85rem; }
+    </style>
+    <?php if ($spaMode === 'prod'): ?>
+      <?php foreach ($spaCss as $href): ?>
+      <link rel="stylesheet" crossorigin href="<?= $e($basePath . $href) ?>" />
+      <?php endforeach; ?>
+    <?php elseif ($spaMode === 'dev'): ?>
+      <script type="module" src="<?= $e($viteUrl) ?>/@vite/client"></script>
+    <?php endif; ?>
+  </head>
+  <body>
+    <!-- SSR content lives inside #root: crawlers / no-JS read it; the SPA
+         (PublicBrowsePage) replaces it with the interactive list on mount. -->
+    <div id="root">
+      <header>
+        <h1><?= $e($typeName) ?></h1>
+        <p class="archive__count"><?= $e($countLabel) ?></p>
+      </header>
+      <?php if ($items === []): ?>
+        <p class="archive__empty"><?= $e($emptyLabel) ?></p>
+      <?php else: ?>
+        <ul class="archive__list">
+          <?php foreach ($items as $item): ?>
+            <li class="archive__item">
+              <a href="<?= $e($basePath . $item->path) ?>"><?= $e($item->label) ?></a>
+              <?php if ($item->publishedAt !== null): ?>
+                <time class="archive__date" datetime="<?= $e($item->publishedAt->format(DATE_ATOM)) ?>">
+                  <?= $e($item->publishedAt->format('Y-m-d')) ?>
+                </time>
+              <?php endif; ?>
+            </li>
+          <?php endforeach; ?>
+        </ul>
+      <?php endif; ?>
+      <?php if ($prevUrl !== null || $nextUrl !== null): ?>
+        <nav class="archive__pager" aria-label="Pagination">
+          <?php if ($prevUrl !== null): ?>
+            <a rel="prev" href="<?= $e($prevUrl) ?>">← <?= $e($prevLabel) ?></a>
+          <?php endif; ?>
+          <?php if ($nextUrl !== null): ?>
+            <a rel="next" href="<?= $e($nextUrl) ?>"><?= $e($nextLabel) ?> →</a>
+          <?php endif; ?>
+        </nav>
+      <?php endif; ?>
+    </div>
+    <?php if ($spaMode === 'dev'): ?>
+      <script type="module" src="<?= $e($viteUrl) ?>/src/main.tsx"></script>
+    <?php elseif ($spaMode === 'prod' && $spaJs !== null): ?>
+      <?php foreach ($spaPreload as $href): ?>
+      <link rel="modulepreload" crossorigin href="<?= $e($basePath . $href) ?>" />
+      <?php endforeach; ?>
+      <script type="module" crossorigin src="<?= $e($basePath . $spaJs) ?>"></script>
+    <?php endif; ?>
+  </body>
+</html>

--- a/tests/Http/SingleOriginKernelTest.php
+++ b/tests/Http/SingleOriginKernelTest.php
@@ -13,12 +13,17 @@ use NeNeRecords\Http\PublicPermalinkRendererInterface;
 use NeNeRecords\Http\SingleOriginKernel;
 use NeNeRecords\Http\SpaShellFallback;
 use NeNeRecords\PublicRecord\FrontPageSetting;
+use NeNeRecords\PublicRecord\GetPublicTypeArchiveOutput;
+use NeNeRecords\PublicRecord\GetPublicTypeArchiveUseCase;
 use NeNeRecords\PublicRecord\PublicRecordViewRendererInterface;
+use NeNeRecords\PublicRecord\PublicTypeArchiveRendererInterface;
 use NeNeRecords\PublicRecord\RenderPublicHomeHandler;
+use NeNeRecords\PublicRecord\RenderPublicTypeArchiveHandler;
 use NeNeRecords\Setting\SettingDef;
 use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
 use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
 use NeNeRecords\Tests\Setting\InMemorySettingRepository;
+use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
 use NeNeRecords\Tests\UrlRedirect\InMemoryUrlRedirectRepository;
 use NeNeRecords\UrlRedirect\UrlRedirectResolver;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -74,14 +79,55 @@ final class SingleOriginKernelTest extends TestCase
         RequestHandlerInterface $app,
         ?CustomPermalinkResolver $customPermalink = null,
         ?RenderPublicHomeHandler $frontPage = null,
+        ?RenderPublicTypeArchiveHandler $typeArchive = null,
     ): SingleOriginKernel {
         return new SingleOriginKernel(
             $app,
             $customPermalink ?? new CustomPermalinkResolver($this->nullPermalinkRenderer()),
             new UrlRedirectResolver($this->redirects, $this->factory),
+            $typeArchive ?? $this->typeArchive(),
             $frontPage ?? $this->frontPage(false),
             new SpaShellFallback($this->shellPath, $this->factory, $this->factory),
         );
+    }
+
+    /**
+     * A type-archive edge layer over the given entity types (#877). With no types
+     * seeded it resolves nothing and passes through — the default for tests that are
+     * about the other layers.
+     *
+     * @param list<EntityType> $types
+     * @param list<Entity>     $entities
+     */
+    private function typeArchive(array $types = [], array $entities = []): RenderPublicTypeArchiveHandler
+    {
+        return new RenderPublicTypeArchiveHandler(
+            new GetPublicTypeArchiveUseCase(
+                new InMemoryEntityTypeRepository($types),
+                new InMemoryEntityRepository($entities),
+                new InMemoryTextFieldRepository([]),
+            ),
+            $this->archiveRenderer(),
+        );
+    }
+
+    /** Tags the response so tests can assert the archive layer answered. */
+    private function archiveRenderer(): PublicTypeArchiveRendererInterface
+    {
+        return new class ($this->factory) implements PublicTypeArchiveRendererInterface {
+            public function __construct(private Psr17Factory $factory)
+            {
+            }
+
+            public function render(
+                GetPublicTypeArchiveOutput $archive,
+                ServerRequestInterface $request,
+            ): ResponseInterface {
+                return $this->factory->createResponse(200)
+                    ->withHeader('Content-Type', 'text/html')
+                    ->withHeader('X-Test-Archive', $archive->typeSlug);
+            }
+        };
     }
 
     /**
@@ -310,5 +356,105 @@ final class SingleOriginKernelTest extends TestCase
         $response = $this->kernel($this->appReturning(200))->handle($request);
 
         self::assertStringContainsString('id="root"', (string) $response->getBody());
+    }
+
+    /**
+     * #877: `/posts` was SPA-only — the router 404'd it and the shell fallback answered,
+     * so crawlers got a 1.6KB shell titled "NeNe Records Admin" instead of the listing.
+     */
+    public function testTypeArchiveRendersOn404ForAKnownTypeSlug(): void
+    {
+        $archive = $this->typeArchive(
+            [new EntityType(name: 'Posts', slug: 'posts', id: 2)],
+            [new Entity(id: 5, entityTypeId: 2, slug: 'hello', status: EntityStatus::Published)],
+        );
+
+        $response = $this->kernel($this->appReturning(404), null, null, $archive)->handle(
+            $this->factory->createServerRequest('GET', 'https://site.test/posts')
+                ->withHeader('Accept', 'text/html'),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('posts', $response->getHeaderLine('X-Test-Archive'));
+    }
+
+    /** #877: an unknown slug is not an archive — it must keep falling through to the shell. */
+    public function testUnknownTypeSlugStillFallsThroughToTheShell(): void
+    {
+        $archive = $this->typeArchive([new EntityType(name: 'Posts', slug: 'posts', id: 2)]);
+
+        $response = $this->kernel($this->appReturning(404), null, null, $archive)->handle(
+            $this->factory->createServerRequest('GET', 'https://site.test/blog')
+                ->withHeader('Accept', 'text/html'),
+        );
+
+        self::assertSame('', $response->getHeaderLine('X-Test-Archive'));
+    }
+
+    /**
+     * #877 ordering: a real record parked at a path is explicit content and must beat the
+     * derived archive, even when its permalink happens to equal a type slug.
+     */
+    public function testCustomPermalinkRecordBeatsTheTypeArchiveOnTheSamePath(): void
+    {
+        $archive = $this->typeArchive([new EntityType(name: 'Posts', slug: 'posts', id: 2)]);
+
+        $response = $this->kernel(
+            $this->appReturning(404),
+            $this->permalinkResolverTagging(),
+            null,
+            $archive,
+        )->handle(
+            $this->factory->createServerRequest('GET', 'https://site.test/posts')
+                ->withHeader('Accept', 'text/html'),
+        );
+
+        self::assertSame('hit', $response->getHeaderLine('X-Test-Permalink'));
+        self::assertSame('', $response->getHeaderLine('X-Test-Archive'), 'archive must not override a real record');
+    }
+
+    /** #877: a deep path is a record route, never an archive. */
+    public function testTypeArchiveIgnoresMultiSegmentPaths(): void
+    {
+        $archive = $this->typeArchive([new EntityType(name: 'Posts', slug: 'posts', id: 2)]);
+
+        $response = $this->kernel($this->appReturning(404), null, null, $archive)->handle(
+            $this->factory->createServerRequest('GET', 'https://site.test/posts/hello')
+                ->withHeader('Accept', 'text/html'),
+        );
+
+        self::assertSame('', $response->getHeaderLine('X-Test-Archive'));
+    }
+
+    /** #877: a 200 from the app is the real answer — the archive only fills 404s. */
+    public function testTypeArchiveDoesNotTouchNon404Responses(): void
+    {
+        $archive = $this->typeArchive([new EntityType(name: 'Posts', slug: 'posts', id: 2)]);
+
+        $response = $this->kernel($this->appReturning(200), null, null, $archive)->handle(
+            $this->factory->createServerRequest('GET', 'https://site.test/posts')
+                ->withHeader('Accept', 'text/html'),
+        );
+
+        self::assertSame('', $response->getHeaderLine('X-Test-Archive'));
+    }
+
+    /** A permalink resolver that claims every 404 path, tagging the response. */
+    private function permalinkResolverTagging(): CustomPermalinkResolver
+    {
+        return new CustomPermalinkResolver(
+            new class ($this->factory) implements PublicPermalinkRendererInterface {
+                public function __construct(private Psr17Factory $factory)
+                {
+                }
+
+                public function renderByPermalink(string $path, ServerRequestInterface $request): ResponseInterface
+                {
+                    return $this->factory->createResponse(200)
+                        ->withHeader('Content-Type', 'text/html')
+                        ->withHeader('X-Test-Permalink', 'hit');
+                }
+            },
+        );
     }
 }

--- a/tests/PublicRecord/GetPublicTypeArchiveUseCaseTest.php
+++ b/tests/PublicRecord/GetPublicTypeArchiveUseCaseTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use DateTimeImmutable;
+use NeNeRecords\Entity\Entity;
+use NeNeRecords\Entity\EntityStatus;
+use NeNeRecords\EntityType\EntityType;
+use NeNeRecords\PublicRecord\GetPublicTypeArchiveUseCase;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
+use NeNeRecords\TextField\TextField;
+use PHPUnit\Framework\TestCase;
+
+final class GetPublicTypeArchiveUseCaseTest extends TestCase
+{
+    /**
+     * @param list<EntityType> $types
+     * @param list<Entity>     $entities
+     * @param list<TextField>  $textFields
+     */
+    private function useCase(array $types, array $entities, array $textFields = []): GetPublicTypeArchiveUseCase
+    {
+        $entityRepo = new InMemoryEntityRepository($entities);
+
+        return new GetPublicTypeArchiveUseCase(
+            new InMemoryEntityTypeRepository($types),
+            $entityRepo,
+            new InMemoryTextFieldRepository($textFields, $entityRepo),
+        );
+    }
+
+    public function testUnknownTypeSlugYieldsNull(): void
+    {
+        $archive = $this->useCase([new EntityType(name: 'Posts', slug: 'posts', id: 2)], [])->execute('blog');
+
+        self::assertNull($archive, 'a slug with no type must not synthesize an archive');
+    }
+
+    public function testListsOnlyPublishedRecordsOfTheType(): void
+    {
+        $types = [new EntityType(name: 'Posts', slug: 'posts', id: 2, permalinkPattern: '/posts/{slug}')];
+        $entities = [
+            new Entity(id: 1, entityTypeId: 2, slug: 'live', status: EntityStatus::Published),
+            new Entity(id: 2, entityTypeId: 2, slug: 'wip', status: EntityStatus::Draft),
+            // Same status, different type: must not leak into this archive.
+            new Entity(id: 3, entityTypeId: 9, slug: 'other', status: EntityStatus::Published),
+        ];
+
+        $archive = $this->useCase($types, $entities)->execute('posts');
+
+        self::assertNotNull($archive);
+        self::assertSame(1, $archive->total);
+        self::assertCount(1, $archive->items);
+        self::assertSame('/posts/live', $archive->items[0]->path);
+    }
+
+    /** Labels follow the #875 rule: title → meta_title → stripped+capped excerpt. */
+    public function testTitlelessRecordUsesMetaTitleRatherThanRawHtml(): void
+    {
+        $types = [new EntityType(name: 'Pages', slug: 'pages', id: 3, permalinkPattern: '/{slug}')];
+        $entities = [
+            new Entity(id: 7, entityTypeId: 3, slug: 'company', permalink: '/company', status: EntityStatus::Published, metaTitle: '会社案内'),
+        ];
+        $textFields = [
+            new TextField(entityId: 7, fieldKey: 'content', value: '<div><nav>SERVICE</nav></div>', id: 1),
+        ];
+
+        $archive = $this->useCase($types, $entities, $textFields)->execute('pages');
+
+        self::assertNotNull($archive);
+        self::assertSame('会社案内', $archive->items[0]->label);
+        self::assertStringNotContainsString('<div', $archive->items[0]->label);
+    }
+
+    /** A per-record custom permalink is the canonical path and wins over the type pattern. */
+    public function testCustomPermalinkWinsOverTheTypePattern(): void
+    {
+        $types = [new EntityType(name: 'Pages', slug: 'pages', id: 3, permalinkPattern: '/pages/{slug}')];
+        $entities = [
+            new Entity(id: 7, entityTypeId: 3, slug: 'privacy', permalink: '/privacy', status: EntityStatus::Published),
+        ];
+
+        $archive = $this->useCase($types, $entities)->execute('pages');
+
+        self::assertNotNull($archive);
+        self::assertSame('/privacy', $archive->items[0]->path);
+    }
+
+    public function testPaginationExposesNeighbouringOffsetsAndClampsNegatives(): void
+    {
+        $types = [new EntityType(name: 'Posts', slug: 'posts', id: 2, permalinkPattern: '/posts/{id}')];
+        $entities = [];
+        for ($i = 1; $i <= 45; $i++) {
+            $entities[] = new Entity(
+                id: $i,
+                entityTypeId: 2,
+                slug: 'p' . $i,
+                status: EntityStatus::Published,
+                publishedAt: new DateTimeImmutable('2026-01-01 00:00:00'),
+            );
+        }
+
+        $useCase = $this->useCase($types, $entities);
+
+        $first = $useCase->execute('posts');
+        self::assertNotNull($first);
+        self::assertSame(45, $first->total);
+        self::assertCount(GetPublicTypeArchiveUseCase::PAGE_SIZE, $first->items);
+        self::assertNull($first->prevOffset(), 'first page has no previous');
+        self::assertSame(20, $first->nextOffset());
+
+        $last = $useCase->execute('posts', 40);
+        self::assertNotNull($last);
+        self::assertCount(5, $last->items);
+        self::assertSame(20, $last->prevOffset());
+        self::assertNull($last->nextOffset(), 'last page has no next');
+
+        $clamped = $useCase->execute('posts', -10);
+        self::assertNotNull($clamped);
+        self::assertSame(0, $clamped->offset);
+    }
+
+    public function testEmptyTypeYieldsAnEmptyArchiveRatherThanNull(): void
+    {
+        $archive = $this->useCase([new EntityType(name: 'Posts', slug: 'posts', id: 2)], [])->execute('posts');
+
+        self::assertNotNull($archive, 'a real type with no records is still a real page');
+        self::assertSame(0, $archive->total);
+        self::assertSame([], $archive->items);
+        self::assertNull($archive->nextOffset());
+    }
+}

--- a/tests/PublicRecord/PublicRecordHierarchyBuilderTest.php
+++ b/tests/PublicRecord/PublicRecordHierarchyBuilderTest.php
@@ -122,4 +122,74 @@ final class PublicRecordHierarchyBuilderTest extends TestCase
         self::assertSame([], $hierarchy->breadcrumbs);
         self::assertSame([], $hierarchy->childPages);
     }
+
+    /**
+     * Regression (#875): a bespoke page (bare layout, one html field, no `title`)
+     * must not dump its whole source into an ancestor crumb or a child link.
+     * Production served a 57KB breadcrumb label and a 61.8KB JSON-LD BreadcrumbList
+     * this way — the public twin of the admin listing bug (#849/#853).
+     */
+    public function testTitlelessBespokeAncestorAndChildLabelsAreDerivedNotRawHtml(): void
+    {
+        $body = '<div style="background:#F6F3EC"><header>' . str_repeat('本文テキスト', 400) . '</header></div>';
+
+        $entities = new InMemoryEntityRepository([
+            new Entity(id: 1, entityTypeId: 1, slug: 'company', permalink: '/company', status: EntityStatus::Published),
+            new Entity(id: 2, entityTypeId: 1, slug: 'ceo', permalink: '/company/ceo', status: EntityStatus::Published),
+        ]);
+        $textFields = new InMemoryTextFieldRepository([
+            new TextField(entityId: 1, fieldKey: 'content', value: $body, id: 1),
+            new TextField(entityId: 2, fieldKey: 'content', value: $body, id: 2),
+        ], $entities);
+
+        $hierarchy = $this->builder($entities, $textFields)->buildById(2);
+
+        $ancestor = $hierarchy->breadcrumbs[0]->label;
+        self::assertStringNotContainsString('<div', $ancestor, 'markup must be stripped');
+        self::assertStringNotContainsString('style=', $ancestor);
+        self::assertLessThanOrEqual(121, mb_strlen($ancestor), 'derived label must stay capped');
+        self::assertStringEndsWith('…', $ancestor);
+
+        $child = $this->builder($entities, $textFields)->build('/company', '/company', 'Company')->childPages;
+        self::assertCount(1, $child);
+        self::assertStringNotContainsString('<div', $child[0]->title);
+        self::assertLessThanOrEqual(121, mb_strlen($child[0]->title));
+    }
+
+    /** #875: meta_title beats the derived excerpt, mirroring the admin listing (#853). */
+    public function testMetaTitleBeatsDerivedExcerptForTitlelessPages(): void
+    {
+        $body = '<div><nav>SERVICE PRODUCTS COMPANY</nav><h1>会社案内</h1></div>';
+
+        $entities = new InMemoryEntityRepository([
+            new Entity(id: 1, entityTypeId: 1, slug: 'company', permalink: '/company', status: EntityStatus::Published, metaTitle: '会社案内｜彩音インターナショナル株式会社'),
+            new Entity(id: 2, entityTypeId: 1, slug: 'ceo', permalink: '/company/ceo', status: EntityStatus::Published, metaTitle: '代表紹介 森 秀之'),
+        ]);
+        $textFields = new InMemoryTextFieldRepository([
+            new TextField(entityId: 1, fieldKey: 'content', value: $body, id: 1),
+            new TextField(entityId: 2, fieldKey: 'content', value: $body, id: 2),
+        ], $entities);
+
+        $hierarchy = $this->builder($entities, $textFields)->buildById(2);
+        self::assertSame('会社案内｜彩音インターナショナル株式会社', $hierarchy->breadcrumbs[0]->label);
+
+        $children = $this->builder($entities, $textFields)->build('/company', '/company', 'Company')->childPages;
+        self::assertSame('代表紹介 森 秀之', $children[0]->title);
+    }
+
+    /** #875: an explicit `title` field still wins over meta_title and is kept verbatim. */
+    public function testExplicitTitleFieldStillWinsOverMetaTitle(): void
+    {
+        $entities = new InMemoryEntityRepository([
+            new Entity(id: 1, entityTypeId: 1, slug: 'about', permalink: '/company/about', status: EntityStatus::Published, metaTitle: 'SEO Title'),
+            new Entity(id: 2, entityTypeId: 1, slug: 'team', permalink: '/company/about/team', status: EntityStatus::Published),
+        ]);
+        $textFields = new InMemoryTextFieldRepository([
+            new TextField(entityId: 1, fieldKey: 'title', value: 'About Us', id: 1),
+            new TextField(entityId: 2, fieldKey: 'title', value: 'Our Team', id: 2),
+        ], $entities);
+
+        $hierarchy = $this->builder($entities, $textFields)->buildById(2);
+        self::assertSame('About Us', $hierarchy->breadcrumbs[1]->label);
+    }
 }


### PR DESCRIPTION
## 目的

**タイプ一覧ページは SPA には実装済みだが SSR が無い**ため、クローラと no-JS には存在しなかった。

SPA router には `{ path: ':entityTypeSlug', element: <PublicBrowsePage /> }` が既にあるが、
サーバ側に該当ルートが無く、1 セグメントのパスは
router 404 → `CustomPermalinkResolver`（該当なし）→ `SpaShellFallback` に落ちていた。

### 本番実測（2026-07-15）

| path | 実測 |
|---|---|
| `ayane.nene-records.com/posts` / `/pages` | 200・**1,661 bytes**・`<title>NeNe Records Admin</title>`・SSR本文なし |
| `aozora.nene-records.com/work` | 同上（**published 1,114 件**が1件もクロールされない） |

**会社サイト／小説サイトの公開ページなのに、タイトルが "NeNe Records Admin" で索引される。**
ポスト #536 の主題は real-URL crawlable SSR で、個別レコードは #544/#549/#553 で SSR 化済みだが、
**一覧側が丸ごと取り残されていた**（`templates/public/` はテンプレ1枚だけだった）。

## 変更

- **`GetPublicTypeArchiveUseCase`** — slug → 型解決 → published を `findByCriteria`。
  **SPA の `usePublicBrowseEntityRecordsPage` と同じ条件を意図的に写した**（published のみ・
  `PAGE_SIZE=20`・既定の id 降順）。ずれるとクローラと訪問者が別の一覧を見るため。
  ラベルは **`RecordDisplayLabel`（#875）**、URL は **`PublicPermalinkResolver::canonicalPath`**
  （custom permalink が型パターンに優先＝レコード自身の canonical/sitemap と必ず一致）。
- **`RenderPublicTypeArchiveHandler`** — 404 + GET + `text/html` + 1セグメントのみのエッジ層。
  `SingleOriginKernel` の **customPermalink / redirects の後・shell の前**。
  実レコードと管理者が明示した 301 は「明示」なので、**導出でしかないアーカイブより優先**させる。
- **`templates/public/type-archive.php`** — title / canonical / og / `rel=prev,next`。
  **bootstrap は積まない**（SPA 側が自前で公開 API から取り直すので、SSR は crawler / no-JS 用で足りる）。

## 検証

**テストが通ることと動くことは別なので、ローカルを起動して実際に叩いて確認しました。**

- `/pages` → 200・title「ページ」・canonical・件数「**1–10 / 10**」・SPA mount あり
  ・リンクは **`/privacy` 等の custom permalink 優先**・ラベルは **meta_title**（生HTMLでない）
- `?offset=5` → `rel=prev` ・「**6–10 / 10**」・offset 付き canonical
- **型を持たない org では素通り**（`/docs` は org スコープで対象外→従来どおりシェル）＝org 分離が効いている
- **既存レコード `/privacy` が横取りされない**ことを実地確認
- 新規テスト **11 本**（kernel の順序・素通り条件 5本 ／ UseCase 6本）
- **`composer check` 緑（1345 tests / PHPStan L8 / CS / OpenAPI / MCP）**

## チェックリスト

- [x] Issue 駆動（#877）
- [x] `main` から `feat/877-...` ブランチ
- [x] Conventional Commits（type/scope 英語・本文日本語・`(#877)`）
- [x] シークレット無し

## 範囲外（別 Issue 候補）

- 索引フィード（`PublicIndexPage`）／タグ・日付アーカイブの SSR 化 — **同じ穴**だが別スコープ。
- #671（phantom セグメントのセクション index）— permalink 階層由来で本 PR とは別軸。

## 備考

**AYANE の `/blog` は本 PR では直りません**（`blog` という型が無いため）。
`/blog` の扱い（ページを作る or 型 slug を合わせる）は別途相談。

Closes #877