### PR TITLE
fix(public): SSR を layout に従わせ bare/custom の汎用 chrome を止める（#879）

### DIFF
--- a/src/PreviewToken/GetPreviewRecordViewUseCase.php
+++ b/src/PreviewToken/GetPreviewRecordViewUseCase.php
@@ -19,6 +19,7 @@ use NeNeRecords\FieldDef\FieldDef;
 use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
 use NeNeRecords\IntField\IntField;
 use NeNeRecords\IntField\IntFieldRepositoryInterface;
+use NeNeRecords\Layout\PublicLayouts;
 use NeNeRecords\Media\MediaDerivativeUrl;
 use NeNeRecords\PublicRecord\ChapterNavBuilder;
 use NeNeRecords\PublicRecord\GetPublicRecordViewOutput;
@@ -230,6 +231,8 @@ final readonly class GetPreviewRecordViewUseCase implements GetPreviewRecordView
             chapterNav: $chapterNav,
             breadcrumbs: $hierarchy->breadcrumbs,
             childPages: $hierarchy->childPages,
+            // Preview must scaffold exactly like the public page it previews (#879).
+            layout: PublicLayouts::resolve($entity->layout, $entityType->defaultLayout),
         );
     }
 

--- a/src/PublicRecord/GetPublicRecordViewOutput.php
+++ b/src/PublicRecord/GetPublicRecordViewOutput.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NeNeRecords\PublicRecord;
 
+use NeNeRecords\Layout\PublicLayouts;
+
 final readonly class GetPublicRecordViewOutput
 {
     /**
@@ -28,6 +30,12 @@ final readonly class GetPublicRecordViewOutput
         public ?PublicRecordChapterNav $chapterNav = null,
         public array $breadcrumbs = [],
         public array $childPages = [],
+        /**
+         * Effective page layout (`PublicLayouts::resolve`: entity override → type
+         * default → `standard`). The SSR must honour it or it renders chrome the SPA
+         * then removes — visible as a flash, and permanent for crawlers (#879).
+         */
+        public string $layout = PublicLayouts::DEFAULT,
     ) {
     }
 }

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -19,6 +19,7 @@ use NeNeRecords\FieldDef\FieldDef;
 use NeNeRecords\FieldDef\FieldDefRepositoryInterface;
 use NeNeRecords\IntField\IntField;
 use NeNeRecords\IntField\IntFieldRepositoryInterface;
+use NeNeRecords\Layout\PublicLayouts;
 use NeNeRecords\Media\MediaDerivativeUrl;
 use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
 use NeNeRecords\Setting\SettingEntry;
@@ -223,6 +224,9 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             chapterNav: $chapterNav,
             breadcrumbs: $hierarchy->breadcrumbs,
             childPages: $hierarchy->childPages,
+            // Resolve here so the SSR renders the same scaffold the SPA will (#879):
+            // the resolver already existed but nothing on the render path called it.
+            layout: PublicLayouts::resolve($entity->layout, $entityType->defaultLayout),
         );
     }
 

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -208,6 +208,10 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
             'chapterNav' => $output->chapterNav,
             // The front page is a site root, not a node in the path hierarchy: drop the
             // breadcrumb trail + its BreadcrumbList JSON-LD (the template hides both when empty).
+            // `bare` ships a fully custom page (its own chrome, its own CSS) and
+            // `custom` hosts a bundle: neither wants the article scaffold the SPA
+            // also omits. Passing the resolved layout lets the template match (#879).
+            'layout' => $output->layout,
             'breadcrumbs' => $asFrontPage ? [] : $output->breadcrumbs,
             'childPages' => $output->childPages,
             // og:type is `website` for the home page, `article` for a normal record.

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -120,8 +120,22 @@ if ($ogImageUrl !== null) {
     <!-- SSR content lives inside #root: crawlers / no-JS read it; the SPA
          (createRoot().render) replaces it with the interactive app on mount. -->
     <div id="root">
+    <?php
+      /*
+       * Layout scaffold (#879). `bare` = "no header/footer, no theme — fully custom
+       * page" and `custom` = a bundle host: the SPA renders neither the article chrome
+       * (backlink / title) nor per-field labels for them, so the SSR must not either.
+       * Emitting them anyway made every navigation flash the standard layout and — far
+       * worse — left it as the *only* thing crawlers ever saw.
+       */
+      $bareLayout = $layout === 'bare';
+      $customLayout = $layout === 'custom';
+      $showArticleChrome = !$bareLayout && !$customLayout;
+      /* `bare` owns the whole page: even the path chrome is the author's job. */
+      $showPathChrome = !$bareLayout;
+    ?>
     <?php /* Permalink-path breadcrumb (#651 PR2): populated only on custom-permalink pages. */ ?>
-    <?php if ($breadcrumbs !== []): ?>
+    <?php if ($showPathChrome && $breadcrumbs !== []): ?>
       <nav class="breadcrumb" aria-label="Breadcrumb">
         <ol>
           <li><a href="<?= $e($basePath) ?>/"><?= $e($siteName) ?></a></li>
@@ -137,10 +151,12 @@ if ($ogImageUrl !== null) {
         </ol>
       </nav>
     <?php endif; ?>
+    <?php if ($showArticleChrome): ?>
     <header>
       <p><a href="<?= $e($basePath) ?>/view/<?= $e($entityTypeSlug) ?>">← <?= $e($entityTypeName) ?></a></p>
       <h1><?= $e($pageTitle) ?></h1>
     </header>
+    <?php endif; ?>
     <article>
       <?php foreach ($displayFields as $field): ?>
         <?php if ($field->dataType === 'relation'): ?>
@@ -158,12 +174,15 @@ if ($ogImageUrl !== null) {
           </section>
         <?php elseif ($field->dataType === 'html'): ?>
           <section>
-            <h2><?= $e($field->fieldKey) ?></h2>
+            <?php /* The SPA renders body prose with no field-key label (it reads as an
+                     article, not a labelled definition row). Match that where the SPA
+                     drops the article chrome, so the SSR and the mounted DOM agree (#879). */ ?>
+            <?php if ($showArticleChrome): ?><h2><?= $e($field->fieldKey) ?></h2><?php endif; ?>
             <div class="markdown-body"><?= $renderHtml($field->displayValue) ?></div>
           </section>
         <?php elseif ($field->fieldKey === 'body'): ?>
           <section>
-            <h2><?= $e($field->fieldKey) ?></h2>
+            <?php if ($showArticleChrome): ?><h2><?= $e($field->fieldKey) ?></h2><?php endif; ?>
             <div class="markdown-body"><?= $renderMarkdown($field->displayValue) ?></div>
           </section>
         <?php elseif ($field->dataType === 'bundle'): ?>
@@ -179,7 +198,7 @@ if ($ogImageUrl !== null) {
       <?php endforeach; ?>
     </article>
     <?php /* Section child pages (#651 PR2): a section parent lists its direct children. */ ?>
-    <?php if ($childPages !== []): ?>
+    <?php if ($showPathChrome && $childPages !== []): ?>
       <nav class="child-pages" aria-label="In this section">
         <h2>In this section</h2>
         <ul>
@@ -190,7 +209,7 @@ if ($ogImageUrl !== null) {
       </nav>
     <?php endif; ?>
     <?php /* Derived chapter navigation (#novel): only on a chapter of a multi-chapter work. */ ?>
-    <?php if ($chapterNav !== null): ?>
+    <?php if ($showPathChrome && $chapterNav !== null): ?>
       <nav class="chapter-nav" aria-label="章ナビゲーション">
         <?php if ($chapterNav->prevUrl !== null): ?>
           <a rel="prev" href="<?= $e($basePath . $chapterNav->prevUrl) ?>">← 前の章</a>

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -79,9 +79,11 @@ final class PublicRecordHttpTest extends TestCase
         ?string $entity10Permalink = null,
         bool $withCollision = false,
         ?int $frontPageId = null,
+        ?string $entity10Layout = null,
+        string $typeDefaultLayout = 'standard',
     ): RequestHandlerInterface {
         $entityTypes = new InMemoryEntityTypeRepository([
-            new EntityType(name: 'Article', slug: 'article', id: 1),
+            new EntityType(name: 'Article', slug: 'article', id: 1, defaultLayout: $typeDefaultLayout),
         ]);
         $entityRecords = [
             new Entity(
@@ -93,6 +95,7 @@ final class PublicRecordHttpTest extends TestCase
                 publishedAt: new DateTimeImmutable('2026-01-15T00:00:00+00:00'),
                 updatedAt: new DateTimeImmutable('2026-02-20T00:00:00+00:00'),
                 metaDescription: 'A short summary.',
+                layout: $entity10Layout,
             ),
         ];
         $textFieldRecords = [
@@ -696,5 +699,76 @@ final class PublicRecordHttpTest extends TestCase
         }
 
         return $payload;
+    }
+
+    /**
+     * #879: `bare` means "no header/footer, no theme — fully custom page". The SSR used
+     * to ignore `layout` entirely and always emit the standard article scaffold, which
+     * flashed on every navigation and — because crawlers never run the SPA — was the
+     * only version they ever indexed ("← Article", a duplicate <h1>, `<h2>richbody</h2>`).
+     */
+    public function testBareLayoutOmitsArticleChromeFromTheCrawlableSsr(): void
+    {
+        $app = $this->buildApplication(true, $this->projectRoot, entity10Layout: 'bare');
+
+        $html = (string) $app->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        )->getBody();
+
+        self::assertStringNotContainsString('← Article', $html, 'backlink is article chrome');
+        self::assertStringNotContainsString('<h1>Hello world</h1>', $html, 'the page owns its own heading');
+        self::assertStringNotContainsString('<h2>richbody</h2>', $html, 'field-key labels are article chrome');
+        self::assertStringNotContainsString('<h2>body</h2>', $html);
+
+        // The content itself must still be server-rendered — that is the whole point.
+        self::assertStringContainsString('imported <strong>kept</strong>', $html);
+        self::assertStringContainsString('id="nene-records-public-record-bootstrap"', $html);
+    }
+
+    /** #879: the type default applies when the record itself does not override it. */
+    public function testBareTypeDefaultAlsoOmitsArticleChrome(): void
+    {
+        $app = $this->buildApplication(true, $this->projectRoot, typeDefaultLayout: 'bare');
+
+        $html = (string) $app->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        )->getBody();
+
+        self::assertStringNotContainsString('← Article', $html);
+        self::assertStringNotContainsString('<h1>Hello world</h1>', $html);
+    }
+
+    /** #879: a per-record layout beats the type default (PublicLayouts::resolve order). */
+    public function testRecordLayoutBeatsBareTypeDefault(): void
+    {
+        $app = $this->buildApplication(
+            true,
+            $this->projectRoot,
+            entity10Layout: 'standard',
+            typeDefaultLayout: 'bare',
+        );
+
+        $html = (string) $app->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        )->getBody();
+
+        self::assertStringContainsString('← Article', $html);
+        self::assertStringContainsString('<h1>Hello world</h1>', $html);
+    }
+
+    /**
+     * #879 regression pin: the default layout must keep emitting exactly what it did
+     * before, so fixing `bare` cannot quietly restyle every existing site.
+     */
+    public function testStandardLayoutKeepsArticleChromeUnchanged(): void
+    {
+        $html = (string) $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        )->getBody();
+
+        self::assertStringContainsString('← Article', $html);
+        self::assertStringContainsString('<h1>Hello world</h1>', $html);
+        self::assertStringContainsString('<h2>richbody</h2>', $html);
+        self::assertStringContainsString('<h2>body</h2>', $html);
     }
 }


### PR DESCRIPTION
## 目的

**`layout` が SSR に一切届いていなかった。** `bare`（no header/footer, no theme）を指定した
ページでも、SSR は常に `standard` 相当の汎用 chrome を本文の周りに描いていた。

`ayane.nene-records.com/privacy`（`layout=bare`）の実測:

```html
<nav class="breadcrumb">…</nav>
<header>
  <p><a href="/view/pages">← ページ</a></p>   <!-- 404 リンク -->
  <h1>プライバシーポリシー｜彩音インターナショナル株式会社</h1>  <!-- 本文 h1 と重複 -->
</header>
<article><section>
  <h2>content</h2>                            <!-- フィールド名が見出しに -->
  <div class="markdown-body"> …ここでようやく bespoke 本文…
```

### 影響は2つ。SEO の方が重い

1. **ちらつき**: ページ遷移のたびに汎用レイアウトが一瞬見え、SPA マウントで消える。
2. **🔴 クロール結果の恒久的な汚染**: **クローラは SPA を実行しない**ので、Google が見る
   `/privacy` は上記の汚染版が**すべて**。**#536 の crawlable SSR（#544/#549/#553）が
   bespoke ページ全部にゴミを出し続けていた。** 人間に見えるちらつきは一瞬だが、こちらは不可視で永続。

## 原因は「配線漏れ」でした

**`PublicLayouts::resolve()`（entity → type既定 → standard）は実装もテストも既に存在していた**が、
**呼んでいるのは自身のテストだけ**で、描画経路からは一度も呼ばれていなかった。
`PublicLayouts` は書き込み境界の `isValid` でしか使われていない状態だった。

**仕様書自身が違反を明示**: `PublicLayouts.php` の docblock は
`bare: no header/footer, no theme — fully custom page` と書いている。

## 変更

- `GetPublicRecordViewOutput` に `layout` を追加し、**public / preview 両 UseCase**で
  `PublicLayouts::resolve` を呼ぶ（#875 と同じく**双子に両方**入れる）。
- ハンドラがテンプレへ `layout` を渡す。
- テンプレで出し分け:

| layout | SSR |
|---|---|
| `bare` | **本文のみ**（path chrome も article chrome も無し） |
| `custom` | article chrome だけ落とす（サイト chrome は保つ） |
| `standard` / `full` / `two-col` / `three-col` | **不変** |

- **フィールド見出し（`<h2>{field_key}</h2>`）も article chrome 扱い**。SPA の
  `PublicRecordFieldList` は html/markdown を「no field-key label, so it reads like a magazine
  article rather than a labelled definition row」というコメント付きで**ラベル無し**に描くため、
  SSR も揃えた（parity）。

## 検証

**テストだけでなく、実際にローカルで叩いて目視確認しました。**

- `/privacy` `/company` `/company/ceo` `/services` すべてで、パンくず・`← ページ`・`<h1>`・
  `<h2>content</h2>` が**消滅**し、`#root` 直後から bespoke 本文に入ることを確認。
- **負のコントロール**: テンプレを `main` の版に戻すと **bare のテスト2本が落ちる**ことを実測。
- **standard の回帰 pin** を追加（`← Article` / `<h1>` / `<h2>richbody>` が従来どおり出る）＝
  bare の修正が既存サイトを静かに壊さないことを固定。
- 新規テスト **4本**。**`composer check` 緑（1338 tests / PHPStan L8 / CS / OpenAPI / MCP）**。

## チェックリスト

- [x] Issue 駆動（#879）
- [x] `main` から `fix/879-...` ブランチ
- [x] Conventional Commits（type/scope 英語・本文日本語・`(#879)`）
- [x] シークレット無し

## 関連

- `← ページ`（`/view/{typeSlug}`）が 404 だった件は **#878** で SSR アーカイブを足したので、
  そちらがマージされればリンク先が実在するようになる。
- **ダークモード**: `ThemeSwitch` は `PublicSiteShell` の chrome 内にしか無く `bare` は shell を
  通らないため切替 UI が無いのに、`mode` 既定は `auto`＝OS 追従だった。本 PR で bare が
  テーマを描かなくなるため解消する。テーマ描画ページ向けの「light固定/dark固定」管理設定は
  別レイヤーの改善として #879 に記載（本 PR の範囲外）。
- **chrome の重複**（AYANE が header/footer を12ページに焼き込んでいる）は、本 PR で `custom` が
  SSR でも実用になって初めて「デザインをテーマ化するか」を判断できる → **後続の別 Issue**。

Closes #879