### PR TITLE
fix(public): bootstrap から permalink 解決を seed し遷移中の通常レイアウトを止める（#881）

### DIFF
--- a/frontend/src/shared/lib/public-record-bootstrap.ts
+++ b/frontend/src/shared/lib/public-record-bootstrap.ts
@@ -35,6 +35,8 @@ export interface PublicRecordBootstrapDto {
   relationTextFieldsByEntityTypeId: Record<string, PublicRecordBootstrapFieldListDto>
   publicSettings?: PublicSettingListDto
   hierarchy?: PublicRecordHierarchyDto
+  /** The path the SPA resolves this record by — lets us seed the resolve query (#881). */
+  canonicalPath?: string
 }
 
 export function readPublicRecordBootstrap(): PublicRecordBootstrapDto | null {

--- a/frontend/src/shared/lib/seed-public-record-view-cache.ts
+++ b/frontend/src/shared/lib/seed-public-record-view-cache.ts
@@ -33,6 +33,10 @@ import {
   type PublicRecordBootstrapDto,
 } from '@/shared/lib/public-record-bootstrap'
 import {
+  publicPermalinkResolveKeys,
+  type PublicPermalinkResolutionDto,
+} from '@/shared/lib/public-permalink-resolve'
+import {
   EMPTY_PUBLIC_RECORD_HIERARCHY,
   publicRecordHierarchyKeys,
 } from '@/shared/lib/public-record-hierarchy'
@@ -119,5 +123,18 @@ export function seedPublicRecordViewCache(
       settingKeys.publicList(),
       mapPublicSettingListDtoToModel(bootstrap.publicSettings),
     )
+  }
+
+  // The permalink resolution for the very page we were served. Without it the SPA
+  // asks /public/records/resolve for a record the server already handed it, and
+  // `PublicRecordByPermalink` renders the site shell ("Loading…") while it waits —
+  // flashing the standard layout over a `bare` page for ~400ms (#881). The bootstrap
+  // carries the same answer the endpoint would give.
+  if (bootstrap.canonicalPath !== undefined && bootstrap.canonicalPath !== '') {
+    queryClient.setQueryData(publicPermalinkResolveKeys.byPath(bootstrap.canonicalPath), {
+      found: true,
+      entityId: bootstrap.entityId,
+      entityTypeSlug: bootstrap.entityTypeSlug,
+    } satisfies PublicPermalinkResolutionDto)
   }
 }

--- a/src/PreviewToken/GetPreviewRecordViewUseCase.php
+++ b/src/PreviewToken/GetPreviewRecordViewUseCase.php
@@ -202,6 +202,8 @@ final readonly class GetPreviewRecordViewUseCase implements GetPreviewRecordView
         // breadcrumb + child-list it will have once published (#651 PR2).
         $hierarchy = $this->hierarchyBuilder->build($entity->permalink, $canonicalPath, $pageTitle);
         $bootstrap['hierarchy'] = $hierarchy->toArray();
+        // Same seed the public page ships, so a preview mounts without the shell flash (#881).
+        $bootstrap['canonicalPath'] = $canonicalPath;
 
         $ogImagePath = null;
         foreach ($displayFields as $field) {

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -205,6 +205,11 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
         // ordinary `/{type}/{slug}` records; populated for custom-permalink pages.
         $hierarchy = $this->hierarchyBuilder->build($entity->permalink, $canonicalPath, $pageTitle);
         $bootstrap['hierarchy'] = $hierarchy->toArray();
+        // The path the SPA will look this record up by. Without it the SPA re-asks
+        // /public/records/resolve for a page it was just handed, and renders the site
+        // shell ("Loading…") meanwhile — which flashes the standard layout over a
+        // `bare` page (#881). The server already knows the answer; ship it.
+        $bootstrap['canonicalPath'] = $canonicalPath;
 
         $ogImagePath = $this->resolveOgImagePath($displayFields);
 


### PR DESCRIPTION
## 目的

`layout=bare` の bespoke ページで、**SSR が正しい本文を返しているのに、SPA マウント直後に
サイト chrome（通常レイアウト）＋「Loading…」が一瞬描画される**問題を止める。

施主報告:「これはクリティカルで、これがあるだけで WordPress から乗り換えないっていう人が
かなりの割合で出るレベルの問題」

### 実ブラウザで再現（Playwright・本番・#880 デプロイ後）

```
  ~80ms   chrome=no    "Loading…"=no
  ~400ms  chrome=🔴YES  "Loading…"=🔴YES   ← 通常レイアウトが実際に描かれている
  ~800ms  chrome=no    bespoke=YES        ← ようやく bare
```

## 原因は seed の漏れ

`PublicRecordDetailPage` は `resolution.isLoading` の間 `RecordShellMessage`
（= `PublicSiteShell` = `.nene-public` = **通常レイアウト**）を描く。

一方 `seedPublicRecordViewCache` は entityTypes / entity / hierarchy / 各フィールドを seed
するのに、**`publicPermalinkResolveKeys.byPath` だけ seed していなかった**。

そのため SSR で全データを渡しているのに、SPA は **`/api/v1/public/records/resolve` を必ず
叩き直し**（実測でリクエストを確認）、その往復のあいだ「layout 未確定」の状態で
サイト chrome を描いていた。**bootstrap は resolve の戻り値と同じ情報を既に持っている。**

### #880 との関係

**#880 は SSR 側の同じ症状**を直したもので（実際に SSR からは chrome が消えた）、
**本件は SPA マウント後の別経路**。症状が同じため混同しており、
**#880 デプロイ後も施主の実機で再現して発覚**した。2つの独立したバグだった。

## 変更

- **bootstrap に `canonicalPath` を追加**（public / preview 両 UseCase）。
  SPA が resolve するキーは**トップページだけ `frontPagePath`** になるため、
  `window.location` では足りず**サーバ側の canonical を渡す必要がある**。
- `seedPublicRecordViewCache` が `publicPermalinkResolveKeys.byPath(canonicalPath)` に
  `{found, entityId, entityTypeSlug}` を seed。

## 検証（実ブラウザ・MutationObserver で DOM 出現回数を計測）

| | 修正前 | 修正後 |
|---|---|---|
| 通常レイアウト(`.nene-public`)の出現 | 🔴 出現 | **✅ 0回** |
| 「Loading…」の出現 | 🔴 出現 | **✅ 0回** |
| `resolve` API | 🔴 毎回呼ぶ | **✅ 呼ばれず** |

`/privacy` `/services` の両方で確認。スクリーンショットで正常描画も目視。
`npm run check --prefix frontend` 緑 / `composer check` 緑（1349 tests）。

## ★教訓

**本件は curl で SSR HTML を見るだけでは検出できない。** SPA マウント後の挙動は
**実ブラウザで確認する**こと。#880 で「直った」と誤報告した原因がこれ。

## チェックリスト

- [x] Issue 駆動（#881）
- [x] `main` から `fix/881-...` ブランチ
- [x] Conventional Commits（type/scope 英語・本文日本語・`(#881)`）
- [x] シークレット無し

Closes #881