### PR TITLE
fix(public): 1セグメント URL のちらつきを止める — browse の型一覧 seed 一致 ＋ blocks の条件フェッチ（#883）

### DIFF
--- a/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.ts
+++ b/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.ts
@@ -27,7 +27,14 @@ export interface PublicBrowseType {
 
 export function usePublicBrowseEntityRecordsPage(entityTypeSlug: string, offset: number) {
   const { locale } = useTranslation()
-  const entityTypeQuery = useEntityTypeList()
+  // Must match the key `seedPublicRecordViewCache` primes from the SSR bootstrap
+  // ({limit:100}), or this misses the cache and refetches. That matters here beyond a
+  // wasted request: a single-segment bespoke URL (`/services`) routes to this page
+  // first, and until the type list answers we cannot know the slug is a permalink
+  // rather than a type — so the site chrome renders over a `bare` page and then
+  // disappears (#883). 100 is also what the other public consumers ask for, and it
+  // avoids truncating orgs with more than 20 types.
+  const entityTypeQuery = useEntityTypeList({ limit: 100, offset: 0 })
   const entityType = useMemo(
     () => findEntityTypeBySlug(entityTypeQuery.data?.items ?? [], entityTypeSlug),
     [entityTypeQuery.data?.items, entityTypeSlug],

--- a/frontend/src/features/public-view-entity-record/hooks/use-public-view-entity-record-page.ts
+++ b/frontend/src/features/public-view-entity-record/hooks/use-public-view-entity-record-page.ts
@@ -44,7 +44,16 @@ export function usePublicViewEntityRecordPage(entityTypeId: number, entityId: nu
   const enumFieldQuery = useEnumFieldList(listParams)
   const boolFieldQuery = useBoolFieldList(listParams)
   const dateTimeFieldQuery = useDateTimeFieldList(listParams)
-  const blocksFieldQuery = useBlocksFieldList(listParams)
+  // Every other field list is primed from the SSR bootstrap, but `blocks` is not in
+  // it, so an unconditional fetch here is the one request that still gates
+  // `isLoading` — replacing the server-rendered page with "Loading…" on every visit
+  // (#883). The server itself only reads a field table when the type declares that
+  // data type; mirror that, so a type without a `blocks` field asks for nothing.
+  const hasBlocksField = useMemo(
+    () => (fieldDefQuery.data?.items ?? []).some((def) => def.dataType === 'blocks'),
+    [fieldDefQuery.data?.items],
+  )
+  const blocksFieldQuery = useBlocksFieldList(listParams, { enabled: hasBlocksField })
 
   const fieldRows = useMemo((): PublicFieldRow[] => {
     const fieldDefs = fieldDefQuery.data?.items ?? []


### PR DESCRIPTION
## 目的

`layout=bare` の bespoke ページ（`/services` 等の**1セグメント カスタム permalink**）で、
**サイト chrome（デフォルトレイアウト）＋「Loading…」が一瞬描画される**のを止める。

**#879（SSR）・#881（resolve の seed）を直してもなお残っていた。**
施主が実機（Firefox・キャッシュなし）で再現し発覚。

### 実ブラウザの録画をフレーム分解して確定

| 時刻 | 画面 |
|---|---|
| ~0.5s | SSR の bespoke 本文（正しい） |
| ~1.0s | **真っ白** |
| ~1.2s | **「Loading…」** |
| その後 | bespoke 本文 |

「Loading…」の DOM チェーン: `p.searchhint < div.pagehead < div.layout__main` ＝ `PublicSiteShell` 内。

## 原因は2つ。どちらも「seed 漏れ → フェッチ待ち → 未確定のまま chrome を描く」

### ① browse の型一覧クエリが seed のキーと不一致

SPA ルータは**1セグメント URL をタイプ一覧と解釈**して `PublicBrowsePage` に入る。同ページは
`isUnknownType`（`= !entityTypeQuery.isLoading && entityType === undefined`）が確定するまで
`PublicSiteShell` ＋ Loading を描き、確定して初めて `PublicRecordByPermalink` に切り替わる。

| | queryKey |
|---|---|
| seed が載せる | `{limit: 100, offset: 0}` |
| browse hook（`useEntityTypeList()` 素呼び） | **`{limit: 20, offset: 0}`** |

キー不一致 → キャッシュミス → `/api/v1/entity-types?limit=20&offset=0` を取得（実測）。
**公開側の他コンシューマは `{limit:100}` を使っており、browse だけが素呼び**だった。

→ `{limit:100}` に統一。**型が20を超える org で `findEntityTypeBySlug` が取りこぼす潜在バグ**も消える。

### ② blocks だけ seed 不能で毎回フェッチ

bootstrap に `blocksFields` が無い（**SSR は blocks を扱っていない**）ため、blocks だけは
seed できず毎回 `/api/v1/blocks-fields` を取得し、**それが `isLoading` を握って**「Loading…」を出していた。

サーバは**型が宣言するデータ型のフィールド表しか読まない**設計（`in_array('int', $dataTypes)` 等）なので、
SPA も同じ規律に揃え、blocks フィールドを持たない型では取りに行かないようにした（`enabled`）。
**ayane の `pages` 型は `content`(html) のみ＝blocks は存在しないのに毎回叩いていた。**

## 検証（実ブラウザ・Firefox）

| | 修正前 | 修正後 |
|---|---|---|
| デフォルトレイアウト(`.nene-public`) | 🔴 出現 | **✅ 0回** |
| 「Loading…」 | 🔴 出現 | **✅ 0回** |
| `entity-types` / `resolve` / `blocks-fields` | 🔴 毎回 | **✅ 0回** |

- 15ms 間隔で ~1.4s ポーリング（`/services` `/privacy`）
- **動画を撮って全12フレームの支配色を機械走査 → 異物フレーム 0**（白→生成色のみ）
- `npm run check --prefix frontend` 緑

## ★教訓（3度目）

**同じ症状に独立した原因が3つあった**: #879（SSR が layout 無視）/ #881（resolve 未 seed）/ 本件。

- **curl や DOM の一点観測では足りない。** 実ブラウザで**録画してフレームを見る**のが確実だった。
- `addInitScript` 内の `MutationObserver` は `document.documentElement` 未生成で登録に失敗し
  **「0回」と誤検出する**（#881 をこれで検証し「直った」と誤報告した原因）。

## チェックリスト

- [x] Issue 駆動（#883）
- [x] `main` から `fix/883-...` ブランチ
- [x] Conventional Commits（type/scope 英語・本文日本語・`(#883)`）
- [x] シークレット無し

## 残（別 Issue 候補）

- **bootstrap に blocksFields を載せる**（SSR が blocks を扱う）。本 PR は「無い型では叩かない」で
  症状を消すが、**blocks フィールドを持つ型では依然フェッチが走る**。構造的には他フィールドと同様に
  bootstrap へ載せるのが筋。
- **layout 未確定の間は chrome を描かない**。今回は seed で「分からない時間」を 0 にして回避したが、
  推測で chrome を描く構造そのものが根本原因。

Closes #883