### PR TITLE
feat(public): bespoke ページの生 <a> を SPA ルーティングへ横取りする（#885・案A）

### DIFF
--- a/frontend/src/pages/consumer/PublicShell.tsx
+++ b/frontend/src/pages/consumer/PublicShell.tsx
@@ -12,6 +12,7 @@ import { useAnalyticsPageView } from '@/shared/lib/use-analytics-page-view'
 import { resolveWebAnalytics } from '@/shared/lib/web-analytics'
 import { parseLayoutConfig } from '@/shared/lib/layout-config'
 import { parseRecordPageConfig } from '@/shared/lib/record-page-config'
+import { useSpaLinkInterception } from './use-spa-link-interception'
 import {
   buildThemeStylesheet,
   readStoredRuntimeTheme,
@@ -70,6 +71,8 @@ export function PublicShell() {
   // SPA reports client-side navigations and offers the consent prompt.
   const analytics = useMemo(() => resolveWebAnalytics(settings), [settings])
   useAnalyticsPageView(analytics)
+  // Plain `<a href>` inside a bespoke page's own chrome would otherwise full-load (#885).
+  useSpaLinkInterception()
 
   // Apply the last-known theme synchronously on first paint, then reconcile with
   // the fetched setting — avoids a default→saved theme flash (FOUC) while the

--- a/frontend/src/pages/consumer/resolve-spa-link.test.ts
+++ b/frontend/src/pages/consumer/resolve-spa-link.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import { resolveSpaLink, type SpaLinkContext } from './resolve-spa-link'
+
+const CTX: SpaLinkContext = {
+  basePath: '',
+  origin: 'https://ayane.example',
+  currentPath: '/privacy',
+}
+
+const PLAIN_CLICK = {
+  button: 0,
+  metaKey: false,
+  ctrlKey: false,
+  shiftKey: false,
+  altKey: false,
+  defaultPrevented: false,
+}
+
+function anchor(html: string): HTMLAnchorElement {
+  const el = document.createElement('div')
+  el.innerHTML = html
+  const a = el.querySelector('a')
+  if (a === null) {
+    throw new Error('fixture must contain an anchor')
+  }
+  return a
+}
+
+describe('resolveSpaLink', () => {
+  // The 239 internal links baked into AYANE's bespoke chrome are the whole point:
+  // these must stop doing a full document load (#885).
+  it.each([
+    ['/services', '/services'],
+    ['/company/ceo', '/company/ceo'],
+    ['/', '/'],
+    ['/services?offset=20', '/services?offset=20'],
+  ])('routes the internal link %s', (href, expected) => {
+    expect(resolveSpaLink(anchor(`<a href="${href}">x</a>`), PLAIN_CLICK, CTX)).toBe(expected)
+  })
+
+  // Everything below must stay with the browser. Getting any of these wrong breaks a
+  // link that works today, which is worse than the flash we are fixing.
+  it('leaves another origin alone', () => {
+    expect(
+      resolveSpaLink(anchor('<a href="https://github.com/x">x</a>'), PLAIN_CLICK, CTX),
+    ).toBeNull()
+  })
+
+  it('leaves mailto: and tel: alone', () => {
+    expect(resolveSpaLink(anchor('<a href="mailto:a@b.c">x</a>'), PLAIN_CLICK, CTX)).toBeNull()
+    expect(resolveSpaLink(anchor('<a href="tel:0474043740">x</a>'), PLAIN_CLICK, CTX)).toBeNull()
+  })
+
+  it('leaves uploaded media alone (a real file the server serves)', () => {
+    expect(
+      resolveSpaLink(anchor('<a href="/media/2026/07/terms.pdf">x</a>'), PLAIN_CLICK, CTX),
+    ).toBeNull()
+  })
+
+  it.each(['/api/v1/public/records/resolve', '/assets/index.css', '/downloads/x.pdf'])(
+    'leaves the server-owned path %s alone',
+    (href) => {
+      expect(resolveSpaLink(anchor(`<a href="${href}">x</a>`), PLAIN_CLICK, CTX)).toBeNull()
+    },
+  )
+
+  it('leaves target/_blank and download alone', () => {
+    expect(
+      resolveSpaLink(anchor('<a href="/services" target="_blank">x</a>'), PLAIN_CLICK, CTX),
+    ).toBeNull()
+    expect(
+      resolveSpaLink(anchor('<a href="/services" download>x</a>'), PLAIN_CLICK, CTX),
+    ).toBeNull()
+    expect(
+      resolveSpaLink(anchor('<a href="/services" rel="external">x</a>'), PLAIN_CLICK, CTX),
+    ).toBeNull()
+  })
+
+  it('honours target="_self" as a normal in-app link', () => {
+    expect(
+      resolveSpaLink(anchor('<a href="/services" target="_self">x</a>'), PLAIN_CLICK, CTX),
+    ).toBe('/services')
+  })
+
+  it.each(['metaKey', 'ctrlKey', 'shiftKey', 'altKey'] as const)(
+    'leaves %s clicks to the browser (open in new tab / window)',
+    (key) => {
+      expect(
+        resolveSpaLink(anchor('<a href="/services">x</a>'), { ...PLAIN_CLICK, [key]: true }, CTX),
+      ).toBeNull()
+    },
+  )
+
+  it('leaves middle-click and already-handled clicks alone', () => {
+    expect(
+      resolveSpaLink(anchor('<a href="/services">x</a>'), { ...PLAIN_CLICK, button: 1 }, CTX),
+    ).toBeNull()
+    expect(
+      resolveSpaLink(
+        anchor('<a href="/services">x</a>'),
+        { ...PLAIN_CLICK, defaultPrevented: true },
+        CTX,
+      ),
+    ).toBeNull()
+  })
+
+  it('lets the browser scroll a same-page hash', () => {
+    expect(resolveSpaLink(anchor('<a href="#pricing">x</a>'), PLAIN_CLICK, CTX)).toBeNull()
+  })
+
+  it('routes a hash that points at another page', () => {
+    expect(resolveSpaLink(anchor('<a href="/services#pricing">x</a>'), PLAIN_CLICK, CTX)).toBe(
+      '/services#pricing',
+    )
+  })
+
+  it('strips the base path so the result is router-relative (#zip-install S2)', () => {
+    const sub: SpaLinkContext = { ...CTX, basePath: '/blog', currentPath: '/blog/privacy' }
+    expect(resolveSpaLink(anchor('<a href="/blog/services">x</a>'), PLAIN_CLICK, sub)).toBe(
+      '/services',
+    )
+    expect(resolveSpaLink(anchor('<a href="/blog">x</a>'), PLAIN_CLICK, sub)).toBe('/')
+    // Outside our install → someone else's app.
+    expect(resolveSpaLink(anchor('<a href="/other/page">x</a>'), PLAIN_CLICK, sub)).toBeNull()
+  })
+
+  it('ignores an anchor with no href', () => {
+    expect(resolveSpaLink(anchor('<a>x</a>'), PLAIN_CLICK, CTX)).toBeNull()
+  })
+})

--- a/frontend/src/pages/consumer/resolve-spa-link.ts
+++ b/frontend/src/pages/consumer/resolve-spa-link.ts
@@ -1,0 +1,122 @@
+import { normalizeBasePath } from '@/shared/lib/base-path'
+
+/**
+ * Paths the SPA router does not own — the server serves them as real responses
+ * (JSON, uploaded media, built assets). Mirrors the server's edge-layer passthrough
+ * in `CustomPermalinkResolver::PASSTHROUGH`.
+ */
+const SERVER_OWNED = /^\/(api|media|assets|theme-thumbnails)(\/|$)/
+
+/** A path segment that looks like a file (`report.pdf`) is served, not routed. */
+const LOOKS_LIKE_FILE = /\.[a-z0-9]{2,5}$/i
+
+export interface SpaLinkContext {
+  /** `document.baseURI`-derived base (`''` or `/segment`). */
+  basePath: string
+  /** The page's own origin. */
+  origin: string
+  /** Current path *including* the base, i.e. `window.location.pathname`. */
+  currentPath: string
+}
+
+/**
+ * Decide whether a click on an anchor should become a client-side navigation, and
+ * to which router path.
+ *
+ * Why this exists: a `bare`/bespoke page's chrome lives inside the sanitized `html`
+ * field, so its links are plain `<a href>` — a React `<Link>` cannot survive there.
+ * The browser therefore does a full document load on every navigation, which remounts
+ * the whole SPA each time (#885). Intercepting the click restores SPA routing for
+ * content the SPA cannot author.
+ *
+ * Returns the router-relative path (basename stripped, so it can go straight to
+ * `navigate()`), or `null` when the browser must keep the click: anything not a
+ * plain left-click, another origin, a download, a real file, an `/api|/media` path,
+ * or a same-page hash (which the browser scrolls natively).
+ */
+export function resolveSpaLink(
+  anchor: HTMLAnchorElement,
+  event: Pick<
+    MouseEvent,
+    'button' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey' | 'defaultPrevented'
+  >,
+  ctx: SpaLinkContext,
+): string | null {
+  // Anything but a plain primary click is the user asking the browser for something
+  // else: a new tab, a download, a context menu.
+  if (event.defaultPrevented || event.button !== 0) {
+    return null
+  }
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+    return null
+  }
+
+  if (anchor.hasAttribute('download')) {
+    return null
+  }
+
+  const target = anchor.getAttribute('target')
+  if (target !== null && target !== '' && target !== '_self') {
+    return null
+  }
+
+  const rel = anchor.getAttribute('rel') ?? ''
+  if (rel.split(/\s+/).includes('external')) {
+    return null
+  }
+
+  const href = anchor.getAttribute('href')
+  if (href === null || href === '') {
+    return null
+  }
+  // `mailto:`/`tel:`/`javascript:` never reach the router.
+  if (/^[a-z][a-z0-9+.-]*:/i.test(href) && !/^https?:/i.test(href)) {
+    return null
+  }
+
+  let url: URL
+  try {
+    url = new URL(href, ctx.origin + ctx.currentPath)
+  } catch {
+    return null
+  }
+
+  if (url.origin !== ctx.origin) {
+    return null
+  }
+
+  const withinBase = stripBasePath(url.pathname, normalizeBasePath(ctx.basePath))
+
+  // A same-origin link outside our base path belongs to whatever else is installed there.
+  if (withinBase === null) {
+    return null
+  }
+
+  if (SERVER_OWNED.test(withinBase) || LOOKS_LIKE_FILE.test(withinBase)) {
+    return null
+  }
+
+  // A hash pointing at the current page: let the browser scroll to the anchor.
+  if (url.hash !== '' && url.pathname === ctx.currentPath) {
+    return null
+  }
+
+  return withinBase + url.search + url.hash
+}
+
+/** Router-relative path, or null when the URL sits outside the install's base path. */
+function stripBasePath(pathname: string, base: string): string | null {
+  if (base === '') {
+    return pathname
+  }
+
+  if (pathname === base) {
+    return '/'
+  }
+
+  if (pathname.startsWith(base + '/')) {
+    return pathname.slice(base.length)
+  }
+
+  return null
+}

--- a/frontend/src/pages/consumer/use-spa-link-interception.ts
+++ b/frontend/src/pages/consumer/use-spa-link-interception.ts
@@ -1,0 +1,55 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { getBasePath } from '@/shared/lib/base-path'
+import { resolveSpaLink } from './resolve-spa-link'
+
+/**
+ * Route plain `<a href>` clicks through the SPA router (#885).
+ *
+ * A `bare`/bespoke page authors its own header and footer inside the sanitized
+ * `html` field, where a React `<Link>` cannot exist — so every link is a plain
+ * anchor and the browser does a full document load, remounting the whole SPA on
+ * each navigation. This delegated listener gives that content the client-side
+ * routing it cannot ask for itself, while {@see resolveSpaLink} keeps the browser
+ * in charge of anything that is not an in-app navigation (other origins, media,
+ * downloads, modified clicks).
+ *
+ * Attached at the public shell so it covers every public route, including `bare`
+ * pages that never render the themed chrome.
+ */
+export function useSpaLinkInterception(): void {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const onClick = (event: MouseEvent) => {
+      const target = event.target
+      if (!(target instanceof Element)) {
+        return
+      }
+
+      const anchor = target.closest('a')
+      if (anchor === null) {
+        return
+      }
+
+      const to = resolveSpaLink(anchor, event, {
+        basePath: getBasePath(),
+        origin: window.location.origin,
+        currentPath: window.location.pathname,
+      })
+
+      if (to === null) {
+        return
+      }
+
+      event.preventDefault()
+      void navigate(to)
+    }
+
+    document.addEventListener('click', onClick)
+
+    return () => {
+      document.removeEventListener('click', onClick)
+    }
+  }, [navigate])
+}


### PR DESCRIPTION
## 目的

**bespoke（`layout=bare`）サイトはナビゲーションのたびにブラウザがフルリロードしており、
テーマ利用サイトだけがクライアント遷移していた。** 同じ製品で挙動が割れていた。

施主の指摘:「組み始めた時、SPA でページ遷移した時ブラウザがリロードする作りじゃなかった気がする」
→ **記憶は正確。** bespoke 化した時点で SPA 遷移を失っていた。

### 実測（Playwright・本番）

`window.__mark` を仕込んでクリックし、印の生存と document リクエストを計測:

| サイト | window の印 | document リクエスト | 判定 |
|---|---|---|---|
| aozora（テーマ） | ✅ 残る | 0件 | クライアント遷移 |
| **ayane（bespoke）** | 🔴 消える | **1件** | **フルリロード** |

## 原因は bespoke 機構そのものの帰結

**`content` フィールドには React の `<Link>` を書けない。** ClaudeDesign の chrome は
**生の `<a href>`** として焼き込まれる。これはサニタイザを通る安全な HTML であって React
コンポーネントではないので、ブラウザが素直に HTML を取りに行く。AYANE 固有の設定ミスではない。

**これが #879 / #881 / #883 のちらつきを毎回引き起こす土台でもあった**（フルリロード＝毎回 SPA を
再マウント）。テーマ chrome なら SPA は1回しかマウントしないので、あれは初回だけの問題だった。

## 変更

- **`resolve-spa-link.ts`** — 横取り可否の判断を**純関数に切り出し**。
  誤ると**今動くリンクが壊れる**ので、ここをテストで固定する。
- **`use-spa-link-interception.ts`** — `PublicShell` に委譲クリックリスナ。
  **bare も `PublicShell` は通る**ので、ここに置けば全公開ルートを覆う。

**ブラウザに任せる（横取りしない）もの**: 別オリジン / `mailto:`・`tel:` /
`/api`・`/media`・`/assets` 等サーバ所有 / 拡張子つき実ファイル / `target` 指定 / `download` /
`rel=external` / 修飾キー・中クリック / 同一ページの `#` アンカー / base path 外。

**AYANE 全12ページの実リンクを数えて除外条件を設計**（内部 **239** / 外部 78 / PDF 1 / mailto 1）。

## 検証

**実ブラウザ:**

| | 結果 |
|---|---|
| 内部リンクのクリック | **window の印が残り document リクエスト 0件**＝クライアント遷移 |
| 外部リンク | href が保たれる |
| Ctrl+クリック | **新規タブが開き、現ページは遷移しない** |

**単体テスト 21本**（上記の除外条件を実データ由来のケースで固定）。
`npm run check` 緑（104 files / 580 tests）。

## チェックリスト

- [x] Issue 駆動（#885）
- [x] `main` から `fix/885-...` ブランチ
- [x] Conventional Commits（type/scope 英語・本文日本語・`(#885)`）
- [x] シークレット無し

## 位置づけ（#885 の案A）

本 PR は **案A（リンク横取り）**。**案B（`custom` レイアウト ＋ デザインのテーマ化）** は
chrome の複製（ナビ1項目の変更＝12ページ再生成）も同時に解決する本質的な答えだが、
デザインのテーマ化が前提で launch（2026-07-25）には間に合わない。

**案Aは案Bを妨げない**（テーマ化しても横取りは無害）。#885 は案B のために open のままにする。

Closes #885