### PR TITLE
fix(public): bootstrap の entityTypes を API と同形にする ＋ layout 未確定時の推測描画をやめる（#887）

### DIFF
--- a/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
@@ -526,14 +526,10 @@ function PublicRecordDetailBySlug({
   )
 
   if (isLoading) {
-    return (
-      <RecordShellMessage
-        site={site}
-        entityTypeSlug={entityTypeSlug}
-        title="Loading…"
-        description="Fetching this record."
-      />
-    )
+    // Same reason as the permalink resolver above (#885): the record's layout is not
+    // known yet, so painting the themed shell here would flash chrome over a `bare`
+    // page. Render nothing until we know what this page is.
+    return null
   }
   if (isError || entityId === null) {
     return (
@@ -636,14 +632,13 @@ export function PublicRecordByPermalink({
   )
 
   if (resolution.isLoading || entityTypeQuery.isLoading) {
-    return (
-      <RecordShellMessage
-        site={site}
-        entityTypeSlug={null}
-        title="Loading…"
-        description="Fetching this record."
-      />
-    )
+    // Render nothing rather than the themed shell: until this resolves we do not know
+    // the record's layout, and guessing "standard" paints a header/footer/theme over
+    // what may be a `bare` page — then rips it away (#885). On a full load the SSR
+    // markup is already on screen and React keeps it until the first commit; on a
+    // client-side navigation this is a brief blank instead of a wrong layout. A wrong
+    // layout reads as a broken site; a blank reads as loading.
+    return null
   }
 
   const data = resolution.data

--- a/src/PublicRecord/PublicRecordViewHttpMapper.php
+++ b/src/PublicRecord/PublicRecordViewHttpMapper.php
@@ -48,12 +48,26 @@ final readonly class PublicRecordViewHttpMapper
         array $relationQueries,
         array $relationTextFieldRowsByEntityTypeId,
     ): array {
+        // The SPA hydrates useEntityTypeList from this payload and never refetches, so
+        // every field it reads must ride along — the same rule the entity payload below
+        // learned twice (#778 visibility flags, #816 canonical identity). Shipping only
+        // id/name/slug left `permalinkPattern` and `defaultLayout` undefined forever:
+        // record URLs fell back to the default pattern, and `resolveLayout` fell back to
+        // `standard`, painting the themed chrome over a `bare` page until the record
+        // itself arrived (#887). Keep this in step with ListEntityTypesHandler, which is
+        // what the SPA would have fetched.
         $entityTypesPayload = [
             'items' => array_map(
                 static fn (EntityType $item) => [
                     'id' => $item->id,
                     'name' => $item->name,
                     'slug' => $item->slug,
+                    'is_pinned' => $item->isPinned,
+                    'labels' => $item->labels ?? new \stdClass(),
+                    'permalink_pattern' => $item->permalinkPattern,
+                    'previous_permalink_pattern' => $item->previousPermalinkPattern,
+                    'display_order' => $item->displayOrder,
+                    'default_layout' => $item->defaultLayout,
                 ],
                 $allEntityTypes,
             ),

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -771,4 +771,69 @@ final class PublicRecordHttpTest extends TestCase
         self::assertStringContainsString('<h2>richbody</h2>', $html);
         self::assertStringContainsString('<h2>body</h2>', $html);
     }
+
+    /**
+     * #887: the SPA hydrates `useEntityTypeList` from this payload and never refetches,
+     * so a field missing here is missing forever. Shipping only id/name/slug left
+     * `defaultLayout` undefined, so `resolveLayout` fell back to `standard` and painted
+     * the themed chrome over a `bare` page until the record itself arrived.
+     *
+     * The same class of bug already cost #778 (visibility flags) and #816 (canonical
+     * identity) on the entity payload — pin the type payload so it is not a third.
+     */
+    public function testBootstrapEntityTypesCarryEveryFieldTheSpaReadsBack(): void
+    {
+        $html = (string) $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        )->getBody();
+
+        $item = $this->bootstrapOf($html)['entityTypes']['items'][0];
+
+        // Exactly the keys ListEntityTypesHandler emits — i.e. what the SPA would have
+        // fetched had it not been handed this payload instead.
+        self::assertSame(
+            [
+                'id',
+                'name',
+                'slug',
+                'is_pinned',
+                'labels',
+                'permalink_pattern',
+                'previous_permalink_pattern',
+                'display_order',
+                'default_layout',
+            ],
+            array_keys($item),
+        );
+    }
+
+    /** #887: a `bare` type default must survive into the bootstrap, not just the SSR. */
+    public function testBootstrapCarriesTheBareTypeDefaultSoTheSpaDoesNotGuessStandard(): void
+    {
+        $app = $this->buildApplication(true, $this->projectRoot, typeDefaultLayout: 'bare');
+
+        $html = (string) $app->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        )->getBody();
+
+        self::assertSame('bare', $this->bootstrapOf($html)['entityTypes']['items'][0]['default_layout']);
+    }
+
+    /** @return array<string, mixed> the SSR bootstrap payload the SPA hydrates from */
+    private function bootstrapOf(string $html): array
+    {
+        $matched = preg_match(
+            '~<script[^>]*id="nene-records-public-record-bootstrap"[^>]*>(.*?)</script>~s',
+            $html,
+            $m,
+        );
+
+        self::assertSame(1, $matched, 'the bootstrap script must be present');
+        self::assertArrayHasKey(1, $m);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode(html_entity_decode($m[1], ENT_QUOTES), true, 512, JSON_THROW_ON_ERROR);
+
+        return $decoded;
+    }
 }


### PR DESCRIPTION
## 目的

**SSR bootstrap の `entityTypes` payload が `{id, name, slug}` だけ**で、SPA は
`useEntityTypeList` をこの payload で hydrate し**二度と取り直さない**ため、
**`defaultLayout` と `permalinkPattern` が永久に `undefined`** だった。

```json
"entityTypes":{"items":[{"id":18,"name":"ページ","slug":"pages"}]}
```

SPA が本来叩く `ListEntityTypesHandler` は **9フィールド**を返す。

## 影響

1. **`resolveLayout` が `standard` にフォールバック** → レコードが届くまで **`bare` ページに
   テーマ chrome を描く**。**DB の `default_layout` を `bare` に直しても SPA に伝わっていなかった。**
   #885 の案A でクライアント遷移にした結果、**遷移のたびに顕在化**した。
2. `permalinkPattern` も欠落 → `entityTypePatternById` / `extractEntityKeyFromSplat` /
   `resolvePermalink` が既定パターンに落ちる（**URL 生成の誤りにつながりうる**）。

## これは3度目の同型バグ

`entity` payload には既に同じ教訓のコメントが2つ付いている:

> The SPA hydrates useEntity from this payload and never refetches, so the tri-state
> visibility overrides must ride along（**#778**）
> Canonical URL identity must ride along too（**#816**）

**個別に気づいて足す運用が破綻している**ので、**payload の形をテストで pin** した。

## 変更

- `PublicRecordViewHttpMapper::toBootstrap` の `entityTypesPayload` を
  **`ListEntityTypesHandler` と同じ9フィールド**に。
- **回帰テスト2本**: キー集合の**厳密一致** ＋ 型既定 `bare` が bootstrap に載ること
  （bootstrap を JSON パースして検証するヘルパを追加）。
- **併せて: layout 未確定の間はテーマ chrome を推測描画しない**（2箇所）。
  #887 で型既定は即座に分かるようになったが、**推測描画そのものを残すと
  「型既定 standard × 実レコード bare」の org で同じことが起きる**。
  間違ったレイアウトは「壊れたサイト」に見え、空白は「読み込み中」に見える。

## 検証（実ブラウザ・Firefox・クライアント遷移3回を15ms間隔で監視）

| | 修正前 | 修正後 |
|---|---|---|
| デフォルトレイアウト出現 | 🔴 5〜51回 / 120 | **✅ 0回 / 120** |
| SPA 遷移（document リクエスト） | 0件 | **0件（維持）** |
| 空白 | — | ~75ms（resolve 待ち・**間違ったレイアウトではない**） |

`composer check` 緑（1351 tests）/ `npm run check` 緑。

## チェックリスト

- [x] Issue 駆動（#887）
- [x] `main` から `fix/887-...` ブランチ
- [x] Conventional Commits
- [x] シークレット無し

## 関連

- **#885（案A: リンク横取り）** — これでクライアント遷移になり本件が顕在化した
- **#879 / #881 / #883** — 本件は同じ症状の**4つ目の独立した原因**
- #778 / #816 — 同型の先例

## 残

遷移中の **~75ms の空白**（resolve 待ち）。間違ったレイアウトではないが、
リンク hover/pointerdown での **resolve プリフェッチ**で消せる見込み（別 Issue 候補）。

Closes #887