### PR TITLE
fix(public): 公開タイプ一覧の SPA にラベル導出の metaTitle を渡す（#891）

### DIFF
--- a/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.test.ts
+++ b/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.test.ts
@@ -1,0 +1,138 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { waitFor } from '@testing-library/react'
+import { usePublicBrowseEntityRecordsPage } from './use-public-browse-entity-records-page'
+import { resetEntityStore, seedEntities } from '@tests/msw/handlers/entity'
+import { resetEntityTypeStore, seedEntityTypes } from '@tests/msw/handlers/entity-type'
+import { resetTextFieldStore, seedTextFields } from '@tests/msw/handlers/text-field'
+import { mswServer } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+
+const TYPE_ID = 7
+
+function seedType(): void {
+  seedEntityTypes([{ id: TYPE_ID, name: 'Pages', slug: 'pages', permalink_pattern: '/{slug}' }])
+}
+
+function published(id: number, slug: string, metaTitle: string | null) {
+  return {
+    id,
+    entity_type_id: TYPE_ID,
+    slug,
+    status: 'published' as const,
+    published_at: '2026-07-11T00:00:00Z',
+    is_deleted: false,
+    deleted_at: null,
+    meta_title: metaTitle,
+  }
+}
+
+describe('usePublicBrowseEntityRecordsPage — label parity with the SSR archive', () => {
+  beforeAll(() => {
+    mswServer.listen()
+  })
+  afterEach(() => {
+    mswServer.resetHandlers()
+    resetEntityStore()
+    resetEntityTypeStore()
+    resetTextFieldStore()
+  })
+  afterAll(() => {
+    mswServer.close()
+  })
+
+  /**
+   * The PHP twin is `RecordDisplayLabel::resolve` (title → meta_title → derived
+   * excerpt → fallback), consumed by GetPublicTypeArchiveUseCase. These cases pin
+   * each rung so the SPA listing cannot drift from what crawlers were served.
+   */
+
+  it('prefers the title field, exactly like the SSR archive', async () => {
+    seedType()
+    seedEntities([published(1, 'a', 'meta title')])
+    seedTextFields([{ id: 1, entity_id: 1, field_key: 'title', value: '『文学論』序' }])
+
+    const { result } = renderHookWithProviders(() => usePublicBrowseEntityRecordsPage('pages', 0))
+
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(1)
+    })
+    expect(result.current.items[0]?.label).toBe('『文学論』序')
+  })
+
+  it('falls back to meta_title when the record has no title field (#891)', async () => {
+    // A bespoke page: one html field, no `title`. Without meta_title the derived
+    // excerpt dumps the shared header/nav, so every row reads the same (#853).
+    seedType()
+    seedEntities([published(1, 'privacy', 'プライバシーポリシー｜彩音インターナショナル株式会社')])
+    seedTextFields([
+      {
+        id: 1,
+        entity_id: 1,
+        field_key: 'content',
+        value: '<header><nav><a href="/services">サービスと料金</a></nav></header><h1>本文</h1>',
+      },
+    ])
+
+    const { result } = renderHookWithProviders(() => usePublicBrowseEntityRecordsPage('pages', 0))
+
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(1)
+    })
+    expect(result.current.items[0]?.label).toBe(
+      'プライバシーポリシー｜彩音インターナショナル株式会社',
+    )
+  })
+
+  it('does not let two bespoke pages that share one html field collapse to the same label', async () => {
+    // The production symptom of #891: 12 AYANE pages all listed as
+    // "SYSTEM DEV / WEB APP / 受託ソフトウェア開発 …" — their common nav markup.
+    const shared = '<header><nav>SYSTEM DEV / WEB APP / 受託ソフトウェア開発</nav></header>'
+    seedType()
+    seedEntities([
+      published(1, 'privacy', 'プライバシーポリシー'),
+      published(2, 'trust', 'セキュリティと品質'),
+    ])
+    seedTextFields([
+      { id: 1, entity_id: 1, field_key: 'content', value: `${shared}<p>privacy body</p>` },
+      { id: 2, entity_id: 2, field_key: 'content', value: `${shared}<p>trust body</p>` },
+    ])
+
+    const { result } = renderHookWithProviders(() => usePublicBrowseEntityRecordsPage('pages', 0))
+
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(2)
+    })
+    const labels = result.current.items.map((item) => item.label)
+    expect(new Set(labels).size).toBe(2)
+    expect(labels).not.toContain('SYSTEM DEV / WEB APP / 受託ソフトウェア開発')
+  })
+
+  it('uses meta_title when the title field is outside the fetched text-field window (#892)', async () => {
+    // The listing shows 20 records id-desc while text fields are fetched
+    // {limit:100, offset:0}; on a large type the window holds none of them, which
+    // is why aozora/work listed "Record #1115". meta_title keeps the label right.
+    seedType()
+    seedEntities([published(1115, 'w1115', '『文学論』序')])
+    seedTextFields([{ id: 1, entity_id: 999, field_key: 'title', value: 'some other record' }])
+
+    const { result } = renderHookWithProviders(() => usePublicBrowseEntityRecordsPage('pages', 0))
+
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(1)
+    })
+    expect(result.current.items[0]?.label).toBe('『文学論』序')
+    expect(result.current.items[0]?.label).not.toBe('Record #1115')
+  })
+
+  it('falls back to Record #id only when nothing resolves', async () => {
+    seedType()
+    seedEntities([published(42, 'empty', null)])
+
+    const { result } = renderHookWithProviders(() => usePublicBrowseEntityRecordsPage('pages', 0))
+
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(1)
+    })
+    expect(result.current.items[0]?.label).toBe('Record #42')
+  })
+})

--- a/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.ts
+++ b/frontend/src/features/public-browse-entity-records/hooks/use-public-browse-entity-records-page.ts
@@ -64,7 +64,19 @@ export function usePublicBrowseEntityRecordsPage(entityTypeSlug: string, offset:
       const id = Number(entity.id)
       return {
         id,
-        label: getRecordDisplayLabel(id, textFields, `Record #${String(id)}`, locale),
+        // metaTitle must be passed, or bespoke pages (one html field, no `title`)
+        // fall through to the derived excerpt and every row shows the same stripped
+        // header/nav text — and records whose title is outside the text-field
+        // window (#892) show the `Record #id` fallback. The SSR twin
+        // (RecordDisplayLabel::resolve) passes it, so omitting it here silently
+        // breaks SSR/SPA label parity (#891).
+        label: getRecordDisplayLabel(
+          id,
+          textFields,
+          `Record #${String(id)}`,
+          locale,
+          entity.metaTitle ?? null,
+        ),
         publicUrl: resolvePermalink(pattern, {
           typeSlug: entityTypeSlug,
           entitySlug: entity.slug ?? null,

--- a/frontend/tests/msw/handlers/entity.ts
+++ b/frontend/tests/msw/handlers/entity.ts
@@ -5,15 +5,25 @@ import { getTagBySlug } from './tag'
 
 export type EntityStatusDto = 'draft' | 'published' | 'archived'
 
+/**
+ * Mirrors `EntityResponse` in docs/openapi/openapi.yaml. Every field the contract
+ * marks required must exist here, or a consumer can silently drop one and no test
+ * notices: `meta_title` was missing, so the public listing forgot to pass it to the
+ * label resolver and shipped raw html as record titles (#891).
+ */
 interface EntityRecord {
   id: number
   entity_type_id: number
   slug: string | null
   permalink: string | null
+  layout: string | null
   status: EntityStatusDto
   published_at: string | null
+  scheduled_at: string | null
   is_deleted: boolean
   deleted_at: string | null
+  meta_title: string | null
+  meta_description: string | null
   created_at: string | null
   updated_at: string | null
   /** Tri-state visibility overrides; null = follow record_page_config (#775). */
@@ -35,10 +45,14 @@ export function seedEntities(
     entity_type_id: number
     slug?: string | null
     permalink?: string | null
+    layout?: string | null
     status?: EntityStatusDto
     published_at?: string | null
+    scheduled_at?: string | null
     is_deleted: boolean
     deleted_at: string | null
+    meta_title?: string | null
+    meta_description?: string | null
     created_at?: string | null
     updated_at?: string | null
     show_comments?: boolean | null
@@ -49,8 +63,12 @@ export function seedEntities(
     ...item,
     slug: item.slug ?? null,
     permalink: item.permalink ?? null,
+    layout: item.layout ?? null,
     status: item.status ?? 'draft',
     published_at: item.published_at ?? null,
+    scheduled_at: item.scheduled_at ?? null,
+    meta_title: item.meta_title ?? null,
+    meta_description: item.meta_description ?? null,
     created_at: item.created_at ?? null,
     updated_at: item.updated_at ?? null,
     show_comments: item.show_comments ?? null,
@@ -208,7 +226,10 @@ export const entityHandlers = [
       entity_type_id?: number
       slug?: string | null
       permalink?: string | null
+      layout?: string | null
       status?: EntityStatusDto
+      meta_title?: string | null
+      meta_description?: string | null
       show_comments?: boolean | null
       show_related?: boolean | null
     }
@@ -232,10 +253,14 @@ export const entityHandlers = [
       entity_type_id: body.entity_type_id,
       slug: body.slug ?? null,
       permalink: body.permalink ?? null,
+      layout: body.layout ?? null,
       status: body.status ?? 'draft',
       published_at: null,
+      scheduled_at: null,
       is_deleted: false,
       deleted_at: null,
+      meta_title: body.meta_title ?? null,
+      meta_description: body.meta_description ?? null,
       created_at: now,
       updated_at: now,
       show_comments: body.show_comments ?? null,


### PR DESCRIPTION
## 目的

公開タイプ一覧（`PublicBrowsePage`）のタイトルが SSR と SPA で食い違い、**クローラには正しい題名が、訪問者には壊れた題名**が出ていた（通常の逆）。本番実測で発見。

| ページ | 人間（SPA マウント後） | クローラ（SSR） |
| --- | --- | --- |
| `aozora/work`（最新20件） | `Record #1115` / `Record #1114` | 『文学論』序 / おはなし |
| `ayane/pages`（全12件） | `SYSTEM&nbsp;DEV / WEB&nbsp;APP / 受託ソフトウェア開発 1営業日以内に…`（**12件とも同一**） | セキュリティと品質（Trust）｜彩音… |

aozora は本番稼働中で、公開一覧の最新ページが全件 `Record #<id>` の状態だった。

## 変更

1. **`use-public-browse-entity-records-page.ts`** — `getRecordDisplayLabel()` に `entity.metaTitle ?? null`（第5引数）を渡す。
2. **`tests/msw/handlers/entity.ts`** — msw の `EntityRecord` を OpenAPI の `EntityResponse` と同形にする（必須の `meta_title` / `meta_description` / `layout` / `scheduled_at` が丸ごと欠けていた）。
3. **`use-public-browse-entity-records-page.test.ts`（新規）** — 解決順を各段で pin する parity テスト5本。

## 原因

`getRecordDisplayLabel()` は **`title` → `metaTitle` → derived excerpt → fallback** の順で解決する。呼び出し側が `metaTitle` を渡していなかったため excerpt に落ち、bespoke ページ（html 1フィールド・`title` 無し）は共通ナビの HTML 全文をタイトルに出していた。

**配線漏れ**であり #879/#880 と同型。PHP の双子 `RecordDisplayLabel::resolve` は docblock で

> `PHP twin of the frontend shared/lib/get-record-display-label.ts; the order is deliberately identical so the SSR label and the SPA label agree`

と宣言し、`GetPublicTypeArchiveUseCase.php:72` で `$entity->metaTitle` を渡している。**SPA だけが約束を破っていた。** `get-record-display-label.ts:62` のコメントは症状をそのまま予言していた（`bespoke pages sharing one html field would otherwise all show the same stripped header/nav text (#853)`）。

系譜: #849/#853（管理画面）→ #875/#876（公開 PHP）→ **本 PR（SPA＝3つ目の双子）**。

## なぜテストで捕まらなかったか（再発防止の本体）

msw の `EntityRecord` が API 契約と同形でなく、**`meta_title` が存在しなかった**。モックに無い値は落としても誰も気づけない。契約の必須4フィールドを補ったので、今後は同種の取りこぼしがテストに現れる。

## 検証

- **本番 API で実証**: `GET /api/v1/entities?entity_type_id=15&status=published&limit=3` は `id=1115 → meta_title='『文学論』序'` を返す。**SPA は正しい題名を手にしたまま捨てていた**（追加フェッチ不要）。
- **テストが本当にバグを捕まえることを確認済み**: 修正を戻すと、本番と同じ文字列で落ちる。
  - `AssertionError: expected 'サービスと料金 本文' to be 'プライバシーポリシー｜彩音インターナショナル株式会社'`
  - `AssertionError: expected 'Record #1115' to be '『文学論』序'`
- `npm run check --prefix frontend` 緑（type-check / lint / format / test / themes / knip / storybook）。
- PHP 未変更。

## 残（別 issue）

**#892** — `textFields` の取得窓（`{limit:100, offset:0}`）が表示窓（id 降順20件）を覆っていない構造問題。本 PR で実害はほぼ消えるが、`meta_title` が空のレコードでは再発し、100件の無駄フェッチも残る。SSR は `findByEntityIds($ids)` で表示中の ID だけを引いており、そちらが正解の形。

## チェックリスト

- [x] Issue 紐付け（#891）
- [x] テストが修正前に落ちることを確認
- [x] 本番データで前提を実証
- [x] frontend ゲート緑

Closes #891