### PR TITLE
docs: 日報の置き場 docs/daily/ を CLAUDE.md に明記する（#901）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Claude Code / AI agent guide for this repository. Cursor summaries live in `.cur
 - **Commits**: Conventional Commits; type/scope English, description/body Japanese, include `(#issue)`.
 - **PR**: purpose, changes, verification, checklist name, `Closes #n`.
 - **Secrets**: never commit `.env`, tokens, or credentials.
+- **Daily reports**: `docs/daily/YYYY-MM-DD.md`（この repo の正。`docs/daily-reports/` は旧置き場・追記しない。フリート裁定 2026-07-16＝リポごとの慣習が正）.
 - **design-export/**: local claudeDesign working directory — keep it untracked (kept out of git via local `.git/info/exclude`, not the shared `.gitignore`); never `git add` it.
 - **Framework**: NENE2 via Composer — read `vendor/hideyukimori/nene2/docs/` for runtime patterns.
 - **MCP**: tools go through OpenAPI HTTP boundary only.


### PR DESCRIPTION
## 目的

日報置き場のフリート裁定（2026-07-16・リポごとの慣習が正）を受け、この repo の口伝ルールを CLAUDE.md に1行で規範化する（payout #178 / fleet #54 / vault #222 と同型対応）。

## 変更内容

- CLAUDE.md Quick Rules に追記: 日報は `docs/daily/YYYY-MM-DD.md` が正・`docs/daily-reports/` は旧置き場（追記しない）。

## 検証

- 実態確認済み: `docs/daily/` は 07-14〜16 現役、`docs/daily-reports/` は 2026-06-19 で停止。
- 文書1行のみ・コード変更なし。

Closes #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)