### PR TITLE
fix(public): #894 の廃止漏れ2箇所 — 「読み込み中…」素テキストをスケルトンに置換する（#905）

### DIFF
--- a/frontend/src/features/public-view-entity-record/ui/PublicRecordDetailView.test.tsx
+++ b/frontend/src/features/public-view-entity-record/ui/PublicRecordDetailView.test.tsx
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, screen } from '@testing-library/react'
+import { renderWithI18n } from '@/shared/i18n/test-helpers'
+import { PublicRecordDetailView } from './PublicRecordDetailView'
+
+afterEach(cleanup)
+
+describe('PublicRecordDetailView', () => {
+  it('renders a skeleton — never a loading text — while the record body loads (#905)', () => {
+    const { container } = renderWithI18n(
+      <PublicRecordDetailView
+        entity={null}
+        fieldRows={[]}
+        entityTypeSlugById={{}}
+        entityTypePatternById={{}}
+        isLoading={true}
+        isError={false}
+        errorTitle={null}
+        onRetry={() => {}}
+      />,
+    )
+
+    // #894's rule: the loading signal is shape, not words. The old text leaked
+    // through in every locale, so pin the absence of all of them.
+    expect(screen.queryByText(/読み込み中/)).toBeNull()
+    expect(screen.queryByText(/Loading/)).toBeNull()
+    expect(container.querySelector('[aria-busy="true"]')).not.toBeNull()
+    expect(container.querySelector('.sk-article')).not.toBeNull()
+  })
+})

--- a/frontend/src/features/public-view-entity-record/ui/PublicRecordDetailView.tsx
+++ b/frontend/src/features/public-view-entity-record/ui/PublicRecordDetailView.tsx
@@ -1,6 +1,7 @@
 import type { Entity } from '@/entities/entity'
 import { useTranslation } from '@/shared/i18n'
 import { Button, Stack, Text } from '@/shared/ui'
+import { LoadingArticle } from '@/shared/ui/loading'
 import type { PublicFieldRow } from '../hooks/use-public-view-entity-record-page'
 import { PublicRecordFieldList } from './PublicRecordFieldList'
 
@@ -28,7 +29,10 @@ export function PublicRecordDetailView({
   const { t } = useTranslation()
 
   if (isLoading) {
-    return <Text muted>{t('public.record.loading')}</Text>
+    // Skeleton, not text (#894/#905): the layout is known here (B群), so mirror the
+    // article body's shape — the swap must not move the page, and the signal must
+    // stay language-independent like the rest of the loading states.
+    return <LoadingArticle />
   }
 
   if (isError) {

--- a/frontend/src/features/public-view-entity-record/ui/PublicRelationFieldDisplay.test.tsx
+++ b/frontend/src/features/public-view-entity-record/ui/PublicRelationFieldDisplay.test.tsx
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, screen } from '@testing-library/react'
+import type { RelationFieldDef } from '@/entities/field-def'
+import { renderWithI18n } from '@/shared/i18n/test-helpers'
+import { PublicRelationFieldDisplay } from './PublicRelationFieldDisplay'
+
+vi.mock('../hooks/use-public-relation-field-display', () => ({
+  usePublicRelationFieldDisplay: () => ({
+    targets: [],
+    isLoading: true,
+    isError: false,
+    errorTitle: null,
+    refetch: () => {},
+  }),
+}))
+
+afterEach(cleanup)
+
+const fieldDef = {
+  id: 1,
+  fieldKey: 'related_works',
+  dataType: 'relation',
+} as unknown as RelationFieldDef
+
+describe('PublicRelationFieldDisplay', () => {
+  it('keeps the field key and shows a line skeleton — no loading text — while resolving (#905)', () => {
+    const { container } = renderWithI18n(
+      <PublicRelationFieldDisplay
+        entityId={1}
+        fieldDef={fieldDef}
+        entityTypeSlugById={{}}
+        entityTypePatternById={{}}
+      />,
+    )
+
+    expect(screen.getByText('related_works')).not.toBeNull()
+    expect(screen.queryByText(/読み込み中/)).toBeNull()
+    expect(screen.queryByText(/Loading/)).toBeNull()
+    expect(container.querySelector('dd[aria-busy="true"] .sk-line')).not.toBeNull()
+  })
+})

--- a/frontend/src/features/public-view-entity-record/ui/PublicRelationFieldDisplay.tsx
+++ b/frontend/src/features/public-view-entity-record/ui/PublicRelationFieldDisplay.tsx
@@ -26,14 +26,16 @@ export function PublicRelationFieldDisplay({
   )
 
   if (isLoading) {
+    // Skeleton, not text (#894/#905): the dt (field key) is real content and stays;
+    // only the resolving value gets a line-shaped placeholder.
     return (
       <div className="flex flex-col gap-stack-xs">
         <Text as="dt" variant="heading-sm">
           {fieldDef.fieldKey}
         </Text>
-        <Text as="dd" muted>
-          {t('public.record.loading')}
-        </Text>
+        <dd className="loading-view m-0" aria-busy="true">
+          <span className="skeleton sk-line" />
+        </dd>
       </div>
     )
   }

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -2861,6 +2861,29 @@
   border-radius: var(--radius-lg);
   margin: 0 0 var(--space-lg);
 }
+/* Article body (#905) — the record detail: a heading bar, then paragraph groups. */
+.nene-public .sk-article {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+.nene-public .sk-article__title {
+  width: 46%;
+  max-width: 22rem;
+  height: calc(var(--text-body) * 1.6);
+}
+.nene-public .sk-para {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+/* One dd-sized line (#905) — a relation field's value while it resolves. */
+.nene-public .sk-line {
+  display: block;
+  height: var(--text-body);
+  width: 84%;
+  max-width: 26rem;
+}
 @media (prefers-reduced-motion: reduce) {
   .nene-public .skeleton::after {
     animation: none;

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -499,7 +499,6 @@ export const de = {
   'public.home.error.fallback': 'Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.',
   'public.home.readArticle': 'Artikel lesen',
   'public.home.types.eyebrow': 'Einstiege',
-  'public.record.loading': 'Wird geladen…',
   'public.record.error.title': 'Datensatz konnte nicht geladen werden',
   'public.record.noFields': 'Für diesen Datensatz sind keine Felder definiert.',
   'public.record.chapterNav.prev': 'Vorheriges Kapitel',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -503,7 +503,6 @@ export const en = {
   'public.home.error.fallback': 'Something went wrong. Please try again.',
   'public.home.readArticle': 'Read article',
   'public.home.types.eyebrow': 'Entrances',
-  'public.record.loading': 'Loading…',
   'public.record.error.title': 'Could not load record',
   'public.record.noFields': 'No fields defined for this record.',
   'public.record.chapterNav.prev': 'Previous chapter',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -501,7 +501,6 @@ export const fr = {
   'public.home.error.fallback': 'Une erreur est survenue. Veuillez réessayer.',
   'public.home.readArticle': "Lire l'article",
   'public.home.types.eyebrow': 'Entrées',
-  'public.record.loading': 'Chargement…',
   'public.record.error.title': 'Impossible de charger la fiche',
   'public.record.noFields': 'Aucun champ défini pour cette fiche.',
   'public.record.chapterNav.prev': 'Chapitre précédent',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -496,7 +496,6 @@ export const ja = {
   'public.home.error.fallback': '問題が発生しました。もう一度お試しください。',
   'public.home.readArticle': '記事を読む',
   'public.home.types.eyebrow': '入口',
-  'public.record.loading': '読み込み中…',
   'public.record.error.title': 'レコードを読み込めませんでした',
   'public.record.noFields': 'このレコードにはフィールドが定義されていません。',
   'public.record.chapterNav.prev': '前の章',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -498,7 +498,6 @@ export const ptBR = {
   'public.home.error.fallback': 'Algo deu errado. Por favor, tente novamente.',
   'public.home.readArticle': 'Ler artigo',
   'public.home.types.eyebrow': 'Entradas',
-  'public.record.loading': 'Carregando…',
   'public.record.error.title': 'Não foi possível carregar o registro',
   'public.record.noFields': 'Nenhum campo definido para este registro.',
   'public.record.chapterNav.prev': 'Capítulo anterior',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -473,7 +473,6 @@ export const zhHans = {
   'public.home.error.fallback': '出了点问题。请重试。',
   'public.home.readArticle': '阅读文章',
   'public.home.types.eyebrow': '入口',
-  'public.record.loading': '加载中…',
   'public.record.error.title': '无法加载记录',
   'public.record.noFields': '此记录未定义任何字段。',
   'public.record.chapterNav.prev': '上一章',

--- a/frontend/src/shared/ui/loading/LoadingSkeleton.tsx
+++ b/frontend/src/shared/ui/loading/LoadingSkeleton.tsx
@@ -43,6 +43,24 @@ export function LoadingRows() {
   )
 }
 
+/** An article body — the record detail: a heading bar, then paragraph groups (#905). */
+export function LoadingArticle() {
+  return (
+    <div className="loading-view" aria-busy="true">
+      <div className="sk-article">
+        <div className="skeleton sk-article__title" />
+        {[0, 1].map((p) => (
+          <div className="sk-para" key={p}>
+            <div className="skeleton sk-row" />
+            <div className="skeleton sk-row sk-row--2" />
+            <div className="skeleton sk-row sk-row--3" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 /** A featured masthead above a card grid — the home feed. */
 export function LoadingFeatured({ count = 3 }: { count?: number }) {
   return (

--- a/frontend/src/shared/ui/loading/index.ts
+++ b/frontend/src/shared/ui/loading/index.ts
@@ -1,1 +1,1 @@
-export { LoadingCardGrid, LoadingFeatured, LoadingRows } from './LoadingSkeleton'
+export { LoadingArticle, LoadingCardGrid, LoadingFeatured, LoadingRows } from './LoadingSkeleton'


### PR DESCRIPTION
## 目的

#894 の読み込み表示リデザインは9箇所（S1〜S9）の棚卸しに基づいたが、棚卸しに入っていなかった公開側の読み込みテキストが2箇所残り、施主が本番で「読み込み中…」を目撃した（デプロイ漏れではなく棚卸し漏れ。本番バンドルに `public.record.loading` が現存することを実測確認済み）。

## 変更内容

- **`PublicRecordDetailView`（レコード本文の読み込み中）** → `LoadingArticle` 新設（見出しバー＋段落群・実コンテンツと同形＝差し替え時にレイアウトが飛ばない）
- **`PublicRelationFieldDisplay`（関連フィールドの読み込み中）** → dt（fieldKey）は実物のまま、dd を1行スケルトン `sk-line` に
- どちらもレイアウト確定後＝ **B群の作法**: `.nene-public` スコープ・140ms 遅延 fade-in（速い応答では出ない）・生の色0（全てトークン経由）・`prefers-reduced-motion` は既存の共通ルールが適用
- 未使用になった `public.record.loading` を全6ロケール（ja 権威＋en/de/fr/pt-BR/zh-Hans）から削除
- 「文字を出さない」を pin するテスト2本を追加（全ロケールの文言不在＋skeleton 存在）

## 検証

- 新規テスト2本 pass
- `npm run check --prefix frontend` 全緑（type-check / lint / prettier / test / knip / storybook）
- 公開側の他の読み込みテキストは grep 済み: 残るは `public.comments.loading`（コメント欄・別コンポーネント）のみでスコープ外として issue に明記

## チェックリスト

- [x] Issue 駆動（#905）
- [x] Conventional Commits
- [x] secrets なし

Closes #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)