### PR TITLE
fix(public): document title の社名二重付与を除去し SPA 遷移後もページ題名を維持する（#909）

### DIFF
--- a/frontend/src/pages/consumer/PublicBrowsePage.tsx
+++ b/frontend/src/pages/consumer/PublicBrowsePage.tsx
@@ -10,6 +10,7 @@ import {
 import { PublicRecordByPermalink } from './PublicRecordDetailPage'
 import { PublicSiteShell } from './PublicSiteShell'
 import { usePublicSite } from './public-site-context'
+import { usePublicDocumentTitle } from './use-public-document-title'
 
 export function PublicBrowsePage() {
   const site = usePublicSite()
@@ -31,6 +32,11 @@ export function PublicBrowsePage() {
     errorTitle,
     refetch,
   } = usePublicBrowseEntityRecordsPage(entityTypeSlug, offset)
+
+  // Tab title parity with the SSR type-archive `<title>` (#909), which uses the
+  // type's display name as the page title. When the slug turns out to be a
+  // custom permalink (isUnknownType), the delegate page owns the title instead.
+  usePublicDocumentTitle(isUnknownType ? undefined : (entityType?.name ?? null), site.siteName)
 
   const goToOffset = (nextOffset: number) => {
     const params = new URLSearchParams(searchParams)

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
@@ -37,6 +37,7 @@ import { useEntityIdBySlug } from './hooks/use-entity-id-by-slug'
 import { PublicSiteShell } from './PublicSiteShell'
 import { usePublicSite, type PublicSite } from './public-site-context'
 import { RouteProgress } from './RouteProgress'
+import { usePublicDocumentTitle } from './use-public-document-title'
 
 // ── Presentation helpers ──────────────────────────────────────────────────────
 
@@ -245,6 +246,12 @@ function PublicRecordDetailContent({
     humanizeSlug(entity?.slug) ||
     humanizeSlug(permalinkSegments.at(-1)) ||
     `Record #${String(entityId)}`
+  // Tab title parity with the SSR `<title>` (#909): meta_title wins over the
+  // title field there (GetPublicRecordViewUseCase), so mirror that order here.
+  usePublicDocumentTitle(
+    entity === null ? null : entity.metaTitle?.trim() || resolvedTitle,
+    site.siteName,
+  )
   // Reserved chapter-nav metadata (series/chapter_no/chapter_total) is surfaced
   // as the derived chapter navigation, never as an ordinary field row.
   const contentRows = useMemo(

--- a/frontend/src/pages/consumer/PublicShell.tsx
+++ b/frontend/src/pages/consumer/PublicShell.tsx
@@ -36,12 +36,13 @@ import {
 import type { PublicSite } from './public-site-context'
 import { RouteProgress } from './RouteProgress'
 
-function useSiteDocumentMeta(siteName: string, metaDescription: string): void {
+function useSiteDocumentMeta(metaDescription: string): void {
   useEffect(() => {
-    if (siteName !== '') {
-      document.title = siteName
-    }
-
+    // document.title is deliberately NOT set here (#909). Parent effects run
+    // after child effects, so a shell-level write overwrote every page's own
+    // title on hydration — the SSR title collapsed to the bare site name. Pages
+    // own the title via usePublicDocumentTitle; its unmount cleanup restores the
+    // site name for pages that don't set one.
     let meta = document.querySelector('meta[name="description"]')
 
     if (metaDescription === '') {
@@ -56,7 +57,7 @@ function useSiteDocumentMeta(siteName: string, metaDescription: string): void {
     }
 
     meta.setAttribute('content', metaDescription)
-  }, [siteName, metaDescription])
+  }, [metaDescription])
 }
 
 export function PublicShell() {
@@ -169,7 +170,7 @@ export function PublicShell() {
     frontPagePath: settings.front_page ?? '',
   }
 
-  useSiteDocumentMeta(site.siteName, site.metaDescription)
+  useSiteDocumentMeta(site.metaDescription)
 
   // PublicShell only resolves site-wide data and the document meta. The visual
   // scaffold (header / footer / drawer / theme) is the magazine PublicSiteShell,

--- a/frontend/src/pages/consumer/use-public-document-title.test.tsx
+++ b/frontend/src/pages/consumer/use-public-document-title.test.tsx
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import { usePublicDocumentTitle } from './use-public-document-title'
+
+afterEach(cleanup)
+
+function Probe({ pageTitle }: { pageTitle: string | null | undefined }) {
+  usePublicDocumentTitle(pageTitle, '彩音インターナショナル株式会社')
+  return null
+}
+
+describe('usePublicDocumentTitle', () => {
+  it('sets the composed title and skips the suffix when the site name is already carried (#909)', () => {
+    render(<Probe pageTitle="サービスと料金｜彩音インターナショナル株式会社" />)
+    expect(document.title).toBe('サービスと料金｜彩音インターナショナル株式会社')
+  })
+
+  it('appends the site name when the page title does not carry it', () => {
+    render(<Probe pageTitle="お知らせ" />)
+    expect(document.title).toBe('お知らせ — 彩音インターナショナル株式会社')
+  })
+
+  it('restores the site name on unmount so the next page never inherits a stale title', () => {
+    const { unmount } = render(<Probe pageTitle="お知らせ" />)
+    unmount()
+    expect(document.title).toBe('彩音インターナショナル株式会社')
+  })
+
+  it('leaves the title alone when the page delegates (undefined)', () => {
+    document.title = '委譲先のタイトル'
+    const { unmount } = render(<Probe pageTitle={undefined} />)
+    expect(document.title).toBe('委譲先のタイトル')
+    unmount()
+    expect(document.title).toBe('委譲先のタイトル')
+  })
+})

--- a/frontend/src/pages/consumer/use-public-document-title.ts
+++ b/frontend/src/pages/consumer/use-public-document-title.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'react'
+import { composePublicDocumentTitle } from '@/shared/lib/public-document-title'
+
+/**
+ * Keeps `document.title` on the page's own title during hydration and client
+ * navigation (#909). Before this, the only public writer was `PublicShell`'s
+ * site-level effect, so every page collapsed to the bare site name after
+ * hydration — and the GA4 page_view payload (which sends `document.title`)
+ * became identical across all pages.
+ *
+ * On unmount the title falls back to the site name, so pages that don't set
+ * their own title never inherit the previous page's.
+ */
+export function usePublicDocumentTitle(
+  /**
+   * `undefined` means "this render delegates the page to another component —
+   * don't manage the title at all". Needed because parent effects run after
+   * child effects: a delegating page that still set `siteName` would overwrite
+   * the delegate's title (e.g. PublicBrowsePage → PublicRecordByPermalink).
+   */
+  pageTitle: string | null | undefined,
+  siteName: string,
+): void {
+  useEffect(() => {
+    if (pageTitle === undefined) {
+      return
+    }
+
+    const composed = composePublicDocumentTitle(pageTitle, siteName)
+
+    if (composed !== '') {
+      document.title = composed
+    }
+
+    return () => {
+      if (siteName !== '') {
+        document.title = siteName
+      }
+    }
+  }, [pageTitle, siteName])
+}

--- a/frontend/src/shared/lib/public-document-title.test.ts
+++ b/frontend/src/shared/lib/public-document-title.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { composePublicDocumentTitle } from './public-document-title'
+
+describe('composePublicDocumentTitle', () => {
+  it('appends the site name when the title does not carry it', () => {
+    expect(composePublicDocumentTitle('『文学論』序', 'NeNe Records')).toBe(
+      '『文学論』序 — NeNe Records',
+    )
+  })
+
+  it('skips the suffix when the title already contains the site name (#909)', () => {
+    expect(
+      composePublicDocumentTitle(
+        'サービスと料金｜彩音インターナショナル株式会社',
+        '彩音インターナショナル株式会社',
+      ),
+    ).toBe('サービスと料金｜彩音インターナショナル株式会社')
+  })
+
+  it('falls back to the site name for an empty or missing title', () => {
+    expect(composePublicDocumentTitle('  ', 'NeNe Records')).toBe('NeNe Records')
+    expect(composePublicDocumentTitle(null, 'NeNe Records')).toBe('NeNe Records')
+  })
+
+  it('keeps the bare title when the site name is empty', () => {
+    expect(composePublicDocumentTitle('ページ名', '')).toBe('ページ名')
+  })
+})

--- a/frontend/src/shared/lib/public-document-title.ts
+++ b/frontend/src/shared/lib/public-document-title.ts
@@ -1,0 +1,21 @@
+/**
+ * Composes the public document title from a page title and the site name (#909).
+ *
+ * Twin: `src/PublicRecord/PublicDocumentTitle.php` — the SSR emits the same
+ * rule, so hydration and client navigation must never change the string the
+ * server rendered. Change both together.
+ */
+export function composePublicDocumentTitle(pageTitle: string | null, siteName: string): string {
+  const page = (pageTitle ?? '').trim()
+  const site = siteName.trim()
+
+  if (page === '') {
+    return site
+  }
+
+  if (site === '' || page.includes(site)) {
+    return page
+  }
+
+  return `${page} — ${site}`
+}

--- a/src/PublicRecord/PublicDocumentTitle.php
+++ b/src/PublicRecord/PublicDocumentTitle.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+/**
+ * Composes the public `<title>` from a page title and the site name (#909).
+ *
+ * The suffix is skipped when the page title already carries the site name —
+ * meta_title values imported from other CMSes (and the AYANE delivery) come as
+ * "ページ名｜社名", and appending " — 社名" again doubled the brand on every tab.
+ *
+ * Twin: `frontend/src/shared/lib/public-document-title.ts` — the SPA sets
+ * `document.title` with the same rule so hydration/client navigation renders the
+ * exact string the SSR emitted. Change both together.
+ */
+final class PublicDocumentTitle
+{
+    public static function compose(string $pageTitle, string $siteName): string
+    {
+        $pageTitle = trim($pageTitle);
+        $siteName = trim($siteName);
+
+        if ($pageTitle === '') {
+            return $siteName;
+        }
+
+        if ($siteName === '' || str_contains($pageTitle, $siteName)) {
+            return $pageTitle;
+        }
+
+        return $pageTitle . ' — ' . $siteName;
+    }
+}

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -10,7 +10,8 @@
     <?php if ($metaDescription !== ''): ?>
       <meta name="description" content="<?= $e($metaDescription) ?>" />
     <?php endif; ?>
-    <title><?= $e($pageTitle) ?> — <?= $e($siteName) ?></title>
+    <?php /* Suffix skipped when the title already carries the site name (#909). */ ?>
+    <title><?= $e(\NeNeRecords\PublicRecord\PublicDocumentTitle::compose($pageTitle, $siteName)) ?></title>
     <link rel="canonical" href="<?= $e($canonicalUrl) ?>" />
     <?php /* hreflang alternates for the public content locales (#540). */ ?>
     <?php foreach ($alternateLinks as $alt): ?>

--- a/templates/public/type-archive.php
+++ b/templates/public/type-archive.php
@@ -9,7 +9,8 @@
     <?php if ($metaDescription !== ''): ?>
       <meta name="description" content="<?= $e($metaDescription) ?>" />
     <?php endif; ?>
-    <title><?= $e($pageTitle) ?> — <?= $e($siteName) ?></title>
+    <?php /* Suffix skipped when the title already carries the site name (#909). */ ?>
+    <title><?= $e(\NeNeRecords\PublicRecord\PublicDocumentTitle::compose($pageTitle, $siteName)) ?></title>
     <link rel="canonical" href="<?= $e($canonicalUrl) ?>" />
     <?php /* Paged archives: point crawlers along the sequence rather than at dead ends. */ ?>
     <?php if ($prevUrl !== null): ?>

--- a/tests/PublicRecord/PublicDocumentTitleTest.php
+++ b/tests/PublicRecord/PublicDocumentTitleTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use NeNeRecords\PublicRecord\PublicDocumentTitle;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PublicDocumentTitleTest extends TestCase
+{
+    #[Test]
+    public function appends_site_name_when_title_does_not_carry_it(): void
+    {
+        self::assertSame(
+            '『文学論』序 — NeNe Records',
+            PublicDocumentTitle::compose('『文学論』序', 'NeNe Records'),
+        );
+    }
+
+    #[Test]
+    public function skips_suffix_when_title_already_contains_site_name(): void
+    {
+        self::assertSame(
+            'サービスと料金｜彩音インターナショナル株式会社',
+            PublicDocumentTitle::compose(
+                'サービスと料金｜彩音インターナショナル株式会社',
+                '彩音インターナショナル株式会社',
+            ),
+        );
+    }
+
+    #[Test]
+    public function falls_back_to_site_name_for_empty_title(): void
+    {
+        self::assertSame('NeNe Records', PublicDocumentTitle::compose('  ', 'NeNe Records'));
+    }
+
+    #[Test]
+    public function keeps_bare_title_when_site_name_is_empty(): void
+    {
+        self::assertSame('ページ名', PublicDocumentTitle::compose('ページ名', ''));
+    }
+}

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -277,6 +277,9 @@ final class PublicRecordHttpTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
         self::assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
         self::assertStringContainsString('<h1>Hello world</h1>', $html);
+        // Pins the PublicDocumentTitle wiring (#909): suffix present when the page
+        // title does not already carry the site name.
+        self::assertStringContainsString('<title>Hello world — NeNe Records</title>', $html);
         self::assertStringContainsString('id="nene-records-public-record-bootstrap"', $html);
         self::assertStringContainsString('"entityTypeSlug":"article"', $html);
         self::assertStringContainsString('<h2>Sample</h2>', $html);


### PR DESCRIPTION
## 目的

AYANE launch 前倒し監査（2026-07-16・施主GO「自走前倒し」）で実測した公開 title の2欠陥を修正する。

1. **SSR `<title>` の社名二重**: AYANE 全13ページで `サービスと料金｜彩音インターナショナル株式会社 — 彩音インターナショナル株式会社`（meta_title が既に社名を含むのに無条件でサフィックス付加）
2. **SPA hydration 後の題名消失**: 公開側の document.title 書き込みが `PublicShell` の `= siteName` のみ。実測（Playwright・本番）で hydration 後に全ページ「社名」だけに退化し、**GA4 page_view の title も全ページ同一**だった

## 変更内容

- **PHP** `PublicDocumentTitle::compose(pageTitle, siteName)` — siteName を含む pageTitle にはサフィックスを付けない。`record-detail.php` / `type-archive.php` に配線
- **TS twin** `composePublicDocumentTitle`＋`usePublicDocumentTitle` — レコード詳細（SSR と同じ meta_title 優先順）・型一覧（`entityType.name`）で設定、unmount で siteName に復帰
- **PublicShell の title 書き込みを撤去** — React は親 effect が子より後に走るため、shell の書き込みが**ページの題名を hydration で必ず潰していた**（今回の SPA 側欠陥の根本）
- 委譲ケース（1セグメント URL が custom permalink だった場合）は `undefined` で title 管理をスキップ（親が委譲先の題名を上書きしない）
- PHP/TS の compose は意図的に同一仕様（#891 の教訓: SSR/SPA parity は twin で守る）

## 検証

- 新規テスト: PHP 4本（compose）＋ HTTP テストに `<title>` pin 1本／TS 4本（compose）＋ hook 4本（設定・復帰・委譲スキップ）
- `composer check` 全緑（PHPUnit 1355+・PHPStan 8・CS・OpenAPI・conformance・MCP）
- `npm run check --prefix frontend` 全緑

## チェックリスト

- [x] Issue 駆動（#909） / Conventional Commits / secrets なし

Closes #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)