### PR TITLE
docs: launch 前倒し監査と第38回デプロイの記録を同期する（#913）

### DIFF
--- a/docs/daily/2026-07-16.md
+++ b/docs/daily/2026-07-16.md
@@ -128,3 +128,25 @@
 ### 教訓（追記）
 
 7. **「表示されない」の一次疑いは「古い」ではなく「出番が無い」or「漏れ」。** 今日の2件はどちらもデプロイは最新だった。ローディングが見えない=キャッシュで待ちゼロ（正常）、文言が見える=棚卸し漏れ（バグ）。バンドル hash と dist grep で「何が焼かれているか」を先に確定させると切り分けが速い。
+
+---
+
+## 追補2（深夜）— launch 前倒し監査＋title parity 修正（第38回デプロイ）
+
+施主「自走前倒し」GO（hub 経由）を受け、AYANE 第1弾の go-live 手前監査を実施。
+
+### 監査結果（全て本番実測）
+
+- ✅ **全13ページ**: 200・soft404 なし・title/canonical/description/JSON-LD 完備・**サイト内リンクは sitemap 集合と完全一致**（迷子リンク 0＝/for-accountants 除去の完遂を再確認）
+- ✅ robots.txt（admin/superadmin/login を Disallow・sitemap 参照）・sitemap.xml 配信・3PDF media URL 200
+- 🔴→修正済: **title の2欠陥**（下記 #909）
+- 🟡 issue 化: **#911** sitemap の `/` 二重（front_page 設定時。静的 home エントリ＋置換済みレコードの両方が出る）／**#912** og:image が全ページ不在（image フィールドの media 派生のみが対象という仕様。org 既定ソーシャルカードは製品判断・launch ブロッカーではない）
+
+### #909 / PR #910 — 公開 title の parity（第38回デプロイで本番反映）
+
+1. **SSR 社名二重**: AYANE の meta_title は「◯◯｜社名」形式なのにテンプレートが無条件で「 — 社名」を付加。`PublicDocumentTitle::compose`（含有時サフィックス抑止）を新設し record-detail/type-archive に配線。HTTP テストで `<title>` を pin。
+2. **SPA hydration 後の題名消失**: 公開側の document.title 書き込みは `PublicShell` の `= siteName` だけ。実測で hydration 後に全ページ「社名」に退化＝ **GA4 page_view の title も全ページ同一**だった。`usePublicDocumentTitle`（TS twin・record=meta_title 優先＝SSR と同順・browse=型名・unmount で siteName 復帰）を新設。
+3. ★構造の教訓: **React の親 effect は子 effect の後に走る**。shell レベルの title 書き込みは、ページがどう頑張っても hydration で必ず勝ってしまう＝ページ所有＋unmount 復帰の形にしか出来ない。委譲ケース（browse→custom permalink）は `undefined` で管理スキップ（親が委譲先を上書きしない）。
+4. デプロイ38: バックアップ→dry-run（deletions 0・14ファイル）→build→up。live 検証: apex/aozora/ayane 200・www 301・エラーログ 0・SSR title 両ケース正・**Playwright で hydration 後/遷移後のタブ題名維持を実測**。
+
+→ **launch まで records 側の残タスクなし**（contact 開通＝別リポのみ）。#911/#912 は launch 後で可。

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,20 @@
 # Current Work
 
-Last updated: 2026-07-16（夜）
+Last updated: 2026-07-16（深夜）
+
+## 最新: AYANE launch 前倒し監査＋公開 title の parity 修正（2026-07-16 深夜・**本番反映済み・第38回**）
+
+> 施主「自走前倒し」GO（hub 経由）で go-live 手前の launch 準備監査を実施。**全13ページ機械監査は緑**
+> （200・soft404 なし・canonical/description/JSON-LD 完備・迷子リンク 0・robots/sitemap 配信・3PDF 200）。
+> 監査で見つけた title の2欠陥を #909/PR #910 で修正し**第38回デプロイで本番反映・live 検証済み**:
+> ①SSR `<title>` の社名二重（meta_title「◯◯｜社名」＋無条件サフィックス）→ `PublicDocumentTitle::compose`
+> （含有時サフィックス抑止・TS twin と両側 pin）②**SPA hydration 後に全ページのタブ題名が siteName だけに退化**
+> （公開側の document.title 書き込みが PublicShell の1箇所のみ・**親 effect は子より後に走る**ため
+> ページ側で設定しても必ず潰される構造）→ `usePublicDocumentTitle`（record=meta_title 優先・browse=型名・
+> unmount で siteName 復帰・委譲時は undefined でスキップ）。**GA4 page_view の title が全ページ同一**だった
+> 問題も同時解消。live 実測: `/services` hydration 後も「サービスと料金｜彩音…」、遷移後「会社案内｜彩音…」。
+> 残所見は issue 化: **#911**（sitemap の `/` 二重・front_page 設定時・軽微）**#912**（og:image が image
+> フィールド無しページで常に不在 → org 既定ソーシャルカードの製品判断・launch ブロッカーではない）。
 
 ## 最新: repo-status 齟齬解消＋#896 クローズ＋読み込み中文言の廃止漏れ修正（2026-07-16 午後〜夜・**本番反映済み**）
 


### PR DESCRIPTION
launch 前倒し監査の結果（全13ページ緑・#911/#912 起票）と #909/#910 第38回デプロイの記録を current.md / daily に同期。文書のみ。

Closes #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)