### PR TITLE
fix(public): / と型アーカイブを catch-all Accept にも HTML で答える（#915）

### DIFF
--- a/src/Http/AcceptPrefersHtml.php
+++ b/src/Http/AcceptPrefersHtml.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Http;
+
+/**
+ * Should a public-site edge layer answer this request with HTML? (#915)
+ *
+ * Yes for an explicit `text/html`, for the catch-all wildcard (what plain curl and
+ * the major SNS unfurlers — Twitterbot, facebookexternalhit, Slackbot,
+ * Discordbot — send), and for a missing Accept header (RFC 7231: no header
+ * means the client accepts anything). Only a client that names another type
+ * without either token (e.g. `Accept: application/json`) keeps the framework's
+ * JSON answer.
+ *
+ * Requiring the literal `text/html` here is what made the site root unfurl as
+ * the NENE2 API index on every SNS while the browser view looked fine.
+ */
+final class AcceptPrefersHtml
+{
+    public static function check(string $acceptHeader): bool
+    {
+        $accept = trim($acceptHeader);
+
+        return $accept === ''
+            || str_contains($accept, 'text/html')
+            || str_contains($accept, '*/*');
+    }
+}

--- a/src/PublicRecord/RenderPublicHomeHandler.php
+++ b/src/PublicRecord/RenderPublicHomeHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\PublicRecord;
 
+use NeNeRecords\Http\AcceptPrefersHtml;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -37,7 +38,10 @@ final readonly class RenderPublicHomeHandler
             return $response;
         }
 
-        if (!str_contains($request->getHeaderLine('Accept'), 'text/html')) {
+        // The catch-all wildcard (plain curl, SNS unfurlers) and a missing header count as wanting
+        // HTML (#915) — only an explicit non-HTML Accept keeps the framework's
+        // JSON index at `/`.
+        if (!AcceptPrefersHtml::check($request->getHeaderLine('Accept'))) {
             return $response;
         }
 

--- a/src/PublicRecord/RenderPublicTypeArchiveHandler.php
+++ b/src/PublicRecord/RenderPublicTypeArchiveHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\PublicRecord;
 
+use NeNeRecords\Http\AcceptPrefersHtml;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -40,7 +41,9 @@ final readonly class RenderPublicTypeArchiveHandler
             return $response;
         }
 
-        if (!str_contains($request->getHeaderLine('Accept'), 'text/html')) {
+        // Same HTML-preference rule as the site root (#915): the catch-all wildcard and a missing
+        // Accept header get the archive page, not the framework's 404 JSON.
+        if (!AcceptPrefersHtml::check($request->getHeaderLine('Accept'))) {
             return $response;
         }
 

--- a/tests/Http/AcceptPrefersHtmlTest.php
+++ b/tests/Http/AcceptPrefersHtmlTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Http;
+
+use NeNeRecords\Http\AcceptPrefersHtml;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class AcceptPrefersHtmlTest extends TestCase
+{
+    #[Test]
+    public function wants_html_for_browser_and_catch_all_and_missing_accept(): void
+    {
+        self::assertTrue(AcceptPrefersHtml::check('text/html,application/xhtml+xml,*/*;q=0.8'));
+        self::assertTrue(AcceptPrefersHtml::check('*/*'));
+        self::assertTrue(AcceptPrefersHtml::check(''));
+        // Real unfurler shapes: catch-all with parameters.
+        self::assertTrue(AcceptPrefersHtml::check('*/*;q=0.9'));
+    }
+
+    #[Test]
+    public function keeps_json_for_an_explicit_non_html_accept(): void
+    {
+        self::assertFalse(AcceptPrefersHtml::check('application/json'));
+        self::assertFalse(AcceptPrefersHtml::check('application/problem+json, application/json'));
+        self::assertFalse(AcceptPrefersHtml::check('text/plain'));
+    }
+}

--- a/tests/Http/SingleOriginKernelTest.php
+++ b/tests/Http/SingleOriginKernelTest.php
@@ -439,6 +439,48 @@ final class SingleOriginKernelTest extends TestCase
         self::assertSame('', $response->getHeaderLine('X-Test-Archive'));
     }
 
+    /** #915: a catch-all Accept (plain curl, SNS unfurlers) must get the front page, not the JSON index. */
+    public function testFrontPageIsServedAtRootForCatchAllAccept(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('GET', 'https://site.test/')
+            ->withHeader('Accept', '*/*');
+
+        $response = $this->kernel($this->appReturning(200), null, $this->frontPage(true))->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('1', $response->getHeaderLine('X-Front-Page'));
+    }
+
+    /** #915: an explicit non-HTML Accept keeps the framework's JSON answer at `/`. */
+    public function testExplicitJsonAcceptAtRootKeepsTheFrameworkAnswer(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('GET', 'https://site.test/')
+            ->withHeader('Accept', 'application/json');
+
+        $response = $this->kernel($this->appReturning(200), null, $this->frontPage(true))->handle($request);
+
+        self::assertSame('', $response->getHeaderLine('X-Front-Page'));
+    }
+
+    /** #915: the type archive answers a catch-all Accept too — it was a 404 problem+json for unfurlers. */
+    public function testTypeArchiveRendersForCatchAllAccept(): void
+    {
+        $archive = $this->typeArchive(
+            [new EntityType(name: 'Posts', slug: 'posts', id: 2)],
+            [new Entity(id: 5, entityTypeId: 2, slug: 'hello', status: EntityStatus::Published)],
+        );
+
+        $response = $this->kernel($this->appReturning(404), null, null, $archive)->handle(
+            $this->factory->createServerRequest('GET', 'https://site.test/posts')
+                ->withHeader('Accept', '*/*'),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('posts', $response->getHeaderLine('X-Test-Archive'));
+    }
+
     /** A permalink resolver that claims every 404 path, tagging the response. */
     private function permalinkResolverTagging(): CustomPermalinkResolver
     {


### PR DESCRIPTION
## 目的

hub の独立検証で発見: `ayane.nene-records.com/` が `Accept: */*`（curl 既定＝Twitterbot / facebookexternalhit / Slackbot / Discordbot が送る形）に **NENE2 の JSON index（og 無し・132B）** を返す ＝ **マーケサイトで最も共有されるトップ URL が SNS で unfurl しない**。型アーカイブ（`/work` 等）も同条件で 404 problem+json。

custom permalink ページ（`/services` 等）は元から `*/*` に HTML を返しており「API-first の一貫した設計」ではなく**この2ゲートだけの不揃い**と判断（実測表は #915）。

## 変更内容

- `AcceptPrefersHtml::check` 新設 — 空 Accept・`text/html`・catch-all wildcard → HTML。明示 `application/json` 等のみ JSON 維持（RFC 7231 の既定に一致）
- `RenderPublicHomeHandler` / `RenderPublicTypeArchiveHandler` のゲートを差し替え
- `SpaShellFallback` は**不変**（任意パス 404 の JSON ergonomics を保持）

## 検証

- 新規テスト: ヘルパ2本＋kernel レベル3本（`*/*` で front page SSR・明示 JSON で従来挙動・`*/*` で型アーカイブ）
- `composer check` 全緑（PHPUnit 1363・PHPStan 8・CS・OpenAPI・conformance・MCP）
- フロント変更なし

## 追従（マージ後）

- デプロイ runbook の gotcha「素の curl は `/` で JSON が正常」の記述更新（marketing リポ側）

Closes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)