### PR TITLE
docs: #915 と第39回デプロイの記録を同期する（#917）

### DIFF
--- a/docs/daily/2026-07-16.md
+++ b/docs/daily/2026-07-16.md
@@ -150,3 +150,14 @@
 4. デプロイ38: バックアップ→dry-run（deletions 0・14ファイル）→build→up。live 検証: apex/aozora/ayane 200・www 301・エラーログ 0・SSR title 両ケース正・**Playwright で hydration 後/遷移後のタブ題名維持を実測**。
 
 → **launch まで records 側の残タスクなし**（contact 開通＝別リポのみ）。#911/#912 は launch 後で可。
+
+---
+
+## 追補3（深夜・店じまい間際）— #915: トップが SNS で unfurl しない（hub 独立検証→即修正・第39回デプロイ）
+
+- **hub の独立 read-only 検証**が発見: `/`（front_page）が `Accept: */*` に **NENE2 の JSON index（og 無し・132B）** を返す。records 追実測で射程を確定: **型アーカイブ（/work 等）も同条件で 404 problem+json**、一方 **custom permalink ページ（/services 等）は元から `*/*` に HTML** ＝「API-first の一貫した設計」ではなく**2ゲートだけの不揃い**。主要 SNS unfurler（Twitterbot/facebookexternalhit/Slackbot/Discordbot・既定 Accept は catch-all）で全滅＝**最も共有されるトップ URL が unfurl しない**。
+- 判断（hub から委任）: **(b) launch 前に是正**。`AcceptPrefersHtml`（空 Accept・text/html・catch-all → HTML。明示 application/json は従来どおり JSON＝RFC 7231 の既定に一致）を新設し、`RenderPublicHomeHandler`/`RenderPublicTypeArchiveHandler` の2ゲートを差し替え。`SpaShellFallback` は不変（任意パス 404 の JSON ergonomics 保持）。
+- #915 / PR #916・kernel テスト3本＋ヘルパ2本・composer check 全緑・**第39回デプロイ**（バックアップ→dry-run deletions 0→build→up）。
+- live 検証: `/` 素 curl → 200 text/html 580KB・og:title あり／明示 JSON → 132B JSON 維持／`/work` `*/*` → 200 HTML／**unfurler UA 4種すべて HTML**／定例（apex/aozora/ayane 200・www 301・エラーログ 0）。
+- 追従済み: デプロイ runbook（marketing リポ）の gotcha「素の curl は `/` で JSON が正常」を #915 後の挙動に更新。メモリ quirk 6 も同期。
+- ★教訓: PHP の docblock/コメントに `*/*` を書くとコメント終端になる（`*/` を含むため）。「catch-all wildcard」と書く。


### PR DESCRIPTION
hub 独立検証で発見された unfurler 問題（トップが Accept: */* に JSON）の是正 #915/PR #916 と第39回デプロイ・live 検証・runbook 追従の記録を daily 追補3 に同期。文書のみ。

Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)