### PR TITLE
feat(public): ページ遷移を View Transitions のクロスフェードにする（#921）

### DIFF
--- a/frontend/src/features/public-browse-entity-records/ui/PublicRecordListView.tsx
+++ b/frontend/src/features/public-browse-entity-records/ui/PublicRecordListView.tsx
@@ -45,7 +45,7 @@ export interface PublicRecordListViewProps {
 
 function TypeBadge({ slug, name }: { slug: string; name: string }) {
   return (
-    <Link className="tbadge" to={`/${slug}`}>
+    <Link viewTransition className="tbadge" to={`/${slug}`}>
       {name.toLowerCase()}
     </Link>
   )
@@ -73,7 +73,7 @@ function GridCard({
 }) {
   return (
     <article className="card">
-      <Link to={item.publicUrl}>
+      <Link viewTransition to={item.publicUrl}>
         <Eyecatch label="eyecatch · 16:10" className="card__media" />
       </Link>
       <div className="card__metarow">
@@ -81,7 +81,9 @@ function GridCard({
         {item.publishedLabel !== '' ? <span className="meta">{item.publishedLabel}</span> : null}
       </div>
       <h3 className="card__title">
-        <Link to={item.publicUrl}>{item.label}</Link>
+        <Link viewTransition to={item.publicUrl}>
+          {item.label}
+        </Link>
       </h3>
     </article>
   )
@@ -98,7 +100,7 @@ function ListRow({
 }) {
   return (
     <article className="row">
-      <Link to={item.publicUrl}>
+      <Link viewTransition to={item.publicUrl}>
         <Eyecatch label="eyecatch · 16:10" className="row__media" />
       </Link>
       <div className="row__body">
@@ -107,7 +109,9 @@ function ListRow({
           {item.publishedLabel !== '' ? <span className="meta">{item.publishedLabel}</span> : null}
         </div>
         <h3 className="row__title">
-          <Link to={item.publicUrl}>{item.label}</Link>
+          <Link viewTransition to={item.publicUrl}>
+            {item.label}
+          </Link>
         </h3>
       </div>
     </article>
@@ -154,7 +158,7 @@ export function PublicRecordListView({
 
   return (
     <div className="pagehead">
-      <Link className="backlink" to="/">
+      <Link viewTransition className="backlink" to="/">
         <IconArrowLeft size={16} /> {t('public.nav.allRecords')}
       </Link>
       <h1 className="pagehead__title">{typeName}</h1>
@@ -164,6 +168,7 @@ export function PublicRecordListView({
         <div className="filterchips">
           {entityTypes.map((type) => (
             <Link
+              viewTransition
               key={type.slug}
               className="chip"
               to={type.href}
@@ -216,7 +221,7 @@ export function PublicRecordListView({
           <p className="empty__text">
             {t('public.browse.unknownType.description', { slug: entityTypeSlug })}
           </p>
-          <Link className="btn btn--ghost" to="/">
+          <Link viewTransition className="btn btn--ghost" to="/">
             {t('public.nav.backToLatest')}
           </Link>
         </div>
@@ -229,7 +234,7 @@ export function PublicRecordListView({
             {t('public.browse.empty.title', { type: typeName.toLowerCase() })}
           </h3>
           <p className="empty__text">{t('public.browse.empty.description')}</p>
-          <Link className="btn btn--ghost" to="/">
+          <Link viewTransition className="btn btn--ghost" to="/">
             {t('public.nav.backToLatest')}
           </Link>
         </div>

--- a/frontend/src/features/public-date-archive/ui/PublicDateArchiveView.tsx
+++ b/frontend/src/features/public-date-archive/ui/PublicDateArchiveView.tsx
@@ -32,7 +32,7 @@ export function PublicDateArchiveView({
 
   return (
     <div className="pagehead">
-      <Link className="backlink" to="/">
+      <Link viewTransition className="backlink" to="/">
         <IconArrowLeft size={16} /> {t('public.nav.allRecords')}
       </Link>
       <h1 className="pagehead__title">{title}</h1>
@@ -52,7 +52,7 @@ export function PublicDateArchiveView({
           </span>
           <h3 className="empty__title">{t('public.dateArchive.invalid.title')}</h3>
           <p className="empty__text">{t('public.dateArchive.invalid.description')}</p>
-          <Link className="btn btn--ghost" to="/">
+          <Link viewTransition className="btn btn--ghost" to="/">
             {t('public.nav.backToLatest')}
           </Link>
         </div>
@@ -73,7 +73,7 @@ export function PublicDateArchiveView({
           </span>
           <h3 className="empty__title">{t('public.dateArchive.empty.title')}</h3>
           <p className="empty__text">{t('public.dateArchive.empty.description')}</p>
-          <Link className="btn btn--ghost" to="/">
+          <Link viewTransition className="btn btn--ghost" to="/">
             {t('public.nav.backToLatest')}
           </Link>
         </div>

--- a/frontend/src/features/public-entity-results/ui/PublicEntityResultGroup.tsx
+++ b/frontend/src/features/public-entity-results/ui/PublicEntityResultGroup.tsx
@@ -36,12 +36,12 @@ export function PublicEntityResultGroup({ entityType, entities }: PublicEntityRe
             <article key={id} className="row row--compact">
               <div className="row__body">
                 <div className="row__metarow">
-                  <Link className="tbadge" to={`/${entityType.slug}`}>
+                  <Link viewTransition className="tbadge" to={`/${entityType.slug}`}>
                     {entityType.name.toLowerCase()}
                   </Link>
                 </div>
                 <h3 className="row__title">
-                  <Link to={url}>
+                  <Link viewTransition to={url}>
                     {getRecordDisplayLabel(
                       id,
                       textFields,

--- a/frontend/src/features/public-home/ui/PublicHomeView.tsx
+++ b/frontend/src/features/public-home/ui/PublicHomeView.tsx
@@ -18,7 +18,7 @@ function Eyecatch({ label, className }: { label: string; className: string }) {
 
 function TypeBadge({ slug, name }: { slug: string; name: string }) {
   return (
-    <Link className="tbadge" to={`/${slug}`}>
+    <Link viewTransition className="tbadge" to={`/${slug}`}>
       {name.toLowerCase()}
     </Link>
   )
@@ -35,11 +35,13 @@ function Featured({ item }: { item: HomeFeedItem }) {
           {item.publishedLabel !== '' ? <span className="meta">{item.publishedLabel}</span> : null}
         </div>
         <h3 className="featured__title">
-          <Link to={item.href}>{item.title}</Link>
+          <Link viewTransition to={item.href}>
+            {item.title}
+          </Link>
         </h3>
         {item.excerpt !== '' ? <p className="featured__excerpt">{item.excerpt}</p> : null}
         <div className="featured__foot">
-          <Link className="section__link" to={item.href}>
+          <Link viewTransition className="section__link" to={item.href}>
             {t('public.home.readArticle')} <IconArrow size={15} />
           </Link>
         </div>
@@ -51,7 +53,7 @@ function Featured({ item }: { item: HomeFeedItem }) {
 function ArticleCard({ item }: { item: HomeFeedItem }) {
   return (
     <article className="card">
-      <Link to={item.href}>
+      <Link viewTransition to={item.href}>
         <Eyecatch label={item.eyecatchLabel} className="card__media" />
       </Link>
       <div className="card__metarow">
@@ -59,7 +61,9 @@ function ArticleCard({ item }: { item: HomeFeedItem }) {
         {item.publishedLabel !== '' ? <span className="meta">{item.publishedLabel}</span> : null}
       </div>
       <h3 className="card__title">
-        <Link to={item.href}>{item.title}</Link>
+        <Link viewTransition to={item.href}>
+          {item.title}
+        </Link>
       </h3>
       {item.excerpt !== '' ? <p className="card__excerpt">{item.excerpt}</p> : null}
     </article>
@@ -75,7 +79,7 @@ function EmptyFeed() {
       </span>
       <h3 className="empty__title">{t('public.home.empty.title')}</h3>
       <p className="empty__text">{t('public.home.empty.description')}</p>
-      <Link className="btn btn--ghost" to="/search">
+      <Link viewTransition className="btn btn--ghost" to="/search">
         {t('public.home.empty.searchCta')}
       </Link>
     </div>
@@ -124,10 +128,10 @@ export function PublicHomeHero({
           </h1>
           {metaDescription !== '' ? <p className="hero__lead">{metaDescription}</p> : null}
           <div className="hero__cta">
-            <Link className="btn btn--primary" to="#latest">
+            <Link viewTransition className="btn btn--primary" to="#latest">
               {t('public.home.hero.ctaLatest')} <IconArrow size={17} />
             </Link>
-            <Link className="btn btn--ghost" to={browseHref}>
+            <Link viewTransition className="btn btn--ghost" to={browseHref}>
               {t('public.home.browseByType')}
             </Link>
           </div>
@@ -191,7 +195,7 @@ export function PublicHomeBody({
             </h2>
           </div>
           {types[0] !== undefined ? (
-            <Link className="section__link" to={types[0].href}>
+            <Link viewTransition className="section__link" to={types[0].href}>
               {t('public.nav.allRecords')} <IconArrowUpRight size={15} />
             </Link>
           ) : null}
@@ -228,7 +232,7 @@ export function PublicHomeBody({
           </div>
           <div className="types">
             {types.map((type) => (
-              <Link key={type.slug} className="typecard" to={type.href}>
+              <Link viewTransition key={type.slug} className="typecard" to={type.href}>
                 <span className="typecard__main">
                   <span className="typecard__name">{type.name}</span>
                   <span className="typecard__slug">/{type.slug}</span>

--- a/frontend/src/features/public-search/ui/PublicSearchView.tsx
+++ b/frontend/src/features/public-search/ui/PublicSearchView.tsx
@@ -37,7 +37,7 @@ export function PublicSearchView({
 
   return (
     <div className="pagehead">
-      <Link className="backlink" to="/">
+      <Link viewTransition className="backlink" to="/">
         <IconArrowLeft size={16} /> {t('public.nav.allRecords')}
       </Link>
       <h1 className="pagehead__title">{t('public.search.title')}</h1>
@@ -85,7 +85,7 @@ export function PublicSearchView({
           </span>
           <h3 className="empty__title">{t('public.search.empty.title', { query })}</h3>
           <p className="empty__text">{t('public.search.empty.description')}</p>
-          <Link className="btn btn--ghost" to="/">
+          <Link viewTransition className="btn btn--ghost" to="/">
             {t('public.nav.backToLatest')}
           </Link>
         </div>

--- a/frontend/src/features/public-tag-archive/ui/PublicTagArchiveView.tsx
+++ b/frontend/src/features/public-tag-archive/ui/PublicTagArchiveView.tsx
@@ -30,7 +30,7 @@ export function PublicTagArchiveView({
 
   return (
     <div className="pagehead">
-      <Link className="backlink" to="/">
+      <Link viewTransition className="backlink" to="/">
         <IconArrowLeft size={16} /> {t('public.nav.allRecords')}
       </Link>
       <h1 className="pagehead__title">#{tagName}</h1>
@@ -60,7 +60,7 @@ export function PublicTagArchiveView({
           </span>
           <h3 className="empty__title">{t('public.tagArchive.empty.title', { tag: tagName })}</h3>
           <p className="empty__text">{t('public.tagArchive.empty.description')}</p>
-          <Link className="btn btn--ghost" to="/">
+          <Link viewTransition className="btn btn--ghost" to="/">
             {t('public.nav.backToLatest')}
           </Link>
         </div>

--- a/frontend/src/features/public-view-entity-record/ui/ChapterNav.tsx
+++ b/frontend/src/features/public-view-entity-record/ui/ChapterNav.tsx
@@ -18,15 +18,15 @@ export function ChapterNav({ nav }: ChapterNavProps) {
   return (
     <nav className="chapter-nav" aria-label={t('public.record.chapterNav.index')}>
       {nav.prevUrl !== null ? (
-        <Link className="btn btn--ghost" rel="prev" to={nav.prevUrl}>
+        <Link viewTransition className="btn btn--ghost" rel="prev" to={nav.prevUrl}>
           ← {t('public.record.chapterNav.prev')}
         </Link>
       ) : null}
-      <Link className="btn btn--ghost" to={nav.indexUrl}>
+      <Link viewTransition className="btn btn--ghost" to={nav.indexUrl}>
         {t('public.record.chapterNav.index')}
       </Link>
       {nav.nextUrl !== null ? (
-        <Link className="btn btn--ghost" rel="next" to={nav.nextUrl}>
+        <Link viewTransition className="btn btn--ghost" rel="next" to={nav.nextUrl}>
           {t('public.record.chapterNav.next')} →
         </Link>
       ) : null}

--- a/frontend/src/features/public-view-entity-record/ui/PublicRelationFieldDisplay.tsx
+++ b/frontend/src/features/public-view-entity-record/ui/PublicRelationFieldDisplay.tsx
@@ -71,6 +71,7 @@ export function PublicRelationFieldDisplay({
         <dd className="flex flex-col gap-stack-xs">
           {targets.map((target) => (
             <Link
+              viewTransition
               key={`${fieldDef.fieldKey}-${String(target.targetEntityId)}`}
               to={target.href}
               className="font-sans text-body text-accent hover:text-accent-hover"

--- a/frontend/src/features/public-view-entity-record/ui/RecordBreadcrumb.tsx
+++ b/frontend/src/features/public-view-entity-record/ui/RecordBreadcrumb.tsx
@@ -23,7 +23,9 @@ export function RecordBreadcrumb({ items }: RecordBreadcrumbProps) {
     <nav className="breadcrumb" aria-label={t('public.record.breadcrumb.label')}>
       <ol className="breadcrumb__list">
         <li className="breadcrumb__item">
-          <Link to="/">{t('public.record.breadcrumb.home')}</Link>
+          <Link viewTransition to="/">
+            {t('public.record.breadcrumb.home')}
+          </Link>
         </li>
         {items.map((crumb, index) => (
           <li className="breadcrumb__item" key={`${crumb.path ?? crumb.label}-${String(index)}`}>
@@ -32,7 +34,9 @@ export function RecordBreadcrumb({ items }: RecordBreadcrumbProps) {
             ) : crumb.path === null ? (
               <span>{crumb.label}</span>
             ) : (
-              <Link to={crumb.path}>{crumb.label}</Link>
+              <Link viewTransition to={crumb.path}>
+                {crumb.label}
+              </Link>
             )}
           </li>
         ))}

--- a/frontend/src/features/public-view-entity-record/ui/RecordChildPages.tsx
+++ b/frontend/src/features/public-view-entity-record/ui/RecordChildPages.tsx
@@ -24,7 +24,9 @@ export function RecordChildPages({ items }: RecordChildPagesProps) {
       <ul className="child-pages__list">
         {items.map((child) => (
           <li className="child-pages__item" key={child.path}>
-            <Link to={child.path}>{child.title}</Link>
+            <Link viewTransition to={child.path}>
+              {child.title}
+            </Link>
           </li>
         ))}
       </ul>

--- a/frontend/src/pages/consumer/PublicBrowsePage.tsx
+++ b/frontend/src/pages/consumer/PublicBrowsePage.tsx
@@ -45,7 +45,8 @@ export function PublicBrowsePage() {
     } else {
       params.set('offset', String(nextOffset))
     }
-    setSearchParams(params)
+    // Cross-fade pagination like every other public navigation (#921).
+    setSearchParams(params, { viewTransition: true })
   }
 
   // A single-segment URL whose slug isn't a known type may be a top-level custom

--- a/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
+++ b/frontend/src/pages/consumer/PublicRecordDetailPage.tsx
@@ -69,7 +69,7 @@ function RecordShellMessage({
   return (
     <PublicSiteShell site={site} activeTypeSlug={entityTypeSlug} withSidebar={false}>
       <div className="pagehead">
-        <Link className="backlink" to="/">
+        <Link viewTransition className="backlink" to="/">
           <IconArrowLeft size={16} /> Home
         </Link>
         <div className="empty">
@@ -80,7 +80,7 @@ function RecordShellMessage({
           ) : null}
           <h3 className="empty__title">{title}</h3>
           <p className="empty__text">{description}</p>
-          <Link className="btn btn--ghost" to="/">
+          <Link viewTransition className="btn btn--ghost" to="/">
             Back to latest
           </Link>
         </div>
@@ -115,14 +115,14 @@ function RelatedRecords({
             More from {entityTypeName}
           </h2>
         </div>
-        <Link className="section__link" to={`/${entityTypeSlug}`}>
+        <Link viewTransition className="section__link" to={`/${entityTypeSlug}`}>
           All {entityTypeName.toLowerCase()} <IconArrowUpRight size={15} />
         </Link>
       </div>
       <div className="cardgrid">
         {related.map((item) => (
           <article key={item.id} className="card">
-            <Link to={item.publicUrl}>
+            <Link viewTransition to={item.publicUrl}>
               <div
                 className="eyecatch card__media"
                 role="img"
@@ -131,7 +131,7 @@ function RelatedRecords({
               />
             </Link>
             <div className="card__metarow">
-              <Link className="tbadge" to={`/${entityTypeSlug}`}>
+              <Link viewTransition className="tbadge" to={`/${entityTypeSlug}`}>
                 {entityTypeName.toLowerCase()}
               </Link>
               {item.publishedLabel !== '' ? (
@@ -139,7 +139,9 @@ function RelatedRecords({
               ) : null}
             </div>
             <h3 className="card__title">
-              <Link to={item.publicUrl}>{item.label}</Link>
+              <Link viewTransition to={item.publicUrl}>
+                {item.label}
+              </Link>
             </h3>
           </article>
         ))}
@@ -376,12 +378,12 @@ function PublicRecordDetailContent({
       >
         <article className="article">
           <RecordBreadcrumb items={hierarchy.breadcrumbs} />
-          <Link className="backlink" to={`/${entityTypeSlug}`}>
+          <Link viewTransition className="backlink" to={`/${entityTypeSlug}`}>
             <IconArrowLeft size={16} /> Back to {entityTypeName}
           </Link>
           <header className="article__head">
             <div className="article__metarow">
-              <Link className="tbadge" to={`/${entityTypeSlug}`}>
+              <Link viewTransition className="tbadge" to={`/${entityTypeSlug}`}>
                 {entityTypeName.toLowerCase()}
               </Link>
             </div>

--- a/frontend/src/pages/consumer/PublicShell.tsx
+++ b/frontend/src/pages/consumer/PublicShell.tsx
@@ -1,6 +1,7 @@
 import { Suspense, useEffect, useMemo } from 'react'
 import './consumer-theme.css'
 import './public-fonts'
+import './view-transition.css'
 import { Outlet, ScrollRestoration } from 'react-router-dom'
 import { ConsentBanner } from '@/features/consent-banner'
 import { usePublicNavigationItems } from '@/entities/navigation-item'

--- a/frontend/src/pages/consumer/PublicSiteShell.tsx
+++ b/frontend/src/pages/consumer/PublicSiteShell.tsx
@@ -73,6 +73,7 @@ function NavLinkItem({ link, onClick }: { link: ShellNavLink; onClick?: () => vo
   }
   return (
     <Link
+      viewTransition
       className="navlink"
       to={link.to}
       aria-current={link.current ? 'page' : undefined}
@@ -171,7 +172,7 @@ function Brand({ siteName, tagline, logo }: { siteName: string; tagline?: string
   // ロゴ未設定時はマーク枠ごと描画しない（サイト名のみ）。テナントのサイトに
   // プラットフォームのブランド（NeneMark）をフォールバック表示しない (#752)。
   return (
-    <Link className="brand" to="/">
+    <Link viewTransition className="brand" to="/">
       {logo !== undefined && logo !== '' ? (
         <span className="brand__mark">
           <img className="brand__logo" src={logo} alt={siteName} />
@@ -443,7 +444,13 @@ export function PublicSiteShell({
           </nav>
           <div className="hd__actions">
             {hasCta(site.headerConfig.cta) ? <HeaderCtaButton cta={site.headerConfig.cta} /> : null}
-            <Link className="iconbtn hd__search" to="/search" aria-label="Search" title="Search">
+            <Link
+              viewTransition
+              className="iconbtn hd__search"
+              to="/search"
+              aria-label="Search"
+              title="Search"
+            >
               <IconSearch size={18} />
             </Link>
             <LanguageSwitch />
@@ -524,7 +531,9 @@ export function PublicSiteShell({
                           {external ? (
                             <a href={href}>{item.label}</a>
                           ) : (
-                            <Link to={item.url}>{item.label}</Link>
+                            <Link viewTransition to={item.url}>
+                              {item.label}
+                            </Link>
                           )}
                         </li>
                       )
@@ -540,11 +549,15 @@ export function PublicSiteShell({
               <FooterColumn title="Content">
                 <ul>
                   <li>
-                    <Link to="/">Latest</Link>
+                    <Link viewTransition to="/">
+                      Latest
+                    </Link>
                   </li>
                   {footerTypeLinks.map((type) => (
                     <li key={type.slug}>
-                      <Link to={type.href}>{type.name}</Link>
+                      <Link viewTransition to={type.href}>
+                        {type.name}
+                      </Link>
                     </li>
                   ))}
                 </ul>
@@ -552,7 +565,7 @@ export function PublicSiteShell({
               <FooterColumn title="Browse">
                 <ul>
                   <li>
-                    <Link to="/search">
+                    <Link viewTransition to="/search">
                       <IconSearch size={14} /> Search
                     </Link>
                   </li>
@@ -590,7 +603,7 @@ export function PublicSiteShell({
                   {legal.label}
                 </a>
               ) : (
-                <Link key={`${legal.label}-${legal.url}`} to={legal.url}>
+                <Link viewTransition key={`${legal.label}-${legal.url}`} to={legal.url}>
                   {legal.label}
                 </Link>
               )

--- a/frontend/src/pages/consumer/use-spa-link-interception.ts
+++ b/frontend/src/pages/consumer/use-spa-link-interception.ts
@@ -43,7 +43,9 @@ export function useSpaLinkInterception(): void {
       }
 
       event.preventDefault()
-      void navigate(to)
+      // viewTransition: the browser cross-fades the old and new page (#921).
+      // Unsupported browsers and prefers-reduced-motion swap instantly as before.
+      void navigate(to, { viewTransition: true })
     }
 
     document.addEventListener('click', onClick)

--- a/frontend/src/pages/consumer/view-transition.css
+++ b/frontend/src/pages/consumer/view-transition.css
@@ -1,0 +1,18 @@
+/**
+ * 公開サイトのページ遷移クロスフェード（#921）。
+ *
+ * 遷移そのものは View Transitions API（react-router の `viewTransition`）が行い、
+ * duration はブラウザ既定の 0.25s のまま（施主指定 2026-07-16）。ここにあるのは
+ * reduced-motion の無効化だけ — アニメを止めれば即時スワップに退化する。
+ *
+ * ::view-transition-* はドキュメントレベルの擬似要素なので `.nene-public` では
+ * スコープできない（route-progress.css と同じ理由で bare ページにも効かせる必要が
+ * ある）。admin 側は viewTransition 付きのナビゲーションを行わないため無影響。
+ */
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## 目的

公開サイトの SPA 遷移（実測 ~50ms・瞬時スワップ）を 0.25s のクロスフェードにし、「パッパッとガチャガチャ切り替わる」印象を消す（施主提案・GO 済み・duration=ブラウザ既定 0.25s 指定）。

## 実装

手組みの unmount 延命ではなく **View Transitions API**（react-router-dom 7.9.6 の `viewTransition` ネイティブサポート）に乗る:

- **bespoke（ayane）**: #885 委譲リスナの `navigate(to, { viewTransition: true })` — 1箇所で bespoke 全遷移をカバー
- **テーマサイト**: 公開側 `<Link>` 51箇所に `viewTransition` prop、browse ページネーション（setSearchParams）にも付与
- `view-transition.css` 新設（PublicShell で常時ロード＝bare ページにも効く）: `prefers-reduced-motion: reduce` で view-transition アニメを停止＝即時スワップに退化。duration 変更なし（既定 0.25s）
- 検索の as-you-type（setSearchParams）は**意図的に対象外**（入力ごとのフェードは煩い）。`<Navigate>` の canonical リダイレクトも対象外（即時が正）
- 非対応ブラウザは従来どおり即時切替。admin 側は viewTransition を呼ばないため不変

## 検証

- `npm run check --prefix frontend` 全緑
- デプロイ後に本番で startViewTransition の発火と視覚挙動を実ブラウザ検証予定（ayane クロスフェード・reduced-motion 退化）

Closes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)