### PR TITLE
fix(deploy): app コンテナに PHP zip 拡張を追加する（#932）

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -7,9 +7,10 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip libicu-dev libsqlite3-dev \
-        libjpeg-dev libpng-dev libwebp-dev libavif-dev libfreetype-dev \
+        libjpeg-dev libpng-dev libwebp-dev libavif-dev libfreetype-dev libzip-dev \
     && docker-php-ext-configure gd --with-jpeg --with-webp --with-avif --with-freetype \
-    && docker-php-ext-install pdo_mysql pdo_sqlite intl gd \
+    # zip: ZipArchive for the org-transfer CLIs (#798/#932) — parity with prod.
+    && docker-php-ext-install pdo_mysql pdo_sqlite intl gd zip \
     && rm -rf /var/lib/apt/lists/* \
     && a2enmod rewrite headers \
     && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n\n# Single-origin: serve the built SPA assets (Vite /assets/*) directly from the\n# frontend build so the PHP-rendered pages can mount the production SPA.\n# Vite copies frontend/public/* to the dist ROOT (not dist/assets), so every\n# public/ passthrough directory the app references needs its own Alias here\n# (theme-thumbnails = built-in theme picker images, #705).\nAlias /assets /var/www/html/frontend/dist/assets\n<Directory /var/www/html/frontend/dist/assets>\n    Require all granted\n</Directory>\nAlias /theme-thumbnails /var/www/html/frontend/dist/theme-thumbnails\n<Directory /var/www/html/frontend/dist/theme-thumbnails>\n    Require all granted\n</Directory>\n' > /etc/apache2/conf-available/nene-records.conf \

--- a/docker/php/Dockerfile.prod
+++ b/docker/php/Dockerfile.prod
@@ -25,9 +25,11 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip libicu-dev libsqlite3-dev \
-        libjpeg-dev libpng-dev libwebp-dev libavif-dev libfreetype-dev \
+        libjpeg-dev libpng-dev libwebp-dev libavif-dev libfreetype-dev libzip-dev \
     && docker-php-ext-configure gd --with-jpeg --with-webp --with-avif --with-freetype \
-    && docker-php-ext-install pdo_mysql pdo_sqlite intl gd opcache \
+    # zip: tools/export-org.php / import-org.php (org transfer archives, #798) need
+    # ZipArchive at runtime — unzip(1) alone does not provide the PHP extension (#932).
+    && docker-php-ext-install pdo_mysql pdo_sqlite intl gd zip opcache \
     && rm -rf /var/lib/apt/lists/* \
     && a2enmod rewrite headers \
     && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n\n# Single-origin: serve the built SPA assets (Vite /assets/*) directly.\n# Vite copies frontend/public/* to the dist ROOT (not dist/assets), so every\n# public/ passthrough directory the app references needs its own Alias here\n# (theme-thumbnails = built-in theme picker images, #705).\nAlias /assets /var/www/html/frontend/dist/assets\n<Directory /var/www/html/frontend/dist/assets>\n    Require all granted\n</Directory>\nAlias /theme-thumbnails /var/www/html/frontend/dist/theme-thumbnails\n<Directory /var/www/html/frontend/dist/theme-thumbnails>\n    Require all granted\n</Directory>\n' > /etc/apache2/conf-available/nene-records.conf \


### PR DESCRIPTION
## 目的

AYANE Tier A 移送のプリステージ（本番 export リハーサル）で、`tools/export-org.php` が **ZipArchive not found** で失敗することを検出。GO 当日に移送経路が止まる欠陥を事前に塞ぐ。

## 変更内容

- `docker/php/Dockerfile{,.prod}`: apt に `libzip-dev`、`docker-php-ext-install` に `zip` を追加（dev/prod parity）

## 検証

- マージ後の第41回デプロイで本番 export リハーサルを再実行し zip 生成まで確認する（プリステージ手順の一部）

Closes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)