### PR TITLE
chore(standards): errors.ts に problem-map exemplar アンカーを植栽する（#935）

### DIFF
--- a/frontend/src/shared/api/errors.ts
+++ b/frontend/src/shared/api/errors.ts
@@ -1,3 +1,4 @@
+// [nene2-exemplar:problem-map] — fleet frontend-standards ER-2 RFC 9457 problem-details error model exemplar (check:exemplars).
 export interface ValidationError {
   field: string
   message: string


### PR DESCRIPTION
## 目的

規約批准の機械判定・前提(b) `check:exemplars` green に必要な [X] アンカー8本のうち、records 持ち分の残1本（`shared/api/errors.ts#nene2-exemplar:problem-map`）を植栽する。指示書 = `_work/handoff-records-exemplar-anchors-2026-07-15-work-order.md`。

## アンカー綴りの根拠（指示書 §2.3 要求）

- **実装を実読**: `nene2-fleet-tooling/packages/nene2-standards/src/checks/exemplars.ts:41-42` — `ANCHOR_PREFIX='nene2-exemplar:'`・`ANCHOR_RE=/^nene2-exemplar:[A-Za-z0-9_-]+$/`。`[X:<repo>/<path>#nene2-exemplar:<name>]` を実ファイル中の `[nene2-exemplar:<name>]` コメント実在と突合する（nene2-standards **1.1.0** に dist 同梱を確認）。
- **植栽済み現物と同綴り**: `frontend/src/shared/i18n/map-problem-details.ts:12` の形式を踏襲。

## 検証

- `git diff origin/main` 全数目視: **追加コメント1行のみ**（ロジック変更ゼロ）
- `npm run check --prefix frontend` green

## 運用

指示書 §5 の定型に従い**マージしない（PR まで）**。レビュー/マージ判断は施主・hub に委ねる。

Closes #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)