### PR TITLE
fix(public): SanitizedHtml で target を許可し noopener/noreferrer を強制する（#939）

### DIFF
--- a/frontend/src/shared/ui/html/SanitizedHtml.test.tsx
+++ b/frontend/src/shared/ui/html/SanitizedHtml.test.tsx
@@ -47,12 +47,30 @@ describe('SanitizedHtml', () => {
     expect(container.querySelector('p')?.textContent).toBe('kept')
   })
 
-  it('strips new-tab target from author links (no reverse-tabnabbing surface)', () => {
+  it('keeps new-tab target and forces noopener/noreferrer onto it (#939 — SSR parity)', () => {
     const { container } = render(
       <SanitizedHtml html={'<a href="https://example.com" target="_blank">x</a>'} />,
     )
     const a = container.querySelector('a')
     expect(a?.getAttribute('href')).toBe('https://example.com')
-    expect(a?.getAttribute('target')).toBeNull()
+    expect(a?.getAttribute('target')).toBe('_blank')
+    const rel = (a?.getAttribute('rel') ?? '').split(/\s+/)
+    expect(rel).toContain('noopener')
+    expect(rel).toContain('noreferrer')
+  })
+
+  it('preserves an existing rel while enforcing the tabnabbing guard', () => {
+    const { container } = render(
+      <SanitizedHtml html={'<a href="https://example.com" target="_blank" rel="me">x</a>'} />,
+    )
+    const rel = (container.querySelector('a')?.getAttribute('rel') ?? '').split(/\s+/)
+    expect(rel).toContain('me')
+    expect(rel).toContain('noopener')
+    expect(rel).toContain('noreferrer')
+  })
+
+  it('leaves targetless links without a forced rel', () => {
+    const { container } = render(<SanitizedHtml html={'<a href="/services">x</a>'} />)
+    expect(container.querySelector('a')?.getAttribute('rel')).toBeNull()
   })
 })

--- a/frontend/src/shared/ui/html/SanitizedHtml.tsx
+++ b/frontend/src/shared/ui/html/SanitizedHtml.tsx
@@ -8,21 +8,35 @@ export interface SanitizedHtmlProps {
 
 /**
  * Explicit policy — do not lean on shifting library defaults. DOMPurify core
- * strips scripts / `on*` handlers / `javascript:` URLs and the `target`
- * attribute; we additionally forbid global `<style>` blocks (the default keeps
- * them) to enforce the documented contract below. Inline `style` attributes
+ * strips scripts / `on*` handlers / `javascript:` URLs; we additionally forbid
+ * global `<style>` blocks (the default keeps them). Inline `style` attributes
  * (scoped CSS) are kept.
+ *
+ * `target` is allowed (#939): the SSR twin (`PublicHtmlSanitizer`, PHP) keeps
+ * it, and stripping it here made hydration silently downgrade new-tab links —
+ * an SSR/SPA parity break (#891 family). The reverse-tabnabbing surface that
+ * justified stripping is closed by the hook below instead, which forces
+ * `rel="noopener noreferrer"` onto every anchor that carries a `target`.
  */
-const SANITIZE_CONFIG = { FORBID_TAGS: ['style'] }
+const SANITIZE_CONFIG = { FORBID_TAGS: ['style'], ADD_ATTR: ['target'] }
+
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A' && node.getAttribute('target') !== null) {
+    const rel = new Set((node.getAttribute('rel') ?? '').split(/\s+/).filter(Boolean))
+    rel.add('noopener')
+    rel.add('noreferrer')
+    node.setAttribute('rel', [...rel].join(' '))
+  }
+})
 
 /**
- * Renders author-supplied HTML after sanitizing it. Safe markup and inline
- * `style` attributes (scoped CSS) are kept, but scripts, event handlers (`on*`),
- * `javascript:` URLs and new-tab `target`s are stripped — so an `html` field can
- * carry rich, styled markup without becoming an XSS vector. Global `<style>`
- * blocks and JS are intentionally not supported here; full custom pages that
- * need those use the sandboxed-iframe path (a separate feature), not this
- * component.
+ * Renders author-supplied HTML after sanitizing it. Safe markup, inline
+ * `style` attributes (scoped CSS) and new-tab `target`s (with `noopener
+ * noreferrer` enforced) are kept, but scripts, event handlers (`on*`) and
+ * `javascript:` URLs are stripped — so an `html` field can carry rich, styled
+ * markup without becoming an XSS vector. Global `<style>` blocks and JS are
+ * intentionally not supported here; full custom pages that need those use the
+ * sandboxed-iframe path (a separate feature), not this component.
  */
 export function SanitizedHtml({ html, className }: SanitizedHtmlProps) {
   const clean = useMemo(() => DOMPurify.sanitize(html, SANITIZE_CONFIG), [html])


### PR DESCRIPTION
## 目的

フッター SNS リンク実装（施主GO）の live 検証で発見: `target=\"_blank\"` が **SSR では保持・ハイドレーションで剥落**する SSR/SPA parity 違反。/contact リンクアウト（hub 指定「新しいタブで」）も同罪になるため launch 前に修正。

## 変更内容

- `ADD_ATTR: ['target']` ＋ DOMPurify `afterSanitizeAttributes` フックで **target 付き `<a>` に noopener/noreferrer を強制**（属性許可とセキュリティガードをセットで交換）
- 旧契約を pin していたテストを新契約に差し替え＋既存 rel 保持・targetless 非干渉の3本

## 検証

- SanitizedHtml tests 9/9・`npm run check` 全緑
- マージ後デプロイで footer SNS リンクの target 保持を本番実測予定

Closes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)