### PR TITLE
docs(daily): AYANE launch 当日の全作業を記録する（#953）

### DIFF
--- a/docs/daily/2026-07-18.md
+++ b/docs/daily/2026-07-18.md
@@ -1,0 +1,57 @@
+# 日報 — 2026-07-18（NeNe Records）
+
+> **ayane.co.jp launch の日**。DNS 切替を捨てて「同一サーバのフォルダ切替」へ前夜ピボットした方式が完勝——伝播ゼロ・SSL 窓ゼロでカットオーバー。未明のコンテンツ確定ラッシュ（✎プレースホルダ 15→0）、通しリハでの発見2件（#949/#952）、お問い合わせの同一ドメイン化→ button＋朱スキンまで、launch 前後の全補正を当日中に closed。施主・hub・contact リナ・ClaudeDesign の4者協調。
+
+## ヘッドライン
+
+- 🚀 **ayane.co.jp LIVE**（18年ぶり刷新・WordPress→NeNe Records Tier A・hub 独立検証と二重で全緑）
+- 📮 お問い合わせが**同一ドメイン・ブランド一体**に（/contact 静的オーバーライド＋embed button＋朱スキン＋ブランドフォント）
+- 🧹 公開前の ✎プレースホルダ **15→0**・PDF 3点 v2 化・favicon 一式・年表の事実整合（NENE2=2026 / NeNe=2018 系譜）
+
+## A. launch 本体（時系列）
+
+1. **前夜ピボット**: DNS 切替→**同一サーバ（HETEML）内フォルダ切替**方式へ（施主決定）。records の実測回答=「ホスト焼き込みは .env `BASE_DOMAIN`＋`system_config.tenant_base_domain` の2箇所のみ・出力系は全てリクエストホスト由来・export 内焼き込み0」→ 切替は2行で済むと確定。
+2. **前半デプロイ**: v0.5.3 zip 転送（sha256一致）→ `~/web/domain/ayane_co_jp/www/` 展開・**install/ を .htaccess で一時封鎖**（公開ホストの wizard 露出対策）・stg noindex（robots 差替方式）・CLI precheck READY（PHP 8.4.23・全拡張）。
+3. **wizard→import**: DB 疎通確認→封鎖解除→wizard 完走（migration 82・再訪404・install/ 削除）→ fresh export（写真3点込み 3.7MB）→ import 82行＋media 7点。
+4. **stg 事象と是正（#952）**: 施主目視で「title / —」スタブ＋ヘッダー押し下げを発見。機序=**import が entity_type をマージせず新規作成＋新規型に既定 defs（title/body）を生成**＋wizard シード残存。外科的是正（余剰 defs 無効化・seed 型3/空メニュー2 削除）＋ **PHP tz=JST による日時 +09:00 直列化**を `.user.ini date.timezone=UTC` で解消。受入=**URL 正規化 diff 6ページ差分ゼロ**（内在差=数値ID/設定並び順/embed_allowlist のみ正規化）。
+5. **カットオーバー**: ホスト切替2行→施主が HETEML パネルで apex+www の公開フォルダ切替→**伝播ゼロで着地**。
+6. **apex 検証**: 全13ページ 200・canonical=ayane.co.jp（リクエストホスト由来の設計どおり自動転換）・WP痕跡0・SSL CN=ayane.co.jp・写真派生 image/*・静的2ページの stg 焼き込み11箇所を sed 是正。
+7. **301 マップ投入**: DB url_redirects=会社系9本＋ .htaccess 接頭辞=旧WP群（product-category/product-tag/product/shop/*/post/category/business→ /shop /blog /services）で40+URL 網羅。**新パス誤爆ゼロを11パスで実証**。
+8. **送信 E2E**: apex 実ブラウザで POST /submissions=201（id:9, 10）。
+9. 旧サイトは `xion.ayane.co.jp` に退避・保全（Basic 認証・noindex・別DB・hub 施工）。SaaS 側 favicon の兄弟テナント漏れも撤去済み。
+
+## B. コンテンツ確定ラッシュ（未明・すべて施主裁定・両DB同時適用）
+
+- **✎ プレースホルダ 15→0**: 法人番号 **1010901023618**（登記12桁から算出→gBizINFO 照合）／特商法4行（旧 /shop/law から移植＋返品特約を新設）／shop 3日付（**閉店7/19・受付終了7/18・対応継続7/31**＝切替と整合する設計）／privacy 制定日 2019-09-23＋改定 2026-07-19＋**05 アクセス解析節を新設**（GA4/GoatCounter 開示・旧ページに無かった欠落の補完）／SLA 確定表示化（制作メモ口調も除去）／検収 **10営業日**・契約不適合 **6か月**（施主GO）。
+- **保険・注記の除去**: 賠償責任保険行（2ページ・掲載しない=施主決定）・「（正社員ではありません）」。
+- **年表の事実整合**: NENE2 は 2026-05 リポ作成（git 実測）→ **/company/ip・/company 両方の「2020〜NENE2」を分割是正**＋ **2018 NeNe 系譜行を追加**（NeNe リポ 2018-06-05 public・原型は大手〜小規模で数十件稼働=施主証言・実名は出さない）。
+- **TRACK B 肉付け（案A・施主GO）**: 2010〜2015 の世界巡回行（ninja*arts・9地域）＋自社ギャラリー **12G.**（12g.jp）＋2018 ジャンプ公式WEB 追記。一次資料=xion アーカイブ /company/history。**BlueRoses は施主指示で取下げ**。
+- 理念行: 「生活に、少しの『楽しい』を。」→「**暮らしに、『楽しい』という彩りを。**」（「彩」=社名の一字）。ねねにゃんのタイトル/副題の役割是正・作品ビジュアル実画像投入（media id8）。ゲーム事業行・3巻編集中の削除。
+- ★運用学: カットオーバー前の二重管理は **permalink JOIN**（import で entity_id 振り直し・/company/ip=SaaS 1147→heteml 11 で実証）＋ SET NAMES＋live 残存 grep の3点セット。
+
+## C. お問い合わせの同一ドメイン化 → embed 再スキン（step1-5）
+
+- 施主「contact.ayane.co.jp に飛ばされるのが気になる。リリース前に」→ 実測で contact の embed 設計（currentScript origin・simple request・**ayane.co.jp を CORS 許可済み**）を発見。
+- 第1形=/inquiry 静的ページ → 施主指示で格上げ=**/contact 自体を静的オーバーライド**（SSR 完全文書から SPA 起動部を除去・実ファイル優先で配信・site 内 `/contact` リンク73本×両DB に rel="external"）。配置ミスで stg /contact が約1分 403（空dir 先行）→即復旧・以後 atomic 配置。stg 送信 E2E→apex E2E とも 201。
+- **embed 再スキン列**（contact/hub 協調): stable alias `/embed/embed.js`＋新スキン→records が**button モード張替**（両ページ・integrity なし）→ appearance patch（朱#D64525・CONTACT キッカー・brand font）→ 検証で **fonts が CORS ブロック**＝CSP でなく「フォントは cross-origin で CORS 必須」が機序（/embed-fonts に ACAO 無しを実測）→ contact 側 ACAO 付与→ **woff2 全7本 200・document.fonts に Zen Kaku/IBM Plex 実ロード**。旧ハッシュ掃除済み（404）。
+- ClaudeDesign 往復: /contact 親要素デザイン（contact-standalone-v2.html・--pv-* 25変数で shadow DOM テーマ）を検収→反映。
+
+## D. 資材（ClaudeDesign 協業・HTML 版下方式の確立）
+
+- **配布 PDF 3点 v2**: 依頼 zip（PDF+抽出テキスト+指示書=確定値一覧）→ 納品は **HTML 版下＋フォント**→ records が Playwright print-to-PDF で A4 化。検収=必須事実あり/禁止残存ゼロの機械チェック＋目視。**インボイス登録番号の断定を検収で捕捉**→施主確認「未登録」→行削除して確定。**同一 URL に in-place 差替**（contact 自動返信のリンク3本を無効化しない）・旧版 .v1bak 温存。
+- **favicon**: ClaudeDesign の favicon-pack（ink 角丸+朱A）→ ico 生成（16/32/48）＋svg/apple-touch を docroot 配置・静的2ページに link 明示。
+- 士業導線の質問→「07-16 に節ごと除去済み・PDF は元々未作成」を記録から即答（復活は launch 後判断）。
+
+## E. 発見・起票・学び
+
+- **#952** org-import の型重複生成＋既定 defs 生成＋シード残存（上流バグ級・#741 実走の副産物）。postfix 手順として「シード残骸の後始末→正規化 diff 受入」を確立。
+- **#949** 派生書き込み失敗が 200/text/html で警告漏れ（リハの副産物）。
+- 検証手法の学び: **SSR curl だけでは hydration 後の欠陥が見えない**（title スタブは実ブラウザでのみ露見）→「curl+実ブラウザの二層」を標準に。LIKE 検証の `%` ワイルドカード誤爆・embed.js は shadow DOM（Playwright ロケータ貫通/querySelector 不可）。
+- 記事ネタ4本を articles リナへ供給（sanitizer 双子事前実測・200で静かに壊れる画像・entity_id 振り直し・hydration 盲点）。
+
+## 数字（実測）
+
+- デプロイ: Tier A 設置1回＋カットオーバー1回（デプロイ回数の系譜としては「第43回相当・方式転換後の初回」）
+- DB 内容変更: 20件超（全てバックアップ `pre_*_20260718` 付き・SaaS/heteml 両系）
+- Issue/PR: #943〜#953・release v0.5.3（#947/#948）・プロフィール README 同期
+- E2E 送信: 3本（stg 1・apex 2＝id:9,10）全て 201


### PR DESCRIPTION
## 目的
ayane.co.jp launch 当日（カットオーバー・コンテンツ確定15件・embed 再スキン・PDF v2 ほか）を daily に一括記録する。

## 変更
- `docs/daily/2026-07-18.md` 新設。

## 検証
- 記録は当日実測の写し（受入 diff・E2E 201×3・#949/#952 起票済み）。docs のみ。

## チェックリスト
- [x] Issue 駆動（#953）
- [x] Conventional Commits

Closes #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)