### PR TITLE
fix(org-export): import でシード残骸を照合し merged 型の defs を移送元に揃える（#952）

### DIFF
--- a/docs/install-tier-a.md
+++ b/docs/install-tier-a.md
@@ -49,6 +49,15 @@ NeNe Records を「zip をアップロードして install ページを開くだ
 5. **後片付け（推奨）**: サーバー上の `public_html/install/` ディレクトリを削除する。
    削除しなくても `var/.installed` マーカーと DB 検査により再実行は 403 で遮断される。
 
+6. **PHP タイムゾーンを UTC に固定する（推奨）**: 共有ホスティングは PHP の
+   `date.timezone` がローカル時（例: HETEML は `Asia/Tokyo`）のことがあり、そのままだと
+   JSON-LD 等の日時が `+09:00` で直列化されて他インスタンス（SaaS は `+00:00`）と実時刻が
+   9 時間ズレる（#952 実測）。`public_html/.user.ini` に 1 行置けば解消する:
+
+   ```ini
+   date.timezone=UTC
+   ```
+
 ## フォントパック（任意）
 
 本体 ZIP は配布サイズを抑えるため（66MB → 約11MB・#709）、フォントを最小セットだけ
@@ -167,7 +176,17 @@ php tools/import-org.php --file=org-export.json --org=<id|slug>
 
 取り込みは 1 トランザクションで走り、失敗時は org 無傷（部分取り込みなし）。設置時に
 シード済みのコンテンツタイプ（posts/pages）・設定定義は **マージ**される（重複しない・
-移送元の値で更新）。取り込み後、公開ページの見た目と URL が移送元と一致することを確認する。
+移送元の値で更新）。シード残骸も自動で照合される（#952）:
+
+- マージされた型の **フィールド定義は移送元の集合に揃う**（移送元に無いシード defs
+  （title/body）は論理削除される。残すと全公開ページに空の「title / —」スタブが出る）。
+- 移送元に無いシード型（posts/pages）は、**どのエンティティ・リレーション定義からも
+  参照されていない場合に限り**削除される（pinned のまま残ると公開 bootstrap に露出するため）。
+
+**取り込み後の検証は SSR の curl だけでは不十分**。SPA hydration 後にだけ出る崩れがある
+（#952 の「title / —」スタブは SSR に出ず curl では不可視だった）ので、実ブラウザで数ページ
+確認するか、移送元・移送先の公開ページを URL 正規化して diff する（AYANE 本走の受入は
+「正規化 diff 6 ページ差分ゼロ」で判定した）。
 
 - **Webhook の secret は移送されない**（移送先で再設定する。`webhooks` / `webhook_deliveries`
   の secret はエクスポートに含めない）。
@@ -177,11 +196,11 @@ php tools/import-org.php --file=org-export.json --org=<id|slug>
   `var/media/` に無いため、export/import 双方が明示エラーで停止する）。バケットを別途複製し、
   JSON export を使うこと。
 
-> **注意（現行の制限）**: ブロック本文や一部設定（`home_hero` / `footer_config` 等）の JSON に
-> 埋め込まれた **media URL・entity 参照は書き換えられない**（`logo_media_id` と
-> `navigation_items.menu_id`・ウィジェットの `menuId` は移送先 id に再マップ済み）。
-> メディアは手順 2 で同じ相対パスに置くため相対 URL は解決するが、絶対 URL を埋め込んでいる
-> 場合はドメインの読み替えが要る。
+> **注意（現行の制限）**: id 参照の再マップは `logo_media_id` / `front_page`（#801）/
+> `navigation_items.menu_id`・ウィジェットの `menuId`、およびブロック本文・`home_hero` に
+> 埋め込まれた media 参照（mediaId＋URL の相対化・#795）まで対応済み。ただし **テキスト系
+> フィールド値（html/markdown 等）の本文中に絶対 URL を直書きしている場合**は書き換えられない
+> ため、ドメインの読み替えが要る（内部リンクを相対 URL で書いていれば解決する）。
 
 ## 既知の制約（v1）
 

--- a/src/OrgExport/PdoOrgImportRepository.php
+++ b/src/OrgExport/PdoOrgImportRepository.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\OrgExport;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
+use NeNeRecords\Organization\DefaultContentTypeSeederInterface;
 
 /**
  * Inserts an exported org payload into the target organization.
@@ -23,6 +24,14 @@ use Nene2\Http\ClockInterface;
  *    navigation_items.menu_id, media.alt_text/width/height/storage_key, …).
  *    The round-trip is exercised by tests/OrgExport/PdoOrgImportRepositoryTest so
  *    a future column addition that is not mirrored here fails CI.
+ *  - Seed residue is reconciled, not left behind (#952, found on the first real
+ *    Tier A transport): source-wins extends to the field-def SET of a merged
+ *    type (active target defs the source does not ship are soft-deleted —
+ *    otherwise the wizard-seeded title/body defs survive the merge and render
+ *    as empty "title / —" stubs on every public page), and a seeded default
+ *    type (SEED_SLUGS) that the source does not ship is removed entirely when
+ *    nothing references it (seeded types are pinned, so they leak into the
+ *    public bootstrap's entityTypes if left in place).
  */
 final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterface
 {
@@ -59,6 +68,10 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
         // ── entity_types (merge on org+slug) ───────────────────────────────
         /** @var array<int, int> $entityTypeMap  old_id → new_id */
         $entityTypeMap = [];
+        /** @var array<int, true> $mergedTypeIds  new_id of types that already existed on the target */
+        $mergedTypeIds = [];
+        /** @var array<string, true> $payloadTypeSlugs */
+        $payloadTypeSlugs = [];
         foreach ((array) ($payload['entity_types'] ?? []) as $row) {
             $oldId = (int) $row['id'];
             $slug  = (string) $row['slug'];
@@ -80,6 +93,7 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
 
             if ($existing !== null) {
                 $newId = (int) $existing['id'];
+                $mergedTypeIds[$newId] = true;
                 $query->execute(
                     'UPDATE entity_types
                         SET name = ?, is_pinned = ?, default_layout = ?, display_order = ?,
@@ -96,13 +110,16 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
                     [$targetOrgId, ...$params, $slug],
                 );
             }
-            $entityTypeMap[$oldId] = $newId;
+            $entityTypeMap[$oldId]   = $newId;
+            $payloadTypeSlugs[$slug] = true;
         }
         $counts['entity_types'] = count($entityTypeMap);
 
         // ── field_defs (merge on org+entity_type+field_key, active) ────────
         /** @var array<int, int> $fieldDefMap  old_id → new_id */
         $fieldDefMap = [];
+        /** @var array<int, list<int>> $keptDefIdsByType  new_type_id → def ids shipped by the source */
+        $keptDefIdsByType = [];
         foreach ((array) ($payload['field_defs'] ?? []) as $row) {
             $oldId           = (int) $row['id'];
             $newEntityTypeId = $entityTypeMap[(int) $row['entity_type_id']] ?? null;
@@ -160,9 +177,13 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
                     ],
                 );
             }
-            $fieldDefMap[$oldId] = $newId;
+            $fieldDefMap[$oldId]                  = $newId;
+            $keptDefIdsByType[$newEntityTypeId][] = $newId;
         }
         $counts['field_defs'] = count($fieldDefMap);
+
+        $counts['field_defs_pruned']    = $this->pruneMergedTypeFieldDefs($query, $targetOrgId, $mergedTypeIds, $keptDefIdsByType);
+        $counts['seeded_types_removed'] = $this->removeUntouchedSeededTypes($query, $targetOrgId, $payloadTypeSlugs);
 
         // ── entities (append; carries permalink/menu_order/layout/flags) ───
         /** @var array<int, int> $entityMap  old_id → new_id */
@@ -754,6 +775,91 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
         $counts['user_profiles_skipped'] = $profileSkipped;
 
         return $counts;
+    }
+
+    /**
+     * Soft-deletes active field_defs on MERGED types that the source did not ship (#952).
+     *
+     * Merge semantics are source-wins; that must extend to the def SET, or the
+     * wizard-seeded title/body defs survive the merge and the SPA renders them as
+     * empty "title / —" stubs above every record. Soft delete (not physical) so a
+     * mistaken import stays recoverable. Types created by this import only carry
+     * source defs, and types the source does not ship at all are left untouched.
+     *
+     * @param  array<int, true>      $mergedTypeIds
+     * @param  array<int, list<int>> $keptDefIdsByType
+     * @return int                   Number of defs soft-deleted.
+     */
+    private function pruneMergedTypeFieldDefs(
+        DatabaseQueryExecutorInterface $query,
+        int $targetOrgId,
+        array $mergedTypeIds,
+        array $keptDefIdsByType,
+    ): int {
+        $pruned = 0;
+        foreach (array_keys($mergedTypeIds) as $typeId) {
+            $keptIds = $keptDefIdsByType[$typeId] ?? [];
+            $sql     = 'UPDATE field_defs SET is_deleted = 1, deleted_at = ?
+                      WHERE organization_id = ? AND entity_type_id = ? AND is_deleted = 0';
+            $params  = [$this->clock->now()->format('Y-m-d H:i:s'), $targetOrgId, $typeId];
+            if ($keptIds !== []) {
+                $sql .= ' AND id NOT IN (' . implode(', ', array_fill(0, count($keptIds), '?')) . ')';
+                $params = [...$params, ...$keptIds];
+            }
+            $pruned += $query->execute($sql, $params);
+        }
+
+        return $pruned;
+    }
+
+    /**
+     * Removes seeded default types the source does not ship (#952).
+     *
+     * A fresh install seeds pinned Posts/Pages types; when the imported org does
+     * not have them, they linger as empty pinned types and leak into the public
+     * bootstrap's entityTypes. Removal is guarded three ways so it can never eat
+     * real data: slug must be one of the seeder's SEED_SLUGS, no entity row
+     * (deleted or not) may reference the type, and no active relation field_def
+     * may target it.
+     *
+     * @param  array<string, true> $payloadTypeSlugs
+     * @return int                 Number of seeded types removed.
+     */
+    private function removeUntouchedSeededTypes(
+        DatabaseQueryExecutorInterface $query,
+        int $targetOrgId,
+        array $payloadTypeSlugs,
+    ): int {
+        $removed = 0;
+        foreach (DefaultContentTypeSeederInterface::SEED_SLUGS as $slug) {
+            if (isset($payloadTypeSlugs[$slug])) {
+                continue;
+            }
+            $type = $query->fetchOne(
+                'SELECT id FROM entity_types WHERE organization_id = ? AND slug = ?',
+                [$targetOrgId, $slug],
+            );
+            if ($type === null) {
+                continue;
+            }
+            $typeId = (int) $type['id'];
+            $inUse  = $query->fetchOne('SELECT id FROM entities WHERE entity_type_id = ? LIMIT 1', [$typeId]);
+            if ($inUse !== null) {
+                continue;
+            }
+            $targeted = $query->fetchOne(
+                'SELECT id FROM field_defs WHERE target_entity_type_id = ? AND is_deleted = 0 LIMIT 1',
+                [$typeId],
+            );
+            if ($targeted !== null) {
+                continue;
+            }
+            $query->execute('DELETE FROM field_defs WHERE organization_id = ? AND entity_type_id = ?', [$targetOrgId, $typeId]);
+            $query->execute('DELETE FROM entity_types WHERE id = ?', [$typeId]);
+            $removed++;
+        }
+
+        return $removed;
     }
 
     /**

--- a/src/Organization/DefaultContentTypeSeederInterface.php
+++ b/src/Organization/DefaultContentTypeSeederInterface.php
@@ -7,6 +7,15 @@ namespace NeNeRecords\Organization;
 interface DefaultContentTypeSeederInterface
 {
     /**
+     * Slugs of the seeded default entity types. Consumers that reconcile
+     * seed residue (org import, #952) key off this list — an entity type is
+     * only ever treated as "seed leftover" when its slug is in here.
+     *
+     * @var list<string>
+     */
+    public const SEED_SLUGS = ['posts', 'pages'];
+
+    /**
      * Seed the default entity types (Posts, Pages) and their field definitions
      * for the given organization.
      *

--- a/tests/OrgExport/PdoOrgImportRepositoryTest.php
+++ b/tests/OrgExport/PdoOrgImportRepositoryTest.php
@@ -122,6 +122,112 @@ final class PdoOrgImportRepositoryTest extends TestCase
         self::assertSame(2, $counts['entity_types']);
     }
 
+    public function testExtendsSourceWinsToTheFieldDefSetOfMergedTypesAndRemovesUntouchedSeeds(): void
+    {
+        // The AYANE Tier A shape (#952): the source org's `pages` type carries a
+        // single bespoke `content` def, while the fresh target was wizard-seeded
+        // with pinned posts/pages + title/body defs.
+        $payload = [
+            'meta'         => ['organization_id' => 42],
+            'entity_types' => [['id' => 10, 'name' => 'Pages', 'slug' => 'pages', 'is_pinned' => 1]],
+            'field_defs'   => [
+                ['id' => 20, 'entity_type_id' => 10, 'field_key' => 'content', 'data_type' => 'html', 'is_deleted' => 0],
+            ],
+            'entities'     => [
+                ['id' => 30, 'entity_type_id' => 10, 'slug' => 'company', 'permalink' => '/company', 'status' => 'published'],
+            ],
+        ];
+
+        $repository = new PdoOrgImportRepository(
+            new PdoDatabaseTransactionManager($this->factory),
+            new FixedClock(),
+        );
+
+        $counts = $repository->import(1, $payload);
+
+        // Merged `pages` ends with exactly the source's def set — the seeded
+        // title/body defs are soft-deleted, not rendered as "title / —" stubs.
+        $activeDefs = $this->executor->fetchAll(
+            "SELECT f.field_key FROM field_defs f
+              JOIN entity_types t ON t.id = f.entity_type_id
+             WHERE t.slug = 'pages' AND f.is_deleted = 0 ORDER BY f.field_key",
+        );
+        self::assertSame(['content'], array_map(static fn ($r) => $r['field_key'], $activeDefs));
+
+        $prunedDefs = $this->executor->fetchAll(
+            "SELECT f.field_key, f.deleted_at FROM field_defs f
+              JOIN entity_types t ON t.id = f.entity_type_id
+             WHERE t.slug = 'pages' AND f.is_deleted = 1 ORDER BY f.field_key",
+        );
+        self::assertSame(['body', 'title'], array_map(static fn ($r) => $r['field_key'], $prunedDefs));
+        self::assertSame('2026-06-01 10:00:00', $prunedDefs[0]['deleted_at']);
+
+        // The seeded `posts` type is not in the payload and nothing references it
+        // → removed entirely (pinned seed types leak into the public bootstrap).
+        $posts = $this->executor->fetchAll("SELECT id FROM entity_types WHERE organization_id = 1 AND slug = 'posts'");
+        self::assertSame([], $posts);
+        $orphanDefs = $this->executor->fetchAll(
+            'SELECT f.id FROM field_defs f LEFT JOIN entity_types t ON t.id = f.entity_type_id
+              WHERE f.organization_id = 1 AND t.id IS NULL',
+        );
+        self::assertSame([], $orphanDefs);
+
+        self::assertSame(2, $counts['field_defs_pruned']);
+        self::assertSame(1, $counts['seeded_types_removed']);
+    }
+
+    public function testKeepsSeededTypesThatAreInUseReferencedOrNotSeedSlugs(): void
+    {
+        // posts holds a (soft-deleted, even) entity; pages is targeted by a live
+        // relation def; events is operator-created (not a seed slug). None of the
+        // three may be swept, and defs of types the source does not ship stay.
+        $posts = $this->executor->fetchOne("SELECT id FROM entity_types WHERE organization_id = 1 AND slug = 'posts'");
+        self::assertNotNull($posts);
+        $this->executor->execute(
+            "INSERT INTO entities (organization_id, entity_type_id, slug, status, is_deleted) VALUES (1, ?, 'old-post', 'draft', 1)",
+            [(int) $posts['id']],
+        );
+        $pages = $this->executor->fetchOne("SELECT id FROM entity_types WHERE organization_id = 1 AND slug = 'pages'");
+        self::assertNotNull($pages);
+        $peopleId = $this->executor->insert(
+            "INSERT INTO entity_types (organization_id, name, slug, is_pinned) VALUES (1, 'People', 'people', 0)",
+        );
+        $this->executor->execute(
+            "INSERT INTO field_defs (organization_id, entity_type_id, field_key, data_type, target_entity_type_id, cardinality)
+             VALUES (1, ?, 'homepage', 'relation', ?, 'one')",
+            [$peopleId, (int) $pages['id']],
+        );
+        $this->executor->execute(
+            "INSERT INTO entity_types (organization_id, name, slug, is_pinned) VALUES (1, 'Events', 'events', 0)",
+        );
+
+        $repository = new PdoOrgImportRepository(
+            new PdoDatabaseTransactionManager($this->factory),
+            new FixedClock(),
+        );
+
+        $counts = $repository->import(1, [
+            'meta'         => ['organization_id' => 42],
+            'entity_types' => [['id' => 11, 'name' => 'Books', 'slug' => 'books', 'is_pinned' => 0]],
+        ]);
+
+        $slugs = $this->executor->fetchAll('SELECT slug FROM entity_types WHERE organization_id = 1 ORDER BY slug');
+        self::assertSame(
+            ['books', 'events', 'pages', 'people', 'posts'],
+            array_map(static fn ($r) => $r['slug'], $slugs),
+        );
+
+        // posts was not merged (source did not ship it) → its seeded defs are untouched.
+        $postsDefs = $this->executor->fetchAll(
+            'SELECT field_key FROM field_defs WHERE entity_type_id = ? AND is_deleted = 0 ORDER BY field_key',
+            [(int) $posts['id']],
+        );
+        self::assertSame(['body', 'title'], array_map(static fn ($r) => $r['field_key'], $postsDefs));
+
+        self::assertSame(0, $counts['field_defs_pruned']);
+        self::assertSame(0, $counts['seeded_types_removed']);
+    }
+
     public function testImportsPhase2TablesWithIdRemap(): void
     {
         $repository = new PdoOrgImportRepository(
@@ -426,19 +532,22 @@ final class PdoOrgImportRepositoryTest extends TestCase
 
     private function seedFreshOrg(int $orgId): void
     {
-        // Mirror the fresh-install seed: posts type + title/body field_defs, and one setting_def.
-        $postsId = $this->executor->insert(
-            "INSERT INTO entity_types (organization_id, name, slug, is_pinned) VALUES (?, 'Posts', 'posts', 1)",
-            [$orgId],
-        );
-        $this->executor->execute(
-            "INSERT INTO field_defs (organization_id, entity_type_id, field_key, data_type) VALUES (?, ?, 'title', 'text')",
-            [$orgId, $postsId],
-        );
-        $this->executor->execute(
-            "INSERT INTO field_defs (organization_id, entity_type_id, field_key, data_type) VALUES (?, ?, 'body', 'markdown')",
-            [$orgId, $postsId],
-        );
+        // Mirror the fresh-install seed: posts + pages types with title/body
+        // field_defs each (DefaultContentTypeSeeder), and one setting_def.
+        foreach ([['Posts', 'posts'], ['Pages', 'pages']] as [$name, $slug]) {
+            $typeId = $this->executor->insert(
+                'INSERT INTO entity_types (organization_id, name, slug, is_pinned) VALUES (?, ?, ?, 1)',
+                [$orgId, $name, $slug],
+            );
+            $this->executor->execute(
+                "INSERT INTO field_defs (organization_id, entity_type_id, field_key, data_type) VALUES (?, ?, 'title', 'text')",
+                [$orgId, $typeId],
+            );
+            $this->executor->execute(
+                "INSERT INTO field_defs (organization_id, entity_type_id, field_key, data_type) VALUES (?, ?, 'body', 'markdown')",
+                [$orgId, $typeId],
+            );
+        }
         $this->executor->execute(
             "INSERT INTO setting_defs (organization_id, setting_key, data_type, default_value, is_public, label, created_at, updated_at)
              VALUES (?, 'site_name', 'text', 'NeNe Records', 1, 'Site name', '2026-01-01 00:00:00', '2026-01-01 00:00:00')",


### PR DESCRIPTION
## 目的

AYANE Tier A 本走（07-18）で実測した #952 の製品側修正。fresh 設置→import で
wizard シードの残骸が公開面に漏れる問題を、import 側の照合で根治する。

## 実測した機序（コードで裏取り済み・issue 記載の推定を一部訂正）

- import は **v0.5.3 時点で既に org+slug マージ実装済み**（`entity_types` は
  UNIQUE (organization_id, slug) なので同一 org 内の型二重化は起こり得ない）。
  stg で見えた「posts/pages 各2重化」の実体は **migration `20260601000000` が
  fresh DB の org 列追加前に seed する org_id=0 番兵行×2 ＋ wizard シードの
  org 行×2**（公開面には出ない・raw DB 検分でのみ見える）。
- 公開面に出た「title / —」スタブの実体は「import が新規型に defs を生やす」
  ではなく、**merge が対象org側にしか無い active defs（シード title/body）を
  温存する**こと（merge は行値のみ source-wins で、defs の集合は照合していなかった）。
- 「無参照 seed 型3」= org0 posts/pages ＋ org1 posts（AYANE 移送元に posts 型が
  無いため merge されず、pinned のまま公開 bootstrap に露出）。

## 変更

1. **merged 型の field_defs を source-wins の集合に揃える**: 移送元が送って
   こない active defs を論理削除（`is_deleted=1`・復旧可能）。import が新規作成
   した型・移送元に無い型は触らない。
2. **無参照シード型の削除**: slug が `SEED_SLUGS`（posts/pages）・移送元 payload に
   無い・エンティティ行（論理削除含む）ゼロ・active な relation def から未参照、の
   全条件を満たす場合のみ物理削除。3重ガードで実データは食えない。
3. `counts` に `field_defs_pruned` / `seeded_types_removed` を追加
   （CLI 出力・superadmin import レスポンスに自動反映。superadmin 経路は
   OpenAPI 契約外のため契約変更なし）。
4. **docs/install-tier-a.md**: シード照合の挙動・`.user.ini` `date.timezone=UTC`
   （共有ホスティングの +09:00 直列化ズレ・#952 実測）・「検証は SSR curl だけでは
   不十分（実ブラウザ or URL 正規化 diff）」を追記。#795/#801 で解消済みの古い
   制限注記も実装に合わせて是正。

## スコープ外（理由つき）

- **org_id=0 番兵行の掃除 migration**: 公開面・org スコープの全 surface に不可視の
  不活性ゴミで、既存本番 DB への delete migration はリスクの割に益が薄い。要るなら別 issue。
- **menus の空重複**: 実測の 4 本は移送元 org 由来の汚れ（wizard は menus を seed しない）。
  import 側では判別不能のため対象外。

## 検証

- 新テスト2本（AYANE 形の merge → defs 集合一致＋スタブ元 defs の論理削除、
  3重ガードの各ケース）＋既存 seed を実インストールと同じ posts+pages 対に強化。
- `composer check` 全緑（PHPUnit 1362 / PHPStan level 8 / CS-Fixer / OpenAPI / MCP）。
- ⚠️ 実 MySQL での CLI e2e は未実施（Docker Desktop がこの環境で起動せず・Windows 側手番）。
  追加 SQL は方言非依存（UPDATE/DELETE/NOT IN/LIMIT 1）で、import テスト群は従来どおり
  実スキーマ SQL を食わせた SQLite で回している。

Closes #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)