### PR TITLE
fix(media): 派生キャッシュ書き込み失敗を未キャッシュ配信＋警告ログに落とす（#949）

### DIFF
--- a/src/Media/LocalStorage.php
+++ b/src/Media/LocalStorage.php
@@ -24,31 +24,46 @@ final readonly class LocalStorage implements StorageInterface
     public function writeFromUpload(string $key, string $tmpPath): void
     {
         $dest = $this->resolve($key);
-        $dir = dirname($dest);
-
-        if (!is_dir($dir) && !mkdir($dir, 0755, true) && !is_dir($dir)) {
-            throw new RuntimeException('Failed to create media directory: ' . $dir);
-        }
+        $this->ensureDirectory(dirname($dest));
 
         // Fall back to copy() in test environments where the source is not an
         // actual HTTP upload and move_uploaded_file() therefore refuses it.
-        if (!move_uploaded_file($tmpPath, $dest) && !copy($tmpPath, $dest)) {
-            throw new RuntimeException('Failed to move uploaded file to: ' . $dest);
+        error_clear_last();
+        if (!@move_uploaded_file($tmpPath, $dest) && !@copy($tmpPath, $dest)) {
+            throw new RuntimeException('Failed to move uploaded file to: ' . $dest . ' (' . self::lastErrorMessage() . ')');
         }
     }
 
     public function write(string $key, string $contents): void
     {
         $dest = $this->resolve($key);
-        $dir = dirname($dest);
+        $this->ensureDirectory(dirname($dest));
 
-        if (!is_dir($dir) && !mkdir($dir, 0755, true) && !is_dir($dir)) {
-            throw new RuntimeException('Failed to create media directory: ' . $dir);
+        error_clear_last();
+        if (@file_put_contents($dest, $contents) === false) {
+            throw new RuntimeException('Failed to write media object: ' . $key . ' (' . self::lastErrorMessage() . ')');
         }
+    }
 
-        if (file_put_contents($dest, $contents) === false) {
-            throw new RuntimeException('Failed to write media object: ' . $key);
+    /**
+     * Failures must surface as the RuntimeException only — a raw PHP warning
+     * (mkdir/file_put_contents on an unwritable var/media) would be echoed into
+     * the response body on display_errors hosts, committing the 200 status
+     * before the handler can answer (#949).
+     */
+    private function ensureDirectory(string $dir): void
+    {
+        error_clear_last();
+        if (!is_dir($dir) && !@mkdir($dir, 0755, true) && !is_dir($dir)) {
+            throw new RuntimeException('Failed to create media directory: ' . $dir . ' (' . self::lastErrorMessage() . ')');
         }
+    }
+
+    private static function lastErrorMessage(): string
+    {
+        $error = error_get_last();
+
+        return $error === null ? 'unknown error' : $error['message'];
     }
 
     public function exists(string $key): bool

--- a/src/Media/MediaServiceProvider.php
+++ b/src/Media/MediaServiceProvider.php
@@ -17,6 +17,7 @@ use NeNeRecords\Http\RuntimeServiceProvider;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Log\LoggerInterface;
 
 final readonly class MediaServiceProvider implements ServiceProviderInterface
 {
@@ -251,6 +252,7 @@ final readonly class MediaServiceProvider implements ServiceProviderInterface
                     $processor = $c->get(ImageProcessorInterface::class);
                     $responseFactory = $c->get(ResponseFactoryInterface::class);
                     $streamFactory = $c->get(StreamFactoryInterface::class);
+                    $logger = $c->get(LoggerInterface::class);
 
                     if (!$storage instanceof StorageInterface) {
                         throw new LogicException('Media storage service is invalid.');
@@ -268,7 +270,11 @@ final readonly class MediaServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Stream factory service is invalid.');
                     }
 
-                    return new ServeDerivativeHandler($storage, $processor, $responseFactory, $streamFactory);
+                    if (!$logger instanceof LoggerInterface) {
+                        throw new LogicException('Logger service is invalid.');
+                    }
+
+                    return new ServeDerivativeHandler($storage, $processor, $responseFactory, $streamFactory, $logger);
                 },
             )
             ->set(

--- a/src/Media/ServeDerivativeHandler.php
+++ b/src/Media/ServeDerivativeHandler.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * On-demand image derivatives: GET /media/{preset}/{year}/{month}/{filename}.
@@ -25,6 +26,7 @@ final readonly class ServeDerivativeHandler
         private ImageProcessorInterface $processor,
         private ResponseFactoryInterface $responseFactory,
         private StreamFactoryInterface $streamFactory,
+        private LoggerInterface $logger,
     ) {
     }
 
@@ -57,6 +59,7 @@ final readonly class ServeDerivativeHandler
 
         $base = pathinfo($filename, PATHINFO_FILENAME);
         $derivativeKey = "derivatives/{$preset}/{$format}/{$year}/{$month}/{$base}.{$ext}";
+        $etag = '"' . md5($derivativeKey) . '"';
 
         if (!$this->storage->exists($derivativeKey)) {
             try {
@@ -66,14 +69,32 @@ final readonly class ServeDerivativeHandler
                     MediaImagePresets::maxWidth($preset),
                     $format,
                 );
-                $this->storage->write($derivativeKey, $derived);
             } catch (\RuntimeException) {
                 // Source could not be decoded/encoded (corrupt or unsupported payload).
                 return $this->responseFactory->createResponse(404);
             }
-        }
 
-        $etag = '"' . md5($derivativeKey) . '"';
+            try {
+                $this->storage->write($derivativeKey, $derived);
+            } catch (\RuntimeException $e) {
+                // Only the CACHE write failed (unwritable var/media — permission or
+                // disk trouble); the derivative itself was generated fine. Serve it
+                // from memory instead of failing the image, and log so the broken
+                // cache directory is visible to operators (#949: this used to leak
+                // a PHP warning into a 200/text/html body and no log at all).
+                $this->logger->warning('media: derivative cache write failed, serving uncached', [
+                    'derivative_key' => $derivativeKey,
+                    'error' => $e->getMessage(),
+                ]);
+
+                return $this->responseFactory->createResponse(200)
+                    ->withHeader('Content-Type', $mime)
+                    ->withHeader('Content-Length', (string) strlen($derived))
+                    ->withHeader('Cache-Control', 'public, max-age=31536000, immutable')
+                    ->withHeader('ETag', $etag)
+                    ->withBody($this->streamFactory->createStream($derived));
+            }
+        }
 
         if (trim($request->getHeaderLine('If-None-Match')) === $etag) {
             return $this->responseFactory->createResponse(304)->withHeader('ETag', $etag);

--- a/tests/Media/LocalStorageTest.php
+++ b/tests/Media/LocalStorageTest.php
@@ -25,6 +25,33 @@ final class LocalStorageTest extends TestCase
         $this->rmdirRecursive($this->root);
     }
 
+    public function testWriteFailureThrowsWithoutEmittingAPhpWarning(): void
+    {
+        // #949: display_errors な共有ホスティングでは、mkdir/file_put_contents の
+        // raw warning が HTTP 本文へ流れて 200/text/html を確定させてしまう。
+        // 失敗は RuntimeException だけで表面化しなければならない。
+        // 平ファイルでディレクトリの場所を塞ぐ — root 実行でも必ず失敗する。
+        file_put_contents($this->root . '/blocked', 'plain file');
+        $storage = new LocalStorage($this->root);
+
+        set_error_handler(static function (int $severity, string $message): bool {
+            if ((error_reporting() & $severity) !== 0) {
+                self::fail('an unsuppressed PHP warning leaked: ' . $message);
+            }
+
+            return true;
+        });
+
+        try {
+            $storage->write('blocked/2026/x.png', 'bytes');
+            self::fail('expected RuntimeException');
+        } catch (RuntimeException $e) {
+            self::assertStringContainsString('Failed to create media directory', $e->getMessage());
+        } finally {
+            restore_error_handler();
+        }
+    }
+
     public function testWriteFromUploadStoresFileUnderKey(): void
     {
         $storage = new LocalStorage($this->root);

--- a/tests/Media/MediaHttpTest.php
+++ b/tests/Media/MediaHttpTest.php
@@ -33,6 +33,8 @@ use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\AbstractLogger;
+use Psr\Log\NullLogger;
 
 final class MediaHttpTest extends TestCase
 {
@@ -93,7 +95,7 @@ final class MediaHttpTest extends TestCase
                 new UpdateMediaAltUseCase($this->repository),
                 $jsonResponse,
             ),
-            new ServeDerivativeHandler($this->storage, new GdImageProcessor(), $this->factory, $this->factory),
+            new ServeDerivativeHandler($this->storage, new GdImageProcessor(), $this->factory, $this->factory, new NullLogger()),
             new ListMediaUsagesHandler(
                 new FindMediaUsagesUseCase($this->repository),
                 $jsonResponse,
@@ -173,7 +175,7 @@ final class MediaHttpTest extends TestCase
             new DeleteMediaHandler(new DeleteMediaUseCase($emptyRepo, $this->storage), $this->factory),
             new ServeMediaHandler($this->storage, $this->factory, $this->factory),
             new UpdateMediaAltHandler(new UpdateMediaAltUseCase($emptyRepo), $jsonResponse),
-            new ServeDerivativeHandler($this->storage, new GdImageProcessor(), $this->factory, $this->factory),
+            new ServeDerivativeHandler($this->storage, new GdImageProcessor(), $this->factory, $this->factory, new NullLogger()),
             new ListMediaUsagesHandler(new FindMediaUsagesUseCase($emptyRepo), $jsonResponse),
         );
 
@@ -427,6 +429,46 @@ final class MediaHttpTest extends TestCase
         self::assertFileExists($this->storageRoot . '/derivatives/sm/png/2026/05/pic.png');
     }
 
+    public function testDerivativeCacheWriteFailureServesUncachedImageAndLogs(): void
+    {
+        // #949: var/media が web ユーザ非書き込みのとき、200 + text/html（mkdir の
+        // PHP Warning 本文）で画像だけ静かに壊れていた。派生自体は生成済みなので、
+        // キャッシュ書き込み失敗は「未キャッシュのまま画像を返す＋warning ログ」に落とす。
+        $this->seedStorageImage('2026/05/pic.png', 800, 400);
+        // derivatives/ の場所を平ファイルで塞ぐ — root 実行でも mkdir が必ず失敗する。
+        file_put_contents($this->storageRoot . '/derivatives', 'not a directory');
+
+        $log = new class () extends AbstractLogger {
+            /** @var list<array{level: string, message: string}> */
+            public array $records = [];
+
+            /** @param array<mixed> $context */
+            public function log($level, \Stringable|string $message, array $context = []): void
+            {
+                $this->records[] = ['level' => (string) (is_scalar($level) ? $level : ''), 'message' => (string) $message];
+            }
+        };
+        $handler = new ServeDerivativeHandler(
+            $this->storage,
+            new GdImageProcessor(),
+            $this->factory,
+            $this->factory,
+            $log,
+        );
+
+        $response = $handler->handle($this->derivativeRequest('sm', 'pic.png'));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('image/png', $response->getHeaderLine('Content-Type'));
+        $info = getimagesizefromstring((string) $response->getBody());
+        self::assertNotFalse($info, 'the body is the resized image itself, not a PHP warning');
+        self::assertSame(320, $info[0], 'sm preset still constrains width to 320');
+        self::assertFileDoesNotExist($this->storageRoot . '/derivatives/sm/png/2026/05/pic.png');
+        self::assertCount(1, $log->records);
+        self::assertSame('warning', $log->records[0]['level']);
+        self::assertStringContainsString('derivative cache write failed', $log->records[0]['message']);
+    }
+
     public function testDerivativeNegotiatesWebpFromAcceptHeader(): void
     {
         $this->seedStorageImage('2026/05/pic.png', 200, 200);
@@ -546,7 +588,7 @@ final class MediaHttpTest extends TestCase
             }
         };
 
-        return new ServeDerivativeHandler($this->storage, $processor, $this->factory, $this->factory);
+        return new ServeDerivativeHandler($this->storage, $processor, $this->factory, $this->factory, new NullLogger());
     }
 
     private function derivativeRequest(string $preset, string $filename, string $query = ''): \Psr\Http\Message\ServerRequestInterface


### PR DESCRIPTION
## 目的

#949（Tier A 通しリハ 07-17 実測）: `var/media` が web ユーザ非書き込みのとき、
派生画像 URL が **HTTP 200・text/html・本文=mkdir の PHP Warning（126B）** になり、
ステータスが 200 なので監視でも拾えない問題の修正。

## 実測した機序（issue 記載の推定を訂正）

「ServeDerivativeHandler が例外にせず素通り」ではない。`LocalStorage::write` の
RuntimeException は catch されて 404 が返る実装だが、**display_errors 環境では
mkdir の raw warning が catch より先に SAPI 出力へ流れ、その時点で 200 +
text/html の headers が確定**する（以後の 404 は無効）。本文 126B = warning 文そのもの。

## 変更

1. **LocalStorage**: `mkdir` / `file_put_contents` / `move_uploaded_file` / `copy` の
   warning を抑止（既存の `@fopen` / `@unlink` と同じ流儀）し、失敗理由
   （`error_get_last`）を例外メッセージに集約。警告がどの display_errors 環境でも
   HTTP 本文へ漏れなくなる＝ステータスコードが常に有効になる根治。
2. **ServeDerivativeHandler**: デコード/エンコード失敗（→404・従来どおり）と
   **キャッシュ書き込み失敗を分離**。後者は派生バイト列を生成済みなので、
   **メモリから未キャッシュのまま 200/image で配信**し、`warning` ログ
   （derivative_key＋理由）を残す。issue 期待の「500 or 原本フォールバック」より
   一段良い縮退（画像は正しいサイズで表示され続け、ログで検知できる）。
3. **MediaServiceProvider**: `LoggerInterface` を注入。

## 検証

- 新テスト2本:
  - 書き込み不能（`derivatives/` の場所を平ファイルで塞ぐ＝root 実行でも再現）で
    **200・image/png・320px 実画像・キャッシュ未生成・warning ログ1件** を pin。
  - `LocalStorage::write` 失敗が **未抑止の PHP warning を1件も漏らさない**ことを
    error handler（`error_reporting()` マスク判定）で pin。
- `composer check` 全緑（PHPUnit 1364 / PHPStan level 8 / CS-Fixer / OpenAPI / MCP）。
- 実 HETEML 再現（`chown root var/media` → GET）は本番環境のため未実施。
  次回 Tier A リハの確認項目として issue に記録する。

Closes #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)