### PR TITLE
ci: backend/frontend の job 名衝突を backend-check / frontend-check に分離する（#960）

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  check:
+  backend-check:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  check:
+  frontend-check:
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## 目的

T0 実測で発見した統治穴の是正: backend-ci.yml / frontend-ci.yml の job 名が
どちらも `check` で、branch protection の required context `check` に畳み込まれて
いた（片方の赤をもう片方の緑が覆い隠しうる）。

## 変更

- backend-ci.yml: job `check` → `backend-check`
- frontend-ci.yml: job `check` → `frontend-check`

## ⚠️ マージ手順（rename 罠の正順・hub 指定）

1. hub が required に `backend-check` / `frontend-check` を追加 PATCH ← **これを待つ**
2. 本 PR merge
3. hub が旧 `check` を required から除去 PATCH

**手順1完了の hub GO が出るまでマージしないこと。**

Closes #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)