### PR TITLE
test(frontend): 公開 SSR seed 系のテスト0を解消する（#964）

### DIFF
--- a/frontend/src/shared/lib/public-record-bootstrap.test.ts
+++ b/frontend/src/shared/lib/public-record-bootstrap.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { readPublicRecordBootstrap } from './public-record-bootstrap'
+
+const SCRIPT_ID = 'nene-records-public-record-bootstrap'
+
+function injectBootstrapScript(content: string): void {
+  const script = document.createElement('script')
+  script.id = SCRIPT_ID
+  script.type = 'application/json'
+  script.textContent = content
+  document.body.appendChild(script)
+}
+
+afterEach(() => {
+  document.getElementById(SCRIPT_ID)?.remove()
+})
+
+describe('readPublicRecordBootstrap', () => {
+  it('returns null when the bootstrap script tag is absent (plain SPA load)', () => {
+    expect(readPublicRecordBootstrap()).toBeNull()
+  })
+
+  it('returns null for an empty or whitespace-only payload', () => {
+    injectBootstrapScript('   \n  ')
+    expect(readPublicRecordBootstrap()).toBeNull()
+  })
+
+  it('returns null for corrupted JSON instead of throwing', () => {
+    injectBootstrapScript('{"entityId": 5,')
+    expect(readPublicRecordBootstrap()).toBeNull()
+  })
+
+  it('parses a valid payload', () => {
+    injectBootstrapScript('{"entityId": 5, "entityTypeSlug": "pages", "canonicalPath": "/company"}')
+    const bootstrap = readPublicRecordBootstrap()
+    expect(bootstrap?.entityId).toBe(5)
+    expect(bootstrap?.entityTypeSlug).toBe('pages')
+    expect(bootstrap?.canonicalPath).toBe('/company')
+  })
+})

--- a/frontend/src/shared/lib/seed-public-record-view-cache.test.ts
+++ b/frontend/src/shared/lib/seed-public-record-view-cache.test.ts
@@ -1,0 +1,156 @@
+import { QueryClient } from '@tanstack/react-query'
+import { describe, expect, it } from 'vitest'
+import type { EntityDto } from '@/entities/entity/api-types'
+import { toEntityId } from '@/entities/entity/ids'
+import { mapEntityDtoToModel } from '@/entities/entity/mapper'
+import { entityKeys } from '@/entities/entity/query-keys'
+import { entityRelationKeys } from '@/entities/entity-relation/query-keys'
+import { entityTypeKeys } from '@/entities/entity-type/query-keys'
+import { boolFieldKeys } from '@/entities/bool-field/query-keys'
+import { dateTimeFieldKeys } from '@/entities/datetime-field/query-keys'
+import { enumFieldKeys } from '@/entities/enum-field/query-keys'
+import { fieldDefKeys } from '@/entities/field-def/query-keys'
+import { intFieldKeys } from '@/entities/int-field/query-keys'
+import { settingKeys } from '@/entities/setting/query-keys'
+import { textFieldKeys } from '@/entities/text-field/query-keys'
+import { publicPermalinkResolveKeys } from '@/shared/lib/public-permalink-resolve'
+import type { PublicRecordBootstrapDto } from '@/shared/lib/public-record-bootstrap'
+import {
+  EMPTY_PUBLIC_RECORD_HIERARCHY,
+  publicRecordHierarchyKeys,
+} from '@/shared/lib/public-record-hierarchy'
+import { seedPublicRecordViewCache } from './seed-public-record-view-cache'
+
+const ENTITY_ID = 11
+const ENTITY_TYPE_ID = 3
+
+const entityDto: EntityDto = {
+  id: ENTITY_ID,
+  entity_type_id: ENTITY_TYPE_ID,
+  slug: 'company',
+  permalink: '/company',
+  layout: 'bare',
+  status: 'published',
+  published_at: '2026-07-01 00:00:00',
+  scheduled_at: null,
+  is_deleted: false,
+  deleted_at: null,
+  meta_title: '会社案内',
+  meta_description: null,
+  created_at: '2026-07-01 00:00:00',
+  updated_at: '2026-07-01 00:00:00',
+}
+
+function emptyList() {
+  return { items: [], limit: 100, offset: 0 }
+}
+
+function bootstrap(overrides: Partial<PublicRecordBootstrapDto> = {}): PublicRecordBootstrapDto {
+  return {
+    entityTypeSlug: 'pages',
+    entityTypeId: ENTITY_TYPE_ID,
+    entityId: ENTITY_ID,
+    entityTypes: emptyList(),
+    entity: entityDto,
+    fieldDefs: { items: [], limit: 20, offset: 0 },
+    textFields: emptyList(),
+    intFields: emptyList(),
+    enumFields: emptyList(),
+    boolFields: emptyList(),
+    dateTimeFields: emptyList(),
+    entityRelations: [
+      { fieldKey: 'related', items: [{ field_key: 'related', target_entity_id: 42 }] },
+    ],
+    relationTextFieldsByEntityTypeId: { '7': emptyList() },
+    ...overrides,
+  }
+}
+
+describe('seedPublicRecordViewCache', () => {
+  it('leaves the cache untouched when there is no bootstrap', () => {
+    const queryClient = new QueryClient()
+    seedPublicRecordViewCache(queryClient, null)
+    expect(queryClient.getQueryCache().getAll()).toHaveLength(0)
+  })
+
+  it('seeds every query the record view reads, under the exact keys (#883)', () => {
+    // #883 の教訓: seed はキーが1文字でもずれると黙って空振りし、SPA が再フェッチ
+    // して Loading を描く。ここでは「どのキーに何が入るか」を完全列挙で固定する。
+    const queryClient = new QueryClient()
+    seedPublicRecordViewCache(queryClient, bootstrap())
+
+    // 型一覧は limit:100（#883 ①: 消費側 {limit:100} と seed {limit:20} の不一致が原因だった）
+    expect(queryClient.getQueryData(entityTypeKeys.list({ limit: 100, offset: 0 }))).toBeDefined()
+    // fieldDefs だけは limit:20
+    expect(
+      queryClient.getQueryData(
+        fieldDefKeys.list({ entityTypeId: ENTITY_TYPE_ID, limit: 20, offset: 0 }),
+      ),
+    ).toBeDefined()
+
+    expect(queryClient.getQueryData(entityKeys.detail(toEntityId(ENTITY_ID)))).toEqual(
+      mapEntityDtoToModel(entityDto),
+    )
+
+    const fieldParams = { entityId: ENTITY_ID, limit: 100, offset: 0 }
+    for (const keys of [
+      textFieldKeys,
+      intFieldKeys,
+      enumFieldKeys,
+      boolFieldKeys,
+      dateTimeFieldKeys,
+    ]) {
+      expect(queryClient.getQueryData(keys.list(fieldParams))).toEqual({
+        items: [],
+        limit: 100,
+        offset: 0,
+      })
+    }
+
+    expect(queryClient.getQueryData(entityRelationKeys.list(ENTITY_ID, 'related'))).toEqual({
+      items: [{ fieldKey: 'related', targetEntityId: 42 }],
+    })
+
+    // relationTextFieldsByEntityTypeId の文字列キーは数値 entityTypeId に変換して seed される
+    expect(
+      queryClient.getQueryData(textFieldKeys.list({ entityTypeId: 7, limit: 100, offset: 0 })),
+    ).toEqual({ items: [], limit: 100, offset: 0 })
+
+    // 総数 = 上で列挙した 11 本（型一覧/entity/hierarchy/fieldDefs/値5種/relation1/relation-text1）
+    expect(queryClient.getQueryCache().getAll()).toHaveLength(11)
+  })
+
+  it('defaults the hierarchy to EMPTY so the view never waits on it', () => {
+    const queryClient = new QueryClient()
+    seedPublicRecordViewCache(queryClient, bootstrap())
+    expect(queryClient.getQueryData(publicRecordHierarchyKeys.detail(ENTITY_ID))).toEqual(
+      EMPTY_PUBLIC_RECORD_HIERARCHY,
+    )
+  })
+
+  it('seeds public settings only when the bootstrap carries them', () => {
+    const bare = new QueryClient()
+    seedPublicRecordViewCache(bare, bootstrap())
+    expect(bare.getQueryData(settingKeys.publicList())).toBeUndefined()
+
+    const withSettings = new QueryClient()
+    seedPublicRecordViewCache(withSettings, bootstrap({ publicSettings: { items: [] } }))
+    expect(withSettings.getQueryData(settingKeys.publicList())).toBeDefined()
+  })
+
+  it('seeds the permalink resolution for the served path (#881) and skips it when absent', () => {
+    // #881 の教訓: これが無いと SPA は自分が既に持っているレコードを /resolve に
+    // 聞き直し、bare ページの上にテーマ chrome の Loading を ~400ms ちらつかせる。
+    const seeded = new QueryClient()
+    seedPublicRecordViewCache(seeded, bootstrap({ canonicalPath: '/company' }))
+    expect(seeded.getQueryData(publicPermalinkResolveKeys.byPath('/company'))).toEqual({
+      found: true,
+      entityId: ENTITY_ID,
+      entityTypeSlug: 'pages',
+    })
+
+    const noPath = new QueryClient()
+    seedPublicRecordViewCache(noPath, bootstrap({ canonicalPath: '' }))
+    expect(noPath.getQueryData(publicPermalinkResolveKeys.byPath(''))).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## 目的

フロントテスト厳格化 T1-lite 第2弾（T0 TOP5 の⑤・hub 発注 2026-07-18）。
公開 SSR→SPA seed 系2ファイル（テスト0だった）にテストを追加する。
**テスト追加のみ**（実装・config・依存は不変）。

## 追加テスト（2ファイル・9 テスト）

- `public-record-bootstrap.test.ts` — SSR bootstrap JSON 読み取りの縮退
  （script 欠落＝素の SPA ロード / 空 / 破損 JSON → null で throw しない）。
- `seed-public-record-view-cache.test.ts` — **seed 先キーの完全列挙（11 本）を pin**。
  #883 の教訓「seed はキーが1文字ずれると黙って空振りし SPA が Loading を描く」に
  正対し、キャッシュ総数まで固定して増減を検知する。あわせて:
  - entityTypes=`limit:100`・fieldDefs=`limit:20` の非対称（#883 ①の現物）
  - `canonicalPath` の permalink resolve seed（#881 の bare ちらつき防止）と空文字 skip
  - hierarchy の `EMPTY` 既定・publicSettings の条件 seed・relation-text の数値キー変換
  - null bootstrap はキャッシュ無変更

## 検証

- `npm run check` 全緑（test 621→628・type-check / lint / format / validate:themes / knip / storybook）。
- 干渉回避: 両ファイルとも ST-2 準拠済み・移設対象外（T0 判定・hub 確認済み）。

Closes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)