### PR TITLE
test(frontend): apiClient と permalink 解決のテスト0を解消する（#966）

### DIFF
--- a/frontend/src/shared/api/client.test.ts
+++ b/frontend/src/shared/api/client.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { authStore } from '@/entities/auth/model'
+import { apiClient, AppError } from './client'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function problemResponse(status: number, title: string): Response {
+  return new Response(
+    JSON.stringify({ type: 'about:blank', title, status, instance: '/api/v1/x' }),
+    { status, headers: { 'Content-Type': 'application/problem+json' } },
+  )
+}
+
+function stubFetch(response: Response): ReturnType<typeof vi.fn> {
+  const spy = vi.fn().mockResolvedValue(response)
+  vi.stubGlobal('fetch', spy)
+  return spy
+}
+
+function lastRequest(spy: ReturnType<typeof vi.fn>): { url: string; init: RequestInit } {
+  const call = spy.mock.calls.at(-1)
+  return { url: call?.[0] as string, init: call?.[1] as RequestInit }
+}
+
+function storeSession(): void {
+  authStore.setSession({
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    email: 'admin@example.test',
+    role: 'admin',
+    emailVerified: true,
+  })
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe('apiClient request shape', () => {
+  it('always sends the CSRF header and the session cookie (credentials: include)', async () => {
+    const spy = stubFetch(jsonResponse({ ok: true }))
+    await apiClient.get('/entities')
+
+    const { url, init } = lastRequest(spy)
+    expect(url).toBe('/entities')
+    expect(init.credentials).toBe('include')
+    expect((init.headers as Record<string, string>)['X-Requested-With']).toBe('fetch')
+  })
+
+  it('sets Content-Type only when a body is sent', async () => {
+    const spy = stubFetch(jsonResponse({ ok: true }))
+    await apiClient.get('/entities')
+    expect(
+      (lastRequest(spy).init.headers as Record<string, string>)['Content-Type'],
+    ).toBeUndefined()
+
+    stubFetch(jsonResponse({ ok: true }, 201))
+    const postSpy = vi.mocked(fetch)
+    await apiClient.post('/entities', { slug: 'a' })
+    const { init } = lastRequest(postSpy as ReturnType<typeof vi.fn>)
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+    expect(init.body).toBe('{"slug":"a"}')
+    expect(init.method).toBe('POST')
+  })
+
+  it('returns undefined for 204 responses', async () => {
+    stubFetch(new Response(null, { status: 204 }))
+    await expect(apiClient.delete('/entities/1')).resolves.toBeUndefined()
+  })
+
+  it('does not set Content-Type on uploads (the browser owns the multipart boundary)', async () => {
+    const spy = stubFetch(jsonResponse({ id: 1 }))
+    await apiClient.upload('/media', new FormData())
+
+    const { init } = lastRequest(spy)
+    const headers = init.headers as Record<string, string>
+    expect(headers['X-Requested-With']).toBe('fetch')
+    expect(headers['Content-Type']).toBeUndefined()
+    expect(init.credentials).toBe('include')
+  })
+})
+
+describe('apiClient error handling', () => {
+  it('throws an AppError built from the problem-details body', async () => {
+    stubFetch(problemResponse(422, 'Validation Failed'))
+    const error = await apiClient.post('/entities', {}).catch((e: unknown) => e)
+
+    expect(error).toBeInstanceOf(AppError)
+    expect((error as AppError).status).toBe(422)
+    expect((error as AppError).title).toBe('Validation Failed')
+  })
+
+  it('clears the stored session on 401 (fail-closed logout)', async () => {
+    storeSession()
+    stubFetch(problemResponse(401, 'Unauthorized'))
+
+    await expect(apiClient.get('/entities')).rejects.toBeInstanceOf(AppError)
+    expect(authStore.getSession()).toBeNull()
+  })
+
+  it('keeps the session on a failed login attempt (401 from /auth/login)', async () => {
+    // ログイン失敗で既存セッションの表示状態まで壊さない（path 除外の仕様を pin）
+    storeSession()
+    stubFetch(problemResponse(401, 'Bad Credentials'))
+
+    await expect(apiClient.post('/auth/login', { email: 'x' })).rejects.toBeInstanceOf(AppError)
+    expect(authStore.getSession()).not.toBeNull()
+  })
+})

--- a/frontend/src/shared/lib/resolve-permalink.test.ts
+++ b/frontend/src/shared/lib/resolve-permalink.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  extractEntityKeyFromSplat,
+  patternUsesSlug,
+  resolvePermalink,
+  type PermalinkContext,
+} from './resolve-permalink'
+
+const ctx: PermalinkContext = {
+  typeSlug: 'posts',
+  entitySlug: 'my-article',
+  entityId: 42,
+  publishedAt: '2026-07-18T09:30:00+00:00',
+}
+
+describe('resolvePermalink', () => {
+  it('falls back to the default pattern /{type}/{id} for null/undefined patterns', () => {
+    expect(resolvePermalink(null, ctx)).toBe('/posts/42')
+    expect(resolvePermalink(undefined, ctx)).toBe('/posts/42')
+  })
+
+  it('expands each built-in preset', () => {
+    expect(resolvePermalink('/{type}/{id}', ctx)).toBe('/posts/42')
+    expect(resolvePermalink('/{type}/{slug}', ctx)).toBe('/posts/my-article')
+    expect(resolvePermalink('/{type}/{year}/{month}/{slug}', ctx)).toBe('/posts/2026/07/my-article')
+    expect(resolvePermalink('/{type}/{year}/{month}/{day}/{slug}', ctx)).toBe(
+      '/posts/2026/07/18/my-article',
+    )
+  })
+
+  it('substitutes the numeric id when the slug is missing', () => {
+    expect(resolvePermalink('/{type}/{slug}', { ...ctx, entitySlug: null })).toBe('/posts/42')
+  })
+
+  it('uses 0000/00/00 placeholders when publishedAt is missing', () => {
+    expect(
+      resolvePermalink('/{type}/{year}/{month}/{day}/{slug}', { ...ctx, publishedAt: null }),
+    ).toBe('/posts/0000/00/00/my-article')
+  })
+
+  it('derives date tokens in UTC, not the browser timezone', () => {
+    // JST 元日 00:30 は UTC ではまだ前年の大晦日 — SSR（サーバ）と URL が割れない
+    // よう、日付トークンは常に UTC で切る。
+    expect(
+      resolvePermalink('/{type}/{year}/{month}/{day}/{slug}', {
+        ...ctx,
+        publishedAt: '2026-01-01T00:30:00+09:00',
+      }),
+    ).toBe('/posts/2025/12/31/my-article')
+  })
+})
+
+describe('extractEntityKeyFromSplat', () => {
+  it('extracts a numeric id for id-only patterns', () => {
+    expect(extractEntityKeyFromSplat('/{type}/{id}', '42')).toEqual({ kind: 'id', id: 42 })
+    expect(extractEntityKeyFromSplat(null, '42')).toEqual({ kind: 'id', id: 42 })
+  })
+
+  it('uses the last path segment as slug for slug patterns', () => {
+    expect(extractEntityKeyFromSplat('/{type}/{slug}', 'my-article')).toEqual({
+      kind: 'slug',
+      slug: 'my-article',
+    })
+    expect(
+      extractEntityKeyFromSplat('/{type}/{year}/{month}/{slug}', '2026/07/my-article'),
+    ).toEqual({ kind: 'slug', slug: 'my-article' })
+  })
+
+  it('ignores a trailing slash when picking the slug segment', () => {
+    expect(extractEntityKeyFromSplat('/{type}/{slug}', 'my-article/')).toEqual({
+      kind: 'slug',
+      slug: 'my-article',
+    })
+  })
+
+  it('falls back to slug lookup when the id segment is not numeric', () => {
+    expect(extractEntityKeyFromSplat('/{type}/{id}', 'not-a-number')).toEqual({
+      kind: 'slug',
+      slug: 'not-a-number',
+    })
+  })
+})
+
+describe('patternUsesSlug', () => {
+  it('reports whether the pattern needs a slug in the URL', () => {
+    expect(patternUsesSlug('/{type}/{slug}')).toBe(true)
+    expect(patternUsesSlug('/{type}/{id}')).toBe(false)
+    // 既定パターンは id ベース
+    expect(patternUsesSlug(null)).toBe(false)
+    expect(patternUsesSlug(undefined)).toBe(false)
+  })
+})


### PR DESCRIPTION
## 目的

フロントテスト厳格化 T1-lite 第3弾（T0 TOP5 の②③・hub 続行 GO）。
**テスト追加のみ**（実装・config・依存は不変）。

## 追加テスト（2ファイル・17 テスト）

- `client.test.ts` — CSRF 防御（`X-Requested-With` 常時付与）・HttpOnly cookie 認証
  （`credentials: 'include'`）・Content-Type は body があるときだけ（upload は
  multipart boundary をブラウザに委ねるため付けない）・204→undefined・
  problem-details→AppError 変換・**401 でセッション破棄（fail-closed）と
  /auth/login だけは破棄しない除外**を pin。
- `resolve-permalink.test.ts` — preset 4種の展開・slug 欠落時の id fallback・
  publishedAt 欠落時の 0000/00/00・**日付トークンの UTC 固定**（ブラウザ TZ に
  引きずられると SSR と URL が割れる）・splat からの id/slug 抽出（非数値は
  slug へ縮退・末尾スラッシュ無視）・patternUsesSlug。

## 検証

- `npm run check` 全緑（test 628→645）。
- 干渉回避: 両ファイルとも hooks/ 外・移設対象外。

Closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)