### PR TITLE
docs(daily): launch 後の製品修正・CI 是正・フロントテスト強化を追補する（#968）

### DIFF
--- a/docs/daily/2026-07-18.md
+++ b/docs/daily/2026-07-18.md
@@ -55,3 +55,35 @@
 - DB 内容変更: 20件超（全てバックアップ `pre_*_20260718` 付き・SaaS/heteml 両系）
 - Issue/PR: #943〜#953・release v0.5.3（#947/#948）・プロフィール README 同期
 - E2E 送信: 3本（stg 1・apex 2＝id:9,10）全て 201
+
+## F. launch 後の同日作業（records リナ・hub 指揮体制）
+
+> 施主が指揮を hub（統合リナ）へ委任。発注→実装→hub レビュー APPROVE→CI 緑→self-merge→3点セット報告のループで、launch で生まれた製品バグ2件＋テスト強化3弾＋CI 統治穴1件を同日中に本流へ。**本番デプロイは未実施**（merge ≠ deploy・hub/施主 seam 維持）。
+
+### 製品修正（launch の副産物2件・いずれも issue 記載の推定機序を実装裏取りで訂正してから根治）
+
+- **#952 → PR #957**: import の org+slug マージは v0.5.3 で実装済み・entity_types は UNIQUE(org,slug)＝「slug 一致でも新規作成」は起こり得ないと確定。stg の「各2重化」の実体= **migration 20260601000000 が fresh DB に残す org_id=0 番兵行×2＋wizard シード org 行×2**。「title / —」スタブの真因= **merge が対象側にしか無い active defs（シード title/body）を温存**すること。修正= merged 型の defs を source-wins の集合に照合（余剰は論理削除）＋無参照シード型を3重ガード付き削除＋counts 可視化。org_id=0 は **#959** に切り出し（急がない）。docs へ tz=UTC・「実ブラウザ or 正規化 diff」検証を追記。
+- **#949 → PR #958**: 「handler が例外を素通し」ではなく、**display_errors 環境で mkdir の raw warning が catch より先に SAPI 出力へ流れて 200/text/html の headers が確定**していた。修正= LocalStorage 書き込み系の warning 抑止（根治）＋キャッシュ書き込み失敗は**生成済み派生をメモリから未キャッシュ配信＋warning ログ**（500 より良い縮退・hub 追認）。監視前提の変化は hub がインフラ台帳へ記載。
+
+### CI 統治穴の是正（#960 → PR #961）
+
+- T0 で発見: backend/frontend の job 名がどちらも `check` で required が1本に畳み込まれ、**片方の赤をもう片方の緑が隠しうる**。`backend-check` / `frontend-check` に分離。手順は rename 罠の正順（hub が required を**置換** PATCH → merge。「追加→除去」だと rename PR 自身が旧 required で BLOCK する裏面も hub が実測で訂正）。以後の PR で2コンテキストが個別に効いているのを実測確認。
+
+### フロントテスト厳格化 T0/T1-lite（hub キャンペーン・テスト追加のみ・実装/config/依存 不変）
+
+- **T0 棚卸し**: 604 テスト・Lines 69.9%（フリート最高）・XSS テスト保有はフリート唯一。テスト0の TOP5 と干渉判定（React Query 層は A1 隣接で除外・SSR seed 系は ST-2 準拠で対象内）を hub へ固定フォーマット報告。#893 の「msw handler の OpenAPI 乖離が本番バグを隠した」教訓は共有ハーネス設計の入力に採用された。
+- **#962 → PR #963（authz 17本）**: role×capability 全マトリクス・**未知ロールは昇格させない**・破損セッション JSON=「セッション無し」・expiresAt 境界。
+- **#964 → PR #965（SSR seed 系 9本）**: **seed 先キー11本の完全列挙＋キャッシュ総数固定**（#883「1文字ずれると黙って空振り」の再発防止・総数固定は hub 裁定で意図的設計として支持）・canonicalPath resolve seed（#881）・破損 bootstrap の null 縮退。
+- **#966 → PR #967（client/permalink 17本）**: CSRF ヘッダ常時付与・401 セッション破棄と /auth/login 除外・204/AppError 経路・permalink preset 展開と**日付トークンの UTC 固定**・splat 抽出の縮退。
+- フロントテスト **604 → 645（+41）**。
+
+### 残・特記
+
+- 実 MySQL での import CLI e2e 未実走（**この WSL から Docker Desktop が起動しない**＝Windows 側・施主手番。hub 裁定リスト登載済み）→ 次回 Tier A リハで実走確認。
+- #949 の実 HETEML 再現（chown で権限故障を作る）も次回リハ項目。
+- T1-lite 残り＝T1 本発注（共有ハーネス設計）待ち。波（W1）の号令が来たらそちら優先。
+
+## 数字（実測・F 節分の追記）
+
+- Issue: #952 #949 #960 #962 #964 #966 クローズ・#959 #968 起票 ／ PR: #957 #958 #961 #963 #965 #967 マージ（全て CI 緑・hub レビュー付き）
+- バックエンドテスト 1362→1364・フロントテスト 604→645・composer check / npm run check 全緑維持


### PR DESCRIPTION
## 目的

launch 当日日報に、同日午後の hub 指揮体制下の作業（F 節）を追補する。

## 内容

- 製品修正2件（#952/#957・#949/#958）— いずれも issue の推定機序を実装裏取りで訂正してから根治した経緯を記録
- CI 統治穴の是正（#960/#961・required 置換の rename 罠正順）
- フロントテスト厳格化 T0/T1-lite 3弾（#962/#963・#964/#965・#966/#967・604→645）
- 残: 実 MySQL e2e（Docker Desktop 起動不可＝施主手番）・次回 Tier A リハ確認2項目

Closes #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)