### PR TITLE
feat(public): 画像なしページに org 既定の og:image フォールバックを追加する（#912）

### DIFF
--- a/database/migrations/20260719000001_add_default_og_image_setting.php
+++ b/database/migrations/20260719000001_add_default_og_image_setting.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * 公開ソーシャルカードの既定画像 `default_og_image`（#912）。
+ *
+ * `image` フィールドを持たないページ（bespoke の 1 html フィールド・トップ・text 主体の
+ * レコード・型アーカイブ）では og:image が出せず、SNS/チャット共有時にカード画像が空になる。
+ * この設定は org スコープの**メディア id**（`logo_media_id` と同形式）で、レコード側で
+ * og 画像を解決できないときのフォールバックになる。空（未設定）なら従来どおり画像なし。
+ * 公開 SSR が {@see \NeNeRecords\PublicRecord\DefaultOgImageResolver} 経由で og 派生に解決する。
+ *
+ * 既定は空文字（フォールバック無効＝現状維持）。べき等（既存はスキップ）。
+ * `setting_defs` は org スコープなので組織ごとに insert。
+ */
+final class AddDefaultOgImageSetting extends AbstractMigration
+{
+    private const SETTING_KEY = 'default_og_image';
+
+    public function up(): void
+    {
+        if (!$this->hasTable('organizations') || !$this->hasTable('setting_defs')) {
+            return;
+        }
+
+        $pdo = $this->getAdapter()->getConnection();
+        $now = date('Y-m-d H:i:s');
+
+        $orgs = $pdo->query('SELECT id FROM organizations ORDER BY id ASC')->fetchAll(PDO::FETCH_COLUMN);
+
+        $check = $pdo->prepare('SELECT id FROM setting_defs WHERE organization_id = ? AND setting_key = ?');
+        $insert = $pdo->prepare(
+            'INSERT INTO setting_defs (organization_id, setting_key, data_type, default_value, is_public, label, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        );
+
+        foreach ($orgs as $orgIdRaw) {
+            $orgId = (int) $orgIdRaw;
+            $check->execute([$orgId, self::SETTING_KEY]);
+            if ($check->fetch() !== false) {
+                continue;
+            }
+            $insert->execute([
+                $orgId,
+                self::SETTING_KEY,
+                'media',
+                '',
+                1,
+                'Default social image (og:image)',
+                $now,
+                $now,
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        $this->execute("DELETE FROM setting_defs WHERE setting_key = 'default_og_image'");
+    }
+}

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -21,6 +21,7 @@ use NeNeRecords\IntField\IntField;
 use NeNeRecords\IntField\IntFieldRepositoryInterface;
 use NeNeRecords\Layout\PublicLayouts;
 use NeNeRecords\Media\MediaDerivativeUrl;
+use NeNeRecords\Setting\ListPublicSettingsOutput;
 use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
 use NeNeRecords\Setting\SettingEntry;
 use NeNeRecords\Setting\SettingHttpMapper;
@@ -211,7 +212,12 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
         // `bare` page (#881). The server already knows the answer; ship it.
         $bootstrap['canonicalPath'] = $canonicalPath;
 
-        $ogImagePath = $this->resolveOgImagePath($displayFields);
+        // Per-record image field first; site-wide `default_og_image` as the fallback
+        // so image-less pages (bespoke/front page/text records) still get a card (#912).
+        // The setting is already resolved to a media URL by ListPublicSettings; run it
+        // through the same 'og' derivative the per-record path uses ('' → no match → null).
+        $ogImagePath = $this->resolveOgImagePath($displayFields)
+            ?? MediaDerivativeUrl::forPreset($this->settingValue($publicSettingsOutput, 'default_og_image'), 'og');
 
         return new GetPublicRecordViewOutput(
             entityTypeSlug: $input->entityTypeSlug,
@@ -233,6 +239,18 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             // the resolver already existed but nothing on the render path called it.
             layout: PublicLayouts::resolve($entity->layout, $entityType->defaultLayout),
         );
+    }
+
+    /** Read a public setting's effective value by key; '' when absent. */
+    private function settingValue(ListPublicSettingsOutput $settings, string $key): string
+    {
+        foreach ($settings->items as $entry) {
+            if ($entry->def->settingKey === $key) {
+                return $entry->effectiveValue;
+            }
+        }
+
+        return '';
     }
 
     /**

--- a/src/PublicRecord/RenderPublicTypeArchiveRenderer.php
+++ b/src/PublicRecord/RenderPublicTypeArchiveRenderer.php
@@ -10,6 +10,7 @@ use NeNeRecords\Http\BasePath;
 use NeNeRecords\Http\PublicHtmlCsp;
 use NeNeRecords\Http\WebAnalyticsConfig;
 use NeNeRecords\Http\WebAnalyticsHeadSnippet;
+use NeNeRecords\Media\MediaDerivativeUrl;
 use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -50,6 +51,14 @@ final readonly class RenderPublicTypeArchiveRenderer implements PublicTypeArchiv
         $baseUrl = $uri->getScheme() . '://' . $uri->getAuthority();
         $archiveUrl = $baseUrl . BasePath::prefix($effectiveBase, '/' . $archive->typeSlug);
 
+        // Archives have no image field of their own, so the social card comes from
+        // the site-wide `default_og_image` setting when set, else stays imageless (#912).
+        // The setting is already a media URL; run it through the 'og' derivative.
+        $ogImagePath = MediaDerivativeUrl::forPreset($settings['default_og_image'] ?? '', 'og');
+        $ogImageUrl = $ogImagePath === null
+            ? null
+            : (str_starts_with($ogImagePath, 'http') ? $ogImagePath : $baseUrl . BasePath::prefix($effectiveBase, $ogImagePath));
+
         $prev = $archive->prevOffset();
         $next = $archive->nextOffset();
 
@@ -81,6 +90,7 @@ final readonly class RenderPublicTypeArchiveRenderer implements PublicTypeArchiv
             'basePath' => $effectiveBase,
             'siteName' => $siteName,
             'metaDescription' => $metaDescription,
+            'ogImageUrl' => $ogImageUrl,
             'analyticsHead' => $analyticsHead,
             // The first page is the archive's canonical address; deeper pages carry
             // their offset so each paged view has its own stable URL.

--- a/src/Setting/PdoDefaultSettingDefsSeeder.php
+++ b/src/Setting/PdoDefaultSettingDefsSeeder.php
@@ -35,6 +35,7 @@ final readonly class PdoDefaultSettingDefsSeeder implements DefaultSettingDefsSe
         ['setting_key' => 'active_theme', 'data_type' => 'text', 'default_value' => 'consumer', 'is_public' => 1, 'label' => 'Public site theme'],
         ['setting_key' => 'theme_overrides', 'data_type' => 'text', 'default_value' => '{}', 'is_public' => 1, 'label' => 'Theme customizations'],
         ['setting_key' => 'logo_media_id', 'data_type' => 'media', 'default_value' => '', 'is_public' => 1, 'label' => 'Logo'],
+        ['setting_key' => 'default_og_image', 'data_type' => 'media', 'default_value' => '', 'is_public' => 1, 'label' => 'Default social image (og:image)'],
         ['setting_key' => 'copyright_text', 'data_type' => 'text', 'default_value' => '© {year} {site}', 'is_public' => 1, 'label' => 'Copyright'],
         ['setting_key' => 'layout_config', 'data_type' => 'text', 'default_value' => '{"home":{"columns":2,"mainPos":"left","swap":false},"record":{"columns":3,"mainPos":"left","swap":false}}', 'is_public' => 1, 'label' => 'Layout'],
         ['setting_key' => 'excerpt_source', 'data_type' => 'text', 'default_value' => 'auto', 'is_public' => 0, 'label' => 'Excerpt source (auto / body / meta)'],

--- a/templates/public/type-archive.php
+++ b/templates/public/type-archive.php
@@ -27,8 +27,14 @@
     <?php endif; ?>
     <meta property="og:site_name" content="<?= $e($siteName) ?>" />
     <meta property="og:url" content="<?= $e($canonicalUrl) ?>" />
-    <meta name="twitter:card" content="summary" />
+    <?php if ($ogImageUrl !== null): ?>
+      <meta property="og:image" content="<?= $e($ogImageUrl) ?>" />
+    <?php endif; ?>
+    <meta name="twitter:card" content="<?= $ogImageUrl !== null ? 'summary_large_image' : 'summary' ?>" />
     <meta name="twitter:title" content="<?= $e($pageTitle) ?>" />
+    <?php if ($ogImageUrl !== null): ?>
+      <meta name="twitter:image" content="<?= $e($ogImageUrl) ?>" />
+    <?php endif; ?>
 
     <style>
       .archive__list { margin: 1rem 0 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 0.75rem; }

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -142,7 +142,20 @@ final class PublicRecordHttpTest extends TestCase
         }
 
         $frontPage = new FrontPageSetting($frontPageSettings, $entities, $entityTypes);
-        $publicSettings = new ListPublicSettingsUseCase(new InMemorySettingRepository($settingDefs), new InMemoryMediaRepository(), $frontPage);
+        // Media id 7 backs the `default_og_image` fallback (#912) in tests that seed
+        // that setting; other tests leave the setting absent, so it never resolves.
+        $mediaRepository = new InMemoryMediaRepository([
+            new \NeNeRecords\Media\Media(
+                id: 7,
+                originalName: 'card.png',
+                storedName: 'card.png',
+                mimeType: 'image/png',
+                size: 1000,
+                url: '/media/2026/06/card.png',
+                createdAt: '2026-06-01 00:00:00',
+            ),
+        ]);
+        $publicSettings = new ListPublicSettingsUseCase(new InMemorySettingRepository($settingDefs), $mediaRepository, $frontPage);
 
         $useCase = new GetPublicRecordViewUseCase(
             $entityTypes,
@@ -320,6 +333,24 @@ final class PublicRecordHttpTest extends TestCase
         self::assertStringContainsString('"datePublished":"2026-01-15T00:00:00+00:00"', $html);
         self::assertStringContainsString('"dateModified":"2026-02-20T00:00:00+00:00"', $html);
         self::assertStringContainsString('"image":"https://example.test/media/og/2026/06/hero.png"', $html);
+    }
+
+    public function testPerRecordImageWinsOverDefaultOgImage(): void
+    {
+        // With `default_og_image` set (media id 7 → card.png), a record that HAS its
+        // own image field must still use that image — the site default is only a
+        // fallback for image-less pages (#912).
+        $app = $this->buildApplication(true, $this->projectRoot, [
+            new SettingDef('site_name', 'text', 'NeNe Records', true, 'Site name'),
+            new SettingDef('default_og_image', 'media', '7', true, 'Default social image (og:image)'),
+        ]);
+
+        $html = (string) $app->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        )->getBody();
+
+        self::assertStringContainsString('property="og:image" content="https://example.test/media/og/2026/06/hero.png"', $html);
+        self::assertStringNotContainsString('/media/og/2026/06/card.png', $html);
     }
 
     public function testViewUrlRedirectsToCanonicalPermalink(): void

--- a/tests/PublicRecord/RenderPublicTypeArchiveRendererTest.php
+++ b/tests/PublicRecord/RenderPublicTypeArchiveRendererTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use Nene2\Config\AppConfig;
+use Nene2\Config\AppEnvironment;
+use Nene2\Config\DatabaseConfig;
+use Nene2\View\HtmlResponseFactory;
+use Nene2\View\NativePhpViewRenderer;
+use NeNeRecords\Media\Media;
+use NeNeRecords\PublicRecord\FrontPageSetting;
+use NeNeRecords\PublicRecord\GetPublicTypeArchiveOutput;
+use NeNeRecords\PublicRecord\RenderPublicTypeArchiveRenderer;
+use NeNeRecords\Setting\ListPublicSettingsUseCase;
+use NeNeRecords\Setting\SettingDef;
+use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
+use NeNeRecords\Tests\EntityType\InMemoryEntityTypeRepository;
+use NeNeRecords\Tests\Media\InMemoryMediaRepository;
+use NeNeRecords\Tests\Setting\InMemorySettingRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A type archive has no image field of its own, so it exercises the
+ * `default_og_image` fallback (#912) directly: og:image appears only when the
+ * setting is configured.
+ */
+final class RenderPublicTypeArchiveRendererTest extends TestCase
+{
+    /** @param list<SettingDef> $settingDefs */
+    private function renderArchive(array $settingDefs): string
+    {
+        $factory = new Psr17Factory();
+        $media = new InMemoryMediaRepository([
+            new Media(
+                id: 7,
+                originalName: 'card.png',
+                storedName: 'card.png',
+                mimeType: 'image/png',
+                size: 1000,
+                url: '/media/2026/06/card.png',
+                createdAt: '2026-06-01 00:00:00',
+            ),
+        ]);
+
+        $frontPage = new FrontPageSetting(
+            new InMemorySettingRepository([new SettingDef('front_page', 'text', '', true, 'Front page')]),
+            new InMemoryEntityRepository(),
+            new InMemoryEntityTypeRepository(),
+        );
+        $publicSettings = new ListPublicSettingsUseCase(
+            new InMemorySettingRepository($settingDefs),
+            $media,
+            $frontPage,
+        );
+
+        $renderer = new NativePhpViewRenderer(dirname(__DIR__, 2) . '/templates');
+        $html = new HtmlResponseFactory($factory, $factory, $renderer);
+        $config = new AppConfig(
+            environment: AppEnvironment::Test,
+            debug: true,
+            name: 'NeNe Records',
+            database: new DatabaseConfig(
+                url: null,
+                environment: 'test',
+                adapter: 'sqlite',
+                host: '',
+                port: 1,
+                name: ':memory:',
+                user: '',
+                password: '',
+                charset: '',
+            ),
+            machineApiKey: null,
+        );
+
+        $archiveRenderer = new RenderPublicTypeArchiveRenderer(
+            $publicSettings,
+            $html,
+            $config,
+            dirname(__DIR__, 2),
+        );
+
+        $archive = new GetPublicTypeArchiveOutput('article', 'Articles', [], 0, 0, 20);
+        $request = $factory->createServerRequest('GET', 'https://example.test/article');
+
+        return (string) $archiveRenderer->render($archive, $request)->getBody();
+    }
+
+    public function testEmitsDefaultOgImageWhenSet(): void
+    {
+        $html = $this->renderArchive([
+            new SettingDef('site_name', 'text', 'NeNe Records', true, 'Site name'),
+            new SettingDef('default_og_image', 'media', '7', true, 'Default social image (og:image)'),
+        ]);
+
+        self::assertStringContainsString('property="og:image" content="https://example.test/media/og/2026/06/card.png"', $html);
+        self::assertStringContainsString('name="twitter:image" content="https://example.test/media/og/2026/06/card.png"', $html);
+        self::assertStringContainsString('name="twitter:card" content="summary_large_image"', $html);
+    }
+
+    public function testOmitsOgImageWhenUnset(): void
+    {
+        $html = $this->renderArchive([
+            new SettingDef('site_name', 'text', 'NeNe Records', true, 'Site name'),
+        ]);
+
+        self::assertStringNotContainsString('property="og:image"', $html);
+        self::assertStringContainsString('name="twitter:card" content="summary"', $html);
+    }
+}


### PR DESCRIPTION
## 目的

`image` フィールドを持たないページ（bespoke の 1 html フィールド・トップ固定ページ・text 主体レコード・型アーカイブ）で `og:image` が出ず、SNS/チャット共有時にカード画像が空だった（#912・AYANE launch 前倒し監査で本番実測）。会社サイト（AYANE）の一次共有品質に直結するため、org 既定のソーシャルカード画像を導入する。

## 変更

- **設定新設** `default_og_image`（`data_type=media`・public・`logo_media_id` と同形式でメディア id を保持）
  - `PdoDefaultSettingDefsSeeder` に追加（新規 install 用）
  - 既存 org 向け seed migration `20260719000001_add_default_og_image_setting`（べき等・既定は空＝現状維持）
- **フォールバック配線**（per-record 画像を優先し、無ければ既定へ）
  - `GetPublicRecordViewUseCase`（トップ・固定・記事詳細）
  - `RenderPublicTypeArchiveRenderer` + `templates/public/type-archive.php`（型アーカイブ）— `og:image` / `twitter:image` / `summary_large_image` を record-detail と揃える
  - 設定は `ListPublicSettings` が既にメディア URL へ解決するので、per-record と同じ `MediaDerivativeUrl::forPreset(url, 'og')` に通して同寸（1200px）カードを出す
- 管理 UI は public 設定 def を自動列挙し `media` 型 picker を持つため**フロント改修不要**

## 検証

- `composer test` … 1367 tests OK（precedence 単体＋アーカイブ統合テスト追加）
- `composer analyse`（PHPStan L8）… No errors
- `composer cs` … clean
- `composer openapi` … valid（エンドポイント未変更）
- `npm run type-check --prefix frontend` … clean（フロント未変更）
- ⚠️ **実 MySQL での migration 適用は環境都合（docker 未起動）で未実施** → deploy 時に VPS + AYANE(HETEML) 側で `migrations:migrate` 実行が必要

## デプロイ後の手番（施主/運用）

1. 本番 org (AYANE) の管理 → 設定 → 「Default social image (og:image)」に OGP 画像（クリーム地 `ogp-default.png`・`_work/assets/ayane/ogp/` に保全）をメディア登録してセット
2. 社名検索・URL 共有時のカード表示を実機確認（X/Slack のカードバリデータ）

Closes #912