### PR TITLE
feat(public): 公開ページの Organization JSON-LD を強化する（#978）

### DIFF
--- a/src/PublicRecord/PublicOrganizationSchema.php
+++ b/src/PublicRecord/PublicOrganizationSchema.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+/**
+ * Builds the schema.org `Organization` node for public pages (#978) from the org's
+ * existing public settings — the single signal Google's company knowledge panel reads.
+ *
+ * Reuses settings the admin already fills elsewhere (no new knobs):
+ *  - name         ← `site_name`
+ *  - url          ← the site home (passed in, base-path aware)
+ *  - logo         ← `logo_media_id` (absolutized by the caller; omitted when unset)
+ *  - sameAs       ← `footer_config.social[].url` (the footer's canonical SNS links)
+ *  - contactPoint ← `header_config.topbar.email` / `.phone` (omitted when both blank)
+ *
+ * Unset fields are dropped so a site that configured nothing keeps a bare
+ * `{@type, name, url}` — identical in spirit to the previous name-only publisher.
+ * Follows the {@see \NeNeRecords\Http\WebAnalyticsConfig}::fromSettings() convention.
+ */
+final class PublicOrganizationSchema
+{
+    /**
+     * @param array<string, string> $settings resolved public settings map
+     * @return array<string, mixed> a schema.org Organization node (no @context)
+     */
+    public static function build(string $siteName, string $homeUrl, ?string $logoUrl, array $settings): array
+    {
+        $org = [
+            '@type' => 'Organization',
+            'name' => $siteName,
+            'url' => $homeUrl,
+        ];
+
+        if ($logoUrl !== null && $logoUrl !== '') {
+            $org['logo'] = $logoUrl;
+        }
+
+        $sameAs = self::socialUrls($settings['footer_config'] ?? '');
+        if ($sameAs !== []) {
+            $org['sameAs'] = $sameAs;
+        }
+
+        $contactPoint = self::contactPoint($settings['header_config'] ?? '');
+        if ($contactPoint !== null) {
+            $org['contactPoint'] = $contactPoint;
+        }
+
+        return $org;
+    }
+
+    /**
+     * Distinct, non-empty SNS profile URLs from `footer_config.social`.
+     *
+     * @return list<string>
+     */
+    private static function socialUrls(string $footerConfigJson): array
+    {
+        if ($footerConfigJson === '') {
+            return [];
+        }
+
+        /** @var mixed $decoded */
+        $decoded = json_decode($footerConfigJson, true);
+        if (!is_array($decoded) || !isset($decoded['social']) || !is_array($decoded['social'])) {
+            return [];
+        }
+
+        $urls = [];
+        foreach ($decoded['social'] as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+            $url = $item['url'] ?? null;
+            if (is_string($url) && $url !== '' && !in_array($url, $urls, true)) {
+                $urls[] = $url;
+            }
+        }
+
+        return $urls;
+    }
+
+    /**
+     * A schema.org ContactPoint from `header_config.topbar` email/phone, or null when
+     * neither is set (schema.org requires at least one contact method).
+     *
+     * @return array<string, string>|null
+     */
+    private static function contactPoint(string $headerConfigJson): ?array
+    {
+        if ($headerConfigJson === '') {
+            return null;
+        }
+
+        /** @var mixed $decoded */
+        $decoded = json_decode($headerConfigJson, true);
+        if (!is_array($decoded) || !isset($decoded['topbar']) || !is_array($decoded['topbar'])) {
+            return null;
+        }
+        $topbar = $decoded['topbar'];
+
+        $email = is_string($topbar['email'] ?? null) ? trim($topbar['email']) : '';
+        $phone = is_string($topbar['phone'] ?? null) ? trim($topbar['phone']) : '';
+        if ($email === '' && $phone === '') {
+            return null;
+        }
+
+        $contactPoint = ['@type' => 'ContactPoint', 'contactType' => 'sales'];
+        if ($email !== '') {
+            $contactPoint['email'] = $email;
+        }
+        if ($phone !== '') {
+            $contactPoint['telephone'] = $phone;
+        }
+
+        return $contactPoint;
+    }
+}

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -163,6 +163,16 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
                 : $baseUrl . BasePath::prefix($effectiveBase, $output->ogImagePath);
         }
 
+        // Organization JSON-LD (#978): the company signal Google's knowledge panel reads.
+        // logo_media_id is resolved to a (base-relative) media URL by ListPublicSettings;
+        // absolutize it like the og:image so structured data carries an absolute URL.
+        $logoValue = $settings['logo_media_id'] ?? '';
+        $logoUrl = $logoValue === ''
+            ? null
+            : (str_starts_with($logoValue, 'http') ? $logoValue : $baseUrl . BasePath::prefix($effectiveBase, $logoValue));
+        $homeUrl = $baseUrl . BasePath::prefix($effectiveBase, '/');
+        $organizationLd = PublicOrganizationSchema::build($siteName, $homeUrl, $logoUrl, $settings);
+
         // Prefer the per-entity meta description, falling back to the site default.
         $metaDescription = $output->metaDescription !== ''
             ? $output->metaDescription
@@ -228,6 +238,7 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
             'basePath' => $effectiveBase,
             'canonicalUrl' => $canonicalUrl,
             'ogImageUrl' => $ogImageUrl,
+            'organizationLd' => $organizationLd,
             'publishedAtIso' => $output->publishedAtIso,
             'updatedAtIso' => $output->updatedAtIso,
             'bootstrapJson' => $bootstrapJson,

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -47,7 +47,7 @@
           'headline' => $pageTitle,
           'url' => $canonicalUrl,
           'mainEntityOfPage' => $canonicalUrl,
-          'publisher' => ['@type' => 'Organization', 'name' => $siteName],
+          'publisher' => $organizationLd,
       ];
 if ($metaDescription !== '') {
     $jsonLd['description'] = $metaDescription;
@@ -63,6 +63,13 @@ if ($ogImageUrl !== null) {
 }
 ?>
     <script type="application/ld+json"><?= json_encode($jsonLd, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?></script>
+    <?php /* Standalone Organization on the front page — Google's company knowledge-panel
+             signal (logo/sameAs/contactPoint from settings); article pages carry it as
+             the publisher above instead (#978). */ ?>
+    <?php if ($ogType === 'website'): ?>
+    <?php $organizationStandalone = array_merge(['@context' => 'https://schema.org'], $organizationLd); ?>
+    <script type="application/ld+json"><?= json_encode($organizationStandalone, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?></script>
+    <?php endif; ?>
     <?php /* BreadcrumbList JSON-LD (#651 PR2): the path-hierarchy signal Google actually ranks on. */ ?>
     <?php if ($breadcrumbs !== []): ?>
     <?php

--- a/tests/PublicRecord/PublicOrganizationSchemaTest.php
+++ b/tests/PublicRecord/PublicOrganizationSchemaTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use NeNeRecords\PublicRecord\PublicOrganizationSchema;
+use PHPUnit\Framework\TestCase;
+
+final class PublicOrganizationSchemaTest extends TestCase
+{
+    public function testMinimalWhenNoOptionalSettings(): void
+    {
+        $org = PublicOrganizationSchema::build('彩音インターナショナル株式会社', 'https://ayane.co.jp/', null, []);
+
+        self::assertSame([
+            '@type' => 'Organization',
+            'name' => '彩音インターナショナル株式会社',
+            'url' => 'https://ayane.co.jp/',
+        ], $org);
+    }
+
+    public function testLogoAddedWhenProvided(): void
+    {
+        $org = PublicOrganizationSchema::build('Acme', 'https://acme.test/', 'https://acme.test/media/2026/07/logo.png', []);
+
+        self::assertSame('https://acme.test/media/2026/07/logo.png', $org['logo']);
+    }
+
+    public function testSameAsFromFooterSocialLinks(): void
+    {
+        $settings = ['footer_config' => json_encode([
+            'social' => [
+                ['platform' => 'x', 'url' => 'https://twitter.com/ayane_inc'],
+                ['platform' => 'facebook', 'url' => 'https://www.facebook.com/AyaneInternational'],
+            ],
+        ], JSON_THROW_ON_ERROR)];
+
+        $org = PublicOrganizationSchema::build('Acme', 'https://acme.test/', null, $settings);
+
+        self::assertSame([
+            'https://twitter.com/ayane_inc',
+            'https://www.facebook.com/AyaneInternational',
+        ], $org['sameAs']);
+    }
+
+    public function testSameAsDedupesAndSkipsBlankUrls(): void
+    {
+        $settings = ['footer_config' => json_encode([
+            'social' => [
+                ['platform' => 'x', 'url' => 'https://x.test/a'],
+                ['platform' => 'y', 'url' => ''],
+                ['platform' => 'z', 'url' => 'https://x.test/a'],
+            ],
+        ], JSON_THROW_ON_ERROR)];
+
+        $org = PublicOrganizationSchema::build('Acme', 'https://acme.test/', null, $settings);
+
+        self::assertSame(['https://x.test/a'], $org['sameAs']);
+    }
+
+    public function testNoSameAsKeyWhenNoSocialLinks(): void
+    {
+        $settings = ['footer_config' => json_encode(['social' => []], JSON_THROW_ON_ERROR)];
+
+        $org = PublicOrganizationSchema::build('Acme', 'https://acme.test/', null, $settings);
+
+        self::assertArrayNotHasKey('sameAs', $org);
+    }
+
+    public function testContactPointFromHeaderTopbar(): void
+    {
+        $settings = ['header_config' => json_encode([
+            'topbar' => ['enabled' => true, 'phone' => '03-1234-5678', 'email' => 'info@ayane.co.jp', 'infoText' => ''],
+        ], JSON_THROW_ON_ERROR)];
+
+        $org = PublicOrganizationSchema::build('Acme', 'https://acme.test/', null, $settings);
+
+        self::assertSame([
+            '@type' => 'ContactPoint',
+            'contactType' => 'sales',
+            'email' => 'info@ayane.co.jp',
+            'telephone' => '03-1234-5678',
+        ], $org['contactPoint']);
+    }
+
+    public function testContactPointOmittedWhenEmailAndPhoneBlank(): void
+    {
+        $settings = ['header_config' => json_encode([
+            'topbar' => ['enabled' => false, 'phone' => '', 'email' => '', 'infoText' => ''],
+        ], JSON_THROW_ON_ERROR)];
+
+        $org = PublicOrganizationSchema::build('Acme', 'https://acme.test/', null, $settings);
+
+        self::assertArrayNotHasKey('contactPoint', $org);
+    }
+
+    public function testMalformedConfigJsonIsIgnored(): void
+    {
+        $settings = ['footer_config' => '{not json', 'header_config' => 'also bad'];
+
+        $org = PublicOrganizationSchema::build('Acme', 'https://acme.test/', null, $settings);
+
+        self::assertArrayNotHasKey('sameAs', $org);
+        self::assertArrayNotHasKey('contactPoint', $org);
+    }
+}

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -414,6 +414,44 @@ final class PublicRecordHttpTest extends TestCase
         self::assertStringNotContainsString('"dateModified"', $html);
     }
 
+    public function testFrontPageEmitsOrganizationJsonLdFromSettings(): void
+    {
+        // The front page carries a standalone Organization node (Google's company
+        // knowledge-panel signal) built from existing settings: sameAs from the
+        // footer social links, contactPoint from the header topbar (#978).
+        $this->buildApplication(true, $this->projectRoot, [
+            new SettingDef('site_name', 'text', '彩音インターナショナル株式会社', true, 'Site name'),
+            new SettingDef('footer_config', 'text', '{"social":[{"platform":"x","url":"https://twitter.com/ayane_inc"},{"platform":"facebook","url":"https://www.facebook.com/AyaneInternational"}]}', true, 'Footer content'),
+            new SettingDef('header_config', 'text', '{"topbar":{"enabled":true,"phone":"03-1234-5678","email":"info@ayane.co.jp","infoText":""}}', true, 'Header'),
+        ], frontPageId: 10);
+
+        $html = (string) $this->renderHandler->renderEntity(
+            'article',
+            null,
+            10,
+            $this->factory->createServerRequest('GET', 'https://example.test/'),
+            asFrontPage: true,
+        )->getBody();
+
+        self::assertStringContainsString('"@context":"https://schema.org","@type":"Organization"', $html);
+        self::assertStringContainsString('"name":"彩音インターナショナル株式会社"', $html);
+        self::assertStringContainsString('"url":"https://example.test/"', $html);
+        self::assertStringContainsString('"sameAs":["https://twitter.com/ayane_inc","https://www.facebook.com/AyaneInternational"]', $html);
+        self::assertStringContainsString('"contactPoint":{"@type":"ContactPoint","contactType":"sales","email":"info@ayane.co.jp","telephone":"03-1234-5678"}', $html);
+    }
+
+    public function testArticlePublisherIsEnrichedButNoStandaloneOrganization(): void
+    {
+        // A normal article's publisher Organization now carries url (not just name);
+        // the standalone Organization block is front-page-only (#978).
+        $html = (string) $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        )->getBody();
+
+        self::assertStringContainsString('"publisher":{"@type":"Organization","name":"NeNe Records","url":"https://example.test/"}', $html);
+        self::assertStringNotContainsString('"@context":"https://schema.org","@type":"Organization"', $html);
+    }
+
     public function testRealPermalinkServesCrawlableHtmlByIdPattern(): void
     {
         // The "article" type uses the default pattern /{type}/{id}, so /article/10 is the permalink.


### PR DESCRIPTION
## 目的
公開ページの JSON-LD `publisher` が `{@type:Organization, name}` だけで会社サイトとして弱かった。Google の**会社ナレッジパネル**が読む Organization 構造化データ（logo/url/sameAs/contactPoint）を既存設定から充実させる。#912(og:image) と対で「社名ググり」の一次品質を上げる。

## 変更（既存設定を再利用・新 knob なし）
- 新規 `PublicOrganizationSchema`（`WebAnalyticsConfig::fromSettings` と同型の値オブジェクト）
  - `name`←`site_name` / `url`←サイトホーム / `logo`←`logo_media_id`(絶対URL) / `sameAs`←`footer_config.social[].url` / `contactPoint`←`header_config.topbar` email/phone
- `RenderPublicRecordViewHandler` が logo 絶対URL・home を算出しヘルパへ
- `record-detail.php`: `publisher` をリッチ化＋**トップ(website)で standalone Organization** を出力（Google 会社パネル推奨形。記事ページは publisher が担う）
- 未設定項目は出さない（現状維持）

## 検証
- `composer test` 1377 / `analyse`(L8) No errors / `cs` clean
- 単体 `PublicOrganizationSchemaTest`（sameAs/contactPoint/dedup/malformed）＋HTTP統合（フロントの standalone Organization・記事の publisher 強化）

## デプロイ後の効果（ayane.co.jp）
- `footer_config.social` に3件（X/FB/YouTube）ある → **sameAs が即載る**
- logo は `logo_media_id` を設定した時、contactPoint は topbar に email/phone を入れた時に自動で増える

Closes #978