### PR TITLE
fix(public): 未知の公開パスをソフト404でなく正規の404にする（#980）

### DIFF
--- a/src/Http/SpaShellFallback.php
+++ b/src/Http/SpaShellFallback.php
@@ -30,6 +30,15 @@ final readonly class SpaShellFallback
     /** Surfaces that must never carry public analytics (logged-in / back office). */
     private const ANALYTICS_SKIP = '#^/(admin|login|superadmin)(/|$)#';
 
+    /**
+     * Real client-routed SPA surfaces (see `frontend/src/app/router.tsx`): the shell
+     * serves these at 200 because the router genuinely renders them. Everything else
+     * that reaches the fallback via a router 404 is an unknown page — type archives
+     * and record permalinks are SSR'd upstream (#877/#701), so a path landing here is
+     * not a valid public URL and must keep a hard 404 rather than a soft one (#980).
+     */
+    private const SPA_APP_ROUTES = '#^/(admin|superadmin|login|signup|verify-email|forbidden|search|tag|archive)(/|$)#';
+
     public function __construct(
         private string $shellPath,
         private ResponseFactoryInterface $responseFactory,
@@ -98,7 +107,14 @@ final readonly class SpaShellFallback
             $html = $this->injectIntoHead($html, WebAnalyticsHeadSnippet::render($analytics, $nonce));
         }
 
-        return $this->responseFactory->createResponse(200)
+        // Keep 200 for the HTML home and known client-routed SPA surfaces; a genuine
+        // router 404 on any other path is an unknown page, so serve the shell body
+        // (the SPA renders its NotFound) but preserve a hard 404 for crawlers (#980).
+        $status = ($response->getStatusCode() === 404 && $path !== '/' && preg_match(self::SPA_APP_ROUTES, $path) !== 1)
+            ? 404
+            : 200;
+
+        return $this->responseFactory->createResponse($status)
             ->withHeader('Content-Type', 'text/html; charset=utf-8')
             ->withHeader('Content-Security-Policy', PublicHtmlCsp::build($analytics, $nonce !== '' ? $nonce : null, $embeds))
             ->withBody($this->streamFactory->createStream($html));

--- a/tests/Http/SpaShellFallbackTest.php
+++ b/tests/Http/SpaShellFallbackTest.php
@@ -55,12 +55,30 @@ final class SpaShellFallbackTest extends TestCase
         self::assertStringContainsString("font-src 'self' data:", $csp);
     }
 
-    public function testServesShellForBrowsePath(): void
+    public function testUnknownPathGetsHardNotFoundWithShellBody(): void
     {
-        // 1-segment browse path (e.g. /posts) is not a record permalink → SPA shell.
-        $result = $this->fallback->apply($this->request('GET', '/posts'), $this->notFound());
+        // Valid type archives (/posts) and record permalinks are SSR'd upstream
+        // (#877/#701), so a path reaching the fallback is genuinely unknown. Serve the
+        // shell body (the SPA renders NotFound) but keep a hard 404 so crawlers don't
+        // index it as a soft 404 (#980).
+        foreach (['/nonexistent-abc', '/posts', '/blog/no-such-post', '/aaa/bbb'] as $path) {
+            $result = $this->fallback->apply($this->request('GET', $path), $this->notFound());
 
-        self::assertSame(200, $result->getStatusCode());
+            self::assertSame(404, $result->getStatusCode(), $path . ' must be a hard 404');
+            self::assertStringContainsString('<div id="root">', (string) $result->getBody(), $path . ' still serves the shell');
+        }
+    }
+
+    public function testKnownSpaRoutesKeep200(): void
+    {
+        // Real client-routed SPA surfaces render for the user, so the shell serves
+        // them at 200 even though the server router 404'd (they are not SSR'd).
+        foreach (['/admin/users', '/superadmin', '/login', '/signup', '/search', '/tag/design', '/archive/2026/07'] as $path) {
+            $result = $this->fallback->apply($this->request('GET', $path), $this->notFound());
+
+            self::assertSame(200, $result->getStatusCode(), $path . ' is a valid SPA route');
+            self::assertStringContainsString('<div id="root">', (string) $result->getBody());
+        }
     }
 
     public function testPassesThroughApiMediaViewAssetPaths(): void
@@ -187,7 +205,7 @@ final class SpaShellFallbackTest extends TestCase
     public function testNoAnalyticsWhenNoSettingsUseCase(): void
     {
         // Default construction (no settings) keeps the strict baseline policy.
-        $result = $this->fallback->apply($this->request('GET', '/posts'), $this->notFound());
+        $result = $this->fallback->apply($this->request('GET', '/search'), $this->notFound());
 
         self::assertSame(PublicHtmlCsp::POLICY, $result->getHeaderLine('Content-Security-Policy'));
         self::assertStringNotContainsString('googletagmanager', (string) $result->getBody());
@@ -196,7 +214,7 @@ final class SpaShellFallbackTest extends TestCase
     public function testInjectsAnalyticsOnPublicPathWhenConfigured(): void
     {
         $fallback = $this->fallbackWith(['analytics_ga4_id' => 'G-XYZ987']);
-        $result = $fallback->apply($this->request('GET', '/posts'), $this->notFound());
+        $result = $fallback->apply($this->request('GET', '/search'), $this->notFound());
 
         $body = (string) $result->getBody();
         $csp = $result->getHeaderLine('Content-Security-Policy');
@@ -232,7 +250,7 @@ final class SpaShellFallbackTest extends TestCase
         };
         $fallback = new SpaShellFallback($this->shellPath, $this->factory, $this->factory, $throwing);
 
-        $result = $fallback->apply($this->request('GET', '/posts'), $this->notFound());
+        $result = $fallback->apply($this->request('GET', '/search'), $this->notFound());
 
         // A failed lookup must never break the shell — serve it with the strict policy.
         self::assertSame(200, $result->getStatusCode());


### PR DESCRIPTION
## 目的
存在しないURL（`/nonexistent`, `/blog/no-such-post` 等）が **HTTP 200 ＋ SPAシェル**を返すソフト404だった（ayane.co.jp本番実測）。Googleがゴミ URL を200でインデックスしうる＋タイポ時に管理シェルのタイトルが露出する。

## 変更
`SpaShellFallback::apply()` のステータスを出し分け。型アーカイブ(#877)・レコードpermalink(#701)・フロントは fallback より前に SSR 済みなので、fallback 到達＝実在しない公開パス。
- HTMLホーム `/` ＋ 実在のSPAルート接頭辞（admin/superadmin/login/signup/verify-email/forbidden/search/tag/archive）→ **200**（従来どおり）
- それ以外の未知パス（元404）→ シェル body は返しつつ **404**（SPAのNotFound描画・クローラは hard 404 を見る）

最小変更・SSR公開レコードには無影響。

## 検証
- `composer test` 1378 / `analyse`(L8) / `cs` すべて green
- `SpaShellFallbackTest`: 未知パス(/nonexistent,/posts,/blog/no-such-post)→404＋shell body / 実SPAルート(/admin,/search,/tag,...)→200 を追加。#877前提だった既存テストを更新

Closes #980