### PR TITLE
feat(public): フローティングCTA に第一者キュレーション SVG アイコンを追加する（#982 P2 一部）

### DIFF
--- a/frontend/src/features/manage-appearance/ui/FloatingCtaView.tsx
+++ b/frontend/src/features/manage-appearance/ui/FloatingCtaView.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 import { useTranslation } from '@/shared/i18n'
-import { joinList, parseList, safeHref } from '@/shared/lib/floating-cta'
+import { FLOATING_CTA_ICONS, joinList, parseList, safeHref } from '@/shared/lib/floating-cta'
 import { Button, Card, Stack, Text } from '@/shared/ui'
 import type { FloatingCtaPageState } from '../hooks/useFloatingCtaPage'
 
@@ -120,6 +120,42 @@ export function FloatingCtaView({
         </Stack>
 
         <Stack gap="sm">
+          <Row label={t('admin.floatingCta.iconId')}>
+            <div className="flex flex-wrap items-center gap-inline-sm">
+              <button
+                type="button"
+                aria-pressed={draft.content.iconId === ''}
+                className={
+                  draft.content.iconId === ''
+                    ? 'rounded-sm border-1.5 border-accent bg-surface px-inline-sm py-stack-xs font-chrome text-caption text-text-primary'
+                    : 'rounded-sm border border-border bg-surface px-inline-sm py-stack-xs font-chrome text-caption text-text-secondary'
+                }
+                onClick={() => {
+                  setContent({ iconId: '' })
+                }}
+              >
+                {t('admin.floatingCta.iconNone')}
+              </button>
+              {FLOATING_CTA_ICONS.map((icon) => (
+                <button
+                  key={icon.id}
+                  type="button"
+                  title={icon.id}
+                  aria-label={icon.id}
+                  aria-pressed={draft.content.iconId === icon.id}
+                  className={
+                    draft.content.iconId === icon.id
+                      ? 'inline-flex h-9 w-9 items-center justify-center rounded-sm border-1.5 border-accent bg-surface text-text-primary'
+                      : 'inline-flex h-9 w-9 items-center justify-center rounded-sm border border-border bg-surface text-text-secondary'
+                  }
+                  onClick={() => {
+                    setContent({ iconId: icon.id })
+                  }}
+                  dangerouslySetInnerHTML={{ __html: icon.svg }}
+                />
+              ))}
+            </div>
+          </Row>
           <Row label={t('admin.floatingCta.icon')}>
             <TextInput
               value={draft.content.icon}

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -217,6 +217,8 @@ export const de = {
   'admin.floatingCta.positionBl': 'Unten links',
   'admin.floatingCta.accent': 'Akzentfarbe',
   'admin.floatingCta.icon': 'Symbol (Emoji)',
+  'admin.floatingCta.iconId': 'Symbol',
+  'admin.floatingCta.iconNone': 'Keine / Emoji',
   'admin.floatingCta.label': 'Beschriftung',
   'admin.floatingCta.sub': 'Untertext',
   'admin.floatingCta.url': 'Link-URL',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -230,6 +230,8 @@ export const en = {
   'admin.floatingCta.positionBl': 'Bottom left',
   'admin.floatingCta.accent': 'Accent color',
   'admin.floatingCta.icon': 'Icon (emoji)',
+  'admin.floatingCta.iconId': 'Icon',
+  'admin.floatingCta.iconNone': 'None / emoji',
   'admin.floatingCta.label': 'Label',
   'admin.floatingCta.sub': 'Sub text',
   'admin.floatingCta.url': 'Link URL',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -220,6 +220,8 @@ export const fr = {
   'admin.floatingCta.positionBl': 'En bas à gauche',
   'admin.floatingCta.accent': 'Couleur d’accent',
   'admin.floatingCta.icon': 'Icône (emoji)',
+  'admin.floatingCta.iconId': 'Icône',
+  'admin.floatingCta.iconNone': 'Aucune / emoji',
   'admin.floatingCta.label': 'Libellé',
   'admin.floatingCta.sub': 'Sous-texte',
   'admin.floatingCta.url': 'URL du lien',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -226,6 +226,8 @@ export const ja = {
   'admin.floatingCta.positionBl': '左下',
   'admin.floatingCta.accent': 'アクセント色',
   'admin.floatingCta.icon': 'アイコン（絵文字）',
+  'admin.floatingCta.iconId': 'アイコン',
+  'admin.floatingCta.iconNone': 'なし / 絵文字',
   'admin.floatingCta.label': 'ラベル',
   'admin.floatingCta.sub': 'サブテキスト',
   'admin.floatingCta.url': 'リンク先URL',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -218,6 +218,8 @@ export const ptBR = {
   'admin.floatingCta.positionBl': 'Inferior esquerdo',
   'admin.floatingCta.accent': 'Cor de destaque',
   'admin.floatingCta.icon': 'Ícone (emoji)',
+  'admin.floatingCta.iconId': 'Ícone',
+  'admin.floatingCta.iconNone': 'Nenhum / emoji',
   'admin.floatingCta.label': 'Rótulo',
   'admin.floatingCta.sub': 'Texto secundário',
   'admin.floatingCta.url': 'URL do link',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -214,6 +214,8 @@ export const zhHans = {
   'admin.floatingCta.positionBl': '左下角',
   'admin.floatingCta.accent': '强调色',
   'admin.floatingCta.icon': '图标（表情）',
+  'admin.floatingCta.iconId': '图标',
+  'admin.floatingCta.iconNone': '无 / 表情',
   'admin.floatingCta.label': '文字',
   'admin.floatingCta.sub': '副文字',
   'admin.floatingCta.url': '链接地址',

--- a/frontend/src/shared/lib/floating-cta.test.ts
+++ b/frontend/src/shared/lib/floating-cta.test.ts
@@ -23,7 +23,7 @@ describe('parseFloatingCta', () => {
         enabled: true,
         position: 'bl',
         accent: '#D64525',
-        content: { icon: '📅', label: 'Book', sub: 'Online' },
+        content: { icon: '📅', iconId: 'calendar', label: 'Book', sub: 'Online' },
         link: { url: 'https://x.test', newTab: false },
         conditions: { types: ['page'], urlGlobs: ['/services*'], exclude: ['/admin*'] },
       }),
@@ -32,6 +32,7 @@ describe('parseFloatingCta', () => {
     expect(cfg.position).toBe('bl')
     expect(cfg.accent).toBe('#D64525')
     expect(cfg.content.label).toBe('Book')
+    expect(cfg.content.iconId).toBe('calendar')
     expect(cfg.link.newTab).toBe(false)
     expect(cfg.conditions.urlGlobs).toEqual(['/services*'])
   })
@@ -77,7 +78,7 @@ describe('isFloatingCtaRenderable', () => {
       isFloatingCtaRenderable({
         ...DEFAULT_FLOATING_CTA,
         enabled: true,
-        content: { icon: '', label: 'Book', sub: '' },
+        content: { icon: '', iconId: '', label: 'Book', sub: '' },
         link: { url: 'https://x.test', newTab: true },
       }),
     ).toBe(true)
@@ -85,7 +86,7 @@ describe('isFloatingCtaRenderable', () => {
       isFloatingCtaRenderable({
         ...DEFAULT_FLOATING_CTA,
         enabled: true,
-        content: { icon: '', label: 'Book', sub: '' },
+        content: { icon: '', iconId: '', label: 'Book', sub: '' },
         link: { url: 'javascript:alert(1)', newTab: true },
       }),
     ).toBe(false)

--- a/frontend/src/shared/lib/floating-cta.ts
+++ b/frontend/src/shared/lib/floating-cta.ts
@@ -30,7 +30,7 @@ export interface FloatingCtaConfig {
   position: FloatingCtaPosition
   /** `#RRGGBB` accent, or '' to use the built-in default. */
   accent: string
-  content: { icon: string; label: string; sub: string }
+  content: { icon: string; iconId: string; label: string; sub: string }
   link: { url: string; newTab: boolean }
   conditions: FloatingCtaConditions
 }
@@ -39,7 +39,7 @@ export const DEFAULT_FLOATING_CTA: FloatingCtaConfig = {
   enabled: false,
   position: 'br',
   accent: '',
-  content: { icon: '', label: '', sub: '' },
+  content: { icon: '', iconId: '', label: '', sub: '' },
   link: { url: '', newTab: true },
   conditions: { types: [], urlGlobs: [], exclude: [] },
 }
@@ -92,6 +92,7 @@ export function parseFloatingCta(raw: string | undefined): FloatingCtaConfig {
     accent: /^#[0-9A-Fa-f]{6}$/.test(asString(record.accent)) ? asString(record.accent) : '',
     content: {
       icon: asString(content.icon),
+      iconId: asString(content.iconId),
       label: asString(content.label),
       sub: asString(content.sub),
     },
@@ -128,4 +129,52 @@ export function joinList(list: string[]): string {
 /** True when the CTA is enabled and resolves to a safe, labelled link. */
 export function isFloatingCtaRenderable(config: FloatingCtaConfig): boolean {
   return config.enabled && config.content.label.trim() !== '' && safeHref(config.link.url) !== ''
+}
+
+/**
+ * Curated first-party SVG icons for the floating CTA picker (#982 P2). The ids and
+ * markup mirror the backend `FloatingCtaIcons` (the server is the validation authority);
+ * this copy powers the admin picker preview. `svg` is our own constant markup — safe to
+ * render (no org input).
+ */
+export const FLOATING_CTA_ICONS: ReadonlyArray<{ id: string; svg: string }> = [
+  {
+    id: 'calendar',
+    svg: wrap(
+      '<rect x="3" y="4.5" width="18" height="16" rx="2"/><path d="M3 9.5h18M8 2.5v4M16 2.5v4"/>',
+    ),
+  },
+  {
+    id: 'video',
+    svg: wrap('<rect x="2" y="6" width="13" height="12" rx="2"/><path d="M22 8.5 15 12l7 3.5z"/>'),
+  },
+  {
+    id: 'chat',
+    svg: wrap('<path d="M21 11.5a8.5 8.5 0 0 1-12.3 7.6L3 21l1.9-5.7A8.5 8.5 0 1 1 21 11.5z"/>'),
+  },
+  {
+    id: 'mail',
+    svg: wrap('<rect x="2" y="4.5" width="20" height="15" rx="2"/><path d="m3 6 9 7 9-7"/>'),
+  },
+  {
+    id: 'phone',
+    svg: wrap(
+      '<path d="M6.6 3H4a1.9 1.9 0 0 0-1.9 2.1 16.9 16.9 0 0 0 14.8 14.8A1.9 1.9 0 0 0 19 18v-2.6a1.3 1.3 0 0 0-1-1.3l-3-.6a1.3 1.3 0 0 0-1.2.4l-1 1a13 13 0 0 1-5-5l1-1a1.3 1.3 0 0 0 .4-1.3l-.6-3A1.3 1.3 0 0 0 6.6 3z"/>',
+    ),
+  },
+  { id: 'clock', svg: wrap('<circle cx="12" cy="12" r="9"/><path d="M12 7.5V12l3 2"/>') },
+  {
+    id: 'sparkle',
+    svg: wrap('<path d="M12 3l1.9 5.1L19 10l-5.1 1.9L12 17l-1.9-5.1L5 10l5.1-1.9z"/>'),
+  },
+  { id: 'arrow-right', svg: wrap('<path d="M4 12h15M13 6l6 6-6 6"/>') },
+]
+
+function wrap(inner: string): string {
+  return (
+    '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"' +
+    ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+    inner +
+    '</svg>'
+  )
 }

--- a/src/PublicRecord/FloatingCta.php
+++ b/src/PublicRecord/FloatingCta.php
@@ -38,6 +38,8 @@ final readonly class FloatingCta
         public string $position,
         public string $accent,
         public string $icon,
+        /** A curated icon id ({@see FloatingCtaIcons}), or '' to use $icon/none. Takes priority over $icon. */
+        public string $iconId,
         public string $label,
         public string $sub,
         public string $url,
@@ -50,7 +52,7 @@ final readonly class FloatingCta
 
     public static function disabled(): self
     {
-        return new self(false, 'br', self::DEFAULT_ACCENT, '', '', '', '', true, [], [], []);
+        return new self(false, 'br', self::DEFAULT_ACCENT, '', '', '', '', '', true, [], [], []);
     }
 
     /**
@@ -107,6 +109,9 @@ final readonly class FloatingCta
             position: $position,
             accent: $accent,
             icon: self::asString($content['icon'] ?? ''),
+            // A curated icon id only if it is one of the vetted keys; anything else → '' (falls
+            // back to the emoji). This read-side allowlist mirrors the write-side validator.
+            iconId: FloatingCtaIcons::has(self::asString($content['iconId'] ?? '')) ? self::asString($content['iconId'] ?? '') : '',
             label: $label,
             sub: self::asString($content['sub'] ?? ''),
             url: $url,

--- a/src/PublicRecord/FloatingCtaHtml.php
+++ b/src/PublicRecord/FloatingCtaHtml.php
@@ -37,9 +37,16 @@ final class FloatingCtaHtml
         $rel = $cta->newTab ? ' rel="noopener noreferrer"' : '';
         $target = $cta->newTab ? ' target="_blank"' : '';
 
-        $icon = $cta->icon !== ''
-            ? '<span class="nene-fab__icon" aria-hidden="true">' . self::e($cta->icon) . '</span>'
-            : '';
+        // A curated icon id (vetted first-party SVG) takes priority over the emoji. Only the
+        // one selected icon's markup is emitted, and it is our own repo-shipped SVG — never
+        // org-supplied — so verbatim output stays safe.
+        if ($cta->iconId !== '') {
+            $icon = '<span class="nene-fab__icon" aria-hidden="true">' . FloatingCtaIcons::svg($cta->iconId) . '</span>';
+        } elseif ($cta->icon !== '') {
+            $icon = '<span class="nene-fab__icon" aria-hidden="true">' . self::e($cta->icon) . '</span>';
+        } else {
+            $icon = '';
+        }
         $sub = $cta->sub !== ''
             ? '<span class="nene-fab__sub">' . self::e($cta->sub) . '</span>'
             : '';

--- a/src/PublicRecord/FloatingCtaIcons.php
+++ b/src/PublicRecord/FloatingCtaIcons.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+/**
+ * Curated first-party SVG icon set for the floating CTA (#982 P2).
+ *
+ * Admins pick an icon by kebab id ({@see FloatingCta::$iconId}); only these vetted,
+ * repo-shipped icons are ever emitted — an org never supplies raw SVG, so there is no
+ * `<script>`/`on*`/`foreignObject` XSS surface even though the CTA is emitted verbatim
+ * into the (unsanitized) public shell. The validator's allowed set is derived from
+ * {@see self::keys()} so the enum can never drift from these constants.
+ *
+ * Each entry is the INNER markup (paths only, ≤400B); {@see self::svg()} wraps it in a
+ * uniform 24-viewBox, `currentColor`-stroked `<svg>` so line weight is consistent and
+ * the FAB's text color is inherited. Only the one selected icon is ever rendered.
+ */
+final class FloatingCtaIcons
+{
+    /** @var array<string, string> id => inner svg markup (paths only). */
+    private const PATHS = [
+        'calendar' => '<rect x="3" y="4.5" width="18" height="16" rx="2"/><path d="M3 9.5h18M8 2.5v4M16 2.5v4"/>',
+        'video' => '<rect x="2" y="6" width="13" height="12" rx="2"/><path d="M22 8.5 15 12l7 3.5z"/>',
+        'chat' => '<path d="M21 11.5a8.5 8.5 0 0 1-12.3 7.6L3 21l1.9-5.7A8.5 8.5 0 1 1 21 11.5z"/>',
+        'mail' => '<rect x="2" y="4.5" width="20" height="15" rx="2"/><path d="m3 6 9 7 9-7"/>',
+        'phone' => '<path d="M6.6 3H4a1.9 1.9 0 0 0-1.9 2.1 16.9 16.9 0 0 0 14.8 14.8A1.9 1.9 0 0 0 19 18v-2.6a1.3 1.3 0 0 0-1-1.3l-3-.6a1.3 1.3 0 0 0-1.2.4l-1 1a13 13 0 0 1-5-5l1-1a1.3 1.3 0 0 0 .4-1.3l-.6-3A1.3 1.3 0 0 0 6.6 3z"/>',
+        'clock' => '<circle cx="12" cy="12" r="9"/><path d="M12 7.5V12l3 2"/>',
+        'sparkle' => '<path d="M12 3l1.9 5.1L19 10l-5.1 1.9L12 17l-1.9-5.1L5 10l5.1-1.9z"/>',
+        'arrow-right' => '<path d="M4 12h15M13 6l6 6-6 6"/>',
+    ];
+
+    /**
+     * Allowed icon ids — the single source the validator derives its enum from.
+     *
+     * @return list<string>
+     */
+    public static function keys(): array
+    {
+        return array_keys(self::PATHS);
+    }
+
+    public static function has(string $id): bool
+    {
+        return isset(self::PATHS[$id]);
+    }
+
+    /** Wrap the vetted inner markup in a uniform svg; '' for an unknown id. */
+    public static function svg(string $id): string
+    {
+        if (!isset(self::PATHS[$id])) {
+            return '';
+        }
+
+        return '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"'
+            . ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+            . self::PATHS[$id] . '</svg>';
+    }
+}

--- a/src/Setting/FloatingCtaValidator.php
+++ b/src/Setting/FloatingCtaValidator.php
@@ -6,6 +6,7 @@ namespace NeNeRecords\Setting;
 
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
+use NeNeRecords\PublicRecord\FloatingCtaIcons;
 
 /**
  * Server-side validator for the `floating_cta` public setting (EPIC #982, P1).
@@ -77,6 +78,12 @@ final class FloatingCtaValidator
             $content = [];
         }
         $this->validateOptionalString('value.content.icon', $content['icon'] ?? null, self::MAX_ICON_LEN, $errors);
+        // iconId (P2) selects a curated first-party SVG; fail-closed against the shipped set.
+        // The allowed enum is derived from FloatingCtaIcons::keys() so it can never drift.
+        $iconId = $content['iconId'] ?? null;
+        if ($iconId !== null && $iconId !== '' && (!is_string($iconId) || !FloatingCtaIcons::has($iconId))) {
+            $errors[] = new ValidationError('value.content.iconId', 'iconId must be one of: ' . implode(', ', FloatingCtaIcons::keys()) . '.', 'invalid');
+        }
         $this->validateOptionalString('value.content.sub', $content['sub'] ?? null, self::MAX_SUB_LEN, $errors);
         $label = $content['label'] ?? null;
         $this->validateOptionalString('value.content.label', $label, self::MAX_LABEL_LEN, $errors);

--- a/tests/PublicRecord/FloatingCtaHtmlTest.php
+++ b/tests/PublicRecord/FloatingCtaHtmlTest.php
@@ -81,4 +81,39 @@ final class FloatingCtaHtmlTest extends TestCase
         self::assertStringNotContainsString('target="_blank"', $html);
         self::assertStringNotContainsString('rel="noopener', $html);
     }
+
+    public function testCuratedIconIdRendersSvg(): void
+    {
+        $cta = self::cta([
+            'content' => ['label' => 'Book', 'iconId' => 'calendar'],
+            'link' => ['url' => 'https://x.test'],
+        ]);
+        $html = FloatingCtaHtml::render($cta, 'page', '/');
+        self::assertStringContainsString('<span class="nene-fab__icon"', $html);
+        self::assertStringContainsString('<svg width="18" height="18" viewBox="0 0 24 24"', $html);
+        self::assertStringContainsString('stroke="currentColor"', $html);
+    }
+
+    public function testIconIdTakesPriorityOverEmoji(): void
+    {
+        $cta = self::cta([
+            'content' => ['icon' => '📅', 'label' => 'Book', 'iconId' => 'video'],
+            'link' => ['url' => 'https://x.test'],
+        ]);
+        $html = FloatingCtaHtml::render($cta, 'page', '/');
+        self::assertStringContainsString('<svg', $html);
+        // The emoji is dropped in favour of the curated svg.
+        self::assertStringNotContainsString('📅', $html);
+    }
+
+    public function testInvalidIconIdFallsBackToEmoji(): void
+    {
+        $cta = self::cta([
+            'content' => ['icon' => '📅', 'label' => 'Book', 'iconId' => 'bogus'],
+            'link' => ['url' => 'https://x.test'],
+        ]);
+        $html = FloatingCtaHtml::render($cta, 'page', '/');
+        self::assertStringNotContainsString('<svg', $html);
+        self::assertStringContainsString('📅', $html);
+    }
 }

--- a/tests/PublicRecord/FloatingCtaIconsTest.php
+++ b/tests/PublicRecord/FloatingCtaIconsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use NeNeRecords\PublicRecord\FloatingCtaIcons;
+use PHPUnit\Framework\TestCase;
+
+final class FloatingCtaIconsTest extends TestCase
+{
+    public function testKeysAndHaveStayInSync(): void
+    {
+        $keys = FloatingCtaIcons::keys();
+        self::assertContains('calendar', $keys);
+        self::assertContains('video', $keys);
+        foreach ($keys as $id) {
+            self::assertTrue(FloatingCtaIcons::has($id));
+        }
+        self::assertFalse(FloatingCtaIcons::has('nope'));
+        self::assertFalse(FloatingCtaIcons::has(''));
+    }
+
+    public function testSvgIsUniformAndScriptFree(): void
+    {
+        foreach (FloatingCtaIcons::keys() as $id) {
+            $svg = FloatingCtaIcons::svg($id);
+            self::assertStringStartsWith('<svg width="18" height="18" viewBox="0 0 24 24"', $svg);
+            self::assertStringContainsString('stroke="currentColor"', $svg);
+            self::assertStringContainsString('fill="none"', $svg);
+            self::assertStringContainsString('aria-hidden="true"', $svg);
+            self::assertStringEndsWith('</svg>', $svg);
+            // Curated + safe: no script-bearing constructs.
+            self::assertStringNotContainsStringIgnoringCase('<script', $svg);
+            self::assertStringNotContainsStringIgnoringCase('onload', $svg);
+            self::assertStringNotContainsString('foreignObject', $svg);
+            self::assertLessThanOrEqual(600, strlen($svg));
+        }
+    }
+
+    public function testUnknownIdRendersEmpty(): void
+    {
+        self::assertSame('', FloatingCtaIcons::svg('nope'));
+    }
+}

--- a/tests/Setting/FloatingCtaValidatorTest.php
+++ b/tests/Setting/FloatingCtaValidatorTest.php
@@ -26,7 +26,7 @@ final class FloatingCtaValidatorTest extends TestCase
             'position' => 'bl',
             'trigger' => 'always',
             'accent' => '#D64525',
-            'content' => ['icon' => '📅', 'label' => '30分無料相談を予約', 'sub' => 'オンライン'],
+            'content' => ['icon' => '📅', 'iconId' => 'calendar', 'label' => '30分無料相談を予約', 'sub' => 'オンライン'],
             'link' => ['url' => 'https://calendar.app.google/x', 'newTab' => true],
             'conditions' => ['types' => ['page'], 'urlGlobs' => ['/services*'], 'exclude' => ['/admin*']],
         ]));
@@ -56,6 +56,7 @@ final class FloatingCtaValidatorTest extends TestCase
         yield 'protocol-relative url' => [(string) json_encode(['link' => ['url' => '//evil.test/x']] + ['enabled' => true, 'content' => ['label' => 'x']])];
         yield 'backslash authority url' => [(string) json_encode(['link' => ['url' => '/\\evil.test']] + ['enabled' => true, 'content' => ['label' => 'x']])];
         yield 'bad accent' => [(string) json_encode(['accent' => 'red'] + $base)];
+        yield 'unknown iconId (fail-closed)' => [(string) json_encode(['content' => ['label' => 'x', 'iconId' => 'skull']] + ['enabled' => true, 'link' => ['url' => 'https://x.test']])];
         yield 'enabled without label' => [(string) json_encode(['enabled' => true, 'link' => ['url' => 'https://x.test']])];
         yield 'enabled without url' => [(string) json_encode(['enabled' => true, 'content' => ['label' => 'x']])];
         yield 'conditions.types not array' => [(string) json_encode(['conditions' => ['types' => 'page']] + $base)];


### PR DESCRIPTION
## 目的

#982 P2 の一部（施主リクエスト先行スコープ・hub GO 済み）。フローティングCTA のアイコンを絵文字だけでなく**第一者キュレーション SVG**から選べるようにする。

CTA はサニタイザ非経由のシェル chrome なので SVG が正規に効く一方、org の生 SVG は XSS 面（`<script>`/`on*`/`foreignObject`）になるため**受けない＝同梱アイコンのみ**。enum は SVG 定数キーから導出（二重管理なし）。

## 変更

- **`FloatingCtaIcons`**（新）＝id→SVG の単一ソース。8種（calendar/video/chat/mail/phone/clock/sparkle/arrow-right）。24 viewBox・stroke=currentColor・fill=none・stroke-width 統一・各 path ≤400B・選択1個のみ emit。
- **`FloatingCta`** に `iconId`（読み側 allowlist・不正→''）／**`FloatingCtaHtml`** は iconId 優先で `.nene-fab__icon` 内に同梱SVGを emit（無ければ絵文字・aria-hidden 継続・CSS only）。
- **`FloatingCtaValidator`**＝iconId を `FloatingCtaIcons::keys()` で fail-closed 検証。
- **管理UI**（外観>フローティングCTA）にアイコンピッカー（SVGプレビュー＋「なし/絵文字」）＋i18n 6ロケール。

## 検証

- backend: PHPUnit 41（アイコン定数の一様性/script-free・iconId 検証・描画優先・絵文字フォールバック）・**PHPStan level8 緑**・CS-Fixer クリーン
- frontend: type-check(strict)・eslint・prettier・vitest 緑

## スコープ / チェックリスト

- hub 締め4点準拠（①24 viewBox/currentColor/fill none/stroke統一 ②`.nene-fab__icon` span＋aria-hidden ③path≤400B・1個のみ emit ④enum は SVG 定数キー導出）。
- 後方互換: 既存の絵文字 `icon` は維持（iconId 優先・無ければ絵文字）。既存 disabled/emoji config 無影響。
- P2 の残（画像アップロード/hover強化/複数トリガー/dismiss）は本 PR 対象外。
- ayane は反映後、管理画面で iconId=calendar/video を選べば手置きなしで SVG アイコンに。

Refs #982

🤖 Generated with [Claude Code](https://claude.com/claude-code)
