### PR TITLE
fix(public): 公開SSRのheadにfaviconリンクを出力する（#986）

### DIFF
--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -5,6 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <?php /* Runtime base path: anchors the SPA (router/API derive it from <base>). #zip-install S2 */ ?>
     <base href="<?= $e($basePath . '/') ?>" />
+    <?php /* Favicon: the crawlable SSR shell must declare it so Google/browsers use the
+             real icon instead of an auto-generated letter monogram (#986). Base-relative
+             paths resolve against <base> on any deep path; assets ship in dist/assets/favicon. */ ?>
+    <link rel="icon" href="assets/favicon/favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href="assets/favicon/favicon-32.png" sizes="32x32" />
+    <link rel="icon" href="assets/favicon/favicon-16.png" sizes="16x16" />
+    <link rel="apple-touch-icon" href="assets/favicon/apple-touch-icon.png" />
+    <link rel="manifest" href="assets/favicon/site.webmanifest" />
     <?php /* GA4 / GTM + Consent Mode v2 — pre-built, nonce'd, '' when analytics is off. */ ?>
     <?= $analyticsHead ?>
     <?php if ($metaDescription !== ''): ?>

--- a/templates/public/type-archive.php
+++ b/templates/public/type-archive.php
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <?php /* Runtime base path: anchors the SPA (router/API derive it from <base>). #zip-install S2 */ ?>
     <base href="<?= $e($basePath . '/') ?>" />
+    <?php /* Favicon: declared in the crawlable SSR shell so Google/browsers use the real
+             icon instead of an auto-generated letter monogram (#986). Base-relative. */ ?>
+    <link rel="icon" href="assets/favicon/favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href="assets/favicon/favicon-32.png" sizes="32x32" />
+    <link rel="icon" href="assets/favicon/favicon-16.png" sizes="16x16" />
+    <link rel="apple-touch-icon" href="assets/favicon/apple-touch-icon.png" />
+    <link rel="manifest" href="assets/favicon/site.webmanifest" />
     <?= $analyticsHead ?>
     <?php if ($metaDescription !== ''): ?>
       <meta name="description" content="<?= $e($metaDescription) ?>" />

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -312,6 +312,10 @@ final class PublicRecordHttpTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
         // Canonical / og:url point at the user-facing permalink (default /{type}/{id}), not /view/.
         self::assertStringContainsString('<link rel="canonical" href="https://example.test/article/10" />', $html);
+        // Favicon declared in the crawlable SSR head so Google uses the real icon, not a
+        // generated letter monogram (#986). Base-relative → resolves against <base>.
+        self::assertStringContainsString('<link rel="icon" href="assets/favicon/favicon.svg" type="image/svg+xml" />', $html);
+        self::assertStringContainsString('<link rel="apple-touch-icon" href="assets/favicon/apple-touch-icon.png" />', $html);
         self::assertStringContainsString('content="https://example.test/article/10"', $html);
         // Open Graph
         self::assertStringContainsString('property="og:type" content="article"', $html);

--- a/tests/PublicRecord/RenderPublicTypeArchiveRendererTest.php
+++ b/tests/PublicRecord/RenderPublicTypeArchiveRendererTest.php
@@ -110,4 +110,16 @@ final class RenderPublicTypeArchiveRendererTest extends TestCase
         self::assertStringNotContainsString('property="og:image"', $html);
         self::assertStringContainsString('name="twitter:card" content="summary"', $html);
     }
+
+    public function testDeclaresFaviconInHead(): void
+    {
+        // The archive shell must declare a favicon so Google/browsers use the real icon
+        // instead of an auto-generated letter monogram (#986). Base-relative paths.
+        $html = $this->renderArchive([
+            new SettingDef('site_name', 'text', 'NeNe Records', true, 'Site name'),
+        ]);
+
+        self::assertStringContainsString('<link rel="icon" href="assets/favicon/favicon.svg" type="image/svg+xml" />', $html);
+        self::assertStringContainsString('<link rel="manifest" href="assets/favicon/site.webmanifest" />', $html);
+    }
 }


### PR DESCRIPTION
## 目的
公開ページの検索結果ファビコンが、サイト本来のアイコンでなく **Google が自動生成する頭文字モノグラム**（色付き丸＋頭文字）で表示される問題を解消する。ayane.co.jp では黄色い「A」として顕在化していた。

## 原因
クローラブル SSR テンプレート `templates/public/record-detail.php` / `type-archive.php` の `<head>` は canonical / hreflang / og:* / twitter:* / JSON-LD まで出すが、**`<link rel="icon">`（favicon）を一切出力していなかった**。SPA シェル `frontend/index.html` は出しているが、クローラが見る SSR 側だけ欠落。宣言が無いと Google はモノグラムにフォールバックする。

## 変更
- 両 SSR テンプレートの `<head>` に既定 favicon リンク一式を追加（`favicon.svg` / `favicon-32` / `favicon-16` / `apple-touch-icon` / `site.webmanifest`）。
- `<base href>` が既にあるため **SPA シェルと同一の相対パス**で deep path も正しく解決。アセットは `frontend/public/assets/favicon/` に存在し、Vite で `dist/assets/favicon/` に同梱・prod 配信 200 を確認済み。

## 検証
- `PublicRecordHttpTest`：レコード SSR head に `rel="icon"` / `apple-touch-icon` が含まれることを assert。
- `RenderPublicTypeArchiveRendererTest`：アーカイブ SSR head に `rel="icon"` / `manifest` を assert（`testDeclaresFaviconInHead`）。
- `composer check` 緑（PHPUnit 1420 / PHPStan level8 no errors / CS-Fixer / OpenAPI / MCP）。

## スコープ外（follow-up）
- **per-org カスタム favicon**（`favicon_media_id` 設定＋派生プリセット＋外観 UI）。`logo_media_id` 流用は 16px 可読性の問題があり別途製品判断 → 別 Issue 予定。
- **ayane.co.jp**（HETEML Tier A v0.5.3・別インスタンス）は本修正の手パッチ＋既存の朱A `/favicon.ico` を指す運用対応（別途・要 GO）。

## チェックリスト
- [x] Issue 紐付け（Closes #986）
- [x] `composer check` 緑
- [x] 回帰テスト追加
- [ ] レビュー

Closes #986

🤖 Generated with [Claude Code](https://claude.com/claude-code)