### PR TITLE
chore(i18n): 非権威4ロケールの satisfies 綴りを規約I18N-9正例に揃える（#988）

### DIFF
--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -1,4 +1,4 @@
-import type { MessageCatalog } from './en'
+import type { MessageKey } from './en'
 
 /** German — complete CMS admin & public-site catalog. Missing keys fall back to English. */
 export const de = {
@@ -1563,4 +1563,4 @@ export const de = {
   // ── Misc (#728) ───────────────────────────────────────────────────────────
   'common.tableOfContents': 'Inhaltsverzeichnis',
   'admin.entityRecords.breadcrumbLabel': 'Brotkrümelnavigation',
-} satisfies Record<keyof MessageCatalog, string>
+} satisfies Record<MessageKey, string>

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -1,4 +1,4 @@
-import type { MessageCatalog } from './en'
+import type { MessageKey } from './en'
 
 /** French — complete admin and public UI catalog. Missing keys fall back to English. */
 export const fr = {
@@ -1601,4 +1601,4 @@ export const fr = {
   // ── Misc (#728) ───────────────────────────────────────────────────────────
   'common.tableOfContents': 'Table des matières',
   'admin.entityRecords.breadcrumbLabel': 'Fil d’Ariane',
-} satisfies Record<keyof MessageCatalog, string>
+} satisfies Record<MessageKey, string>

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -1,4 +1,4 @@
-import type { MessageCatalog } from './en'
+import type { MessageKey } from './en'
 
 /** Brazilian Portuguese — complete admin/public UI catalog. Missing keys fall back to English. */
 export const ptBR = {
@@ -1583,4 +1583,4 @@ export const ptBR = {
   // ── Misc (#728) ───────────────────────────────────────────────────────────
   'common.tableOfContents': 'Sumário',
   'admin.entityRecords.breadcrumbLabel': 'Trilha de navegação',
-} satisfies Record<keyof MessageCatalog, string>
+} satisfies Record<MessageKey, string>

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -1,4 +1,4 @@
-import type { MessageCatalog } from './en'
+import type { MessageKey } from './en'
 
 /** Simplified Chinese (简体中文) message catalog. Missing keys fall back to English. */
 export const zhHans = {
@@ -1512,4 +1512,4 @@ export const zhHans = {
   // ── Misc (#728) ───────────────────────────────────────────────────────────
   'common.tableOfContents': '目录',
   'admin.entityRecords.breadcrumbLabel': '面包屑导航',
-} satisfies Record<keyof MessageCatalog, string>
+} satisfies Record<MessageKey, string>


### PR DESCRIPTION
## 目的
規約 I18N-9（frontend-standards.md:844）の正例 `satisfies Record<MessageKey, string>`（`en.ts:1575` と同綴り）に、非権威4ロケールの宣言を揃える。2026-07-15 施主裁定「実装を規約に合わせる」の対象（#871 担当の「型同一につきスコープ外」判断を覆す）＋ W0a 規約正例アンカー照合の前提。

## 変更（値・キーは一切不変・宣言行と import のみ / 8行）
`frontend/src/shared/i18n/messages/{de,fr,pt-BR,zh-Hans}.ts` 各ファイルで:
1. `} satisfies Record<keyof MessageCatalog, string>` → `} satisfies Record<MessageKey, string>`
2. `import type { MessageCatalog } from './en'` → `import type { MessageKey } from './en'`

`MessageKey = keyof MessageCatalog` のエイリアス（`translate.ts`）で**型は完全に同一**。`MessageCatalog` は他所未使用になるため import を `MessageKey` に置換（`en.ts:1582` が re-export 済み）。

## 検証
- `npm run check --prefix frontend` 緑（type-check / eslint 0-warning / prettier / vitest / storybook build 全通過）
- locales テスト 14 緑
- `git diff` は8行（各ファイル import+satisfies の2行）のみ・翻訳値/キーの diff ゼロ

## チェックリスト
- [x] Issue 紐付け（Closes #988）
- [x] `npm run check` 緑
- [x] 値・キー不変を diff で確認

Closes #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)