### PR TITLE
fix(admin): ページ一覧ディレクトリ表示の bespoke ページ名が全行同一になるのを直す（#990）

### DIFF
--- a/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
+++ b/frontend/src/features/manage-entities/hooks/use-manage-entities-page.ts
@@ -19,10 +19,12 @@ import {
   useFieldDefList,
   type RelationFieldDef,
 } from '@/entities/field-def'
+import { publicSettingsToMap, usePublicSettings } from '@/entities/setting'
 import { useTagList } from '@/entities/tag'
 import { defaultTextFieldListParamsForEntityType, useTextFieldList } from '@/entities/text-field'
 import { useTranslation } from '@/shared/i18n'
 import { getRecordDisplayLabel } from '@/shared/lib/get-record-display-label'
+import { stripSiteNameSuffix } from '@/shared/lib/strip-site-name-suffix'
 import { type DirectoryRecord } from '../lib/build-permalink-tree'
 
 export const PAGE_SIZE_OPTIONS = [20, 50, 100] as const
@@ -110,22 +112,33 @@ export function useManageEntitiesPage(entityTypeId: number) {
 
   const items = useMemo(() => listQuery.data?.items ?? [], [listQuery.data?.items])
 
+  // Site name drives the `｜{site}` SEO-suffix trim on list labels (#990); an
+  // unauthenticated public-settings read, so it works in the admin shell too.
+  const publicSettingsQuery = usePublicSettings()
+  const siteName = useMemo(
+    () => publicSettingsToMap(publicSettingsQuery.data?.items ?? [])['site_name'] ?? '',
+    [publicSettingsQuery.data?.items],
+  )
+
   const recordLabels = useMemo((): Record<string, string> => {
     const textFields = textFieldQuery.data?.items ?? []
 
     return Object.fromEntries(
       items.map((entity) => [
         String(entity.id),
-        getRecordDisplayLabel(
-          Number(entity.id),
-          textFields,
-          t('admin.entityRecord.id', { id: entity.id }),
-          null,
-          entity.metaTitle,
+        stripSiteNameSuffix(
+          getRecordDisplayLabel(
+            Number(entity.id),
+            textFields,
+            t('admin.entityRecord.id', { id: entity.id }),
+            null,
+            entity.metaTitle,
+          ),
+          siteName,
         ),
       ]),
     )
-  }, [items, t, textFieldQuery.data?.items])
+  }, [items, siteName, t, textFieldQuery.data?.items])
 
   const recordBodyMap = useMemo((): Record<string, string> => {
     const textFields = textFieldQuery.data?.items ?? []
@@ -142,8 +155,10 @@ export function useManageEntitiesPage(entityTypeId: number) {
     return result
   }, [items, textFieldQuery.data?.items])
 
-  // Directory-mode records: only those carrying a custom permalink, labelled from
-  // the type-wide title fields (falling back to meta_title or the last segment).
+  // Directory-mode records: only those carrying a custom permalink. Labelled from
+  // the title field, then meta_title (bespoke pages share one html field, so the
+  // derived excerpt would repeat the same header text on every row — #853/#990),
+  // then the last permalink segment. The `｜{site}` suffix is trimmed for the list.
   const directoryRecords = useMemo((): DirectoryRecord[] => {
     const textFields = textFieldQuery.data?.items ?? []
     return (directoryQuery.data?.items ?? [])
@@ -151,21 +166,26 @@ export function useManageEntitiesPage(entityTypeId: number) {
       .map((entity) => {
         const permalink = entity.permalink ?? ''
         const lastSegment = permalink.split('/').filter(Boolean).pop() ?? String(entity.id)
-        const fallback =
-          entity.metaTitle !== null && entity.metaTitle.trim() !== ''
-            ? entity.metaTitle
-            : lastSegment
         return {
           id: Number(entity.id),
           permalink,
-          label: getRecordDisplayLabel(Number(entity.id), textFields, fallback),
+          label: stripSiteNameSuffix(
+            getRecordDisplayLabel(
+              Number(entity.id),
+              textFields,
+              lastSegment,
+              null,
+              entity.metaTitle,
+            ),
+            siteName,
+          ),
           status: entity.status,
           updatedAt: entity.updatedAt,
           menuOrder: entity.menuOrder,
           viewCount: entity.viewCount ?? 0,
         }
       })
-  }, [directoryQuery.data?.items, textFieldQuery.data?.items])
+  }, [directoryQuery.data?.items, siteName, textFieldQuery.data?.items])
 
   const toggleTagSlug = useCallback((slug: string) => {
     setSelectedTagSlugs((current) =>

--- a/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
+++ b/frontend/src/features/manage-entities/ui/EntityDirectoryPanel.tsx
@@ -447,6 +447,11 @@ function DirectoryNodeRow({
             >
               {highlightMatch(record.label, query)}
             </Link>
+            {/* The permalink segment stays visible so pages whose names derive
+                from a shared bespoke body remain distinguishable by path (#990). */}
+            <span className="shrink-0 font-mono text-caption text-text-muted">
+              {highlightMatch(node.segment, query)}
+            </span>
             {hasChildren ? (
               <span className="shrink-0 font-mono text-caption text-text-muted">
                 ({node.children.length})

--- a/frontend/src/shared/lib/strip-site-name-suffix.test.ts
+++ b/frontend/src/shared/lib/strip-site-name-suffix.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import { stripSiteNameSuffix } from './strip-site-name-suffix'
+
+describe('stripSiteNameSuffix', () => {
+  it('strips a fullwidth-bar site suffix (authored meta_title convention)', () => {
+    expect(
+      stripSiteNameSuffix(
+        '会社案内｜彩音インターナショナル株式会社',
+        '彩音インターナショナル株式会社',
+      ),
+    ).toBe('会社案内')
+    expect(
+      stripSiteNameSuffix(
+        '代表紹介 森 秀之｜彩音インターナショナル株式会社',
+        '彩音インターナショナル株式会社',
+      ),
+    ).toBe('代表紹介 森 秀之')
+  })
+
+  it('strips an em-dash site suffix (product-composed convention)', () => {
+    expect(stripSiteNameSuffix('サービスと料金 — NeNe Records', 'NeNe Records')).toBe(
+      'サービスと料金',
+    )
+  })
+
+  it('leaves the title untouched when it is exactly the site name (front page)', () => {
+    expect(
+      stripSiteNameSuffix('彩音インターナショナル株式会社', '彩音インターナショナル株式会社'),
+    ).toBe('彩音インターナショナル株式会社')
+  })
+
+  it('leaves the title untouched when the site name is not a trailing suffix', () => {
+    // Front page: site name leads, tagline trails — nothing to strip.
+    expect(
+      stripSiteNameSuffix(
+        '彩音インターナショナル株式会社｜見積書より先に、動くものを。',
+        '彩音インターナショナル株式会社',
+      ),
+    ).toBe('彩音インターナショナル株式会社｜見積書より先に、動くものを。')
+  })
+
+  it('is a no-op when the site name is empty or whitespace', () => {
+    expect(stripSiteNameSuffix('会社案内｜彩音', '')).toBe('会社案内｜彩音')
+    expect(stripSiteNameSuffix('会社案内', '   ')).toBe('会社案内')
+  })
+
+  it('never returns an empty string even if the head collapses to separators', () => {
+    expect(stripSiteNameSuffix('｜彩音', '彩音')).toBe('｜彩音')
+  })
+})

--- a/frontend/src/shared/lib/strip-site-name-suffix.ts
+++ b/frontend/src/shared/lib/strip-site-name-suffix.ts
@@ -1,0 +1,19 @@
+/**
+ * Strips a trailing `｜{siteName}` / `— {siteName}` SEO suffix from an authored
+ * page title so admin lists show a short, distinct name (#990).
+ *
+ * Authored `meta_title`s often follow the `PageName｜SiteName` convention, which
+ * reads as noise when the same site name repeats on every row of a list. This is
+ * a no-op when the site name is unknown, equals the whole title, or is not a
+ * trailing suffix — safe for any input, and it never empties a title.
+ */
+export function stripSiteNameSuffix(title: string, siteName: string): string {
+  const t = title.trim()
+  const s = siteName.trim()
+  if (s === '' || t === s || !t.endsWith(s)) {
+    return t
+  }
+  // Drop the site name and any separators/whitespace that joined it to the head.
+  const head = t.slice(0, t.length - s.length).replace(/[\s｜|—–・:：-]+$/u, '')
+  return head === '' ? t : head
+}


### PR DESCRIPTION
## 現象
管理画面ページ一覧「ディレクトリ表示」で、bespoke ページ（`title` フィールド無し・`content` html 1本）の**表示名が全行同一**になる。ayane.co.jp 実測: 全13ページとも `SYSTEM DEV / WEB APP / 受託ソフトウェア開発 …`（共有ヘッダー抜粋）で見分け不能。

## 原因
`use-manage-entities-page.ts` の `directoryRecords` が `getRecordDisplayLabel` を**3引数で呼び第5引数 `metaTitle` を渡していない** → #853 の「meta_title が派生抜粋に勝つ」分岐が効かず `toDerivedLabel(content)` に落ちる。全ページ html 先頭がヘッダー複製なので抜粋が同一化。フラット側 `recordLabels` は既に `entity.metaTitle` を渡していた（＝ディレクトリ側だけの取りこぼし）。

## 変更
1. **①** `directoryRecords` でも `entity.metaTitle` を第5引数で渡す（fallback は permalink 末尾セグメント）。
2. **②** 一覧表示のみ `｜{site_name}` / `— {site_name}` サフィックスを除去（`stripSiteNameSuffix` 新設・pure・siteName 不明/非該当時 no-op・空文字を返さない）。`site_name` は `usePublicSettings`（未認証GETで admin でも可）。**共有 `getRecordDisplayLabel` は不変**で他7呼び出し元に無影響。
3. **③** `EntityDirectoryPanel` の leaf 行に permalink セグメントを mono 併記しパスで見分け可能に。

## 結果（ayane 例）
`会社案内` / `代表紹介 森 秀之` / `サービスと料金` / `お問い合わせ` … と固有名に。

## 検証
- `stripSiteNameSuffix` 単体テスト6件（全角バー/emダッシュ/前置社名の非除去/空社名 no-op/空化防止）
- `npm run check --prefix frontend` 全緑（type-check / eslint0 / prettier / vitest / validate:themes / knip / storybook build）

## 備考
bespoke/LP 型ページを使う全 org 共通の製品バグ。ayane は次のフロント更新波で反映（本 PR は records 本体・ConoHa デプロイ対象）。長期案（bespoke に明示「ページ名」項目）は別途。

Closes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)