### PR TITLE
feat(public): フローティングCTA に bottom offset（フッタークリアランス）を追加（#982 P2 (c)）

### DIFF
--- a/frontend/src/features/manage-appearance/hooks/useFloatingCtaPage.ts
+++ b/frontend/src/features/manage-appearance/hooks/useFloatingCtaPage.ts
@@ -15,7 +15,9 @@ export interface FloatingCtaPageState {
   /** Current draft (local edits, not yet saved). */
   draft: FloatingCtaConfig
   /** Patch top-level fields (enabled / position / accent). */
-  setConfig: (patch: Partial<Pick<FloatingCtaConfig, 'enabled' | 'position' | 'accent'>>) => void
+  setConfig: (
+    patch: Partial<Pick<FloatingCtaConfig, 'enabled' | 'position' | 'accent' | 'bottomOffset'>>,
+  ) => void
   /** Patch the content fields (icon / label / sub). */
   setContent: (patch: Partial<FloatingCtaConfig['content']>) => void
   /** Patch the link fields (url / newTab). */

--- a/frontend/src/features/manage-appearance/ui/FloatingCtaView.tsx
+++ b/frontend/src/features/manage-appearance/ui/FloatingCtaView.tsx
@@ -1,6 +1,12 @@
 import type { ReactNode } from 'react'
 import { useTranslation } from '@/shared/i18n'
-import { FLOATING_CTA_ICONS, joinList, parseList, safeHref } from '@/shared/lib/floating-cta'
+import {
+  FLOATING_CTA_ICONS,
+  joinList,
+  MAX_FLOATING_CTA_BOTTOM_OFFSET,
+  parseList,
+  safeHref,
+} from '@/shared/lib/floating-cta'
 import { Button, Card, Stack, Text } from '@/shared/ui'
 import type { FloatingCtaPageState } from '../hooks/useFloatingCtaPage'
 
@@ -116,6 +122,28 @@ export function FloatingCtaView({
                 setConfig({ accent })
               }}
             />
+          </Row>
+          <Row label={t('admin.floatingCta.bottomOffset')}>
+            <div className="flex items-center gap-inline-sm">
+              <input
+                type="number"
+                min={0}
+                max={MAX_FLOATING_CTA_BOTTOM_OFFSET}
+                step={4}
+                className="w-24 rounded-sm border border-border bg-surface px-inline-sm py-stack-xs font-sans text-body text-text-primary"
+                value={draft.bottomOffset}
+                onChange={(event) => {
+                  const parsed = Number.parseInt(event.target.value, 10)
+                  const clamped = Number.isFinite(parsed)
+                    ? Math.max(0, Math.min(parsed, MAX_FLOATING_CTA_BOTTOM_OFFSET))
+                    : 0
+                  setConfig({ bottomOffset: clamped })
+                }}
+              />
+              <Text muted variant="caption">
+                {t('admin.floatingCta.bottomOffsetHelp')}
+              </Text>
+            </div>
           </Row>
         </Stack>
 

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -216,6 +216,9 @@ export const de = {
   'admin.floatingCta.positionBr': 'Unten rechts',
   'admin.floatingCta.positionBl': 'Unten links',
   'admin.floatingCta.accent': 'Akzentfarbe',
+  'admin.floatingCta.bottomOffset': 'Abstand unten (px)',
+  'admin.floatingCta.bottomOffsetHelp':
+    'Reserviert Platz über der Fußzeile, damit die Schaltfläche sie nicht verdeckt. 0 = aus.',
   'admin.floatingCta.icon': 'Symbol (Emoji)',
   'admin.floatingCta.iconId': 'Symbol',
   'admin.floatingCta.iconNone': 'Keine / Emoji',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -229,6 +229,9 @@ export const en = {
   'admin.floatingCta.positionBr': 'Bottom right',
   'admin.floatingCta.positionBl': 'Bottom left',
   'admin.floatingCta.accent': 'Accent color',
+  'admin.floatingCta.bottomOffset': 'Bottom clearance (px)',
+  'admin.floatingCta.bottomOffsetHelp':
+    'Reserves space above the footer so the button never covers it. 0 = off.',
   'admin.floatingCta.icon': 'Icon (emoji)',
   'admin.floatingCta.iconId': 'Icon',
   'admin.floatingCta.iconNone': 'None / emoji',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -219,6 +219,9 @@ export const fr = {
   'admin.floatingCta.positionBr': 'En bas à droite',
   'admin.floatingCta.positionBl': 'En bas à gauche',
   'admin.floatingCta.accent': 'Couleur d’accent',
+  'admin.floatingCta.bottomOffset': 'Marge inférieure (px)',
+  'admin.floatingCta.bottomOffsetHelp':
+    'Réserve de l’espace au-dessus du pied de page pour que le bouton ne le masque pas. 0 = désactivé.',
   'admin.floatingCta.icon': 'Icône (emoji)',
   'admin.floatingCta.iconId': 'Icône',
   'admin.floatingCta.iconNone': 'Aucune / emoji',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -225,6 +225,9 @@ export const ja = {
   'admin.floatingCta.positionBr': '右下',
   'admin.floatingCta.positionBl': '左下',
   'admin.floatingCta.accent': 'アクセント色',
+  'admin.floatingCta.bottomOffset': '下部クリアランス（px）',
+  'admin.floatingCta.bottomOffsetHelp':
+    'フッターの上に余白を確保し、ボタンが重ならないようにします。0=なし。',
   'admin.floatingCta.icon': 'アイコン（絵文字）',
   'admin.floatingCta.iconId': 'アイコン',
   'admin.floatingCta.iconNone': 'なし / 絵文字',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -217,6 +217,9 @@ export const ptBR = {
   'admin.floatingCta.positionBr': 'Inferior direito',
   'admin.floatingCta.positionBl': 'Inferior esquerdo',
   'admin.floatingCta.accent': 'Cor de destaque',
+  'admin.floatingCta.bottomOffset': 'Espaço inferior (px)',
+  'admin.floatingCta.bottomOffsetHelp':
+    'Reserva espaço acima do rodapé para o botão não cobri-lo. 0 = desativado.',
   'admin.floatingCta.icon': 'Ícone (emoji)',
   'admin.floatingCta.iconId': 'Ícone',
   'admin.floatingCta.iconNone': 'Nenhum / emoji',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -213,6 +213,8 @@ export const zhHans = {
   'admin.floatingCta.positionBr': '右下角',
   'admin.floatingCta.positionBl': '左下角',
   'admin.floatingCta.accent': '强调色',
+  'admin.floatingCta.bottomOffset': '底部留白（px）',
+  'admin.floatingCta.bottomOffsetHelp': '在页脚上方预留空间，避免按钮遮挡。0 = 关闭。',
   'admin.floatingCta.icon': '图标（表情）',
   'admin.floatingCta.iconId': '图标',
   'admin.floatingCta.iconNone': '无 / 表情',

--- a/frontend/src/shared/lib/floating-cta.test.ts
+++ b/frontend/src/shared/lib/floating-cta.test.ts
@@ -43,6 +43,15 @@ describe('parseFloatingCta', () => {
     expect(cfg.position).toBe('br')
   })
 
+  it('parses and clamps bottomOffset (#982 P2 c)', () => {
+    expect(parseFloatingCta(JSON.stringify({ bottomOffset: 120 })).bottomOffset).toBe(120)
+    expect(parseFloatingCta(JSON.stringify({ bottomOffset: 9999 })).bottomOffset).toBe(400)
+    expect(parseFloatingCta(JSON.stringify({ bottomOffset: -5 })).bottomOffset).toBe(0)
+    expect(parseFloatingCta(JSON.stringify({ bottomOffset: '80' })).bottomOffset).toBe(0)
+    expect(parseFloatingCta(JSON.stringify({ bottomOffset: 12.5 })).bottomOffset).toBe(0)
+    expect(parseFloatingCta('{}').bottomOffset).toBe(0)
+  })
+
   it('round-trips through serialize', () => {
     const cfg = parseFloatingCta(
       JSON.stringify({ enabled: true, content: { label: 'x' }, link: { url: '/c' } }),

--- a/frontend/src/shared/lib/floating-cta.ts
+++ b/frontend/src/shared/lib/floating-cta.ts
@@ -25,6 +25,9 @@ export interface FloatingCtaConditions {
   exclude: string[]
 }
 
+/** Upper bound for the page-bottom clearance reserved for the FAB (#982 P2 (c)). */
+export const MAX_FLOATING_CTA_BOTTOM_OFFSET = 400
+
 export interface FloatingCtaConfig {
   enabled: boolean
   position: FloatingCtaPosition
@@ -33,6 +36,8 @@ export interface FloatingCtaConfig {
   content: { icon: string; iconId: string; label: string; sub: string }
   link: { url: string; newTab: boolean }
   conditions: FloatingCtaConditions
+  /** Extra clearance (px) reserved at the page bottom so the fixed FAB never covers footer content; 0 = none. */
+  bottomOffset: number
 }
 
 export const DEFAULT_FLOATING_CTA: FloatingCtaConfig = {
@@ -42,6 +47,7 @@ export const DEFAULT_FLOATING_CTA: FloatingCtaConfig = {
   content: { icon: '', iconId: '', label: '', sub: '' },
   link: { url: '', newTab: true },
   conditions: { types: [], urlGlobs: [], exclude: [] },
+  bottomOffset: 0,
 }
 
 /** Re-exported so the CTA editor shares the exact header-CTA scheme allowlist. */
@@ -66,6 +72,13 @@ function asStringList(value: unknown): string[] {
 
 function asPosition(value: unknown): FloatingCtaPosition {
   return value === 'bl' ? 'bl' : 'br'
+}
+
+/** Clamp a stored bottom offset to a valid, non-negative px within bounds (#982 P2 (c)). */
+function asBottomOffset(value: unknown): number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
+    ? Math.min(value, MAX_FLOATING_CTA_BOTTOM_OFFSET)
+    : 0
 }
 
 /** Parse the stored `floating_cta` JSON defensively into a full config. */
@@ -105,6 +118,7 @@ export function parseFloatingCta(raw: string | undefined): FloatingCtaConfig {
       urlGlobs: asStringList(conditions.urlGlobs),
       exclude: asStringList(conditions.exclude),
     },
+    bottomOffset: asBottomOffset(record.bottomOffset),
   }
 }
 

--- a/src/PublicRecord/FloatingCta.php
+++ b/src/PublicRecord/FloatingCta.php
@@ -27,6 +27,9 @@ final readonly class FloatingCta
 {
     private const DEFAULT_ACCENT = '#1f6feb';
 
+    /** Upper bound for the page-bottom clearance reserved for the FAB (#982 P2 (c)). */
+    public const MAX_BOTTOM_OFFSET = 400;
+
     /**
      * @param 'br'|'bl'          $position
      * @param list<string>       $conditionTypes    entity type slugs; empty = all types
@@ -47,12 +50,14 @@ final readonly class FloatingCta
         public array $conditionTypes,
         public array $conditionUrlGlobs,
         public array $conditionExclude,
+        /** Extra clearance (px) reserved at the page bottom so the fixed FAB never covers footer content; 0 = none (#982 P2 (c)). */
+        public int $bottomOffset = 0,
     ) {
     }
 
     public static function disabled(): self
     {
-        return new self(false, 'br', self::DEFAULT_ACCENT, '', '', '', '', '', true, [], [], []);
+        return new self(false, 'br', self::DEFAULT_ACCENT, '', '', '', '', '', true, [], [], [], 0);
     }
 
     /**
@@ -94,6 +99,11 @@ final readonly class FloatingCta
         $link = is_array($decoded['link'] ?? null) ? $decoded['link'] : [];
         $conditions = is_array($decoded['conditions'] ?? null) ? $decoded['conditions'] : [];
 
+        // Page-bottom clearance (#982 P2 (c)). Clamp defensively; the write-side validator
+        // is the real boundary. Non-int / out-of-range → 0 (no clearance = P1 behaviour).
+        $rawOffset = $decoded['bottomOffset'] ?? 0;
+        $bottomOffset = is_int($rawOffset) ? max(0, min($rawOffset, self::MAX_BOTTOM_OFFSET)) : 0;
+
         $label = self::asString($content['label'] ?? '');
         $url = self::asString($link['url'] ?? '');
 
@@ -119,6 +129,7 @@ final readonly class FloatingCta
             conditionTypes: self::asStringList($conditions['types'] ?? []),
             conditionUrlGlobs: self::asStringList($conditions['urlGlobs'] ?? []),
             conditionExclude: self::asStringList($conditions['exclude'] ?? []),
+            bottomOffset: $bottomOffset,
         );
     }
 

--- a/src/PublicRecord/FloatingCtaHtml.php
+++ b/src/PublicRecord/FloatingCtaHtml.php
@@ -51,7 +51,7 @@ final class FloatingCtaHtml
             ? '<span class="nene-fab__sub">' . self::e($cta->sub) . '</span>'
             : '';
 
-        $style = self::style($accent, $side);
+        $style = self::style($accent, $side, $cta->bottomOffset);
 
         return $style . "\n"
             . '<a class="nene-fab" href="' . $href . '"' . $target . $rel . '>'
@@ -63,12 +63,20 @@ final class FloatingCtaHtml
             . '</a>';
     }
 
-    private static function style(string $accent, string $side): string
+    private static function style(string $accent, string $side, int $bottomOffset): string
     {
+        // Page-bottom clearance (#982 P2 (c)): reserve space so the fixed FAB never covers
+        // footer content at scroll-end. Replaces the ad-hoc per-site `footer{padding-bottom}`
+        // hack with a first-party, no-JS config knob. `$bottomOffset` is a validated int.
+        $clearance = $bottomOffset > 0
+            ? 'body{padding-bottom:calc(env(safe-area-inset-bottom,0px) + ' . $bottomOffset . 'px)}'
+            : '';
+
         // Scoped to `.nene-fab`; safe to inline (CSP style-src allows 'unsafe-inline').
         // `$accent` is a validated hex and `$side` is a fixed keyword, so interpolation
         // is injection-free.
         return '<style>'
+            . $clearance
             . '.nene-fab{position:fixed;bottom:calc(env(safe-area-inset-bottom,0px) + 20px);'
             . $side . ':calc(env(safe-area-inset-' . $side . ',0px) + 20px);z-index:2147483000;'
             . 'display:inline-flex;align-items:center;gap:10px;'

--- a/src/Setting/FloatingCtaValidator.php
+++ b/src/Setting/FloatingCtaValidator.php
@@ -6,6 +6,7 @@ namespace NeNeRecords\Setting;
 
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
+use NeNeRecords\PublicRecord\FloatingCta;
 use NeNeRecords\PublicRecord\FloatingCtaIcons;
 
 /**
@@ -69,6 +70,14 @@ final class FloatingCtaValidator
         if (isset($decoded['accent'])) {
             if (!is_string($decoded['accent']) || preg_match('/^#[0-9A-Fa-f]{6}$/', $decoded['accent']) !== 1) {
                 $errors[] = new ValidationError('value.accent', 'accent must be a #RRGGBB hex color.', 'invalid');
+            }
+        }
+
+        // bottomOffset (#982 P2 (c)): page-bottom clearance in px reserved for the FAB.
+        if (isset($decoded['bottomOffset'])) {
+            $offset = $decoded['bottomOffset'];
+            if (!is_int($offset) || $offset < 0 || $offset > FloatingCta::MAX_BOTTOM_OFFSET) {
+                $errors[] = new ValidationError('value.bottomOffset', 'bottomOffset must be an integer between 0 and ' . FloatingCta::MAX_BOTTOM_OFFSET . '.', 'invalid');
             }
         }
 

--- a/tests/PublicRecord/FloatingCtaHtmlTest.php
+++ b/tests/PublicRecord/FloatingCtaHtmlTest.php
@@ -59,6 +59,23 @@ final class FloatingCtaHtmlTest extends TestCase
         self::assertStringContainsString('left:calc(env(safe-area-inset-left', $html);
     }
 
+    public function testBottomOffsetEmitsFooterClearance(): void
+    {
+        $cta = self::cta([
+            'content' => ['label' => 'x'], 'link' => ['url' => 'https://x.test'],
+            'bottomOffset' => 120,
+        ]);
+        $html = FloatingCtaHtml::render($cta, 'page', '/');
+        self::assertStringContainsString('body{padding-bottom:calc(env(safe-area-inset-bottom,0px) + 120px)}', $html);
+    }
+
+    public function testNoBottomOffsetOmitsClearance(): void
+    {
+        $cta = self::cta(['content' => ['label' => 'x'], 'link' => ['url' => 'https://x.test']]);
+        $html = FloatingCtaHtml::render($cta, 'page', '/');
+        self::assertStringNotContainsString('body{padding-bottom', $html);
+    }
+
     public function testEscapesAdminSuppliedText(): void
     {
         $cta = self::cta([

--- a/tests/PublicRecord/FloatingCtaTest.php
+++ b/tests/PublicRecord/FloatingCtaTest.php
@@ -61,6 +61,18 @@ final class FloatingCtaTest extends TestCase
         self::assertSame('Book', $cta->label);
     }
 
+    public function testBottomOffsetIsParsedAndClamped(): void
+    {
+        $base = ['enabled' => true, 'content' => ['label' => 'x'], 'link' => ['url' => 'https://x.test']];
+
+        self::assertSame(120, FloatingCta::fromSettings(self::settings($base + ['bottomOffset' => 120]))->bottomOffset);
+        // Out of range / wrong type all resolve to 0 (no clearance).
+        self::assertSame(FloatingCta::MAX_BOTTOM_OFFSET, FloatingCta::fromSettings(self::settings($base + ['bottomOffset' => 9999]))->bottomOffset);
+        self::assertSame(0, FloatingCta::fromSettings(self::settings($base + ['bottomOffset' => -50]))->bottomOffset);
+        self::assertSame(0, FloatingCta::fromSettings(self::settings($base + ['bottomOffset' => '80']))->bottomOffset);
+        self::assertSame(0, FloatingCta::fromSettings(self::settings($base))->bottomOffset);
+    }
+
     public function testInvalidPositionFallsBackToBr(): void
     {
         $cta = FloatingCta::fromSettings(self::settings([

--- a/tests/Setting/FloatingCtaValidatorTest.php
+++ b/tests/Setting/FloatingCtaValidatorTest.php
@@ -29,6 +29,7 @@ final class FloatingCtaValidatorTest extends TestCase
             'content' => ['icon' => '📅', 'iconId' => 'calendar', 'label' => '30分無料相談を予約', 'sub' => 'オンライン'],
             'link' => ['url' => 'https://calendar.app.google/x', 'newTab' => true],
             'conditions' => ['types' => ['page'], 'urlGlobs' => ['/services*'], 'exclude' => ['/admin*']],
+            'bottomOffset' => 120,
         ]));
         $this->addToAssertionCount(1);
     }
@@ -61,6 +62,9 @@ final class FloatingCtaValidatorTest extends TestCase
         yield 'enabled without url' => [(string) json_encode(['enabled' => true, 'content' => ['label' => 'x']])];
         yield 'conditions.types not array' => [(string) json_encode(['conditions' => ['types' => 'page']] + $base)];
         yield 'label too long' => [(string) json_encode(['enabled' => true, 'content' => ['label' => str_repeat('a', 61)], 'link' => ['url' => 'https://x.test']])];
+        yield 'bottomOffset over max' => [(string) json_encode(['bottomOffset' => 9999] + $base)];
+        yield 'bottomOffset negative' => [(string) json_encode(['bottomOffset' => -1] + $base)];
+        yield 'bottomOffset not int' => [(string) json_encode(['bottomOffset' => '100'] + $base)];
     }
 
     public function testMailtoAndTelAndRelativeAreAccepted(): void


### PR DESCRIPTION
## 目的
#982 P1 の FAB は `position:fixed; bottom:20px` 固定で、スクロール末尾にフッター最下行（例: SNS リンク）を覆う。ayane.co.jp では ayane-local パッチ `footer{padding-bottom:calc(safe-area + 100px)!important}` で凌いでいた（コード内コメントに「proper solution は #982 P2」と明記）。

hub 裁定（07-22・daily §I）の P2 着手順の先頭＝**(c) bottom offset の config 化（無JS・ayane footer hack を正規化）**。

## 変更
`floating_cta` に整数 **`bottomOffset`（0–400・既定0）** を追加。>0 のとき公開 SSR が `body{padding-bottom:calc(env(safe-area-inset-bottom,0px) + Npx)}` を emit ＝ 固定 FAB 分のクリアランスをページ下部に確保（**JS 不要**）。既定 0 で既存挙動は不変。

- **backend**: `FloatingCta`（parse+clamp・`MAX_BOTTOM_OFFSET=400`）/ `FloatingCtaValidator`（int 0–400・fail-closed・書込境界）/ `FloatingCtaHtml`（clearance emit・検証済み int の安全補間）
- **frontend**: `floating-cta.ts`（型+parse+clamp）/ `FloatingCtaView`（数値入力＋ヘルプ）/ `useFloatingCtaPage`（`setConfig` 拡張）/ i18n 6ロケール
- **tests**: validator 境界（over-max/negative/non-int）・fromSettings clamp・html emit/omit・`floating-cta.test.ts`

## 検証
- `composer check` 緑（PHPUnit 1426 / PHPStan level8 no errors / CS-Fixer / OpenAPI / MCP）
- `npm run check --prefix frontend` 全緑（type-check / eslint0 / prettier / vitest 9 / validate:themes / knip / storybook build）

## 効果 / スコープ
ayane は次フロント波でこの config を採用し、footer ハックを撤去できる（正規化）。**スコープ外の後続 P2**: (a) dismiss 記憶（JS要・2案比較）／(d) scroll・delay トリガー／画像アイコン／`:hover` = #367 束ね。(b) IntersectionObserver auto-hide は見送り。

Closes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)