### PR TITLE
feat(public): フローティングCTA に dismiss（×で閉じて記憶）を追加（#982 P2 (a)）

### DIFF
--- a/frontend/src/features/manage-appearance/hooks/useFloatingCtaPage.ts
+++ b/frontend/src/features/manage-appearance/hooks/useFloatingCtaPage.ts
@@ -16,7 +16,9 @@ export interface FloatingCtaPageState {
   draft: FloatingCtaConfig
   /** Patch top-level fields (enabled / position / accent). */
   setConfig: (
-    patch: Partial<Pick<FloatingCtaConfig, 'enabled' | 'position' | 'accent' | 'bottomOffset'>>,
+    patch: Partial<
+      Pick<FloatingCtaConfig, 'enabled' | 'position' | 'accent' | 'bottomOffset' | 'dismissible'>
+    >,
   ) => void
   /** Patch the content fields (icon / label / sub). */
   setContent: (patch: Partial<FloatingCtaConfig['content']>) => void

--- a/frontend/src/features/manage-appearance/ui/FloatingCtaView.tsx
+++ b/frontend/src/features/manage-appearance/ui/FloatingCtaView.tsx
@@ -145,6 +145,16 @@ export function FloatingCtaView({
               </Text>
             </div>
           </Row>
+          <Checkbox
+            checked={draft.dismissible}
+            label={t('admin.floatingCta.dismissible')}
+            onChange={(dismissible) => {
+              setConfig({ dismissible })
+            }}
+          />
+          <Text muted variant="caption">
+            {t('admin.floatingCta.dismissibleHelp')}
+          </Text>
         </Stack>
 
         <Stack gap="sm">

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -217,6 +217,9 @@ export const de = {
   'admin.floatingCta.positionBl': 'Unten links',
   'admin.floatingCta.accent': 'Akzentfarbe',
   'admin.floatingCta.bottomOffset': 'Abstand unten (px)',
+  'admin.floatingCta.dismissible': 'Schließbar (× zum Schließen)',
+  'admin.floatingCta.dismissibleHelp':
+    'Fügt ein × hinzu und merkt sich das Schließen pro Gerät (nutzt ein kleines Skript).',
   'admin.floatingCta.bottomOffsetHelp':
     'Reserviert Platz über der Fußzeile, damit die Schaltfläche sie nicht verdeckt. 0 = aus.',
   'admin.floatingCta.icon': 'Symbol (Emoji)',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -230,6 +230,9 @@ export const en = {
   'admin.floatingCta.positionBl': 'Bottom left',
   'admin.floatingCta.accent': 'Accent color',
   'admin.floatingCta.bottomOffset': 'Bottom clearance (px)',
+  'admin.floatingCta.dismissible': 'Dismissible (× to close)',
+  'admin.floatingCta.dismissibleHelp':
+    'Adds a × and remembers the dismissal per device (uses a small script).',
   'admin.floatingCta.bottomOffsetHelp':
     'Reserves space above the footer so the button never covers it. 0 = off.',
   'admin.floatingCta.icon': 'Icon (emoji)',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -220,6 +220,9 @@ export const fr = {
   'admin.floatingCta.positionBl': 'En bas à gauche',
   'admin.floatingCta.accent': 'Couleur d’accent',
   'admin.floatingCta.bottomOffset': 'Marge inférieure (px)',
+  'admin.floatingCta.dismissible': 'Fermable (× pour fermer)',
+  'admin.floatingCta.dismissibleHelp':
+    'Ajoute un × et mémorise la fermeture par appareil (utilise un petit script).',
   'admin.floatingCta.bottomOffsetHelp':
     'Réserve de l’espace au-dessus du pied de page pour que le bouton ne le masque pas. 0 = désactivé.',
   'admin.floatingCta.icon': 'Icône (emoji)',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -226,6 +226,9 @@ export const ja = {
   'admin.floatingCta.positionBl': '左下',
   'admin.floatingCta.accent': 'アクセント色',
   'admin.floatingCta.bottomOffset': '下部クリアランス（px）',
+  'admin.floatingCta.dismissible': '閉じるボタン（×）を表示',
+  'admin.floatingCta.dismissibleHelp':
+    '× を表示し、閉じたことを端末に記憶します（小さなスクリプトを使用）。',
   'admin.floatingCta.bottomOffsetHelp':
     'フッターの上に余白を確保し、ボタンが重ならないようにします。0=なし。',
   'admin.floatingCta.icon': 'アイコン（絵文字）',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -218,6 +218,9 @@ export const ptBR = {
   'admin.floatingCta.positionBl': 'Inferior esquerdo',
   'admin.floatingCta.accent': 'Cor de destaque',
   'admin.floatingCta.bottomOffset': 'Espaço inferior (px)',
+  'admin.floatingCta.dismissible': 'Dispensável (× para fechar)',
+  'admin.floatingCta.dismissibleHelp':
+    'Adiciona um × e memoriza o fechamento por dispositivo (usa um pequeno script).',
   'admin.floatingCta.bottomOffsetHelp':
     'Reserva espaço acima do rodapé para o botão não cobri-lo. 0 = desativado.',
   'admin.floatingCta.icon': 'Ícone (emoji)',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -214,6 +214,8 @@ export const zhHans = {
   'admin.floatingCta.positionBl': '左下角',
   'admin.floatingCta.accent': '强调色',
   'admin.floatingCta.bottomOffset': '底部留白（px）',
+  'admin.floatingCta.dismissible': '可关闭（× 关闭）',
+  'admin.floatingCta.dismissibleHelp': '显示 × 并在设备上记住已关闭（使用一小段脚本）。',
   'admin.floatingCta.bottomOffsetHelp': '在页脚上方预留空间，避免按钮遮挡。0 = 关闭。',
   'admin.floatingCta.icon': '图标（表情）',
   'admin.floatingCta.iconId': '图标',

--- a/frontend/src/shared/lib/floating-cta.test.ts
+++ b/frontend/src/shared/lib/floating-cta.test.ts
@@ -52,6 +52,12 @@ describe('parseFloatingCta', () => {
     expect(parseFloatingCta('{}').bottomOffset).toBe(0)
   })
 
+  it('parses dismissible defensively (#982 P2 a)', () => {
+    expect(parseFloatingCta(JSON.stringify({ dismissible: true })).dismissible).toBe(true)
+    expect(parseFloatingCta(JSON.stringify({ dismissible: 'yes' })).dismissible).toBe(false)
+    expect(parseFloatingCta('{}').dismissible).toBe(false)
+  })
+
   it('round-trips through serialize', () => {
     const cfg = parseFloatingCta(
       JSON.stringify({ enabled: true, content: { label: 'x' }, link: { url: '/c' } }),

--- a/frontend/src/shared/lib/floating-cta.ts
+++ b/frontend/src/shared/lib/floating-cta.ts
@@ -38,6 +38,8 @@ export interface FloatingCtaConfig {
   conditions: FloatingCtaConditions
   /** Extra clearance (px) reserved at the page bottom so the fixed FAB never covers footer content; 0 = none. */
   bottomOffset: number
+  /** When true, the FAB shows a "×" and remembers dismissal in localStorage (needs a CSP nonce'd script). */
+  dismissible: boolean
 }
 
 export const DEFAULT_FLOATING_CTA: FloatingCtaConfig = {
@@ -48,6 +50,7 @@ export const DEFAULT_FLOATING_CTA: FloatingCtaConfig = {
   link: { url: '', newTab: true },
   conditions: { types: [], urlGlobs: [], exclude: [] },
   bottomOffset: 0,
+  dismissible: false,
 }
 
 /** Re-exported so the CTA editor shares the exact header-CTA scheme allowlist. */
@@ -119,6 +122,7 @@ export function parseFloatingCta(raw: string | undefined): FloatingCtaConfig {
       exclude: asStringList(conditions.exclude),
     },
     bottomOffset: asBottomOffset(record.bottomOffset),
+    dismissible: asBool(record.dismissible),
   }
 }
 

--- a/src/Http/PublicHtmlCsp.php
+++ b/src/Http/PublicHtmlCsp.php
@@ -51,19 +51,32 @@ final class PublicHtmlCsp
     ): string {
         $embedOrigins = $embeds?->origins() ?? [];
 
-        // ── Fast path: no embeds ⇒ existing behaviour, byte-for-byte unchanged ──
-        // (This block is intentionally identical to the pre-#802 implementation so
-        // adding the allowlist parameter cannot regress any analytics/nonce output.)
+        $hasNonce = $scriptNonce !== null && $scriptNonce !== '';
+
+        // ── Fast path: no embeds ──
         if ($embedOrigins === []) {
-            if (!$analytics->isEnabled()) {
+            // Nothing to widen: strict POLICY unchanged (byte-for-byte as pre-#802).
+            if (!$analytics->isEnabled() && !$hasNonce) {
                 return self::POLICY;
             }
 
             $scriptSrc = "'self'";
-            if ($scriptNonce !== null && $scriptNonce !== '') {
+            if ($hasNonce) {
                 $scriptSrc .= " 'nonce-{$scriptNonce}'";
             }
-            $scriptSrc .= ' https://www.googletagmanager.com';
+            if ($analytics->isEnabled()) {
+                $scriptSrc .= ' https://www.googletagmanager.com';
+            }
+
+            // A nonce with no analytics (e.g. the floating-CTA dismiss script, #982 P2 a)
+            // widens only script-src; the analytics-host img/connect stay off.
+            if (!$analytics->isEnabled()) {
+                return "default-src 'self'; "
+                    . "script-src {$scriptSrc}; "
+                    . "style-src 'self' 'unsafe-inline'; "
+                    . "font-src 'self' data:; "
+                    . "img-src 'self' data:";
+            }
 
             return "default-src 'self'; "
                 . "script-src {$scriptSrc}; "
@@ -77,7 +90,7 @@ final class PublicHtmlCsp
         $embedList = implode(' ', $embedOrigins);
 
         $script = "'self'";
-        if ($analytics->isEnabled() && $scriptNonce !== null && $scriptNonce !== '') {
+        if ($hasNonce) {
             $script .= " 'nonce-{$scriptNonce}'";
         }
         if ($analytics->isEnabled()) {

--- a/src/PublicRecord/FloatingCta.php
+++ b/src/PublicRecord/FloatingCta.php
@@ -52,12 +52,14 @@ final readonly class FloatingCta
         public array $conditionExclude,
         /** Extra clearance (px) reserved at the page bottom so the fixed FAB never covers footer content; 0 = none (#982 P2 (c)). */
         public int $bottomOffset = 0,
+        /** When true, the FAB shows a dismiss (×) button and remembers dismissal in localStorage (#982 P2 (a)). */
+        public bool $dismissible = false,
     ) {
     }
 
     public static function disabled(): self
     {
-        return new self(false, 'br', self::DEFAULT_ACCENT, '', '', '', '', '', true, [], [], [], 0);
+        return new self(false, 'br', self::DEFAULT_ACCENT, '', '', '', '', '', true, [], [], [], 0, false);
     }
 
     /**
@@ -104,6 +106,8 @@ final readonly class FloatingCta
         $rawOffset = $decoded['bottomOffset'] ?? 0;
         $bottomOffset = is_int($rawOffset) ? max(0, min($rawOffset, self::MAX_BOTTOM_OFFSET)) : 0;
 
+        $dismissible = ($decoded['dismissible'] ?? false) === true;
+
         $label = self::asString($content['label'] ?? '');
         $url = self::asString($link['url'] ?? '');
 
@@ -130,6 +134,7 @@ final readonly class FloatingCta
             conditionUrlGlobs: self::asStringList($conditions['urlGlobs'] ?? []),
             conditionExclude: self::asStringList($conditions['exclude'] ?? []),
             bottomOffset: $bottomOffset,
+            dismissible: $dismissible,
         );
     }
 
@@ -169,6 +174,18 @@ final readonly class FloatingCta
         }
 
         return true;
+    }
+
+    /**
+     * Whether the FAB will render its dismiss UI on this page (#982 P2 (a)).
+     *
+     * True only when enabled, dismissible, and the page matches. The renderer uses this
+     * to decide whether a CSP script nonce is needed at all — so pages without a
+     * dismissible FAB keep the strict `script-src 'self'` (no nonce) policy.
+     */
+    public function isDismissActiveFor(string $typeSlug, string $path): bool
+    {
+        return $this->dismissible && $this->shouldRender($typeSlug, $path);
     }
 
     /**

--- a/src/PublicRecord/FloatingCtaHtml.php
+++ b/src/PublicRecord/FloatingCtaHtml.php
@@ -23,7 +23,7 @@ namespace NeNeRecords\PublicRecord;
  */
 final class FloatingCtaHtml
 {
-    public static function render(FloatingCta $cta, string $typeSlug, string $path): string
+    public static function render(FloatingCta $cta, string $typeSlug, string $path, ?string $nonce = null, string $lang = 'en'): string
     {
         if (!$cta->shouldRender($typeSlug, $path)) {
             return '';
@@ -51,19 +51,37 @@ final class FloatingCtaHtml
             ? '<span class="nene-fab__sub">' . self::e($cta->sub) . '</span>'
             : '';
 
-        $style = self::style($accent, $side, $cta->bottomOffset);
+        // Dismiss (#982 P2 (a)): a "×" that remembers dismissal in localStorage via a small
+        // nonce'd inline script. The renderer only supplies a nonce when it will also add it
+        // to the CSP, so a missing nonce means "no dismiss UI" (graceful, still a working FAB).
+        $dismiss = $cta->dismissible && $nonce !== null && $nonce !== '';
 
-        return $style . "\n"
-            . '<a class="nene-fab" href="' . $href . '"' . $target . $rel . '>'
+        $style = self::style($accent, $side, $cta->bottomOffset, $dismiss);
+
+        $button = '<a class="nene-fab" href="' . $href . '"' . $target . $rel . '>'
             . $icon
             . '<span class="nene-fab__text">'
             . '<span class="nene-fab__label">' . $label . '</span>'
             . $sub
             . '</span>'
             . '</a>';
+
+        $dismissBtn = '';
+        $script = '';
+        if ($dismiss) {
+            $dismissBtn = '<button type="button" class="nene-fab__dismiss" aria-label="'
+                . self::e(self::dismissLabel($lang)) . '">&#215;</button>';
+            $script = self::script((string) $nonce);
+        }
+
+        // The wrapper is the fixed-positioned element so the dismiss button can sit at its
+        // corner; the SPA never touches it (rendered outside #root before </body>).
+        return $style . "\n"
+            . '<div class="nene-fab-wrap" id="nene-fab-wrap">' . $button . $dismissBtn . '</div>'
+            . $script;
     }
 
-    private static function style(string $accent, string $side, int $bottomOffset): string
+    private static function style(string $accent, string $side, int $bottomOffset, bool $dismiss): string
     {
         // Page-bottom clearance (#982 P2 (c)): reserve space so the fixed FAB never covers
         // footer content at scroll-end. Replaces the ad-hoc per-site `footer{padding-bottom}`
@@ -72,14 +90,24 @@ final class FloatingCtaHtml
             ? 'body{padding-bottom:calc(env(safe-area-inset-bottom,0px) + ' . $bottomOffset . 'px)}'
             : '';
 
-        // Scoped to `.nene-fab`; safe to inline (CSP style-src allows 'unsafe-inline').
-        // `$accent` is a validated hex and `$side` is a fixed keyword, so interpolation
-        // is injection-free.
+        // The dismiss "×" sits at the wrapper's outer corner (opposite side stays clear).
+        $dismissCss = $dismiss
+            ? '.nene-fab__dismiss{position:absolute;top:-9px;' . $side . ':-9px;width:24px;height:24px;'
+                . 'border:none;border-radius:999px;cursor:pointer;background:#14120F;color:#fff;'
+                . 'font-size:15px;line-height:1;padding:0;display:flex;align-items:center;justify-content:center;'
+                . 'box-shadow:0 2px 6px rgba(20,18,15,.3)}'
+                . '.nene-fab__dismiss:hover{filter:brightness(1.25)}'
+                . '.nene-fab__dismiss:focus-visible{outline:2px solid #14120F;outline-offset:2px}'
+            : '';
+
+        // Scoped to `.nene-fab*`; safe to inline (CSP style-src allows 'unsafe-inline').
+        // The wrapper carries the fixed position; `.nene-fab` is the button visual. `$accent`
+        // is a validated hex and `$side` a fixed keyword, so interpolation is injection-free.
         return '<style>'
             . $clearance
-            . '.nene-fab{position:fixed;bottom:calc(env(safe-area-inset-bottom,0px) + 20px);'
-            . $side . ':calc(env(safe-area-inset-' . $side . ',0px) + 20px);z-index:2147483000;'
-            . 'display:inline-flex;align-items:center;gap:10px;'
+            . '.nene-fab-wrap{position:fixed;bottom:calc(env(safe-area-inset-bottom,0px) + 20px);'
+            . $side . ':calc(env(safe-area-inset-' . $side . ',0px) + 20px);z-index:2147483000}'
+            . '.nene-fab{display:inline-flex;align-items:center;gap:10px;'
             . 'background:var(--nene-fab-bg,' . $accent . ');color:var(--nene-fab-fg,#fff);'
             . 'text-decoration:none;font-family:inherit;font-weight:700;font-size:.92rem;line-height:1.15;'
             . 'padding:13px 20px;border-radius:999px;'
@@ -91,9 +119,39 @@ final class FloatingCtaHtml
             . '.nene-fab__icon{font-size:1.2em;line-height:1}'
             . '.nene-fab__text{display:inline-flex;flex-direction:column}'
             . '.nene-fab__sub{font-size:.62rem;font-weight:500;letter-spacing:.04em;opacity:.85;margin-top:2px}'
-            . '@media(max-width:560px){.nene-fab{left:14px;right:14px;justify-content:center;padding:15px 18px}}'
+            . $dismissCss
+            . '@media(max-width:560px){.nene-fab-wrap{left:14px;right:14px}.nene-fab{display:flex;justify-content:center;padding:15px 18px}}'
             . '@media(prefers-reduced-motion:reduce){.nene-fab{transition:none}.nene-fab:hover{transform:none}}'
             . '</style>';
+    }
+
+    /**
+     * The nonce'd dismiss script: a first-party constant (no interpolated data) that hides
+     * the FAB immediately when already dismissed and remembers a "×" click in localStorage.
+     * `$nonce` is hex from the renderer, so attribute interpolation carries no injection.
+     */
+    private static function script(string $nonce): string
+    {
+        $n = self::e($nonce);
+        $js = "(function(){try{var k='nene-fab-dismissed',w=document.getElementById('nene-fab-wrap');"
+            . "if(!w)return;if(localStorage.getItem(k)==='1'){w.style.display='none';return}"
+            . "var b=w.querySelector('.nene-fab__dismiss');if(b){b.addEventListener('click',function(){"
+            . "try{localStorage.setItem(k,'1')}catch(e){}w.style.display='none'})}}catch(e){}})();";
+
+        return "<script nonce=\"{$n}\">{$js}</script>";
+    }
+
+    /** Localized accessible label for the dismiss button across the supported public locales. */
+    private static function dismissLabel(string $lang): string
+    {
+        return match ($lang) {
+            'ja' => '閉じる',
+            'de' => 'Schließen',
+            'fr' => 'Fermer',
+            'pt-BR' => 'Fechar',
+            'zh-Hans' => '关闭',
+            default => 'Close',
+        };
     }
 
     private static function e(string $value): string

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -120,8 +120,14 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
 
         // GA4 / GTM + Consent Mode v2 — emitted only when the org configured a tag id.
         $analytics = WebAnalyticsConfig::fromSettings($settings);
-        $analyticsNonce = $analytics->isEnabled() ? bin2hex(random_bytes(16)) : '';
-        $analyticsHead = WebAnalyticsHeadSnippet::render($analytics, $analyticsNonce);
+        // One per-response nonce covers analytics AND the floating-CTA dismiss script
+        // (#982 P2 a). It is generated — and added to the CSP script-src below — only when
+        // one of them needs it, so pages with neither keep the strict `script-src 'self'`.
+        $floatingCtaConfig = FloatingCta::fromSettings($settings);
+        $fabPath = $request->getUri()->getPath();
+        $fabDismissActive = $floatingCtaConfig->isDismissActiveFor($output->entityTypeSlug, $fabPath);
+        $nonce = ($analytics->isEnabled() || $fabDismissActive) ? bin2hex(random_bytes(16)) : '';
+        $analyticsHead = WebAnalyticsHeadSnippet::render($analytics, $nonce);
 
         // Trusted-embed primitive (#802 Phase 2): when the org has an embed
         // allowlist, render its `trusted-embed` widgets into the crawlable shell
@@ -141,9 +147,11 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
         // the shell (NOT sanitized) when enabled and the page matches the org's conditions.
         // '' when disabled / no match — same "no config, no output" shape as analytics.
         $floatingCta = FloatingCtaHtml::render(
-            FloatingCta::fromSettings($settings),
+            $floatingCtaConfig,
             $output->entityTypeSlug,
-            $request->getUri()->getPath(),
+            $fabPath,
+            $fabDismissActive ? $nonce : null,
+            $locale ?? PublicLocale::DEFAULT_LANG,
         );
 
         // Canonical / og:url point at the user-facing permalink (not this /view/ twin).
@@ -269,7 +277,7 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
             'Content-Security-Policy',
             PublicHtmlCsp::build(
                 $analytics,
-                $analyticsNonce !== '' ? $analyticsNonce : null,
+                $nonce !== '' ? $nonce : null,
                 $embedAllowlist,
             ),
         );

--- a/src/PublicRecord/RenderPublicTypeArchiveRenderer.php
+++ b/src/PublicRecord/RenderPublicTypeArchiveRenderer.php
@@ -43,15 +43,23 @@ final readonly class RenderPublicTypeArchiveRenderer implements PublicTypeArchiv
         $metaDescription = $settings['default_meta_description'] ?? '';
 
         $analytics = WebAnalyticsConfig::fromSettings($settings);
-        $analyticsNonce = $analytics->isEnabled() ? bin2hex(random_bytes(16)) : '';
-        $analyticsHead = WebAnalyticsHeadSnippet::render($analytics, $analyticsNonce);
 
         // First-party floating CTA (#982) for the type-archive shell — same server-rendered
-        // chrome as the record shell. '' when disabled / the archive type is excluded.
+        // chrome as the record shell. '' when disabled / the archive type is excluded. One
+        // nonce covers analytics AND the dismiss script (#982 P2 a); generated only when
+        // needed so pages with neither keep the strict `script-src 'self'`.
+        $floatingCtaConfig = FloatingCta::fromSettings($settings);
+        $fabPath = $request->getUri()->getPath();
+        $fabDismissActive = $floatingCtaConfig->isDismissActiveFor($archive->typeSlug, $fabPath);
+        $nonce = ($analytics->isEnabled() || $fabDismissActive) ? bin2hex(random_bytes(16)) : '';
+        $analyticsHead = WebAnalyticsHeadSnippet::render($analytics, $nonce);
+
         $floatingCta = FloatingCtaHtml::render(
-            FloatingCta::fromSettings($settings),
+            $floatingCtaConfig,
             $archive->typeSlug,
-            $request->getUri()->getPath(),
+            $fabPath,
+            $fabDismissActive ? $nonce : null,
+            PublicLocale::DEFAULT_LANG,
         );
 
         $effectiveBase = $this->basePath . (string) $request->getAttribute('nene2.base_prefix', '');
@@ -120,7 +128,7 @@ final readonly class RenderPublicTypeArchiveRenderer implements PublicTypeArchiv
             'spaPreload' => $spaPreload,
         ])->withHeader(
             'Content-Security-Policy',
-            PublicHtmlCsp::build($analytics, $analyticsNonce !== '' ? $analyticsNonce : null, null),
+            PublicHtmlCsp::build($analytics, $nonce !== '' ? $nonce : null, null),
         );
     }
 

--- a/src/Setting/FloatingCtaValidator.php
+++ b/src/Setting/FloatingCtaValidator.php
@@ -81,6 +81,11 @@ final class FloatingCtaValidator
             }
         }
 
+        // dismissible (#982 P2 (a)): whether the FAB shows a "×" and remembers dismissal.
+        if (isset($decoded['dismissible']) && !is_bool($decoded['dismissible'])) {
+            $errors[] = new ValidationError('value.dismissible', 'dismissible must be a boolean.', 'invalid');
+        }
+
         $content = $decoded['content'] ?? [];
         if (!is_array($content) || array_is_list($content)) {
             $errors[] = new ValidationError('value.content', 'content must be an object.', 'invalid');

--- a/tests/Http/PublicHtmlCspTest.php
+++ b/tests/Http/PublicHtmlCspTest.php
@@ -11,15 +11,27 @@ use PHPUnit\Framework\TestCase;
 
 final class PublicHtmlCspTest extends TestCase
 {
-    public function testDisabledAnalyticsReturnsStrictBaseline(): void
+    public function testDisabledAnalyticsWithoutNonceReturnsStrictBaseline(): void
     {
-        $csp = PublicHtmlCsp::build(WebAnalyticsConfig::disabled(), 'noncevalue');
+        $csp = PublicHtmlCsp::build(WebAnalyticsConfig::disabled(), null);
 
         self::assertSame(PublicHtmlCsp::POLICY, $csp);
         self::assertStringNotContainsString('googletagmanager', $csp);
         self::assertStringNotContainsString('nonce-', $csp);
         // Scripts stay 'self' (inherited from default-src) — no script-src directive.
         self::assertStringNotContainsString('script-src', $csp);
+    }
+
+    public function testNonceWithoutAnalyticsWidensOnlyScriptSrc(): void
+    {
+        // #982 P2 (a): the floating-CTA dismiss script needs its nonce in script-src even
+        // with analytics off — but nothing else widens (no GTM / analytics hosts / connect).
+        $csp = PublicHtmlCsp::build(WebAnalyticsConfig::disabled(), 'fabnonce');
+
+        self::assertStringContainsString("script-src 'self' 'nonce-fabnonce'", $csp);
+        self::assertStringNotContainsString('googletagmanager', $csp);
+        self::assertStringNotContainsString('google-analytics', $csp);
+        self::assertStringNotContainsString('connect-src', $csp);
     }
 
     public function testEnabledAddsNonceAndTagManagerToScriptSrc(): void
@@ -71,8 +83,9 @@ final class PublicHtmlCspTest extends TestCase
         // The whole guarantee of the feature: an empty allowlist changes nothing.
         self::assertSame(
             PublicHtmlCsp::POLICY,
-            PublicHtmlCsp::build(WebAnalyticsConfig::disabled(), 'nonce', self::embeds([])),
+            PublicHtmlCsp::build(WebAnalyticsConfig::disabled(), null, self::embeds([])),
         );
+        // Holds with a nonce too: empty allowlist == no allowlist (both widen script-src only).
         self::assertSame(
             PublicHtmlCsp::build(WebAnalyticsConfig::disabled(), 'nonce'),
             PublicHtmlCsp::build(WebAnalyticsConfig::disabled(), 'nonce', self::embeds([])),

--- a/tests/PublicRecord/FloatingCtaHtmlTest.php
+++ b/tests/PublicRecord/FloatingCtaHtmlTest.php
@@ -40,7 +40,8 @@ final class FloatingCtaHtmlTest extends TestCase
         $html = FloatingCtaHtml::render($cta, 'page', '/');
 
         self::assertStringContainsString('<style>', $html);
-        self::assertStringContainsString('.nene-fab{position:fixed', $html);
+        self::assertStringContainsString('.nene-fab-wrap{position:fixed', $html);
+        self::assertStringContainsString('<div class="nene-fab-wrap" id="nene-fab-wrap">', $html);
         self::assertStringContainsString('#D64525', $html);
         self::assertStringContainsString('href="https://calendar.app.google/x"', $html);
         self::assertStringContainsString('target="_blank"', $html);
@@ -74,6 +75,57 @@ final class FloatingCtaHtmlTest extends TestCase
         $cta = self::cta(['content' => ['label' => 'x'], 'link' => ['url' => 'https://x.test']]);
         $html = FloatingCtaHtml::render($cta, 'page', '/');
         self::assertStringNotContainsString('body{padding-bottom', $html);
+    }
+
+    public function testDismissibleWithNonceEmitsButtonAndNoncedScript(): void
+    {
+        $cta = self::cta([
+            'content' => ['label' => 'x'], 'link' => ['url' => 'https://x.test'],
+            'dismissible' => true,
+        ]);
+        $html = FloatingCtaHtml::render($cta, 'page', '/', 'abc123', 'ja');
+
+        self::assertStringContainsString('class="nene-fab__dismiss"', $html);
+        self::assertStringContainsString('aria-label="閉じる"', $html);
+        self::assertStringContainsString('<script nonce="abc123">', $html);
+        self::assertStringContainsString("localStorage.setItem(k,'1')", $html);
+        self::assertStringContainsString("localStorage.getItem(k)==='1'", $html);
+        self::assertStringContainsString('.nene-fab__dismiss{position:absolute', $html);
+    }
+
+    public function testDismissibleWithoutNonceOmitsScript(): void
+    {
+        // No nonce available (analytics off, renderer supplies none) → no dismiss UI, but a
+        // fully working FAB still renders (graceful degradation, no CSP violation).
+        $cta = self::cta([
+            'content' => ['label' => 'x'], 'link' => ['url' => 'https://x.test'],
+            'dismissible' => true,
+        ]);
+        $html = FloatingCtaHtml::render($cta, 'page', '/');
+
+        self::assertStringNotContainsString('<script', $html);
+        self::assertStringNotContainsString('nene-fab__dismiss', $html);
+        self::assertStringContainsString('class="nene-fab"', $html);
+    }
+
+    public function testNonDismissibleNeverEmitsScriptEvenWithNonce(): void
+    {
+        $cta = self::cta(['content' => ['label' => 'x'], 'link' => ['url' => 'https://x.test']]);
+        $html = FloatingCtaHtml::render($cta, 'page', '/', 'abc123', 'en');
+
+        self::assertStringNotContainsString('<script', $html);
+        self::assertStringNotContainsString('nene-fab__dismiss', $html);
+    }
+
+    public function testDismissButtonSitsOnPositionSide(): void
+    {
+        $cta = self::cta([
+            'position' => 'bl', 'content' => ['label' => 'x'], 'link' => ['url' => 'https://x.test'],
+            'dismissible' => true,
+        ]);
+        $html = FloatingCtaHtml::render($cta, 'page', '/', 'n0nce', 'en');
+        self::assertStringContainsString('.nene-fab__dismiss{position:absolute;top:-9px;left:-9px', $html);
+        self::assertStringContainsString('aria-label="Close"', $html);
     }
 
     public function testEscapesAdminSuppliedText(): void

--- a/tests/PublicRecord/FloatingCtaTest.php
+++ b/tests/PublicRecord/FloatingCtaTest.php
@@ -73,6 +73,30 @@ final class FloatingCtaTest extends TestCase
         self::assertSame(0, FloatingCta::fromSettings(self::settings($base))->bottomOffset);
     }
 
+    public function testDismissibleIsParsed(): void
+    {
+        $base = ['enabled' => true, 'content' => ['label' => 'x'], 'link' => ['url' => 'https://x.test']];
+        self::assertFalse(FloatingCta::fromSettings(self::settings($base))->dismissible);
+        self::assertTrue(FloatingCta::fromSettings(self::settings($base + ['dismissible' => true]))->dismissible);
+        self::assertFalse(FloatingCta::fromSettings(self::settings($base + ['dismissible' => 'yes']))->dismissible);
+    }
+
+    public function testIsDismissActiveForRequiresEnabledDismissibleAndMatch(): void
+    {
+        $base = ['enabled' => true, 'dismissible' => true, 'content' => ['label' => 'x'], 'link' => ['url' => 'https://x.test']];
+
+        self::assertTrue(FloatingCta::fromSettings(self::settings($base))->isDismissActiveFor('page', '/'));
+        // Not dismissible → false even though it renders.
+        self::assertFalse(FloatingCta::fromSettings(self::settings(['dismissible' => false] + $base))->isDismissActiveFor('page', '/'));
+        // Page excluded → false even though dismissible.
+        self::assertFalse(
+            FloatingCta::fromSettings(self::settings($base + ['conditions' => ['exclude' => ['/secret*']]]))
+                ->isDismissActiveFor('page', '/secret'),
+        );
+        // Disabled → false.
+        self::assertFalse(FloatingCta::disabled()->isDismissActiveFor('page', '/'));
+    }
+
     public function testInvalidPositionFallsBackToBr(): void
     {
         $cta = FloatingCta::fromSettings(self::settings([

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -513,6 +513,61 @@ final class PublicRecordHttpTest extends TestCase
         self::assertStringNotContainsString('googletagmanager', (string) $response->getBody());
     }
 
+    public function testSsrGivesDismissibleFabANonceEvenWithAnalyticsOff(): void
+    {
+        // Analytics OFF — the nonce must come from the dismissible FAB alone (#982 P2 a).
+        $cfg = (string) json_encode([
+            'enabled' => true,
+            'content' => ['label' => 'Book'],
+            'link' => ['url' => 'https://x.test'],
+            'dismissible' => true,
+        ]);
+        $app = $this->buildApplication(true, $this->projectRoot, [
+            new \NeNeRecords\Setting\SettingDef('floating_cta', 'text', $cfg, true, 'FAB'),
+        ]);
+
+        $response = $app->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        );
+        $html = (string) $response->getBody();
+        $csp = $response->getHeaderLine('Content-Security-Policy');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('class="nene-fab__dismiss"', $html);
+
+        // The FAB dismiss script carries a nonce that is present in the CSP script-src.
+        preg_match('/<script nonce="([0-9a-f]{32})">/', $html, $m);
+        $nonce = $m[1] ?? '';
+        self::assertNotSame('', $nonce);
+        self::assertStringContainsString("'nonce-{$nonce}'", $csp);
+        self::assertStringNotContainsString('googletagmanager', $csp);
+    }
+
+    public function testSsrKeepsStrictCspWhenFabNotDismissible(): void
+    {
+        $cfg = (string) json_encode([
+            'enabled' => true,
+            'content' => ['label' => 'Book'],
+            'link' => ['url' => 'https://x.test'],
+        ]);
+        $app = $this->buildApplication(true, $this->projectRoot, [
+            new \NeNeRecords\Setting\SettingDef('floating_cta', 'text', $cfg, true, 'FAB'),
+        ]);
+
+        $response = $app->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        );
+        $html = (string) $response->getBody();
+        $csp = $response->getHeaderLine('Content-Security-Policy');
+
+        // A working FAB renders, but with no dismiss script → strict `script-src 'self'`
+        // (the page's own bootstrap/dev scripts carry no nonce).
+        self::assertStringContainsString('class="nene-fab"', $html);
+        self::assertStringNotContainsString('nene-fab__dismiss', $html);
+        self::assertStringNotContainsString('<script nonce=', $html);
+        self::assertStringNotContainsString("'nonce-", $csp);
+    }
+
     public function testSitemapXmlListsHomeAndPublishedRecords(): void
     {
         $response = $this->application->handle(

--- a/tests/Setting/FloatingCtaValidatorTest.php
+++ b/tests/Setting/FloatingCtaValidatorTest.php
@@ -30,6 +30,7 @@ final class FloatingCtaValidatorTest extends TestCase
             'link' => ['url' => 'https://calendar.app.google/x', 'newTab' => true],
             'conditions' => ['types' => ['page'], 'urlGlobs' => ['/services*'], 'exclude' => ['/admin*']],
             'bottomOffset' => 120,
+            'dismissible' => true,
         ]));
         $this->addToAssertionCount(1);
     }
@@ -65,6 +66,7 @@ final class FloatingCtaValidatorTest extends TestCase
         yield 'bottomOffset over max' => [(string) json_encode(['bottomOffset' => 9999] + $base)];
         yield 'bottomOffset negative' => [(string) json_encode(['bottomOffset' => -1] + $base)];
         yield 'bottomOffset not int' => [(string) json_encode(['bottomOffset' => '100'] + $base)];
+        yield 'dismissible not bool' => [(string) json_encode(['dismissible' => 'yes'] + $base)];
     }
 
     public function testMailtoAndTelAndRelativeAreAccepted(): void


### PR DESCRIPTION
## 目的
訪問者が FAB を「×」で閉じ、**閉じたことを記憶**して再表示しない（#982 P2 の本命）。方式は施主裁定＝**案A（nonce付き script＋localStorage）**。設計ノート: `_work/scratch/records-fab-dismiss-design.md`（2案＋α比較）。

## 実装
- `floating_cta` に `dismissible`（bool・既定 false）。有効時、FAB を `.nene-fab-wrap` に包み `×` ボタン＋**nonce付きインライン script** を emit。script は localStorage フラグを読み dismissed なら即非表示・× で set＋非表示。非 dismissible/nonce 無し時は従来の素の `<a>`（no-JS）＝**後方互換**。
- **CSP**: 公開面は `script-src 'self'`（nonce は従来 分析有効時のみ生成・付与）。dismiss script のため `PublicHtmlCsp::build` を **「nonce があれば分析非依存で script-src に付与」** へ拡張。nonce は **FAB が dismiss 描画するページだけ** 生成し、影響ページを最小化（分析OFFのサイトでも成立）。他ページ・管理シェルは厳格 `script-src 'self'` のまま。
- **安全性**: script は org 入力を通さない固定文字列・nonce は hex。× の `aria-label` は公開6ロケールを内蔵ローカライズ。
- **FOUC**: dismissed は即非表示（設計ノートで許容）。記憶=端末ローカル恒久（将来 N日再表示はオプション化余地）。

## 変更
- backend: `FloatingCta`（`dismissible`＋`isDismissActiveFor()`）/ `FloatingCtaValidator`（bool）/ `FloatingCtaHtml`（wrapper＋×＋nonce script・side 対応）/ `RenderPublicRecordViewHandler`＋`RenderPublicTypeArchiveRenderer`（統一 nonce 生成→FAB＋CSP）/ `PublicHtmlCsp`（nonce 拡張）
- frontend: `floating-cta.ts`（型＋parse）/ `FloatingCtaView`（トグル）/ `useFloatingCtaPage`（setConfig 拡張）/ i18n 6ロケール
- tests: html（dismiss＋nonce/nonce無し/非dismissible/side）・fromSettings・validator・**handler の CSP nonce（分析OFFでも FAB dismiss で nonce・非dismissibleで厳格CSP維持）**・`PublicHtmlCspTest`（nonce-only 経路）・`floating-cta.test.ts`

## 検証
- `composer check` 緑（PHPUnit 1436 / PHPStan level8 no errors / CS-Fixer / OpenAPI / MCP）
- `npm run check --prefix frontend` 全緑（type-check / eslint0 / prettier / vitest 661 / validate:themes / knip / storybook build）

## スコープ外（後続 P2）
(d) scroll/delay トリガー・画像アイコン・`:hover`＝#367 束ね。(b) IntersectionObserver auto-hide は見送り。ayane 反映は次フロント波で（footer ハック撤去＝#992 とまとめ）。

Closes #994

🤖 Generated with [Claude Code](https://claude.com/claude-code)