### PR TITLE
feat(public): フローティングCTA に scroll トリガー（Npxスクロール後に表示）を追加（#982 P2 (d) 後半）

### DIFF
--- a/frontend/src/features/manage-appearance/ui/FloatingCtaView.tsx
+++ b/frontend/src/features/manage-appearance/ui/FloatingCtaView.tsx
@@ -5,6 +5,7 @@ import {
   joinList,
   MAX_FLOATING_CTA_BOTTOM_OFFSET,
   MAX_FLOATING_CTA_DELAY_SECONDS,
+  MAX_FLOATING_CTA_SCROLL_PX,
   parseList,
   safeHref,
 } from '@/shared/lib/floating-cta'
@@ -161,31 +162,44 @@ export function FloatingCtaView({
               className="w-56 rounded-sm border border-border bg-surface px-inline-sm py-stack-xs font-sans text-body text-text-primary"
               value={draft.trigger}
               onChange={(event) => {
-                const trigger = event.target.value === 'delay' ? 'delay' : 'always'
-                setConfig({
-                  trigger,
-                  triggerValue: trigger === 'delay' ? Math.max(1, draft.triggerValue) : 0,
-                })
+                const value = event.target.value
+                const trigger = value === 'delay' || value === 'scroll' ? value : 'always'
+                // Units differ (seconds vs px), so reset to a sensible per-trigger default.
+                const triggerValue = trigger === 'delay' ? 3 : trigger === 'scroll' ? 400 : 0
+                setConfig({ trigger, triggerValue })
               }}
             >
               <option value="always">{t('admin.floatingCta.triggerAlways')}</option>
               <option value="delay">{t('admin.floatingCta.triggerDelay')}</option>
+              <option value="scroll">{t('admin.floatingCta.triggerScroll')}</option>
             </select>
           </Row>
-          {draft.trigger === 'delay' ? (
-            <Row label={t('admin.floatingCta.triggerDelaySeconds')}>
+          {draft.trigger !== 'always' ? (
+            <Row
+              label={
+                draft.trigger === 'delay'
+                  ? t('admin.floatingCta.triggerDelaySeconds')
+                  : t('admin.floatingCta.triggerScrollPx')
+              }
+            >
               <input
                 type="number"
                 min={1}
-                max={MAX_FLOATING_CTA_DELAY_SECONDS}
-                step={1}
+                max={
+                  draft.trigger === 'delay'
+                    ? MAX_FLOATING_CTA_DELAY_SECONDS
+                    : MAX_FLOATING_CTA_SCROLL_PX
+                }
+                step={draft.trigger === 'delay' ? 1 : 50}
                 className="w-24 rounded-sm border border-border bg-surface px-inline-sm py-stack-xs font-sans text-body text-text-primary"
                 value={draft.triggerValue}
                 onChange={(event) => {
+                  const max =
+                    draft.trigger === 'delay'
+                      ? MAX_FLOATING_CTA_DELAY_SECONDS
+                      : MAX_FLOATING_CTA_SCROLL_PX
                   const parsed = Number.parseInt(event.target.value, 10)
-                  const clamped = Number.isFinite(parsed)
-                    ? Math.max(1, Math.min(parsed, MAX_FLOATING_CTA_DELAY_SECONDS))
-                    : 1
+                  const clamped = Number.isFinite(parsed) ? Math.max(1, Math.min(parsed, max)) : 1
                   setConfig({ triggerValue: clamped })
                 }}
               />

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -222,6 +222,8 @@ export const de = {
   'admin.floatingCta.triggerAlways': 'Sofort',
   'admin.floatingCta.triggerDelay': 'Nach Verzögerung',
   'admin.floatingCta.triggerDelaySeconds': 'Verzögerung (Sekunden)',
+  'admin.floatingCta.triggerScroll': 'Nach dem Scrollen',
+  'admin.floatingCta.triggerScrollPx': 'Scroll-Distanz (px)',
   'admin.floatingCta.dismissibleHelp':
     'Fügt ein × hinzu und merkt sich das Schließen pro Gerät (nutzt ein kleines Skript).',
   'admin.floatingCta.bottomOffsetHelp':

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -235,6 +235,8 @@ export const en = {
   'admin.floatingCta.triggerAlways': 'Immediately',
   'admin.floatingCta.triggerDelay': 'After a delay',
   'admin.floatingCta.triggerDelaySeconds': 'Delay (seconds)',
+  'admin.floatingCta.triggerScroll': 'After scrolling',
+  'admin.floatingCta.triggerScrollPx': 'Scroll distance (px)',
   'admin.floatingCta.dismissibleHelp':
     'Adds a × and remembers the dismissal per device (uses a small script).',
   'admin.floatingCta.bottomOffsetHelp':

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -225,6 +225,8 @@ export const fr = {
   'admin.floatingCta.triggerAlways': 'Immédiatement',
   'admin.floatingCta.triggerDelay': 'Après un délai',
   'admin.floatingCta.triggerDelaySeconds': 'Délai (secondes)',
+  'admin.floatingCta.triggerScroll': 'Après défilement',
+  'admin.floatingCta.triggerScrollPx': 'Distance de défilement (px)',
   'admin.floatingCta.dismissibleHelp':
     'Ajoute un × et mémorise la fermeture par appareil (utilise un petit script).',
   'admin.floatingCta.bottomOffsetHelp':

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -231,6 +231,8 @@ export const ja = {
   'admin.floatingCta.triggerAlways': 'すぐに表示',
   'admin.floatingCta.triggerDelay': '遅らせて表示',
   'admin.floatingCta.triggerDelaySeconds': '遅延（秒）',
+  'admin.floatingCta.triggerScroll': 'スクロール後に表示',
+  'admin.floatingCta.triggerScrollPx': 'スクロール量（px）',
   'admin.floatingCta.dismissibleHelp':
     '× を表示し、閉じたことを端末に記憶します（小さなスクリプトを使用）。',
   'admin.floatingCta.bottomOffsetHelp':

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -223,6 +223,8 @@ export const ptBR = {
   'admin.floatingCta.triggerAlways': 'Imediatamente',
   'admin.floatingCta.triggerDelay': 'Após um atraso',
   'admin.floatingCta.triggerDelaySeconds': 'Atraso (segundos)',
+  'admin.floatingCta.triggerScroll': 'Após rolagem',
+  'admin.floatingCta.triggerScrollPx': 'Distância de rolagem (px)',
   'admin.floatingCta.dismissibleHelp':
     'Adiciona um × e memoriza o fechamento por dispositivo (usa um pequeno script).',
   'admin.floatingCta.bottomOffsetHelp':

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -219,6 +219,8 @@ export const zhHans = {
   'admin.floatingCta.triggerAlways': '立即显示',
   'admin.floatingCta.triggerDelay': '延迟显示',
   'admin.floatingCta.triggerDelaySeconds': '延迟（秒）',
+  'admin.floatingCta.triggerScroll': '滚动后显示',
+  'admin.floatingCta.triggerScrollPx': '滚动距离（px）',
   'admin.floatingCta.dismissibleHelp': '显示 × 并在设备上记住已关闭（使用一小段脚本）。',
   'admin.floatingCta.bottomOffsetHelp': '在页脚上方预留空间，避免按钮遮挡。0 = 关闭。',
   'admin.floatingCta.icon': '图标（表情）',

--- a/frontend/src/shared/lib/floating-cta.test.ts
+++ b/frontend/src/shared/lib/floating-cta.test.ts
@@ -74,10 +74,21 @@ describe('parseFloatingCta', () => {
     ).toBe(1)
     expect(parseFloatingCta(JSON.stringify({ trigger: 'delay' })).triggerValue).toBe(1)
 
-    // Unknown trigger (e.g. reserved 'scroll') coerces to 'always' with no delay.
+    // Scroll trigger: triggerValue is px, clamped to 1–5000.
     const scroll = parseFloatingCta(JSON.stringify({ trigger: 'scroll', triggerValue: 300 }))
-    expect(scroll.trigger).toBe('always')
-    expect(scroll.triggerValue).toBe(0)
+    expect(scroll.trigger).toBe('scroll')
+    expect(scroll.triggerValue).toBe(300)
+    expect(
+      parseFloatingCta(JSON.stringify({ trigger: 'scroll', triggerValue: 99999 })).triggerValue,
+    ).toBe(5000)
+    expect(
+      parseFloatingCta(JSON.stringify({ trigger: 'scroll', triggerValue: 0 })).triggerValue,
+    ).toBe(1)
+
+    // A genuinely unknown trigger coerces to 'always'.
+    const unknown = parseFloatingCta(JSON.stringify({ trigger: 'hover', triggerValue: 5 }))
+    expect(unknown.trigger).toBe('always')
+    expect(unknown.triggerValue).toBe(0)
   })
 
   it('round-trips through serialize', () => {

--- a/frontend/src/shared/lib/floating-cta.ts
+++ b/frontend/src/shared/lib/floating-cta.ts
@@ -16,11 +16,14 @@ import { safeHref } from '@/shared/lib/header-config'
 
 export type FloatingCtaPosition = 'br' | 'bl'
 
-/** When the FAB appears: immediately, or after a delay (#982 P2 d). `scroll` is reserved. */
-export type FloatingCtaTrigger = 'always' | 'delay'
+/** When the FAB appears: immediately, after a delay, or after scrolling N px (#982 P2 d). */
+export type FloatingCtaTrigger = 'always' | 'delay' | 'scroll'
 
 /** Delay-trigger bounds in seconds (#982 P2 d). */
 export const MAX_FLOATING_CTA_DELAY_SECONDS = 60
+
+/** Scroll-trigger threshold bounds in px (#982 P2 d). */
+export const MAX_FLOATING_CTA_SCROLL_PX = 5000
 
 export interface FloatingCtaConditions {
   /** Entity type slugs the CTA shows on; empty = all types. */
@@ -97,15 +100,19 @@ function asBottomOffset(value: unknown): number {
 }
 
 function asTrigger(value: unknown): FloatingCtaTrigger {
-  return value === 'delay' ? 'delay' : 'always'
+  return value === 'delay' || value === 'scroll' ? value : 'always'
 }
 
-/** Delay seconds are only meaningful for the `delay` trigger; clamp to 1–60 there, else 0. */
+/** triggerValue is seconds for `delay` (1–60) and px for `scroll` (1–5000); 0 for `always`. */
 function asTriggerValue(trigger: FloatingCtaTrigger, value: unknown): number {
-  if (trigger !== 'delay' || typeof value !== 'number' || !Number.isInteger(value)) {
-    return trigger === 'delay' ? 1 : 0
+  if (trigger === 'always') {
+    return 0
   }
-  return Math.max(1, Math.min(value, MAX_FLOATING_CTA_DELAY_SECONDS))
+  const max = trigger === 'delay' ? MAX_FLOATING_CTA_DELAY_SECONDS : MAX_FLOATING_CTA_SCROLL_PX
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    return 1
+  }
+  return Math.max(1, Math.min(value, max))
 }
 
 /** Parse the stored `floating_cta` JSON defensively into a full config. */

--- a/src/PublicRecord/FloatingCta.php
+++ b/src/PublicRecord/FloatingCta.php
@@ -54,15 +54,18 @@ final readonly class FloatingCta
         public int $bottomOffset = 0,
         /** When true, the FAB shows a dismiss (×) button and remembers dismissal in localStorage (#982 P2 (a)). */
         public bool $dismissible = false,
-        /** When the FAB appears: 'always' (immediately) or 'delay' (after $triggerValue seconds) (#982 P2 (d)). */
+        /** When the FAB appears: 'always', 'delay' (after N s), or 'scroll' (after N px) (#982 P2 (d)). */
         public string $trigger = 'always',
-        /** Trigger parameter: seconds for the 'delay' trigger (1–60); ignored for 'always'. */
+        /** Trigger parameter: seconds for 'delay' (1–60), px for 'scroll' (1–5000); 0 for 'always'. */
         public int $triggerValue = 0,
     ) {
     }
 
     /** Delay-trigger bounds in seconds (#982 P2 (d)). */
     public const MAX_DELAY_SECONDS = 60;
+
+    /** Scroll-trigger threshold bounds in px (#982 P2 (d)). */
+    public const MAX_SCROLL_PX = 5000;
 
     public static function disabled(): self
     {
@@ -116,12 +119,16 @@ final readonly class FloatingCta
         $dismissible = ($decoded['dismissible'] ?? false) === true;
 
         // Appearance trigger (#982 P2 (d)). Unknown values fall back to 'always'; the delay
-        // seconds are clamped defensively (the write-side validator is the real boundary).
-        $trigger = ($decoded['trigger'] ?? 'always') === 'delay' ? 'delay' : 'always';
+        // seconds / scroll px are clamped defensively (the write-side validator is the real
+        // boundary). `triggerValue` is seconds for 'delay' and px for 'scroll'.
+        $rawTriggerName = $decoded['trigger'] ?? 'always';
+        $trigger = in_array($rawTriggerName, ['delay', 'scroll'], true) ? $rawTriggerName : 'always';
         $rawTrigger = $decoded['triggerValue'] ?? 0;
-        $triggerValue = $trigger === 'delay'
-            ? (is_int($rawTrigger) ? max(1, min($rawTrigger, self::MAX_DELAY_SECONDS)) : 1)
-            : 0;
+        $triggerValue = match ($trigger) {
+            'delay' => is_int($rawTrigger) ? max(1, min($rawTrigger, self::MAX_DELAY_SECONDS)) : 1,
+            'scroll' => is_int($rawTrigger) ? max(1, min($rawTrigger, self::MAX_SCROLL_PX)) : 1,
+            default => 0,
+        };
 
         $label = self::asString($content['label'] ?? '');
         $url = self::asString($link['url'] ?? '');
@@ -194,15 +201,16 @@ final readonly class FloatingCta
     }
 
     /**
-     * Whether the FAB will render its dismiss UI on this page (#982 P2 (a)).
+     * Whether the FAB needs a nonce'd inline script on this page (#982 P2 a/d).
      *
-     * True only when enabled, dismissible, and the page matches. The renderer uses this
-     * to decide whether a CSP script nonce is needed at all — so pages without a
-     * dismissible FAB keep the strict `script-src 'self'` (no nonce) policy.
+     * True when enabled, the page matches, and either the dismiss "×" (localStorage) or
+     * the scroll trigger (reveal past a px threshold) is active — both require JS. The
+     * renderer uses this to decide whether a CSP script nonce is needed at all, so pages
+     * without either keep the strict `script-src 'self'` (no nonce) policy.
      */
-    public function isDismissActiveFor(string $typeSlug, string $path): bool
+    public function needsScriptFor(string $typeSlug, string $path): bool
     {
-        return $this->dismissible && $this->shouldRender($typeSlug, $path);
+        return ($this->dismissible || $this->trigger === 'scroll') && $this->shouldRender($typeSlug, $path);
     }
 
     /**

--- a/src/PublicRecord/FloatingCtaHtml.php
+++ b/src/PublicRecord/FloatingCtaHtml.php
@@ -51,15 +51,19 @@ final class FloatingCtaHtml
             ? '<span class="nene-fab__sub">' . self::e($cta->sub) . '</span>'
             : '';
 
-        // Dismiss (#982 P2 (a)): a "×" that remembers dismissal in localStorage via a small
-        // nonce'd inline script. The renderer only supplies a nonce when it will also add it
-        // to the CSP, so a missing nonce means "no dismiss UI" (graceful, still a working FAB).
-        $dismiss = $cta->dismissible && $nonce !== null && $nonce !== '';
+        // Nonce-backed behaviours (#982 P2 a/d): the dismiss "×" (localStorage) and the
+        // scroll reveal both need a small nonce'd inline script. The renderer only supplies
+        // a nonce when it will also add it to the CSP, so a missing nonce means "no JS
+        // behaviour" (graceful: a dismissible FAB just loses its ×; a scroll FAB shows always).
+        $nonceOk = $nonce !== null && $nonce !== '';
+        $dismiss = $cta->dismissible && $nonceOk;
+        $scrollPx = ($cta->trigger === 'scroll' && $cta->triggerValue > 0 && $nonceOk) ? $cta->triggerValue : 0;
+        $hasScript = $dismiss || $scrollPx > 0;
 
         // Delay trigger (#982 P2 d): reveal after N seconds with a pure-CSS animation (no JS).
         $delaySeconds = ($cta->trigger === 'delay' && $cta->triggerValue > 0) ? $cta->triggerValue : 0;
 
-        $style = self::style($accent, $side, $cta->bottomOffset, $dismiss, $delaySeconds);
+        $style = self::style($accent, $side, $cta->bottomOffset, $dismiss, $delaySeconds, $scrollPx > 0);
 
         $button = '<a class="nene-fab" href="' . $href . '"' . $target . $rel . '>'
             . $icon
@@ -69,22 +73,26 @@ final class FloatingCtaHtml
             . '</span>'
             . '</a>';
 
-        $dismissBtn = '';
-        $script = '';
-        if ($dismiss) {
-            $dismissBtn = '<button type="button" class="nene-fab__dismiss" aria-label="'
-                . self::e(self::dismissLabel($lang)) . '">&#215;</button>';
-            $script = self::script((string) $nonce);
-        }
+        $dismissBtn = $dismiss
+            ? '<button type="button" class="nene-fab__dismiss" aria-label="'
+                . self::e(self::dismissLabel($lang)) . '">&#215;</button>'
+            : '';
+        $script = $hasScript ? self::script((string) $nonce, $scrollPx) : '';
+        // For a scroll-triggered FAB the CSS hides it until the script reveals it; give
+        // no-JS visitors a way to still see it (reveal immediately).
+        $noscript = $scrollPx > 0
+            ? '<noscript><style>.nene-fab-wrap{opacity:1;pointer-events:auto}</style></noscript>'
+            : '';
 
         // The wrapper is the fixed-positioned element so the dismiss button can sit at its
         // corner; the SPA never touches it (rendered outside #root before </body>).
         return $style . "\n"
             . '<div class="nene-fab-wrap" id="nene-fab-wrap">' . $button . $dismissBtn . '</div>'
+            . $noscript
             . $script;
     }
 
-    private static function style(string $accent, string $side, int $bottomOffset, bool $dismiss, int $delaySeconds): string
+    private static function style(string $accent, string $side, int $bottomOffset, bool $dismiss, int $delaySeconds, bool $scrollReveal): string
     {
         // Delay reveal (#982 P2 d): `animation-fill-mode:both` keeps the FAB at the 0%
         // (hidden) keyframe during `animation-delay`, then fades it in — all in CSS, no JS.
@@ -94,10 +102,19 @@ final class FloatingCtaHtml
                 . '.nene-fab-wrap{animation:nene-fab-appear .35s ease both;animation-delay:' . $delaySeconds . 's}'
             : '';
 
-        // Reduced motion: keep the delay (appear after N s) but drop the fade/slide.
-        $reducedMotion = $delaySeconds > 0
-            ? '@media(prefers-reduced-motion:reduce){.nene-fab{transition:none}.nene-fab:hover{transform:none}.nene-fab-wrap{animation-duration:1ms}}'
-            : '@media(prefers-reduced-motion:reduce){.nene-fab{transition:none}.nene-fab:hover{transform:none}}';
+        // Scroll reveal (#982 P2 d): hidden until the nonce'd script adds `.is-visible` past
+        // the px threshold. Delay and scroll are mutually exclusive (one trigger value).
+        $scrollCss = $scrollReveal
+            ? '.nene-fab-wrap{opacity:0;pointer-events:none;transition:opacity .3s ease}'
+                . '.nene-fab-wrap.is-visible{opacity:1;pointer-events:auto}'
+            : '';
+
+        // Reduced motion: keep the trigger behaviour but drop the fade/slide/transition.
+        $wrapReduce = $delaySeconds > 0
+            ? '.nene-fab-wrap{animation-duration:1ms}'
+            : ($scrollReveal ? '.nene-fab-wrap{transition:none}' : '');
+        $reducedMotion = '@media(prefers-reduced-motion:reduce){.nene-fab{transition:none}.nene-fab:hover{transform:none}'
+            . $wrapReduce . '}';
 
         // Page-bottom clearance (#982 P2 (c)): reserve space so the fixed FAB never covers
         // footer content at scroll-end. Replaces the ad-hoc per-site `footer{padding-bottom}`
@@ -137,6 +154,7 @@ final class FloatingCtaHtml
             . '.nene-fab__sub{font-size:.62rem;font-weight:500;letter-spacing:.04em;opacity:.85;margin-top:2px}'
             . $dismissCss
             . $delayCss
+            . $scrollCss
             . '@media(max-width:560px){.nene-fab-wrap{left:14px;right:14px}.nene-fab{display:flex;justify-content:center;padding:15px 18px}}'
             . $reducedMotion
             . '</style>';
@@ -147,13 +165,19 @@ final class FloatingCtaHtml
      * the FAB immediately when already dismissed and remembers a "×" click in localStorage.
      * `$nonce` is hex from the renderer, so attribute interpolation carries no injection.
      */
-    private static function script(string $nonce): string
+    private static function script(string $nonce, int $scrollPx): string
     {
         $n = self::e($nonce);
+        // `$scrollPx` is a validated int (0 when not scroll-triggered), so interpolation is safe.
         $js = "(function(){try{var k='nene-fab-dismissed',w=document.getElementById('nene-fab-wrap');"
             . "if(!w)return;if(localStorage.getItem(k)==='1'){w.style.display='none';return}"
             . "var b=w.querySelector('.nene-fab__dismiss');if(b){b.addEventListener('click',function(){"
-            . "try{localStorage.setItem(k,'1')}catch(e){}w.style.display='none'})}}catch(e){}})();";
+            . "try{localStorage.setItem(k,'1')}catch(e){}w.style.display='none'})}"
+            . "var t={$scrollPx};if(t>0){var s=function(){"
+            . 'if((window.pageYOffset||document.documentElement.scrollTop||0)>=t){'
+            . "w.classList.add('is-visible');window.removeEventListener('scroll',s)}};"
+            . "window.addEventListener('scroll',s,{passive:true});s()}"
+            . '}catch(e){}})();';
 
         return "<script nonce=\"{$n}\">{$js}</script>";
     }

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -125,8 +125,8 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
         // one of them needs it, so pages with neither keep the strict `script-src 'self'`.
         $floatingCtaConfig = FloatingCta::fromSettings($settings);
         $fabPath = $request->getUri()->getPath();
-        $fabDismissActive = $floatingCtaConfig->isDismissActiveFor($output->entityTypeSlug, $fabPath);
-        $nonce = ($analytics->isEnabled() || $fabDismissActive) ? bin2hex(random_bytes(16)) : '';
+        $fabNeedsScript = $floatingCtaConfig->needsScriptFor($output->entityTypeSlug, $fabPath);
+        $nonce = ($analytics->isEnabled() || $fabNeedsScript) ? bin2hex(random_bytes(16)) : '';
         $analyticsHead = WebAnalyticsHeadSnippet::render($analytics, $nonce);
 
         // Trusted-embed primitive (#802 Phase 2): when the org has an embed
@@ -150,7 +150,7 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
             $floatingCtaConfig,
             $output->entityTypeSlug,
             $fabPath,
-            $fabDismissActive ? $nonce : null,
+            $fabNeedsScript ? $nonce : null,
             $locale ?? PublicLocale::DEFAULT_LANG,
         );
 

--- a/src/PublicRecord/RenderPublicTypeArchiveRenderer.php
+++ b/src/PublicRecord/RenderPublicTypeArchiveRenderer.php
@@ -50,15 +50,15 @@ final readonly class RenderPublicTypeArchiveRenderer implements PublicTypeArchiv
         // needed so pages with neither keep the strict `script-src 'self'`.
         $floatingCtaConfig = FloatingCta::fromSettings($settings);
         $fabPath = $request->getUri()->getPath();
-        $fabDismissActive = $floatingCtaConfig->isDismissActiveFor($archive->typeSlug, $fabPath);
-        $nonce = ($analytics->isEnabled() || $fabDismissActive) ? bin2hex(random_bytes(16)) : '';
+        $fabNeedsScript = $floatingCtaConfig->needsScriptFor($archive->typeSlug, $fabPath);
+        $nonce = ($analytics->isEnabled() || $fabNeedsScript) ? bin2hex(random_bytes(16)) : '';
         $analyticsHead = WebAnalyticsHeadSnippet::render($analytics, $nonce);
 
         $floatingCta = FloatingCtaHtml::render(
             $floatingCtaConfig,
             $archive->typeSlug,
             $fabPath,
-            $fabDismissActive ? $nonce : null,
+            $fabNeedsScript ? $nonce : null,
             PublicLocale::DEFAULT_LANG,
         );
 

--- a/src/Setting/FloatingCtaValidator.php
+++ b/src/Setting/FloatingCtaValidator.php
@@ -28,8 +28,8 @@ final class FloatingCtaValidator
     /** @var list<string> P1 position presets. `right-tab`/`bottom-bar` are reserved for P2. */
     private const POSITIONS = ['br', 'bl'];
 
-    /** @var list<string> Supported triggers. `delay` = pure-CSS reveal (#982 P2 d); `scroll` reserved. */
-    private const TRIGGERS = ['always', 'delay'];
+    /** @var list<string> Supported triggers. `delay` = pure-CSS reveal, `scroll` = JS reveal (#982 P2 d). */
+    private const TRIGGERS = ['always', 'delay', 'scroll'];
 
     private const MAX_ICON_LEN = 16;
     private const MAX_LABEL_LEN = 60;
@@ -67,12 +67,17 @@ final class FloatingCtaValidator
             $errors[] = new ValidationError('value.trigger', 'trigger must be one of: ' . implode(', ', self::TRIGGERS) . ' (others are not available yet).', 'invalid');
         }
 
-        // triggerValue is the delay in seconds and is required (1–60) for the 'delay' trigger;
-        // for 'always' it is ignored, so only reject a wrong-typed value when present.
+        // triggerValue is required and bounded per trigger: seconds (1–60) for 'delay',
+        // px (1–5000) for 'scroll'. For 'always' it is ignored (reject only a wrong type).
         if ($trigger === 'delay') {
             $triggerValue = $decoded['triggerValue'] ?? null;
             if (!is_int($triggerValue) || $triggerValue < 1 || $triggerValue > FloatingCta::MAX_DELAY_SECONDS) {
                 $errors[] = new ValidationError('value.triggerValue', 'triggerValue must be an integer between 1 and ' . FloatingCta::MAX_DELAY_SECONDS . ' seconds for the delay trigger.', 'invalid');
+            }
+        } elseif ($trigger === 'scroll') {
+            $triggerValue = $decoded['triggerValue'] ?? null;
+            if (!is_int($triggerValue) || $triggerValue < 1 || $triggerValue > FloatingCta::MAX_SCROLL_PX) {
+                $errors[] = new ValidationError('value.triggerValue', 'triggerValue must be an integer between 1 and ' . FloatingCta::MAX_SCROLL_PX . ' px for the scroll trigger.', 'invalid');
             }
         } elseif (isset($decoded['triggerValue']) && !is_int($decoded['triggerValue'])) {
             $errors[] = new ValidationError('value.triggerValue', 'triggerValue must be an integer.', 'invalid');

--- a/tests/PublicRecord/FloatingCtaHtmlTest.php
+++ b/tests/PublicRecord/FloatingCtaHtmlTest.php
@@ -139,6 +139,54 @@ final class FloatingCtaHtmlTest extends TestCase
         self::assertStringNotContainsString('animation-delay', $html);
     }
 
+    public function testScrollTriggerHidesUntilNoncedScriptReveals(): void
+    {
+        $cta = self::cta([
+            'content' => ['label' => 'x'], 'link' => ['url' => 'https://x.test'],
+            'trigger' => 'scroll', 'triggerValue' => 400,
+        ]);
+        $html = FloatingCtaHtml::render($cta, 'page', '/', 'sc0ped', 'en');
+
+        // Hidden until revealed; script carries the threshold and toggles .is-visible.
+        self::assertStringContainsString('.nene-fab-wrap{opacity:0;pointer-events:none', $html);
+        self::assertStringContainsString('.nene-fab-wrap.is-visible{opacity:1', $html);
+        self::assertStringContainsString('<script nonce="sc0ped">', $html);
+        self::assertStringContainsString('var t=400;', $html);
+        self::assertStringContainsString("w.classList.add('is-visible')", $html);
+        // No-JS visitors still get the FAB.
+        self::assertStringContainsString('<noscript><style>.nene-fab-wrap{opacity:1;pointer-events:auto}</style></noscript>', $html);
+        // Scroll-only (no dismiss config) → no × button element (the script still queries for one).
+        self::assertStringNotContainsString('<button type="button" class="nene-fab__dismiss"', $html);
+    }
+
+    public function testScrollWithoutNonceFallsBackToAlwaysVisible(): void
+    {
+        // No nonce → the reveal script can't run, so the FAB must not be hidden (shows always).
+        $cta = self::cta([
+            'content' => ['label' => 'x'], 'link' => ['url' => 'https://x.test'],
+            'trigger' => 'scroll', 'triggerValue' => 400,
+        ]);
+        $html = FloatingCtaHtml::render($cta, 'page', '/');
+
+        self::assertStringNotContainsString('<script', $html);
+        self::assertStringNotContainsString('opacity:0', $html);
+        self::assertStringNotContainsString('<noscript', $html);
+    }
+
+    public function testScrollAndDismissShareOneScript(): void
+    {
+        $cta = self::cta([
+            'content' => ['label' => 'x'], 'link' => ['url' => 'https://x.test'],
+            'trigger' => 'scroll', 'triggerValue' => 250, 'dismissible' => true,
+        ]);
+        $html = FloatingCtaHtml::render($cta, 'page', '/', 'nn', 'en');
+
+        self::assertSame(1, substr_count($html, '<script nonce="nn">'));
+        self::assertStringContainsString('nene-fab__dismiss', $html);
+        self::assertStringContainsString('var t=250;', $html);
+        self::assertStringContainsString("localStorage.setItem(k,'1')", $html);
+    }
+
     public function testDismissButtonSitsOnPositionSide(): void
     {
         $cta = self::cta([

--- a/tests/PublicRecord/FloatingCtaTest.php
+++ b/tests/PublicRecord/FloatingCtaTest.php
@@ -81,20 +81,24 @@ final class FloatingCtaTest extends TestCase
         self::assertFalse(FloatingCta::fromSettings(self::settings($base + ['dismissible' => 'yes']))->dismissible);
     }
 
-    public function testIsDismissActiveForRequiresEnabledDismissibleAndMatch(): void
+    public function testNeedsScriptForRequiresEnabledAndDismissibleOrScrollAndMatch(): void
     {
-        $base = ['enabled' => true, 'dismissible' => true, 'content' => ['label' => 'x'], 'link' => ['url' => 'https://x.test']];
+        $link = ['content' => ['label' => 'x'], 'link' => ['url' => 'https://x.test']];
 
-        self::assertTrue(FloatingCta::fromSettings(self::settings($base))->isDismissActiveFor('page', '/'));
-        // Not dismissible → false even though it renders.
-        self::assertFalse(FloatingCta::fromSettings(self::settings(['dismissible' => false] + $base))->isDismissActiveFor('page', '/'));
-        // Page excluded → false even though dismissible.
+        // Dismissible → needs a script.
+        self::assertTrue(FloatingCta::fromSettings(self::settings(['enabled' => true, 'dismissible' => true] + $link))->needsScriptFor('page', '/'));
+        // Scroll trigger → needs a script (even without dismiss).
+        self::assertTrue(FloatingCta::fromSettings(self::settings(['enabled' => true, 'trigger' => 'scroll', 'triggerValue' => 300] + $link))->needsScriptFor('page', '/'));
+        // Neither dismissible nor scroll (e.g. delay) → no script.
+        self::assertFalse(FloatingCta::fromSettings(self::settings(['enabled' => true, 'trigger' => 'delay', 'triggerValue' => 3] + $link))->needsScriptFor('page', '/'));
+        self::assertFalse(FloatingCta::fromSettings(self::settings(['enabled' => true] + $link))->needsScriptFor('page', '/'));
+        // Page excluded → false even when dismissible.
         self::assertFalse(
-            FloatingCta::fromSettings(self::settings($base + ['conditions' => ['exclude' => ['/secret*']]]))
-                ->isDismissActiveFor('page', '/secret'),
+            FloatingCta::fromSettings(self::settings(['enabled' => true, 'dismissible' => true, 'conditions' => ['exclude' => ['/secret*']]] + $link))
+                ->needsScriptFor('page', '/secret'),
         );
         // Disabled → false.
-        self::assertFalse(FloatingCta::disabled()->isDismissActiveFor('page', '/'));
+        self::assertFalse(FloatingCta::disabled()->needsScriptFor('page', '/'));
     }
 
     public function testTriggerAndDelayAreParsedAndClamped(): void
@@ -113,9 +117,12 @@ final class FloatingCtaTest extends TestCase
         self::assertSame(60, FloatingCta::fromSettings(self::settings($base + ['trigger' => 'delay', 'triggerValue' => 9999]))->triggerValue);
         self::assertSame(1, FloatingCta::fromSettings(self::settings($base + ['trigger' => 'delay', 'triggerValue' => 0]))->triggerValue);
         self::assertSame(1, FloatingCta::fromSettings(self::settings($base + ['trigger' => 'delay', 'triggerValue' => '5']))->triggerValue);
-        $unknown = FloatingCta::fromSettings(self::settings($base + ['trigger' => 'scroll', 'triggerValue' => 300]));
-        self::assertSame('always', $unknown->trigger);
-        self::assertSame(0, $unknown->triggerValue);
+        // Scroll trigger: triggerValue is px, clamped to 1–5000.
+        $scroll = FloatingCta::fromSettings(self::settings($base + ['trigger' => 'scroll', 'triggerValue' => 300]));
+        self::assertSame('scroll', $scroll->trigger);
+        self::assertSame(300, $scroll->triggerValue);
+        self::assertSame(5000, FloatingCta::fromSettings(self::settings($base + ['trigger' => 'scroll', 'triggerValue' => 99999]))->triggerValue);
+        self::assertSame(1, FloatingCta::fromSettings(self::settings($base + ['trigger' => 'scroll', 'triggerValue' => 0]))->triggerValue);
     }
 
     public function testInvalidPositionFallsBackToBr(): void

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -543,6 +543,34 @@ final class PublicRecordHttpTest extends TestCase
         self::assertStringNotContainsString('googletagmanager', $csp);
     }
 
+    public function testSsrGivesScrollFabANonceEvenWithAnalyticsOff(): void
+    {
+        // A scroll-triggered FAB needs its reveal script — so a nonce even with analytics off.
+        $cfg = (string) json_encode([
+            'enabled' => true,
+            'trigger' => 'scroll',
+            'triggerValue' => 300,
+            'content' => ['label' => 'Book'],
+            'link' => ['url' => 'https://x.test'],
+        ]);
+        $app = $this->buildApplication(true, $this->projectRoot, [
+            new \NeNeRecords\Setting\SettingDef('floating_cta', 'text', $cfg, true, 'FAB'),
+        ]);
+
+        $response = $app->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        );
+        $html = (string) $response->getBody();
+        $csp = $response->getHeaderLine('Content-Security-Policy');
+
+        self::assertStringContainsString('var t=300;', $html);
+        self::assertStringContainsString('.nene-fab-wrap{opacity:0', $html);
+        preg_match('/<script nonce="([0-9a-f]{32})">/', $html, $m);
+        $nonce = $m[1] ?? '';
+        self::assertNotSame('', $nonce);
+        self::assertStringContainsString("'nonce-{$nonce}'", $csp);
+    }
+
     public function testSsrKeepsStrictCspWhenFabNotDismissible(): void
     {
         $cfg = (string) json_encode([

--- a/tests/Setting/FloatingCtaValidatorTest.php
+++ b/tests/Setting/FloatingCtaValidatorTest.php
@@ -36,6 +36,18 @@ final class FloatingCtaValidatorTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    public function testScrollTriggerWithPxPasses(): void
+    {
+        (new FloatingCtaValidator())->validate((string) json_encode([
+            'enabled' => true,
+            'trigger' => 'scroll',
+            'triggerValue' => 600,
+            'content' => ['label' => 'Book'],
+            'link' => ['url' => 'https://x.test'],
+        ]));
+        $this->addToAssertionCount(1);
+    }
+
     #[DataProvider('provideInvalid')]
     public function testInvalidConfigThrows(string $json): void
     {
@@ -53,7 +65,7 @@ final class FloatingCtaValidatorTest extends TestCase
         yield 'reserved position right-tab (P2)' => [(string) json_encode(['position' => 'right-tab'] + $base)];
         yield 'reserved position bottom-bar (P2)' => [(string) json_encode(['position' => 'bottom-bar'] + $base)];
         yield 'unknown position' => [(string) json_encode(['position' => 'top'] + $base)];
-        yield 'reserved trigger scroll (P2)' => [(string) json_encode(['trigger' => 'scroll'] + $base)];
+        yield 'unknown trigger' => [(string) json_encode(['trigger' => 'hover'] + $base)];
         yield 'javascript: url' => [(string) json_encode(['link' => ['url' => 'javascript:alert(1)']] + ['enabled' => true, 'content' => ['label' => 'x']])];
         yield 'data: url' => [(string) json_encode(['link' => ['url' => 'data:text/html,x']] + ['enabled' => true, 'content' => ['label' => 'x']])];
         yield 'protocol-relative url' => [(string) json_encode(['link' => ['url' => '//evil.test/x']] + ['enabled' => true, 'content' => ['label' => 'x']])];
@@ -72,6 +84,9 @@ final class FloatingCtaValidatorTest extends TestCase
         yield 'delay seconds too large' => [(string) json_encode(['trigger' => 'delay', 'triggerValue' => 61] + $base)];
         yield 'delay seconds zero' => [(string) json_encode(['trigger' => 'delay', 'triggerValue' => 0] + $base)];
         yield 'delay seconds not int' => [(string) json_encode(['trigger' => 'delay', 'triggerValue' => '5'] + $base)];
+        yield 'scroll without px' => [(string) json_encode(['trigger' => 'scroll'] + $base)];
+        yield 'scroll px too large' => [(string) json_encode(['trigger' => 'scroll', 'triggerValue' => 5001] + $base)];
+        yield 'scroll px zero' => [(string) json_encode(['trigger' => 'scroll', 'triggerValue' => 0] + $base)];
     }
 
     public function testMailtoAndTelAndRelativeAreAccepted(): void


### PR DESCRIPTION
> **⚠️ スタックPR**: base = `feat/997-fab-delay-trigger`（#998）。**#997 マージ後に main へ retarget/rebase**。差分は scroll 分のみをレビュー対象に。

## 目的
FAB を「N px スクロール後」に現す trigger（#982 P2 (d) 後半・#997 の続き）。純CSS の `scroll-timeline` はブラウザ対応が新しすぎるため、**dismiss(#994) の nonce 機構を再利用した JS** で実装。

## 実装
- `trigger` に `scroll` を解禁。`triggerValue` は scroll 時 **px（1–5000）**。
- scroll 時：CSS で初期非表示（`opacity:0;pointer-events:none;transition`）→ **nonce付き script** が `pageYOffset >= 閾値` で `.is-visible` 付与（一度で listener 解除・`passive`）。**dismiss と同一 script に統合**（両方有効なら1本）。
- **`<noscript>` フォールバック**で JS 無効時は即表示。scroll 時に nonce 未供給なら常時表示にフォールバック（hidden-forever 回避）。
- nonce 生成条件を `dismissible || trigger==='scroll'` に一般化（`FloatingCta::needsScriptFor`・旧 `isDismissActiveFor` から改称）。delay(#997) は純CSSのまま無関係。

## 変更
- backend: `FloatingCta`（scroll parse＋px clamp＋`needsScriptFor`）/ `FloatingCtaValidator`（scroll 解禁＋px 検証）/ `FloatingCtaHtml`（scroll CSS＋統合 reveal/dismiss script＋noscript）/ 両レンダラ（nonce 条件一般化）
- frontend: `floating-cta.ts`（scroll＋px）/ `FloatingCtaView`（scroll 選択肢＋px 入力・単位差でデフォルト切替）/ i18n 6ロケール
- tests: html（scroll hidden/reveal script/noscript/dismiss統合/nonce無しフォールバック）・fromSettings・validator（scroll 範囲）・**handler の CSP nonce（scroll でも生成）**・floating-cta.test

## 検証
- `composer check` 緑（PHPUnit 1451 / PHPStan level8 no errors / CS-Fixer / OpenAPI / MCP）
- `npm run check --prefix frontend` 全緑（type-check / eslint0 / prettier / vitest 662 / validate:themes / knip / storybook build）

これで **#982 P2 の (c)(a)(d) が全て完了**（(b) auto-hide は見送り／画像・:hover は #367 束ね）。

Closes #999