### PR TITLE
feat(analytics): Path B の土台 — ADR0006・visitor列 migration・opt-in設定def（#1007）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ NeNe Records does not yet follow Semantic Versioning — entries are grouped by 
 
 ---
 
+## [AYANE launch ＋ 公開サイト機能拡充 — v0.5.3] — 2026-07-17 〜 2026-07-24
+
+> **AYANE（ayane.co.jp）が 2026-07-18 に Tier A（共有ホスティング）で本番稼働**したのを機に、公開サイト側の
+> 機能拡充と品質是正を連続出荷した。目玉は **フローティングCTA の first-party 機能化（epic #982）**。あわせて
+> 公開 SEO（og:image 既定・Organization JSON-LD・正規 404・favicon）を強化し、運用ログ（`docs/todo`・
+> `docs/daily` 相当）を private `internal-docs` へ移設した。版は **v0.5.2 → v0.5.3**（#948・`VERSION` 単一ソース、
+> `/machine/health` も同値を報告）。本番反映は都度施主 GO。Issue/PR の詳細内訳と再開手順は private
+> `internal-docs/records/todo/current.md` を正本とする。
+
+### Added
+- **フローティングCTA の first-party 機能化（epic #982）** — 管理画面で条件・位置・中身を設定し公開 SSR で描画する
+  第一者フローティング CTA。P1 基盤（#983）＋ キュレーション SVG アイコン（#985）＋ bottom offset フッター
+  クリアランス（#993）＋ ×で閉じて記憶する dismiss（#995）＋ delay トリガー（N 秒後・純 CSS #998）＋
+  scroll トリガー（Npx スクロール後 #1000）。
+- **画像なしページの og:image フォールバック（#912/#977）** — image フィールドが無い公開ページに org 既定の
+  ソーシャルカードを補完。
+- **公開 SSR head の favicon リンク出力（#986/#987）** — 公開ページの `<head>` に favicon を出力。
+
+### Changed
+- **公開ページの Organization JSON-LD 強化（#978/#979）** — 構造化データを拡充。
+- **`VERSION` を 0.5.3 にバンプ（#948）** — 版の単一ソースを更新（`/machine/health` も同値を報告）。
+- **運用ログを private `internal-docs` へ移設（#974/#975）＋ 公開 docs の生き導線を repoint（#976）** —
+  `docs/todo`・`docs/daily` 相当を公開リポから撤去し private へ集約。
+- **日報の追補・一般化（#968/#969・#970/#971）** — launch 後の製品修正・CI 是正・フロントテスト強化を追補し、
+  日報規約 v2 §8 に沿って該当行を一般化。
+
+### Fixed
+- **未知の公開パスをソフト 404 でなく正規の 404 にする（#980/#981）**。
+- **公開同梱フォント Zen Kaku Gothic New subset を JIS 第 1 水準へ拡張し漢字欠落を解消（#1003/#1004）**。
+- **管理のページ一覧ディレクトリ表示で bespoke ページ名が全行同一になるのを修正（#990/#991）**。
+- **メディア派生キャッシュの書き込み失敗を未キャッシュ配信＋警告ログに落として 500 を回避（#949/#958）**。
+- **org-export/import でシード残骸を照合し merged 型の defs を移送元に揃える（#952/#957）**。
+- **非権威 4 ロケールの `satisfies` 綴りを規約 I18N-9 の正例へ揃える（#988/#989）**。
+- **CI: backend/frontend の job 名衝突を `backend-check` / `frontend-check` に分離（#960/#961）**。
+- **フロントの テスト 0 を解消** — 認可 entities/auth（#962/#963）・公開 SSR seed 系（#964/#965）・
+  apiClient と permalink 解決（#966/#967）。
+
+---
+
 ## [ポスト #536 続 — Tier A インストーラ・移送経路・公開サイト堅牢化] — 2026-06-27 〜 2026-07-16
 
 > ポスト #536（本番 SaaS 稼働）以降、**共有ホスティング向け Tier A インストーラ**（自己完結 zip）を

--- a/database/migrations/20260724000000_add_visitor_columns_to_access_logs.php
+++ b/database/migrations/20260724000000_add_visitor_columns_to_access_logs.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Path B visitor analytics — privacy-first columns on access_logs + daily salt store.
+ *
+ * See ADR 0006 (visitor analytics privacy model). All new columns are NULLable and only
+ * populated when an org opts in (`analytics_visitor_tracking`); existing rows and the
+ * default behaviour are unchanged. No raw client IP is ever stored: `visitor_hash` is a
+ * daily-salted, org-scoped SHA-256 whose salt lives in `analytics_salts` and rotates per
+ * calendar day, so past days cannot be re-identified once salts are pruned.
+ *
+ * - visitor_hash  : lowercase hex sha256(daily_salt || client_ip || ':' || org_id)
+ * - referer_host  : host only (never the full referer URL — it can carry PII/query)
+ * - utm_* / ref   : campaign + outreach attribution only (raw query strings are never
+ *                   stored — the beacon may send the full query, but the server persists
+ *                   only this allowlist and discards the rest)
+ * - client_type   : derived UA class (never the raw UA); is_bot enables bot filtering
+ *
+ * `analytics_salts` holds one 32-byte random salt per day (get-or-create at first use),
+ * pruned on the same retention window as the visitor rows.
+ */
+final class AddVisitorColumnsToAccessLogs extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('access_logs')
+            ->addColumn('visitor_hash', 'string', ['limit' => 64, 'null' => true, 'default' => null])
+            ->addColumn('referer_host', 'string', ['limit' => 255, 'null' => true, 'default' => null])
+            ->addColumn('utm_source', 'string', ['limit' => 255, 'null' => true, 'default' => null])
+            ->addColumn('utm_medium', 'string', ['limit' => 255, 'null' => true, 'default' => null])
+            ->addColumn('utm_campaign', 'string', ['limit' => 255, 'null' => true, 'default' => null])
+            ->addColumn('ref', 'string', ['limit' => 255, 'null' => true, 'default' => null])
+            ->addColumn('client_type', 'enum', ['values' => ['bot', 'mobile', 'desktop', 'other'], 'null' => true, 'default' => null])
+            ->addColumn('is_bot', 'boolean', ['null' => true, 'default' => null])
+            ->addIndex(['access_date', 'visitor_hash'], ['name' => 'idx_access_logs_date_visitor'])
+            ->update();
+
+        $this->table('analytics_salts', ['id' => false, 'primary_key' => ['salt_date']])
+            ->addColumn('salt_date', 'date', ['null' => false])
+            ->addColumn('salt', 'varbinary', ['limit' => 32, 'null' => false])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->create();
+    }
+}

--- a/database/migrations/20260724000001_add_analytics_visitor_tracking_setting.php
+++ b/database/migrations/20260724000001_add_analytics_visitor_tracking_setting.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Per-org opt-in for Path B visitor analytics — `analytics_visitor_tracking` (ADR 0006 / #1007).
+ *
+ * Boolean setting, default 'false' (opt-in OFF): when OFF the access-log middleware behaves
+ * exactly as before (no visitor_hash / referer_host / utm / UA-class computed). Operational
+ * flag — not exposed via the public settings API (is_public 0), like `maintenance_mode`.
+ *
+ * `setting_defs` is org-scoped, so insert one row per organization. Idempotent (skips
+ * existing). New orgs get this via PdoDefaultSettingDefsSeeder (the catalog duplicates this
+ * value by design — migrations must stay self-contained snapshots).
+ */
+final class AddAnalyticsVisitorTrackingSetting extends AbstractMigration
+{
+    private const SETTING_KEY = 'analytics_visitor_tracking';
+    private const DEFAULT_VALUE = 'false';
+
+    public function up(): void
+    {
+        if (!$this->hasTable('organizations') || !$this->hasTable('setting_defs')) {
+            return;
+        }
+
+        $pdo = $this->getAdapter()->getConnection();
+        $now = date('Y-m-d H:i:s');
+
+        $orgs = $pdo->query('SELECT id FROM organizations ORDER BY id ASC')->fetchAll(PDO::FETCH_COLUMN);
+
+        $check = $pdo->prepare('SELECT id FROM setting_defs WHERE organization_id = ? AND setting_key = ?');
+        $insert = $pdo->prepare(
+            'INSERT INTO setting_defs (organization_id, setting_key, data_type, default_value, is_public, label, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        );
+
+        foreach ($orgs as $orgIdRaw) {
+            $orgId = (int) $orgIdRaw;
+            $check->execute([$orgId, self::SETTING_KEY]);
+            if ($check->fetch() !== false) {
+                continue;
+            }
+            $insert->execute([
+                $orgId,
+                self::SETTING_KEY,
+                'bool',
+                self::DEFAULT_VALUE,
+                0,
+                'Visitor analytics tracking',
+                $now,
+                $now,
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        $this->execute("DELETE FROM setting_defs WHERE setting_key = 'analytics_visitor_tracking'");
+    }
+}

--- a/docs/adr/0006-visitor-analytics-privacy-model.md
+++ b/docs/adr/0006-visitor-analytics-privacy-model.md
@@ -1,0 +1,118 @@
+# ADR 0006: Visitor analytics privacy model
+
+## Status
+
+proposed
+
+## Context
+
+`access_logs`（`AccessLogMiddleware` + `PdoAccessLogRepository`・#69/#70）は現状
+`method / path / status_code / duration_ms / accessed_at / access_date`（＋`organization_id`）だけを持ち、
+**クライアント IP・User-Agent・Referer・query を一切記録していない**。
+
+調査（2026-07-24）の結論:
+
+- この「PII を持たない」状態は **明文化された設計判断ではない**。#69/#70 は Phase 5 の機能タスク（日次
+  request 数＋平均レイテンシのダッシュボード）で、フィールドは*その集計に必要な分だけ*選ばれた。IP/UA/referer/query は
+  「privacy のため意図的に外した」のではなく最初からスコープ外。ADR も設計コメントも無い。
+- ただし製品は事実上 **生 IP をどこにも永続化していない**（comment のレート制限で `REMOTE_ADDR` を
+  一時的にキーへ使うだけで DB 保存はしない）。＝実態はプライバシー寄り。
+
+施主裁定により、ユニーク訪問者・流入元・キャンペーン計測などの**高機能化（Path B）を実装する**（#1007）。
+これは**製品初の「訪問者由来データの永続化」**であり、NeNe Records は**マルチテナント SaaS**（全 org 横断）なので、
+visitor IP/UA を素で持つと個人情報保護法／GDPR／保持期間／同意の論点が全テナントに一斉に発生する。
+よって *privacy by design* をここで明文化し、以降の実装を縛る。
+
+計測の producer は 2 系統ある。ユニーク計数を両者で一致させるため、ハッシュのレシピを本 ADR で固定する:
+
+1. **Records SSR / API（Path B・本リポジトリ）** — `access_logs` に visitor 派生列を足す。
+2. **静的 LP ビーコン（hub 管轄・#1008）** — HETEML docroot の flat HTML（`/invoice-lp` `/clear-lp`
+   `/deal-lp` `/contact` `/inquiry`）は Apache 直配信で `access_logs` を通らないため、別系統で計測する。
+
+## Decision
+
+### D1. 生の PII を永続化しない
+
+生 IP・完全な UA・完全な query・完全な Referer URL は **DB に書かない**。IP は算出時にメモリ上でのみ使い、
+ハッシュ化後に破棄する。
+
+### D2. ユニーク訪問者＝日次ソルトのハッシュ
+
+```
+visitor_hash = lowercase_hex( sha256( daily_salt_bytes || client_ip_utf8 || ":" || org_id_decimal ) )
+```
+
+- **daily_salt**: 32 バイト（256-bit）のランダム値。**カレンダー日ごとに 1 つ**生成し、専用テーブル
+  `analytics_salts(salt_date DATE PK, salt VARBINARY(32), created_at DATETIME)` に保存。日付基準は
+  `access_date` と同じ TZ（アプリ設定 TZ・ayane は JST）。初回アクセス時に無ければ生成（get-or-create）。
+- **client_ip**: `NeNeRecords\Http\ClientIp`（既存・X-Forwarded-For 対応）で解決した実 IP の文字列。
+- **org スコープ**: `organization_id` を混ぜる → 同一訪問者がテナント横断で相関しない（マルチテナント分離）。
+- **日跨ぎ不可**: ソルトは日ごとにローテし、保持期間後に破棄する（D6）。よって過去日の hash を既知 IP で
+  総当たり再識別することはできない（ソルトが残らない）。ユニーク計数は `COUNT(DISTINCT visitor_hash)` を
+  `access_date` 単位で行う（＝「日次ユニーク」。ソルトが日次なので週/月ユニークは定義上出せない＝プライバシー上の意図的制約）。
+
+### D3. Referer はホストのみ
+
+`referer_host`（VARCHAR）に **ホスト名だけ**を保存する。完全な Referer URL は path/query に PII を含みうるため保存しない。
+
+### D4. query は保存しない・許可リストのみ抽出（utm_* ＋ ref）
+
+生 query 文字列は保存しない（email・token・検索語などの PII 温床）。**許可リスト**
+`utm_source / utm_medium / utm_campaign / ref` だけを抽出し、長さ制限・サニタイズのうえ保存する。
+`ref` は営業導線の attribution 用（署名リンクのキャンペーン識別子・非 PII）。LP ビーコン（D8）は
+`location.search` をそのまま送ってよいが、**サーバはこの許可リスト以外を破棄する**（生 query は永続化しない）。
+
+### D5. UA は素で持たず「分類」だけ
+
+生 UA は保存しない。`client_type`（enum: `bot` / `mobile` / `desktop` / `other`）＋ `is_bot`（bool）を導出して保存する。
+fingerprint 面を最小化しつつ bot 除外を可能にする。生 UA が必要な用途は将来の別 opt-in（本 ADR のスコープ外）。
+
+### D6. org 単位 opt-in・既定 OFF・保持 prune
+
+- SettingDef `analytics_visitor_tracking`（`bool` / 既定 `false` / `is_public` 0）。
+  **OFF のときミドルウェアは現状と完全に同一挙動**（hash/referer/utm/ua 分類を一切作らない）＝既存 org の挙動は不変。
+  ON のときのみ D2–D5 を計算する。テナントが自らのプライバシーポリシー／同意運用に合わせて収集を制御する。
+- **保持期間**: visitor 派生列（`visitor_hash` 等）を持つ行は既定 **180 日**で prune（将来 org 可変）。
+  `analytics_salts` も同期間で prune。匿名の日次ロールアップは無期限保持可。日次の prune ジョブを回す。
+- **同意連携（注記）**: GDPR 運用の org は公開 SSR の同意トラック（`analytics_consent_default` 等）と連動して
+  opt-in をゲートすべき。Cookie を使わない IP ハッシュは厳密には Cookie トラッキングではないが、テナント責任として文書化する。
+  既定 OFF が安全側の既定。
+
+### D7. 後方互換
+
+`access_logs` への追加列は**全て NULL 許容**（backfill 不要・既存行は NULL）。既存の集計クエリ
+（`aggregateByDate` / `aggregateEntityViews` / `countByDate`）は無改変。新指標（`unique_visitors` /
+`top_referrers` / `utm` / `bot_rate`）は集計 API・OpenAPI・MCP に **nullable で追加**（契約安全）。
+
+### D8. 2 producer の一致（hub の LP ビーコンとの整合）
+
+hub 管轄の LP ビーコン（#1008）は**同一の visitor_hash レシピ（D2）**と**同一の `analytics_salts`**を使う。
+両者は同じ HETEML Tier A インスタンス（同一 DB）で動くため、ビーコン側は `analytics_salts` から当日ソルトを
+直接読んで LP ヒットの hash を計算する → SSR（Path B）と LP のユニーク計数が名寄せ・合算できる。
+生 IP 非保存・host-only referer・utm-only の方針も踏襲する。
+
+## Consequences
+
+**得られるもの**
+- 生 PII を持たずに「日次ユニーク訪問者・流入元ホスト・utm キャンペーン・bot 率」を算出できる。
+- SSR（Records）と LP（hub ビーコン）でユニーク計数のレシピが一致し、mori 日次メールの 2(3) ソース集約で
+  重複なく合算できる。
+
+**コスト・追随作業**
+- 新テーブル `analytics_salts`。`access_logs` への追加列＋`INDEX(access_date, visitor_hash)`。
+- 新 SettingDef `analytics_visitor_tracking`（seeder カタログ＋既存 org 向け backfill migration の**両方**に足す
+  ＝ `PdoDefaultSettingDefsSeeder` の規約）。
+- 収集ミドルウェアの分岐（opt-in ON 時のみ）。日次ソルト get-or-create ＋保持 prune ジョブ（cron・`.sh` ラッパー越し）。
+- 集計 API／ダッシュボード／OpenAPI／MCP の nullable 追加。
+- export CLI（`tools/export-access-summary.php`）＋ `AccessLogMiddleware` の `'/'` 除外解除（トップ訪問を数える）。
+
+**本番反映のガード**
+- Tier A への migration＋cron 設置＋ayane（org 1）の opt-in ON は**実装＋テスト完了→施主最終 GO**の順。
+- opt-in 既定 OFF なので、既存の全 org・全インスタンスの挙動は本変更で変わらない。
+
+## Related
+
+- Issue: `#1007`（epic）, `#1008`（LP ビーコン・hub 管轄）
+- PR: `#000`
+- Supersedes: none
+- Superseded by: none

--- a/src/Setting/PdoDefaultSettingDefsSeeder.php
+++ b/src/Setting/PdoDefaultSettingDefsSeeder.php
@@ -60,6 +60,11 @@ final readonly class PdoDefaultSettingDefsSeeder implements DefaultSettingDefsSe
         // maintenance page on the public surface; logged-in staff pass through.
         // Operational flag — not exposed via the public settings API (is_public 0).
         ['setting_key' => 'maintenance_mode', 'data_type' => 'bool', 'default_value' => 'false', 'is_public' => 0, 'label' => 'Maintenance mode'],
+        // Path B visitor analytics opt-in (ADR 0006 / #1007): when 'true', the access-log
+        // middleware computes privacy-first visitor fields (daily-salted org-scoped hash,
+        // referer host, utm, UA class) — no raw IP stored. Default OFF preserves current
+        // behaviour. Operational flag — not exposed via the public settings API (is_public 0).
+        ['setting_key' => 'analytics_visitor_tracking', 'data_type' => 'bool', 'default_value' => 'false', 'is_public' => 0, 'label' => 'Visitor analytics tracking'],
     ];
 
     public function __construct(private DatabaseQueryExecutorInterface $query)


### PR DESCRIPTION
## 目的
Path B（プライバシー優先の visitor 解析・#1007）の**土台**。製品初の「訪問者由来データ永続化」を privacy by design で導入するためのスキーマ／設定／方針を確定する。段階PR の1本目（収集ミドルウェア・ingest endpoint・集計API・export CLI は後続）。

## 変更
- **ADR 0006「visitor analytics privacy model」** — 生IP非保持／日次ソルトhash＋org_id／referer-host-only／query は許可リスト（utm_* ＋ ref）のみ／UA分類（bot/mobile/desktop/other）＋is_bot／org opt-in 既定OFF／保持prune。`visitor_hash` レシピと日次ソルト方式を固定（hub の LP ビーコンと一致させるため）。
- **migration `20260724000000`** — `access_logs` に `visitor_hash/referer_host/utm_source/utm_medium/utm_campaign/ref/client_type(enum)/is_bot` を**全NULL**で追加＋`INDEX idx_access_logs_date_visitor(access_date, visitor_hash)`、日次ソルト保管 `analytics_salts(salt_date PK, salt VARBINARY(32), created_at)` を新設。
- **migration `20260724000001`** ＋ **`PdoDefaultSettingDefsSeeder`** — 設定def `analytics_visitor_tracking`（bool・既定 `false`・is_public 0）を既存org backfill＋新orgカタログの両方に追加（seeder 規約どおり二重定義）。

## 検証
- real-MySQL（ローカル docker）で migrate 成功。schema 実測: 8列＋enum＋`idx_access_logs_date_visitor(access_date, visitor_hash)`＋`analytics_salts`＋設定def（4 org・default false）を確認。
- CS-Fixer 0件・php -l クリーン。rollback→再migrate も確認済（index 明示名 `idx_access_logs_date_visitor`）。

## 安全性
- **opt-in 既定OFF なので既存の全org・全インスタンスの挙動は不変**（列は全NULL・収集コードは後続PR）。
- 本番反映（Tier A migration＋cron＋org opt-in ON）は**実装＋テスト完了→施主最終GO**。

## チェックリスト
- [x] Conventional Commits / Issue駆動（#1007）
- [x] migration は composer migrations:new 生成・real-MySQL 検証済
- [x] シークレット無し

Refs #1007