### PR TITLE
feat(analytics): Path B 収集層 — opt-in時のみ visitor派生を記録（#1007）

### DIFF
--- a/database/schema/access_logs.sql
+++ b/database/schema/access_logs.sql
@@ -7,9 +7,18 @@ CREATE TABLE access_logs (
     status_code INTEGER NOT NULL,
     duration_ms REAL NOT NULL,
     accessed_at TEXT NOT NULL,
-    access_date TEXT NOT NULL
+    access_date TEXT NOT NULL,
+    visitor_hash VARCHAR(64) NULL,
+    referer_host VARCHAR(255) NULL,
+    utm_source VARCHAR(255) NULL,
+    utm_medium VARCHAR(255) NULL,
+    utm_campaign VARCHAR(255) NULL,
+    ref VARCHAR(255) NULL,
+    client_type VARCHAR(16) NULL,
+    is_bot INTEGER NULL
 );
 
 CREATE INDEX idx_access_logs_access_date ON access_logs (access_date);
 CREATE INDEX idx_access_logs_accessed_at ON access_logs (accessed_at);
 CREATE INDEX access_logs_org ON access_logs (organization_id);
+CREATE INDEX idx_access_logs_date_visitor ON access_logs (access_date, visitor_hash);

--- a/src/Analytics/AccessLogEntry.php
+++ b/src/Analytics/AccessLogEntry.php
@@ -15,6 +15,16 @@ final readonly class AccessLogEntry
         public int $statusCode,
         public float $durationMs,
         public DateTimeImmutable $accessedAt,
+        // Path B visitor fields (ADR 0006). All nullable — populated only when the owning
+        // org opts in (`analytics_visitor_tracking`); null preserves the pre-Path-B row.
+        public ?string $visitorHash = null,
+        public ?string $refererHost = null,
+        public ?string $utmSource = null,
+        public ?string $utmMedium = null,
+        public ?string $utmCampaign = null,
+        public ?string $ref = null,
+        public ?string $clientType = null,
+        public ?bool $isBot = null,
     ) {
     }
 }

--- a/src/Analytics/AccessLogMiddleware.php
+++ b/src/Analytics/AccessLogMiddleware.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace NeNeRecords\Analytics;
 
 use Nene2\Http\ClockInterface;
+use Nene2\Http\RequestScopedHolder;
 use Nene2\Middleware\RequestIdMiddleware;
+use NeNeRecords\Http\ClientIp;
+use NeNeRecords\Setting\SettingRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -13,14 +16,33 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
+/**
+ * Persists one access_logs row per request. Base fields (method/path/status/duration) are
+ * always recorded except for the infrastructure paths in {@see self::$excludedPaths}.
+ *
+ * When the owning org opts in (`analytics_visitor_tracking` = true, ADR 0006 / #1007) the
+ * privacy-first visitor fields are additionally computed: a daily-salted org-scoped hash of
+ * the client IP (the raw IP is never stored), the referer host only, the utm_* / ref
+ * allowlist, and a coarse UA class + bot flag. Opt-in OFF (the default) reproduces the exact
+ * pre-Path-B behaviour.
+ *
+ * Note: the homepage `/` is intentionally NOT excluded (Path B counts front-page visits);
+ * only true infrastructure/health endpoints are skipped.
+ */
 final readonly class AccessLogMiddleware implements MiddlewareInterface
 {
-    /** @param list<string> $excludedPaths */
+    /**
+     * @param RequestScopedHolder<int> $orgId
+     * @param list<string>             $excludedPaths
+     */
     public function __construct(
         private AccessLogRepositoryInterface $accessLogs,
         private LoggerInterface $logger,
         private ClockInterface $clock,
-        private array $excludedPaths = ['/health', '/', '/machine/health', '/examples/ping'],
+        private SettingRepositoryInterface $settings,
+        private AnalyticsSaltRepositoryInterface $salts,
+        private RequestScopedHolder $orgId,
+        private array $excludedPaths = ['/health', '/machine/health', '/examples/ping'],
     ) {
     }
 
@@ -36,6 +58,8 @@ final readonly class AccessLogMiddleware implements MiddlewareInterface
         $response = $handler->handle($request);
 
         try {
+            $visitor = $this->resolveVisitor($request);
+
             $this->accessLogs->insert(new AccessLogEntry(
                 requestId: $this->requestId($request),
                 method: $request->getMethod(),
@@ -43,6 +67,14 @@ final readonly class AccessLogMiddleware implements MiddlewareInterface
                 statusCode: $response->getStatusCode(),
                 durationMs: $this->durationMilliseconds($startedAt),
                 accessedAt: $this->clock->now(),
+                visitorHash: $visitor['visitorHash'],
+                refererHost: $visitor['refererHost'],
+                utmSource: $visitor['utmSource'],
+                utmMedium: $visitor['utmMedium'],
+                utmCampaign: $visitor['utmCampaign'],
+                ref: $visitor['ref'],
+                clientType: $visitor['clientType'],
+                isBot: $visitor['isBot'],
             ));
         } catch (Throwable $exception) {
             $this->logger->error('Failed to persist access log entry.', [
@@ -53,6 +85,52 @@ final readonly class AccessLogMiddleware implements MiddlewareInterface
         }
 
         return $response;
+    }
+
+    /**
+     * @return array{
+     *     visitorHash: ?string, refererHost: ?string, utmSource: ?string, utmMedium: ?string,
+     *     utmCampaign: ?string, ref: ?string, clientType: ?string, isBot: ?bool
+     * }
+     */
+    private function resolveVisitor(ServerRequestInterface $request): array
+    {
+        $empty = [
+            'visitorHash' => null, 'refererHost' => null, 'utmSource' => null,
+            'utmMedium' => null, 'utmCampaign' => null, 'ref' => null,
+            'clientType' => null, 'isBot' => null,
+        ];
+
+        if (!$this->visitorTrackingEnabled()) {
+            return $empty;
+        }
+
+        $salt = $this->salts->saltForDate($this->clock->now());
+        $hash = VisitorHasher::hash($salt, ClientIp::resolve($request), (int) $this->orgId->get());
+        $attribution = QueryAttribution::fromQueryString($request->getUri()->getQuery());
+        $ua = UserAgentClassifier::classify($request->getHeaderLine('User-Agent'));
+
+        return [
+            'visitorHash' => $hash,
+            'refererHost' => RefererHost::fromReferer($request->getHeaderLine('Referer')),
+            'utmSource' => $attribution['utmSource'],
+            'utmMedium' => $attribution['utmMedium'],
+            'utmCampaign' => $attribution['utmCampaign'],
+            'ref' => $attribution['ref'],
+            'clientType' => $ua['type'],
+            'isBot' => $ua['isBot'],
+        ];
+    }
+
+    private function visitorTrackingEnabled(): bool
+    {
+        try {
+            $value = $this->settings->findValueByKey('analytics_visitor_tracking');
+        } catch (Throwable) {
+            return false;
+        }
+
+        return $value !== null && ($value->value === 'true' || $value->value === '1');
     }
 
     private function requestId(ServerRequestInterface $request): ?string

--- a/src/Analytics/AnalyticsSaltRepositoryInterface.php
+++ b/src/Analytics/AnalyticsSaltRepositoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+use DateTimeImmutable;
+
+/**
+ * Store for the per-day visitor-hash salt (ADR 0006 D2 / D6).
+ */
+interface AnalyticsSaltRepositoryInterface
+{
+    /**
+     * Returns the 32-byte raw salt for the given calendar day, creating it on first use.
+     * Stable within a day (so all hashes that day are comparable), rotated across days.
+     */
+    public function saltForDate(DateTimeImmutable $date): string;
+
+    /**
+     * Deletes salts dated strictly before the cutoff (retention prune). Returns rows removed.
+     */
+    public function pruneBefore(DateTimeImmutable $cutoff): int;
+}

--- a/src/Analytics/AnalyticsServiceProvider.php
+++ b/src/Analytics/AnalyticsServiceProvider.php
@@ -12,6 +12,7 @@ use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\Entity\EntityRepositoryInterface;
+use NeNeRecords\Setting\SettingRepositoryInterface;
 use NeNeRecords\TextField\TextFieldRepositoryInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -36,6 +37,22 @@ final readonly class AnalyticsServiceProvider implements ServiceProviderInterfac
                     }
 
                     return new PdoAccessLogRepository($query, $orgId);
+                },
+            )
+            ->set(
+                AnalyticsSaltRepositoryInterface::class,
+                static function (ContainerInterface $c): AnalyticsSaltRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    $clock = $c->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new PdoAnalyticsSaltRepository($query, $clock);
                 },
             )
             ->set(
@@ -130,7 +147,22 @@ final readonly class AnalyticsServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('ClockInterface service is invalid.');
                     }
 
-                    return new AccessLogMiddleware($repository, $logger, $clock);
+                    $settings = $c->get(SettingRepositoryInterface::class);
+                    if (!$settings instanceof SettingRepositoryInterface) {
+                        throw new LogicException('Setting repository service is invalid.');
+                    }
+
+                    $salts = $c->get(AnalyticsSaltRepositoryInterface::class);
+                    if (!$salts instanceof AnalyticsSaltRepositoryInterface) {
+                        throw new LogicException('Analytics salt repository service is invalid.');
+                    }
+
+                    $orgId = $c->get('nene-records.org_id_holder');
+                    if (!$orgId instanceof RequestScopedHolder) {
+                        throw new LogicException('Org ID holder service is invalid.');
+                    }
+
+                    return new AccessLogMiddleware($repository, $logger, $clock, $settings, $salts, $orgId);
                 },
             )
             ->set(

--- a/src/Analytics/PdoAccessLogRepository.php
+++ b/src/Analytics/PdoAccessLogRepository.php
@@ -22,7 +22,7 @@ final readonly class PdoAccessLogRepository implements AccessLogRepositoryInterf
     public function insert(AccessLogEntry $entry): void
     {
         $this->query->execute(
-            'INSERT INTO access_logs (organization_id, request_id, method, path, status_code, duration_ms, accessed_at, access_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            'INSERT INTO access_logs (organization_id, request_id, method, path, status_code, duration_ms, accessed_at, access_date, visitor_hash, referer_host, utm_source, utm_medium, utm_campaign, ref, client_type, is_bot) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
                 $this->orgId->get(),
                 $entry->requestId,
@@ -32,6 +32,14 @@ final readonly class PdoAccessLogRepository implements AccessLogRepositoryInterf
                 $entry->durationMs,
                 $entry->accessedAt->format(DateTimeImmutable::ATOM),
                 $entry->accessedAt->format('Y-m-d'),
+                $entry->visitorHash,
+                $entry->refererHost,
+                $entry->utmSource,
+                $entry->utmMedium,
+                $entry->utmCampaign,
+                $entry->ref,
+                $entry->clientType,
+                $entry->isBot === null ? null : ($entry->isBot ? 1 : 0),
             ],
         );
     }

--- a/src/Analytics/PdoAnalyticsSaltRepository.php
+++ b/src/Analytics/PdoAnalyticsSaltRepository.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+use DateTimeImmutable;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
+
+/**
+ * MySQL-backed daily salt store (ADR 0006). Get-or-create is race-safe via INSERT IGNORE on
+ * the `salt_date` primary key: concurrent first-hits of a new day may both generate a salt,
+ * but only one row wins and every caller re-reads the persisted value, so the whole day
+ * shares one salt. Salts are global (not org-scoped) — org isolation comes from mixing the
+ * org id into the hash, not from separate salts.
+ */
+final readonly class PdoAnalyticsSaltRepository implements AnalyticsSaltRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function saltForDate(DateTimeImmutable $date): string
+    {
+        $day = $date->format('Y-m-d');
+
+        $existing = $this->read($day);
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        $this->query->execute(
+            'INSERT IGNORE INTO analytics_salts (salt_date, salt, created_at) VALUES (?, ?, ?)',
+            [$day, random_bytes(32), $this->clock->now()->format(DateTimeImmutable::ATOM)],
+        );
+
+        $stored = $this->read($day);
+        if ($stored === null) {
+            // Should not happen (we just inserted or someone else did), but never hand back
+            // an empty salt — regenerate transiently rather than weaken the hash.
+            return random_bytes(32);
+        }
+
+        return $stored;
+    }
+
+    public function pruneBefore(DateTimeImmutable $cutoff): int
+    {
+        return $this->query->execute(
+            'DELETE FROM analytics_salts WHERE salt_date < ?',
+            [$cutoff->format('Y-m-d')],
+        );
+    }
+
+    private function read(string $day): ?string
+    {
+        $row = $this->query->fetchOne(
+            'SELECT salt FROM analytics_salts WHERE salt_date = ?',
+            [$day],
+        );
+
+        $salt = $row['salt'] ?? null;
+
+        return is_string($salt) && $salt !== '' ? $salt : null;
+    }
+}

--- a/src/Analytics/QueryAttribution.php
+++ b/src/Analytics/QueryAttribution.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+/**
+ * Extracts the attribution allowlist from a query string (ADR 0006 D4).
+ *
+ * The raw query is never stored — only `utm_source / utm_medium / utm_campaign` and `ref`
+ * (outreach campaign identifier) are pulled out; everything else (which may carry PII such
+ * as emails, tokens or search terms) is discarded. Values are trimmed and length-capped.
+ */
+final class QueryAttribution
+{
+    private const MAX_LENGTH = 255;
+
+    /**
+     * @return array{utmSource: ?string, utmMedium: ?string, utmCampaign: ?string, ref: ?string}
+     */
+    public static function fromQueryString(string $query): array
+    {
+        parse_str(ltrim($query, '?'), $params);
+
+        return [
+            'utmSource' => self::pick($params, 'utm_source'),
+            'utmMedium' => self::pick($params, 'utm_medium'),
+            'utmCampaign' => self::pick($params, 'utm_campaign'),
+            'ref' => self::pick($params, 'ref'),
+        ];
+    }
+
+    /**
+     * @param array<array-key, mixed> $params
+     */
+    private static function pick(array $params, string $key): ?string
+    {
+        $value = $params[$key] ?? null;
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        if ($value === '') {
+            return null;
+        }
+
+        return mb_substr($value, 0, self::MAX_LENGTH);
+    }
+}

--- a/src/Analytics/RefererHost.php
+++ b/src/Analytics/RefererHost.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+/**
+ * Extracts the host from a Referer (ADR 0006 D3).
+ *
+ * Only the host is kept — never the full referer URL, whose path/query can carry PII.
+ * Returns null for empty, relative, or unparseable referers.
+ */
+final class RefererHost
+{
+    private const MAX_LENGTH = 255;
+
+    public static function fromReferer(string $referer): ?string
+    {
+        $referer = trim($referer);
+
+        if ($referer === '') {
+            return null;
+        }
+
+        $host = parse_url($referer, PHP_URL_HOST);
+
+        if (!is_string($host) || $host === '') {
+            return null;
+        }
+
+        return mb_substr(strtolower($host), 0, self::MAX_LENGTH);
+    }
+}

--- a/src/Analytics/UserAgentClassifier.php
+++ b/src/Analytics/UserAgentClassifier.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+/**
+ * Derives a coarse device class + bot flag from a User-Agent (ADR 0006 D5).
+ *
+ * The raw UA is never stored — only this classification is. Bot detection is a substring
+ * match against common crawler / preview / tool markers (best effort, not exhaustive):
+ * bots that do not run JS are also excluded from the LP beacon by nature, so the two
+ * signals reinforce each other.
+ */
+final class UserAgentClassifier
+{
+    /** @var list<string> */
+    private const BOT_MARKERS = [
+        'bot', 'crawl', 'spider', 'slurp', 'bingpreview', 'facebookexternalhit', 'embedly',
+        'quora link preview', 'pinterest', 'vkshare', 'w3c_validator', 'curl', 'wget',
+        'python-requests', 'httpclient', 'go-http-client', 'headless', 'lighthouse',
+        'ahrefs', 'semrush', 'mj12', 'dotbot', 'petalbot', 'bytespider', 'gptbot', 'ccbot',
+        'claudebot', 'google-inspectiontool', 'applebot', 'yandex', 'baiduspider',
+    ];
+
+    /**
+     * @return array{type: string, isBot: bool} type is one of bot|mobile|desktop|other
+     */
+    public static function classify(string $userAgent): array
+    {
+        $ua = strtolower(trim($userAgent));
+
+        if ($ua === '') {
+            return ['type' => 'other', 'isBot' => false];
+        }
+
+        foreach (self::BOT_MARKERS as $marker) {
+            if (str_contains($ua, $marker)) {
+                return ['type' => 'bot', 'isBot' => true];
+            }
+        }
+
+        if (
+            preg_match('/(android|iphone|ipod|ipad|iemobile|blackberry|windows phone|mobile)/', $ua) === 1
+        ) {
+            return ['type' => 'mobile', 'isBot' => false];
+        }
+
+        if (preg_match('/(windows nt|macintosh|mac os x|x11|linux|cros)/', $ua) === 1) {
+            return ['type' => 'desktop', 'isBot' => false];
+        }
+
+        return ['type' => 'other', 'isBot' => false];
+    }
+}

--- a/src/Analytics/VisitorHasher.php
+++ b/src/Analytics/VisitorHasher.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+/**
+ * Computes the privacy-preserving visitor hash (ADR 0006 D2).
+ *
+ *   visitor_hash = lowercase_hex( sha256( daily_salt || client_ip || ':' || org_id ) )
+ *
+ * The raw IP is only ever used here to derive the hash and is never persisted. The salt
+ * rotates per calendar day (see {@see AnalyticsSaltRepositoryInterface}), and the org id
+ * is mixed in so the same visitor is not correlatable across tenants. Because the salt is
+ * discarded after the retention window, past days cannot be re-identified from known IPs.
+ *
+ * The hub-owned LP beacon (#1008) mirrors this exact recipe against the same salt store so
+ * unique counts reconcile between SSR (Records) and LP hits.
+ */
+final class VisitorHasher
+{
+    public static function hash(string $dailySalt, string $clientIp, int $orgId): string
+    {
+        return hash('sha256', $dailySalt . $clientIp . ':' . (string) $orgId);
+    }
+}

--- a/tests/Analytics/AccessLogMiddlewareTest.php
+++ b/tests/Analytics/AccessLogMiddlewareTest.php
@@ -5,8 +5,14 @@ declare(strict_types=1);
 namespace NeNeRecords\Tests\Analytics;
 
 use DateTimeImmutable;
+use Nene2\Http\RequestScopedHolder;
 use Nene2\Http\UtcClock;
 use NeNeRecords\Analytics\AccessLogMiddleware;
+use NeNeRecords\Analytics\AccessLogRepositoryInterface;
+use NeNeRecords\Analytics\AnalyticsSaltRepositoryInterface;
+use NeNeRecords\Analytics\VisitorHasher;
+use NeNeRecords\Setting\SettingRepositoryInterface;
+use NeNeRecords\Setting\SettingValue;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -16,6 +22,8 @@ use Psr\Log\NullLogger;
 
 final class AccessLogMiddlewareTest extends TestCase
 {
+    private const SALT = "\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01";
+
     private Psr17Factory $factory;
     private InMemoryAccessLogRepository $repository;
 
@@ -29,21 +37,10 @@ final class AccessLogMiddlewareTest extends TestCase
 
     public function testPersistsAccessLogForApiRequest(): void
     {
-        $middleware = new AccessLogMiddleware($this->repository, new NullLogger(), new UtcClock(), excludedPaths: ['/health']);
-
-        $response = $middleware->process(
+        $response = $this->makeMiddleware()->process(
             $this->factory->createServerRequest('GET', 'https://example.test/api/v1/tags')
                 ->withAttribute('nene2.request_id', 'req-abc'),
-            new readonly class ($this->factory) implements RequestHandlerInterface {
-                public function __construct(private Psr17Factory $factory)
-                {
-                }
-
-                public function handle(ServerRequestInterface $request): ResponseInterface
-                {
-                    return $this->factory->createResponse(200);
-                }
-            },
+            $this->handler(200),
         );
 
         self::assertSame(200, $response->getStatusCode());
@@ -59,73 +56,140 @@ final class AccessLogMiddlewareTest extends TestCase
 
     public function testSkipsExcludedPaths(): void
     {
-        $middleware = new AccessLogMiddleware($this->repository, new NullLogger(), new UtcClock());
-
-        $middleware->process(
+        $this->makeMiddleware()->process(
             $this->factory->createServerRequest('GET', 'https://example.test/health'),
-            new readonly class ($this->factory) implements RequestHandlerInterface {
-                public function __construct(private Psr17Factory $factory)
-                {
-                }
-
-                public function handle(ServerRequestInterface $request): ResponseInterface
-                {
-                    return $this->factory->createResponse(200);
-                }
-            },
+            $this->handler(200),
         );
 
         self::assertSame([], $this->repository->all());
     }
 
-    public function testDoesNotFailRequestWhenInsertFails(): void
+    public function testRecordsHomepageNowThatSlashIsNoLongerExcluded(): void
     {
-        $middleware = new AccessLogMiddleware(
-            new readonly class () implements \NeNeRecords\Analytics\AccessLogRepositoryInterface {
-                public function insert(\NeNeRecords\Analytics\AccessLogEntry $entry): void
-                {
-                    throw new \RuntimeException('db down');
-                }
-
-                public function countByDate(DateTimeImmutable $date): int
-                {
-                    return 0;
-                }
-
-                public function countByYearMonth(int $year, int $month): int
-                {
-                    return 0;
-                }
-
-                public function aggregateByDate(DateTimeImmutable $from, DateTimeImmutable $to): array
-                {
-                    return [];
-                }
-
-                public function aggregateEntityViews(string $sinceDate): array
-                {
-                    return [];
-                }
-            },
-            new NullLogger(),
-            new UtcClock(),
-            excludedPaths: ['/health'],
+        $this->makeMiddleware()->process(
+            $this->factory->createServerRequest('GET', 'https://example.test/'),
+            $this->handler(200),
         );
 
-        $response = $middleware->process(
-            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/tags'),
-            new readonly class ($this->factory) implements RequestHandlerInterface {
-                public function __construct(private Psr17Factory $factory)
-                {
-                }
+        self::assertCount(1, $this->repository->all());
+        self::assertSame('/', $this->repository->all()[0]->path);
+    }
 
-                public function handle(ServerRequestInterface $request): ResponseInterface
-                {
-                    return $this->factory->createResponse(200);
-                }
-            },
+    public function testOptInOffLeavesVisitorFieldsNull(): void
+    {
+        $this->makeMiddleware(optInValue: null)->process(
+            $this->factory->createServerRequest('GET', 'https://example.test/services?utm_source=news&ref=lawfirm1')
+                ->withHeader('Referer', 'https://google.com/search?q=x')
+                ->withHeader('User-Agent', 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)'),
+            $this->handler(200),
+        );
+
+        $entry = $this->repository->all()[0];
+        self::assertNull($entry->visitorHash);
+        self::assertNull($entry->refererHost);
+        self::assertNull($entry->utmSource);
+        self::assertNull($entry->ref);
+        self::assertNull($entry->clientType);
+        self::assertNull($entry->isBot);
+    }
+
+    public function testOptInOnPopulatesPrivacyFirstVisitorFields(): void
+    {
+        $this->makeMiddleware(optInValue: 'true')->process(
+            $this->factory->createServerRequest('GET', 'https://example.test/services?utm_source=news&utm_medium=email&ref=lawfirm1&secret=leak')
+                ->withHeader('Referer', 'https://www.google.com/search?q=x')
+                ->withHeader('User-Agent', 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)'),
+            $this->handler(200),
+        );
+
+        $entry = $this->repository->all()[0];
+        // Raw IP is never stored — only the daily-salted org-scoped hash.
+        self::assertSame(VisitorHasher::hash(self::SALT, 'unknown', 1), $entry->visitorHash);
+        self::assertSame('www.google.com', $entry->refererHost);
+        self::assertSame('news', $entry->utmSource);
+        self::assertSame('email', $entry->utmMedium);
+        self::assertNull($entry->utmCampaign);
+        self::assertSame('lawfirm1', $entry->ref);
+        self::assertSame('mobile', $entry->clientType);
+        self::assertFalse($entry->isBot);
+    }
+
+    public function testDoesNotFailRequestWhenInsertFails(): void
+    {
+        $throwing = new readonly class () implements AccessLogRepositoryInterface {
+            public function insert(\NeNeRecords\Analytics\AccessLogEntry $entry): void
+            {
+                throw new \RuntimeException('db down');
+            }
+
+            public function countByDate(DateTimeImmutable $date): int
+            {
+                return 0;
+            }
+
+            public function countByYearMonth(int $year, int $month): int
+            {
+                return 0;
+            }
+
+            public function aggregateByDate(DateTimeImmutable $from, DateTimeImmutable $to): array
+            {
+                return [];
+            }
+
+            public function aggregateEntityViews(string $sinceDate): array
+            {
+                return [];
+            }
+        };
+
+        $response = $this->makeMiddleware(repository: $throwing)->process(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/tags'),
+            $this->handler(200),
         );
 
         self::assertSame(200, $response->getStatusCode());
+    }
+
+    private function makeMiddleware(
+        ?AccessLogRepositoryInterface $repository = null,
+        ?string $optInValue = null,
+    ): AccessLogMiddleware {
+        $settings = $this->createStub(SettingRepositoryInterface::class);
+        $settings->method('findValueByKey')->willReturn(
+            $optInValue === null
+                ? null
+                : new SettingValue('analytics_visitor_tracking', $optInValue, false, null, null, null, '2026-01-01 00:00:00', '2026-01-01 00:00:00'),
+        );
+
+        $salts = $this->createStub(AnalyticsSaltRepositoryInterface::class);
+        $salts->method('saltForDate')->willReturn(self::SALT);
+
+        /** @var RequestScopedHolder<int> $orgId */
+        $orgId = new RequestScopedHolder();
+        $orgId->set(1);
+
+        return new AccessLogMiddleware(
+            $repository ?? $this->repository,
+            new NullLogger(),
+            new UtcClock(),
+            $settings,
+            $salts,
+            $orgId,
+        );
+    }
+
+    private function handler(int $status): RequestHandlerInterface
+    {
+        return new readonly class ($this->factory, $status) implements RequestHandlerInterface {
+            public function __construct(private Psr17Factory $factory, private int $status)
+            {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->factory->createResponse($this->status);
+            }
+        };
     }
 }

--- a/tests/Analytics/QueryAttributionTest.php
+++ b/tests/Analytics/QueryAttributionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Analytics;
+
+use NeNeRecords\Analytics\QueryAttribution;
+use PHPUnit\Framework\TestCase;
+
+final class QueryAttributionTest extends TestCase
+{
+    public function testExtractsAllowlistedParams(): void
+    {
+        $result = QueryAttribution::fromQueryString('?utm_source=news&utm_medium=email&utm_campaign=spring&ref=lawfirm1');
+
+        self::assertSame('news', $result['utmSource']);
+        self::assertSame('email', $result['utmMedium']);
+        self::assertSame('spring', $result['utmCampaign']);
+        self::assertSame('lawfirm1', $result['ref']);
+    }
+
+    public function testDropsEverythingOutsideTheAllowlist(): void
+    {
+        $result = QueryAttribution::fromQueryString('q=alice@example.com&token=secret&utm_source=news');
+
+        self::assertSame('news', $result['utmSource']);
+        self::assertNull($result['utmMedium']);
+        self::assertNull($result['ref']);
+    }
+
+    public function testEmptyOrMissingYieldsNulls(): void
+    {
+        $result = QueryAttribution::fromQueryString('');
+
+        self::assertNull($result['utmSource']);
+        self::assertNull($result['utmMedium']);
+        self::assertNull($result['utmCampaign']);
+        self::assertNull($result['ref']);
+    }
+
+    public function testCapsLength(): void
+    {
+        $result = QueryAttribution::fromQueryString('ref=' . str_repeat('x', 500));
+
+        self::assertNotNull($result['ref']);
+        self::assertSame(255, mb_strlen($result['ref']));
+    }
+}

--- a/tests/Analytics/RefererHostTest.php
+++ b/tests/Analytics/RefererHostTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Analytics;
+
+use NeNeRecords\Analytics\RefererHost;
+use PHPUnit\Framework\TestCase;
+
+final class RefererHostTest extends TestCase
+{
+    public function testKeepsHostOnly(): void
+    {
+        self::assertSame('www.google.com', RefererHost::fromReferer('https://www.google.com/search?q=alice@example.com'));
+        self::assertSame('t.co', RefererHost::fromReferer('https://t.co/abc123'));
+    }
+
+    public function testLowercasesHost(): void
+    {
+        self::assertSame('example.com', RefererHost::fromReferer('https://EXAMPLE.com/Path'));
+    }
+
+    public function testNullForEmptyOrRelativeOrUnparseable(): void
+    {
+        self::assertNull(RefererHost::fromReferer(''));
+        self::assertNull(RefererHost::fromReferer('   '));
+        self::assertNull(RefererHost::fromReferer('/relative/path'));
+    }
+}

--- a/tests/Analytics/UserAgentClassifierTest.php
+++ b/tests/Analytics/UserAgentClassifierTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Analytics;
+
+use NeNeRecords\Analytics\UserAgentClassifier;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class UserAgentClassifierTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string, bool}>
+     */
+    public static function agents(): iterable
+    {
+        yield 'googlebot' => ['Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)', 'bot', true];
+        yield 'gptbot' => ['Mozilla/5.0 (compatible; GPTBot/1.0)', 'bot', true];
+        yield 'curl' => ['curl/8.1.2', 'bot', true];
+        yield 'iphone' => ['Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)', 'mobile', false];
+        yield 'android' => ['Mozilla/5.0 (Linux; Android 14; Pixel 8) Mobile', 'mobile', false];
+        yield 'ipad' => ['Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X)', 'mobile', false];
+        yield 'windows' => ['Mozilla/5.0 (Windows NT 10.0; Win64; x64)', 'desktop', false];
+        yield 'mac' => ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)', 'desktop', false];
+        yield 'empty' => ['', 'other', false];
+        yield 'unknown' => ['SomeRandomAgent/1.0', 'other', false];
+    }
+
+    #[DataProvider('agents')]
+    public function testClassify(string $ua, string $expectedType, bool $expectedBot): void
+    {
+        $result = UserAgentClassifier::classify($ua);
+
+        self::assertSame($expectedType, $result['type']);
+        self::assertSame($expectedBot, $result['isBot']);
+    }
+}

--- a/tests/Analytics/VisitorHasherTest.php
+++ b/tests/Analytics/VisitorHasherTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Analytics;
+
+use NeNeRecords\Analytics\VisitorHasher;
+use PHPUnit\Framework\TestCase;
+
+final class VisitorHasherTest extends TestCase
+{
+    public function testMatchesTheDocumentedRecipe(): void
+    {
+        $salt = str_repeat("\x01", 32);
+        $expected = hash('sha256', $salt . '203.0.113.5' . ':' . '1');
+
+        self::assertSame($expected, VisitorHasher::hash($salt, '203.0.113.5', 1));
+        self::assertSame(64, strlen(VisitorHasher::hash($salt, '203.0.113.5', 1)));
+    }
+
+    public function testSameVisitorIsStableWithinASalt(): void
+    {
+        $salt = random_bytes(32);
+
+        self::assertSame(
+            VisitorHasher::hash($salt, '203.0.113.5', 1),
+            VisitorHasher::hash($salt, '203.0.113.5', 1),
+        );
+    }
+
+    public function testDifferentOrgYieldsDifferentHashForSameIp(): void
+    {
+        $salt = random_bytes(32);
+
+        self::assertNotSame(
+            VisitorHasher::hash($salt, '203.0.113.5', 1),
+            VisitorHasher::hash($salt, '203.0.113.5', 2),
+        );
+    }
+
+    public function testDifferentSaltYieldsDifferentHash(): void
+    {
+        self::assertNotSame(
+            VisitorHasher::hash(str_repeat("\x01", 32), '203.0.113.5', 1),
+            VisitorHasher::hash(str_repeat("\x02", 32), '203.0.113.5', 1),
+        );
+    }
+}


### PR DESCRIPTION
## 目的
Path B 段階PRの **2本目（収集層）**。opt-in ON の org でのみ、access_logs にプライバシー優先の visitor 派生を記録する。**base は #1009（foundation）** — マージ後に main へ自動 retarget。

## 変更（ADR 0006 準拠）
- **VisitorHasher** — `sha256(日次ソルト || IP || ':' || org_id)`。生IPは算出時のみ・**非保存**。
- **UserAgentClassifier** — 生UAを持たず `bot/mobile/desktop/other` ＋ `is_bot` に分類。
- **QueryAttribution** — 生queryを保存せず `utm_source/medium/campaign` ＋ `ref` のみ許可リスト抽出（残りは破棄）。
- **RefererHost** — referer はホストのみ。
- **PdoAnalyticsSaltRepository**（+interface）— `analytics_salts` に日次ソルトを get-or-create（`INSERT IGNORE` でレース安全）＋保持 prune。
- **AccessLogMiddleware** — `analytics_visitor_tracking` **ON時のみ**上記を計算。併せて **`/`（トップ）を除外解除**しフロントページ訪問を数える。`AccessLogEntry`／insert に visitor 列を追加。
- test schema `access_logs.sql` に visitor 列を追随。

## 検証
- **Analytics 38 tests green**（opt-in ON=hash等populate / OFF=全null / '/'記録 / hash recipe / UA分類 / utm+ref抽出 / referer host）。
- **PHPStan level 8 クリーン・CS-Fixer クリーン**。
- 全体スイートの残り失敗（ZipArchive×3・system_config already exists×4）は **main でも同一に出る環境/テスト隔離要因**で本変更と無関係（CI クリーン環境で解消）。

## 安全性
- **opt-in 既定OFF ＝ 既存の全org・全インスタンスで挙動不変**（visitor 計算はゲート内）。生IP・生UA・生referer・生query は**一切保存しない**。
- 本番反映は実装完了→施主最終GO。

## 次
③集計API（unique/referrer/utm/bot率 nullable追加＋OpenAPI/MCP）→ ④ingest endpoint＋export CLI＋保持prune配線。

Refs #1007