### PR TITLE
feat(analytics): Path B 集計API — stats に visitor サマリを nullable 追加（#1007）

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -6259,6 +6259,7 @@ components:
         - from
         - to
         - items
+        - visitor
       properties:
         from:
           type: string
@@ -6270,6 +6271,82 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AccessStatsDayItem'
+        visitor:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/AccessStatsVisitorSummary'
+      additionalProperties: false
+    AccessStatsVisitorSummary:
+      type: object
+      description: >
+        Privacy-first range-level visitor aggregates (Path B / ADR 0006). Null on the parent
+        when the org collected no visitor data (opt-in OFF or a pre-Path-B range).
+      required:
+        - unique_visitors
+        - bot_rate
+        - top_referrers
+        - utm
+        - ref
+      properties:
+        unique_visitors:
+          type: integer
+          minimum: 0
+        bot_rate:
+          type: number
+          nullable: true
+          minimum: 0
+          maximum: 1
+        top_referrers:
+          type: array
+          items:
+            type: object
+            required:
+              - host
+              - count
+            properties:
+              host:
+                type: string
+              count:
+                type: integer
+                minimum: 0
+            additionalProperties: false
+        utm:
+          type: array
+          items:
+            type: object
+            required:
+              - source
+              - medium
+              - campaign
+              - count
+            properties:
+              source:
+                type: string
+                nullable: true
+              medium:
+                type: string
+                nullable: true
+              campaign:
+                type: string
+                nullable: true
+              count:
+                type: integer
+                minimum: 0
+            additionalProperties: false
+        ref:
+          type: array
+          items:
+            type: object
+            required:
+              - ref
+              - count
+            properties:
+              ref:
+                type: string
+              count:
+                type: integer
+                minimum: 0
+            additionalProperties: false
       additionalProperties: false
     AccessStatsDayItem:
       type: object

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -2526,6 +2526,26 @@ export interface components {
             /** Format: date */
             to: string;
             items: components["schemas"]["AccessStatsDayItem"][];
+            visitor: components["schemas"]["AccessStatsVisitorSummary"] | null;
+        };
+        /** @description Privacy-first range-level visitor aggregates (Path B / ADR 0006). Null on the parent when the org collected no visitor data (opt-in OFF or a pre-Path-B range). */
+        AccessStatsVisitorSummary: {
+            unique_visitors: number;
+            bot_rate: number | null;
+            top_referrers: {
+                host: string;
+                count: number;
+            }[];
+            utm: {
+                source: string | null;
+                medium: string | null;
+                campaign: string | null;
+                count: number;
+            }[];
+            ref: {
+                ref: string;
+                count: number;
+            }[];
         };
         AccessStatsDayItem: {
             /** Format: date */

--- a/src/Analytics/AccessLogRepositoryInterface.php
+++ b/src/Analytics/AccessLogRepositoryInterface.php
@@ -26,4 +26,10 @@ interface AccessLogRepositoryInterface
      * @return array<int, int> entityId => viewCount, ordered by viewCount desc
      */
     public function aggregateEntityViews(string $sinceDate): array;
+
+    /**
+     * Range-level privacy-first visitor aggregates (ADR 0006). Breakdown lists are capped at
+     * `$limit`, highest first. Derived from Path B columns only (no raw PII).
+     */
+    public function aggregateVisitorSummary(DateTimeImmutable $from, DateTimeImmutable $to, int $limit): VisitorSummary;
 }

--- a/src/Analytics/GetAccessStatsByDateHandler.php
+++ b/src/Analytics/GetAccessStatsByDateHandler.php
@@ -36,6 +36,30 @@ final readonly class GetAccessStatsByDateHandler
                 ],
                 $output->items,
             ),
+            'visitor' => $this->serializeVisitor($output->visitor),
         ]);
+    }
+
+    /**
+     * @return array{
+     *     unique_visitors: int, bot_rate: ?float,
+     *     top_referrers: list<array{host: string, count: int}>,
+     *     utm: list<array{source: ?string, medium: ?string, campaign: ?string, count: int}>,
+     *     ref: list<array{ref: string, count: int}>
+     * }|null
+     */
+    private function serializeVisitor(?VisitorSummary $visitor): ?array
+    {
+        if ($visitor === null) {
+            return null;
+        }
+
+        return [
+            'unique_visitors' => $visitor->uniqueVisitors,
+            'bot_rate' => $visitor->botRate,
+            'top_referrers' => $visitor->topReferrers,
+            'utm' => $visitor->utm,
+            'ref' => $visitor->ref,
+        ];
     }
 }

--- a/src/Analytics/GetAccessStatsByDateOutput.php
+++ b/src/Analytics/GetAccessStatsByDateOutput.php
@@ -13,6 +13,9 @@ final readonly class GetAccessStatsByDateOutput
         public string $from,
         public string $to,
         public array $items,
+        // Path B (ADR 0006). Null when the org has collected no visitor data
+        // (opt-in OFF or a range predating Path B) — the frontend/consumer degrades gracefully.
+        public ?VisitorSummary $visitor = null,
     ) {
     }
 }

--- a/src/Analytics/GetAccessStatsByDateUseCase.php
+++ b/src/Analytics/GetAccessStatsByDateUseCase.php
@@ -11,14 +11,31 @@ final readonly class GetAccessStatsByDateUseCase implements GetAccessStatsByDate
     ) {
     }
 
+    private const BREAKDOWN_LIMIT = 10;
+
     public function execute(GetAccessStatsByDateInput $input): GetAccessStatsByDateOutput
     {
         $items = $this->accessLogs->aggregateByDate($input->from, $input->to);
+        $summary = $this->accessLogs->aggregateVisitorSummary($input->from, $input->to, self::BREAKDOWN_LIMIT);
+
+        // No visitor data collected (opt-in OFF / pre-Path-B range) → expose null so
+        // consumers degrade rather than render a misleading all-zero panel.
+        $visitor = $this->hasVisitorData($summary) ? $summary : null;
 
         return new GetAccessStatsByDateOutput(
             from: $input->from->format('Y-m-d'),
             to: $input->to->format('Y-m-d'),
             items: $items,
+            visitor: $visitor,
         );
+    }
+
+    private function hasVisitorData(VisitorSummary $summary): bool
+    {
+        return $summary->uniqueVisitors > 0
+            || $summary->botRate !== null
+            || $summary->topReferrers !== []
+            || $summary->utm !== []
+            || $summary->ref !== [];
     }
 }

--- a/src/Analytics/PdoAccessLogRepository.php
+++ b/src/Analytics/PdoAccessLogRepository.php
@@ -125,4 +125,72 @@ final readonly class PdoAccessLogRepository implements AccessLogRepositoryInterf
             $rows,
         );
     }
+
+    public function aggregateVisitorSummary(DateTimeImmutable $from, DateTimeImmutable $to, int $limit): VisitorSummary
+    {
+        $fromDay = $from->format('Y-m-d');
+        $toDay = $to->format('Y-m-d');
+        $org = $this->orgId->get();
+        // $limit is an internal integer (not user input); inlined because MySQL rejects a
+        // bound placeholder in LIMIT under emulated prepares.
+        $cap = max(1, $limit);
+
+        $unique = $this->query->fetchOne(
+            'SELECT COUNT(DISTINCT visitor_hash) AS c FROM access_logs
+             WHERE access_date >= ? AND access_date <= ? AND organization_id = ? AND visitor_hash IS NOT NULL',
+            [$fromDay, $toDay, $org],
+        );
+
+        $bot = $this->query->fetchOne(
+            'SELECT AVG(is_bot) AS r FROM access_logs
+             WHERE access_date >= ? AND access_date <= ? AND organization_id = ? AND is_bot IS NOT NULL',
+            [$fromDay, $toDay, $org],
+        );
+        $botRateRaw = $bot['r'] ?? null;
+        $botRate = $botRateRaw === null ? null : round((float) $botRateRaw, 4);
+
+        $referrers = $this->query->fetchAll(
+            'SELECT referer_host AS host, COUNT(*) AS cnt FROM access_logs
+             WHERE access_date >= ? AND access_date <= ? AND organization_id = ? AND referer_host IS NOT NULL
+             GROUP BY referer_host ORDER BY cnt DESC, referer_host ASC LIMIT ' . $cap,
+            [$fromDay, $toDay, $org],
+        );
+
+        $utm = $this->query->fetchAll(
+            'SELECT utm_source, utm_medium, utm_campaign, COUNT(*) AS cnt FROM access_logs
+             WHERE access_date >= ? AND access_date <= ? AND organization_id = ?
+               AND (utm_source IS NOT NULL OR utm_medium IS NOT NULL OR utm_campaign IS NOT NULL)
+             GROUP BY utm_source, utm_medium, utm_campaign ORDER BY cnt DESC LIMIT ' . $cap,
+            [$fromDay, $toDay, $org],
+        );
+
+        $refs = $this->query->fetchAll(
+            'SELECT ref, COUNT(*) AS cnt FROM access_logs
+             WHERE access_date >= ? AND access_date <= ? AND organization_id = ? AND ref IS NOT NULL
+             GROUP BY ref ORDER BY cnt DESC, ref ASC LIMIT ' . $cap,
+            [$fromDay, $toDay, $org],
+        );
+
+        return new VisitorSummary(
+            uniqueVisitors: (int) ($unique['c'] ?? 0),
+            botRate: $botRate,
+            topReferrers: array_map(
+                static fn (array $r): array => ['host' => (string) $r['host'], 'count' => (int) $r['cnt']],
+                $referrers,
+            ),
+            utm: array_map(
+                static fn (array $r): array => [
+                    'source' => $r['utm_source'] === null ? null : (string) $r['utm_source'],
+                    'medium' => $r['utm_medium'] === null ? null : (string) $r['utm_medium'],
+                    'campaign' => $r['utm_campaign'] === null ? null : (string) $r['utm_campaign'],
+                    'count' => (int) $r['cnt'],
+                ],
+                $utm,
+            ),
+            ref: array_map(
+                static fn (array $r): array => ['ref' => (string) $r['ref'], 'count' => (int) $r['cnt']],
+                $refs,
+            ),
+        );
+    }
 }

--- a/src/Analytics/VisitorSummary.php
+++ b/src/Analytics/VisitorSummary.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+/**
+ * Range-level visitor aggregates derived from the Path B fields (ADR 0006 / #1007).
+ *
+ * All figures come from privacy-preserving derived columns only — never raw IP/UA/referer/
+ * query. `uniqueVisitors` counts distinct daily-salted hashes; because the salt rotates
+ * daily this is a per-day-union count, not a stable cross-day identity. Returned by the
+ * stats API and the export CLI; null at the call site when the org has collected no visitor
+ * data (opt-in OFF or pre-Path-B range).
+ */
+final readonly class VisitorSummary
+{
+    /**
+     * @param list<array{host: string, count: int}>                                    $topReferrers
+     * @param list<array{source: ?string, medium: ?string, campaign: ?string, count: int}> $utm
+     * @param list<array{ref: string, count: int}>                                     $ref
+     */
+    public function __construct(
+        public int $uniqueVisitors,
+        public ?float $botRate,
+        public array $topReferrers,
+        public array $utm,
+        public array $ref,
+    ) {
+    }
+}

--- a/tests/Analytics/AccessLogMiddlewareTest.php
+++ b/tests/Analytics/AccessLogMiddlewareTest.php
@@ -141,6 +141,11 @@ final class AccessLogMiddlewareTest extends TestCase
             {
                 return [];
             }
+
+            public function aggregateVisitorSummary(DateTimeImmutable $from, DateTimeImmutable $to, int $limit): \NeNeRecords\Analytics\VisitorSummary
+            {
+                return new \NeNeRecords\Analytics\VisitorSummary(0, null, [], [], []);
+            }
         };
 
         $response = $this->makeMiddleware(repository: $throwing)->process(

--- a/tests/Analytics/AnalyticsHttpTest.php
+++ b/tests/Analytics/AnalyticsHttpTest.php
@@ -99,6 +99,8 @@ final class AnalyticsHttpTest extends TestCase
         self::assertSame('2026-05-01', $payload['items'][0]['date']);
         self::assertSame(1, $payload['items'][0]['request_count']);
         self::assertSame(10.0, $payload['items'][0]['avg_duration_ms']);
+        self::assertArrayHasKey('visitor', $payload);
+        self::assertNull($payload['visitor']); // no opt-in visitor data seeded → null
     }
 
     public function testGetPopularEntitiesReturnsPublishedRankedByViews(): void

--- a/tests/Analytics/InMemoryAccessLogRepository.php
+++ b/tests/Analytics/InMemoryAccessLogRepository.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use NeNeRecords\Analytics\AccessLogEntry;
 use NeNeRecords\Analytics\AccessLogRepositoryInterface;
 use NeNeRecords\Analytics\AccessStatsDayItem;
+use NeNeRecords\Analytics\VisitorSummary;
 
 final class InMemoryAccessLogRepository implements AccessLogRepositoryInterface
 {
@@ -106,5 +107,64 @@ final class InMemoryAccessLogRepository implements AccessLogRepositoryInterface
         }
 
         return $items;
+    }
+
+    public function aggregateVisitorSummary(DateTimeImmutable $from, DateTimeImmutable $to, int $limit): VisitorSummary
+    {
+        $fromDay = $from->format('Y-m-d');
+        $toDay = $to->format('Y-m-d');
+
+        $hashes = [];
+        $botFlags = [];
+        $referrers = [];
+        $utm = [];
+        $refs = [];
+
+        foreach ($this->entries as $entry) {
+            $day = $entry->accessedAt->format('Y-m-d');
+            if ($day < $fromDay || $day > $toDay) {
+                continue;
+            }
+
+            if ($entry->visitorHash !== null) {
+                $hashes[$entry->visitorHash] = true;
+            }
+            if ($entry->isBot !== null) {
+                $botFlags[] = $entry->isBot ? 1 : 0;
+            }
+            if ($entry->refererHost !== null) {
+                $referrers[$entry->refererHost] = ($referrers[$entry->refererHost] ?? 0) + 1;
+            }
+            if ($entry->utmSource !== null || $entry->utmMedium !== null || $entry->utmCampaign !== null) {
+                $key = ($entry->utmSource ?? '') . "\0" . ($entry->utmMedium ?? '') . "\0" . ($entry->utmCampaign ?? '');
+                $utm[$key] ??= ['source' => $entry->utmSource, 'medium' => $entry->utmMedium, 'campaign' => $entry->utmCampaign, 'count' => 0];
+                ++$utm[$key]['count'];
+            }
+            if ($entry->ref !== null) {
+                $refs[$entry->ref] = ($refs[$entry->ref] ?? 0) + 1;
+            }
+        }
+
+        arsort($referrers);
+        arsort($refs);
+        usort($utm, static fn (array $a, array $b): int => $b['count'] <=> $a['count']);
+
+        $topReferrers = [];
+        foreach (array_slice($referrers, 0, $limit, true) as $host => $count) {
+            $topReferrers[] = ['host' => (string) $host, 'count' => $count];
+        }
+
+        $refItems = [];
+        foreach (array_slice($refs, 0, $limit, true) as $ref => $count) {
+            $refItems[] = ['ref' => (string) $ref, 'count' => $count];
+        }
+
+        return new VisitorSummary(
+            uniqueVisitors: count($hashes),
+            botRate: $botFlags === [] ? null : round(array_sum($botFlags) / count($botFlags), 4),
+            topReferrers: $topReferrers,
+            utm: array_slice($utm, 0, $limit),
+            ref: $refItems,
+        );
     }
 }

--- a/tests/Analytics/PdoAccessLogRepositoryTest.php
+++ b/tests/Analytics/PdoAccessLogRepositoryTest.php
@@ -110,4 +110,76 @@ final class PdoAccessLogRepositoryTest extends TestCase
         self::assertSame(1, $items[1]->requestCount);
         self::assertSame(30.0, $items[1]->avgDurationMs);
     }
+
+    public function testAggregateVisitorSummary(): void
+    {
+        $utc = new DateTimeZone('UTC');
+        $at = static fn (string $iso): DateTimeImmutable => new DateTimeImmutable($iso, $utc);
+
+        // Two distinct visitors (hashes h1, h2); h1 visits twice. One bot, three humans.
+        $this->repository->insert($this->visitorEntry($at('2026-05-01T10:00:00+00:00'), 'h1', 'google.com', 'news', 'email', 'lawfirm1', false));
+        $this->repository->insert($this->visitorEntry($at('2026-05-01T11:00:00+00:00'), 'h1', 'google.com', 'news', 'email', 'lawfirm1', false));
+        $this->repository->insert($this->visitorEntry($at('2026-05-02T09:00:00+00:00'), 'h2', 't.co', null, null, 'lawfirm2', false));
+        $this->repository->insert($this->visitorEntry($at('2026-05-02T09:30:00+00:00'), 'h3', null, null, null, null, true));
+
+        $summary = $this->repository->aggregateVisitorSummary($at('2026-05-01'), $at('2026-05-02'), 10);
+
+        self::assertSame(3, $summary->uniqueVisitors);
+        self::assertSame(0.25, $summary->botRate);
+        self::assertSame([['host' => 'google.com', 'count' => 2], ['host' => 't.co', 'count' => 1]], $summary->topReferrers);
+        self::assertSame([['source' => 'news', 'medium' => 'email', 'campaign' => null, 'count' => 2]], $summary->utm);
+        self::assertSame([['ref' => 'lawfirm1', 'count' => 2], ['ref' => 'lawfirm2', 'count' => 1]], $summary->ref);
+    }
+
+    public function testAggregateVisitorSummaryIsEmptyWhenNoVisitorData(): void
+    {
+        $utc = new DateTimeZone('UTC');
+        $this->repository->insert(new AccessLogEntry(
+            requestId: 'req-1',
+            method: 'GET',
+            path: '/api/v1/tags',
+            statusCode: 200,
+            durationMs: 10.0,
+            accessedAt: new DateTimeImmutable('2026-05-01T10:00:00+00:00', $utc),
+        ));
+
+        $summary = $this->repository->aggregateVisitorSummary(
+            new DateTimeImmutable('2026-05-01', $utc),
+            new DateTimeImmutable('2026-05-02', $utc),
+            10,
+        );
+
+        self::assertSame(0, $summary->uniqueVisitors);
+        self::assertNull($summary->botRate);
+        self::assertSame([], $summary->topReferrers);
+        self::assertSame([], $summary->utm);
+        self::assertSame([], $summary->ref);
+    }
+
+    private function visitorEntry(
+        DateTimeImmutable $at,
+        string $hash,
+        ?string $refererHost,
+        ?string $utmSource,
+        ?string $utmMedium,
+        ?string $ref,
+        bool $isBot,
+    ): AccessLogEntry {
+        return new AccessLogEntry(
+            requestId: null,
+            method: 'GET',
+            path: '/services',
+            statusCode: 200,
+            durationMs: 5.0,
+            accessedAt: $at,
+            visitorHash: $hash,
+            refererHost: $refererHost,
+            utmSource: $utmSource,
+            utmMedium: $utmMedium,
+            utmCampaign: null,
+            ref: $ref,
+            clientType: $isBot ? 'bot' : 'desktop',
+            isBot: $isBot,
+        );
+    }
 }


### PR DESCRIPTION
## 目的
Path B 段階PRの **3本目（集計API）**。管理ダッシュボード/export が使う access-stats に、プライバシー優先の range 集計を **nullable** で追加する。base=main（#1009/#1011 マージ済の上）。

## 変更
- **VisitorSummary** 値オブジェクト ＋ `AccessLogRepositoryInterface::aggregateVisitorSummary(from,to,limit)` — `COUNT(DISTINCT visitor_hash)` / `AVG(is_bot)` / referer_host・utm・ref の上位N。Pdo/InMemory 両実装。
- `GetAccessStatsByDateOutput` に `?VisitorSummary`。**visitor データ皆無（opt-in OFF / Path B 前の範囲）は `null`** を返し、消費側は degrade（誤解を招く全ゼロ表示を避ける）。
- Handler が `unique_visitors / bot_rate / top_referrers / utm / ref` を出力。**OpenAPI に `AccessStatsVisitorSummary` 追加 ＋ response の `visitor`(nullable)**、frontend 型を再生成。

## 検証
- **Analytics 40 tests green**（Pdo で unique/bot率/referrer/utm/ref を実DB検証＋visitorなし空、HTTP で `visitor=null` 契約）。
- **PHPStan L8 / OpenAPI valid / MCP valid / frontend type-check clean / CS クリーン**。

## 契約
- 出力キーは hub 合意の **summary v1** と一致（`visitor.*` は Path B 稼働まで null）。hub 受け側は追加実装ゼロで乗る。

## 次
④ ingest endpoint（`POST /api/v1/public/beacon`）＋ export CLI（`~/site-logs/ayane/summary-<date>.json`）＋ 保持prune。本番反映は全部揃って施主最終GO。

Refs #1007