### PR TITLE
feat(analytics): Path B ingest endpoint — 公開LPビーコン POST /api/v1/public/beacon（#1007）

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -6259,6 +6259,7 @@ components:
         - from
         - to
         - items
+        - visitor
       properties:
         from:
           type: string
@@ -6270,6 +6271,82 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AccessStatsDayItem'
+        visitor:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/AccessStatsVisitorSummary'
+      additionalProperties: false
+    AccessStatsVisitorSummary:
+      type: object
+      description: >
+        Privacy-first range-level visitor aggregates (Path B / ADR 0006). Null on the parent
+        when the org collected no visitor data (opt-in OFF or a pre-Path-B range).
+      required:
+        - unique_visitors
+        - bot_rate
+        - top_referrers
+        - utm
+        - ref
+      properties:
+        unique_visitors:
+          type: integer
+          minimum: 0
+        bot_rate:
+          type: number
+          nullable: true
+          minimum: 0
+          maximum: 1
+        top_referrers:
+          type: array
+          items:
+            type: object
+            required:
+              - host
+              - count
+            properties:
+              host:
+                type: string
+              count:
+                type: integer
+                minimum: 0
+            additionalProperties: false
+        utm:
+          type: array
+          items:
+            type: object
+            required:
+              - source
+              - medium
+              - campaign
+              - count
+            properties:
+              source:
+                type: string
+                nullable: true
+              medium:
+                type: string
+                nullable: true
+              campaign:
+                type: string
+                nullable: true
+              count:
+                type: integer
+                minimum: 0
+            additionalProperties: false
+        ref:
+          type: array
+          items:
+            type: object
+            required:
+              - ref
+              - count
+            properties:
+              ref:
+                type: string
+              count:
+                type: integer
+                minimum: 0
+            additionalProperties: false
       additionalProperties: false
     AccessStatsDayItem:
       type: object

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -3791,6 +3791,31 @@ paths:
           $ref: '#/components/responses/ValidationFailed'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/v1/public/beacon:
+    post:
+      tags:
+        - Analytics
+      summary: LP visit beacon (Path B)
+      description: >-
+        Public, unauthenticated ingest for static landing-page visits (ADR 0006 / #1008).
+        The page's beacon posts `{path, referrer, query}`; the server records a `BEACON`
+        access-log row for allowlisted LP paths and — only when the org opts in — the
+        privacy-first visitor fields (daily-salted hash, referer host, utm/ref allowlist,
+        UA class). Raw IP/UA/referer/query are never stored. Fire-and-forget: always 204,
+        or 429 when the per-IP rate limit is exceeded. Unknown paths are silently dropped.
+      operationId: postVisitBeacon
+      security: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VisitBeaconRequest'
+      responses:
+        '204':
+          description: Accepted (recorded or silently dropped).
+        '429':
+          description: Per-IP rate limit exceeded.
   /api/v1/analytics/popular-entities:
     get:
       tags:
@@ -6253,6 +6278,22 @@ components:
           type: integer
         offset:
           type: integer
+    VisitBeaconRequest:
+      type: object
+      description: >-
+        LP beacon payload. `path` is matched against the server-side LP allowlist; `query`
+        may be the raw location.search but only the utm_*/ref allowlist is persisted (ADR 0006).
+      properties:
+        path:
+          type: string
+          description: LP path (location.pathname).
+        referrer:
+          type: string
+          description: document.referrer (only its host is stored).
+        query:
+          type: string
+          description: location.search (raw; server keeps only utm_source/medium/campaign/ref).
+      additionalProperties: false
     AccessStatsByDateResponse:
       type: object
       required:

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -1592,6 +1592,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/public/beacon": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * LP visit beacon (Path B)
+         * @description Public, unauthenticated ingest for static landing-page visits (ADR 0006 / #1008). The page's beacon posts `{path, referrer, query}`; the server records a `BEACON` access-log row for allowlisted LP paths and — only when the org opts in — the privacy-first visitor fields (daily-salted hash, referer host, utm/ref allowlist, UA class). Raw IP/UA/referer/query are never stored. Fire-and-forget: always 204, or 429 when the per-IP rate limit is exceeded. Unknown paths are silently dropped.
+         */
+        post: operations["postVisitBeacon"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/analytics/popular-entities": {
         parameters: {
             query?: never;
@@ -2519,6 +2539,15 @@ export interface components {
             items: components["schemas"]["DateTimeFieldResponse"][];
             limit: number;
             offset: number;
+        };
+        /** @description LP beacon payload. `path` is matched against the server-side LP allowlist; `query` may be the raw location.search but only the utm_*\/ref allowlist is persisted (ADR 0006). */
+        VisitBeaconRequest: {
+            /** @description LP path (location.pathname). */
+            path?: string;
+            /** @description document.referrer (only its host is stored). */
+            referrer?: string;
+            /** @description location.search (raw; server keeps only utm_source/medium/campaign/ref). */
+            query?: string;
         };
         AccessStatsByDateResponse: {
             /** Format: date */
@@ -6831,6 +6860,35 @@ export interface operations {
             };
             422: components["responses"]["ValidationFailed"];
             500: components["responses"]["InternalServerError"];
+        };
+    };
+    postVisitBeacon: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["VisitBeaconRequest"];
+            };
+        };
+        responses: {
+            /** @description Accepted (recorded or silently dropped). */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Per-IP rate limit exceeded. */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     getPopularEntities: {

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -2526,6 +2526,26 @@ export interface components {
             /** Format: date */
             to: string;
             items: components["schemas"]["AccessStatsDayItem"][];
+            visitor: components["schemas"]["AccessStatsVisitorSummary"] | null;
+        };
+        /** @description Privacy-first range-level visitor aggregates (Path B / ADR 0006). Null on the parent when the org collected no visitor data (opt-in OFF or a pre-Path-B range). */
+        AccessStatsVisitorSummary: {
+            unique_visitors: number;
+            bot_rate: number | null;
+            top_referrers: {
+                host: string;
+                count: number;
+            }[];
+            utm: {
+                source: string | null;
+                medium: string | null;
+                campaign: string | null;
+                count: number;
+            }[];
+            ref: {
+                ref: string;
+                count: number;
+            }[];
         };
         AccessStatsDayItem: {
             /** Format: date */

--- a/src/Analytics/AccessLogMiddleware.php
+++ b/src/Analytics/AccessLogMiddleware.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace NeNeRecords\Analytics;
 
 use Nene2\Http\ClockInterface;
-use Nene2\Http\RequestScopedHolder;
 use Nene2\Middleware\RequestIdMiddleware;
 use NeNeRecords\Http\ClientIp;
-use NeNeRecords\Setting\SettingRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -21,28 +19,26 @@ use Throwable;
  * always recorded except for the infrastructure paths in {@see self::$excludedPaths}.
  *
  * When the owning org opts in (`analytics_visitor_tracking` = true, ADR 0006 / #1007) the
- * privacy-first visitor fields are additionally computed: a daily-salted org-scoped hash of
- * the client IP (the raw IP is never stored), the referer host only, the utm_* / ref
- * allowlist, and a coarse UA class + bot flag. Opt-in OFF (the default) reproduces the exact
- * pre-Path-B behaviour.
+ * privacy-first visitor fields are additionally computed via {@see VisitorFieldsResolver}:
+ * a daily-salted org-scoped hash of the client IP (the raw IP is never stored), the referer
+ * host only, the utm_* / ref allowlist, and a coarse UA class + bot flag. Opt-in OFF (the
+ * default) reproduces the exact pre-Path-B behaviour.
  *
  * Note: the homepage `/` is intentionally NOT excluded (Path B counts front-page visits);
- * only true infrastructure/health endpoints are skipped.
+ * only true infrastructure/health endpoints and the beacon ingest (recorded by its own
+ * handler as a BEACON row) are skipped.
  */
 final readonly class AccessLogMiddleware implements MiddlewareInterface
 {
     /**
-     * @param RequestScopedHolder<int> $orgId
-     * @param list<string>             $excludedPaths
+     * @param list<string> $excludedPaths
      */
     public function __construct(
         private AccessLogRepositoryInterface $accessLogs,
         private LoggerInterface $logger,
         private ClockInterface $clock,
-        private SettingRepositoryInterface $settings,
-        private AnalyticsSaltRepositoryInterface $salts,
-        private RequestScopedHolder $orgId,
-        private array $excludedPaths = ['/health', '/machine/health', '/examples/ping'],
+        private VisitorFieldsResolver $visitor,
+        private array $excludedPaths = ['/health', '/machine/health', '/examples/ping', '/api/v1/public/beacon'],
     ) {
     }
 
@@ -58,7 +54,12 @@ final readonly class AccessLogMiddleware implements MiddlewareInterface
         $response = $handler->handle($request);
 
         try {
-            $visitor = $this->resolveVisitor($request);
+            $visitor = $this->visitor->resolve(
+                ClientIp::resolve($request),
+                $request->getHeaderLine('Referer'),
+                $request->getUri()->getQuery(),
+                $request->getHeaderLine('User-Agent'),
+            );
 
             $this->accessLogs->insert(new AccessLogEntry(
                 requestId: $this->requestId($request),
@@ -85,52 +86,6 @@ final readonly class AccessLogMiddleware implements MiddlewareInterface
         }
 
         return $response;
-    }
-
-    /**
-     * @return array{
-     *     visitorHash: ?string, refererHost: ?string, utmSource: ?string, utmMedium: ?string,
-     *     utmCampaign: ?string, ref: ?string, clientType: ?string, isBot: ?bool
-     * }
-     */
-    private function resolveVisitor(ServerRequestInterface $request): array
-    {
-        $empty = [
-            'visitorHash' => null, 'refererHost' => null, 'utmSource' => null,
-            'utmMedium' => null, 'utmCampaign' => null, 'ref' => null,
-            'clientType' => null, 'isBot' => null,
-        ];
-
-        if (!$this->visitorTrackingEnabled()) {
-            return $empty;
-        }
-
-        $salt = $this->salts->saltForDate($this->clock->now());
-        $hash = VisitorHasher::hash($salt, ClientIp::resolve($request), (int) $this->orgId->get());
-        $attribution = QueryAttribution::fromQueryString($request->getUri()->getQuery());
-        $ua = UserAgentClassifier::classify($request->getHeaderLine('User-Agent'));
-
-        return [
-            'visitorHash' => $hash,
-            'refererHost' => RefererHost::fromReferer($request->getHeaderLine('Referer')),
-            'utmSource' => $attribution['utmSource'],
-            'utmMedium' => $attribution['utmMedium'],
-            'utmCampaign' => $attribution['utmCampaign'],
-            'ref' => $attribution['ref'],
-            'clientType' => $ua['type'],
-            'isBot' => $ua['isBot'],
-        ];
-    }
-
-    private function visitorTrackingEnabled(): bool
-    {
-        try {
-            $value = $this->settings->findValueByKey('analytics_visitor_tracking');
-        } catch (Throwable) {
-            return false;
-        }
-
-        return $value !== null && ($value->value === 'true' || $value->value === '1');
     }
 
     private function requestId(ServerRequestInterface $request): ?string

--- a/src/Analytics/AccessLogRepositoryInterface.php
+++ b/src/Analytics/AccessLogRepositoryInterface.php
@@ -26,4 +26,10 @@ interface AccessLogRepositoryInterface
      * @return array<int, int> entityId => viewCount, ordered by viewCount desc
      */
     public function aggregateEntityViews(string $sinceDate): array;
+
+    /**
+     * Range-level privacy-first visitor aggregates (ADR 0006). Breakdown lists are capped at
+     * `$limit`, highest first. Derived from Path B columns only (no raw PII).
+     */
+    public function aggregateVisitorSummary(DateTimeImmutable $from, DateTimeImmutable $to, int $limit): VisitorSummary;
 }

--- a/src/Analytics/AnalyticsRouteRegistrar.php
+++ b/src/Analytics/AnalyticsRouteRegistrar.php
@@ -12,6 +12,7 @@ final readonly class AnalyticsRouteRegistrar
     public function __construct(
         private GetAccessStatsByDateHandler $getAccessStatsHandler,
         private GetPopularEntitiesHandler $getPopularEntitiesHandler,
+        private BeaconIngestHandler $beaconIngestHandler,
     ) {
     }
 
@@ -19,6 +20,7 @@ final readonly class AnalyticsRouteRegistrar
     {
         $getAccessStatsHandler = $this->getAccessStatsHandler;
         $getPopularEntitiesHandler = $this->getPopularEntitiesHandler;
+        $beaconIngestHandler = $this->beaconIngestHandler;
 
         $router->get(
             '/api/v1/analytics/access-stats',
@@ -27,6 +29,11 @@ final readonly class AnalyticsRouteRegistrar
         $router->get(
             '/api/v1/analytics/popular-entities',
             static fn (ServerRequestInterface $request) => $getPopularEntitiesHandler->handle($request),
+        );
+        // Public LP beacon (Path B). Always-open under /api/v1/public/*; no auth.
+        $router->post(
+            '/api/v1/public/beacon',
+            static fn (ServerRequestInterface $request) => $beaconIngestHandler->handle($request),
         );
     }
 }

--- a/src/Analytics/AnalyticsServiceProvider.php
+++ b/src/Analytics/AnalyticsServiceProvider.php
@@ -11,10 +11,12 @@ use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
+use Nene2\Middleware\RateLimitStorageInterface;
 use NeNeRecords\Entity\EntityRepositoryInterface;
 use NeNeRecords\Setting\SettingRepositoryInterface;
 use NeNeRecords\TextField\TextFieldRepositoryInterface;
 use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Log\LoggerInterface;
 
 final readonly class AnalyticsServiceProvider implements ServiceProviderInterface
@@ -129,6 +131,32 @@ final readonly class AnalyticsServiceProvider implements ServiceProviderInterfac
                 },
             )
             ->set(
+                VisitorFieldsResolver::class,
+                static function (ContainerInterface $c): VisitorFieldsResolver {
+                    $settings = $c->get(SettingRepositoryInterface::class);
+                    if (!$settings instanceof SettingRepositoryInterface) {
+                        throw new LogicException('Setting repository service is invalid.');
+                    }
+
+                    $salts = $c->get(AnalyticsSaltRepositoryInterface::class);
+                    if (!$salts instanceof AnalyticsSaltRepositoryInterface) {
+                        throw new LogicException('Analytics salt repository service is invalid.');
+                    }
+
+                    $clock = $c->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    $orgId = $c->get('nene-records.org_id_holder');
+                    if (!$orgId instanceof RequestScopedHolder) {
+                        throw new LogicException('Org ID holder service is invalid.');
+                    }
+
+                    return new VisitorFieldsResolver($settings, $salts, $clock, $orgId);
+                },
+            )
+            ->set(
                 AccessLogMiddleware::class,
                 static function (ContainerInterface $c): AccessLogMiddleware {
                     $repository = $c->get(AccessLogRepositoryInterface::class);
@@ -147,22 +175,43 @@ final readonly class AnalyticsServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('ClockInterface service is invalid.');
                     }
 
-                    $settings = $c->get(SettingRepositoryInterface::class);
-                    if (!$settings instanceof SettingRepositoryInterface) {
-                        throw new LogicException('Setting repository service is invalid.');
+                    $visitor = $c->get(VisitorFieldsResolver::class);
+                    if (!$visitor instanceof VisitorFieldsResolver) {
+                        throw new LogicException('Visitor fields resolver service is invalid.');
                     }
 
-                    $salts = $c->get(AnalyticsSaltRepositoryInterface::class);
-                    if (!$salts instanceof AnalyticsSaltRepositoryInterface) {
-                        throw new LogicException('Analytics salt repository service is invalid.');
+                    return new AccessLogMiddleware($repository, $logger, $clock, $visitor);
+                },
+            )
+            ->set(
+                BeaconIngestHandler::class,
+                static function (ContainerInterface $c): BeaconIngestHandler {
+                    $repository = $c->get(AccessLogRepositoryInterface::class);
+                    if (!$repository instanceof AccessLogRepositoryInterface) {
+                        throw new LogicException('Access log repository service is invalid.');
                     }
 
-                    $orgId = $c->get('nene-records.org_id_holder');
-                    if (!$orgId instanceof RequestScopedHolder) {
-                        throw new LogicException('Org ID holder service is invalid.');
+                    $visitor = $c->get(VisitorFieldsResolver::class);
+                    if (!$visitor instanceof VisitorFieldsResolver) {
+                        throw new LogicException('Visitor fields resolver service is invalid.');
                     }
 
-                    return new AccessLogMiddleware($repository, $logger, $clock, $settings, $salts, $orgId);
+                    $clock = $c->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    $rateLimit = $c->get(RateLimitStorageInterface::class);
+                    if (!$rateLimit instanceof RateLimitStorageInterface) {
+                        throw new LogicException('Rate limit storage service is invalid.');
+                    }
+
+                    $responses = $c->get(ResponseFactoryInterface::class);
+                    if (!$responses instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    return new BeaconIngestHandler($repository, $visitor, $clock, $rateLimit, $responses);
                 },
             )
             ->set(
@@ -170,6 +219,7 @@ final readonly class AnalyticsServiceProvider implements ServiceProviderInterfac
                 static function (ContainerInterface $c): AnalyticsRouteRegistrar {
                     $handler = $c->get(GetAccessStatsByDateHandler::class);
                     $popularHandler = $c->get(GetPopularEntitiesHandler::class);
+                    $beaconHandler = $c->get(BeaconIngestHandler::class);
 
                     if (!$handler instanceof GetAccessStatsByDateHandler) {
                         throw new LogicException('GetAccessStatsByDate handler service is invalid.');
@@ -179,7 +229,11 @@ final readonly class AnalyticsServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('GetPopularEntities handler service is invalid.');
                     }
 
-                    return new AnalyticsRouteRegistrar($handler, $popularHandler);
+                    if (!$beaconHandler instanceof BeaconIngestHandler) {
+                        throw new LogicException('Beacon ingest handler service is invalid.');
+                    }
+
+                    return new AnalyticsRouteRegistrar($handler, $popularHandler, $beaconHandler);
                 },
             );
     }

--- a/src/Analytics/BeaconIngestHandler.php
+++ b/src/Analytics/BeaconIngestHandler.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+use Nene2\Http\ClockInterface;
+use Nene2\Middleware\RateLimitStorageInterface;
+use NeNeRecords\Http\ClientIp;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+/**
+ * Public LP-beacon ingest (Path B / #1007, #1008). Static LP pages (served by the web
+ * server, invisible to the access-log middleware) POST a tiny payload here so their visits
+ * ride the same pipeline as SSR — one hash recipe, one store, unified aggregation. The hub-
+ * owned snippet sends `{path, referrer, query}` via `navigator.sendBeacon`.
+ *
+ * Abuse controls for this unauthenticated endpoint: a per-IP rate limit, a strict path
+ * allowlist (unknown paths are silently dropped), and a bounded body. Visitor fields are
+ * computed only when the org opts in (via {@see VisitorFieldsResolver}); raw IP/UA/referer/
+ * query are never stored. Always answers 204 (fire-and-forget) except 429 when throttled.
+ */
+final readonly class BeaconIngestHandler
+{
+    private const MAX_BODY_BYTES = 2048;
+
+    /**
+     * @param list<string> $allowedPaths exact public LP paths this endpoint will record
+     */
+    public function __construct(
+        private AccessLogRepositoryInterface $accessLogs,
+        private VisitorFieldsResolver $visitor,
+        private ClockInterface $clock,
+        private RateLimitStorageInterface $rateLimit,
+        private ResponseFactoryInterface $responses,
+        private array $allowedPaths = ['/invoice-lp', '/clear-lp', '/deal-lp', '/contact', '/inquiry'],
+        private int $maxPerWindow = 120,
+        private int $windowSeconds = 60,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $ip = ClientIp::resolve($request);
+
+        $hit = $this->rateLimit->hit('beacon:' . $ip, $this->windowSeconds);
+        if ($hit['count'] > $this->maxPerWindow) {
+            return $this->responses->createResponse(429);
+        }
+
+        $payload = $this->decode($request);
+        $path = $this->allowedPath($payload);
+
+        // Unknown/absent path → accept and drop (204). Never records arbitrary paths.
+        if ($path !== null) {
+            $this->record($request, $ip, $path, $payload);
+        }
+
+        return $this->responses->createResponse(204);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function record(ServerRequestInterface $request, string $ip, string $path, array $payload): void
+    {
+        $referrer = is_string($payload['referrer'] ?? null) ? $payload['referrer'] : '';
+        $query = is_string($payload['query'] ?? null) ? $payload['query'] : '';
+
+        $visitor = $this->visitor->resolve($ip, $referrer, $query, $request->getHeaderLine('User-Agent'));
+
+        try {
+            $this->accessLogs->insert(new AccessLogEntry(
+                requestId: null,
+                method: 'BEACON',
+                path: $path,
+                statusCode: 204,
+                durationMs: 0.0,
+                accessedAt: $this->clock->now(),
+                visitorHash: $visitor['visitorHash'],
+                refererHost: $visitor['refererHost'],
+                utmSource: $visitor['utmSource'],
+                utmMedium: $visitor['utmMedium'],
+                utmCampaign: $visitor['utmCampaign'],
+                ref: $visitor['ref'],
+                clientType: $visitor['clientType'],
+                isBot: $visitor['isBot'],
+            ));
+        } catch (Throwable) {
+            // Fire-and-forget: a failed insert must never surface to the beacon caller.
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(ServerRequestInterface $request): array
+    {
+        $raw = (string) $request->getBody();
+        if ($raw === '' || strlen($raw) > self::MAX_BODY_BYTES) {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($raw, true, 8, JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            return [];
+        }
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function allowedPath(array $payload): ?string
+    {
+        $path = $payload['path'] ?? null;
+        if (!is_string($path)) {
+            return null;
+        }
+
+        // Normalise a trailing slash so "/clear-lp/" and "/clear-lp" match one allowlist entry.
+        $normalised = rtrim($path, '/');
+        if ($normalised === '') {
+            $normalised = '/';
+        }
+
+        return in_array($normalised, $this->allowedPaths, true) ? $normalised : null;
+    }
+}

--- a/src/Analytics/GetAccessStatsByDateHandler.php
+++ b/src/Analytics/GetAccessStatsByDateHandler.php
@@ -36,6 +36,30 @@ final readonly class GetAccessStatsByDateHandler
                 ],
                 $output->items,
             ),
+            'visitor' => $this->serializeVisitor($output->visitor),
         ]);
+    }
+
+    /**
+     * @return array{
+     *     unique_visitors: int, bot_rate: ?float,
+     *     top_referrers: list<array{host: string, count: int}>,
+     *     utm: list<array{source: ?string, medium: ?string, campaign: ?string, count: int}>,
+     *     ref: list<array{ref: string, count: int}>
+     * }|null
+     */
+    private function serializeVisitor(?VisitorSummary $visitor): ?array
+    {
+        if ($visitor === null) {
+            return null;
+        }
+
+        return [
+            'unique_visitors' => $visitor->uniqueVisitors,
+            'bot_rate' => $visitor->botRate,
+            'top_referrers' => $visitor->topReferrers,
+            'utm' => $visitor->utm,
+            'ref' => $visitor->ref,
+        ];
     }
 }

--- a/src/Analytics/GetAccessStatsByDateOutput.php
+++ b/src/Analytics/GetAccessStatsByDateOutput.php
@@ -13,6 +13,9 @@ final readonly class GetAccessStatsByDateOutput
         public string $from,
         public string $to,
         public array $items,
+        // Path B (ADR 0006). Null when the org has collected no visitor data
+        // (opt-in OFF or a range predating Path B) — the frontend/consumer degrades gracefully.
+        public ?VisitorSummary $visitor = null,
     ) {
     }
 }

--- a/src/Analytics/GetAccessStatsByDateUseCase.php
+++ b/src/Analytics/GetAccessStatsByDateUseCase.php
@@ -11,14 +11,31 @@ final readonly class GetAccessStatsByDateUseCase implements GetAccessStatsByDate
     ) {
     }
 
+    private const BREAKDOWN_LIMIT = 10;
+
     public function execute(GetAccessStatsByDateInput $input): GetAccessStatsByDateOutput
     {
         $items = $this->accessLogs->aggregateByDate($input->from, $input->to);
+        $summary = $this->accessLogs->aggregateVisitorSummary($input->from, $input->to, self::BREAKDOWN_LIMIT);
+
+        // No visitor data collected (opt-in OFF / pre-Path-B range) → expose null so
+        // consumers degrade rather than render a misleading all-zero panel.
+        $visitor = $this->hasVisitorData($summary) ? $summary : null;
 
         return new GetAccessStatsByDateOutput(
             from: $input->from->format('Y-m-d'),
             to: $input->to->format('Y-m-d'),
             items: $items,
+            visitor: $visitor,
         );
+    }
+
+    private function hasVisitorData(VisitorSummary $summary): bool
+    {
+        return $summary->uniqueVisitors > 0
+            || $summary->botRate !== null
+            || $summary->topReferrers !== []
+            || $summary->utm !== []
+            || $summary->ref !== [];
     }
 }

--- a/src/Analytics/PdoAccessLogRepository.php
+++ b/src/Analytics/PdoAccessLogRepository.php
@@ -125,4 +125,72 @@ final readonly class PdoAccessLogRepository implements AccessLogRepositoryInterf
             $rows,
         );
     }
+
+    public function aggregateVisitorSummary(DateTimeImmutable $from, DateTimeImmutable $to, int $limit): VisitorSummary
+    {
+        $fromDay = $from->format('Y-m-d');
+        $toDay = $to->format('Y-m-d');
+        $org = $this->orgId->get();
+        // $limit is an internal integer (not user input); inlined because MySQL rejects a
+        // bound placeholder in LIMIT under emulated prepares.
+        $cap = max(1, $limit);
+
+        $unique = $this->query->fetchOne(
+            'SELECT COUNT(DISTINCT visitor_hash) AS c FROM access_logs
+             WHERE access_date >= ? AND access_date <= ? AND organization_id = ? AND visitor_hash IS NOT NULL',
+            [$fromDay, $toDay, $org],
+        );
+
+        $bot = $this->query->fetchOne(
+            'SELECT AVG(is_bot) AS r FROM access_logs
+             WHERE access_date >= ? AND access_date <= ? AND organization_id = ? AND is_bot IS NOT NULL',
+            [$fromDay, $toDay, $org],
+        );
+        $botRateRaw = $bot['r'] ?? null;
+        $botRate = $botRateRaw === null ? null : round((float) $botRateRaw, 4);
+
+        $referrers = $this->query->fetchAll(
+            'SELECT referer_host AS host, COUNT(*) AS cnt FROM access_logs
+             WHERE access_date >= ? AND access_date <= ? AND organization_id = ? AND referer_host IS NOT NULL
+             GROUP BY referer_host ORDER BY cnt DESC, referer_host ASC LIMIT ' . $cap,
+            [$fromDay, $toDay, $org],
+        );
+
+        $utm = $this->query->fetchAll(
+            'SELECT utm_source, utm_medium, utm_campaign, COUNT(*) AS cnt FROM access_logs
+             WHERE access_date >= ? AND access_date <= ? AND organization_id = ?
+               AND (utm_source IS NOT NULL OR utm_medium IS NOT NULL OR utm_campaign IS NOT NULL)
+             GROUP BY utm_source, utm_medium, utm_campaign ORDER BY cnt DESC LIMIT ' . $cap,
+            [$fromDay, $toDay, $org],
+        );
+
+        $refs = $this->query->fetchAll(
+            'SELECT ref, COUNT(*) AS cnt FROM access_logs
+             WHERE access_date >= ? AND access_date <= ? AND organization_id = ? AND ref IS NOT NULL
+             GROUP BY ref ORDER BY cnt DESC, ref ASC LIMIT ' . $cap,
+            [$fromDay, $toDay, $org],
+        );
+
+        return new VisitorSummary(
+            uniqueVisitors: (int) ($unique['c'] ?? 0),
+            botRate: $botRate,
+            topReferrers: array_map(
+                static fn (array $r): array => ['host' => (string) $r['host'], 'count' => (int) $r['cnt']],
+                $referrers,
+            ),
+            utm: array_map(
+                static fn (array $r): array => [
+                    'source' => $r['utm_source'] === null ? null : (string) $r['utm_source'],
+                    'medium' => $r['utm_medium'] === null ? null : (string) $r['utm_medium'],
+                    'campaign' => $r['utm_campaign'] === null ? null : (string) $r['utm_campaign'],
+                    'count' => (int) $r['cnt'],
+                ],
+                $utm,
+            ),
+            ref: array_map(
+                static fn (array $r): array => ['ref' => (string) $r['ref'], 'count' => (int) $r['cnt']],
+                $refs,
+            ),
+        );
+    }
 }

--- a/src/Analytics/VisitorFieldsResolver.php
+++ b/src/Analytics/VisitorFieldsResolver.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+use Nene2\Http\ClockInterface;
+use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Setting\SettingRepositoryInterface;
+use Throwable;
+
+/**
+ * Single source of truth for the Path B privacy-first visitor fields (ADR 0006).
+ *
+ * Both the access-log middleware (fields from request headers/URI) and the LP beacon
+ * endpoint (fields from the posted payload) resolve visitor data through here, so the
+ * opt-in gate, hash recipe, and allowlists never drift between the two producers.
+ *
+ * When the owning org has not opted in (`analytics_visitor_tracking`), every field is null
+ * — the raw IP/UA/referer/query are never touched, let alone stored.
+ */
+final readonly class VisitorFieldsResolver
+{
+    /**
+     * @param RequestScopedHolder<int> $orgId
+     */
+    public function __construct(
+        private SettingRepositoryInterface $settings,
+        private AnalyticsSaltRepositoryInterface $salts,
+        private ClockInterface $clock,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    public function trackingEnabled(): bool
+    {
+        try {
+            $value = $this->settings->findValueByKey('analytics_visitor_tracking');
+        } catch (Throwable) {
+            return false;
+        }
+
+        return $value !== null && ($value->value === 'true' || $value->value === '1');
+    }
+
+    /**
+     * @return array{
+     *     visitorHash: ?string, refererHost: ?string, utmSource: ?string, utmMedium: ?string,
+     *     utmCampaign: ?string, ref: ?string, clientType: ?string, isBot: ?bool
+     * }
+     */
+    public function resolve(string $clientIp, string $referer, string $query, string $userAgent): array
+    {
+        if (!$this->trackingEnabled()) {
+            return self::empty();
+        }
+
+        $salt = $this->salts->saltForDate($this->clock->now());
+        $attribution = QueryAttribution::fromQueryString($query);
+        $ua = UserAgentClassifier::classify($userAgent);
+
+        return [
+            'visitorHash' => VisitorHasher::hash($salt, $clientIp, (int) $this->orgId->get()),
+            'refererHost' => RefererHost::fromReferer($referer),
+            'utmSource' => $attribution['utmSource'],
+            'utmMedium' => $attribution['utmMedium'],
+            'utmCampaign' => $attribution['utmCampaign'],
+            'ref' => $attribution['ref'],
+            'clientType' => $ua['type'],
+            'isBot' => $ua['isBot'],
+        ];
+    }
+
+    /**
+     * @return array{
+     *     visitorHash: null, refererHost: null, utmSource: null, utmMedium: null,
+     *     utmCampaign: null, ref: null, clientType: null, isBot: null
+     * }
+     */
+    public static function empty(): array
+    {
+        return [
+            'visitorHash' => null, 'refererHost' => null, 'utmSource' => null,
+            'utmMedium' => null, 'utmCampaign' => null, 'ref' => null,
+            'clientType' => null, 'isBot' => null,
+        ];
+    }
+}

--- a/src/Analytics/VisitorSummary.php
+++ b/src/Analytics/VisitorSummary.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Analytics;
+
+/**
+ * Range-level visitor aggregates derived from the Path B fields (ADR 0006 / #1007).
+ *
+ * All figures come from privacy-preserving derived columns only — never raw IP/UA/referer/
+ * query. `uniqueVisitors` counts distinct daily-salted hashes; because the salt rotates
+ * daily this is a per-day-union count, not a stable cross-day identity. Returned by the
+ * stats API and the export CLI; null at the call site when the org has collected no visitor
+ * data (opt-in OFF or pre-Path-B range).
+ */
+final readonly class VisitorSummary
+{
+    /**
+     * @param list<array{host: string, count: int}>                                    $topReferrers
+     * @param list<array{source: ?string, medium: ?string, campaign: ?string, count: int}> $utm
+     * @param list<array{ref: string, count: int}>                                     $ref
+     */
+    public function __construct(
+        public int $uniqueVisitors,
+        public ?float $botRate,
+        public array $topReferrers,
+        public array $utm,
+        public array $ref,
+    ) {
+    }
+}

--- a/tests/Analytics/AccessLogMiddlewareTest.php
+++ b/tests/Analytics/AccessLogMiddlewareTest.php
@@ -10,6 +10,7 @@ use Nene2\Http\UtcClock;
 use NeNeRecords\Analytics\AccessLogMiddleware;
 use NeNeRecords\Analytics\AccessLogRepositoryInterface;
 use NeNeRecords\Analytics\AnalyticsSaltRepositoryInterface;
+use NeNeRecords\Analytics\VisitorFieldsResolver;
 use NeNeRecords\Analytics\VisitorHasher;
 use NeNeRecords\Setting\SettingRepositoryInterface;
 use NeNeRecords\Setting\SettingValue;
@@ -178,9 +179,7 @@ final class AccessLogMiddlewareTest extends TestCase
             $repository ?? $this->repository,
             new NullLogger(),
             new UtcClock(),
-            $settings,
-            $salts,
-            $orgId,
+            new VisitorFieldsResolver($settings, $salts, new UtcClock(), $orgId),
         );
     }
 

--- a/tests/Analytics/AccessLogMiddlewareTest.php
+++ b/tests/Analytics/AccessLogMiddlewareTest.php
@@ -141,6 +141,11 @@ final class AccessLogMiddlewareTest extends TestCase
             {
                 return [];
             }
+
+            public function aggregateVisitorSummary(DateTimeImmutable $from, DateTimeImmutable $to, int $limit): \NeNeRecords\Analytics\VisitorSummary
+            {
+                return new \NeNeRecords\Analytics\VisitorSummary(0, null, [], [], []);
+            }
         };
 
         $response = $this->makeMiddleware(repository: $throwing)->process(

--- a/tests/Analytics/AnalyticsHttpTest.php
+++ b/tests/Analytics/AnalyticsHttpTest.php
@@ -7,16 +7,22 @@ namespace NeNeRecords\Tests\Analytics;
 use DateTimeImmutable;
 use DateTimeZone;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Http\UtcClock;
+use Nene2\Middleware\RateLimitStorageInterface;
 use NeNeRecords\Analytics\AccessLogEntry;
 use NeNeRecords\Analytics\AnalyticsRouteRegistrar;
+use NeNeRecords\Analytics\AnalyticsSaltRepositoryInterface;
+use NeNeRecords\Analytics\BeaconIngestHandler;
 use NeNeRecords\Analytics\GetAccessStatsByDateHandler;
 use NeNeRecords\Analytics\GetAccessStatsByDateUseCase;
 use NeNeRecords\Analytics\GetPopularEntitiesHandler;
 use NeNeRecords\Analytics\GetPopularEntitiesUseCase;
+use NeNeRecords\Analytics\VisitorFieldsResolver;
 use NeNeRecords\Entity\Entity;
 use NeNeRecords\Entity\EntityStatus;
+use NeNeRecords\Setting\SettingRepositoryInterface;
 use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
 use NeNeRecords\Tests\TextField\InMemoryTextFieldRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -72,6 +78,24 @@ final class AnalyticsHttpTest extends TestCase
                     new UtcClock(),
                 ),
                 $jsonResponse,
+            ),
+            new BeaconIngestHandler(
+                $this->repository,
+                new VisitorFieldsResolver(
+                    $this->createStub(SettingRepositoryInterface::class),
+                    $this->createStub(AnalyticsSaltRepositoryInterface::class),
+                    new UtcClock(),
+                    (static function (): RequestScopedHolder {
+                        /** @var RequestScopedHolder<int> $holder */
+                        $holder = new RequestScopedHolder();
+                        $holder->set(0);
+
+                        return $holder;
+                    })(),
+                ),
+                new UtcClock(),
+                $this->createStub(RateLimitStorageInterface::class),
+                $this->factory,
             ),
         );
 

--- a/tests/Analytics/AnalyticsHttpTest.php
+++ b/tests/Analytics/AnalyticsHttpTest.php
@@ -99,6 +99,8 @@ final class AnalyticsHttpTest extends TestCase
         self::assertSame('2026-05-01', $payload['items'][0]['date']);
         self::assertSame(1, $payload['items'][0]['request_count']);
         self::assertSame(10.0, $payload['items'][0]['avg_duration_ms']);
+        self::assertArrayHasKey('visitor', $payload);
+        self::assertNull($payload['visitor']); // no opt-in visitor data seeded → null
     }
 
     public function testGetPopularEntitiesReturnsPublishedRankedByViews(): void

--- a/tests/Analytics/BeaconIngestHandlerTest.php
+++ b/tests/Analytics/BeaconIngestHandlerTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Analytics;
+
+use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\UtcClock;
+use Nene2\Middleware\RateLimitStorageInterface;
+use NeNeRecords\Analytics\AnalyticsSaltRepositoryInterface;
+use NeNeRecords\Analytics\BeaconIngestHandler;
+use NeNeRecords\Analytics\VisitorFieldsResolver;
+use NeNeRecords\Setting\SettingRepositoryInterface;
+use NeNeRecords\Setting\SettingValue;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class BeaconIngestHandlerTest extends TestCase
+{
+    private const SALT = "\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01";
+
+    private Psr17Factory $factory;
+    private InMemoryAccessLogRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->repository = new InMemoryAccessLogRepository();
+    }
+
+    public function testAllowedPathRecordsBeaconRowAndReturns204(): void
+    {
+        $response = $this->handle('{"path":"/clear-lp","referrer":"https://google.com/x","query":"?ref=lp1"}');
+
+        self::assertSame(204, $response->getStatusCode());
+        self::assertCount(1, $this->repository->all());
+
+        $entry = $this->repository->all()[0];
+        self::assertSame('BEACON', $entry->method);
+        self::assertSame('/clear-lp', $entry->path);
+        self::assertSame(204, $entry->statusCode);
+        // Opt-in OFF (default): visitor fields stay null.
+        self::assertNull($entry->visitorHash);
+        self::assertNull($entry->ref);
+    }
+
+    public function testOptInOnPopulatesVisitorFields(): void
+    {
+        $response = $this->handle(
+            '{"path":"/clear-lp","referrer":"https://www.google.com/x","query":"?utm_source=news&ref=lp1&secret=leak"}',
+            optInValue: 'true',
+        );
+
+        self::assertSame(204, $response->getStatusCode());
+        $entry = $this->repository->all()[0];
+        self::assertNotNull($entry->visitorHash);
+        self::assertSame(64, strlen((string) $entry->visitorHash));
+        self::assertSame('www.google.com', $entry->refererHost);
+        self::assertSame('news', $entry->utmSource);
+        self::assertSame('lp1', $entry->ref);
+    }
+
+    public function testTrailingSlashIsNormalised(): void
+    {
+        $this->handle('{"path":"/clear-lp/"}');
+
+        self::assertCount(1, $this->repository->all());
+        self::assertSame('/clear-lp', $this->repository->all()[0]->path);
+    }
+
+    public function testUnknownPathIsDroppedButStillReturns204(): void
+    {
+        $response = $this->handle('{"path":"/admin/secret"}');
+
+        self::assertSame(204, $response->getStatusCode());
+        self::assertSame([], $this->repository->all());
+    }
+
+    public function testMalformedBodyIsDropped(): void
+    {
+        $response = $this->handle('not-json');
+
+        self::assertSame(204, $response->getStatusCode());
+        self::assertSame([], $this->repository->all());
+    }
+
+    public function testRateLimitExceededReturns429AndRecordsNothing(): void
+    {
+        $response = $this->handle('{"path":"/clear-lp"}', hitCount: 999);
+
+        self::assertSame(429, $response->getStatusCode());
+        self::assertSame([], $this->repository->all());
+    }
+
+    private function handle(string $body, ?string $optInValue = null, int $hitCount = 1): \Psr\Http\Message\ResponseInterface
+    {
+        $settings = $this->createStub(SettingRepositoryInterface::class);
+        $settings->method('findValueByKey')->willReturn(
+            $optInValue === null
+                ? null
+                : new SettingValue('analytics_visitor_tracking', $optInValue, false, null, null, null, '2026-01-01 00:00:00', '2026-01-01 00:00:00'),
+        );
+
+        $salts = $this->createStub(AnalyticsSaltRepositoryInterface::class);
+        $salts->method('saltForDate')->willReturn(self::SALT);
+
+        /** @var RequestScopedHolder<int> $orgId */
+        $orgId = new RequestScopedHolder();
+        $orgId->set(1);
+
+        $rateLimit = $this->createStub(RateLimitStorageInterface::class);
+        $rateLimit->method('hit')->willReturn(['count' => $hitCount, 'reset_at' => 0]);
+
+        $handler = new BeaconIngestHandler(
+            $this->repository,
+            new VisitorFieldsResolver($settings, $salts, new UtcClock(), $orgId),
+            new UtcClock(),
+            $rateLimit,
+            $this->factory,
+        );
+
+        $request = $this->factory->createServerRequest('POST', 'https://ayane.co.jp/api/v1/public/beacon')
+            ->withBody($this->factory->createStream($body));
+
+        return $handler->handle($request);
+    }
+}

--- a/tests/Analytics/InMemoryAccessLogRepository.php
+++ b/tests/Analytics/InMemoryAccessLogRepository.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use NeNeRecords\Analytics\AccessLogEntry;
 use NeNeRecords\Analytics\AccessLogRepositoryInterface;
 use NeNeRecords\Analytics\AccessStatsDayItem;
+use NeNeRecords\Analytics\VisitorSummary;
 
 final class InMemoryAccessLogRepository implements AccessLogRepositoryInterface
 {
@@ -106,5 +107,64 @@ final class InMemoryAccessLogRepository implements AccessLogRepositoryInterface
         }
 
         return $items;
+    }
+
+    public function aggregateVisitorSummary(DateTimeImmutable $from, DateTimeImmutable $to, int $limit): VisitorSummary
+    {
+        $fromDay = $from->format('Y-m-d');
+        $toDay = $to->format('Y-m-d');
+
+        $hashes = [];
+        $botFlags = [];
+        $referrers = [];
+        $utm = [];
+        $refs = [];
+
+        foreach ($this->entries as $entry) {
+            $day = $entry->accessedAt->format('Y-m-d');
+            if ($day < $fromDay || $day > $toDay) {
+                continue;
+            }
+
+            if ($entry->visitorHash !== null) {
+                $hashes[$entry->visitorHash] = true;
+            }
+            if ($entry->isBot !== null) {
+                $botFlags[] = $entry->isBot ? 1 : 0;
+            }
+            if ($entry->refererHost !== null) {
+                $referrers[$entry->refererHost] = ($referrers[$entry->refererHost] ?? 0) + 1;
+            }
+            if ($entry->utmSource !== null || $entry->utmMedium !== null || $entry->utmCampaign !== null) {
+                $key = ($entry->utmSource ?? '') . "\0" . ($entry->utmMedium ?? '') . "\0" . ($entry->utmCampaign ?? '');
+                $utm[$key] ??= ['source' => $entry->utmSource, 'medium' => $entry->utmMedium, 'campaign' => $entry->utmCampaign, 'count' => 0];
+                ++$utm[$key]['count'];
+            }
+            if ($entry->ref !== null) {
+                $refs[$entry->ref] = ($refs[$entry->ref] ?? 0) + 1;
+            }
+        }
+
+        arsort($referrers);
+        arsort($refs);
+        usort($utm, static fn (array $a, array $b): int => $b['count'] <=> $a['count']);
+
+        $topReferrers = [];
+        foreach (array_slice($referrers, 0, $limit, true) as $host => $count) {
+            $topReferrers[] = ['host' => (string) $host, 'count' => $count];
+        }
+
+        $refItems = [];
+        foreach (array_slice($refs, 0, $limit, true) as $ref => $count) {
+            $refItems[] = ['ref' => (string) $ref, 'count' => $count];
+        }
+
+        return new VisitorSummary(
+            uniqueVisitors: count($hashes),
+            botRate: $botFlags === [] ? null : round(array_sum($botFlags) / count($botFlags), 4),
+            topReferrers: $topReferrers,
+            utm: array_slice($utm, 0, $limit),
+            ref: $refItems,
+        );
     }
 }

--- a/tests/Analytics/PdoAccessLogRepositoryTest.php
+++ b/tests/Analytics/PdoAccessLogRepositoryTest.php
@@ -110,4 +110,76 @@ final class PdoAccessLogRepositoryTest extends TestCase
         self::assertSame(1, $items[1]->requestCount);
         self::assertSame(30.0, $items[1]->avgDurationMs);
     }
+
+    public function testAggregateVisitorSummary(): void
+    {
+        $utc = new DateTimeZone('UTC');
+        $at = static fn (string $iso): DateTimeImmutable => new DateTimeImmutable($iso, $utc);
+
+        // Two distinct visitors (hashes h1, h2); h1 visits twice. One bot, three humans.
+        $this->repository->insert($this->visitorEntry($at('2026-05-01T10:00:00+00:00'), 'h1', 'google.com', 'news', 'email', 'lawfirm1', false));
+        $this->repository->insert($this->visitorEntry($at('2026-05-01T11:00:00+00:00'), 'h1', 'google.com', 'news', 'email', 'lawfirm1', false));
+        $this->repository->insert($this->visitorEntry($at('2026-05-02T09:00:00+00:00'), 'h2', 't.co', null, null, 'lawfirm2', false));
+        $this->repository->insert($this->visitorEntry($at('2026-05-02T09:30:00+00:00'), 'h3', null, null, null, null, true));
+
+        $summary = $this->repository->aggregateVisitorSummary($at('2026-05-01'), $at('2026-05-02'), 10);
+
+        self::assertSame(3, $summary->uniqueVisitors);
+        self::assertSame(0.25, $summary->botRate);
+        self::assertSame([['host' => 'google.com', 'count' => 2], ['host' => 't.co', 'count' => 1]], $summary->topReferrers);
+        self::assertSame([['source' => 'news', 'medium' => 'email', 'campaign' => null, 'count' => 2]], $summary->utm);
+        self::assertSame([['ref' => 'lawfirm1', 'count' => 2], ['ref' => 'lawfirm2', 'count' => 1]], $summary->ref);
+    }
+
+    public function testAggregateVisitorSummaryIsEmptyWhenNoVisitorData(): void
+    {
+        $utc = new DateTimeZone('UTC');
+        $this->repository->insert(new AccessLogEntry(
+            requestId: 'req-1',
+            method: 'GET',
+            path: '/api/v1/tags',
+            statusCode: 200,
+            durationMs: 10.0,
+            accessedAt: new DateTimeImmutable('2026-05-01T10:00:00+00:00', $utc),
+        ));
+
+        $summary = $this->repository->aggregateVisitorSummary(
+            new DateTimeImmutable('2026-05-01', $utc),
+            new DateTimeImmutable('2026-05-02', $utc),
+            10,
+        );
+
+        self::assertSame(0, $summary->uniqueVisitors);
+        self::assertNull($summary->botRate);
+        self::assertSame([], $summary->topReferrers);
+        self::assertSame([], $summary->utm);
+        self::assertSame([], $summary->ref);
+    }
+
+    private function visitorEntry(
+        DateTimeImmutable $at,
+        string $hash,
+        ?string $refererHost,
+        ?string $utmSource,
+        ?string $utmMedium,
+        ?string $ref,
+        bool $isBot,
+    ): AccessLogEntry {
+        return new AccessLogEntry(
+            requestId: null,
+            method: 'GET',
+            path: '/services',
+            statusCode: 200,
+            durationMs: 5.0,
+            accessedAt: $at,
+            visitorHash: $hash,
+            refererHost: $refererHost,
+            utmSource: $utmSource,
+            utmMedium: $utmMedium,
+            utmCampaign: null,
+            ref: $ref,
+            clientType: $isBot ? 'bot' : 'desktop',
+            isBot: $isBot,
+        );
+    }
 }


### PR DESCRIPTION
## 目的
Path B 段階PRの **4本目その1（ingest endpoint）**。静的LP（Apache 配信で access_logs 非対象）の訪問を SSR と同じパイプラインに載せる公開ビーコン。base=main（①②③マージ済）。分割: 本PR=endpoint / 次PR5=export CLI＋prune（レビュー容易化のため公開エンドポイントを分離）。

## 変更
- **BeaconIngestHandler** — `POST /api/v1/public/beacon`。LP path 許可リスト照合（未知は 204 で drop・任意path記録しない）＋ IP レート制限（超過 429）＋ body 上限。opt-in ON 時のみ visitor 派生を算出し `method='BEACON'` で1行 insert。fire-and-forget（常に 204）。
- **VisitorFieldsResolver** — opt-in / hash / referer host / utm・ref 許可リスト / UA 分類 の **単一の正**（ADR 0006）。middleware と beacon が共有し privacy ロジックが二重化しない。`AccessLogMiddleware` をこれに委譲へリファクタ（`/api/v1/public/beacon` を除外＝ビーコン POST 自体は二重計上しない）。
- ルート登録（`/api/v1/public/*` は AdminApiAuth で **always-open=無認証**）＋ **OpenAPI**（`postVisitBeacon` / `VisitBeaconRequest`）＋ frontend 型再生成。

## セキュリティ（新しい公開・無認証エンドポイント）
- **path 許可リスト**（LP のみ・未知は記録せず 204）／**per-IP レート制限**（超過 429・comment と同じ `RateLimitStorageInterface`）／**body 2KB 上限**／**不正 JSON は drop**。
- opt-in OFF の org はビーコンでも visitor 派生を作らない（base BEACON 行のみ）。**生 IP/UA/referer/query は非保存**。

## 検証
- **Analytics 46 tests green**（beacon 6ケース: 許可path記録 / opt-in ON populate / 末尾スラッシュ正規化 / 未知 drop / 不正 body drop / 429）。
- **PHPStan L8 / OpenAPI valid / MCP valid / frontend type-check clean / CS クリーン**。全体スイートの残failは main と同一の pre-existing（ZipArchive・system_config E2E）。

## 次
PR5: export CLI（`tools/export-access-summary.php` → `~/site-logs/ayane/summary-<date>.json`）＋ 保持prune。endpoint live 後に hub が実POSTでスキーマ最終確認 → LP snippet 投入。本番反映は施主最終GO。

Refs #1007, #1008