### PR TITLE
feat(analytics): Path B export CLI ＋ 保持prune（#1007）

### DIFF
--- a/src/Analytics/AccessLogRepositoryInterface.php
+++ b/src/Analytics/AccessLogRepositoryInterface.php
@@ -32,4 +32,19 @@ interface AccessLogRepositoryInterface
      * `$limit`, highest first. Derived from Path B columns only (no raw PII).
      */
     public function aggregateVisitorSummary(DateTimeImmutable $from, DateTimeImmutable $to, int $limit): VisitorSummary;
+
+    /**
+     * Request counts grouped by HTTP status class ("2xx".."5xx") over the range.
+     *
+     * @return array<string, int>
+     */
+    public function statusDistribution(DateTimeImmutable $from, DateTimeImmutable $to): array;
+
+    /**
+     * Most-visited public page paths over the range (GET + LP BEACON hits, status < 400),
+     * excluding API, media, robots and sitemap. Highest first, capped at `$limit`.
+     *
+     * @return list<array{path: string, count: int}>
+     */
+    public function popularPages(DateTimeImmutable $from, DateTimeImmutable $to, int $limit): array;
 }

--- a/src/Analytics/PdoAccessLogRepository.php
+++ b/src/Analytics/PdoAccessLogRepository.php
@@ -193,4 +193,40 @@ final readonly class PdoAccessLogRepository implements AccessLogRepositoryInterf
             ),
         );
     }
+
+    public function statusDistribution(DateTimeImmutable $from, DateTimeImmutable $to): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT FLOOR(status_code / 100) AS cls, COUNT(*) AS cnt FROM access_logs
+             WHERE access_date >= ? AND access_date <= ? AND organization_id = ?
+             GROUP BY cls ORDER BY cls ASC',
+            [$from->format('Y-m-d'), $to->format('Y-m-d'), $this->orgId->get()],
+        );
+
+        $out = [];
+        foreach ($rows as $row) {
+            $out[((int) $row['cls']) . 'xx'] = (int) $row['cnt'];
+        }
+
+        return $out;
+    }
+
+    public function popularPages(DateTimeImmutable $from, DateTimeImmutable $to, int $limit): array
+    {
+        $cap = max(1, $limit);
+        $rows = $this->query->fetchAll(
+            "SELECT path, COUNT(*) AS cnt FROM access_logs
+             WHERE access_date >= ? AND access_date <= ? AND organization_id = ?
+               AND method IN ('GET', 'BEACON') AND status_code < 400
+               AND path NOT LIKE '/api/%' AND path NOT LIKE '/media/%'
+               AND path NOT IN ('/robots.txt', '/sitemap.xml')
+             GROUP BY path ORDER BY cnt DESC, path ASC LIMIT " . $cap,
+            [$from->format('Y-m-d'), $to->format('Y-m-d'), $this->orgId->get()],
+        );
+
+        return array_map(
+            static fn (array $r): array => ['path' => (string) $r['path'], 'count' => (int) $r['cnt']],
+            $rows,
+        );
+    }
 }

--- a/tests/Analytics/AccessLogMiddlewareTest.php
+++ b/tests/Analytics/AccessLogMiddlewareTest.php
@@ -147,6 +147,16 @@ final class AccessLogMiddlewareTest extends TestCase
             {
                 return new \NeNeRecords\Analytics\VisitorSummary(0, null, [], [], []);
             }
+
+            public function statusDistribution(DateTimeImmutable $from, DateTimeImmutable $to): array
+            {
+                return [];
+            }
+
+            public function popularPages(DateTimeImmutable $from, DateTimeImmutable $to, int $limit): array
+            {
+                return [];
+            }
         };
 
         $response = $this->makeMiddleware(repository: $throwing)->process(

--- a/tests/Analytics/InMemoryAccessLogRepository.php
+++ b/tests/Analytics/InMemoryAccessLogRepository.php
@@ -167,4 +167,58 @@ final class InMemoryAccessLogRepository implements AccessLogRepositoryInterface
             ref: $refItems,
         );
     }
+
+    public function statusDistribution(DateTimeImmutable $from, DateTimeImmutable $to): array
+    {
+        $fromDay = $from->format('Y-m-d');
+        $toDay = $to->format('Y-m-d');
+        $out = [];
+
+        foreach ($this->entries as $entry) {
+            $day = $entry->accessedAt->format('Y-m-d');
+            if ($day < $fromDay || $day > $toDay) {
+                continue;
+            }
+            $key = intdiv($entry->statusCode, 100) . 'xx';
+            $out[$key] = ($out[$key] ?? 0) + 1;
+        }
+
+        ksort($out);
+
+        return $out;
+    }
+
+    public function popularPages(DateTimeImmutable $from, DateTimeImmutable $to, int $limit): array
+    {
+        $fromDay = $from->format('Y-m-d');
+        $toDay = $to->format('Y-m-d');
+        $counts = [];
+
+        foreach ($this->entries as $entry) {
+            $day = $entry->accessedAt->format('Y-m-d');
+            if ($day < $fromDay || $day > $toDay) {
+                continue;
+            }
+            if (!in_array($entry->method, ['GET', 'BEACON'], true) || $entry->statusCode >= 400) {
+                continue;
+            }
+            if (
+                str_starts_with($entry->path, '/api/')
+                || str_starts_with($entry->path, '/media/')
+                || in_array($entry->path, ['/robots.txt', '/sitemap.xml'], true)
+            ) {
+                continue;
+            }
+            $counts[$entry->path] = ($counts[$entry->path] ?? 0) + 1;
+        }
+
+        arsort($counts);
+
+        $out = [];
+        foreach (array_slice($counts, 0, $limit, true) as $path => $count) {
+            $out[] = ['path' => (string) $path, 'count' => $count];
+        }
+
+        return $out;
+    }
 }

--- a/tests/Analytics/PdoAccessLogRepositoryTest.php
+++ b/tests/Analytics/PdoAccessLogRepositoryTest.php
@@ -182,4 +182,63 @@ final class PdoAccessLogRepositoryTest extends TestCase
             isBot: $isBot,
         );
     }
+
+    public function testStatusDistribution(): void
+    {
+        $utc = new DateTimeZone('UTC');
+        $at = new DateTimeImmutable('2026-05-01T10:00:00+00:00', $utc);
+
+        foreach ([200, 200, 301, 404, 500] as $i => $status) {
+            $this->repository->insert(new AccessLogEntry(
+                requestId: null,
+                method: 'GET',
+                path: '/p' . $i,
+                statusCode: $status,
+                durationMs: 1.0,
+                accessedAt: $at,
+            ));
+        }
+
+        $dist = $this->repository->statusDistribution(
+            new DateTimeImmutable('2026-05-01', $utc),
+            new DateTimeImmutable('2026-05-01', $utc),
+        );
+
+        self::assertSame(['2xx' => 2, '3xx' => 1, '4xx' => 1, '5xx' => 1], $dist);
+    }
+
+    public function testPopularPagesCountsPublicPagesAndBeaconButExcludesApiMediaAndErrors(): void
+    {
+        $utc = new DateTimeZone('UTC');
+        $at = new DateTimeImmutable('2026-05-01T10:00:00+00:00', $utc);
+        $add = function (string $method, string $path, int $status) use ($at): void {
+            $this->repository->insert(new AccessLogEntry(
+                requestId: null,
+                method: $method,
+                path: $path,
+                statusCode: $status,
+                durationMs: 1.0,
+                accessedAt: $at,
+            ));
+        };
+
+        $add('GET', '/services', 200);
+        $add('GET', '/services', 200);
+        $add('BEACON', '/clear-lp', 204);      // LP beacon counts as a page view
+        $add('GET', '/api/v1/entities/1', 200); // excluded (api)
+        $add('GET', '/media/lg/x.jpg', 200);    // excluded (media)
+        $add('GET', '/robots.txt', 200);        // excluded
+        $add('GET', '/services', 404);          // excluded (error)
+
+        $pages = $this->repository->popularPages(
+            new DateTimeImmutable('2026-05-01', $utc),
+            new DateTimeImmutable('2026-05-01', $utc),
+            10,
+        );
+
+        self::assertSame([
+            ['path' => '/services', 'count' => 2],
+            ['path' => '/clear-lp', 'count' => 1],
+        ], $pages);
+    }
 }

--- a/tools/export-access-summary.php
+++ b/tools/export-access-summary.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * CLI daily analytics summary export (Path B / #1007, #1008).
+ *
+ * Writes one org's per-day access summary as JSON so an external daily report (e.g. the
+ * hideyuki-mori.com mail on the same HETEML host) can fold in an "## <site>" section without
+ * touching the DB. Output is aggregate-only — request counts, status distribution, popular
+ * pages (SSR + LP BEACON), popular entities, and the privacy-first visitor summary. No raw
+ * IP/UA/referer/query is ever read or written (ADR 0006).
+ *
+ * HETEML cron cannot run a bare .php; call this from a `#!/bin/sh` wrapper as
+ *   /usr/local/bin/php8.4 tools/export-access-summary.php --org=<id|slug> --date=YYYY-MM-DD
+ *
+ * Usage:
+ *   php tools/export-access-summary.php --org=ayane [--date=2026-07-24] [--out=/path/summary.json]
+ *
+ * Options:
+ *   --org=REF    (required) organization: numeric id or slug
+ *   --date=DATE  target day (YYYY-MM-DD); defaults to yesterday (server TZ)
+ *   --out=PATH   output file; defaults to ~/site-logs/<slug>/summary-<date>.json
+ */
+
+use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Analytics\AccessLogRepositoryInterface;
+use NeNeRecords\Analytics\VisitorSummary;
+use NeNeRecords\Http\RuntimeContainerFactory;
+use NeNeRecords\Organization\OrganizationRepositoryInterface;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+/** @param non-empty-string $name */
+function summaryOption(string $name): ?string
+{
+    foreach ($GLOBALS['argv'] as $arg) {
+        if (is_string($arg) && str_starts_with($arg, "--{$name}=")) {
+            return substr($arg, strlen($name) + 3);
+        }
+    }
+
+    return null;
+}
+
+$orgRef = summaryOption('org');
+if ($orgRef === null || $orgRef === '') {
+    fwrite(STDERR, "ERROR: --org=<id|slug> is required.\n");
+    exit(1);
+}
+
+$date = summaryOption('date');
+if ($date === null || $date === '') {
+    $date = date('Y-m-d', time() - 86400);
+}
+if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) !== 1) {
+    fwrite(STDERR, "ERROR: --date must be YYYY-MM-DD.\n");
+    exit(1);
+}
+
+$projectRoot = dirname(__DIR__);
+$container = (new RuntimeContainerFactory($projectRoot))->create();
+
+$organizations = $container->get(OrganizationRepositoryInterface::class);
+$repository = $container->get(AccessLogRepositoryInterface::class);
+$holder = $container->get('nene-records.org_id_holder');
+
+if (
+    !$organizations instanceof OrganizationRepositoryInterface
+    || !$repository instanceof AccessLogRepositoryInterface
+    || !$holder instanceof RequestScopedHolder
+) {
+    fwrite(STDERR, "ERROR: the application container is misconfigured.\n");
+    exit(1);
+}
+
+$organization = ctype_digit($orgRef)
+    ? $organizations->findById((int) $orgRef)
+    : $organizations->findBySlug($orgRef);
+
+if ($organization === null || $organization->id === null) {
+    fwrite(STDERR, "ERROR: no organization found for '{$orgRef}'.\n");
+    exit(1);
+}
+
+$orgId = (int) $organization->id;
+$holder->set($orgId);
+
+$day = new DateTimeImmutable($date);
+
+$byDate = $repository->aggregateByDate($day, $day);
+$totals = $byDate[0] ?? null;
+
+$entityViews = $repository->aggregateEntityViews($date);
+$popularEntities = [];
+foreach (array_slice($entityViews, 0, 10, true) as $entityId => $count) {
+    $popularEntities[] = ['entity_id' => $entityId, 'count' => $count];
+}
+
+$summary = $repository->aggregateVisitorSummary($day, $day, 10);
+
+$out = [
+    'schema_version' => 1,
+    'site' => $organization->customDomain ?? $organization->slug,
+    'org_id' => $orgId,
+    'date' => $date,
+    'generated_at' => date('c'),
+    'totals' => [
+        'request_count' => $totals !== null ? $totals->requestCount : 0,
+        'avg_duration_ms' => $totals !== null ? $totals->avgDurationMs : 0.0,
+        'status' => $repository->statusDistribution($day, $day),
+    ],
+    'popular_pages' => $repository->popularPages($day, $day, 10),
+    'popular_entities' => $popularEntities,
+    'visitor' => summaryHasData($summary) ? [
+        'unique_visitors' => $summary->uniqueVisitors,
+        'bot_rate' => $summary->botRate,
+        'top_referrers' => $summary->topReferrers,
+        'utm' => $summary->utm,
+        'ref' => $summary->ref,
+    ] : null,
+    'notes' => [
+        'excludes' => ['/api/*', '/media/*', '/robots.txt', '/sitemap.xml'],
+        'visitor_null_reason' => 'opt-in OFF or no Path B data for this range',
+    ],
+];
+
+$outPath = summaryOption('out');
+if ($outPath === null || $outPath === '') {
+    $home = getenv('HOME') ?: $projectRoot;
+    $outPath = $home . '/site-logs/' . $organization->slug . '/summary-' . $date . '.json';
+}
+
+$dir = dirname($outPath);
+if (!is_dir($dir) && !mkdir($dir, 0775, true) && !is_dir($dir)) {
+    fwrite(STDERR, "ERROR: could not create output directory '{$dir}'.\n");
+    exit(1);
+}
+
+$json = json_encode($out, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+if ($json === false || file_put_contents($outPath, $json . "\n") === false) {
+    fwrite(STDERR, "ERROR: could not write '{$outPath}'.\n");
+    exit(1);
+}
+
+fwrite(STDOUT, "Wrote {$outPath}\n");
+
+function summaryHasData(VisitorSummary $summary): bool
+{
+    return $summary->uniqueVisitors > 0
+        || $summary->botRate !== null
+        || $summary->topReferrers !== []
+        || $summary->utm !== []
+        || $summary->ref !== [];
+}

--- a/tools/prune-analytics.php
+++ b/tools/prune-analytics.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * CLI analytics retention prune (Path B / ADR 0006 D6).
+ *
+ * Enforces the visitor-data retention window: drops daily salts older than the cutoff (after
+ * which past visitor_hashes are permanently unlinkable) and NULLs the visitor-derived columns
+ * on old access_logs rows. The anonymous base rows (method/path/status/duration) are kept, so
+ * long-term traffic counts survive. Global (all orgs) — retention is an operator concern.
+ *
+ * HETEML cron: call from a `#!/bin/sh` wrapper as
+ *   /usr/local/bin/php8.4 tools/prune-analytics.php --days=180
+ *
+ * Options:
+ *   --days=N   retention window in days (default 180)
+ */
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeNeRecords\Analytics\AnalyticsSaltRepositoryInterface;
+use NeNeRecords\Http\RuntimeContainerFactory;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$days = 180;
+foreach ($GLOBALS['argv'] as $arg) {
+    if (is_string($arg) && str_starts_with($arg, '--days=')) {
+        $parsed = (int) substr($arg, 7);
+        if ($parsed > 0) {
+            $days = $parsed;
+        }
+    }
+}
+
+$container = (new RuntimeContainerFactory(dirname(__DIR__)))->create();
+
+$salts = $container->get(AnalyticsSaltRepositoryInterface::class);
+$query = $container->get(DatabaseQueryExecutorInterface::class);
+
+if (
+    !$salts instanceof AnalyticsSaltRepositoryInterface
+    || !$query instanceof DatabaseQueryExecutorInterface
+) {
+    fwrite(STDERR, "ERROR: the application container is misconfigured.\n");
+    exit(1);
+}
+
+$cutoff = new DateTimeImmutable("-{$days} days");
+
+$saltsRemoved = $salts->pruneBefore($cutoff);
+
+$rowsCleared = $query->execute(
+    'UPDATE access_logs
+        SET visitor_hash = NULL, referer_host = NULL, utm_source = NULL, utm_medium = NULL,
+            utm_campaign = NULL, ref = NULL, client_type = NULL, is_bot = NULL
+      WHERE access_date < ? AND visitor_hash IS NOT NULL',
+    [$cutoff->format('Y-m-d')],
+);
+
+fwrite(STDOUT, sprintf(
+    "Retention prune (>%d days, before %s): %d salts removed, %d rows cleared of visitor data.\n",
+    $days,
+    $cutoff->format('Y-m-d'),
+    $saltsRemoved,
+    $rowsCleared,
+));


### PR DESCRIPTION
## 目的
Path B 段階PRの **最終（export CLI ＋ 保持prune）**。日次サマリを JSON で吐き、hub の mori 日次メール2ソース化の供給元にする。base=main（①②③④マージ済）。

## 変更
- **`tools/export-access-summary.php`** — `--org --date --out`。totals（`request_count`/`avg_duration_ms`/status分布）＋ **popular_pages（SSR + LP BEACON・api/media/robots/sitemap 除外）** ＋ popular_entities ＋ **visitor サマリ** を **summary v1 JSON** で `~/site-logs/<slug>/summary-<date>.json` へ。集計値のみ・生PII 非出力。
- **`tools/prune-analytics.php`** — `--days`(既定180)。保持窓より古い**日次ソルトを削除**＋**visitor 派生列を NULL 化**（匿名 base 行=リクエスト数は保持）。全org対象。
- 集計メソッド **`statusDistribution` / `popularPages`** を interface/Pdo/InMemory に追加。
- HETEML cron は bare .php 不発のため `#!/bin/sh` ラッパー越しに `/usr/local/bin/php8.4` で呼ぶ（各 CLI の docblock に明記）。

## 検証
- **Analytics 48 tests green**（Pdo で statusDistribution・popularPages を実DB検証：BEACON 算入 / api・media・robots・error 除外 / 並び）。
- **PHPStan L8・CS クリーン**。**実機 smoke**：export が summary v1 JSON を生成（`site`=org 由来・`visitor:null`）、prune が salt削除＋visitor列NULL化で動作。
- 全体スイートの残failは main と同一の pre-existing（ZipArchive・system_config E2E）。新規回帰ゼロ。

## 契約 / 次
- 出力キーは hub 合意の **summary v1** 準拠 → hub 受け側（実装済）が追加ゼロで乗る。
- 本番反映（Tier A migration＋cron設置＋org1 opt-in ON＋snippet deploy）は**全部揃って施主最終GO**。マージ後に endpoint 実POSTでスキーマ最終確認 → hub が LP snippet 投入＋実データ通し。

Refs #1007, #1008