### PR TITLE
fix(analytics): export-access-summary の既定日付を UTC 基準にする（#1007）

### DIFF
--- a/tools/export-access-summary.php
+++ b/tools/export-access-summary.php
@@ -51,7 +51,9 @@ if ($orgRef === null || $orgRef === '') {
 
 $date = summaryOption('date');
 if ($date === null || $date === '') {
-    $date = date('Y-m-d', time() - 86400);
+    // access_date is stored in UTC (the app's clock is UTC), so the default day must be
+    // UTC too — otherwise the cron misaligns at the UTC/JST boundary and drops rows.
+    $date = gmdate('Y-m-d', time() - 86400);
 }
 if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) !== 1) {
     fwrite(STDERR, "ERROR: --date must be YYYY-MM-DD.\n");
@@ -120,6 +122,7 @@ $out = [
         'ref' => $summary->ref,
     ] : null,
     'notes' => [
+        'day_basis' => 'UTC',
         'excludes' => ['/api/*', '/media/*', '/robots.txt', '/sitemap.xml'],
         'visitor_null_reason' => 'opt-in OFF or no Path B data for this range',
     ],


### PR DESCRIPTION
## 問題
`access_date` は UTC 保存（アプリ clock=UTC）だが、`tools/export-access-summary.php` の既定「昨日」が PHP の TZ（HETEML CLI=JST）依存で、cron 既定実行が UTC/JST 境界で行を取りこぼす（本番デプロイ検証で実測: 実データは UTC access_date に入る）。

## 修正
- 既定日付 `date()`→`gmdate()`（UTC）。明示 `--date` は従来どおり `access_date` と直接比較で不変。
- `summary.notes.day_basis = 'UTC'` を明記（消費側=hub mori メールが日基準を判別できる）。

## 検証
- 実機（ayane Tier A）: `--date=2026-07-24` で request_count=545 / status={2xx:522,3xx:23} / popular_pages=実SSRページ を正しく集計。php -l クリーン。

Refs #1007