### PR TITLE
fix(org): org 削除で子データが孤児化するのを直す（#1002）

### DIFF
--- a/database/schema/entity_revisions.sql
+++ b/database/schema/entity_revisions.sql
@@ -1,5 +1,6 @@
 CREATE TABLE entity_revisions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    organization_id INTEGER NOT NULL DEFAULT 0,
     entity_id INTEGER UNSIGNED NOT NULL,
     action VARCHAR(32) NOT NULL,
     status VARCHAR(32) NOT NULL,
@@ -11,3 +12,4 @@ CREATE TABLE entity_revisions (
     FOREIGN KEY (entity_id) REFERENCES entities (id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 CREATE INDEX entity_revisions_entity_id_created_at ON entity_revisions (entity_id, created_at);
+CREATE INDEX idx_entity_revisions_org ON entity_revisions (organization_id);

--- a/src/Organization/OrganizationScopedSchema.php
+++ b/src/Organization/OrganizationScopedSchema.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Organization;
+
+/**
+ * The org-scoped surface of the schema, as a delete-ordered table list (#1002).
+ *
+ * `organization_id` was added across the schema as a *partition key* — a plain indexed
+ * column with **no foreign key to `organizations`** (see
+ * `20260628000001_add_organization_id_to_all_tables.php`). Deleting an organization row
+ * therefore cascades nothing: before this list existed, `DELETE FROM organizations`
+ * orphaned every child row (measured 2026-07-23 on production — 13 `entities` rows
+ * survived the deletion of org 7).
+ *
+ * Two constraints shape the order below:
+ *
+ * 1. **`ON DELETE RESTRICT` FKs.** The field-value tables reference `entities`, and both
+ *    `entities` and `field_defs` reference `entity_types`, with RESTRICT. Deleting a
+ *    parent before its children does not orphan them — MySQL refuses the statement
+ *    outright. Children must go first.
+ * 2. **No reliance on engine cascade.** Rows that *are* covered by an `ON DELETE CASCADE`
+ *    FK (`comments`, `entity_revisions`, `entity_preview_tokens`, `entity_relations`,
+ *    `entity_tags`, `user_profiles`) are still deleted explicitly. The purge then behaves
+ *    identically on any adapter and on installs where a constraint was never created, and
+ *    the full set of affected tables is auditable from this one list rather than from the
+ *    live schema.
+ *
+ * `entity_archive` is deliberately absent: it carries no `organization_id`, and no
+ * migration creates it (only `database/schema/entity_archive.sql`, a test fixture), so
+ * issuing a DELETE against it would fail on a real database.
+ */
+final class OrganizationScopedSchema
+{
+    /**
+     * Tables purged through a parent's org scope because they carry no `organization_id`
+     * of their own. These run **first**, while both parents still exist.
+     *
+     * Each entry is `[table, WHERE clause with one `?` per bound org id]`.
+     *
+     * @var list<array{0: string, 1: string}>
+     */
+    public const DERIVED_PURGES = [
+        ['entity_tags', 'entity_id IN (SELECT id FROM entities WHERE organization_id = ?)'],
+        [
+            'entity_relations',
+            'source_entity_id IN (SELECT id FROM entities WHERE organization_id = ?)'
+            . ' OR target_entity_id IN (SELECT id FROM entities WHERE organization_id = ?)',
+        ],
+        [
+            'webhook_deliveries',
+            'webhook_id IN (SELECT id FROM webhooks WHERE organization_id = ?)'
+            . ' OR entity_id IN (SELECT id FROM entities WHERE organization_id = ?)',
+        ],
+        ['user_profiles', 'user_id IN (SELECT id FROM users WHERE organization_id = ?)'],
+    ];
+
+    /**
+     * Every table carrying `organization_id`, ordered children-before-parents.
+     *
+     * Adding a table with an `organization_id` column without adding it here is a bug —
+     * `OrganizationScopedSchemaCoverageTest` fails when the two drift apart.
+     *
+     * @var list<string>
+     */
+    public const ORG_SCOPED_TABLES = [
+        // Entity field values — RESTRICT FK to entities, so these must precede it.
+        'text_fields',
+        'int_fields',
+        'bool_fields',
+        'enum_fields',
+        'datetime_fields',
+        'blocks_fields',
+        // Remaining entity children (CASCADE FK; deleted explicitly — see class docblock).
+        'comments',
+        'entity_preview_tokens',
+        'entity_revisions',
+        'entities',
+        // entity_type children — RESTRICT FK to entity_types, so these must precede it.
+        'field_defs',
+        'entity_types',
+        // No ordering constraints among the rest.
+        'access_logs',
+        'media',
+        'menus',
+        'navigation_items',
+        'notification_channels',
+        'setting_defs',
+        'setting_revisions',
+        'setting_values',
+        'tags',
+        'themes',
+        'url_redirects',
+        'users',
+        'webhooks',
+        'widgets',
+    ];
+}

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -6,6 +6,7 @@ namespace NeNeRecords\Organization;
 
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
@@ -63,7 +64,14 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
                         throw new LogicException('ClockInterface service is invalid.');
                     }
 
-                    return new PdoOrganizationRepository($query, $clock);
+                    // Deleting an organization purges ~30 tables (#1002); without the manager
+                    // a mid-purge failure would leave the org half-deleted.
+                    $transactions = $c->get(DatabaseTransactionManagerInterface::class);
+                    if (!$transactions instanceof DatabaseTransactionManagerInterface) {
+                        throw new LogicException('Database transaction manager service is invalid.');
+                    }
+
+                    return new PdoOrganizationRepository($query, $clock, $transactions);
                 },
             )
             // ── Use cases ──────────────────────────────────────────────────────

--- a/src/Organization/PdoOrganizationRepository.php
+++ b/src/Organization/PdoOrganizationRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Organization;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use PDOException;
 
@@ -12,9 +13,16 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
 {
     private const COLUMNS = 'id, name, slug, external_id, custom_domain, plan, is_active, created_at, updated_at';
 
+    /**
+     * @param DatabaseTransactionManagerInterface|null $transactions Makes {@see delete()} atomic. Optional so the
+     *                                                              repository stays constructible without one; a
+     *                                                              null manager runs the purge unwrapped, which
+     *                                                              can leave a partial delete behind on failure.
+     */
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
         private ClockInterface $clock,
+        private ?DatabaseTransactionManagerInterface $transactions = null,
     ) {
     }
 
@@ -129,6 +137,13 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
         );
     }
 
+    /**
+     * Deletes the organization **and every row scoped to it**.
+     *
+     * The org-scoped columns carry no foreign key to `organizations`, so nothing cascades
+     * on its own — the child rows are removed explicitly, children before parents. See
+     * {@see OrganizationScopedSchema} for the ordering rules and why each list exists (#1002).
+     */
     public function delete(int $id): void
     {
         $org = $this->findById($id);
@@ -137,7 +152,42 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
             throw new OrganizationNotFoundException($id);
         }
 
-        $this->query->execute('DELETE FROM organizations WHERE id = ?', [$id]);
+        if ($this->transactions === null) {
+            $this->purge($this->query, $id);
+
+            return;
+        }
+
+        $this->transactions->transactional(
+            function (DatabaseQueryExecutorInterface $query) use ($id): null {
+                $this->purge($query, $id);
+
+                return null;
+            },
+        );
+    }
+
+    /**
+     * Removes every org-scoped row, then the organization itself.
+     *
+     * Runs against the executor it is handed rather than `$this->query` so the transactional
+     * path purges inside the transaction's own connection.
+     */
+    private function purge(DatabaseQueryExecutorInterface $query, int $id): void
+    {
+        // Parents are still present here, so the subqueries can still resolve the org's rows.
+        foreach (OrganizationScopedSchema::DERIVED_PURGES as [$table, $where]) {
+            $query->execute(
+                "DELETE FROM {$table} WHERE {$where}",
+                array_fill(0, substr_count($where, '?'), $id),
+            );
+        }
+
+        foreach (OrganizationScopedSchema::ORG_SCOPED_TABLES as $table) {
+            $query->execute("DELETE FROM {$table} WHERE organization_id = ?", [$id]);
+        }
+
+        $query->execute('DELETE FROM organizations WHERE id = ?', [$id]);
     }
 
     /** @param array<string, mixed> $row */

--- a/tests/Organization/OrganizationScopedSchemaCoverageTest.php
+++ b/tests/Organization/OrganizationScopedSchemaCoverageTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Organization;
+
+use NeNeRecords\Organization\OrganizationScopedSchema;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the org-scoped table list against schema drift (#1002).
+ *
+ * Deleting an organization purges every table carrying `organization_id`. A new table with
+ * that column is therefore a silent orphan factory unless it is added to
+ * {@see OrganizationScopedSchema::ORG_SCOPED_TABLES} — this test is what makes that
+ * omission loud. `database/schema/*.sql` is the shipped shape the suite builds from, so it
+ * is the reference the list is compared against.
+ */
+final class OrganizationScopedSchemaCoverageTest extends TestCase
+{
+    public function testEveryTableCarryingOrganizationIdIsPurged(): void
+    {
+        $fromSchema = self::tablesWithOrganizationId();
+
+        self::assertNotSame([], $fromSchema, 'No schema fixture declared organization_id — the parser is wrong.');
+
+        $covered = OrganizationScopedSchema::ORG_SCOPED_TABLES;
+        sort($covered);
+
+        self::assertSame(
+            $fromSchema,
+            $covered,
+            'OrganizationScopedSchema::ORG_SCOPED_TABLES drifted from database/schema/*.sql. '
+            . 'A table with organization_id that is not purged leaves orphans when an org is deleted (#1002).',
+        );
+    }
+
+    public function testDerivedPurgesBindOneOrgIdPerPlaceholder(): void
+    {
+        foreach (OrganizationScopedSchema::DERIVED_PURGES as [$table, $where]) {
+            self::assertGreaterThan(
+                0,
+                substr_count($where, '?'),
+                "Derived purge for {$table} binds no org id — it would delete every row.",
+            );
+            self::assertStringContainsString(
+                'organization_id = ?',
+                $where,
+                "Derived purge for {$table} must scope its subquery by organization_id.",
+            );
+        }
+    }
+
+    /**
+     * Table names declared with an `organization_id` column across the schema fixtures.
+     *
+     * @return list<string>
+     */
+    private static function tablesWithOrganizationId(): array
+    {
+        $tables = [];
+
+        foreach (SchemaFixtures::files() as $path) {
+            $raw = (string) file_get_contents($path);
+
+            preg_match_all(
+                '/CREATE TABLE\s+(?:IF NOT EXISTS\s+)?(\w+)\s*\((.*?)\n\)\s*;/s',
+                $raw,
+                $matches,
+                PREG_SET_ORDER,
+            );
+
+            foreach ($matches as $match) {
+                if (preg_match('/\borganization_id\b/', $match[2]) === 1) {
+                    $tables[] = $match[1];
+                }
+            }
+        }
+
+        sort($tables);
+
+        return $tables;
+    }
+}

--- a/tests/Organization/PdoOrganizationRepositoryDeleteTest.php
+++ b/tests/Organization/PdoOrganizationRepositoryDeleteTest.php
@@ -132,10 +132,11 @@ final class PdoOrganizationRepositoryDeleteTest extends TestCase
     /**
      * Seeds one row in every org-scoped table plus the four tables purged through a parent.
      *
-     * Foreign keys are switched off for the seed only. The rows are generated generically
-     * (see {@see insertRow()}), so FK columns get placeholder ids that need not resolve —
-     * what matters is that the *delete* runs with enforcement on, which is where the
-     * RESTRICT ordering is actually proven.
+     * Foreign keys are switched off for the seed only, so the rows can be written in list
+     * order without a topological sort. The relationships themselves are real
+     * (see {@see insertRow()}): every child points at this organization's actual parent row.
+     * That is what lets enforcement — switched back on before the delete — reject a wrong
+     * delete order, which is the whole point of {@see OrganizationScopedSchema}'s ordering.
      */
     private function seedOrganization(int $org): void
     {
@@ -148,19 +149,19 @@ final class PdoOrganizationRepositoryDeleteTest extends TestCase
         );
 
         foreach (OrganizationScopedSchema::ORG_SCOPED_TABLES as $table) {
-            $this->insertRow($table, ['organization_id' => $org, 'id' => $this->rowId($org, $table)]);
+            $this->insertRow($org, $table, ['organization_id' => $org, 'id' => $this->rowId($org, $table)]);
         }
 
-        $this->insertRow('entity_tags', ['entity_id' => $this->entityId($org)]);
-        $this->insertRow('entity_relations', [
+        $this->insertRow($org, 'entity_tags', ['entity_id' => $this->entityId($org)]);
+        $this->insertRow($org, 'entity_relations', [
             'source_entity_id' => $this->entityId($org),
             'target_entity_id' => $this->entityId($org),
         ]);
-        $this->insertRow('webhook_deliveries', [
+        $this->insertRow($org, 'webhook_deliveries', [
             'webhook_id' => $this->webhookId($org),
             'entity_id' => $this->entityId($org),
         ]);
-        $this->insertRow('user_profiles', ['user_id' => $this->userId($org)]);
+        $this->insertRow($org, 'user_profiles', ['user_id' => $this->userId($org)]);
 
         $this->executor->execute('PRAGMA foreign_keys = ON');
     }
@@ -171,10 +172,18 @@ final class PdoOrganizationRepositoryDeleteTest extends TestCase
      * Generic on purpose: the point of the test is that *all* org-scoped tables are covered,
      * so hand-writing 26 inserts would rot the moment a column is added.
      *
+     * Foreign key columns are pointed at the organization's **real** parent row rather than a
+     * placeholder. Without that the children hang off ids that do not exist, and `RESTRICT`
+     * never fires however wrong the delete order is — a reordered
+     * {@see OrganizationScopedSchema::ORG_SCOPED_TABLES} then passes a green test suite while
+     * failing on MySQL.
+     *
      * @param array<string, int|string> $values
      */
-    private function insertRow(string $table, array $values): void
+    private function insertRow(int $org, string $table, array $values): void
     {
+        $foreignKeys = $this->foreignKeys($table);
+
         foreach ($this->columns($table) as $column) {
             $name = (string) $column['name'];
 
@@ -186,6 +195,14 @@ final class PdoOrganizationRepositoryDeleteTest extends TestCase
             $isRequired = (int) $column['notnull'] === 1 && $column['dflt_value'] === null;
 
             if ($isPrimaryKey || !$isRequired) {
+                continue;
+            }
+
+            $parent = $foreignKeys[$name] ?? null;
+
+            if ($parent !== null && in_array($parent, OrganizationScopedSchema::ORG_SCOPED_TABLES, true)) {
+                $values[$name] = $this->rowId($org, $parent);
+
                 continue;
             }
 
@@ -235,6 +252,22 @@ final class PdoOrganizationRepositoryDeleteTest extends TestCase
     private function columns(string $table): array
     {
         return $this->executor->fetchAll("PRAGMA table_info({$table})");
+    }
+
+    /**
+     * Foreign key columns of a table, mapped to the table they reference.
+     *
+     * @return array<string, string>
+     */
+    private function foreignKeys(string $table): array
+    {
+        $map = [];
+
+        foreach ($this->executor->fetchAll("PRAGMA foreign_key_list({$table})") as $row) {
+            $map[(string) $row['from']] = (string) $row['table'];
+        }
+
+        return $map;
     }
 
     /** Stable, collision-free ids so the derived tables can point at the right parents. */

--- a/tests/Organization/PdoOrganizationRepositoryDeleteTest.php
+++ b/tests/Organization/PdoOrganizationRepositoryDeleteTest.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Organization;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\UtcClock;
+use NeNeRecords\Organization\OrganizationNotFoundException;
+use NeNeRecords\Organization\OrganizationScopedSchema;
+use NeNeRecords\Organization\PdoOrganizationRepository;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Deleting an organization must leave nothing of it behind (#1002).
+ *
+ * Production measured the opposite on 2026-07-23: `DELETE FROM organizations` removed org 7
+ * and left 13 `entities` rows (plus 25 other tables) orphaned, because `organization_id`
+ * carries no foreign key. Every assertion here fails if the purge regresses to that.
+ *
+ * Two organizations are seeded so the tests prove the purge is *scoped* — deleting one must
+ * not touch the other. A purge that forgot its WHERE clause would pass a residue-only check.
+ */
+final class PdoOrganizationRepositoryDeleteTest extends TestCase
+{
+    private const VICTIM = 1;
+    private const BYSTANDER = 2;
+
+    private PdoDatabaseQueryExecutor $executor;
+    private PdoOrganizationRepository $repository;
+    private int $sequence = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene-records-test',
+            '',
+            'utf8',
+        )));
+
+        foreach (SchemaFixtures::statements() as $statement) {
+            $this->executor->execute($statement);
+        }
+
+        $this->repository = new PdoOrganizationRepository($this->executor, new UtcClock());
+
+        $this->seedOrganization(self::VICTIM);
+        $this->seedOrganization(self::BYSTANDER);
+    }
+
+    public function testDeleteLeavesNoRowScopedToTheOrganization(): void
+    {
+        // Proves the assertions below are not vacuous: every table really did hold a row.
+        foreach (OrganizationScopedSchema::ORG_SCOPED_TABLES as $table) {
+            self::assertSame(1, $this->countByOrg($table, self::VICTIM), "{$table} was not seeded.");
+        }
+
+        $this->repository->delete(self::VICTIM);
+
+        foreach (OrganizationScopedSchema::ORG_SCOPED_TABLES as $table) {
+            self::assertSame(
+                0,
+                $this->countByOrg($table, self::VICTIM),
+                "{$table} still holds rows for the deleted organization (#1002).",
+            );
+        }
+
+        self::assertNull($this->repository->findById(self::VICTIM));
+    }
+
+    public function testDeleteAlsoPurgesTablesWithoutAnOrganizationIdColumn(): void
+    {
+        $this->repository->delete(self::VICTIM);
+
+        self::assertSame(0, $this->countWhere('entity_tags', 'entity_id = ?', $this->entityId(self::VICTIM)));
+        self::assertSame(
+            0,
+            $this->countWhere('entity_relations', 'source_entity_id = ?', $this->entityId(self::VICTIM)),
+        );
+        self::assertSame(0, $this->countWhere('webhook_deliveries', 'webhook_id = ?', $this->webhookId(self::VICTIM)));
+        self::assertSame(0, $this->countWhere('user_profiles', 'user_id = ?', $this->userId(self::VICTIM)));
+    }
+
+    public function testDeleteLeavesOtherOrganizationsUntouched(): void
+    {
+        $this->repository->delete(self::VICTIM);
+
+        foreach (OrganizationScopedSchema::ORG_SCOPED_TABLES as $table) {
+            self::assertSame(
+                1,
+                $this->countByOrg($table, self::BYSTANDER),
+                "{$table} lost the surviving organization's row — the purge is not org-scoped.",
+            );
+        }
+
+        self::assertSame(1, $this->countWhere('entity_tags', 'entity_id = ?', $this->entityId(self::BYSTANDER)));
+        self::assertSame(
+            1,
+            $this->countWhere('entity_relations', 'source_entity_id = ?', $this->entityId(self::BYSTANDER)),
+        );
+        self::assertSame(
+            1,
+            $this->countWhere('webhook_deliveries', 'webhook_id = ?', $this->webhookId(self::BYSTANDER)),
+        );
+        self::assertSame(1, $this->countWhere('user_profiles', 'user_id = ?', $this->userId(self::BYSTANDER)));
+        self::assertNotNull($this->repository->findById(self::BYSTANDER));
+    }
+
+    public function testDeleteRejectsAnUnknownOrganizationBeforeTouchingAnything(): void
+    {
+        try {
+            $this->repository->delete(999);
+            self::fail('Expected OrganizationNotFoundException.');
+        } catch (OrganizationNotFoundException) {
+            // expected
+        }
+
+        self::assertSame(1, $this->countByOrg('entities', self::VICTIM));
+        self::assertSame(1, $this->countByOrg('entities', self::BYSTANDER));
+    }
+
+    /**
+     * Seeds one row in every org-scoped table plus the four tables purged through a parent.
+     *
+     * Foreign keys are switched off for the seed only. The rows are generated generically
+     * (see {@see insertRow()}), so FK columns get placeholder ids that need not resolve —
+     * what matters is that the *delete* runs with enforcement on, which is where the
+     * RESTRICT ordering is actually proven.
+     */
+    private function seedOrganization(int $org): void
+    {
+        $this->executor->execute('PRAGMA foreign_keys = OFF');
+
+        $this->executor->execute(
+            'INSERT INTO organizations (id, name, slug, plan, is_active, created_at, updated_at)'
+            . " VALUES (?, ?, ?, 'free', 1, '2026-01-01 00:00:00', '2026-01-01 00:00:00')",
+            [$org, "Org {$org}", "org-{$org}"],
+        );
+
+        foreach (OrganizationScopedSchema::ORG_SCOPED_TABLES as $table) {
+            $this->insertRow($table, ['organization_id' => $org, 'id' => $this->rowId($org, $table)]);
+        }
+
+        $this->insertRow('entity_tags', ['entity_id' => $this->entityId($org)]);
+        $this->insertRow('entity_relations', [
+            'source_entity_id' => $this->entityId($org),
+            'target_entity_id' => $this->entityId($org),
+        ]);
+        $this->insertRow('webhook_deliveries', [
+            'webhook_id' => $this->webhookId($org),
+            'entity_id' => $this->entityId($org),
+        ]);
+        $this->insertRow('user_profiles', ['user_id' => $this->userId($org)]);
+
+        $this->executor->execute('PRAGMA foreign_keys = ON');
+    }
+
+    /**
+     * Inserts one row, filling every NOT NULL column the caller did not supply.
+     *
+     * Generic on purpose: the point of the test is that *all* org-scoped tables are covered,
+     * so hand-writing 26 inserts would rot the moment a column is added.
+     *
+     * @param array<string, int|string> $values
+     */
+    private function insertRow(string $table, array $values): void
+    {
+        foreach ($this->columns($table) as $column) {
+            $name = (string) $column['name'];
+
+            if (array_key_exists($name, $values)) {
+                continue;
+            }
+
+            $isPrimaryKey = (int) $column['pk'] === 1;
+            $isRequired = (int) $column['notnull'] === 1 && $column['dflt_value'] === null;
+
+            if ($isPrimaryKey || !$isRequired) {
+                continue;
+            }
+
+            $values[$name] = $this->placeholderFor((string) $column['type']);
+        }
+
+        $columns = implode(', ', array_keys($values));
+        $marks = implode(', ', array_fill(0, count($values), '?'));
+
+        $this->executor->execute(
+            "INSERT INTO {$table} ({$columns}) VALUES ({$marks})",
+            array_values($values),
+        );
+    }
+
+    /**
+     * A type-appropriate value that is distinct on every call.
+     *
+     * Distinctness matters: several snapshots carry UNIQUE indexes (`entity_preview_tokens.token`,
+     * `users.email`, …), and seeding two organizations with a constant would collide on them.
+     */
+    private function placeholderFor(string $type): int|string
+    {
+        $seq = ++$this->sequence;
+        $upper = strtoupper($type);
+
+        if (str_contains($upper, 'DATE') || str_contains($upper, 'TIME')) {
+            return '2026-01-01 00:00:00';
+        }
+
+        if (
+            str_contains($upper, 'INT')
+            || str_contains($upper, 'BOOL')
+            || str_contains($upper, 'REAL')
+            || str_contains($upper, 'FLOA')
+            || str_contains($upper, 'DOUB')
+        ) {
+            return $seq;
+        }
+
+        return "seed-{$seq}";
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function columns(string $table): array
+    {
+        return $this->executor->fetchAll("PRAGMA table_info({$table})");
+    }
+
+    /** Stable, collision-free ids so the derived tables can point at the right parents. */
+    private function rowId(int $org, string $table): int
+    {
+        $index = array_search($table, OrganizationScopedSchema::ORG_SCOPED_TABLES, true);
+
+        return $org * 1000 + (is_int($index) ? $index : 0) + 1;
+    }
+
+    private function entityId(int $org): int
+    {
+        return $this->rowId($org, 'entities');
+    }
+
+    private function userId(int $org): int
+    {
+        return $this->rowId($org, 'users');
+    }
+
+    private function webhookId(int $org): int
+    {
+        return $this->rowId($org, 'webhooks');
+    }
+
+    private function countByOrg(string $table, int $org): int
+    {
+        return $this->countWhere($table, 'organization_id = ?', $org);
+    }
+
+    private function countWhere(string $table, string $where, int $value): int
+    {
+        $row = $this->executor->fetchOne("SELECT COUNT(*) AS cnt FROM {$table} WHERE {$where}", [$value]);
+
+        return (int) ($row['cnt'] ?? 0);
+    }
+}

--- a/tests/Organization/SchemaFixtures.php
+++ b/tests/Organization/SchemaFixtures.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Organization;
+
+/**
+ * Locates and loads the schema snapshots under `database/schema/`.
+ *
+ * The snapshots are the documented mirror of the migrations' end state
+ * (`docs/development/backend-standards.md`), and all but two are already SQLite-parsable.
+ * The two exceptions are handled here rather than by hand-writing replacement tables, so
+ * a column added to a snapshot still reaches the tests that build from it:
+ *
+ * - `users.sql` declares `status ENUM('active', 'invited')`. SQLite has no ENUM, so it is
+ *   rewritten to a VARCHAR of equivalent width — the tests never assert on the constraint.
+ * - `entity_archive.sql` is full MySQL DDL (`INT UNSIGNED … AUTO_INCREMENT`, `ENGINE=InnoDB`)
+ *   and is skipped outright. No migration creates that table, so it is absent from real
+ *   databases as well (see OrganizationScopedSchema).
+ */
+final class SchemaFixtures
+{
+    /** Snapshots that cannot be executed on SQLite at all. */
+    private const NOT_EXECUTABLE = ['entity_archive.sql'];
+
+    /**
+     * Every snapshot file, including the ones that cannot be executed — callers that read
+     * the DDL as text (coverage checks) still need to see them.
+     *
+     * @return list<string> absolute paths, sorted
+     */
+    public static function files(): array
+    {
+        $paths = glob(dirname(__DIR__, 2) . '/database/schema/*.sql') ?: [];
+        sort($paths);
+
+        return $paths;
+    }
+
+    /**
+     * Every executable DDL statement across the snapshots, ready to run one by one.
+     *
+     * @return list<string>
+     */
+    public static function statements(): array
+    {
+        $statements = [];
+
+        foreach (self::files() as $path) {
+            if (in_array(basename($path), self::NOT_EXECUTABLE, true)) {
+                continue;
+            }
+
+            $raw = trim((string) file_get_contents($path));
+            $raw = (string) preg_replace('/\bENUM\s*\([^)]*\)/i', 'VARCHAR(32)', $raw);
+
+            foreach (preg_split('/;\R/s', $raw) ?: [] as $chunk) {
+                $statement = trim(rtrim(trim($chunk), ';'));
+
+                if ($statement !== '') {
+                    $statements[] = $statement;
+                }
+            }
+        }
+
+        return $statements;
+    }
+}


### PR DESCRIPTION
## 目的

`superadmin` から組織を削除すると **organizations の行だけが消えて子データが全部残る**不具合を直す。

`organization_id` は 2026-06-28 の migration で全テーブルに**パーティションキーとして**追加されたが、`organizations` への外部キーは張られていない。にもかかわらず `DeleteOrganizationUseCase` → `PdoOrganizationRepository::delete` は `DELETE FROM organizations WHERE id=?` だけで、あとを DB の `ON DELETE CASCADE` に任せる前提だった。**その FK は存在しない**ので何も連鎖しない。

2026-07-23 の本番（ayane.nene-records.com・org_id=7）の削除で実測検出。org 行を消したあとも `entities WHERE organization_id=7` が 13件残存し、26テーブル＋2テーブルを手作業で cleanup した。

## 変更内容

### `OrganizationScopedSchema`（新規）

org スコープの削除対象を、**削除順つき**で1か所に集約した。順序は2つの制約で決まる:

1. **`ON DELETE RESTRICT`**: `*_fields` → `entities`、`field_defs`/`entities` → `entity_types`。親を先に消すと孤児化ではなく **MySQL がそもそも文を拒否する**ので、子を先に消す必要がある。
2. **エンジンの cascade に依存しない**: `ON DELETE CASCADE` が張られている子（`comments` / `entity_revisions` / `entity_preview_tokens` / `entity_relations` / `entity_tags` / `user_profiles`）も明示的に消す。アダプタや制約の有無によらず同じ挙動になり、影響範囲がこのリスト1本から追える。

`organization_id` を持たない4テーブルは親の org スコープ経由（サブクエリ）で削除する。**親がまだ存在する最初の段**で流すのが要点。

### `PdoOrganizationRepository::delete`

明示 cascade に変更。`DatabaseTransactionManagerInterface` を**任意注入**で受け、渡されていればトランザクションで包む（本番 DI では必ず渡す）。任意にしたのは既存の構築箇所・テストダブルを壊さないため。

### `database/schema/entity_revisions.sql`

スナップショットが `organization_id` を取りこぼしていた（migration では 2026-06-28 に追加済み・本番の実列にも存在）。実スキーマへ同期した。

### 対象外にしたもの

- **`entity_archive`**: `organization_id` を持たず、しかも**これを作る migration が存在しない**（`database/schema/entity_archive.sql` のスナップショットのみ）。実 DB に存在しないテーブルへ DELETE を撃つと落ちるため除外した。→ **別件として要調査**（`PdoEntityArchiveRepository` は本番に無いテーブルへ INSERT しに行くことになる）。
- **メディアの実ファイル**: DB 行は消えるが `var/media` の実体は残る。Issue のスコープ（DB 孤児）外なので別途。

## 検証

```
composer check   → 全緑（PHPUnit 1491 tests / 4523 assertions・PHPStan level 8・CS-Fixer・OpenAPI・MCP）
```

### 追加テスト

- `PdoOrganizationRepositoryDeleteTest` — スナップショットから SQLite にスキーマを組み、**2つの org** を全 org スコープテーブル＋派生4テーブルに播いてから片方を削除する。
  - 削除側は全テーブルで残骸0
  - **もう一方の org は無傷**（WHERE 句を忘れた実装は残骸チェックだけなら通ってしまうため）
  - `organization_id` を持たない4テーブルも親経由で消える
  - 未知の org は何も触らずに `OrganizationNotFoundException`
  - 削除**前**に全テーブルが1行持つことも assert し、テストが空虚にならないようにした
- `OrganizationScopedSchemaCoverageTest` — `database/schema/*.sql` を走査し、`organization_id` を持つテーブル集合と `ORG_SCOPED_TABLES` の**一致**を検証する。**新しいテーブルを足してリストに入れ忘れると落ちる**（＝この不具合の再発防止）。

### 非空虚性の確認

`src/Organization/PdoOrganizationRepository.php` だけを修正前に戻して実行 → 2テストが失敗することを確認済み。

## チェックリスト

- [x] `composer check` 緑
- [x] Issue 準拠のブランチ名・Conventional Commits
- [x] 新規テーブル追加時の再発防止テストを同梱
- [x] 本番データに触れる変更なし（コードのみ・migration なし）

Closes #1002
