### PR TITLE
fix(entity-archive): entity_archive を作る migration を追加する（#1017）

### DIFF
--- a/database/migrations/20260728000000_create_entity_archive_table.php
+++ b/database/migrations/20260728000000_create_entity_archive_table.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Creates `entity_archive` — the table the archive repository has always written to (#1017).
+ *
+ * `PdoEntityArchiveRepository::archiveAndPurgeSoftDeleted()` snapshots soft-deleted entities
+ * here before purging them, and `DeleteEntityTypeUseCase` calls it on every entity type
+ * deletion. **No migration ever created the table**: it existed only as
+ * `database/schema/entity_archive.sql`, which is a test snapshot that nothing executes
+ * against a real database (the installer applies migrations — `public_html/install/index.php`
+ * states the migrations are the source of truth). Deleting an entity type that owned at least
+ * one soft-deleted entity therefore hit `no such table: entity_archive` and returned 500.
+ * Reproduced 2026-07-29; no data was lost because the INSERT precedes every DELETE.
+ *
+ * `organization_id` is present from the start, unlike the old snapshot. Without it the rows
+ * would survive their organization's deletion exactly the way #1002 described — and
+ * `OrganizationScopedSchema` could not purge them.
+ */
+final class CreateEntityArchiveTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('entity_archive')
+            ->addColumn('organization_id', 'integer', ['signed' => false, 'null' => false, 'default' => 0])
+            ->addColumn('original_entity_id', 'integer', ['signed' => false, 'null' => false])
+            ->addColumn('entity_type_id', 'integer', ['signed' => false, 'null' => false])
+            ->addColumn('entity_type_slug', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('entity_type_name', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('entity_slug', 'string', ['limit' => 255, 'null' => true, 'default' => null])
+            ->addColumn('entity_status', 'string', ['limit' => 16, 'null' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true, 'default' => null])
+            ->addColumn('archived_at', 'datetime', ['null' => false])
+            ->addColumn('archived_reason', 'string', ['limit' => 64, 'null' => false, 'default' => 'entity_type_deleted'])
+            ->addColumn('snapshot', 'json', ['null' => false])
+            ->addIndex(['organization_id'], ['name' => 'idx_entity_archive_org'])
+            ->addIndex(['entity_type_id'], ['name' => 'idx_entity_archive_entity_type_id'])
+            ->addIndex(['original_entity_id'], ['name' => 'idx_entity_archive_original_entity_id'])
+            ->create();
+    }
+}

--- a/database/schema/entity_archive.sql
+++ b/database/schema/entity_archive.sql
@@ -1,7 +1,8 @@
 CREATE TABLE entity_archive (
-    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
-    original_entity_id INT UNSIGNED NOT NULL,
-    entity_type_id INT UNSIGNED NOT NULL,
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    organization_id INTEGER NOT NULL DEFAULT 0,
+    original_entity_id INTEGER UNSIGNED NOT NULL,
+    entity_type_id INTEGER UNSIGNED NOT NULL,
     entity_type_slug VARCHAR(255) NOT NULL,
     entity_type_name VARCHAR(255) NOT NULL,
     entity_slug VARCHAR(255) DEFAULT NULL,
@@ -9,8 +10,8 @@ CREATE TABLE entity_archive (
     deleted_at DATETIME DEFAULT NULL,
     archived_at DATETIME NOT NULL,
     archived_reason VARCHAR(64) NOT NULL DEFAULT 'entity_type_deleted',
-    snapshot JSON NOT NULL,
-    PRIMARY KEY (id),
-    KEY idx_entity_type_id (entity_type_id),
-    KEY idx_original_entity_id (original_entity_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+    snapshot TEXT NOT NULL
+);
+CREATE INDEX idx_entity_archive_org ON entity_archive (organization_id);
+CREATE INDEX idx_entity_archive_entity_type_id ON entity_archive (entity_type_id);
+CREATE INDEX idx_entity_archive_original_entity_id ON entity_archive (original_entity_id);

--- a/src/EntityArchive/PdoEntityArchiveRepository.php
+++ b/src/EntityArchive/PdoEntityArchiveRepository.php
@@ -112,11 +112,13 @@ final readonly class PdoEntityArchiveRepository implements EntityArchiveReposito
             $this->query->execute(
                 <<<SQL
                     INSERT INTO entity_archive
-                        (original_entity_id, entity_type_id, entity_type_slug, entity_type_name,
-                         entity_slug, entity_status, deleted_at, archived_at, archived_reason, snapshot)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'entity_type_deleted', ?)
+                        (organization_id, original_entity_id, entity_type_id, entity_type_slug,
+                         entity_type_name, entity_slug, entity_status, deleted_at, archived_at,
+                         archived_reason, snapshot)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'entity_type_deleted', ?)
                     SQL,
                 [
+                    $this->orgId->get(),
                     $entityId,
                     $entityType->id,
                     $entityType->slug,

--- a/src/Organization/OrganizationScopedSchema.php
+++ b/src/Organization/OrganizationScopedSchema.php
@@ -27,9 +27,10 @@ namespace NeNeRecords\Organization;
  *    the full set of affected tables is auditable from this one list rather than from the
  *    live schema.
  *
- * `entity_archive` is deliberately absent: it carries no `organization_id`, and no
- * migration creates it (only `database/schema/entity_archive.sql`, a test fixture), so
- * issuing a DELETE against it would fail on a real database.
+ * `entity_archive` was absent from the first version of this list: no migration created the
+ * table and it carried no `organization_id`, so a DELETE against it would have failed on a
+ * real database. #1017 created it properly — with `organization_id` from the start, exactly so
+ * that an organization's deletion cannot strand its archive — and it is purged here now.
  */
 final class OrganizationScopedSchema
 {
@@ -79,6 +80,9 @@ final class OrganizationScopedSchema
         'entities',
         // entity_type children — RESTRICT FK to entity_types, so these must precede it.
         'field_defs',
+        // Snapshots of purged entities, keyed by entity_type_id (no FK). #1017 created the table
+        // with organization_id precisely so an org deletion does not strand its archive.
+        'entity_archive',
         'entity_types',
         // No ordering constraints among the rest.
         'access_logs',

--- a/tests/EntityArchive/PdoEntityArchiveRepositoryTest.php
+++ b/tests/EntityArchive/PdoEntityArchiveRepositoryTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\EntityArchive;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\UtcClock;
+use NeNeRecords\EntityArchive\PdoEntityArchiveRepository;
+use NeNeRecords\EntityType\EntityType;
+use NeNeRecords\Tests\Organization\SchemaFixtures;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises the archive repository against a real schema (#1017).
+ *
+ * There was no such test before, and that is precisely why the bug survived: every test that
+ * reached `archiveAndPurgeSoftDeleted()` went through `InMemoryEntityArchiveRepository`, so
+ * **nothing ever executed the INSERT**. `entity_archive` had no migration and did not exist in
+ * any real database, and deleting an entity type that owned a soft-deleted entity returned 500
+ * with `no such table: entity_archive`. Green tests, working code path, absent table.
+ *
+ * The schema here is built from every snapshot in `database/schema/`, so a table that stops
+ * existing again fails these tests rather than only production.
+ */
+final class PdoEntityArchiveRepositoryTest extends TestCase
+{
+    private const ORG = 7;
+    private const OTHER_ORG = 8;
+
+    private PdoDatabaseQueryExecutor $executor;
+    private PdoEntityArchiveRepository $repository;
+
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene-records-test',
+            '',
+            'utf8',
+        )));
+
+        foreach (SchemaFixtures::statements() as $statement) {
+            $this->executor->execute($statement);
+        }
+
+        $this->orgId = new RequestScopedHolder();
+        $this->orgId->set(self::ORG);
+
+        $this->repository = new PdoEntityArchiveRepository($this->executor, $this->orgId, new UtcClock());
+    }
+
+    public function testSoftDeletedEntitiesAreArchivedThenPurged(): void
+    {
+        $this->seedEntityType(1, self::ORG, 'note');
+        $this->seedSoftDeletedEntity(10, self::ORG, 1, 'gone');
+        $this->executor->execute(
+            'INSERT INTO text_fields (organization_id, entity_id, field_key, value) VALUES (?, 10, ?, ?)',
+            [self::ORG, 'body', 'farewell'],
+        );
+
+        $this->repository->archiveAndPurgeSoftDeleted(new EntityType(name: 'Note', slug: 'note', id: 1));
+
+        $archived = $this->executor->fetchOne('SELECT * FROM entity_archive WHERE original_entity_id = 10');
+
+        self::assertNotNull($archived, 'The soft-deleted entity was not archived.');
+        self::assertSame(self::ORG, (int) $archived['organization_id'], 'The archive row is not org-scoped.');
+        self::assertSame('note', $archived['entity_type_slug']);
+        self::assertSame('entity_type_deleted', $archived['archived_reason']);
+
+        $snapshot = json_decode((string) $archived['snapshot'], true);
+
+        self::assertIsArray($snapshot);
+        self::assertSame([['field_key' => 'body', 'value' => 'farewell']], $snapshot['text_fields']);
+
+        self::assertSame(0, $this->rowCount('entities', 'id = 10'), 'The entity was archived but not purged.');
+        self::assertSame(0, $this->rowCount('text_fields', 'entity_id = 10'), 'Field values outlived their entity.');
+    }
+
+    public function testActiveEntitiesAreLeftAlone(): void
+    {
+        $this->seedEntityType(1, self::ORG, 'note');
+        $this->seedSoftDeletedEntity(10, self::ORG, 1, 'gone');
+        $this->executor->execute(
+            "INSERT INTO entities (id, organization_id, entity_type_id, slug, status, is_deleted)
+             VALUES (11, ?, 1, 'kept', 'published', 0)",
+            [self::ORG],
+        );
+
+        $this->repository->archiveAndPurgeSoftDeleted(new EntityType(name: 'Note', slug: 'note', id: 1));
+
+        self::assertSame(0, $this->rowCount('entity_archive', 'original_entity_id = 11'));
+        self::assertSame(1, $this->rowCount('entities', 'id = 11'), 'A live entity was purged.');
+    }
+
+    public function testAnotherOrganizationsSoftDeletedEntityIsUntouched(): void
+    {
+        $this->seedEntityType(1, self::ORG, 'note');
+        $this->seedEntityType(2, self::OTHER_ORG, 'note');
+        $this->seedSoftDeletedEntity(20, self::OTHER_ORG, 2, 'theirs');
+
+        $this->repository->archiveAndPurgeSoftDeleted(new EntityType(name: 'Note', slug: 'note', id: 1));
+
+        self::assertSame(0, $this->rowCount('entity_archive', '1 = 1'), 'Another org\'s entity was archived.');
+        self::assertSame(1, $this->rowCount('entities', 'id = 20'), 'Another org\'s entity was purged.');
+    }
+
+    public function testNothingHappensWhenThereIsNoSoftDeletedEntity(): void
+    {
+        $this->seedEntityType(1, self::ORG, 'note');
+
+        $this->repository->archiveAndPurgeSoftDeleted(new EntityType(name: 'Note', slug: 'note', id: 1));
+
+        self::assertSame(0, $this->rowCount('entity_archive', '1 = 1'));
+    }
+
+    private function seedEntityType(int $id, int $org, string $slug): void
+    {
+        $this->executor->execute(
+            'INSERT INTO entity_types (id, organization_id, slug, name) VALUES (?, ?, ?, ?)',
+            [$id, $org, $slug, ucfirst($slug)],
+        );
+    }
+
+    private function seedSoftDeletedEntity(int $id, int $org, int $typeId, string $slug): void
+    {
+        $this->executor->execute(
+            "INSERT INTO entities (id, organization_id, entity_type_id, slug, status, is_deleted, deleted_at)
+             VALUES (?, ?, ?, ?, 'draft', 1, '2026-01-02 00:00:00')",
+            [$id, $org, $typeId, $slug],
+        );
+    }
+
+    private function rowCount(string $table, string $where): int
+    {
+        $row = $this->executor->fetchOne("SELECT COUNT(*) AS cnt FROM {$table} WHERE {$where}");
+
+        return (int) ($row['cnt'] ?? 0);
+    }
+}

--- a/tests/Organization/SchemaFixtures.php
+++ b/tests/Organization/SchemaFixtures.php
@@ -8,24 +8,22 @@ namespace NeNeRecords\Tests\Organization;
  * Locates and loads the schema snapshots under `database/schema/`.
  *
  * The snapshots are the documented mirror of the migrations' end state
- * (`docs/development/backend-standards.md`), and all but two are already SQLite-parsable.
- * The two exceptions are handled here rather than by hand-writing replacement tables, so
- * a column added to a snapshot still reaches the tests that build from it:
+ * (`docs/development/backend-standards.md`), and **every one of them runs on SQLite**, so the
+ * tests build from the shipped shape rather than from hand-written replacement tables — a
+ * column added to a snapshot reaches them automatically.
  *
- * - `users.sql` declares `status ENUM('active', 'invited')`. SQLite has no ENUM, so it is
- *   rewritten to a VARCHAR of equivalent width — the tests never assert on the constraint.
- * - `entity_archive.sql` is full MySQL DDL (`INT UNSIGNED … AUTO_INCREMENT`, `ENGINE=InnoDB`)
- *   and is skipped outright. No migration creates that table, so it is absent from real
- *   databases as well (see OrganizationScopedSchema).
+ * One dialect gap is bridged here: `users.sql` declares `status ENUM('active', 'invited')` and
+ * SQLite has no ENUM, so it is rewritten to a VARCHAR of equivalent width. No test asserts on
+ * that constraint.
+ *
+ * (`entity_archive.sql` used to be skipped as unexecutable MySQL DDL — it was the one snapshot
+ * no migration backed, and its absence from real databases was the #1017 bug. The migration
+ * now exists and the snapshot was rewritten in the same dialect as the rest.)
  */
 final class SchemaFixtures
 {
-    /** Snapshots that cannot be executed on SQLite at all. */
-    private const NOT_EXECUTABLE = ['entity_archive.sql'];
-
     /**
-     * Every snapshot file, including the ones that cannot be executed — callers that read
-     * the DDL as text (coverage checks) still need to see them.
+     * Every snapshot file.
      *
      * @return list<string> absolute paths, sorted
      */
@@ -38,7 +36,7 @@ final class SchemaFixtures
     }
 
     /**
-     * Every executable DDL statement across the snapshots, ready to run one by one.
+     * Every DDL statement across the snapshots, ready to run one by one.
      *
      * @return list<string>
      */
@@ -47,10 +45,6 @@ final class SchemaFixtures
         $statements = [];
 
         foreach (self::files() as $path) {
-            if (in_array(basename($path), self::NOT_EXECUTABLE, true)) {
-                continue;
-            }
-
             $raw = trim((string) file_get_contents($path));
             $raw = (string) preg_replace('/\bENUM\s*\([^)]*\)/i', 'VARCHAR(32)', $raw);
 


### PR DESCRIPTION
## 目的

**`entity_archive` を作る migration が1本も存在せず、実データベースにこのテーブルが無かった。** 論理削除済み entity を持つ entity type を削除すると 500 になる。

`PdoEntityArchiveRepository::archiveAndPurgeSoftDeleted()` はこのテーブルへ INSERT するが、定義は `database/schema/entity_archive.sql`（テストスナップショット）にしか無く、installer は **migration を正としてスキーマを作る**（`public_html/install/index.php:757` — 「スキーマの正は migration（手書き dump は作らない）」）。したがって **records 本番・ayane Tier A・fresh install のいずれにも実在しない**。

## 再現確認の結果（#1017 のコメントに詳細）

| 論点 | 実測 |
| --- | --- |
| 経路は生きているか | ✅ `DELETE /api/v1/entity-types/{id}` あり・管理画面の mutation も同エンドポイントを叩く |
| 到達すると何が起きるか | `DatabaseConnectionException` → `ErrorHandlerMiddleware` の `catch (Throwable)` で **500** |
| データ破壊は起きるか | ❌ **起きない**。INSERT は全ての DELETE より前なので、途中まで消えた状態にならない |
| 発火条件 | 「アクティブ entity 0件」かつ「論理削除済み entity ≥1件」の entity type を削除したとき |
| 本番に該当データはあるか | 現時点で **0件**（罠は仕掛かっているが、まだ踏める位置に誰もいない） |

## 変更内容

### 1. migration を追加（`20260728000000_create_entity_archive_table.php`）

**`organization_id` を最初から持たせた。** 旧スナップショットは持っておらず、そのまま作ると **org 削除でこのテーブルだけ孤児化する**（#1002 とまったく同じ形）。

### 2. スナップショットを実スキーマへ同期

`organization_id` と org インデックスを追加し、あわせて**他の29本と同じ SQLite 方言に書き直した**。`entity_archive.sql` は `INT UNSIGNED … AUTO_INCREMENT` / `ENGINE=InnoDB` の MySQL DDL で書かれた唯一のスナップショットで、テストから実行できなかった（＝実行されないから誰も気づかなかった）。

### 3. `PdoEntityArchiveRepository` の INSERT に `organization_id` を追加

### 4. `OrganizationScopedSchema::ORG_SCOPED_TABLES` に `entity_archive` を追加

`organization_id` を持つ以上、org 削除の purge 対象。**#1002 で入れたカバレッジテストが、リストに入れ忘れたら落ちる**ようになっている。

### 5. `SchemaFixtures` から除外機構を削除

全スナップショットが実行可能になったので、`NOT_EXECUTABLE` を廃止。

## なぜテストで捕まらなかったか

**`archiveAndPurgeSoftDeleted()` に到達するテストは全て `InMemoryEntityArchiveRepository` を通っており、実 SQL を1度も実行していなかった。** コードは正しく、テストは緑で、テーブルだけが存在しなかった。

→ 実スキーマに当てる **`PdoEntityArchiveRepositoryTest`** を新設した（アーカイブされること・パージされること・`organization_id` が入ること・アクティブな entity は残ること・他 org は無傷・論理削除ゼロ件なら何もしないこと）。

## 検証

```
composer check   → 全緑（PHPUnit 1499 tests・PHPStan level 8・CS-Fixer・OpenAPI・MCP）
```

### 実 MySQL への適用（CI は MySQL を立てないので手動）

ローカルに MySQL を起動し、**まっさらな DB へ全 migration を適用**した（dev DB には触れていない・検証用 DB は削除済み）:

```
== 20260724000001 AddAnalyticsVisitorTrackingSetting: migrated 0.0034s
== 20260728000000 CreateEntityArchiveTable: migrated 0.0274s
All Done. Took 3.9511s
```

生成された列がスナップショットと一致することも確認:

```
id int unsigned NO -                      organization_id int unsigned NO 0
original_entity_id int unsigned NO -      entity_type_id int unsigned NO -
entity_type_slug varchar(255) NO -        entity_type_name varchar(255) NO -
entity_slug varchar(255) YES -            entity_status varchar(16) NO -
deleted_at datetime YES -                 archived_at datetime NO -
archived_reason varchar(64) NO entity_type_deleted
snapshot json NO -
index: idx_entity_archive_org / idx_entity_archive_entity_type_id / idx_entity_archive_original_entity_id / PRIMARY
```

version は `20260728000000` で既存の最大 `20260724000001` より後。依存する `entities` / `entity_types` はずっと古いので順序の逆転なし。

### 破壊実験（テストの非空虚性）

`database/schema/entity_archive.sql` を一時的に外して実行 → **本番と同じ `no such table: entity_archive` で4テストとも落ちる**ことを確認。戻して 4 tests / 13 assertions 緑。

## デプロイ時の注意

**このリリースは migration を含む。** records 本番は現在 migration 2本遅れ（84/86・Path B 分が未適用）なので、次回デプロイでは**コードと migration を必ず揃えて上げる**こと。

## チェックリスト

- [x] `composer check` 緑
- [x] 実 MySQL の fresh DB で migration 適用を確認
- [x] スナップショットと実スキーマの一致を確認
- [x] 破壊実験でテストの実効性を確認
- [x] 本番データには触れていない

Closes #1017
