### PR TITLE
fix(public): 公開HTMLルートが HEAD で壊れるのを直す（#1021）

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -62,4 +62,6 @@ $response = $kernel->handle($request);
 
 $emitter = $container->get(ResponseEmitter::class);
 assert($emitter instanceof ResponseEmitter);
-$emitter->emit($response);
+// Pass the method so the emitter can drop the body on HEAD (RFC 9110 §9.3.2) while
+// keeping the headers. Omitting it made every HEAD response carry a full GET body (#1021).
+$emitter->emit($response, $request->getMethod());

--- a/src/Http/CustomPermalinkResolver.php
+++ b/src/Http/CustomPermalinkResolver.php
@@ -36,7 +36,7 @@ final readonly class CustomPermalinkResolver
             return $response;
         }
 
-        if (strtoupper($request->getMethod()) !== 'GET') {
+        if (!PublicPageMethod::reads($request)) {
             return $response;
         }
 

--- a/src/Http/PublicPageMethod.php
+++ b/src/Http/PublicPageMethod.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Http;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Does this request method ask for a public page's representation? (#1021)
+ *
+ * `GET` and `HEAD` do. RFC 9110 §9.3.2: HEAD is identical to GET except that the
+ * server MUST NOT send a body — the *headers* (status, Content-Type, everything
+ * else) are the same. So every edge layer that builds a public page has to run
+ * for HEAD too; only the body is dropped, and that happens at the emitter.
+ *
+ * This exists because the same `!== 'GET'` guard was written independently in five
+ * places ({@see CustomPermalinkResolver}, {@see SpaShellFallback},
+ * {@see \NeNeRecords\PublicRecord\RenderPublicHomeHandler},
+ * {@see \NeNeRecords\PublicRecord\RenderPublicTypeArchiveHandler},
+ * {@see \NeNeRecords\UrlRedirect\UrlRedirectResolver}). Every one of them skipped
+ * HEAD, so the whole public site answered HEAD wrongly: real pages 404'd, and the
+ * site root fell through to the framework's API index — a **200 with
+ * `application/json`** plus the API rate-limit headers, which is worse than a 404
+ * because monitoring stays quiet while framework details leak. The app-level 301
+ * redirect map was skipped too, so external backlink checkers saw 404 where a
+ * browser sees a redirect.
+ *
+ * Keep the predicate in one place: five copies meant fixing one still left four.
+ */
+final class PublicPageMethod
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * True for the representation-reading methods (`GET` / `HEAD`).
+     */
+    public static function reads(ServerRequestInterface $request): bool
+    {
+        $method = strtoupper($request->getMethod());
+
+        return $method === 'GET' || $method === 'HEAD';
+    }
+}

--- a/src/Http/SpaShellFallback.php
+++ b/src/Http/SpaShellFallback.php
@@ -53,7 +53,8 @@ final readonly class SpaShellFallback
 
     public function apply(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
-        $isGet = strtoupper($request->getMethod()) === 'GET';
+        // GET and HEAD both ask for the page's representation (#1021); only the body differs.
+        $isRead = PublicPageMethod::reads($request);
         $wantsHtml = str_contains($request->getHeaderLine('Accept'), 'text/html');
         $path = $request->getUri()->getPath();
 
@@ -66,14 +67,14 @@ final readonly class SpaShellFallback
         // www→apex 301 from WwwRedirectMiddleware, #834) is a deliberate answer and
         // must never be swallowed by the shell.
         $alreadyHtml = str_contains($response->getHeaderLine('Content-Type'), 'text/html');
-        $isHtmlHome = $isGet && $wantsHtml && $path === '/' && !$alreadyHtml
+        $isHtmlHome = $isRead && $wantsHtml && $path === '/' && !$alreadyHtml
             && $response->getStatusCode() === 200;
 
         if ($response->getStatusCode() !== 404 && !$isHtmlHome) {
             return $response;
         }
 
-        if (!$isGet) {
+        if (!$isRead) {
             return $response;
         }
 

--- a/src/PublicRecord/RenderPublicHomeHandler.php
+++ b/src/PublicRecord/RenderPublicHomeHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\PublicRecord;
 
 use NeNeRecords\Http\AcceptPrefersHtml;
+use NeNeRecords\Http\PublicPageMethod;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -33,8 +34,8 @@ final readonly class RenderPublicHomeHandler
 
     public function apply(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
-        // Only a browser navigation to the exact site root is a candidate.
-        if (strtoupper($request->getMethod()) !== 'GET' || $request->getUri()->getPath() !== '/') {
+        // Only a representation read (GET/HEAD, #1021) of the exact site root is a candidate.
+        if (!PublicPageMethod::reads($request) || $request->getUri()->getPath() !== '/') {
             return $response;
         }
 

--- a/src/PublicRecord/RenderPublicTypeArchiveHandler.php
+++ b/src/PublicRecord/RenderPublicTypeArchiveHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\PublicRecord;
 
 use NeNeRecords\Http\AcceptPrefersHtml;
+use NeNeRecords\Http\PublicPageMethod;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -37,7 +38,7 @@ final readonly class RenderPublicTypeArchiveHandler
 
     public function apply(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
-        if ($response->getStatusCode() !== 404 || strtoupper($request->getMethod()) !== 'GET') {
+        if ($response->getStatusCode() !== 404 || !PublicPageMethod::reads($request)) {
             return $response;
         }
 

--- a/src/UrlRedirect/UrlRedirectResolver.php
+++ b/src/UrlRedirect/UrlRedirectResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\UrlRedirect;
 
+use NeNeRecords\Http\PublicPageMethod;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -35,7 +36,7 @@ final readonly class UrlRedirectResolver
             return $response;
         }
 
-        if (strtoupper($request->getMethod()) !== 'GET') {
+        if (!PublicPageMethod::reads($request)) {
             return $response;
         }
 

--- a/tests/Http/SingleOriginKernelTest.php
+++ b/tests/Http/SingleOriginKernelTest.php
@@ -481,6 +481,104 @@ final class SingleOriginKernelTest extends TestCase
         self::assertSame('posts', $response->getHeaderLine('X-Test-Archive'));
     }
 
+    // ── HEAD parity (#1021) ──────────────────────────────────────────────────
+    //
+    // Every edge layer used to guard on `!== 'GET'`, so HEAD skipped all five: real
+    // pages 404'd, `/` fell through to the framework's JSON API index (a 200, which
+    // is worse than a 404 — monitoring stays quiet while framework details leak), and
+    // the app-level 301 map never ran, so backlink checkers saw 404 where a browser
+    // sees a redirect.
+    //
+    // One test per layer on purpose: reverting any single guard to GET-only must fail
+    // something here. A combined test would let four regressions hide behind one.
+
+    /** The 301 map is the highest-impact layer: external backlink checkers use HEAD. */
+    public function testHeadFollowsTheRedirectMapJustLikeGet(): void
+    {
+        $this->redirects->save('/2024/01/hello-world', '/posts/1');
+
+        $request = $this->factory
+            ->createServerRequest('HEAD', 'https://site.test/2024/01/hello-world')
+            ->withHeader('Accept', 'text/html');
+
+        $response = $this->kernel($this->appReturning(404))->handle($request);
+
+        self::assertSame(301, $response->getStatusCode());
+        self::assertSame('/posts/1', $response->getHeaderLine('Location'));
+    }
+
+    public function testHeadResolvesCustomPermalinks(): void
+    {
+        $response = $this->kernel($this->appReturning(404), $this->permalinkResolverTagging())->handle(
+            $this->factory->createServerRequest('HEAD', 'https://site.test/company/about/team')
+                ->withHeader('Accept', 'text/html'),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('hit', $response->getHeaderLine('X-Test-Permalink'));
+    }
+
+    public function testHeadRendersTheTypeArchive(): void
+    {
+        $archive = $this->typeArchive(
+            [new EntityType(name: 'Posts', slug: 'posts', id: 2)],
+            [new Entity(id: 5, entityTypeId: 2, slug: 'hello', status: EntityStatus::Published)],
+        );
+
+        $response = $this->kernel($this->appReturning(404), null, null, $archive)->handle(
+            $this->factory->createServerRequest('HEAD', 'https://site.test/posts')
+                ->withHeader('Accept', 'text/html'),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('posts', $response->getHeaderLine('X-Test-Archive'));
+    }
+
+    /**
+     * The regression that hid the longest: `HEAD /` answered 200 with the framework's
+     * JSON index, so it looked healthy while serving the wrong thing entirely.
+     */
+    public function testHeadAtRootRendersTheFrontPageAndNotTheFrameworkJson(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('HEAD', 'https://site.test/')
+            ->withHeader('Accept', 'text/html');
+
+        $response = $this->kernel($this->appReturning(200), null, $this->frontPage(true))->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('1', $response->getHeaderLine('X-Front-Page'));
+    }
+
+    public function testHeadFallsBackToTheSpaShell(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('HEAD', 'https://site.test/admin/dashboard')
+            ->withHeader('Accept', 'text/html');
+
+        $response = $this->kernel($this->appReturning(404))->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
+    }
+
+    /**
+     * HEAD widens *which methods* reach the layers — not *what* they answer. A method
+     * that neither reads nor is routed (POST to an unknown path) must still 404.
+     */
+    public function testPostStillSkipsTheEdgeLayers(): void
+    {
+        $this->redirects->save('/2024/01/hello-world', '/posts/1');
+
+        $request = $this->factory
+            ->createServerRequest('POST', 'https://site.test/2024/01/hello-world')
+            ->withHeader('Accept', 'text/html');
+
+        $response = $this->kernel($this->appReturning(404))->handle($request);
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
     /** A permalink resolver that claims every 404 path, tagging the response. */
     private function permalinkResolverTagging(): CustomPermalinkResolver
     {


### PR DESCRIPTION
## 目的

公開HTMLルートが HEAD リクエストで壊れていた（#1021）。統合リナの外形観測を受けて再現確認し、原因を特定して直す。

## 症状（実測・2つの独立した本番環境）

| | ayane.co.jp（HETEML/Apache直） | aozora.nene-records.com（ConoHa/Caddy+Docker） |
|---|---|---|
| `/services` `/products` `/company` `/trust` `/shop` `/blog` | GET=200 / **HEAD=404** | — |
| `/work` | — | GET=200 / **HEAD=404** |

ホスティング構成に依存しない＝製品側の問題。

🔴 **`/` の HEAD=200 は「通っている」のではない**（当初の観測への訂正）:

```
GET  / → 200 text/html; charset=utf-8        （公開トップページ）
HEAD / → 200 application/json; charset=utf-8 ＋ x-ratelimit-* （フレームワークの API インデックス）
```

`x-ratelimit-*` が付くこと自体が「SSR ハンドラに入らず API 面に落ちている」証拠。
**404 より悪い**——200 なので死活監視が鳴らず、フレームワーク情報が匿名で取得できる。

## 原因

公開ページを組み立てる**5つのエッジ層が、それぞれ独立に**同じ GET-only ガードを持っていた:

| 箇所 | 効果 |
|---|---|
| `Http/CustomPermalinkResolver.php:39` | 任意 permalink（`/services` 等）が解決されない |
| `PublicRecord/RenderPublicTypeArchiveHandler.php:40` | 型アーカイブ（`/work` 等）が出ない |
| `PublicRecord/RenderPublicHomeHandler.php:37` | front page SSR が出ない → framework JSON が漏れる |
| `Http/SpaShellFallback.php:56` | SPA シェルのフォールバックも効かない |
| `UrlRedirect/UrlRedirectResolver.php:38` | 🔴 **アプリ層の 301 マップも HEAD に効かない** |

最後のが実害としては最も具体的で、旧WP URL の 301 が HEAD だと 404 になるため
**外部の被リンク健全性チェックが 404 を報告する**（SEO と信用に直接効く）。

## 変更

1. **`PublicPageMethod::reads()` を新設**し、5箇所の重複判定をこれ1つへ寄せた。
   同じ判定が5つに分かれていたのが構造的原因で、**1箇所直すと4つ残る**。
2. **`public_html/index.php` が `ResponseEmitter` に method を渡すようにした。**
   NENE2 の emitter は HEAD で本文を落とす実装を**持っていた**のに、
   フロントコントローラが渡していなかったので効いていなかった
   （ヘッダは GET と同一・本文だけ落ちる＝RFC 9110 §9.3.2）。
   ＝hub 指摘の「本文を出さない責務は誰が持つか」は**実測の結果、emitter が持っていた・配線漏れ**が答え。
3. **`SingleOriginKernelTest` に層ごとに1本ずつ HEAD テストを追加。**
   まとめて1本にしないのは、**5つのうち4つの退行が1本の裏に隠れない**ようにするため。
   POST が従来どおり 404 のままであることも pin した（広げたのは「どのメソッドが層に届くか」であって
   「何を返すか」ではない）。

## 検証

🔴 **5箇所を1つずつ GET-only に戻し、そのたびに落ちることを実測**（hub 指定の受入方法）:

```
① CustomPermalinkResolver        -> 🟢 FAIL
② UrlRedirectResolver            -> 🟢 FAIL
③ RenderPublicHomeHandler        -> 🟢 FAIL
④ RenderPublicTypeArchiveHandler -> 🟢 FAIL
⑤ SpaShellFallback               -> 🟢 FAIL
復元 -> OK (26 tests, 71 assertions)
```

- `composer check` **全緑**: 1501 tests / 4557 assertions・PHPStan level 8 エラー0・CS-Fixer clean・
  OpenAPI valid・conformance OK・MCP valid

**測っていないこと（正直に）**: ローカル docker スタックでの外形 before/after は
**opcache に阻まれて無効**だった（stash 後も旧コードが動き、before/after が同一に見えた）。
外形の証拠は本番2系統の実測と、テストハーネス上の破壊実験で担保している。
実サーバでの最終確認は**デプロイ後の HEAD 実打**で行う（未実施）。

## 副産物（別 issue に分離）

認可側に同型の書き漏れを発見 → **#1023**（`CapabilityResolver` が `/api/v1/users` の読みを
`GET` にしか要求せず HEAD が認可段を素通りする）。匿名では届かない（`ADMIN_ONLY_PREFIXES` で
全メソッド認証必須）が、認証済み低権限ユーザに対して存在・規模のオラクルになる。
スコープが違うので本 PR には含めていない。

## チェックリスト

- [x] Issue 駆動（#1021）
- [x] `main` へ直接コミットしていない
- [x] `composer check` 全緑
- [x] 受入条件を実測で確認（破壊実験まで）
- [x] 本番反映は施主 GO seam（このPRはコードのみ・migration なし）

Closes #1021