### PR TITLE
feat(public-seo): 公開ページの種別を entity type 単位で選べるようにする（#1020）

### DIFF
--- a/database/migrations/20260729000000_add_seo_page_kind_to_entity_types.php
+++ b/database/migrations/20260729000000_add_seo_page_kind_to_entity_types.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Per-entity-type SEO page kind — `webpage` or `article` (#1020).
+ *
+ * Until now the public SSR typed every record that was not the pinned front page as
+ * `og:type=article` + JSON-LD `BlogPosting`, so contact pages and company profiles
+ * claimed to be dated articles (and carried a `datePublished` they do not have).
+ *
+ * **This migration deliberately changes nothing about the rendered output.** The
+ * column default is `webpage` — that is the default for *newly created* types, where
+ * the safer mistake is to under-claim rather than to assert a publication date that
+ * does not exist. But every **existing** row is backfilled to `article`, which is
+ * exactly what the code did before, so `migrate` is output-neutral on every install.
+ *
+ * Why not infer the right value from the slug (`pages` → webpage, `posts` → article)?
+ * Two reasons. It would silently rewrite live structured data as a side effect of
+ * deploying — including aozora's 1,114 `work` records, whose correct schema.org type
+ * is explicitly *undecided* (#1022 tracks whether `Book`/`CreativeWork` fits better);
+ * baking `article` in here would turn that open question into an accomplished fact.
+ * And it would encode "a slug's name implies its meaning" into a migration, which
+ * cannot be validated against data that does not exist yet: an org running a blog
+ * under the slug `pages` would break, and nobody would know when. Migrations should
+ * be mechanical — an inference baked into one is unfalsifiable by construction.
+ *
+ * So the correct value is chosen per type in the admin UI, where the change is
+ * visible, reversible, and attributable. Production has 17 types in total.
+ */
+final class AddSeoPageKindToEntityTypes extends AbstractMigration
+{
+    public function up(): void
+    {
+        $this->table('entity_types')
+            ->addColumn('seo_page_kind', 'string', [
+                'limit' => 16,
+                'null' => false,
+                'default' => 'webpage',
+            ])
+            ->update();
+
+        // Preserve current behaviour for everything that already exists: before this
+        // column, every non-front-page record rendered as an article.
+        $this->execute("UPDATE entity_types SET seo_page_kind = 'article'");
+    }
+
+    public function down(): void
+    {
+        $this->table('entity_types')->removeColumn('seo_page_kind')->update();
+    }
+}

--- a/database/schema/entity_types.sql
+++ b/database/schema/entity_types.sql
@@ -5,6 +5,7 @@ CREATE TABLE entity_types (
     slug VARCHAR(255) NOT NULL,
     is_pinned BOOLEAN NOT NULL DEFAULT 0,
     default_layout VARCHAR(32) NOT NULL DEFAULT 'standard',
+    seo_page_kind VARCHAR(16) NOT NULL DEFAULT 'webpage',
     display_order INTEGER NOT NULL DEFAULT 0,
     labels TEXT NULL DEFAULT NULL,
     permalink_pattern VARCHAR(255) NULL DEFAULT NULL,

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -5173,6 +5173,10 @@ components:
           type: string
           enum: [standard, full, two-col, three-col, bare, custom]
           description: 'Default public-page layout (scaffold preset) for records of this type. Overridable per entity.'
+        seo_page_kind:
+          type: string
+          enum: [webpage, article]
+          description: 'How records of this type present themselves to crawlers. `webpage` = a standing page (og:type=website, JSON-LD WebPage, no publication dates). `article` = a dated entry (og:type=article, JSON-LD BlogPosting, dates included). New types default to `webpage`.'
     CreateEntityTypeRequest:
       type: object
       required:
@@ -5214,6 +5218,10 @@ components:
           type: string
           enum: [standard, full, two-col, three-col, bare, custom]
           description: 'Default public-page layout for records of this type. Defaults to standard.'
+        seo_page_kind:
+          type: string
+          enum: [webpage, article]
+          description: 'Crawler-facing page kind. Omitted = `webpage` (a standing page). Use `article` for types whose records are dated entries; only then are datePublished/dateModified emitted.'
       additionalProperties: false
     ReorderEntityTypesRequest:
       type: object

--- a/frontend/src/entities/entity-type/api-types.ts
+++ b/frontend/src/entities/entity-type/api-types.ts
@@ -1,5 +1,12 @@
 import type { PublicLayoutKey } from '@/shared/lib/resolve-layout'
 
+/**
+ * How a type's records present themselves to crawlers.
+ * `webpage` = standing page (og:type=website, JSON-LD WebPage, no dates).
+ * `article` = dated entry (og:type=article, JSON-LD BlogPosting, dates included).
+ */
+export type SeoPageKind = 'webpage' | 'article'
+
 export interface EntityTypeDto {
   id: number
   name: string
@@ -7,6 +14,8 @@ export interface EntityTypeDto {
   is_pinned: boolean
   /** Default public-page layout for records of this type. May be absent on older payloads. */
   default_layout?: PublicLayoutKey
+  /** Crawler-facing page kind. May be absent on older payloads. */
+  seo_page_kind?: SeoPageKind
   /** Sidebar / pinned ordering (ascending). May be absent on older payloads. */
   display_order?: number
   /** Locale-keyed display names, e.g. {"ja":"投稿","fr":"Articles"}. Empty object = no overrides. */
@@ -40,4 +49,5 @@ export interface UpdateEntityTypeDto {
   labels?: Record<string, string>
   permalink_pattern?: string | null
   default_layout?: PublicLayoutKey
+  seo_page_kind?: SeoPageKind
 }

--- a/frontend/src/entities/entity-type/mapper.test.ts
+++ b/frontend/src/entities/entity-type/mapper.test.ts
@@ -18,6 +18,10 @@ describe('entity-type mapper', () => {
       slug: 'article',
       isPinned: true,
       defaultLayout: 'standard',
+      // A payload without the field comes from a server that predates it, where every
+      // record rendered as an article — so that, not the new default, is the honest
+      // reading of an absent value.
+      seoPageKind: 'article',
       displayOrder: 3,
       permalinkPattern: null,
       previousPermalinkPattern: null,
@@ -27,6 +31,17 @@ describe('entity-type mapper', () => {
   it('defaults displayOrder to 0 when absent', () => {
     const model = mapEntityTypeDtoToModel({ id: 9, name: 'X', slug: 'x', is_pinned: false })
     expect(model.displayOrder).toBe(0)
+  })
+
+  it('keeps the page kind the server sent', () => {
+    const model = mapEntityTypeDtoToModel({
+      id: 9,
+      name: 'Pages',
+      slug: 'pages',
+      is_pinned: false,
+      seo_page_kind: 'webpage',
+    })
+    expect(model.seoPageKind).toBe('webpage')
   })
 
   it('maps list dto to model', () => {

--- a/frontend/src/entities/entity-type/mapper.ts
+++ b/frontend/src/entities/entity-type/mapper.ts
@@ -19,6 +19,9 @@ export function mapEntityTypeDtoToModel(dto: EntityTypeDto): EntityType {
     slug: dto.slug,
     isPinned: dto.is_pinned,
     defaultLayout: dto.default_layout ?? 'standard',
+    // Older payloads predate the field; 'article' is what the server rendered before it
+    // existed, so that is the honest fallback for data written by an older version.
+    seoPageKind: dto.seo_page_kind ?? 'article',
     displayOrder: dto.display_order ?? 0,
     ...(dto.labels && Object.keys(dto.labels).length > 0 ? { labels: dto.labels } : {}),
     permalinkPattern: dto.permalink_pattern ?? null,
@@ -50,5 +53,6 @@ export function mapUpdateInputToDto(input: UpdateEntityTypeInput): UpdateEntityT
     ...(input.labels !== undefined ? { labels: input.labels } : {}),
     ...(input.permalinkPattern !== undefined ? { permalink_pattern: input.permalinkPattern } : {}),
     ...(input.defaultLayout !== undefined ? { default_layout: input.defaultLayout } : {}),
+    ...(input.seoPageKind !== undefined ? { seo_page_kind: input.seoPageKind } : {}),
   }
 }

--- a/frontend/src/entities/entity-type/model.ts
+++ b/frontend/src/entities/entity-type/model.ts
@@ -1,3 +1,4 @@
+import type { SeoPageKind } from './api-types'
 import type { PublicLayoutKey } from '@/shared/lib/resolve-layout'
 import type { EntityTypeId } from './ids'
 
@@ -8,6 +9,11 @@ export interface EntityType {
   isPinned: boolean
   /** Default public-page layout for records of this type. Overridable per entity. */
   defaultLayout: PublicLayoutKey
+  /**
+   * How this type's records present themselves to crawlers. A standing page must not
+   * claim a publication date it does not have, so new types default to 'webpage'.
+   */
+  seoPageKind: SeoPageKind
   /** Sidebar / pinned ordering (ascending). Lower appears first. */
   displayOrder: number
   /** Locale-keyed display names. Empty object / undefined = no overrides. */
@@ -41,4 +47,5 @@ export interface UpdateEntityTypeInput {
   labels?: Record<string, string>
   permalinkPattern?: string | null
   defaultLayout?: PublicLayoutKey
+  seoPageKind?: SeoPageKind
 }

--- a/frontend/src/features/manage-entity-types/hooks/use-create-entity-type-form.ts
+++ b/frontend/src/features/manage-entity-types/hooks/use-create-entity-type-form.ts
@@ -35,6 +35,11 @@ export const editEntityTypeFormSchema = createEntityTypeFormSchema.extend({
   defaultLayout: z
     .enum(['standard', 'full', 'two-col', 'three-col', 'bare', 'custom'])
     .default('standard'),
+  /**
+   * How this type's records present themselves to crawlers. Defaults to a standing
+   * page: claiming a publication date a page does not have is the worse error.
+   */
+  seoPageKind: z.enum(['webpage', 'article']).default('webpage'),
 })
 
 export type EditEntityTypeFormValues = z.infer<typeof editEntityTypeFormSchema>

--- a/frontend/src/features/manage-entity-types/ui/EntityTypeEditForm.tsx
+++ b/frontend/src/features/manage-entity-types/ui/EntityTypeEditForm.tsx
@@ -182,6 +182,7 @@ export function EntityTypeEditForm({
     // null/undefined → store null; will default to DEFAULT_PERMALINK_PATTERN in the UI
     permalinkPattern: entityType.permalinkPattern ?? null,
     defaultLayout: entityType.defaultLayout,
+    seoPageKind: entityType.seoPageKind,
   })
 
   return (
@@ -286,6 +287,28 @@ export function EntityTypeEditForm({
               <option value="bare">{t('admin.layout.bare')}</option>
               <option value="custom">{t('admin.layout.custom')}</option>
             </Select>
+          )}
+        />
+
+        {/* ── Crawler-facing page kind (#1020) ── */}
+        <Controller
+          name="seoPageKind"
+          control={control}
+          render={({ field }) => (
+            <div className="space-y-1">
+              <Select
+                id="entity-type-edit-seo-page-kind"
+                label={t('admin.entityTypes.seoPageKind.label')}
+                disabled={isSubmitting}
+                value={field.value}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+              >
+                <option value="webpage">{t('admin.entityTypes.seoPageKind.webpage')}</option>
+                <option value="article">{t('admin.entityTypes.seoPageKind.article')}</option>
+              </Select>
+              <p className="text-xs text-text-muted">{t('admin.entityTypes.seoPageKind.hint')}</p>
+            </div>
           )}
         />
 

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -2110,6 +2110,11 @@ export interface components {
              * @enum {string}
              */
             default_layout?: "standard" | "full" | "two-col" | "three-col" | "bare" | "custom";
+            /**
+             * @description How records of this type present themselves to crawlers. `webpage` = a standing page (og:type=website, JSON-LD WebPage, no publication dates). `article` = a dated entry (og:type=article, JSON-LD BlogPosting, dates included). New types default to `webpage`.
+             * @enum {string}
+             */
+            seo_page_kind?: "webpage" | "article";
         };
         CreateEntityTypeRequest: {
             name: string;
@@ -2130,6 +2135,11 @@ export interface components {
              * @enum {string}
              */
             default_layout?: "standard" | "full" | "two-col" | "three-col" | "bare" | "custom";
+            /**
+             * @description Crawler-facing page kind. Omitted = `webpage` (a standing page). Use `article` for types whose records are dated entries; only then are datePublished/dateModified emitted.
+             * @enum {string}
+             */
+            seo_page_kind?: "webpage" | "article";
         };
         ReorderEntityTypesRequest: {
             /** @description Entity type ids in the desired display order (ascending). */

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -699,6 +699,11 @@ export const de = {
   'admin.entityTypes.starter.customPage':
     'Individuelle Seite (Titel + isoliertes Bundle, eigenes Layout)',
   'admin.entityTypes.editForm.title': 'Inhaltstyp bearbeiten',
+  'admin.entityTypes.seoPageKind.label': 'Seitenart für Suchmaschinen',
+  'admin.entityTypes.seoPageKind.hint':
+    'Eine ständige Seite darf kein Veröffentlichungsdatum behaupten, das sie nicht hat. Wählen Sie „Datierter Eintrag“ nur für Typen, deren Datensätze wirklich zu einem Datum veröffentlicht werden.',
+  'admin.entityTypes.seoPageKind.webpage': 'Ständige Seite (Über uns, Kontakt, Leistungen)',
+  'admin.entityTypes.seoPageKind.article': 'Datierter Eintrag (Blogbeitrag, Neuigkeit)',
   'admin.entityTypes.editForm.save': 'Änderungen speichern',
   'admin.entityTypes.editForm.saving': 'Wird gespeichert…',
   'admin.entityTypes.editForm.isPinned': 'In Seitenleiste anzeigen',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -707,6 +707,11 @@ export const en = {
   'admin.entityTypes.starter.richPage': 'Rich page (title + blocks body)',
   'admin.entityTypes.starter.customPage': 'Custom page (title + sandboxed bundle, custom layout)',
   'admin.entityTypes.editForm.title': 'Edit content type',
+  'admin.entityTypes.seoPageKind.label': 'Page kind for search engines',
+  'admin.entityTypes.seoPageKind.hint':
+    'A standing page must not claim a publication date it does not have. Choose “Dated entry” only for types whose records really are published on a date.',
+  'admin.entityTypes.seoPageKind.webpage': 'Standing page (about, contact, services)',
+  'admin.entityTypes.seoPageKind.article': 'Dated entry (blog post, news)',
   'admin.entityTypes.editForm.save': 'Save changes',
   'admin.entityTypes.editForm.saving': 'Saving…',
   'admin.entityTypes.editForm.isPinned': 'Show in sidebar',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -706,6 +706,11 @@ export const fr = {
   'admin.entityTypes.starter.customPage':
     'Page personnalisée (titre + bundle isolé, mise en page personnalisée)',
   'admin.entityTypes.editForm.title': 'Modifier le type de contenu',
+  'admin.entityTypes.seoPageKind.label': 'Type de page pour les moteurs de recherche',
+  'admin.entityTypes.seoPageKind.hint':
+    'Une page permanente ne doit pas annoncer une date de publication qu’elle n’a pas. Choisissez « Entrée datée » uniquement pour les types dont les enregistrements sont réellement publiés à une date.',
+  'admin.entityTypes.seoPageKind.webpage': 'Page permanente (à propos, contact, services)',
+  'admin.entityTypes.seoPageKind.article': 'Entrée datée (article de blog, actualité)',
   'admin.entityTypes.editForm.save': 'Enregistrer les modifications',
   'admin.entityTypes.editForm.saving': 'Enregistrement…',
   'admin.entityTypes.editForm.isPinned': 'Afficher dans la barre latérale',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -702,6 +702,11 @@ export const ja = {
   'admin.entityTypes.starter.customPage':
     'カスタムページ（タイトル＋サンドボックスbundle・custom レイアウト）',
   'admin.entityTypes.editForm.title': 'コンテンツタイプを編集',
+  'admin.entityTypes.seoPageKind.label': '検索エンジンから見たページの種類',
+  'admin.entityTypes.seoPageKind.hint':
+    '固定ページに、実際には存在しない公開日を書かせないための設定です。レコードが本当に日付を持って公開されるタイプにだけ「日付のある記事」を選んでください。',
+  'admin.entityTypes.seoPageKind.webpage': '固定ページ（会社案内・お問い合わせ・サービス）',
+  'admin.entityTypes.seoPageKind.article': '日付のある記事（ブログ・お知らせ）',
   'admin.entityTypes.editForm.save': '変更を保存',
   'admin.entityTypes.editForm.saving': '保存中…',
   'admin.entityTypes.editForm.isPinned': 'サイドバーに表示',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -703,6 +703,11 @@ export const ptBR = {
   'admin.entityTypes.starter.customPage':
     'Página personalizada (título + bundle isolado, layout personalizado)',
   'admin.entityTypes.editForm.title': 'Editar tipo de conteúdo',
+  'admin.entityTypes.seoPageKind.label': 'Tipo de página para mecanismos de busca',
+  'admin.entityTypes.seoPageKind.hint':
+    'Uma página permanente não deve declarar uma data de publicação que não tem. Escolha “Entrada datada” apenas para tipos cujos registros são realmente publicados em uma data.',
+  'admin.entityTypes.seoPageKind.webpage': 'Página permanente (sobre, contato, serviços)',
+  'admin.entityTypes.seoPageKind.article': 'Entrada datada (post de blog, notícia)',
   'admin.entityTypes.editForm.save': 'Salvar alterações',
   'admin.entityTypes.editForm.saving': 'Salvando…',
   'admin.entityTypes.editForm.isPinned': 'Mostrar na barra lateral',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -668,6 +668,11 @@ export const zhHans = {
   'admin.entityTypes.starter.richPage': '富页面（标题 + blocks 正文）',
   'admin.entityTypes.starter.customPage': '自定义页面（标题 + 沙盒 bundle，自定义布局）',
   'admin.entityTypes.editForm.title': '编辑内容类型',
+  'admin.entityTypes.seoPageKind.label': '搜索引擎眼中的页面类型',
+  'admin.entityTypes.seoPageKind.hint':
+    '固定页面不应声明并不存在的发布日期。仅当该类型的记录确实按日期发布时，才选择“带日期的条目”。',
+  'admin.entityTypes.seoPageKind.webpage': '固定页面（关于、联系、服务）',
+  'admin.entityTypes.seoPageKind.article': '带日期的条目（博客、新闻）',
   'admin.entityTypes.editForm.save': '保存更改',
   'admin.entityTypes.editForm.saving': '保存中…',
   'admin.entityTypes.editForm.isPinned': '在侧边栏显示',

--- a/frontend/tests/factories/entity-type.ts
+++ b/frontend/tests/factories/entity-type.ts
@@ -12,6 +12,7 @@ export function buildEntityType(overrides: Partial<EntityType> = {}): EntityType
     slug: 'article',
     isPinned: false,
     defaultLayout: 'standard',
+    seoPageKind: 'webpage',
     displayOrder: 0,
     ...overrides,
   }

--- a/src/EntityType/EntityType.php
+++ b/src/EntityType/EntityType.php
@@ -11,6 +11,11 @@ final readonly class EntityType
      * @param string|null                $permalinkPattern   URL pattern for public records.
      *                                                        Tokens: {type} {slug} {id} {year} {month} {day}
      *                                                        Null = use default "/{type}/{id}".
+     * @param SeoPageKind                $seoPageKind        How this type's records present
+     *                                                        themselves to crawlers (#1020).
+     *                                                        New types default to a standing page;
+     *                                                        see {@see SeoPageKind} for why that
+     *                                                        direction is the safer default.
      */
     public function __construct(
         public string $name,
@@ -22,6 +27,7 @@ final readonly class EntityType
         public ?string $previousPermalinkPattern = null,
         public int $displayOrder = 0,
         public string $defaultLayout = 'standard',
+        public SeoPageKind $seoPageKind = SeoPageKind::WebPage,
     ) {
     }
 }

--- a/src/EntityType/GetEntityTypeByIdHandler.php
+++ b/src/EntityType/GetEntityTypeByIdHandler.php
@@ -38,6 +38,7 @@ final readonly class GetEntityTypeByIdHandler
             'previous_permalink_pattern' => $output->previousPermalinkPattern,
             'display_order'              => $output->displayOrder,
             'default_layout'             => $output->defaultLayout,
+            'seo_page_kind'              => $output->seoPageKind->value,
         ]);
     }
 }

--- a/src/EntityType/GetEntityTypeByIdOutput.php
+++ b/src/EntityType/GetEntityTypeByIdOutput.php
@@ -19,6 +19,7 @@ final readonly class GetEntityTypeByIdOutput
         public ?string $previousPermalinkPattern = null,
         public int $displayOrder = 0,
         public string $defaultLayout = 'standard',
+        public SeoPageKind $seoPageKind = SeoPageKind::WebPage,
     ) {
     }
 }

--- a/src/EntityType/GetEntityTypeByIdUseCase.php
+++ b/src/EntityType/GetEntityTypeByIdUseCase.php
@@ -29,6 +29,7 @@ final readonly class GetEntityTypeByIdUseCase implements GetEntityTypeByIdUseCas
             previousPermalinkPattern: $entityType->previousPermalinkPattern,
             displayOrder: $entityType->displayOrder,
             defaultLayout: $entityType->defaultLayout,
+            seoPageKind: $entityType->seoPageKind,
         );
     }
 }

--- a/src/EntityType/ListEntityTypeItem.php
+++ b/src/EntityType/ListEntityTypeItem.php
@@ -19,6 +19,7 @@ final readonly class ListEntityTypeItem
         public ?string $previousPermalinkPattern = null,
         public int $displayOrder = 0,
         public string $defaultLayout = 'standard',
+        public SeoPageKind $seoPageKind = SeoPageKind::WebPage,
     ) {
     }
 }

--- a/src/EntityType/ListEntityTypesHandler.php
+++ b/src/EntityType/ListEntityTypesHandler.php
@@ -37,6 +37,7 @@ final readonly class ListEntityTypesHandler
                         'previous_permalink_pattern'  => $item->previousPermalinkPattern,
                         'display_order'               => $item->displayOrder,
                         'default_layout'              => $item->defaultLayout,
+                        'seo_page_kind'               => $item->seoPageKind->value,
                     ],
                     $output->items,
                 ),

--- a/src/EntityType/ListEntityTypesUseCase.php
+++ b/src/EntityType/ListEntityTypesUseCase.php
@@ -26,6 +26,7 @@ final readonly class ListEntityTypesUseCase implements ListEntityTypesUseCaseInt
                 previousPermalinkPattern: $entityType->previousPermalinkPattern,
                 displayOrder: $entityType->displayOrder,
                 defaultLayout: $entityType->defaultLayout,
+                seoPageKind: $entityType->seoPageKind,
             ),
             $rows,
         );

--- a/src/EntityType/PdoEntityTypeRepository.php
+++ b/src/EntityType/PdoEntityTypeRepository.php
@@ -21,7 +21,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function findById(int $id): ?EntityType
     {
         $row = $this->query->fetchOne(
-            'SELECT id, name, slug, is_pinned, labels, permalink_pattern, previous_permalink_pattern, display_order, default_layout FROM entity_types WHERE id = ? AND organization_id = ?',
+            'SELECT id, name, slug, is_pinned, labels, permalink_pattern, previous_permalink_pattern, display_order, default_layout, seo_page_kind FROM entity_types WHERE id = ? AND organization_id = ?',
             [$id, $this->orgId->get()],
         );
 
@@ -35,7 +35,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function findBySlug(string $slug): ?EntityType
     {
         $row = $this->query->fetchOne(
-            'SELECT id, name, slug, is_pinned, labels, permalink_pattern, previous_permalink_pattern, display_order, default_layout FROM entity_types WHERE slug = ? AND organization_id = ?',
+            'SELECT id, name, slug, is_pinned, labels, permalink_pattern, previous_permalink_pattern, display_order, default_layout, seo_page_kind FROM entity_types WHERE slug = ? AND organization_id = ?',
             [$slug, $this->orgId->get()],
         );
 
@@ -50,7 +50,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function findAll(int $limit, int $offset): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT id, name, slug, is_pinned, labels, permalink_pattern, previous_permalink_pattern, display_order, default_layout FROM entity_types WHERE organization_id = ? ORDER BY display_order ASC, id ASC LIMIT ? OFFSET ?',
+            'SELECT id, name, slug, is_pinned, labels, permalink_pattern, previous_permalink_pattern, display_order, default_layout, seo_page_kind FROM entity_types WHERE organization_id = ? ORDER BY display_order ASC, id ASC LIMIT ? OFFSET ?',
             [$this->orgId->get(), $limit, $offset],
         );
 
@@ -67,7 +67,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
         $nextOrder = ((int) ($maxRow['max_order'] ?? -1)) + 1;
 
         $this->query->execute(
-            'INSERT INTO entity_types (organization_id, name, slug, is_pinned, labels, permalink_pattern, display_order, default_layout) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            'INSERT INTO entity_types (organization_id, name, slug, is_pinned, labels, permalink_pattern, display_order, default_layout, seo_page_kind) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
                 $this->orgId->get(),
                 $entityType->name,
@@ -77,6 +77,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
                 $entityType->permalinkPattern,
                 $nextOrder,
                 $entityType->defaultLayout,
+                $entityType->seoPageKind->value,
             ],
         );
 
@@ -104,7 +105,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
     public function update(EntityType $entityType): void
     {
         $this->query->execute(
-            'UPDATE entity_types SET name = ?, slug = ?, is_pinned = ?, labels = ?, permalink_pattern = ?, previous_permalink_pattern = ?, default_layout = ? WHERE id = ? AND organization_id = ?',
+            'UPDATE entity_types SET name = ?, slug = ?, is_pinned = ?, labels = ?, permalink_pattern = ?, previous_permalink_pattern = ?, default_layout = ?, seo_page_kind = ? WHERE id = ? AND organization_id = ?',
             [
                 $entityType->name,
                 $entityType->slug,
@@ -113,6 +114,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
                 $entityType->permalinkPattern,
                 $entityType->previousPermalinkPattern,
                 $entityType->defaultLayout,
+                $entityType->seoPageKind->value,
                 $entityType->id,
                 $this->orgId->get(),
             ],
@@ -157,6 +159,7 @@ final readonly class PdoEntityTypeRepository implements EntityTypeRepositoryInte
             defaultLayout: isset($row['default_layout']) && is_string($row['default_layout']) && $row['default_layout'] !== ''
                 ? $row['default_layout']
                 : 'standard',
+            seoPageKind: SeoPageKind::fromStorage($row['seo_page_kind'] ?? null),
         );
     }
 }

--- a/src/EntityType/SeoPageKind.php
+++ b/src/EntityType/SeoPageKind.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\EntityType;
+
+/**
+ * How a type's records present themselves to crawlers and unfurlers (#1020).
+ *
+ * Before this existed, every record that was not the pinned front page was typed
+ * `og:type=article` + JSON-LD `BlogPosting` — a contact page, a company profile and
+ * a blog post all claimed to be dated articles. `BlogPosting` also drags
+ * `datePublished` / `dateModified` along, so a page with no publication date
+ * advertised one anyway.
+ *
+ * Chosen per entity type rather than per record: the distinction ("is this type a
+ * catalogue of pages, or a stream of dated posts?") is a property of the type, and
+ * production has 17 types in total, so setting them explicitly is cheap.
+ *
+ * The default for a *new* type is {@see WebPage}, deliberately. The two mistakes are
+ * not symmetric: typing an article as a page loses a little richness, while typing a
+ * page as an article states a publication date that does not exist — a factual claim
+ * to search engines that is simply untrue.
+ */
+enum SeoPageKind: string
+{
+    /** A standing page: `og:type=website`, JSON-LD `WebPage`, no publication dates. */
+    case WebPage = 'webpage';
+
+    /** A dated entry: `og:type=article`, JSON-LD `BlogPosting`, dates included. */
+    case Article = 'article';
+
+    public static function fromStorage(mixed $value): self
+    {
+        return is_string($value) ? (self::tryFrom($value) ?? self::WebPage) : self::WebPage;
+    }
+
+    /** The `og:type` value for this kind. */
+    public function ogType(): string
+    {
+        return $this === self::Article ? 'article' : 'website';
+    }
+}

--- a/src/EntityType/UpdateEntityTypeHandler.php
+++ b/src/EntityType/UpdateEntityTypeHandler.php
@@ -54,6 +54,16 @@ final readonly class UpdateEntityTypeHandler
             $errors[] = new ValidationError('default_layout', 'Unknown layout.', 'invalid');
         }
 
+        // seo_page_kind: optional; omitting it keeps the type a standing page (#1020).
+        // An unknown value is rejected rather than coerced — silently falling back would
+        // let a typo mistype every record of the type with no signal.
+        $rawSeoPageKind = trim((string) ($body['seo_page_kind'] ?? SeoPageKind::WebPage->value));
+        $seoPageKind = SeoPageKind::tryFrom($rawSeoPageKind === '' ? SeoPageKind::WebPage->value : $rawSeoPageKind);
+        if ($seoPageKind === null) {
+            $errors[] = new ValidationError('seo_page_kind', 'Unknown SEO page kind.', 'invalid');
+            $seoPageKind = SeoPageKind::WebPage;
+        }
+
         // labels: optional {"ja":"投稿","fr":"Articles"} – only string values are kept
         $rawLabels = $body['labels'] ?? null;
         $labels = null;
@@ -112,6 +122,7 @@ final readonly class UpdateEntityTypeHandler
             labels: $labels,
             permalinkPattern: $permalinkPattern,
             defaultLayout: $defaultLayout,
+            seoPageKind: $seoPageKind,
         ));
 
         return $this->response->create([
@@ -123,6 +134,7 @@ final readonly class UpdateEntityTypeHandler
             'permalink_pattern'          => $output->permalinkPattern,
             'previous_permalink_pattern' => $output->previousPermalinkPattern,
             'default_layout'             => $output->defaultLayout,
+            'seo_page_kind'              => $output->seoPageKind->value,
         ]);
     }
 }

--- a/src/EntityType/UpdateEntityTypeInput.php
+++ b/src/EntityType/UpdateEntityTypeInput.php
@@ -18,6 +18,7 @@ final readonly class UpdateEntityTypeInput
         public ?string $permalinkPattern = null,
         public ?string $previousPermalinkPattern = null,
         public string $defaultLayout = 'standard',
+        public SeoPageKind $seoPageKind = SeoPageKind::WebPage,
     ) {
     }
 }

--- a/src/EntityType/UpdateEntityTypeOutput.php
+++ b/src/EntityType/UpdateEntityTypeOutput.php
@@ -18,6 +18,7 @@ final readonly class UpdateEntityTypeOutput
         public ?string $permalinkPattern = null,
         public ?string $previousPermalinkPattern = null,
         public string $defaultLayout = 'standard',
+        public SeoPageKind $seoPageKind = SeoPageKind::WebPage,
     ) {
     }
 }

--- a/src/EntityType/UpdateEntityTypeUseCase.php
+++ b/src/EntityType/UpdateEntityTypeUseCase.php
@@ -42,6 +42,7 @@ final readonly class UpdateEntityTypeUseCase implements UpdateEntityTypeUseCaseI
             permalinkPattern: $input->permalinkPattern,
             previousPermalinkPattern: $previousPermalinkPattern,
             defaultLayout: $input->defaultLayout,
+            seoPageKind: $input->seoPageKind,
         );
         $this->entityTypes->update($updated);
 
@@ -54,6 +55,7 @@ final readonly class UpdateEntityTypeUseCase implements UpdateEntityTypeUseCaseI
             permalinkPattern: $input->permalinkPattern,
             previousPermalinkPattern: $previousPermalinkPattern,
             defaultLayout: $input->defaultLayout,
+            seoPageKind: $input->seoPageKind,
         );
     }
 }

--- a/src/OrgExport/PdoOrgImportRepository.php
+++ b/src/OrgExport/PdoOrgImportRepository.php
@@ -85,6 +85,10 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
                 (string) $row['name'],
                 (int) ($row['is_pinned'] ?? 0),
                 (string) ($row['default_layout'] ?? 'standard'),
+                // A snapshot taken before #1020 has no seo_page_kind; 'article' is what
+                // the source install actually rendered, so importing it preserves the
+                // source's behaviour rather than silently retyping its pages.
+                (string) ($row['seo_page_kind'] ?? 'article'),
                 (int) ($row['display_order'] ?? 0),
                 isset($row['labels']) ? (string) $row['labels'] : null,
                 isset($row['permalink_pattern']) ? (string) $row['permalink_pattern'] : null,
@@ -96,7 +100,7 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
                 $mergedTypeIds[$newId] = true;
                 $query->execute(
                     'UPDATE entity_types
-                        SET name = ?, is_pinned = ?, default_layout = ?, display_order = ?,
+                        SET name = ?, is_pinned = ?, default_layout = ?, seo_page_kind = ?, display_order = ?,
                             labels = ?, permalink_pattern = ?, previous_permalink_pattern = ?
                       WHERE id = ?',
                     [...$params, $newId],
@@ -104,9 +108,9 @@ final readonly class PdoOrgImportRepository implements OrgImportRepositoryInterf
             } else {
                 $newId = $query->insert(
                     'INSERT INTO entity_types
-                        (organization_id, name, is_pinned, default_layout, display_order,
+                        (organization_id, name, is_pinned, default_layout, seo_page_kind, display_order,
                          labels, permalink_pattern, previous_permalink_pattern, slug)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
                     [$targetOrgId, ...$params, $slug],
                 );
             }

--- a/src/Organization/PdoDefaultContentTypeSeeder.php
+++ b/src/Organization/PdoDefaultContentTypeSeeder.php
@@ -34,21 +34,33 @@ final readonly class PdoDefaultContentTypeSeeder implements DefaultContentTypeSe
     ];
 
     /**
-     * @var list<array{name: string, slug: string, fields: list<array{field_key: string, data_type: string}>}>
+     * The built-in pair. `seo_page_kind` is the ONE deliberate exception to the
+     * "new types default to webpage" rule (#1020): `posts` is a stream of dated
+     * entries by definition, so seeding it as a standing page would ship every fresh
+     * install with its blog mistyped. `pages` takes the default and is listed
+     * explicitly here only so the two sit side by side and the contrast is visible.
+     *
+     * Keep the exception here and nowhere else. The default belongs to the column and
+     * to {@see \NeNeRecords\EntityType\SeoPageKind}; this is the single place that
+     * knows a specific slug's meaning, because it is the place that invents the slug.
+     *
+     * @var list<array{name: string, slug: string, seo_page_kind: string, fields: list<array{field_key: string, data_type: string}>}>
      */
     private const CONTENT_TYPES = [
         [
-            'name'   => 'Posts',
-            'slug'   => 'posts',
-            'fields' => [
+            'name'          => 'Posts',
+            'slug'          => 'posts',
+            'seo_page_kind' => 'article',
+            'fields'        => [
                 ['field_key' => 'title', 'data_type' => 'text'],
                 ['field_key' => 'body',  'data_type' => 'markdown'],
             ],
         ],
         [
-            'name'   => 'Pages',
-            'slug'   => 'pages',
-            'fields' => [
+            'name'          => 'Pages',
+            'slug'          => 'pages',
+            'seo_page_kind' => 'webpage',
+            'fields'        => [
                 ['field_key' => 'title', 'data_type' => 'text'],
                 ['field_key' => 'body',  'data_type' => 'markdown'],
             ],
@@ -62,7 +74,12 @@ final readonly class PdoDefaultContentTypeSeeder implements DefaultContentTypeSe
     public function seed(int $organizationId): void
     {
         foreach (self::CONTENT_TYPES as $type) {
-            $entityTypeId = $this->upsertEntityType($organizationId, $type['name'], $type['slug']);
+            $entityTypeId = $this->upsertEntityType(
+                $organizationId,
+                $type['name'],
+                $type['slug'],
+                $type['seo_page_kind'],
+            );
 
             foreach ($type['fields'] as $field) {
                 $this->upsertFieldDef($organizationId, $entityTypeId, $field['field_key'], $field['data_type']);
@@ -74,7 +91,7 @@ final readonly class PdoDefaultContentTypeSeeder implements DefaultContentTypeSe
      * Insert entity_type if it does not already exist for this org.
      * Returns the id of the existing or newly inserted row.
      */
-    private function upsertEntityType(int $organizationId, string $name, string $slug): int
+    private function upsertEntityType(int $organizationId, string $name, string $slug, string $seoPageKind): int
     {
         $existing = $this->query->fetchOne(
             'SELECT id FROM entity_types WHERE organization_id = ? AND slug = ?',
@@ -88,8 +105,8 @@ final readonly class PdoDefaultContentTypeSeeder implements DefaultContentTypeSe
         $labels = json_encode(self::LABELS[$slug] ?? [], JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
 
         $this->query->execute(
-            'INSERT INTO entity_types (organization_id, name, slug, is_pinned, labels) VALUES (?, ?, ?, 1, ?)',
-            [$organizationId, $name, $slug, $labels],
+            'INSERT INTO entity_types (organization_id, name, slug, is_pinned, labels, seo_page_kind) VALUES (?, ?, ?, 1, ?, ?)',
+            [$organizationId, $name, $slug, $labels, $seoPageKind],
         );
 
         return $this->query->lastInsertId();

--- a/src/PreviewToken/GetPreviewRecordViewUseCase.php
+++ b/src/PreviewToken/GetPreviewRecordViewUseCase.php
@@ -235,6 +235,7 @@ final readonly class GetPreviewRecordViewUseCase implements GetPreviewRecordView
             childPages: $hierarchy->childPages,
             // Preview must scaffold exactly like the public page it previews (#879).
             layout: PublicLayouts::resolve($entity->layout, $entityType->defaultLayout),
+            seoPageKind: $entityType->seoPageKind,
         );
     }
 

--- a/src/PublicRecord/GetPublicRecordViewOutput.php
+++ b/src/PublicRecord/GetPublicRecordViewOutput.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\PublicRecord;
 
+use NeNeRecords\EntityType\SeoPageKind;
 use NeNeRecords\Layout\PublicLayouts;
 
 final readonly class GetPublicRecordViewOutput
@@ -36,6 +37,14 @@ final readonly class GetPublicRecordViewOutput
          * then removes — visible as a flash, and permanent for crawlers (#879).
          */
         public string $layout = PublicLayouts::DEFAULT,
+        /**
+         * How this record's type presents itself to crawlers (#1020) — decides
+         * `og:type` and the JSON-LD `@type`. Comes from the entity type, not the
+         * record: "is this a catalogue of pages or a stream of dated posts?" is a
+         * property of the type. Rendering as the front page overrides it (a pinned
+         * record is the site home whatever its type says).
+         */
+        public SeoPageKind $seoPageKind = SeoPageKind::WebPage,
     ) {
     }
 }

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -238,6 +238,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             // Resolve here so the SSR renders the same scaffold the SPA will (#879):
             // the resolver already existed but nothing on the render path called it.
             layout: PublicLayouts::resolve($entity->layout, $entityType->defaultLayout),
+            seoPageKind: $entityType->seoPageKind,
         );
     }
 

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -241,8 +241,15 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
             'layout' => $output->layout,
             'breadcrumbs' => $asFrontPage ? [] : $output->breadcrumbs,
             'childPages' => $output->childPages,
-            // og:type is `website` for the home page, `article` for a normal record.
-            'ogType' => $asFrontPage ? 'website' : 'article',
+            // The front page is the site home whatever its type says; otherwise the
+            // entity type decides (#1020). Before that setting existed every non-front
+            // record claimed `article` + BlogPosting, so contact pages advertised a
+            // publication date they do not have.
+            'ogType' => $asFrontPage ? 'website' : $output->seoPageKind->ogType(),
+            // Kept separate from ogType: the standalone Organization JSON-LD belongs to
+            // the site root alone, and since #1020 a non-front page can also be
+            // `website`, so og:type no longer identifies the front page (#978).
+            'isFrontPage' => $asFrontPage,
             'siteOrigin' => $baseUrl,
             'siteName' => $siteName,
             'metaDescription' => $metaDescription,

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -47,8 +47,11 @@
     <?php endif; ?>
 
     <?php
-      // As the front page (og:type=website) the record is the site home, not a dated
-      // article: type it WebPage and omit the publication dates (#701).
+      // The JSON-LD type follows og:type, so both stay consistent by construction and
+      // there is one decision, not two. `website` means a standing page: WebPage, and
+      // no publication dates. That covers the pinned front page (#701) and now any type
+      // configured as a standing page (#1020) — the dates are omitted precisely because
+      // such a page has none, and claiming one is a false statement to search engines.
       $jsonLd = [
           '@context' => 'https://schema.org',
           '@type' => $ogType === 'website' ? 'WebPage' : 'BlogPosting',
@@ -72,9 +75,14 @@ if ($ogImageUrl !== null) {
 ?>
     <script type="application/ld+json"><?= json_encode($jsonLd, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?></script>
     <?php /* Standalone Organization on the front page — Google's company knowledge-panel
-             signal (logo/sameAs/contactPoint from settings); article pages carry it as
-             the publisher above instead (#978). */ ?>
-    <?php if ($ogType === 'website'): ?>
+             signal (logo/sameAs/contactPoint from settings); every other page carries it
+             as the publisher above instead (#978).
+
+             Keyed on `isFrontPage`, NOT on og:type. Until #1020 the two were the same
+             thing (only the front page was `website`), so `$ogType === 'website'` read
+             as "is the front page". Now any type can be a standing page, and one site
+             must still declare its organization exactly once. */ ?>
+    <?php if ($isFrontPage): ?>
     <?php $organizationStandalone = array_merge(['@context' => 'https://schema.org'], $organizationLd); ?>
     <script type="application/ld+json"><?= json_encode($organizationStandalone, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?></script>
     <?php endif; ?>

--- a/tests/EntityType/InMemoryEntityTypeRepository.php
+++ b/tests/EntityType/InMemoryEntityTypeRepository.php
@@ -37,6 +37,7 @@ final class InMemoryEntityTypeRepository implements EntityTypeRepositoryInterfac
                     previousPermalinkPattern: $entityType->previousPermalinkPattern,
                     displayOrder: $entityType->displayOrder,
                     defaultLayout: $entityType->defaultLayout,
+                    seoPageKind: $entityType->seoPageKind,
                 );
                 $this->byId[$id] = $stored;
                 $this->slugToId[$stored->slug] = $id;
@@ -85,6 +86,7 @@ final class InMemoryEntityTypeRepository implements EntityTypeRepositoryInterfac
             permalinkPattern: $entityType->permalinkPattern,
             previousPermalinkPattern: $entityType->previousPermalinkPattern,
             defaultLayout: $entityType->defaultLayout,
+            seoPageKind: $entityType->seoPageKind,
         );
         $this->byId[$id] = $stored;
         $this->slugToId[$stored->slug] = $id;
@@ -124,6 +126,7 @@ final class InMemoryEntityTypeRepository implements EntityTypeRepositoryInterfac
                     previousPermalinkPattern: $existing->previousPermalinkPattern,
                     displayOrder: $position,
                     defaultLayout: $existing->defaultLayout,
+                    seoPageKind: $existing->seoPageKind,
                 );
             }
             $position++;

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -16,6 +16,7 @@ use Nene2\View\NativePhpViewRenderer;
 use NeNeRecords\Entity\Entity;
 use NeNeRecords\Entity\EntityStatus;
 use NeNeRecords\EntityType\EntityType;
+use NeNeRecords\EntityType\SeoPageKind;
 use NeNeRecords\FieldDef\FieldDef;
 use NeNeRecords\PublicRecord\FrontPageSetting;
 use NeNeRecords\PublicRecord\GenerateSitemapUseCase;
@@ -81,9 +82,20 @@ final class PublicRecordHttpTest extends TestCase
         ?int $frontPageId = null,
         ?string $entity10Layout = null,
         string $typeDefaultLayout = 'standard',
+        SeoPageKind $seoPageKind = SeoPageKind::Article,
     ): RequestHandlerInterface {
         $entityTypes = new InMemoryEntityTypeRepository([
-            new EntityType(name: 'Article', slug: 'article', id: 1, defaultLayout: $typeDefaultLayout),
+            // Declared Article on purpose: most tests here assert the dated-entry
+            // rendering (og:type=article, BlogPosting, datePublished). Since #1020 that
+            // comes from the type, so the fixture has to say which kind it is — the
+            // default for a new type is a standing page.
+            new EntityType(
+                name: 'Article',
+                slug: 'article',
+                id: 1,
+                defaultLayout: $typeDefaultLayout,
+                seoPageKind: $seoPageKind,
+            ),
         ]);
         $entityRecords = [
             new Entity(
@@ -337,6 +349,65 @@ final class PublicRecordHttpTest extends TestCase
         self::assertStringContainsString('"datePublished":"2026-01-15T00:00:00+00:00"', $html);
         self::assertStringContainsString('"dateModified":"2026-02-20T00:00:00+00:00"', $html);
         self::assertStringContainsString('"image":"https://example.test/media/og/2026/06/hero.png"', $html);
+    }
+
+    /**
+     * #1020: a type declared as a standing page must not claim to be a dated article.
+     * This is the whole point of the setting — a contact page carrying `datePublished`
+     * is a factual claim to search engines that is simply untrue.
+     */
+    public function testWebPageKindTypeRendersAsWebPageWithoutDates(): void
+    {
+        $app = $this->buildApplication(true, $this->projectRoot, seoPageKind: SeoPageKind::WebPage);
+
+        $html = (string) $app->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        )->getBody();
+
+        self::assertStringContainsString('property="og:type" content="website"', $html);
+        self::assertStringContainsString('"@type":"WebPage"', $html);
+        self::assertStringNotContainsString('"@type":"BlogPosting"', $html);
+        // The record HAS both dates seeded; they must be withheld because the *type*
+        // says this is a standing page. Asserting on a record without dates would pass
+        // for the wrong reason.
+        self::assertStringNotContainsString('"datePublished"', $html);
+        self::assertStringNotContainsString('"dateModified"', $html);
+    }
+
+    /**
+     * The counterpart: nothing about the article rendering changed for types that say
+     * they are articles. Without this, the test above could be satisfied by a change
+     * that broke articles everywhere.
+     */
+    public function testArticleKindTypeStillRendersDatedBlogPosting(): void
+    {
+        $html = (string) $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        )->getBody();
+
+        self::assertStringContainsString('property="og:type" content="article"', $html);
+        self::assertStringContainsString('"@type":"BlogPosting"', $html);
+        self::assertStringContainsString('"datePublished":"2026-01-15T00:00:00+00:00"', $html);
+    }
+
+    /**
+     * #978 regression guard. The standalone Organization node used to be gated on
+     * `og:type === 'website'`, which was a stand-in for "is the front page" back when
+     * only the front page could be `website`. Since #1020 a normal page can be
+     * `website` too, and a site must declare its organization exactly once.
+     */
+    public function testWebPageKindTypeDoesNotEmitTheFrontPageOnlyOrganizationBlock(): void
+    {
+        $app = $this->buildApplication(true, $this->projectRoot, seoPageKind: SeoPageKind::WebPage);
+
+        $html = (string) $app->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/article/10'),
+        )->getBody();
+
+        self::assertStringContainsString('property="og:type" content="website"', $html);
+        self::assertStringNotContainsString('"@context":"https://schema.org","@type":"Organization"', $html);
+        // …while still carrying the organization as the publisher, as every page does.
+        self::assertStringContainsString('"publisher":{"@type":"Organization"', $html);
     }
 
     public function testPerRecordImageWinsOverDefaultOgImage(): void


### PR DESCRIPTION
## 目的

公開 SSR は front_page 以外を**一律 `og:type=article` ＋ JSON-LD `BlogPosting`** にしていた。
お問い合わせも会社案内も「日付のある記事」を名乗り、実際には持っていない
`datePublished` / `dateModified` まで付いていた。**検索エンジンに対して事実と異なる申告**をしている状態。

## 方式（裁定済み）

**entity type 単位**。他案を採らなかった理由:

| 案 | 不採用の理由 |
|---|---|
| `published_at` の有無で導出 | 固定ページにも `published_at` が入りうるので誤爆する |
| レコード単位の SEO フィールド | 運用コストが釣り合わない |

**新規型の既定は `webpage`。** 誤りの重さが対称でないため:
記事を固定ページと書けば richness を少し損なうだけだが、**固定ページを記事と書くと存在しない公開日を主張する**。

### 本番棚卸し（この裁定の根拠・実測）

| | org | entity type | 備考 |
|---|---|---|---|
| ConoHa | 7（＋番兵 org 0） | 実質16 | slug は `pages`/`posts`/`contents`/`work` の4種のみ。実データはほぼ aozora のみ（`work` 1114件） |
| ayane Tier A | 1 | **1**（`pages`・13件） | **`pages` を WebPage にするだけで全13ページが正しくなる** |

明示設定すべき実体は**全部で17行**。移行は現実的。

## 🔴 migration は出力中立（案A）

列の既定は `webpage` だが、**既存行は全部 `article` へ backfill** する。
＝ `migrate` しても**表示は1バイトも変わらない**。

slug 名から意味を推論して振り分ける案（`pages`→webpage）は**不採用**:

- 推論を焼き込むと**まだ存在しないデータに対して検証不能**になる。`pages` という slug で
  ブログを運用する org が現れて初めて壊れ、**いつ壊れるか誰も知らない**
- aozora の `work` 1114件の正しい型は **#1022 で未判断**のまま。migration で既成事実にしたくない
- deploy の副作用で live の構造化データが黙って変わるのは、避けたい形そのもの

正しい値は**管理画面で型ごとに選ぶ**（変更が目に見えて・取り消せて・記録に残る）。

## 変更

- **`SeoPageKind` enum に `ogType()`** を持たせ、種別の判断を1箇所に集約。
  元の症状は同じ判断が handler(`:245`) と template(`:54`) に**分かれていた**ことなので、
  JSON-LD 側は og:type から導出させて「決定は1つ」にした
- migration（上記）／`entity_types.seo_page_kind`
- fresh install の種は **`posts` だけ `article` を明示**（例外を1箇所に閉じ込め、理由をコメントで記録）
- **org import** は `seo_page_kind` 欠落時に `article` へ倒す（#1020 以前のスナップショットは
  移送元が実際にその表示だったので、それを保存するのが正しい）。export は `SELECT *` なので自動追随
- admin UI（型編集フォームに選択＋説明）／OpenAPI ＋ codegen ／ 公開6ロケール

### 🔴 副作用を1つ見つけて直した（#978）

単独 Organization JSON-LD は `og:type === 'website'` で出し分けていたが、これは
**「front page か」の代用**だった（当時は front page だけが `website` だったので等価）。
本 PR で通常ページも `website` になりうるので、**`isFrontPage` で判定するよう分離**した。
1サイトが organization を宣言するのは1回だけ、を保つため。テストで pin 済み。

## 検証

- `composer check` **全緑**（1504 tests / PHPStan L8 / CS-Fixer / OpenAPI / conformance / MCP）
- `npm run check` **全緑**（type-check / lint / prettier / 662 tests / knip / storybook）
- 🔴 **実 MySQL で migrate 実測**（版番号の date-skew も確認）:
  既存13行が全て `article`・列既定は `webpage`・**rollback で列が消え re-migrate も通る**
- 🔴 **破壊実験**: SSR を元のハードコードに戻すと **2本**、Organization を og:type 判定に
  戻すと **1本**、それぞれ落ちることを実測

**測っていないこと（正直に）**: live での before/after は未実施。ローカルはマルチテナントの
ホスト解決があり、公開ページを1本立てるまでの手数が実測の価値に見合わなかった。
**実地確認は ayane の切替時**（デプロイ後・hub 条件つき）に before/after を実測する。

## デプロイ時の注意

本 PR で **records 本番（ConoHa）の migration 遅れは 3本 → 4本**。
「コードと migration を必ず揃えて上げる／単独で migration だけ流さない」は変わらず。
4本目は**出力中立**なので、これが原因で本番の見え方が変わることはない。

## チェックリスト

- [x] Issue 駆動（#1020）
- [x] `main` へ直接コミットしていない
- [x] `composer check` / `npm run check` 全緑
- [x] migration は `composer migrations:new` で採番・実 MySQL で up/down 実測
- [x] 本番反映は施主 GO seam

Closes #1020
Refs #1022