### PR TITLE
fix(auth): /api/v1/users の読み取り認可が HEAD を素通りさせるのを直す（#1023）

### DIFF
--- a/src/Auth/CapabilityResolver.php
+++ b/src/Auth/CapabilityResolver.php
@@ -95,7 +95,7 @@ final class CapabilityResolver
             return Capability::ManageSettings;
         }
 
-        if (str_starts_with($path, '/api/v1/users') && self::isAdminReadPath($path) && $method === 'GET') {
+        if (str_starts_with($path, '/api/v1/users') && self::isAdminReadPath($path) && self::isReadMethod($method)) {
             return Capability::ManageSettings;
         }
 
@@ -116,6 +116,22 @@ final class CapabilityResolver
     private static function isMutationMethod(string $method): bool
     {
         return !in_array($method, ['GET', 'HEAD', 'OPTIONS'], true);
+    }
+
+    /**
+     * The representation-reading methods. `HEAD` must resolve to the same capability as
+     * `GET` (#1023): it returns no body, but it does return the status code, and the
+     * difference between 200 and 404 is an existence oracle for the resource.
+     *
+     * Written as a predicate, not as `$method === 'GET'` at each call site. Every branch
+     * above that enumerates `'GET', 'HEAD'` was correct; the one branch that compared
+     * against `'GET'` alone let HEAD past the authorization check entirely. The same
+     * single-equality habit was later found in two other products, so the shape of the
+     * mistake matters more than this one occurrence.
+     */
+    private static function isReadMethod(string $method): bool
+    {
+        return $method === 'GET' || $method === 'HEAD';
     }
 
     /**

--- a/tests/Auth/CapabilityResolverTest.php
+++ b/tests/Auth/CapabilityResolverTest.php
@@ -307,4 +307,72 @@ final class CapabilityResolverTest extends TestCase
     {
         self::assertNull(CapabilityResolver::resolve('/api/v1/unknown', 'GET'));
     }
+
+    // ── GET / HEAD parity (#1023) ─────────────────────────────────────────────
+
+    /**
+     * HEAD must resolve to the same capability as GET, everywhere. It returns no body,
+     * but it returns the status code, so an unauthorized HEAD is an existence oracle
+     * (200 vs 404 on `/users/{id}`) and, where the server sets it, a size oracle.
+     *
+     * Table-driven and covering every branch of resolve(), not just the one that was
+     * broken: the defect was a habit (`$method === 'GET'`) rather than a one-off, and
+     * the next person adding a branch will copy whatever is nearest.
+     */
+    #[DataProvider('provideAuthorizedPaths')]
+    public function testHeadResolvesToTheSameCapabilityAsGet(string $path): void
+    {
+        self::assertSame(
+            CapabilityResolver::resolve($path, 'GET'),
+            CapabilityResolver::resolve($path, 'HEAD'),
+            sprintf('GET and HEAD must require the same capability for %s', $path),
+        );
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function provideAuthorizedPaths(): iterable
+    {
+        yield 'superadmin'          => ['/api/v1/superadmin/export'];
+        yield 'organizations'       => ['/api/v1/organizations'];
+        yield 'organization by id'  => ['/api/v1/organizations/2'];
+        yield 'account'             => ['/api/v1/account'];
+        yield 'settings'            => ['/api/v1/settings'];
+        yield 'navigation-items'    => ['/api/v1/navigation-items'];
+        yield 'widgets'             => ['/api/v1/widgets'];
+        yield 'entity-types'        => ['/api/v1/entity-types'];
+        yield 'archive csv'         => ['/api/v1/entity-types/5/archive.csv'];
+        yield 'field-defs'          => ['/api/v1/field-defs'];
+        yield 'tags'                => ['/api/v1/tags'];
+        yield 'media'               => ['/api/v1/media'];
+        yield 'media by id'         => ['/api/v1/media/9'];
+        yield 'users list'          => ['/api/v1/users'];
+        yield 'user by id'          => ['/api/v1/users/3'];
+        yield 'user me'             => ['/api/v1/users/me'];
+        yield 'own password'        => ['/api/v1/users/me/password'];
+        yield 'admin comments'      => ['/api/v1/admin/comments'];
+        yield 'entities'            => ['/api/v1/entities'];
+        yield 'text-fields'         => ['/api/v1/text-fields'];
+        yield 'public records'      => ['/api/v1/public/records/article/my-post'];
+        yield 'unknown'             => ['/api/v1/unknown'];
+    }
+
+    /**
+     * The specific regression: reading the user list is admin-only, and used to be
+     * admin-only for GET alone.
+     */
+    public function testUserListReadRequiresManageSettingsForHeadToo(): void
+    {
+        self::assertSame(Capability::ManageSettings, CapabilityResolver::resolve('/api/v1/users', 'HEAD'));
+        self::assertSame(Capability::ManageSettings, CapabilityResolver::resolve('/api/v1/users/3', 'HEAD'));
+    }
+
+    /**
+     * Parity must not be achieved by making everything require a capability: OPTIONS
+     * (CORS preflight) and the self-service password path stay open, as before.
+     */
+    public function testParityDoesNotWidenOptionsOrSelfServicePaths(): void
+    {
+        self::assertNull(CapabilityResolver::resolve('/api/v1/users/me/password', 'HEAD'));
+        self::assertNull(CapabilityResolver::resolve('/api/v1/entities/1', 'HEAD'));
+    }
 }


### PR DESCRIPTION
## 事実

`CapabilityResolver` が `/api/v1/users` 系の**読み取り**に `ManageSettings` を要求する条件を
**`$method === 'GET'` に限定**していた（`src/Auth/CapabilityResolver.php:98`）。
`resolve()` が `null` を返すと `CapabilityMiddleware` は**能力チェックをせずハンドラへ通す**。

```
/api/v1/users    GET  -> ManageSettings
/api/v1/users    HEAD -> NULL（能力チェックなし）
/api/v1/media    HEAD -> ReadSettings   ← 直前の分岐は match で 'GET','HEAD' を列挙＝無事
```

## 影響（確かめた範囲で）

- 🟡 **匿名では届かない。** `/api/v1/users` は `ADMIN_ONLY_PREFIXES` にあり、
  `AdminApiAuthMiddleware` が全メソッドで認証を要求する
- 🔴 **認証済みの低権限ユーザ（editor 等）には効く。** 本文は返らないが**ステータスコードは返る**ので、
  `/users/{id}` の 200 と 404 の差がそのまま**存在オラクル**になる。`Content-Length` が付く構成なら規模も
- 全面漏洩ではなく**存在・規模のオラクル**。実害は限定的だが、
  **認可がメソッドによって効いたり効かなかったりする**構造そのものが欠陥

## 網羅確認（着手前に実施）

`resolve()` の全分岐を GET/HEAD で突き合わせた結果、**不一致は3パス**
（`/api/v1/users`・`/users/3`・`/users/me`）で、**すべてこの1分岐由来**。
他はすべて健全（`isMutationMethod()` は `GET/HEAD/OPTIONS` を正しく除外＝**変更系は全部無事**）。

## 変更

- 読み取り述語 **`isReadMethod()`** を置き、単一等値比較をやめた。
  無事な分岐と壊れた分岐の差は**「列挙で書けているか」だけ**だったので、そこを構造で潰す
- **テストは `resolve()` の全分岐を表で回し**、GET と HEAD が同じ能力を返すことを pin。
  壊れていたのは1分岐だが、原因は**書き癖**なので、次に分岐を足す人が近くのものを写して
  同じ形にならないよう全分岐を覆う
- **認可を広げていないことも pin**（OPTIONS と自己サービスの `/users/me/password` は従来どおり能力不要）。
  「全部に能力を要求する」で parity を達成していないことの担保

## 検証

- 🔴 **`:98` を `$method === 'GET'` に戻すと4本落ちる**ことを実測（戻す→失敗→復元→OK まで確認）
- `composer check` **全緑**（1528 tests / PHPStan L8 / CS-Fixer / OpenAPI / conformance / MCP）

## フリート横断

同型が **nene-concierge 2箇所・nene-payout 1箇所**にあることを統合リナの横断 grep が検出済み
（※ grep 一致のみで**周辺ロジックは未読**＝各艦の実測待ち）。
規約還流の追加条文として提出済み（「読み取りに能力を要求するときは GET と HEAD を必ず同じ扱いにする。
単一等値でなく列挙で書く」）。

Closes #1023
Refs #1021