### PR TITLE
chore(org): org 削除で残るメディアの棚卸しを追加する（#1018）

### DIFF
--- a/src/Organization/DeleteOrganizationUseCase.php
+++ b/src/Organization/DeleteOrganizationUseCase.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Organization;
 
+use Psr\Log\LoggerInterface;
+use Throwable;
+
 final readonly class DeleteOrganizationUseCase implements DeleteOrganizationUseCaseInterface
 {
     public function __construct(
         private OrganizationRepositoryInterface $organizations,
+        private ?OrgMediaInventoryReaderInterface $mediaInventory = null,
+        private ?LoggerInterface $logger = null,
     ) {
     }
 
@@ -19,6 +24,42 @@ final readonly class DeleteOrganizationUseCase implements DeleteOrganizationUseC
             throw new OrganizationNotFoundException($input->id);
         }
 
+        // Record what this delete is about to strand on disk, BEFORE the rows go
+        // (#1018). The purge clears `media`, but the files under `var/media` stay;
+        // a storage key is `YYYY/MM/<random>.<ext>` and carries no tenant, so after
+        // this point nothing can say which org a leftover file belonged to. We only
+        // write it down — deleting files here would put an irreversible operation
+        // inside a path whose whole point is that it can be rolled back.
+        $this->logStrandedMedia($input->id);
+
         $this->organizations->delete($input->id);
+    }
+
+    private function logStrandedMedia(int $organizationId): void
+    {
+        if ($this->mediaInventory === null || $this->logger === null) {
+            return;
+        }
+
+        try {
+            $inventory = $this->mediaInventory->forOrganization($organizationId);
+
+            if ($inventory->isEmpty()) {
+                return;
+            }
+
+            $this->logger->info(
+                'Organization delete leaves media files on disk; nothing is removed. '
+                . 'Run tools/media-orphan-audit.php for the full picture including derivatives.',
+                $inventory->toLogContext(),
+            );
+        } catch (Throwable $exception) {
+            // The inventory is a record, not a precondition: failing to take it must
+            // never block the delete the operator asked for.
+            $this->logger->warning('Failed to inventory media before organization delete.', [
+                'organization_id' => $organizationId,
+                'exception' => $exception->getMessage(),
+            ]);
+        }
     }
 }

--- a/src/Organization/OrgMediaInventory.php
+++ b/src/Organization/OrgMediaInventory.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Organization;
+
+/**
+ * What an organization's media occupies on disk, captured *before* the org is
+ * deleted (#1018).
+ *
+ * Deleting an org purges the `media` rows (see {@see OrganizationScopedSchema})
+ * but leaves the files under `var/media`. That is garbage rather than an orphan —
+ * nothing can reach it, so it cannot leak into another tenant — and the only cost
+ * is disk. Deleting the files during the purge was rejected deliberately: file
+ * removal happens outside the DB transaction, so a rollback would restore the rows
+ * while the bytes stayed gone, and file deletion has no undo.
+ *
+ * So the first step is to write down what was left behind. The timing matters:
+ * **once the rows are purged, nothing on disk records which org a file belonged
+ * to** — the storage key is `YYYY/MM/<random>.<ext>`, with no tenant in the path.
+ * This snapshot is the only moment that attribution exists.
+ *
+ * Derivatives are not listed here. They are not in the DB at all (they are
+ * generated on demand under `derivatives/<preset>/<format>/…` from the original's
+ * stem), so they cannot be enumerated from org-scoped rows. `tools/media-orphan-audit.php`
+ * scans the filesystem and reports both.
+ *
+ * @phpstan-type InventoryEntry array{key: string, bytes: int, present: bool}
+ */
+final readonly class OrgMediaInventory
+{
+    /** @param list<InventoryEntry> $entries */
+    private function __construct(
+        public int $organizationId,
+        public int $fileCount,
+        public int $totalBytes,
+        public int $missingCount,
+        public array $entries,
+    ) {
+    }
+
+    /** @param list<InventoryEntry> $entries */
+    public static function fromEntries(int $organizationId, array $entries): self
+    {
+        $present = array_values(array_filter($entries, static fn (array $e): bool => $e['present']));
+
+        return new self(
+            organizationId: $organizationId,
+            fileCount: count($present),
+            totalBytes: array_sum(array_map(static fn (array $e): int => $e['bytes'], $present)),
+            missingCount: count($entries) - count($present),
+            entries: $entries,
+        );
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->entries === [];
+    }
+
+    /**
+     * Log-friendly context. Keys are capped so a tenant with thousands of files
+     * cannot produce an unbounded log line; the counts stay exact either way, and
+     * the audit tool can always re-derive the full list from disk.
+     *
+     * @return array{organization_id: int, file_count: int, total_bytes: int, missing_count: int, keys: list<string>, keys_truncated: bool}
+     */
+    public function toLogContext(int $maxKeys = 200): array
+    {
+        $keys = array_map(static fn (array $e): string => $e['key'], $this->entries);
+
+        return [
+            'organization_id' => $this->organizationId,
+            'file_count' => $this->fileCount,
+            'total_bytes' => $this->totalBytes,
+            // Rows whose file was already gone. Not a problem to fix here, but a
+            // number that should be 0; anything else means the two sides drifted.
+            'missing_count' => $this->missingCount,
+            'keys' => array_slice($keys, 0, $maxKeys),
+            'keys_truncated' => count($keys) > $maxKeys,
+        ];
+    }
+}

--- a/src/Organization/OrgMediaInventoryReaderInterface.php
+++ b/src/Organization/OrgMediaInventoryReaderInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Organization;
+
+/**
+ * Reads an organization's media footprint by explicit org id (#1018).
+ *
+ * Deliberately not {@see \NeNeRecords\Media\MediaRepositoryInterface}: that one is
+ * request-scoped to the *caller's* org, while deleting an organization is a
+ * superadmin action against a different tenant — the same reason the purge in
+ * {@see PdoOrganizationRepository} takes the id explicitly.
+ */
+interface OrgMediaInventoryReaderInterface
+{
+    public function forOrganization(int $organizationId): OrgMediaInventory;
+}

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -15,11 +15,13 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\ApplicationServiceProvider;
 use NeNeRecords\Entitlement\EntitlementResolverInterface;
+use NeNeRecords\Media\StorageInterface;
 use NeNeRecords\Setting\DefaultSettingDefsSeederInterface;
 use NeNeRecords\Setting\PdoDefaultSettingDefsSeeder;
 use NeNeRecords\SystemConfig\SystemConfigRepositoryInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Log\LoggerInterface;
 
 final readonly class OrganizationServiceProvider implements ServiceProviderInterface
 {
@@ -147,7 +149,21 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
                         throw new LogicException('Organization repository service is invalid.');
                     }
 
-                    return new DeleteOrganizationUseCase($repo);
+                    // The media inventory and logger are optional collaborators: the
+                    // delete must still work if either is unavailable (#1018).
+                    $query   = $c->get(DatabaseQueryExecutorInterface::class);
+                    $storage = $c->get(StorageInterface::class);
+                    $logger  = $c->get(LoggerInterface::class);
+
+                    $inventory = ($query instanceof DatabaseQueryExecutorInterface && $storage instanceof StorageInterface)
+                        ? new PdoOrgMediaInventoryReader($query, $storage)
+                        : null;
+
+                    return new DeleteOrganizationUseCase(
+                        $repo,
+                        $inventory,
+                        $logger instanceof LoggerInterface ? $logger : null,
+                    );
                 },
             )
             // ── Handlers ───────────────────────────────────────────────────────

--- a/src/Organization/PdoOrgMediaInventoryReader.php
+++ b/src/Organization/PdoOrgMediaInventoryReader.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Organization;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeNeRecords\Media\StorageInterface;
+
+final readonly class PdoOrgMediaInventoryReader implements OrgMediaInventoryReaderInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private StorageInterface $storage,
+    ) {
+    }
+
+    public function forOrganization(int $organizationId): OrgMediaInventory
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT storage_key, stored_name FROM media WHERE organization_id = ? ORDER BY id',
+            [$organizationId],
+        );
+
+        $entries = [];
+
+        foreach ($rows as $row) {
+            $key = $this->keyOf($row);
+
+            if ($key === '') {
+                continue;
+            }
+
+            // `exists()` before `size()`: LocalStorage::size() returns 0 for a missing
+            // file, so size alone cannot distinguish "gone" from "empty".
+            $present = $this->storage->exists($key);
+
+            $entries[] = [
+                'key' => $key,
+                'bytes' => $present ? $this->storage->size($key) : 0,
+                'present' => $present,
+            ];
+        }
+
+        return OrgMediaInventory::fromEntries($organizationId, $entries);
+    }
+
+    /**
+     * `storage_key` is the real path and the column that matters. It defaults to ''
+     * in the schema, so rows written before it existed fall back to `stored_name`
+     * — which is the bare filename, not a path. Such a row cannot be resolved to a
+     * file, and reporting it as missing is the honest outcome.
+     *
+     * @param array<string, mixed> $row
+     */
+    private function keyOf(array $row): string
+    {
+        $storageKey = isset($row['storage_key']) && is_string($row['storage_key']) ? trim($row['storage_key']) : '';
+
+        if ($storageKey !== '') {
+            return $storageKey;
+        }
+
+        return isset($row['stored_name']) && is_string($row['stored_name']) ? trim($row['stored_name']) : '';
+    }
+}

--- a/tests/Organization/OrgMediaInventoryTest.php
+++ b/tests/Organization/OrgMediaInventoryTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Organization;
+
+use NeNeRecords\Organization\CreateOrganizationInput;
+use NeNeRecords\Organization\CreateOrganizationUseCase;
+use NeNeRecords\Organization\DeleteOrganizationInput;
+use NeNeRecords\Organization\DeleteOrganizationUseCase;
+use NeNeRecords\Organization\OrgMediaInventory;
+use NeNeRecords\Organization\OrgMediaInventoryReaderInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\NullLogger;
+use RuntimeException;
+
+/**
+ * #1018: deleting an org strands its media files on disk. We do not delete them —
+ * we write down what was stranded, because that is the last moment anyone can tell
+ * which org the files belonged to (storage keys carry no tenant).
+ */
+final class OrgMediaInventoryTest extends TestCase
+{
+    public function testInventorySumsOnlyFilesThatArePresent(): void
+    {
+        $inventory = OrgMediaInventory::fromEntries(7, [
+            ['key' => '2026/07/aaa.png', 'bytes' => 100, 'present' => true],
+            ['key' => '2026/07/bbb.jpg', 'bytes' => 250, 'present' => true],
+            // A row whose file is already gone must not inflate the byte total, but
+            // must still be visible as a count — a non-zero value means the DB and
+            // the disk have drifted, which is worth seeing.
+            ['key' => '2026/07/ccc.pdf', 'bytes' => 0, 'present' => false],
+        ]);
+
+        self::assertSame(2, $inventory->fileCount);
+        self::assertSame(350, $inventory->totalBytes);
+        self::assertSame(1, $inventory->missingCount);
+        self::assertFalse($inventory->isEmpty());
+    }
+
+    public function testLogContextCapsKeysSoOneTenantCannotProduceAnUnboundedLine(): void
+    {
+        $entries = [];
+
+        for ($i = 0; $i < 250; ++$i) {
+            $entries[] = ['key' => sprintf('2026/07/%03d.png', $i), 'bytes' => 1, 'present' => true];
+        }
+
+        $context = OrgMediaInventory::fromEntries(1, $entries)->toLogContext(maxKeys: 200);
+
+        self::assertCount(200, $context['keys']);
+        self::assertTrue($context['keys_truncated']);
+        // The counts stay exact even when the key list is cut.
+        self::assertSame(250, $context['file_count']);
+        self::assertSame(250, $context['total_bytes']);
+    }
+
+    public function testDeleteLogsTheStrandedFilesBeforeRemovingTheOrg(): void
+    {
+        $organizations = new InMemoryOrganizationRepository();
+        $created = (new CreateOrganizationUseCase(
+            $organizations,
+            new RecordingDefaultContentTypeSeeder(),
+            new RecordingDefaultSettingDefsSeeder(),
+        ))->execute(new CreateOrganizationInput(name: 'Doomed', slug: 'doomed'));
+
+        $logger = new class () extends AbstractLogger {
+            /** @var list<array{level: string, message: string, context: array<string, mixed>}> */
+            public array $records = [];
+
+            /**
+             * @param mixed                $level
+             * @param string|\Stringable   $message
+             * @param array<string, mixed> $context
+             */
+            public function log($level, $message, array $context = []): void
+            {
+                $this->records[] = ['level' => (string) $level, 'message' => (string) $message, 'context' => $context];
+            }
+        };
+
+        $reader = new class () implements OrgMediaInventoryReaderInterface {
+            public ?int $askedFor = null;
+
+            public function forOrganization(int $organizationId): OrgMediaInventory
+            {
+                $this->askedFor = $organizationId;
+
+                return OrgMediaInventory::fromEntries($organizationId, [
+                    ['key' => '2026/07/kept.png', 'bytes' => 4096, 'present' => true],
+                ]);
+            }
+        };
+
+        (new DeleteOrganizationUseCase($organizations, $reader, $logger))
+            ->execute(new DeleteOrganizationInput(id: $created->id));
+
+        self::assertSame($created->id, $reader->askedFor, 'the inventory must be taken for the org being deleted');
+        self::assertNull($organizations->findById($created->id), 'the delete itself must still happen');
+
+        self::assertCount(1, $logger->records);
+        self::assertSame('info', $logger->records[0]['level']);
+        self::assertSame(1, $logger->records[0]['context']['file_count']);
+        self::assertSame(4096, $logger->records[0]['context']['total_bytes']);
+        self::assertContains('2026/07/kept.png', $logger->records[0]['context']['keys']);
+    }
+
+    /**
+     * The ordering IS the feature. Once the org is deleted its `media` rows are
+     * purged, and a storage key has no tenant in it — so an inventory taken
+     * afterwards can no longer attribute anything. Asserting only "it was logged"
+     * passes even when the call is moved below the delete, which is why this
+     * observes whether the org still existed at the moment the reader ran.
+     */
+    public function testInventoryIsTakenWhileTheOrgStillExists(): void
+    {
+        $organizations = new InMemoryOrganizationRepository();
+        $created = (new CreateOrganizationUseCase(
+            $organizations,
+            new RecordingDefaultContentTypeSeeder(),
+            new RecordingDefaultSettingDefsSeeder(),
+        ))->execute(new CreateOrganizationInput(name: 'Doomed', slug: 'doomed-3'));
+
+        $reader = new class ($organizations) implements OrgMediaInventoryReaderInterface {
+            public ?bool $orgVisibleWhenRead = null;
+
+            public function __construct(private InMemoryOrganizationRepository $organizations)
+            {
+            }
+
+            public function forOrganization(int $organizationId): OrgMediaInventory
+            {
+                $this->orgVisibleWhenRead = $this->organizations->findById($organizationId) !== null;
+
+                return OrgMediaInventory::fromEntries($organizationId, [
+                    ['key' => '2026/07/kept.png', 'bytes' => 1, 'present' => true],
+                ]);
+            }
+        };
+
+        (new DeleteOrganizationUseCase($organizations, $reader, new NullLogger()))
+            ->execute(new DeleteOrganizationInput(id: $created->id));
+
+        self::assertTrue(
+            $reader->orgVisibleWhenRead,
+            'the inventory must run BEFORE the delete — afterwards the media rows are gone and nothing can be attributed',
+        );
+    }
+
+    public function testAnOrgWithNoMediaLogsNothing(): void
+    {
+        $organizations = new InMemoryOrganizationRepository();
+        $created = (new CreateOrganizationUseCase(
+            $organizations,
+            new RecordingDefaultContentTypeSeeder(),
+            new RecordingDefaultSettingDefsSeeder(),
+        ))->execute(new CreateOrganizationInput(name: 'Empty', slug: 'empty'));
+
+        $logger = new class () extends AbstractLogger {
+            /** @var list<string> */
+            public array $messages = [];
+
+            /**
+             * @param mixed                $level
+             * @param string|\Stringable   $message
+             * @param array<string, mixed> $context
+             */
+            public function log($level, $message, array $context = []): void
+            {
+                $this->messages[] = (string) $message;
+            }
+        };
+
+        $reader = new class () implements OrgMediaInventoryReaderInterface {
+            public function forOrganization(int $organizationId): OrgMediaInventory
+            {
+                return OrgMediaInventory::fromEntries($organizationId, []);
+            }
+        };
+
+        (new DeleteOrganizationUseCase($organizations, $reader, $logger))
+            ->execute(new DeleteOrganizationInput(id: $created->id));
+
+        self::assertSame([], $logger->messages, 'nothing stranded means nothing to say');
+    }
+
+    /**
+     * The inventory is a record, not a precondition. An operator who asked for a
+     * delete must get it even if the bookkeeping fails.
+     */
+    public function testDeleteStillSucceedsWhenTheInventoryThrows(): void
+    {
+        $organizations = new InMemoryOrganizationRepository();
+        $created = (new CreateOrganizationUseCase(
+            $organizations,
+            new RecordingDefaultContentTypeSeeder(),
+            new RecordingDefaultSettingDefsSeeder(),
+        ))->execute(new CreateOrganizationInput(name: 'Doomed', slug: 'doomed-2'));
+
+        $logger = new class () extends AbstractLogger {
+            /** @var list<string> */
+            public array $levels = [];
+
+            /**
+             * @param mixed                $level
+             * @param string|\Stringable   $message
+             * @param array<string, mixed> $context
+             */
+            public function log($level, $message, array $context = []): void
+            {
+                $this->levels[] = (string) $level;
+            }
+        };
+
+        $reader = new class () implements OrgMediaInventoryReaderInterface {
+            public function forOrganization(int $organizationId): OrgMediaInventory
+            {
+                throw new RuntimeException('storage unavailable');
+            }
+        };
+
+        (new DeleteOrganizationUseCase($organizations, $reader, $logger))
+            ->execute(new DeleteOrganizationInput(id: $created->id));
+
+        self::assertNull($organizations->findById($created->id));
+        self::assertSame(['warning'], $logger->levels, 'the failure must be visible, not swallowed');
+    }
+}

--- a/tools/media-orphan-audit.php
+++ b/tools/media-orphan-audit.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * READ-ONLY audit of orphaned media files under var/media (#1018).
+ *
+ * Deleting an organization purges its `media` rows but leaves the files on disk.
+ * That is garbage, not an orphan in the dangerous sense: nothing can reach it and
+ * it cannot surface in another tenant, so the only cost is disk. This tool answers
+ * "how much is out there", which is the prerequisite for deciding whether removing
+ * it is worth the risk.
+ *
+ * **It never deletes, moves, or writes anything.** There is deliberately no --fix
+ * flag: file deletion has no undo, and the point of #1018 is to look before acting.
+ *
+ * What counts as an orphan: a file under the media root whose name matches no
+ * `media` row. Stored names are 16 random bytes in hex, so they are unique across
+ * orgs and the match is unambiguous. Derivatives live at
+ * `derivatives/<preset>/<format>/<year>/<month>/<stem>.<ext>` and are re-encoded
+ * (webp/avif), so they are matched on the stem rather than the full filename —
+ * otherwise every derivative would look orphaned.
+ *
+ * Note what this CANNOT tell you: which org a leftover file belonged to. The
+ * storage key has no tenant in it, and the rows that knew are gone. That
+ * attribution is captured at delete time by {@see \NeNeRecords\Organization\OrgMediaInventory}.
+ *
+ * Usage:
+ *   php tools/media-orphan-audit.php [--root=var/media] [--list] [--json]
+ *   docker compose exec -T app php tools/media-orphan-audit.php --list
+ *
+ * Options:
+ *   --root=PATH  media root; defaults to MEDIA_ROOT env, else <project>/var/media
+ *   --list       print every orphan path (default: a 10-line sample)
+ *   --json       machine-readable output for a cron/report pipeline
+ *
+ * Exit code is 0 whether or not orphans exist — this is a report, not a gate.
+ */
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeNeRecords\Http\RuntimeContainerFactory;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+/** @param non-empty-string $name */
+function auditOption(string $name): ?string
+{
+    foreach ($GLOBALS['argv'] as $arg) {
+        if (str_starts_with($arg, "--{$name}=")) {
+            return substr($arg, strlen($name) + 3);
+        }
+    }
+
+    return null;
+}
+
+/** @param non-empty-string $name */
+function auditFlag(string $name): bool
+{
+    return in_array("--{$name}", $GLOBALS['argv'], true);
+}
+
+$projectRoot = dirname(__DIR__);
+$root = auditOption('root') ?? (getenv('MEDIA_ROOT') ?: $projectRoot . '/var/media');
+$root = rtrim($root, '/');
+$asJson = auditFlag('json');
+$listAll = auditFlag('list');
+
+if (!is_dir($root)) {
+    fwrite(STDERR, "Media root not found: {$root}\n");
+    exit(1);
+}
+
+$container = (new RuntimeContainerFactory($projectRoot))->create();
+$query = $container->get(DatabaseQueryExecutorInterface::class);
+
+if (!$query instanceof DatabaseQueryExecutorInterface) {
+    fwrite(STDERR, "Database service unavailable.\n");
+    exit(1);
+}
+
+/** @var array<string, true> $knownNames */
+$knownNames = [];
+/** @var array<string, true> $knownStems */
+$knownStems = [];
+/** @var array<int, int> $rowsByOrg */
+$rowsByOrg = [];
+
+foreach ($query->fetchAll('SELECT organization_id, stored_name FROM media', []) as $row) {
+    $name = is_string($row['stored_name'] ?? null) ? $row['stored_name'] : '';
+
+    if ($name !== '') {
+        $knownNames[$name] = true;
+        $knownStems[pathinfo($name, PATHINFO_FILENAME)] = true;
+    }
+
+    $org = (int) ($row['organization_id'] ?? 0);
+    $rowsByOrg[$org] = ($rowsByOrg[$org] ?? 0) + 1;
+}
+
+$stats = [
+    'originals' => ['total' => 0, 'orphans' => 0, 'orphan_bytes' => 0],
+    'derivatives' => ['total' => 0, 'orphans' => 0, 'orphan_bytes' => 0],
+];
+/** @var list<array{path: string, bytes: int, modified: string, kind: string}> $orphans */
+$orphans = [];
+
+$iterator = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+);
+
+foreach ($iterator as $file) {
+    if (!$file instanceof SplFileInfo || !$file->isFile()) {
+        continue;
+    }
+
+    $relative = ltrim(substr($file->getPathname(), strlen($root)), '/');
+    $kind = str_starts_with($relative, 'derivatives/') ? 'derivatives' : 'originals';
+    ++$stats[$kind]['total'];
+
+    // Derivatives are re-encoded, so the extension differs from the original's:
+    // match on the stem there, and on the full name for originals.
+    $isKnown = $kind === 'derivatives'
+        ? isset($knownStems[pathinfo($file->getFilename(), PATHINFO_FILENAME)])
+        : isset($knownNames[$file->getFilename()]);
+
+    if ($isKnown) {
+        continue;
+    }
+
+    ++$stats[$kind]['orphans'];
+    $stats[$kind]['orphan_bytes'] += $file->getSize();
+    $orphans[] = [
+        'path' => $relative,
+        'bytes' => $file->getSize(),
+        'modified' => date('Y-m-d', $file->getMTime()),
+        'kind' => $kind,
+    ];
+}
+
+usort($orphans, static fn (array $a, array $b): int => $b['bytes'] <=> $a['bytes']);
+
+$totalOrphans = $stats['originals']['orphans'] + $stats['derivatives']['orphans'];
+$totalBytes = $stats['originals']['orphan_bytes'] + $stats['derivatives']['orphan_bytes'];
+
+if ($asJson) {
+    echo json_encode([
+        'root' => $root,
+        'media_rows' => array_sum($rowsByOrg),
+        'media_rows_by_org' => $rowsByOrg,
+        'originals' => $stats['originals'],
+        'derivatives' => $stats['derivatives'],
+        'orphan_total' => $totalOrphans,
+        'orphan_bytes' => $totalBytes,
+        'orphans' => $listAll ? $orphans : array_slice($orphans, 0, 10),
+        'orphans_truncated' => !$listAll && count($orphans) > 10,
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+    exit(0);
+}
+
+$mb = static fn (int $bytes): string => number_format($bytes / 1048576, 2) . ' MB';
+
+echo "media orphan audit (READ-ONLY — nothing is deleted)\n";
+echo "root: {$root}\n\n";
+echo 'media rows: ' . array_sum($rowsByOrg) . "\n";
+ksort($rowsByOrg);
+
+foreach ($rowsByOrg as $org => $count) {
+    echo "  org {$org}: {$count}\n";
+}
+
+printf(
+    "\noriginals  : %d files, %d orphaned (%s)\n",
+    $stats['originals']['total'],
+    $stats['originals']['orphans'],
+    $mb($stats['originals']['orphan_bytes']),
+);
+printf(
+    "derivatives: %d files, %d orphaned (%s)\n",
+    $stats['derivatives']['total'],
+    $stats['derivatives']['orphans'],
+    $mb($stats['derivatives']['orphan_bytes']),
+);
+printf("orphans    : %d files (%s)\n", $totalOrphans, $mb($totalBytes));
+
+if ($orphans !== []) {
+    $shown = $listAll ? $orphans : array_slice($orphans, 0, 10);
+    echo "\n" . ($listAll ? 'all orphans' : 'largest orphans') . " (by size):\n";
+
+    foreach ($shown as $orphan) {
+        printf("  %-58s %10s  %s\n", $orphan['path'], $mb($orphan['bytes']), $orphan['modified']);
+    }
+
+    if (!$listAll && count($orphans) > 10) {
+        printf("  … and %d more (use --list)\n", count($orphans) - 10);
+    }
+}


### PR DESCRIPTION
## 目的

#1018 の**第1段階＝棚卸し**。org を削除すると `media` 行は purge されるが、`var/media` のファイルは残る。
**消す機能は作らない**（統合リナ裁定）。理由はファイル削除が DB トランザクションの外側になること・復旧不能なこと・実害が小さいこと。

## 🔴 タイミングが要点

`storage_key` は `YYYY/MM/<random>.<ext>` で、**パスに org を含みません**。
つまり行が消えた後は「どのファイルがどの org のものだったか」を**二度と言えません**。
**削除時の記録だけが帰属を残せる唯一の機会**です。これが「削除の前に記録する」設計の理由で、
テストでもそこを pin しています（後述）。

## 本番実測（読み取り専用・この変更を入れる前に採取）

| | media 行 | オリジナル | 派生 | 孤児 |
|---|---|---|---|---|
| **ConoHa** | **0** | 10 (全孤児) | 6 (全孤児) | **16 / 3.91 MB** |
| **ayane Tier A** | 10 (org 1) | 13 (孤児 3) | 9 (孤児 **0**) | **3 / 1.33 MB** |

- ConoHa の 16 件は **07-23 に削除した ayane SaaS コピー由来**（mtime すべて 07-17）＝ #1018 が予測したとおりの残骸
- 🟢 **ayane の孤児3件はすべて `.pdf.v1bak`**（PDF v2 化のとき人が作った手動バックアップ）。
  **アプリ由来の孤児はゼロ・派生の孤児もゼロ** ＝ 定常運用でファイルが漏れているわけではない
- 実害は合計 **5.24 MB**。issue の「実害はディスク使用量のみ・緊急性は低い」を実測で裏づけ

## 変更

- **`OrgMediaInventory`**（値オブジェクト）/ **`OrgMediaInventoryReaderInterface`** / **`PdoOrgMediaInventoryReader`**
  org id を**明示的に**受け取ります。リクエストスコープの `MediaRepositoryInterface` は「呼び出し側の org」に
  閉じており、org 削除は**別テナントへの superadmin 操作**なので使えません（purge が id を明示的に取るのと同じ理由）。
- **`DeleteOrganizationUseCase`**: 削除の**前**に棚卸しして info ログへ。
  棚卸しは**記録であって前提条件ではない**ので、失敗しても削除は止めません（warning は出す）。
  collaborator は optional にして既存の生成箇所を壊しません。
- **`tools/media-orphan-audit.php`**: `var/media` を走査して DB と突合する**読み取り専用**ツール。
  **`--fix` は意図的に用意していません**。派生は再エンコードで拡張子が変わるので **stem で照合**します
  （full name だと全派生が孤児に見える）。

## 🔴 破壊実験でテストの穴が見つかり、塞ぎました

最初のテストは「ログに出たこと」を assert していました。それだと **棚卸しを delete の後ろに動かしても通ります**
——つまり**機能の核心が守られていませんでした**。reader 実行時点で org がまだ見えるかを観測する形に変更。

| 壊し方 | 結果 |
|---|---|
| 棚卸しの呼び出しを削除 | 🟢 FAIL |
| 棚卸しを delete の**後ろ**へ移動 | 🟢 FAIL（**修正後**。修正前は PASS してしまっていた） |
| 例外を握り潰す（warning を出さない） | 🟢 FAIL |

## 検証

- `composer check` **全緑**（1534 tests / PHPStan L8 / CS-Fixer / OpenAPI / conformance / MCP）
- ツールをローカル実スタックで実走（30ファイル / 0.96 MB を検出）＋ 本番2系統でも実測済み

## 次の段階（本 PR の範囲外）

issue のチェックリストどおり、**一覧が実運用で正しいことを確認できてから**削除（または隔離ディレクトリへの退避）を検討します。
本 PR は「見る」だけで終わりです。

Refs #1018