### PR TITLE
feat(embed): connect-token の保管・提示（案1 ①）（#1029）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,14 @@ NENE2_LOCAL_JWT_SECRET=
 # this and NENE2_LOCAL_JWT_SECRET are empty in local/dev, the app fails closed.
 NENE2_ALLOW_DEV_SECRET=1
 PROBLEM_DETAILS_BASE_URL=https://nene-records.dev/problems/
+# Key that encrypts configuration secrets at rest — currently the connect-token another
+# product (contact) issued to this org (#1029). Base64 of exactly 32 bytes:
+#   openssl rand -base64 32
+# Deliberately separate from NENE2_LOCAL_JWT_SECRET so rotating the JWT secret does not make
+# stored tokens unreadable. Unset = records refuses to store or read a connect-token
+# (fail-closed); everything else keeps working. There is no re-encryption path: change this
+# key and the stored token must be pasted again (contact can re-issue it).
+NENE_RECORDS_CONFIG_KEY=
 
 # --- Database (host / PHPUnit default: SQLite) ---
 DATABASE_URL=

--- a/database/migrations/20260729000001_create_org_connect_tokens_table.php
+++ b/database/migrations/20260729000001_create_org_connect_tokens_table.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Creates `org_connect_tokens` — where an organization stores the connect-token it was
+ * *issued by another product* (records-embed 案1 / #1029, epic #1001).
+ *
+ * records is the **holder**, never the issuer: contact mints the token and owns revocation
+ * (`revoked_at` + `isActive`), records only stores it and presents it as a bearer credential
+ * on server-to-server calls. Nothing here mints, rotates, or expires a token.
+ *
+ * **Why a dedicated table rather than a column on `setting_values`**: `PdoOrgExportRepository`
+ * enumerates 25 tables explicitly and reads `SELECT *` from each, so a new column on an
+ * exported table is exported automatically — a secret parked there would silently ride along
+ * into every org export. A table the export never enumerates cannot leak that way, so the
+ * export must never learn about this one.
+ *
+ * The value is stored encrypted (AES-256-GCM, key from `NENE_RECORDS_CONFIG_KEY`): the column
+ * holds ciphertext, never the token. `token_hint` keeps only the trailing characters so the
+ * admin UI can show *which* token is installed without ever returning the secret.
+ */
+final class CreateOrgConnectTokensTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('org_connect_tokens')
+            ->addColumn('organization_id', 'integer', ['signed' => false, 'null' => false])
+            ->addColumn('service', 'string', ['limit' => 32, 'null' => false, 'comment' => 'Issuing product, e.g. "contact".'])
+            ->addColumn('token_ciphertext', 'text', ['null' => false, 'comment' => 'AES-256-GCM envelope (base64). Never the raw token.'])
+            ->addColumn('token_hint', 'string', ['limit' => 8, 'null' => false, 'default' => '', 'comment' => 'Trailing characters only, for admin display.'])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['organization_id', 'service'], ['unique' => true, 'name' => 'uq_org_connect_tokens_org_service'])
+            ->create();
+    }
+}

--- a/database/schema/org_connect_tokens.sql
+++ b/database/schema/org_connect_tokens.sql
@@ -1,0 +1,11 @@
+CREATE TABLE org_connect_tokens (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    organization_id INTEGER UNSIGNED NOT NULL,
+    service VARCHAR(32) NOT NULL,
+    token_ciphertext TEXT NOT NULL,
+    token_hint VARCHAR(8) NOT NULL DEFAULT '',
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+);
+
+CREATE UNIQUE INDEX uq_org_connect_tokens_org_service ON org_connect_tokens (organization_id, service);

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -48,6 +48,10 @@ tags:
     description: Ordered navigation link management for the public site header.
   - name: Webhooks
     description: Webhook endpoints for entity create/update/delete event notifications.
+  - name: ConnectTokens
+    description: >-
+      Credentials issued to this organization by a sibling product, held by records and
+      presented on server-to-server calls. Stored encrypted; never returned (#1029).
   - name: Users
     description: User account management (admin only) and self-service password change.
   - name: Themes
@@ -2534,6 +2538,81 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/connect-tokens:
+    get:
+      tags:
+        - ConnectTokens
+      summary: List connect tokens
+      description: >-
+        Returns the connect tokens installed for the current organization, masked.
+        Only a trailing hint is ever returned — never the token, never its stored
+        ciphertext. Admin-only for every method including GET (#1029).
+      operationId: listConnectTokens
+      responses:
+        '200':
+          description: Installed connect tokens, masked.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectTokenListResponse'
+  /api/v1/connect-tokens/{service}:
+    parameters:
+      - name: service
+        in: path
+        required: true
+        description: The product that issued the token.
+        schema:
+          $ref: '#/components/schemas/ConnectTokenService'
+    put:
+      tags:
+        - ConnectTokens
+      summary: Install or replace a connect token
+      description: >-
+        Stores the token the named product issued to this organization, encrypted at
+        rest. records never mints these — issuance and revocation stay with the issuing
+        product. Replacing an existing token returns 200; the first install returns 201.
+      operationId: saveConnectToken
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SaveConnectTokenRequest'
+      responses:
+        '200':
+          description: Existing token replaced.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectTokenResponse'
+        '201':
+          description: Token installed.
+          headers:
+            Location:
+              schema:
+                type: string
+              example: /api/v1/connect-tokens/contact
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectTokenResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+    delete:
+      tags:
+        - ConnectTokens
+      summary: Remove a connect token
+      description: >-
+        Deletes the stored token. This does not revoke it — revocation belongs to the
+        issuing product.
+      operationId: deleteConnectToken
+      responses:
+        '204':
+          description: Token removed.
         '404':
           $ref: '#/components/responses/NotFound'
   /api/v1/webhooks:
@@ -7401,6 +7480,60 @@ components:
       additionalProperties: false
 
 
+    ConnectTokenService:
+      type: string
+      enum:
+        - contact
+      description: >-
+        Allow-list of products records may hold a connect token for. Not free text —
+        the value is part of the storage key and of this URL.
+    ConnectTokenResponse:
+      type: object
+      required:
+        - service
+        - token_hint
+        - created_at
+        - updated_at
+      properties:
+        service:
+          $ref: '#/components/schemas/ConnectTokenService'
+        token_hint:
+          type: string
+          maxLength: 8
+          description: >-
+            Trailing characters of the installed token, so an operator can tell which
+            one is in place. The token itself is never returned by any endpoint.
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      additionalProperties: false
+    ConnectTokenListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConnectTokenResponse'
+      additionalProperties: false
+    SaveConnectTokenRequest:
+      type: object
+      required:
+        - token
+      properties:
+        token:
+          type: string
+          minLength: 16
+          maxLength: 4096
+          pattern: '^[A-Za-z0-9._~+/=-]+$'
+          description: >-
+            The raw token as issued by the other product. Write-only: it is encrypted
+            before storage and no endpoint reads it back.
+      additionalProperties: false
     WebhookResponse:
       type: object
       required:

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -921,6 +921,53 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/connect-tokens": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List connect tokens
+         * @description Returns the connect tokens installed for the current organization, masked. Only a trailing hint is ever returned — never the token, never its stored ciphertext. Admin-only for every method including GET (#1029).
+         */
+        get: operations["listConnectTokens"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/connect-tokens/{service}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The product that issued the token. */
+                service: components["schemas"]["ConnectTokenService"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Install or replace a connect token
+         * @description Stores the token the named product issued to this organization, encrypted at rest. records never mints these — issuance and revocation stay with the issuing product. Replacing an existing token returns 200; the first install returns 201.
+         */
+        put: operations["saveConnectToken"];
+        post?: never;
+        /**
+         * Remove a connect token
+         * @description Deletes the stored token. This does not revoke it — revocation belongs to the issuing product.
+         */
+        delete: operations["deleteConnectToken"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/webhooks": {
         parameters: {
             query?: never;
@@ -2980,6 +3027,27 @@ export interface components {
             /** @description The full base engine stylesheet (includes flag implementations). */
             css: string;
             note: string;
+        };
+        /**
+         * @description Allow-list of products records may hold a connect token for. Not free text — the value is part of the storage key and of this URL.
+         * @enum {string}
+         */
+        ConnectTokenService: "contact";
+        ConnectTokenResponse: {
+            service: components["schemas"]["ConnectTokenService"];
+            /** @description Trailing characters of the installed token, so an operator can tell which one is in place. The token itself is never returned by any endpoint. */
+            token_hint: string;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        ConnectTokenListResponse: {
+            items: components["schemas"]["ConnectTokenResponse"][];
+        };
+        SaveConnectTokenRequest: {
+            /** @description The raw token as issued by the other product. Write-only: it is encrypted before storage and no endpoint reads it back. */
+            token: string;
         };
         WebhookResponse: {
             /** Format: int64 */
@@ -5640,6 +5708,88 @@ export interface operations {
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    listConnectTokens: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Installed connect tokens, masked. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectTokenListResponse"];
+                };
+            };
+        };
+    };
+    saveConnectToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The product that issued the token. */
+                service: components["schemas"]["ConnectTokenService"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SaveConnectTokenRequest"];
+            };
+        };
+        responses: {
+            /** @description Existing token replaced. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectTokenResponse"];
+                };
+            };
+            /** @description Token installed. */
+            201: {
+                headers: {
+                    /** @example /api/v1/connect-tokens/contact */
+                    Location?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectTokenResponse"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationFailed"];
+        };
+    };
+    deleteConnectToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The product that issued the token. */
+                service: components["schemas"]["ConnectTokenService"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Token removed. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             404: components["responses"]["NotFound"];
         };
     };

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -24,6 +24,7 @@ use NeNeRecords\BoolField\BoolFieldServiceProvider;
 use NeNeRecords\Comment\CommentNotFoundExceptionHandler;
 use NeNeRecords\Comment\CommentRouteRegistrar;
 use NeNeRecords\Comment\CommentServiceProvider;
+use NeNeRecords\Config\ConfigServiceProvider;
 use NeNeRecords\Dashboard\DashboardRouteRegistrar;
 use NeNeRecords\Dashboard\DashboardServiceProvider;
 use NeNeRecords\DataMigration\DataMigrationRouteRegistrar;
@@ -88,6 +89,9 @@ use NeNeRecords\Organization\OrganizationRouteRegistrar;
 use NeNeRecords\Organization\OrganizationServiceProvider;
 use NeNeRecords\Organization\OrganizationSlugConflictExceptionHandler;
 use NeNeRecords\Organization\TlsCheckRouteRegistrar;
+use NeNeRecords\OrgConnect\ConnectTokenNotFoundExceptionHandler;
+use NeNeRecords\OrgConnect\ConnectTokenRouteRegistrar;
+use NeNeRecords\OrgConnect\OrgConnectServiceProvider;
 use NeNeRecords\OrgExport\OrgExportRouteRegistrar;
 use NeNeRecords\OrgExport\OrgExportServiceProvider;
 use NeNeRecords\PreviewToken\PreviewTokenNotFoundExceptionHandler;
@@ -160,6 +164,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
         );
 
         $builder
+            ->addProvider(new ConfigServiceProvider())
             ->addProvider(new AccountServiceProvider())
             ->addProvider(new EntityArchiveServiceProvider())
             ->addProvider(new EntityTypeServiceProvider())
@@ -182,6 +187,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new MenuServiceProvider())
             ->addProvider(new WidgetServiceProvider())
             ->addProvider(new WebhookServiceProvider())
+            ->addProvider(new OrgConnectServiceProvider())
             ->addProvider(new PreviewTokenServiceProvider())
             ->addProvider(new DashboardServiceProvider())
             ->addProvider(new UserServiceProvider())
@@ -230,6 +236,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $menu = $container->get('nene-records.route_registrar.menu');
                     $widget = $container->get('nene-records.route_registrar.widget');
                     $webhook = $container->get('nene-records.route_registrar.webhook');
+                    $connectToken = $container->get('nene-records.route_registrar.connect_token');
                     $previewToken = $container->get('nene-records.route_registrar.preview_token');
                     $dashboard = $container->get('nene-records.route_registrar.dashboard');
                     $account = $container->get('nene-records.route_registrar.account');
@@ -270,6 +277,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         || !$menu instanceof MenuRouteRegistrar
                         || !$widget instanceof WidgetRouteRegistrar
                         || !$webhook instanceof WebhookRouteRegistrar
+                        || !$connectToken instanceof ConnectTokenRouteRegistrar
                         || !$previewToken instanceof PreviewTokenRouteRegistrar
                         || !$dashboard instanceof DashboardRouteRegistrar
                         || !$account instanceof AccountRouteRegistrar
@@ -314,6 +322,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $menu,
                         $widget,
                         $webhook,
+                        $connectToken,
                         $previewToken,
                         $dashboard,
                         $account,
@@ -380,6 +389,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $menuNotFound = $container->get(MenuNotFoundExceptionHandler::class);
                     $widgetNotFound = $container->get(WidgetNotFoundExceptionHandler::class);
                     $webhookNotFound = $container->get(WebhookNotFoundExceptionHandler::class);
+                    $connectTokenNotFound = $container->get(ConnectTokenNotFoundExceptionHandler::class);
                     $previewTokenNotFound = $container->get(PreviewTokenNotFoundExceptionHandler::class);
                     $userNotFound = $container->get(UserNotFoundExceptionHandler::class);
                     $userEmailConflict = $container->get(UserEmailConflictExceptionHandler::class);
@@ -433,6 +443,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $menuNotFound,
                         $widgetNotFound,
                         $webhookNotFound,
+                        $connectTokenNotFound,
                         $previewTokenNotFound,
                         $userNotFound,
                         $userEmailConflict,
@@ -491,6 +502,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         $menuNotFound,
                         $widgetNotFound,
                         $webhookNotFound,
+                        $connectTokenNotFound,
                         $previewTokenNotFound,
                         $userNotFound,
                         $userEmailConflict,

--- a/src/Auth/AdminApiAuthMiddleware.php
+++ b/src/Auth/AdminApiAuthMiddleware.php
@@ -69,6 +69,10 @@ final readonly class AdminApiAuthMiddleware implements MiddlewareInterface
         // (`/api/v1/webhooks/process-deliveries` stays open via ALWAYS_OPEN above,
         // which is matched first.)
         '/api/v1/webhooks',
+        // Connect-tokens: the credentials another product issued to this tenant. Reads are
+        // masked, but the list still says which integrations are installed, and PUT installs
+        // a credential — neither belongs on an anonymous surface. See #1029.
+        '/api/v1/connect-tokens',
         '/api/v1/notification-channels',
         '/api/v1/entities/export',
         '/api/v1/dashboard',

--- a/src/Auth/CapabilityResolver.php
+++ b/src/Auth/CapabilityResolver.php
@@ -47,6 +47,14 @@ final class CapabilityResolver
             };
         }
 
+        // Connect-tokens are admin-only for every method, reads included (#1029). Editors get
+        // ReadSettings, which is why this is not folded into the settings branch above: the
+        // masked list is still an inventory of the tenant's integrations, and installing one
+        // is handing records a credential.
+        if (str_starts_with($path, '/api/v1/connect-tokens')) {
+            return Capability::ManageSettings;
+        }
+
         if (str_starts_with($path, '/api/v1/navigation-items')) {
             return match ($method) {
                 'POST', 'PUT', 'DELETE' => Capability::ManageSettings,

--- a/src/Config/AesGcmConfigCipher.php
+++ b/src/Config/AesGcmConfigCipher.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Config;
+
+use SensitiveParameter;
+
+/**
+ * AES-256-GCM implementation of {@see ConfigCipherInterface}.
+ *
+ * Envelope layout, base64-encoded as one string: `iv(12) || tag(16) || ciphertext`.
+ * GCM is chosen over CBC so a tampered envelope fails to open instead of decrypting into
+ * attacker-influenced plaintext; the tag is what makes `decrypt()` able to reject a value
+ * that was edited in the database.
+ *
+ * The key never appears in the envelope, so rotating `NENE_RECORDS_CONFIG_KEY` does not
+ * corrupt stored rows — it makes them unreadable, which surfaces as {@see ConfigDecryptException}
+ * and is resolved by re-pasting the token (contact can re-issue it).
+ */
+final readonly class AesGcmConfigCipher implements ConfigCipherInterface
+{
+    private const CIPHER = 'aes-256-gcm';
+    private const IV_LENGTH = 12;
+    private const TAG_LENGTH = 16;
+
+    public function __construct(
+        private ConfigKeyResolverInterface $keys,
+    ) {
+    }
+
+    public function encrypt(#[SensitiveParameter] string $plaintext): string
+    {
+        $key = $this->keys->resolve();
+        $iv = random_bytes(self::IV_LENGTH);
+        $tag = '';
+
+        $ciphertext = openssl_encrypt($plaintext, self::CIPHER, $key, OPENSSL_RAW_DATA, $iv, $tag, '', self::TAG_LENGTH);
+
+        if ($ciphertext === false) {
+            throw new ConfigKeyException('Failed to encrypt configuration value.');
+        }
+
+        return base64_encode($iv . $tag . $ciphertext);
+    }
+
+    public function decrypt(#[SensitiveParameter] string $envelope): string
+    {
+        $key = $this->keys->resolve();
+        $raw = base64_decode($envelope, true);
+
+        if ($raw === false || strlen($raw) <= self::IV_LENGTH + self::TAG_LENGTH) {
+            throw new ConfigDecryptException('Configuration envelope is malformed or truncated.');
+        }
+
+        $iv = substr($raw, 0, self::IV_LENGTH);
+        $tag = substr($raw, self::IV_LENGTH, self::TAG_LENGTH);
+        $ciphertext = substr($raw, self::IV_LENGTH + self::TAG_LENGTH);
+
+        $plaintext = openssl_decrypt($ciphertext, self::CIPHER, $key, OPENSSL_RAW_DATA, $iv, $tag);
+
+        if ($plaintext === false || $plaintext === '') {
+            throw new ConfigDecryptException('Configuration envelope could not be opened with the configured key.');
+        }
+
+        return $plaintext;
+    }
+}

--- a/src/Config/AesGcmConfigCipher.php
+++ b/src/Config/AesGcmConfigCipher.php
@@ -59,6 +59,9 @@ final readonly class AesGcmConfigCipher implements ConfigCipherInterface
 
         $plaintext = openssl_decrypt($ciphertext, self::CIPHER, $key, OPENSSL_RAW_DATA, $iv, $tag);
 
+        // An empty result is treated as failure, not as a valid empty secret: nothing that
+        // belongs in here is legitimately empty, and returning '' would hand a caller
+        // something that looks usable. The interface promises a non-empty-string.
         if ($plaintext === false || $plaintext === '') {
             throw new ConfigDecryptException('Configuration envelope could not be opened with the configured key.');
         }

--- a/src/Config/ConfigCipherInterface.php
+++ b/src/Config/ConfigCipherInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Config;
+
+/**
+ * Encrypts configuration secrets that must survive at rest in the database.
+ *
+ * Used for values records is *given* by another product and must present later — the
+ * connect-token of records-embed 案1 is the first (#1029). Not for passwords (those are
+ * hashed, never decrypted) and not for tokens records itself mints (records mints none).
+ */
+interface ConfigCipherInterface
+{
+    /**
+     * @param non-empty-string $plaintext
+     *
+     * @return non-empty-string an opaque envelope safe to store as text
+     *
+     * @throws ConfigKeyException when no usable key is configured
+     */
+    public function encrypt(string $plaintext): string;
+
+    /**
+     * @param non-empty-string $envelope a value previously returned by {@see encrypt()}
+     *
+     * @return non-empty-string
+     *
+     * @throws ConfigKeyException     when no usable key is configured
+     * @throws ConfigDecryptException when the envelope is malformed, truncated, or was
+     *                                produced under a different key
+     */
+    public function decrypt(string $envelope): string;
+}

--- a/src/Config/ConfigDecryptException.php
+++ b/src/Config/ConfigDecryptException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Config;
+
+use RuntimeException;
+
+/**
+ * Raised when an envelope cannot be opened with the configured key.
+ *
+ * The common cause is not corruption but a *rotated key*: the initial implementation ships no
+ * re-encryption path (YAGNI), so changing `NENE_RECORDS_CONFIG_KEY` makes every stored value
+ * unreadable and the operator re-pastes the token. Callers must surface this rather than
+ * treat it as "no token configured" — the two states need different operator actions.
+ */
+final class ConfigDecryptException extends RuntimeException
+{
+}

--- a/src/Config/ConfigKeyException.php
+++ b/src/Config/ConfigKeyException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Config;
+
+use RuntimeException;
+
+/**
+ * Raised when the configuration encryption key is absent or unusable.
+ *
+ * Deliberately fail-closed, mirroring {@see \Nene2\Auth\GuardedJwtSecretResolver}: without a
+ * key records must refuse to *store* a secret as well as to read one back. Falling back to
+ * plaintext would turn a missing environment variable into a silent downgrade, which is the
+ * failure mode this whole design exists to prevent.
+ */
+final class ConfigKeyException extends RuntimeException
+{
+}

--- a/src/Config/ConfigKeyResolverInterface.php
+++ b/src/Config/ConfigKeyResolverInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Config;
+
+/**
+ * Supplies the raw 32-byte key used by {@see AesGcmConfigCipher}.
+ */
+interface ConfigKeyResolverInterface
+{
+    /**
+     * @return non-empty-string raw key bytes (32)
+     *
+     * @throws ConfigKeyException when the key is absent, malformed, or the wrong length
+     */
+    public function resolve(): string;
+}

--- a/src/Config/ConfigServiceProvider.php
+++ b/src/Config/ConfigServiceProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Config;
+
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the at-rest encryption used for configuration secrets (#1029).
+ *
+ * Registered even when `NENE_RECORDS_CONFIG_KEY` is unset: the resolver reads the
+ * environment lazily, so a deployment without a key still boots and only fails when
+ * something actually tries to store or read a secret. Refusing at construction time would
+ * take the whole application down over a feature most tenants never enable.
+ */
+final readonly class ConfigServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                ConfigKeyResolverInterface::class,
+                static fn (ContainerInterface $container): ConfigKeyResolverInterface => new EnvConfigKeyResolver(),
+            )
+            ->set(
+                ConfigCipherInterface::class,
+                static function (ContainerInterface $container): ConfigCipherInterface {
+                    $keys = $container->get(ConfigKeyResolverInterface::class);
+
+                    if (!$keys instanceof ConfigKeyResolverInterface) {
+                        throw new \LogicException('Config key resolver service is invalid.');
+                    }
+
+                    return new AesGcmConfigCipher($keys);
+                },
+            );
+    }
+}

--- a/src/Config/EnvConfigKeyResolver.php
+++ b/src/Config/EnvConfigKeyResolver.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Config;
+
+/**
+ * Reads the configuration key from `NENE_RECORDS_CONFIG_KEY` (base64 of 32 raw bytes).
+ *
+ * Env-sourced and records-owned by decision (#1029): NENE2's `ConfigLoader` allow-list is
+ * framework-owned, and `NENE_RECORDS_*` is already how records reads its own application
+ * variables (`NENE_RECORDS_VITE_URL`). Keeping this key separate from
+ * `NENE2_LOCAL_JWT_SECRET` means rotating the JWT secret does not make stored tokens
+ * unreadable.
+ *
+ * Generate one with: `openssl rand -base64 32`
+ */
+final class EnvConfigKeyResolver implements ConfigKeyResolverInterface
+{
+    public const ENV_NAME = 'NENE_RECORDS_CONFIG_KEY';
+
+    private const KEY_LENGTH = 32;
+
+    public function resolve(): string
+    {
+        $configured = getenv(self::ENV_NAME);
+
+        if (!is_string($configured) || trim($configured) === '') {
+            throw new ConfigKeyException(
+                self::ENV_NAME . ' is not set. Generate one with `openssl rand -base64 32`; '
+                . 'without it records refuses to store or read connect-tokens.',
+            );
+        }
+
+        $key = base64_decode(trim($configured), true);
+
+        if ($key === false || strlen($key) !== self::KEY_LENGTH) {
+            throw new ConfigKeyException(
+                self::ENV_NAME . ' must be base64 of exactly ' . self::KEY_LENGTH . ' bytes '
+                . '(`openssl rand -base64 32`).',
+            );
+        }
+
+        return $key;
+    }
+}

--- a/src/OrgConnect/ConnectTokenHttpMapper.php
+++ b/src/OrgConnect/ConnectTokenHttpMapper.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+final class ConnectTokenHttpMapper
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function toArray(ConnectTokenSummary $summary): array
+    {
+        // Takes a summary, not a row: the token cannot be echoed here because it never
+        // reaches this layer. `token_hint` is trailing characters only — enough to answer
+        // "is the one I pasted still installed?", useless as a credential.
+        return [
+            'service'    => $summary->service->value,
+            'token_hint' => $summary->hint,
+            'created_at' => $summary->createdAt,
+            'updated_at' => $summary->updatedAt,
+        ];
+    }
+}

--- a/src/OrgConnect/ConnectTokenNotFoundException.php
+++ b/src/OrgConnect/ConnectTokenNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+use DomainException;
+
+final class ConnectTokenNotFoundException extends DomainException
+{
+    public function __construct(public readonly string $service)
+    {
+        parent::__construct('Connect token not found: ' . $service);
+    }
+}

--- a/src/OrgConnect/ConnectTokenNotFoundExceptionHandler.php
+++ b/src/OrgConnect/ConnectTokenNotFoundExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class ConnectTokenNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $e): bool
+    {
+        return $e instanceof ConnectTokenNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'not-found', 'Not Found', 404, $exception->getMessage());
+    }
+}

--- a/src/OrgConnect/ConnectTokenProviderInterface.php
+++ b/src/OrgConnect/ConnectTokenProviderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+use NeNeRecords\Config\ConfigDecryptException;
+use NeNeRecords\Config\ConfigKeyException;
+
+/**
+ * The one seam that yields a connect-token in plaintext.
+ *
+ * Server-side callers only — the submission proxy (#1031) attaches the token to a
+ * server-to-server request. Nothing in the HTTP response path may depend on this
+ * interface; `ConnectTokenLeakPinTest` fails if that changes.
+ */
+interface ConnectTokenProviderInterface
+{
+    /**
+     * @return non-empty-string|null null when no token is installed for the service
+     *
+     * @throws ConfigKeyException     when `NENE_RECORDS_CONFIG_KEY` is missing or unusable
+     * @throws ConfigDecryptException when a token is installed but cannot be opened with the
+     *                                configured key (typically a rotated key). Distinct from
+     *                                null on purpose: "broken" and "absent" need different
+     *                                operator actions.
+     */
+    public function secretFor(ConnectTokenService $service): ?string;
+}

--- a/src/OrgConnect/ConnectTokenRepositoryInterface.php
+++ b/src/OrgConnect/ConnectTokenRepositoryInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+/**
+ * Storage for the connect-tokens of the current organization.
+ *
+ * Deliberately split into a summary read (no secret material) and a single envelope read,
+ * so a caller that only wants to display state cannot accidentally hold the ciphertext.
+ * Scoping to the organization is ambient, as everywhere else in this codebase.
+ */
+interface ConnectTokenRepositoryInterface
+{
+    /** @return list<ConnectTokenSummary> */
+    public function findAllSummaries(): array;
+
+    public function findSummary(ConnectTokenService $service): ?ConnectTokenSummary;
+
+    /**
+     * The stored envelope, still encrypted. Decrypting is {@see ConnectTokenProviderInterface}'s job.
+     */
+    public function findEnvelope(ConnectTokenService $service): ?string;
+
+    /**
+     * Installs or replaces the token for one service and returns the resulting state.
+     *
+     * @param non-empty-string $envelope
+     */
+    public function save(ConnectTokenService $service, string $envelope, string $hint): ConnectTokenSummary;
+
+    public function delete(ConnectTokenService $service): void;
+}

--- a/src/OrgConnect/ConnectTokenRouteRegistrar.php
+++ b/src/OrgConnect/ConnectTokenRouteRegistrar.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ConnectTokenRouteRegistrar
+{
+    public function __construct(
+        private ListConnectTokensHandler $listHandler,
+        private SaveConnectTokenHandler $saveHandler,
+        private DeleteConnectTokenHandler $deleteHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $list = $this->listHandler;
+        $save = $this->saveHandler;
+        $delete = $this->deleteHandler;
+
+        // No read route for a single token: the list already carries everything that is
+        // safe to return, so a per-service GET would only add another surface to audit.
+        $router->get(
+            '/api/v1/connect-tokens',
+            static fn (ServerRequestInterface $request) => $list->handle($request),
+        );
+        $router->put(
+            '/api/v1/connect-tokens/{service}',
+            static fn (ServerRequestInterface $request) => $save->handle($request),
+        );
+        $router->delete(
+            '/api/v1/connect-tokens/{service}',
+            static fn (ServerRequestInterface $request) => $delete->handle($request),
+        );
+    }
+}

--- a/src/OrgConnect/ConnectTokenService.php
+++ b/src/OrgConnect/ConnectTokenService.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+/**
+ * The products records may hold a connect-token for.
+ *
+ * An allow-list, not free text: the service is part of the table's unique key and of the
+ * admin URL, so accepting arbitrary strings would let an operator create rows nothing ever
+ * reads, and would make "which integrations exist" unanswerable from the code.
+ *
+ * records never mints these tokens — the named product issues one and the operator pastes
+ * it here (#1029, epic #1001).
+ */
+enum ConnectTokenService: string
+{
+    case Contact = 'contact';
+}

--- a/src/OrgConnect/ConnectTokenServiceResolver.php
+++ b/src/OrgConnect/ConnectTokenServiceResolver.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class ConnectTokenServiceResolver
+{
+    /**
+     * Reads the `{service}` path parameter and maps it onto the allow-list.
+     *
+     * An unknown value is a 404, not a 422: the URL names a slot that does not exist.
+     * The rejected value is echoed back only after being trimmed to a short, harmless
+     * shape — a Problem Details body is not a place to reflect arbitrary input.
+     *
+     * @throws ConnectTokenNotFoundException
+     */
+    public static function fromPath(ServerRequestInterface $request): ConnectTokenService
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $raw = is_array($parameters) ? (string) ($parameters['service'] ?? '') : '';
+        $service = ConnectTokenService::tryFrom($raw);
+
+        if ($service === null) {
+            throw new ConnectTokenNotFoundException(
+                (string) preg_replace('/[^A-Za-z0-9_-]/', '', substr($raw, 0, 32)),
+            );
+        }
+
+        return $service;
+    }
+}

--- a/src/OrgConnect/ConnectTokenSummary.php
+++ b/src/OrgConnect/ConnectTokenSummary.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+/**
+ * Everything about an installed connect-token *except* the token.
+ *
+ * This type is the reason the admin API cannot leak the secret by accident: there is no
+ * property to put it in. The read path (`findAllSummaries` / `findSummary`) never selects
+ * `token_ciphertext`, so the value does not travel far enough to be forgotten about. Only
+ * {@see ConnectTokenProviderInterface} can reach the plaintext, and nothing in the HTTP
+ * layer depends on it.
+ */
+final readonly class ConnectTokenSummary
+{
+    public function __construct(
+        public ConnectTokenService $service,
+        /** Trailing characters of the token, for "which one is installed?" — never enough to use. */
+        public string $hint,
+        public string $createdAt,
+        public string $updatedAt,
+    ) {
+    }
+}

--- a/src/OrgConnect/DeleteConnectTokenHandler.php
+++ b/src/OrgConnect/DeleteConnectTokenHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteConnectTokenHandler
+{
+    public function __construct(
+        private DeleteConnectTokenUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $service = ConnectTokenServiceResolver::fromPath($request);
+
+        $this->useCase->execute(new DeleteConnectTokenInput($service));
+
+        return $this->response->createEmpty(204);
+    }
+}

--- a/src/OrgConnect/DeleteConnectTokenInput.php
+++ b/src/OrgConnect/DeleteConnectTokenInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+final readonly class DeleteConnectTokenInput
+{
+    public function __construct(
+        public ConnectTokenService $service,
+    ) {
+    }
+}

--- a/src/OrgConnect/DeleteConnectTokenUseCase.php
+++ b/src/OrgConnect/DeleteConnectTokenUseCase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+final readonly class DeleteConnectTokenUseCase implements DeleteConnectTokenUseCaseInterface
+{
+    public function __construct(
+        private ConnectTokenRepositoryInterface $tokens,
+    ) {
+    }
+
+    public function execute(DeleteConnectTokenInput $input): void
+    {
+        if ($this->tokens->findSummary($input->service) === null) {
+            throw new ConnectTokenNotFoundException($input->service->value);
+        }
+
+        $this->tokens->delete($input->service);
+    }
+}

--- a/src/OrgConnect/DeleteConnectTokenUseCaseInterface.php
+++ b/src/OrgConnect/DeleteConnectTokenUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+interface DeleteConnectTokenUseCaseInterface
+{
+    public function execute(DeleteConnectTokenInput $input): void;
+}

--- a/src/OrgConnect/ListConnectTokensHandler.php
+++ b/src/OrgConnect/ListConnectTokensHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListConnectTokensHandler
+{
+    public function __construct(
+        private ListConnectTokensUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $output = $this->useCase->execute();
+
+        return $this->response->create([
+            'items' => array_map(
+                static fn (ConnectTokenSummary $summary) => ConnectTokenHttpMapper::toArray($summary),
+                $output->items,
+            ),
+        ]);
+    }
+}

--- a/src/OrgConnect/ListConnectTokensOutput.php
+++ b/src/OrgConnect/ListConnectTokensOutput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+final readonly class ListConnectTokensOutput
+{
+    public function __construct(
+        /** @var list<ConnectTokenSummary> */
+        public array $items,
+    ) {
+    }
+}

--- a/src/OrgConnect/ListConnectTokensUseCase.php
+++ b/src/OrgConnect/ListConnectTokensUseCase.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+final readonly class ListConnectTokensUseCase implements ListConnectTokensUseCaseInterface
+{
+    public function __construct(
+        private ConnectTokenRepositoryInterface $tokens,
+    ) {
+    }
+
+    public function execute(): ListConnectTokensOutput
+    {
+        return new ListConnectTokensOutput(
+            items: $this->tokens->findAllSummaries(),
+        );
+    }
+}

--- a/src/OrgConnect/ListConnectTokensUseCaseInterface.php
+++ b/src/OrgConnect/ListConnectTokensUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+interface ListConnectTokensUseCaseInterface
+{
+    public function execute(): ListConnectTokensOutput;
+}

--- a/src/OrgConnect/OrgConnectServiceProvider.php
+++ b/src/OrgConnect/OrgConnectServiceProvider.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\Config\ConfigCipherInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class OrgConnectServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                ConnectTokenRepositoryInterface::class,
+                static function (ContainerInterface $container): ConnectTokenRepositoryInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    $orgId = $container->get('nene-records.org_id_holder');
+                    if (!$orgId instanceof RequestScopedHolder) {
+                        throw new LogicException('Org ID holder service is invalid.');
+                    }
+
+                    $clock = $container->get(ClockInterface::class);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new PdoConnectTokenRepository($query, $orgId, $clock);
+                },
+            )
+            ->set(
+                ConnectTokenProviderInterface::class,
+                static function (ContainerInterface $container): ConnectTokenProviderInterface {
+                    $tokens = $container->get(ConnectTokenRepositoryInterface::class);
+                    $cipher = $container->get(ConfigCipherInterface::class);
+
+                    if (!$tokens instanceof ConnectTokenRepositoryInterface) {
+                        throw new LogicException('Connect token repository service is invalid.');
+                    }
+
+                    if (!$cipher instanceof ConfigCipherInterface) {
+                        throw new LogicException('Config cipher service is invalid.');
+                    }
+
+                    return new StoredConnectTokenProvider($tokens, $cipher);
+                },
+            )
+            ->set(
+                ListConnectTokensUseCaseInterface::class,
+                static function (ContainerInterface $container): ListConnectTokensUseCaseInterface {
+                    $tokens = $container->get(ConnectTokenRepositoryInterface::class);
+
+                    if (!$tokens instanceof ConnectTokenRepositoryInterface) {
+                        throw new LogicException('Connect token repository service is invalid.');
+                    }
+
+                    return new ListConnectTokensUseCase($tokens);
+                },
+            )
+            ->set(
+                SaveConnectTokenUseCaseInterface::class,
+                static function (ContainerInterface $container): SaveConnectTokenUseCaseInterface {
+                    $tokens = $container->get(ConnectTokenRepositoryInterface::class);
+                    $cipher = $container->get(ConfigCipherInterface::class);
+
+                    if (!$tokens instanceof ConnectTokenRepositoryInterface) {
+                        throw new LogicException('Connect token repository service is invalid.');
+                    }
+
+                    if (!$cipher instanceof ConfigCipherInterface) {
+                        throw new LogicException('Config cipher service is invalid.');
+                    }
+
+                    return new SaveConnectTokenUseCase($tokens, $cipher);
+                },
+            )
+            ->set(
+                DeleteConnectTokenUseCaseInterface::class,
+                static function (ContainerInterface $container): DeleteConnectTokenUseCaseInterface {
+                    $tokens = $container->get(ConnectTokenRepositoryInterface::class);
+
+                    if (!$tokens instanceof ConnectTokenRepositoryInterface) {
+                        throw new LogicException('Connect token repository service is invalid.');
+                    }
+
+                    return new DeleteConnectTokenUseCase($tokens);
+                },
+            )
+            ->set(
+                ListConnectTokensHandler::class,
+                static function (ContainerInterface $container): ListConnectTokensHandler {
+                    $useCase = $container->get(ListConnectTokensUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListConnectTokensUseCaseInterface) {
+                        throw new LogicException('ListConnectTokens use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListConnectTokensHandler($useCase, $response);
+                },
+            )
+            ->set(
+                SaveConnectTokenHandler::class,
+                static function (ContainerInterface $container): SaveConnectTokenHandler {
+                    $useCase = $container->get(SaveConnectTokenUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof SaveConnectTokenUseCaseInterface) {
+                        throw new LogicException('SaveConnectToken use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new SaveConnectTokenHandler($useCase, $response);
+                },
+            )
+            ->set(
+                DeleteConnectTokenHandler::class,
+                static function (ContainerInterface $container): DeleteConnectTokenHandler {
+                    $useCase = $container->get(DeleteConnectTokenUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof DeleteConnectTokenUseCaseInterface) {
+                        throw new LogicException('DeleteConnectToken use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new DeleteConnectTokenHandler($useCase, $response);
+                },
+            )
+            ->set(
+                ConnectTokenNotFoundExceptionHandler::class,
+                static function (ContainerInterface $container): ConnectTokenNotFoundExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new ConnectTokenNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                'nene-records.route_registrar.connect_token',
+                static function (ContainerInterface $container): ConnectTokenRouteRegistrar {
+                    $list = $container->get(ListConnectTokensHandler::class);
+                    $save = $container->get(SaveConnectTokenHandler::class);
+                    $delete = $container->get(DeleteConnectTokenHandler::class);
+
+                    if (!$list instanceof ListConnectTokensHandler) {
+                        throw new LogicException('ListConnectTokens handler service is invalid.');
+                    }
+
+                    if (!$save instanceof SaveConnectTokenHandler) {
+                        throw new LogicException('SaveConnectToken handler service is invalid.');
+                    }
+
+                    if (!$delete instanceof DeleteConnectTokenHandler) {
+                        throw new LogicException('DeleteConnectToken handler service is invalid.');
+                    }
+
+                    return new ConnectTokenRouteRegistrar($list, $save, $delete);
+                },
+            );
+    }
+}

--- a/src/OrgConnect/PdoConnectTokenRepository.php
+++ b/src/OrgConnect/PdoConnectTokenRepository.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\RequestScopedHolder;
+
+final readonly class PdoConnectTokenRepository implements ConnectTokenRepositoryInterface
+{
+    /**
+     * @param RequestScopedHolder<int> $orgId
+     */
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    /** @return list<ConnectTokenSummary> */
+    public function findAllSummaries(): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT service, token_hint, created_at, updated_at
+             FROM org_connect_tokens
+             WHERE organization_id = ?
+             ORDER BY service ASC',
+            [$this->orgId->get()],
+        );
+
+        $summaries = [];
+
+        foreach ($rows as $row) {
+            $summary = $this->mapRow($row);
+
+            // A row whose `service` is no longer in the enum (removed integration, hand-edited
+            // database) is skipped rather than crashing the list: the operator still needs the
+            // page to load in order to delete it.
+            if ($summary !== null) {
+                $summaries[] = $summary;
+            }
+        }
+
+        return $summaries;
+    }
+
+    public function findSummary(ConnectTokenService $service): ?ConnectTokenSummary
+    {
+        $row = $this->query->fetchOne(
+            'SELECT service, token_hint, created_at, updated_at
+             FROM org_connect_tokens
+             WHERE organization_id = ? AND service = ?',
+            [$this->orgId->get(), $service->value],
+        );
+
+        return $row === null ? null : $this->mapRow($row);
+    }
+
+    public function findEnvelope(ConnectTokenService $service): ?string
+    {
+        $row = $this->query->fetchOne(
+            'SELECT token_ciphertext
+             FROM org_connect_tokens
+             WHERE organization_id = ? AND service = ?',
+            [$this->orgId->get(), $service->value],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        $envelope = (string) $row['token_ciphertext'];
+
+        return $envelope === '' ? null : $envelope;
+    }
+
+    public function save(ConnectTokenService $service, string $envelope, string $hint): ConnectTokenSummary
+    {
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
+        $existing = $this->findSummary($service);
+
+        // Upsert written as select-then-write rather than `ON DUPLICATE KEY UPDATE`, which is
+        // MySQL-only: the repository tests run the shipped schema on SQLite.
+        if ($existing === null) {
+            $this->query->execute(
+                'INSERT INTO org_connect_tokens
+                     (organization_id, service, token_ciphertext, token_hint, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?)',
+                [$this->orgId->get(), $service->value, $envelope, $hint, $now, $now],
+            );
+
+            return new ConnectTokenSummary($service, $hint, $now, $now);
+        }
+
+        $this->query->execute(
+            'UPDATE org_connect_tokens
+             SET token_ciphertext = ?, token_hint = ?, updated_at = ?
+             WHERE organization_id = ? AND service = ?',
+            [$envelope, $hint, $now, $this->orgId->get(), $service->value],
+        );
+
+        return new ConnectTokenSummary($service, $hint, $existing->createdAt, $now);
+    }
+
+    public function delete(ConnectTokenService $service): void
+    {
+        $this->query->execute(
+            'DELETE FROM org_connect_tokens WHERE organization_id = ? AND service = ?',
+            [$this->orgId->get(), $service->value],
+        );
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): ?ConnectTokenSummary
+    {
+        $service = ConnectTokenService::tryFrom((string) $row['service']);
+
+        if ($service === null) {
+            return null;
+        }
+
+        return new ConnectTokenSummary(
+            service: $service,
+            hint: (string) $row['token_hint'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/src/OrgConnect/SaveConnectTokenHandler.php
+++ b/src/OrgConnect/SaveConnectTokenHandler.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class SaveConnectTokenHandler
+{
+    /** Short enough to be a paste accident, and no real token is this small. */
+    private const MIN_LENGTH = 16;
+
+    /** Generous for a signed JWT; the point is to bound what reaches the cipher. */
+    private const MAX_LENGTH = 4096;
+
+    /**
+     * base64url plus the separators real bearer tokens use. Whitespace and control
+     * characters are excluded on purpose: a token that "works" with a stray newline in
+     * it would fail later, at the far end of a server-to-server call, where the error is
+     * much harder to read.
+     */
+    private const ALLOWED_PATTERN = '/^[A-Za-z0-9._~+\/=-]+$/';
+
+    public function __construct(
+        private SaveConnectTokenUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $service = ConnectTokenServiceResolver::fromPath($request);
+        $body = JsonRequestBodyParser::parse($request);
+        $raw = $body['token'] ?? null;
+        $token = is_string($raw) ? trim($raw) : '';
+
+        if ($token === '') {
+            throw new ValidationException([
+                new ValidationError('token', 'Token is required.', 'required'),
+            ]);
+        }
+
+        $errors = $this->validate($token);
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new SaveConnectTokenInput($service, $token));
+        $payload = ConnectTokenHttpMapper::toArray($output->summary);
+
+        if (!$output->created) {
+            return $this->response->create($payload);
+        }
+
+        return $this->response->create($payload, 201)
+            ->withHeader('Location', '/api/v1/connect-tokens/' . $service->value);
+    }
+
+    /**
+     * @param non-empty-string $token
+     *
+     * @return list<ValidationError>
+     */
+    private function validate(string $token): array
+    {
+        $errors = [];
+        $length = strlen($token);
+
+        if ($length < self::MIN_LENGTH || $length > self::MAX_LENGTH) {
+            $errors[] = new ValidationError(
+                'token',
+                'Token must be between ' . self::MIN_LENGTH . ' and ' . self::MAX_LENGTH . ' characters.',
+                'invalid',
+            );
+        }
+
+        if (preg_match(self::ALLOWED_PATTERN, $token) !== 1) {
+            $errors[] = new ValidationError(
+                'token',
+                'Token contains characters that are not valid in a bearer token.',
+                'invalid',
+            );
+        }
+
+        return $errors;
+    }
+}

--- a/src/OrgConnect/SaveConnectTokenInput.php
+++ b/src/OrgConnect/SaveConnectTokenInput.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+use SensitiveParameter;
+
+final readonly class SaveConnectTokenInput
+{
+    /**
+     * @param non-empty-string $token the raw token as issued by the other product
+     */
+    public function __construct(
+        public ConnectTokenService $service,
+        #[SensitiveParameter]
+        public string $token,
+    ) {
+    }
+}

--- a/src/OrgConnect/SaveConnectTokenOutput.php
+++ b/src/OrgConnect/SaveConnectTokenOutput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+final readonly class SaveConnectTokenOutput
+{
+    public function __construct(
+        public ConnectTokenSummary $summary,
+        /** False when an existing token was replaced — the caller answers 201 vs 200 with this. */
+        public bool $created,
+    ) {
+    }
+}

--- a/src/OrgConnect/SaveConnectTokenUseCase.php
+++ b/src/OrgConnect/SaveConnectTokenUseCase.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+use NeNeRecords\Config\ConfigCipherInterface;
+
+final readonly class SaveConnectTokenUseCase implements SaveConnectTokenUseCaseInterface
+{
+    /**
+     * How many trailing characters the admin UI gets to see. Four is enough to tell two
+     * pasted tokens apart and far short of useful: the column itself caps at 8.
+     */
+    private const HINT_LENGTH = 4;
+
+    public function __construct(
+        private ConnectTokenRepositoryInterface $tokens,
+        private ConfigCipherInterface $cipher,
+    ) {
+    }
+
+    public function execute(SaveConnectTokenInput $input): SaveConnectTokenOutput
+    {
+        $created = $this->tokens->findSummary($input->service) === null;
+
+        // Encrypt before writing, and let a missing key throw out of here: a fail-closed
+        // refusal is the point, so there is deliberately no branch that stores the plaintext.
+        $envelope = $this->cipher->encrypt($input->token);
+
+        $summary = $this->tokens->save(
+            $input->service,
+            $envelope,
+            substr($input->token, -self::HINT_LENGTH),
+        );
+
+        return new SaveConnectTokenOutput($summary, $created);
+    }
+}

--- a/src/OrgConnect/SaveConnectTokenUseCaseInterface.php
+++ b/src/OrgConnect/SaveConnectTokenUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+interface SaveConnectTokenUseCaseInterface
+{
+    public function execute(SaveConnectTokenInput $input): SaveConnectTokenOutput;
+}

--- a/src/OrgConnect/StoredConnectTokenProvider.php
+++ b/src/OrgConnect/StoredConnectTokenProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\OrgConnect;
+
+use NeNeRecords\Config\ConfigCipherInterface;
+
+final readonly class StoredConnectTokenProvider implements ConnectTokenProviderInterface
+{
+    public function __construct(
+        private ConnectTokenRepositoryInterface $tokens,
+        private ConfigCipherInterface $cipher,
+    ) {
+    }
+
+    public function secretFor(ConnectTokenService $service): ?string
+    {
+        $envelope = $this->tokens->findEnvelope($service);
+
+        if ($envelope === null || $envelope === '') {
+            return null;
+        }
+
+        return $this->cipher->decrypt($envelope);
+    }
+}

--- a/src/Organization/OrganizationScopedSchema.php
+++ b/src/Organization/OrganizationScopedSchema.php
@@ -87,6 +87,10 @@ final class OrganizationScopedSchema
         // No ordering constraints among the rest.
         'access_logs',
         'media',
+        // Connect-tokens another product issued to this org (#1029). Purged with the org so a
+        // deleted tenant leaves no usable credential behind — revocation still belongs to the
+        // issuer, but records must not keep presenting a token for an org that no longer exists.
+        'org_connect_tokens',
         'menus',
         'navigation_items',
         'notification_channels',

--- a/tests/Auth/AdminApiAuthMiddlewareTest.php
+++ b/tests/Auth/AdminApiAuthMiddlewareTest.php
@@ -144,7 +144,7 @@ final class AdminApiAuthMiddlewareTest extends TestCase
         // #824: sensitive reads (webhook signing secrets, notification-channel
         // configs, bulk export, org dashboard metrics) must require auth even for
         // GET — they are in ADMIN_ONLY_PREFIXES.
-        foreach (['/api/v1/webhooks', '/api/v1/notification-channels', '/api/v1/entities/export', '/api/v1/dashboard'] as $path) {
+        foreach (['/api/v1/webhooks', '/api/v1/connect-tokens', '/api/v1/notification-channels', '/api/v1/entities/export', '/api/v1/dashboard'] as $path) {
             $request = $this->factory->createServerRequest('GET', 'https://example.test' . $path);
             self::assertSame(
                 401,

--- a/tests/Auth/CapabilityResolverTest.php
+++ b/tests/Auth/CapabilityResolverTest.php
@@ -85,6 +85,35 @@ final class CapabilityResolverTest extends TestCase
         );
     }
 
+    // ── Connect tokens ────────────────────────────────────────────────────────
+
+    /**
+     * Admin-only for every method, reads included (#1029). Deliberately stricter than the
+     * settings branch next door: an editor holds ReadSettings, and the masked list is still
+     * an inventory of which products this tenant is wired to.
+     */
+    #[DataProvider('provideConnectTokenMethods')]
+    public function testConnectTokensRequireManageSettingsForEveryMethod(string $method): void
+    {
+        self::assertSame(
+            Capability::ManageSettings,
+            CapabilityResolver::resolve('/api/v1/connect-tokens', $method),
+        );
+        self::assertSame(
+            Capability::ManageSettings,
+            CapabilityResolver::resolve('/api/v1/connect-tokens/contact', $method),
+        );
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function provideConnectTokenMethods(): iterable
+    {
+        yield 'GET'    => ['GET'];
+        yield 'HEAD'   => ['HEAD'];
+        yield 'PUT'    => ['PUT'];
+        yield 'DELETE' => ['DELETE'];
+    }
+
     // ── Navigation items ──────────────────────────────────────────────────────
 
     #[DataProvider('provideNavigationItemMutations')]
@@ -350,6 +379,8 @@ final class CapabilityResolverTest extends TestCase
         yield 'user me'             => ['/api/v1/users/me'];
         yield 'own password'        => ['/api/v1/users/me/password'];
         yield 'admin comments'      => ['/api/v1/admin/comments'];
+        yield 'connect-tokens'      => ['/api/v1/connect-tokens'];
+        yield 'connect-token by id' => ['/api/v1/connect-tokens/contact'];
         yield 'entities'            => ['/api/v1/entities'];
         yield 'text-fields'         => ['/api/v1/text-fields'];
         yield 'public records'      => ['/api/v1/public/records/article/my-post'];

--- a/tests/Config/AesGcmConfigCipherTest.php
+++ b/tests/Config/AesGcmConfigCipherTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\Config;
+
+use NeNeRecords\Config\AesGcmConfigCipher;
+use NeNeRecords\Config\ConfigDecryptException;
+use NeNeRecords\Config\ConfigKeyException;
+use NeNeRecords\Config\ConfigKeyResolverInterface;
+use PHPUnit\Framework\TestCase;
+
+final class AesGcmConfigCipherTest extends TestCase
+{
+    public function testRoundTripsAValue(): void
+    {
+        $cipher = new AesGcmConfigCipher($this->keyResolver());
+
+        $envelope = $cipher->encrypt('connect-token-value');
+
+        self::assertSame('connect-token-value', $cipher->decrypt($envelope));
+    }
+
+    public function testEnvelopeNeverContainsThePlaintext(): void
+    {
+        $cipher = new AesGcmConfigCipher($this->keyResolver());
+
+        $envelope = $cipher->encrypt('super-secret-token');
+
+        self::assertStringNotContainsString('super-secret-token', $envelope);
+        self::assertStringNotContainsString('super-secret-token', (string) base64_decode($envelope, true));
+    }
+
+    public function testSameValueEncryptsDifferentlyEachTime(): void
+    {
+        $cipher = new AesGcmConfigCipher($this->keyResolver());
+
+        // A per-call random IV is what stops "these two orgs share a token" from being
+        // readable off the ciphertext column alone.
+        self::assertNotSame($cipher->encrypt('same'), $cipher->encrypt('same'));
+    }
+
+    public function testTamperedEnvelopeIsRejected(): void
+    {
+        $cipher = new AesGcmConfigCipher($this->keyResolver());
+        $raw = (string) base64_decode($cipher->encrypt('connect-token-value'), true);
+
+        // Flip a bit in the ciphertext body; GCM's tag must catch it.
+        $raw[strlen($raw) - 1] = $raw[strlen($raw) - 1] === 'a' ? 'b' : 'a';
+
+        $tampered = base64_encode($raw);
+
+        if ($tampered === '') {
+            self::fail('Re-encoding the tampered envelope produced an empty string.');
+        }
+
+        $this->expectException(ConfigDecryptException::class);
+        $cipher->decrypt($tampered);
+    }
+
+    public function testEnvelopeFromAnotherKeyIsRejected(): void
+    {
+        $envelope = (new AesGcmConfigCipher($this->keyResolver()))->encrypt('connect-token-value');
+        $rotated = new AesGcmConfigCipher($this->keyResolver(str_repeat("\x02", 32)));
+
+        // Rotating the key makes stored values unreadable rather than silently wrong —
+        // the operator re-pastes the token (#1029: no re-encryption path by design).
+        $this->expectException(ConfigDecryptException::class);
+        $rotated->decrypt($envelope);
+    }
+
+    public function testMalformedEnvelopeIsRejected(): void
+    {
+        $cipher = new AesGcmConfigCipher($this->keyResolver());
+
+        $this->expectException(ConfigDecryptException::class);
+        $cipher->decrypt('not-base64-at-all!!');
+    }
+
+    public function testMissingKeyFailsClosedOnEncrypt(): void
+    {
+        $cipher = new AesGcmConfigCipher(new class () implements ConfigKeyResolverInterface {
+            public function resolve(): string
+            {
+                throw new ConfigKeyException('no key');
+            }
+        });
+
+        // Fail-closed: without a key records must refuse to *store* a secret, not fall back
+        // to plaintext.
+        $this->expectException(ConfigKeyException::class);
+        $cipher->encrypt('connect-token-value');
+    }
+
+    private function keyResolver(?string $key = null): ConfigKeyResolverInterface
+    {
+        $resolved = $key ?? str_repeat("\x01", 32);
+
+        return new class ($resolved) implements ConfigKeyResolverInterface {
+            public function __construct(private string $key)
+            {
+            }
+
+            public function resolve(): string
+            {
+                /** @var non-empty-string */
+                return $this->key;
+            }
+        };
+    }
+}

--- a/tests/OrgConnect/ConnectTokenHttpTest.php
+++ b/tests/OrgConnect/ConnectTokenHttpTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\OrgConnect;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Config\AesGcmConfigCipher;
+use NeNeRecords\OrgConnect\ConnectTokenNotFoundExceptionHandler;
+use NeNeRecords\OrgConnect\ConnectTokenRouteRegistrar;
+use NeNeRecords\OrgConnect\ConnectTokenService;
+use NeNeRecords\OrgConnect\DeleteConnectTokenHandler;
+use NeNeRecords\OrgConnect\DeleteConnectTokenUseCase;
+use NeNeRecords\OrgConnect\ListConnectTokensHandler;
+use NeNeRecords\OrgConnect\ListConnectTokensUseCase;
+use NeNeRecords\OrgConnect\SaveConnectTokenHandler;
+use NeNeRecords\OrgConnect\SaveConnectTokenUseCase;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class ConnectTokenHttpTest extends TestCase
+{
+    private const TOKEN = 'eyJhbGciOiJIUzI1NiJ9.payload.signature-abcd';
+
+    private Psr17Factory $factory;
+    private InMemoryConnectTokenRepository $tokens;
+    private RequestHandlerInterface $application;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Psr17Factory();
+        $this->tokens = new InMemoryConnectTokenRepository();
+
+        $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
+        $problemDetails = new ProblemDetailsResponseFactory($this->factory, $this->factory);
+        $cipher = new AesGcmConfigCipher(new TestConfigKeyResolver());
+
+        $registrar = new ConnectTokenRouteRegistrar(
+            new ListConnectTokensHandler(new ListConnectTokensUseCase($this->tokens), $jsonResponse),
+            new SaveConnectTokenHandler(new SaveConnectTokenUseCase($this->tokens, $cipher), $jsonResponse),
+            new DeleteConnectTokenHandler(new DeleteConnectTokenUseCase($this->tokens), $jsonResponse),
+        );
+
+        $this->application = (new RuntimeApplicationFactory(
+            $this->factory,
+            $this->factory,
+            domainExceptionHandlers: [
+                new ConnectTokenNotFoundExceptionHandler($problemDetails),
+            ],
+            routeRegistrars: [$registrar],
+        ))->create();
+    }
+
+    public function testListStartsEmpty(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/connect-tokens'),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame([], $this->decodeJson($response)['items']);
+    }
+
+    public function testInstallingATokenReturns201WithoutEchoingIt(): void
+    {
+        $response = $this->put(self::TOKEN);
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame('/api/v1/connect-tokens/contact', $response->getHeaderLine('Location'));
+        self::assertSame('contact', $payload['service']);
+        self::assertSame('abcd', $payload['token_hint']);
+        self::assertStringNotContainsString(self::TOKEN, (string) $response->getBody());
+    }
+
+    public function testReplacingATokenReturns200(): void
+    {
+        $this->put(self::TOKEN);
+        $response = $this->put('second-token-value-wxyz');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('wxyz', $this->decodeJson($response)['token_hint']);
+    }
+
+    public function testListShowsTheHintAndNeverTheToken(): void
+    {
+        $this->put(self::TOKEN);
+
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('GET', 'https://example.test/api/v1/connect-tokens'),
+        );
+        $body = (string) $response->getBody();
+
+        $items = $this->decodeJson($response)['items'];
+        self::assertIsArray($items);
+        $first = $items[0];
+        self::assertIsArray($first);
+
+        self::assertSame('abcd', $first['token_hint']);
+        self::assertStringNotContainsString(self::TOKEN, $body);
+        self::assertArrayNotHasKey('token', $first);
+        self::assertArrayNotHasKey('token_ciphertext', $first);
+    }
+
+    public function testUnknownServiceIs404(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('PUT', 'https://example.test/api/v1/connect-tokens/invoice')
+                ->withBody($this->factory->createStream((string) json_encode(['token' => self::TOKEN]))),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testMissingTokenIs422(): void
+    {
+        $response = $this->application->handle(
+            $this->factory->createServerRequest('PUT', 'https://example.test/api/v1/connect-tokens/contact')
+                ->withBody($this->factory->createStream((string) json_encode(['token' => '   ']))),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function testTokenWithWhitespaceOrControlCharactersIsRejected(): void
+    {
+        // A pasted token that wrapped across lines would otherwise be stored and only fail
+        // much later, at the far end of a server-to-server call.
+        $response = $this->put("eyJhbGciOiJIUzI1NiJ9.pay\nload.signature");
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function testShortTokenIsRejected(): void
+    {
+        self::assertSame(422, $this->put('too-short')->getStatusCode());
+    }
+
+    public function testDeletingRemovesItAndIsIdempotentOnlyOnce(): void
+    {
+        $this->put(self::TOKEN);
+
+        $deleted = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', 'https://example.test/api/v1/connect-tokens/contact'),
+        );
+
+        self::assertSame(204, $deleted->getStatusCode());
+        self::assertNull($this->tokens->storedEnvelope(ConnectTokenService::Contact));
+
+        $again = $this->application->handle(
+            $this->factory->createServerRequest('DELETE', 'https://example.test/api/v1/connect-tokens/contact'),
+        );
+
+        self::assertSame(404, $again->getStatusCode());
+    }
+
+    private function put(string $token): ResponseInterface
+    {
+        return $this->application->handle(
+            $this->factory->createServerRequest('PUT', 'https://example.test/api/v1/connect-tokens/contact')
+                ->withBody($this->factory->createStream((string) json_encode(['token' => $token]))),
+        );
+    }
+
+    /** @return array<string, mixed> */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $decoded = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+}

--- a/tests/OrgConnect/ConnectTokenLeakPinTest.php
+++ b/tests/OrgConnect/ConnectTokenLeakPinTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\OrgConnect;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\RuntimeApplicationFactory;
+use NeNeRecords\Config\AesGcmConfigCipher;
+use NeNeRecords\OrgConnect\ConnectTokenNotFoundExceptionHandler;
+use NeNeRecords\OrgConnect\ConnectTokenRouteRegistrar;
+use NeNeRecords\OrgConnect\DeleteConnectTokenHandler;
+use NeNeRecords\OrgConnect\DeleteConnectTokenUseCase;
+use NeNeRecords\OrgConnect\ListConnectTokensHandler;
+use NeNeRecords\OrgConnect\ListConnectTokensUseCase;
+use NeNeRecords\OrgConnect\PdoConnectTokenRepository;
+use NeNeRecords\OrgConnect\SaveConnectTokenHandler;
+use NeNeRecords\OrgConnect\SaveConnectTokenUseCase;
+use NeNeRecords\OrgExport\OrgExportRepositoryInterface;
+use NeNeRecords\Tests\Support\FixedClock;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * The four surfaces a stored connect-token must never reach (#1029 acceptance condition).
+ *
+ * Two of these are behavioural and two are structural, and the difference matters when
+ * reading a green run:
+ *
+ * - **Admin API** and **org export** are behavioural: a real token goes into a real store and
+ *   the assertion is about what actually comes out.
+ * - **Public bootstrap JSON** and **SSR HTML** are structural — they assert that the render
+ *   path does not reference this module at all. A behavioural version would be vacuous today
+ *   (those paths read entities and settings, and the token lives in neither), so it would pass
+ *   whether or not the wiring were safe. The structural pin instead fails the moment someone
+ *   makes the render path aware of connect-tokens, which is the regression worth catching.
+ */
+final class ConnectTokenLeakPinTest extends TestCase
+{
+    private const TOKEN = 'eyJhbGciOiJIUzI1NiJ9.payload.signature-abcd';
+
+    /** Pin ①: the admin API returns the hint, never the token or its envelope. */
+    public function testAdminApiNeverReturnsTheTokenOrItsEnvelope(): void
+    {
+        $orgId = new RequestScopedHolder();
+        $orgId->set(1);
+        $executor = $this->sqliteWithConnectTokenSchema();
+        $repository = new PdoConnectTokenRepository($executor, $orgId, new FixedClock());
+
+        $factory = new \Nyholm\Psr7\Factory\Psr17Factory();
+        $jsonResponse = new JsonResponseFactory($factory, $factory);
+        $cipher = new AesGcmConfigCipher(new TestConfigKeyResolver());
+
+        $application = (new RuntimeApplicationFactory(
+            $factory,
+            $factory,
+            domainExceptionHandlers: [
+                new ConnectTokenNotFoundExceptionHandler(new ProblemDetailsResponseFactory($factory, $factory)),
+            ],
+            routeRegistrars: [new ConnectTokenRouteRegistrar(
+                new ListConnectTokensHandler(new ListConnectTokensUseCase($repository), $jsonResponse),
+                new SaveConnectTokenHandler(new SaveConnectTokenUseCase($repository, $cipher), $jsonResponse),
+                new DeleteConnectTokenHandler(new DeleteConnectTokenUseCase($repository), $jsonResponse),
+            )],
+        ))->create();
+
+        $install = $application->handle(
+            $factory->createServerRequest('PUT', 'https://example.test/api/v1/connect-tokens/contact')
+                ->withBody($factory->createStream((string) json_encode(['token' => self::TOKEN]))),
+        );
+        $list = $application->handle(
+            $factory->createServerRequest('GET', 'https://example.test/api/v1/connect-tokens'),
+        );
+
+        $row = $executor->fetchOne('SELECT token_ciphertext FROM org_connect_tokens WHERE organization_id = 1');
+        self::assertNotNull($row, 'The token must actually be stored, or this pin proves nothing.');
+        $envelope = (string) $row['token_ciphertext'];
+
+        foreach ([$install, $list] as $response) {
+            $body = (string) $response->getBody();
+            self::assertStringNotContainsString(self::TOKEN, $body);
+            self::assertStringNotContainsString($envelope, $body);
+        }
+
+        self::assertStringContainsString('abcd', (string) $list->getBody(), 'The hint is what the UI is meant to get.');
+    }
+
+    /** Pin ②: the tenant export must not learn this table exists. */
+    public function testOrgExportNeverEnumeratesConnectTokens(): void
+    {
+        foreach ((new ReflectionClass(OrgExportRepositoryInterface::class))->getMethods() as $method) {
+            self::assertStringNotContainsStringIgnoringCase(
+                'connecttoken',
+                $method->getName(),
+                'The export interface must have no connect-token reader.',
+            );
+        }
+
+        $payloadBuilder = $this->readSource('src/OrgExport/OrgExportPayloadBuilder.php');
+        $exportRepository = $this->readSource('src/OrgExport/PdoOrgExportRepository.php');
+
+        // Anti-vacuous: these files must really be the export, i.e. mention a table that *is*
+        // exported. Without this the assertions below would also pass on an empty read.
+        self::assertStringContainsString('webhooks', $payloadBuilder);
+        self::assertStringContainsString('webhooks', $exportRepository);
+
+        foreach (['org_connect_tokens', 'ConnectToken'] as $needle) {
+            self::assertStringNotContainsString($needle, $payloadBuilder);
+            self::assertStringNotContainsString($needle, $exportRepository);
+        }
+    }
+
+    /** Pin ③: nothing that builds the public bootstrap JSON knows about connect-tokens. */
+    public function testPublicBootstrapPayloadHasNoPathToConnectTokens(): void
+    {
+        $sources = [
+            'src/PublicRecord/PublicRecordViewHttpMapper.php',
+            'src/PublicRecord/GetPublicRecordViewUseCase.php',
+            'src/PreviewToken/GetPreviewRecordViewUseCase.php',
+            'src/Setting/ListPublicSettingsUseCase.php',
+            'src/Setting/SettingHttpMapper.php',
+        ];
+
+        foreach ($sources as $source) {
+            $code = $this->readSource($source);
+
+            self::assertStringContainsString('class', $code, $source . ' was read as empty.');
+            self::assertStringNotContainsString('ConnectToken', $code, $source . ' must not reach connect-tokens.');
+            self::assertStringNotContainsString('org_connect_tokens', $code);
+        }
+    }
+
+    /** Pin ④: nor does anything that renders HTML — SSR templates or the admin SPA shell. */
+    public function testRenderedHtmlHasNoPathToConnectTokens(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $files = [$root . '/src/Http/SpaShellFallback.php'];
+
+        foreach ((array) glob($root . '/templates/public/*.php') as $template) {
+            if (is_string($template)) {
+                $files[] = $template;
+            }
+        }
+
+        foreach ((array) glob($root . '/src/PublicRecord/Render*.php') as $renderer) {
+            if (is_string($renderer)) {
+                $files[] = $renderer;
+            }
+        }
+
+        // Anti-vacuous: the globs must actually have matched the render layer.
+        self::assertGreaterThan(5, count($files), 'The HTML render surface was not found — the globs are stale.');
+
+        foreach ($files as $file) {
+            $code = (string) file_get_contents($file);
+
+            self::assertNotSame('', $code, $file . ' was read as empty.');
+            self::assertStringNotContainsString('ConnectToken', $code, $file . ' must not reach connect-tokens.');
+            self::assertStringNotContainsString('org_connect_tokens', $code);
+        }
+    }
+
+    private function readSource(string $relativePath): string
+    {
+        $path = dirname(__DIR__, 2) . '/' . $relativePath;
+        self::assertFileExists($path, $relativePath . ' has moved — this pin needs repointing, not deleting.');
+
+        return (string) file_get_contents($path);
+    }
+
+    private function sqliteWithConnectTokenSchema(): PdoDatabaseQueryExecutor
+    {
+        $executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene-records-test',
+            '',
+            'utf8',
+        )));
+
+        $raw = trim((string) file_get_contents(dirname(__DIR__, 2) . '/database/schema/org_connect_tokens.sql'));
+
+        foreach (preg_split('/;\R/s', $raw) ?: [] as $chunk) {
+            $statement = trim($chunk);
+            if ($statement !== '') {
+                $executor->execute($statement);
+            }
+        }
+
+        return $executor;
+    }
+}

--- a/tests/OrgConnect/ConnectTokenLeakPinTest.php
+++ b/tests/OrgConnect/ConnectTokenLeakPinTest.php
@@ -115,7 +115,15 @@ final class ConnectTokenLeakPinTest extends TestCase
         }
     }
 
-    /** Pin ③: nothing that builds the public bootstrap JSON knows about connect-tokens. */
+    /**
+     * Pin ③: nothing that builds the public bootstrap JSON knows about connect-tokens.
+     *
+     * Do not "upgrade" this to a behavioural test. The public render path reads entities and
+     * settings; connect-tokens live in their own table behind their own repository, so
+     * seeding a token and asserting it is absent from the bootstrap would pass whether or not
+     * the wiring were safe — a green that proves nothing. This form fails the moment the
+     * render path gains a reference to the module, which is the regression worth catching.
+     */
     public function testPublicBootstrapPayloadHasNoPathToConnectTokens(): void
     {
         $sources = [
@@ -135,7 +143,13 @@ final class ConnectTokenLeakPinTest extends TestCase
         }
     }
 
-    /** Pin ④: nor does anything that renders HTML — SSR templates or the admin SPA shell. */
+    /**
+     * Pin ④: nor does anything that renders HTML — SSR templates or the admin SPA shell.
+     *
+     * Structural for the same reason as pin ③: the renderers read entities and settings, so a
+     * behavioural version would be vacuous today and would stay green through an unsafe
+     * rewiring. Keep it structural, and add new render entry points to the globs below.
+     */
     public function testRenderedHtmlHasNoPathToConnectTokens(): void
     {
         $root = dirname(__DIR__, 2);

--- a/tests/OrgConnect/ConnectTokenUseCaseTest.php
+++ b/tests/OrgConnect/ConnectTokenUseCaseTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\OrgConnect;
+
+use NeNeRecords\Config\AesGcmConfigCipher;
+use NeNeRecords\Config\ConfigDecryptException;
+use NeNeRecords\OrgConnect\ConnectTokenNotFoundException;
+use NeNeRecords\OrgConnect\ConnectTokenService;
+use NeNeRecords\OrgConnect\DeleteConnectTokenInput;
+use NeNeRecords\OrgConnect\DeleteConnectTokenUseCase;
+use NeNeRecords\OrgConnect\ListConnectTokensUseCase;
+use NeNeRecords\OrgConnect\SaveConnectTokenInput;
+use NeNeRecords\OrgConnect\SaveConnectTokenUseCase;
+use NeNeRecords\OrgConnect\StoredConnectTokenProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ConnectTokenUseCaseTest extends TestCase
+{
+    private const TOKEN = 'eyJhbGciOiJIUzI1NiJ9.payload.signature-abcd';
+
+    public function testSaveStoresCiphertextAndNeverThePlaintext(): void
+    {
+        $repository = new InMemoryConnectTokenRepository();
+        $useCase = new SaveConnectTokenUseCase($repository, $this->cipher());
+
+        $output = $useCase->execute(new SaveConnectTokenInput(ConnectTokenService::Contact, self::TOKEN));
+
+        $stored = $repository->storedEnvelope(ConnectTokenService::Contact);
+
+        self::assertTrue($output->created);
+        self::assertNotNull($stored);
+        self::assertStringNotContainsString(self::TOKEN, $stored);
+        self::assertStringNotContainsString(self::TOKEN, (string) base64_decode($stored, true));
+    }
+
+    public function testHintKeepsOnlyTrailingCharacters(): void
+    {
+        $repository = new InMemoryConnectTokenRepository();
+
+        $output = (new SaveConnectTokenUseCase($repository, $this->cipher()))
+            ->execute(new SaveConnectTokenInput(ConnectTokenService::Contact, self::TOKEN));
+
+        self::assertSame('abcd', $output->summary->hint);
+        self::assertStringEndsWith($output->summary->hint, self::TOKEN);
+        self::assertLessThanOrEqual(8, strlen($output->summary->hint), 'The hint column caps at 8 characters.');
+    }
+
+    public function testSavingTwiceReplacesInPlaceAndReportsNotCreated(): void
+    {
+        $repository = new InMemoryConnectTokenRepository();
+        $useCase = new SaveConnectTokenUseCase($repository, $this->cipher());
+
+        $useCase->execute(new SaveConnectTokenInput(ConnectTokenService::Contact, self::TOKEN));
+        $second = $useCase->execute(new SaveConnectTokenInput(ConnectTokenService::Contact, 'second-token-value-wxyz'));
+
+        self::assertFalse($second->created);
+        self::assertSame('wxyz', $second->summary->hint);
+        self::assertCount(1, (new ListConnectTokensUseCase($repository))->execute()->items);
+    }
+
+    public function testProviderReturnsThePlaintextBack(): void
+    {
+        $repository = new InMemoryConnectTokenRepository();
+        $cipher = $this->cipher();
+        (new SaveConnectTokenUseCase($repository, $cipher))
+            ->execute(new SaveConnectTokenInput(ConnectTokenService::Contact, self::TOKEN));
+
+        $provider = new StoredConnectTokenProvider($repository, $cipher);
+
+        self::assertSame(self::TOKEN, $provider->secretFor(ConnectTokenService::Contact));
+    }
+
+    public function testProviderReturnsNullWhenNothingIsInstalled(): void
+    {
+        $provider = new StoredConnectTokenProvider(new InMemoryConnectTokenRepository(), $this->cipher());
+
+        self::assertNull($provider->secretFor(ConnectTokenService::Contact));
+    }
+
+    public function testProviderSurfacesARotatedKeyInsteadOfReportingNoToken(): void
+    {
+        $repository = new InMemoryConnectTokenRepository();
+        (new SaveConnectTokenUseCase($repository, $this->cipher()))
+            ->execute(new SaveConnectTokenInput(ConnectTokenService::Contact, self::TOKEN));
+
+        // "Installed but unreadable" and "not installed" need different operator actions:
+        // re-paste vs. install. Collapsing them into null would hide a broken deployment.
+        $rotated = new StoredConnectTokenProvider(
+            $repository,
+            new AesGcmConfigCipher(new TestConfigKeyResolver(str_repeat("\x02", 32))),
+        );
+
+        $this->expectException(ConfigDecryptException::class);
+        $rotated->secretFor(ConnectTokenService::Contact);
+    }
+
+    public function testDeleteRejectsATokenThatIsNotInstalled(): void
+    {
+        $useCase = new DeleteConnectTokenUseCase(new InMemoryConnectTokenRepository());
+
+        $this->expectException(ConnectTokenNotFoundException::class);
+        $useCase->execute(new DeleteConnectTokenInput(ConnectTokenService::Contact));
+    }
+
+    public function testDeleteRemovesTheStoredEnvelope(): void
+    {
+        $repository = new InMemoryConnectTokenRepository();
+        (new SaveConnectTokenUseCase($repository, $this->cipher()))
+            ->execute(new SaveConnectTokenInput(ConnectTokenService::Contact, self::TOKEN));
+
+        (new DeleteConnectTokenUseCase($repository))->execute(new DeleteConnectTokenInput(ConnectTokenService::Contact));
+
+        self::assertNull($repository->storedEnvelope(ConnectTokenService::Contact));
+        self::assertSame([], (new ListConnectTokensUseCase($repository))->execute()->items);
+    }
+
+    private function cipher(): AesGcmConfigCipher
+    {
+        return new AesGcmConfigCipher(new TestConfigKeyResolver());
+    }
+}

--- a/tests/OrgConnect/InMemoryConnectTokenRepository.php
+++ b/tests/OrgConnect/InMemoryConnectTokenRepository.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\OrgConnect;
+
+use NeNeRecords\OrgConnect\ConnectTokenRepositoryInterface;
+use NeNeRecords\OrgConnect\ConnectTokenService;
+use NeNeRecords\OrgConnect\ConnectTokenSummary;
+
+final class InMemoryConnectTokenRepository implements ConnectTokenRepositoryInterface
+{
+    /** @var array<string, array{envelope: string, hint: string, created: string, updated: string}> */
+    private array $rows = [];
+
+    public function __construct(private readonly string $now = '2026-06-01 10:00:00')
+    {
+    }
+
+    /** @return list<ConnectTokenSummary> */
+    public function findAllSummaries(): array
+    {
+        $summaries = [];
+
+        foreach ($this->rows as $service => $row) {
+            $enum = ConnectTokenService::tryFrom($service);
+
+            if ($enum !== null) {
+                $summaries[] = new ConnectTokenSummary($enum, $row['hint'], $row['created'], $row['updated']);
+            }
+        }
+
+        return $summaries;
+    }
+
+    public function findSummary(ConnectTokenService $service): ?ConnectTokenSummary
+    {
+        $row = $this->rows[$service->value] ?? null;
+
+        return $row === null
+            ? null
+            : new ConnectTokenSummary($service, $row['hint'], $row['created'], $row['updated']);
+    }
+
+    public function findEnvelope(ConnectTokenService $service): ?string
+    {
+        return $this->rows[$service->value]['envelope'] ?? null;
+    }
+
+    public function save(ConnectTokenService $service, string $envelope, string $hint): ConnectTokenSummary
+    {
+        $created = $this->rows[$service->value]['created'] ?? $this->now;
+
+        $this->rows[$service->value] = [
+            'envelope' => $envelope,
+            'hint'     => $hint,
+            'created'  => $created,
+            'updated'  => $this->now,
+        ];
+
+        return new ConnectTokenSummary($service, $hint, $created, $this->now);
+    }
+
+    public function delete(ConnectTokenService $service): void
+    {
+        unset($this->rows[$service->value]);
+    }
+
+    /** Test-only view of what was actually persisted, for asserting the plaintext never lands. */
+    public function storedEnvelope(ConnectTokenService $service): ?string
+    {
+        return $this->rows[$service->value]['envelope'] ?? null;
+    }
+}

--- a/tests/OrgConnect/PdoConnectTokenRepositoryTest.php
+++ b/tests/OrgConnect/PdoConnectTokenRepositoryTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\OrgConnect;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\OrgConnect\ConnectTokenService;
+use NeNeRecords\OrgConnect\PdoConnectTokenRepository;
+use NeNeRecords\Tests\Support\FixedClock;
+use PHPUnit\Framework\TestCase;
+
+final class PdoConnectTokenRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $factory = new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene-records-test',
+            '',
+            'utf8',
+        ));
+
+        $this->executor = new PdoDatabaseQueryExecutor($factory);
+
+        $this->orgId = new RequestScopedHolder();
+        $this->orgId->set(1);
+
+        $path = dirname(__DIR__, 2) . '/database/schema/org_connect_tokens.sql';
+        self::assertFileExists($path);
+        $raw = trim((string) file_get_contents($path));
+
+        foreach (preg_split('/;\R/s', $raw) ?: [] as $chunk) {
+            $statement = trim($chunk);
+            if ($statement !== '') {
+                $this->executor->execute($statement);
+            }
+        }
+    }
+
+    public function testSaveThenReadBackTheEnvelope(): void
+    {
+        $repository = $this->repository();
+
+        $summary = $repository->save(ConnectTokenService::Contact, 'envelope-one', 'abcd');
+
+        self::assertSame(ConnectTokenService::Contact, $summary->service);
+        self::assertSame('abcd', $summary->hint);
+        self::assertSame('envelope-one', $repository->findEnvelope(ConnectTokenService::Contact));
+    }
+
+    public function testSummaryReadsNeverSelectTheCiphertext(): void
+    {
+        $repository = $this->repository();
+        $repository->save(ConnectTokenService::Contact, 'envelope-one', 'abcd');
+
+        // The summary type has nowhere to put a secret; this asserts the SQL agrees, so a
+        // future `SELECT *` cannot quietly start carrying the ciphertext into the HTTP layer.
+        $encoded = (string) json_encode([
+            $repository->findAllSummaries(),
+            $repository->findSummary(ConnectTokenService::Contact),
+        ]);
+
+        self::assertStringNotContainsString('envelope-one', $encoded);
+    }
+
+    public function testSavingTwiceUpdatesInPlaceAndKeepsCreatedAt(): void
+    {
+        $repository = $this->repository();
+
+        $first = $repository->save(ConnectTokenService::Contact, 'envelope-one', 'abcd');
+        $second = $repository->save(ConnectTokenService::Contact, 'envelope-two', 'wxyz');
+
+        self::assertSame($first->createdAt, $second->createdAt);
+        self::assertSame('envelope-two', $repository->findEnvelope(ConnectTokenService::Contact));
+        self::assertCount(1, $repository->findAllSummaries());
+    }
+
+    public function testAnotherOrganizationCannotSeeOrOverwriteTheToken(): void
+    {
+        $repository = $this->repository();
+        $repository->save(ConnectTokenService::Contact, 'envelope-one', 'abcd');
+
+        $this->orgId->set(2);
+
+        self::assertSame([], $repository->findAllSummaries());
+        self::assertNull($repository->findSummary(ConnectTokenService::Contact));
+        self::assertNull($repository->findEnvelope(ConnectTokenService::Contact));
+
+        // A second org installing its own token must not touch the first org's row.
+        $repository->save(ConnectTokenService::Contact, 'envelope-two', 'wxyz');
+        $this->orgId->set(1);
+
+        self::assertSame('envelope-one', $repository->findEnvelope(ConnectTokenService::Contact));
+    }
+
+    public function testDeleteIsScopedToTheOrganization(): void
+    {
+        $repository = $this->repository();
+        $repository->save(ConnectTokenService::Contact, 'envelope-one', 'abcd');
+
+        $this->orgId->set(2);
+        $repository->save(ConnectTokenService::Contact, 'envelope-two', 'wxyz');
+        $repository->delete(ConnectTokenService::Contact);
+
+        self::assertNull($repository->findEnvelope(ConnectTokenService::Contact));
+
+        $this->orgId->set(1);
+        self::assertSame('envelope-one', $repository->findEnvelope(ConnectTokenService::Contact));
+    }
+
+    public function testRowsWithAnUnknownServiceAreSkippedRatherThanFatal(): void
+    {
+        $repository = $this->repository();
+        $repository->save(ConnectTokenService::Contact, 'envelope-one', 'abcd');
+
+        // Simulates an integration that was removed from the enum, or a hand-edited row:
+        // the admin list must still load so the operator can clean up.
+        $this->executor->execute(
+            'INSERT INTO org_connect_tokens
+                 (organization_id, service, token_ciphertext, token_hint, created_at, updated_at)
+             VALUES (1, ?, ?, ?, ?, ?)',
+            ['retired', 'envelope-old', 'zzzz', '2026-01-01 00:00:00', '2026-01-01 00:00:00'],
+        );
+
+        self::assertCount(1, $repository->findAllSummaries());
+    }
+
+    private function repository(): PdoConnectTokenRepository
+    {
+        return new PdoConnectTokenRepository($this->executor, $this->orgId, new FixedClock());
+    }
+}

--- a/tests/OrgConnect/TestConfigKeyResolver.php
+++ b/tests/OrgConnect/TestConfigKeyResolver.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\OrgConnect;
+
+use NeNeRecords\Config\ConfigKeyResolverInterface;
+
+/**
+ * A deterministic key so connect-token tests exercise the real cipher rather than a stub —
+ * the encryption is the part most worth not faking.
+ */
+final readonly class TestConfigKeyResolver implements ConfigKeyResolverInterface
+{
+    private string $key;
+
+    public function __construct(?string $key = null)
+    {
+        $this->key = $key ?? str_repeat("\x01", 32);
+    }
+
+    public function resolve(): string
+    {
+        /** @var non-empty-string */
+        return $this->key;
+    }
+}


### PR DESCRIPTION
## 目的

records-embed 案1（epic #1001）の **① connect-token の保管・提示**。
hub 裁定（2026-07-30）の **(A) contact が発行・records は保管/提示**を前提に、records 側には
**発行も失効も作らない**（invoice `src/ServiceToken/` 20ファイルの写経は不要になった）。

Closes #1029

## 変更

**土台（先行コミット `7e6b17e`）**
- `org_connect_tokens` 専用表 ＋ `database/schema/*.sql` ＋ `ORG_SCOPED_TABLES` 登録
- 設定値の暗号保管を新設（AES-256-GCM・鍵 `NENE_RECORDS_CONFIG_KEY`・鍵が無ければ保存も読み出しも拒否）

**本体（`13dbeac`）**
- `src/OrgConnect/` — 読み出しを「秘密を持たない要約」と「封筒1本」に分離。
  `ConnectTokenSummary` には ciphertext を置く場所が無く、要約クエリは `token_ciphertext` を
  SELECT しない＝ HTTP 層は**規律ではなく構造として**秘密に届かない
- admin API 3本: `GET /api/v1/connect-tokens`（マスク一覧）/ `PUT …/{service}`（設置・貼り替え）/
  `DELETE …/{service}`。単体 GET は作っていない（一覧で足りる surface を増やすと監査対象が増えるだけ）
- 提示は `ConnectTokenProviderInterface` 1点に閉じる（利用者は送信 proxy #1031 のみ）
- 認可: `ADMIN_ONLY_PREFIXES` ＋ `CapabilityResolver`（**全メソッド ManageSettings**）
- OpenAPI ＋ `schema.gen.ts` 再生成

## 設計判断（レビューで見てほしい点）

1. **service を enum の許可リストにした**。未知の値は「テナントに存在しないスロット」なので 404。
2. **settings の枝に相乗りさせなかった**。editor が持つ `ReadSettings` では、マスク済み一覧でも
   「どの製品と繋がっているか」の棚卸しになる。だから GET も admin-only。
3. **鍵ローテ時に null を返さない**。`ConfigDecryptException` で表面化させる——「壊れている」と
   「入っていない」は運用者の次の行動（貼り直す／新規に入れる）が違う。
4. **再暗号化・自動ローテは作っていない**（YAGNI・issue の「やらないこと」どおり）。

## pin テスト4本（`ConnectTokenLeakPinTest`）

| pin | 種別 | 内容 |
|---|---|---|
| ① admin 応答 | **挙動** | 実 SQLite に実トークンを設置 → PUT/GET の body に生トークンも封筒も出ない・hint は出る |
| ② org export | **挙動** | 25表の列挙・payload builder・Pdo 実装のいずれも connect-token を知らない |
| ③ 公開 bootstrap JSON | 構造 | bootstrap を組む5ファイルが本モジュールを参照しない |
| ④ SSR HTML | 構造 | `templates/public/*` ＋ `Render*` ＋ SPA シェルが参照しない |

🔴 **③④が構造テストである理由を明記しておく**: 公開描画系は entities と settings しか読まないため、
挙動版の pin は**配線が安全かどうかに関係なく今日は必ず素通り**する（＝緑が何も証明しない）。
構造 pin は「描画経路が connect-token を知った瞬間に落ちる」形なので、実際に防ぎたい退行を捕まえる。
各 pin には**空振り防止の反証アサート**（対象ファイルを本当に読めているか）を入れてある。

## 検証

- `composer check` 緑 — PHPUnit **1574** / PHPStan L8 / CS / OpenAPI valid / conformance OK / MCP valid
- `npm run check --prefix frontend` 緑
- 実 MySQL で migration の migrate / rollback 往復（土台コミット時）

## 続き

② contact ブロック = #1030 ／ ③ 送信 proxy = #1031（`ConnectTokenProviderInterface` の唯一の利用者）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)