### PR TITLE
feat(embed): contact-form ブロック — 型・サーバ側検証・SSR 描画（#1030 PHP 側）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,3 +101,10 @@ DB_CHARSET=utf8mb4
 # so the web server must strip the prefix (Caddy `handle_path` / Apache rewrite).
 # Empty (default) = served at the domain root. Leading slash, no trailing slash.
 # APP_BASE_PATH=/blog
+
+# Base URL of the contact deployment that issues connect-tokens and serves public form
+# schemas (records-embed 案1 / #1030). Unset is normal: without it a contact-form block
+# reports "form unavailable" instead of rendering, and nothing else changes.
+# No credential is sent to this host on the schema read — the form key is a handle, not a
+# secret. The connect-token belongs to the submission path only (#1031).
+NENE_RECORDS_CONTACT_BASE_URL=

--- a/docs/blocks/blocks.schema.json
+++ b/docs/blocks/blocks.schema.json
@@ -28,7 +28,8 @@
             "group",
             "columns",
             "spacer",
-            "divider"
+            "divider",
+            "contact-form"
           ]
         },
         "data": { "type": "object" }
@@ -69,8 +70,31 @@
         {
           "if": { "properties": { "type": { "const": "divider" } } },
           "then": { "properties": { "data": { "$ref": "#/$defs/dividerData" } } }
+        },
+        {
+          "if": { "properties": { "type": { "const": "contact-form" } } },
+          "then": { "properties": { "data": { "$ref": "#/$defs/contactFormData" } } }
         }
       ]
+    },
+    "contactFormData": {
+      "type": "object",
+      "description": "A contact form issued by a sibling product, rendered server-side by records (#1030). The key is a handle, not a secret; the credential lives only on the submission path.",
+      "required": ["formKey"],
+      "properties": {
+        "formKey": {
+          "type": "string",
+          "description": "The issuing product's public form key. Restricted to URL-path-safe characters because it is interpolated into the schema fetch.",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[A-Za-z0-9_-]+$"
+        },
+        "variant": {
+          "enum": ["inline"],
+          "description": "Absent means inline. Only inline ships in the first version: modal and chat need a CSP nonce and client JS."
+        }
+      },
+      "additionalProperties": false
     },
     "spacerData": {
       "type": "object",

--- a/frontend/src/features/edit-entity-text-fields/ui/BlockInspector.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/BlockInspector.tsx
@@ -348,6 +348,36 @@ export function BlockInspector({
         </span>
       )
 
+    case 'contact-form': {
+      const data = block.data
+      return (
+        <Stack gap="sm">
+          <Input
+            id={`${idPrefix}-form-key`}
+            label={t('admin.blocks.field.formKey')}
+            value={data.formKey}
+            disabled={disabled}
+            autoComplete="off"
+            error={
+              errorCode === 'form-key-required'
+                ? t('admin.blocks.error.formKeyRequired')
+                : errorCode === 'form-key-invalid'
+                  ? t('admin.blocks.error.formKeyInvalid')
+                  : undefined
+            }
+            onChange={(event) => {
+              onChange({ ...data, formKey: event.target.value })
+            }}
+          />
+          {/* The form is drawn by the server, so the editor cannot preview it — say so rather
+              than leaving the author wondering why nothing appears here. */}
+          <span className="font-sans text-caption text-text-muted">
+            {t('admin.blocks.contactForm.hint')}
+          </span>
+        </Stack>
+      )
+    }
+
     case 'hero': {
       const data = block.data
       return (

--- a/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.tsx
+++ b/frontend/src/features/edit-entity-text-fields/ui/BlocksFieldEditor.tsx
@@ -67,6 +67,8 @@ function blockTypeIcon(type: BlockType) {
       return IconChevronDown
     case 'divider':
       return IconMenu
+    case 'contact-form':
+      return IconMessageCircle
   }
 }
 
@@ -95,6 +97,8 @@ function rawSummary(block: Block): string {
     case 'spacer':
     case 'divider':
       return ''
+    case 'contact-form':
+      return block.data.formKey
   }
 }
 

--- a/frontend/src/features/edit-entity-text-fields/ui/block-catalog.ts
+++ b/frontend/src/features/edit-entity-text-fields/ui/block-catalog.ts
@@ -38,6 +38,11 @@ export const BLOCK_CATALOG: readonly BlockCatalogEntry[] = [
     labelKey: 'admin.blocks.type.divider',
     descKey: 'admin.blocks.type.divider.desc',
   },
+  {
+    type: 'contact-form',
+    labelKey: 'admin.blocks.type.contactForm',
+    descKey: 'admin.blocks.type.contactForm.desc',
+  },
 ]
 
 const CATALOG_BY_TYPE = Object.fromEntries(

--- a/frontend/src/pages/consumer/public-site.css
+++ b/frontend/src/pages/consumer/public-site.css
@@ -2759,6 +2759,58 @@
   border-top: 1px solid var(--color-border);
   margin-block: var(--space-xl);
 }
+
+/* contact-form block (#1030). Rendered by the server for crawlers and no-JS, and by the SPA
+   from the same bootstrap payload after mount — one ruleset has to serve both, so the
+   selectors match the markup both sides emit. */
+.nene-public .block--contact-form {
+  display: grid;
+  gap: var(--space-md);
+  margin-block: var(--space-xl);
+}
+
+.nene-public .contact-form__field {
+  display: grid;
+  gap: var(--space-xs);
+  margin: 0;
+}
+
+.nene-public .contact-form__field label {
+  font-weight: 600;
+}
+
+.nene-public .contact-form__field input,
+.nene-public .contact-form__field textarea,
+.nene-public .contact-form__field select {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-xs) var(--space-sm);
+  font: inherit;
+  color: inherit;
+  background: var(--color-surface);
+}
+
+.nene-public .contact-form__field--consent {
+  grid-template-columns: 1fr;
+}
+
+.nene-public .contact-form__field--consent label {
+  display: flex;
+  gap: var(--space-xs);
+  align-items: flex-start;
+  font-weight: 400;
+}
+
+.nene-public .contact-form__actions {
+  margin: 0;
+}
+
+.nene-public .contact-form--unavailable {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-md);
+  color: var(--color-text-muted);
+}
 /* custom-layout page host (#311 / WS3-S3c): full content-width, chrome-less body. */
 .nene-public .custom-page {
   display: block;

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -963,6 +963,17 @@ export const de = {
   'admin.blocks.spacerSize.md': 'Mittel',
   'admin.blocks.spacerSize.lg': 'Groß',
   'admin.blocks.divider.hint': 'Eine horizontale Linie — keine Einstellungen.',
+  // contact-form (#1030) — the form itself is rendered server-side (SSR), so the
+  // consumer renderer only shows the failure notice.
+  'admin.blocks.type.contactForm': 'Kontaktformular',
+  'admin.blocks.type.contactForm.desc': 'Ein eingebettetes Kontaktformular',
+  'admin.blocks.field.formKey': 'Formularschlüssel',
+  'admin.blocks.error.formKeyRequired': 'Ein Formularschlüssel ist erforderlich.',
+  'admin.blocks.error.formKeyInvalid':
+    'Erlaubt sind nur Buchstaben, Ziffern, Bindestrich und Unterstrich.',
+  'admin.blocks.contactForm.hint':
+    'Das Formular wird serverseitig gerendert und hier deshalb nicht als Vorschau angezeigt. Fügen Sie den Formularschlüssel aus dem Produkt „contact“ ein.',
+  'public.blocks.contactForm.unavailable': 'Dieses Formular ist vorübergehend nicht verfügbar.',
   // ── Home hero (#486) ──────────────────────────────────────────────────────
   'admin.homeHero.title': 'Startseiten-Hero',
   'admin.homeHero.description':

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -974,6 +974,16 @@ export const en = {
   'admin.blocks.spacerSize.md': 'Medium',
   'admin.blocks.spacerSize.lg': 'Large',
   'admin.blocks.divider.hint': 'A horizontal rule — no settings.',
+  // contact-form (#1030) — the form itself is rendered server-side (SSR), so the
+  // consumer renderer only shows the failure notice.
+  'admin.blocks.type.contactForm': 'Contact form',
+  'admin.blocks.type.contactForm.desc': 'An embedded contact form',
+  'admin.blocks.field.formKey': 'Form key',
+  'admin.blocks.error.formKeyRequired': 'A form key is required.',
+  'admin.blocks.error.formKeyInvalid': 'Only letters, digits, hyphen and underscore are allowed.',
+  'admin.blocks.contactForm.hint':
+    'The form is rendered by the server, so it is not previewed here. Paste the form key from the contact product.',
+  'public.blocks.contactForm.unavailable': 'This form is temporarily unavailable.',
 
   // ── Home hero (#486) ──────────────────────────────────────────────────────
   'admin.homeHero.title': 'Home hero',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -980,6 +980,17 @@ export const fr = {
   'admin.blocks.spacerSize.md': 'Moyen',
   'admin.blocks.spacerSize.lg': 'Grand',
   'admin.blocks.divider.hint': 'Un filet horizontal — aucun réglage.',
+  // contact-form (#1030) — the form itself is rendered server-side (SSR), so the
+  // consumer renderer only shows the failure notice.
+  'admin.blocks.type.contactForm': 'Formulaire de contact',
+  'admin.blocks.type.contactForm.desc': 'Un formulaire de contact intégré',
+  'admin.blocks.field.formKey': 'Clé du formulaire',
+  'admin.blocks.error.formKeyRequired': 'Une clé de formulaire est requise.',
+  'admin.blocks.error.formKeyInvalid':
+    'Seuls les lettres, chiffres, tirets et tirets bas sont autorisés.',
+  'admin.blocks.contactForm.hint':
+    "Le formulaire est rendu par le serveur : il n'est donc pas prévisualisé ici. Collez la clé du formulaire issue du produit contact.",
+  'public.blocks.contactForm.unavailable': 'Ce formulaire est temporairement indisponible.',
 
   // ── Home hero (#486) ──────────────────────────────────────────────────────
   'admin.homeHero.title': "Bannière d'accueil",

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -972,6 +972,16 @@ export const ja = {
   'admin.blocks.spacerSize.md': '中',
   'admin.blocks.spacerSize.lg': '大',
   'admin.blocks.divider.hint': '水平の罫線です（設定なし）。',
+  // contact-form (#1030) — the form itself is rendered server-side (SSR), so the
+  // consumer renderer only shows the failure notice.
+  'admin.blocks.type.contactForm': 'お問い合わせフォーム',
+  'admin.blocks.type.contactForm.desc': '埋め込みのお問い合わせフォーム',
+  'admin.blocks.field.formKey': 'フォームキー',
+  'admin.blocks.error.formKeyRequired': 'フォームキーを入力してください。',
+  'admin.blocks.error.formKeyInvalid': '使用できるのは英数字・ハイフン・アンダースコアだけです。',
+  'admin.blocks.contactForm.hint':
+    'フォームはサーバー側で描画されるため、ここではプレビューされません。contact 製品のフォームキーを貼り付けてください。',
+  'public.blocks.contactForm.unavailable': 'このフォームは一時的にご利用いただけません。',
 
   // ── Home hero (#486) ──────────────────────────────────────────────────────
   'admin.homeHero.title': 'ホームヒーロー',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -972,6 +972,16 @@ export const ptBR = {
   'admin.blocks.spacerSize.md': 'Médio',
   'admin.blocks.spacerSize.lg': 'Grande',
   'admin.blocks.divider.hint': 'Uma linha horizontal — sem configurações.',
+  // contact-form (#1030) — the form itself is rendered server-side (SSR), so the
+  // consumer renderer only shows the failure notice.
+  'admin.blocks.type.contactForm': 'Formulário de contato',
+  'admin.blocks.type.contactForm.desc': 'Um formulário de contato incorporado',
+  'admin.blocks.field.formKey': 'Chave do formulário',
+  'admin.blocks.error.formKeyRequired': 'A chave do formulário é obrigatória.',
+  'admin.blocks.error.formKeyInvalid': 'São permitidos apenas letras, dígitos, hífen e sublinhado.',
+  'admin.blocks.contactForm.hint':
+    'O formulário é renderizado pelo servidor, portanto não é pré-visualizado aqui. Cole a chave do formulário do produto contact.',
+  'public.blocks.contactForm.unavailable': 'Este formulário está temporariamente indisponível.',
 
   // ── Home hero (#486) ──────────────────────────────────────────────────────
   'admin.homeHero.title': 'Hero da home',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -929,6 +929,16 @@ export const zhHans = {
   'admin.blocks.spacerSize.md': '中',
   'admin.blocks.spacerSize.lg': '大',
   'admin.blocks.divider.hint': '一条水平分隔线——无需设置。',
+  // contact-form (#1030) — the form itself is rendered server-side (SSR), so the
+  // consumer renderer only shows the failure notice.
+  'admin.blocks.type.contactForm': '联系表单',
+  'admin.blocks.type.contactForm.desc': '嵌入式联系表单',
+  'admin.blocks.field.formKey': '表单密钥',
+  'admin.blocks.error.formKeyRequired': '请填写表单密钥。',
+  'admin.blocks.error.formKeyInvalid': '仅允许使用字母、数字、连字符和下划线。',
+  'admin.blocks.contactForm.hint':
+    '该表单由服务器渲染，因此此处不提供预览。请粘贴来自 contact 产品的表单密钥。',
+  'public.blocks.contactForm.unavailable': '该表单暂时不可用。',
 
   // ── Home hero (#486) ──────────────────────────────────────────────────────
   'admin.homeHero.title': '主页主视觉',

--- a/frontend/src/shared/lib/blocks-document.ts
+++ b/frontend/src/shared/lib/blocks-document.ts
@@ -22,6 +22,7 @@ const BLOCK_TYPES = [
   'columns',
   'spacer',
   'divider',
+  'contact-form',
 ] as const
 export type BlockType = (typeof BLOCK_TYPES)[number]
 
@@ -42,6 +43,17 @@ export type GroupTone = (typeof GROUP_TONES)[number]
 
 export const SPACER_SIZES = ['sm', 'md', 'lg'] as const
 export type SpacerSize = (typeof SPACER_SIZES)[number]
+
+/**
+ * Display variants of the contact-form block (#1030). Only `inline` ships first: it renders
+ * as pure SSR, while modal/chat need a CSP nonce and client JS. Keep in sync with
+ * `BlocksDocumentValidator::CONTACT_FORM_VARIANTS`.
+ */
+export const CONTACT_FORM_VARIANTS = ['inline'] as const
+export type ContactFormVariant = (typeof CONTACT_FORM_VARIANTS)[number]
+
+/** Mirrors the server's `MAX_FORM_KEY_LEN`. */
+export const MAX_FORM_KEY_LENGTH = 64
 
 /** Block caps — mirror the server validator (`BlocksDocumentValidator`); enforced in the editor. */
 export const MAX_BLOCKS_PER_DOCUMENT = 200
@@ -115,6 +127,19 @@ export interface SpacerBlockData {
 /** Horizontal rule block (#491 WS2); no options. */
 export type DividerBlockData = Record<string, never>
 
+/**
+ * A contact form issued by a sibling product and rendered server-side by records (#1030).
+ *
+ * `formKey` is a handle, not a secret — the credential lives only on the submission path.
+ * The form itself is rendered by the SSR layer (`SsrBlocksRenderer`), so unlike every other
+ * block type the consumer renderer here does not draw the fields: it must not produce a
+ * second, JS-only form that disagrees with the crawlable one.
+ */
+export interface ContactFormBlockData {
+  formKey: string
+  variant?: ContactFormVariant
+}
+
 /** Leaf (non-container) blocks. A group's children are leaf blocks only (depth 2). */
 export type LeafBlock =
   | { id: string; type: 'text'; data: TextBlockData }
@@ -124,6 +149,7 @@ export type LeafBlock =
   | { id: string; type: 'chart'; data: ChartBlockData }
   | { id: string; type: 'spacer'; data: SpacerBlockData }
   | { id: string; type: 'divider'; data: DividerBlockData }
+  | { id: string; type: 'contact-form'; data: ContactFormBlockData }
 
 /** Layout container holding leaf child blocks (#491 WS2); not nestable in another container. */
 export interface GroupBlockData {
@@ -165,6 +191,8 @@ export type BlockValidationCode =
   | 'summary-required'
   | 'children-required'
   | 'children-invalid'
+  | 'form-key-required'
+  | 'form-key-invalid'
 
 function isBlockType(value: string): value is BlockType {
   return (BLOCK_TYPES as readonly string[]).includes(value)
@@ -185,6 +213,10 @@ function isGroupTone(value: unknown): value is GroupTone {
 /** True for non-container blocks (a container's children are leaf-only; depth 2). */
 function isLeafBlock(block: Block): block is LeafBlock {
   return block.type !== 'group' && block.type !== 'columns'
+}
+
+function isContactFormVariant(value: unknown): value is ContactFormVariant {
+  return typeof value === 'string' && (CONTACT_FORM_VARIANTS as readonly string[]).includes(value)
 }
 
 function isSpacerSize(value: unknown): value is SpacerSize {
@@ -306,6 +338,8 @@ export function createBlock(type: BlockType): Block {
       return { id: newBlockId(), type, data: { size: 'md' } }
     case 'divider':
       return { id: newBlockId(), type, data: {} }
+    case 'contact-form':
+      return { id: newBlockId(), type, data: { formKey: '', variant: 'inline' } }
   }
 }
 
@@ -449,6 +483,18 @@ function coerceBlock(raw: unknown, index: number, allowContainers: boolean): Blo
       return { id, type, data: { size: isSpacerSize(record.size) ? record.size : 'md' } }
     case 'divider':
       return { id, type, data: {} }
+    case 'contact-form':
+      return {
+        id,
+        type,
+        data: {
+          formKey: typeof record.formKey === 'string' ? record.formKey : '',
+          // Absent means inline, and an unrecognised variant coerces to inline rather than
+          // dropping the block: the server already rejected it on write, so seeing one here
+          // means old data, and showing the form beats showing nothing.
+          variant: isContactFormVariant(record.variant) ? record.variant : 'inline',
+        },
+      }
   }
 }
 
@@ -607,6 +653,17 @@ export function validateBlock(block: Block): BlockValidationCode | null {
     case 'spacer':
     case 'divider':
       return null
+    case 'contact-form': {
+      const formKey = block.data.formKey.trim()
+      if (formKey === '') {
+        return 'form-key-required'
+      }
+      // Same rule as the server: the key is interpolated into a URL path when the schema is
+      // fetched, so anything outside this set must not reach save.
+      return /^[A-Za-z0-9_-]+$/.test(formKey) && formKey.length <= MAX_FORM_KEY_LENGTH
+        ? null
+        : 'form-key-invalid'
+    }
   }
 }
 

--- a/frontend/src/shared/lib/public-record-bootstrap.ts
+++ b/frontend/src/shared/lib/public-record-bootstrap.ts
@@ -14,6 +14,33 @@ export interface PublicRecordBootstrapRelationQuery {
   items: Array<{ field_key: string; target_entity_id: number }>
 }
 
+/**
+ * A contact form's public schema, resolved server-side while rendering the SSR form and
+ * handed to the client in the bootstrap (#1030).
+ *
+ * The client never fetches this itself: rendering from the same resolved data is what makes
+ * the crawlable form and the hydrated form provably identical, and it costs no extra request.
+ * Nothing secret is in here — the form key is a handle, and the credential lives only on the
+ * submission path (#1031).
+ */
+export interface PublicContactFormFieldDto {
+  key: string
+  label: string
+  type: string
+  required: boolean
+  options: string[]
+}
+
+export interface PublicContactFormSchemaDto {
+  formKey: string
+  /** Where the form posts — always the records-side proxy, never the issuing product. */
+  submitPath: string
+  consentRequired: boolean
+  consentLabel: string | null
+  submitLabel: string | null
+  fields: PublicContactFormFieldDto[]
+}
+
 export interface PublicRecordBootstrapDto {
   entityTypeSlug: string
   entityTypeId: number
@@ -37,6 +64,17 @@ export interface PublicRecordBootstrapDto {
   hierarchy?: PublicRecordHierarchyDto
   /** The path the SPA resolves this record by — lets us seed the resolve query (#881). */
   canonicalPath?: string
+  /** Form key => schema, for the contact-form blocks on this page (#1030). */
+  contactForms?: Record<string, PublicContactFormSchemaDto>
+}
+
+/**
+ * The schema for one contact form, or null when the page carries none (no block, or the
+ * server could not resolve it — in which case the server rendered a visible notice and there
+ * is nothing for the client to draw either).
+ */
+export function readContactFormSchema(formKey: string): PublicContactFormSchemaDto | null {
+  return readPublicRecordBootstrap()?.contactForms?.[formKey] ?? null
 }
 
 export function readPublicRecordBootstrap(): PublicRecordBootstrapDto | null {

--- a/frontend/src/shared/ui/blocks/BlocksRenderer.test.tsx
+++ b/frontend/src/shared/ui/blocks/BlocksRenderer.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, screen } from '@testing-library/react'
 import { renderWithProviders } from '@tests/render/render-with-providers'
 import { BlocksRenderer } from './BlocksRenderer'
@@ -221,5 +221,82 @@ describe('BlocksRenderer', () => {
       (th) => th.textContent,
     )
     expect(headers).toEqual(['ラベル', '値'])
+  })
+
+  describe('contact-form (#1030)', () => {
+    const DOC = JSON.stringify([
+      { id: 'blk1', type: 'contact-form', data: { formKey: 'ayane-contact', variant: 'inline' } },
+    ])
+
+    function seedBootstrap(contactForms: unknown): void {
+      const script = document.createElement('script')
+      script.id = 'nene-records-public-record-bootstrap'
+      script.type = 'application/json'
+      script.textContent = JSON.stringify({ contactForms })
+      document.head.appendChild(script)
+    }
+
+    afterEach(() => {
+      document.getElementById('nene-records-public-record-bootstrap')?.remove()
+    })
+
+    it('renders the form from the SSR bootstrap without fetching again', () => {
+      // hub pin 2: the "no extra round trip" claim is a check, not a comment.
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      seedBootstrap({
+        'ayane-contact': {
+          formKey: 'ayane-contact',
+          submitPath: '/api/v1/public/contact-submissions',
+          consentRequired: false,
+          consentLabel: null,
+          submitLabel: null,
+          fields: [
+            { key: 'email', label: 'Email', type: 'email', required: true, options: [] },
+            { key: 'message', label: 'Message', type: 'textarea', required: false, options: [] },
+          ],
+        },
+      })
+
+      const { container } = renderWithProviders(<BlocksRenderer documentJson={DOC} />)
+
+      const form = container.querySelector('form.block--contact-form')
+      expect(form?.getAttribute('action')).toBe('/api/v1/public/contact-submissions')
+      expect(form?.getAttribute('method')).toBe('post')
+      expect(container.querySelector('input[type="email"][name="email"]')).not.toBeNull()
+      expect(container.querySelector('textarea[name="message"]')).not.toBeNull()
+      expect(fetchSpy).not.toHaveBeenCalled()
+
+      fetchSpy.mockRestore()
+    })
+
+    it('never exposes a credential or the issuing product URL in the markup', () => {
+      seedBootstrap({
+        'ayane-contact': {
+          formKey: 'ayane-contact',
+          submitPath: '/api/v1/public/contact-submissions',
+          consentRequired: true,
+          consentLabel: '同意します',
+          submitLabel: '送信',
+          fields: [],
+        },
+      })
+
+      const { container } = renderWithProviders(<BlocksRenderer documentJson={DOC} />)
+      const html = container.innerHTML
+
+      expect(html).not.toContain('Bearer')
+      expect(html).not.toContain('Authorization')
+      expect(html).not.toContain('https://')
+      expect(container.querySelector('input[name="consent"]')).not.toBeNull()
+      expect(html).toContain('送信')
+    })
+
+    it('falls back to a visible notice when the page carries no schema for the key', () => {
+      // Mirrors the server's fail-visible behaviour rather than rendering an empty region.
+      const { container } = renderWithProviders(<BlocksRenderer documentJson={DOC} />)
+
+      expect(container.querySelector('.contact-form--unavailable')).not.toBeNull()
+      expect(container.querySelector('form')).toBeNull()
+    })
   })
 })

--- a/frontend/src/shared/ui/blocks/BlocksRenderer.tsx
+++ b/frontend/src/shared/ui/blocks/BlocksRenderer.tsx
@@ -9,6 +9,10 @@ import {
   type GroupBlockData,
   type HeroBlockData,
 } from '@/shared/lib/blocks-document'
+import {
+  readContactFormSchema,
+  type PublicContactFormFieldDto,
+} from '@/shared/lib/public-record-bootstrap'
 import { PublicMarkdownContent } from '@/shared/ui/markdown'
 import { ResponsiveImage } from '@/shared/ui/media/ResponsiveImage'
 
@@ -82,21 +86,87 @@ function ConsumerBlock({ block }: { block: Block }) {
       return <div className="spacer" data-spacer-size={block.data.size} aria-hidden="true" />
     case 'divider':
       return <hr className="divider" />
-    // contact-form (#1030): deliberately not drawn here *yet*.
-    //
-    // The form is rendered server-side so it is crawlable and works without JS. But this
-    // SPA replaces the SSR markup on mount (see the comment above `#root` in
-    // templates/public/record-detail.php), so leaving this case empty means the form
-    // disappears for everyone who has JavaScript — i.e. almost everyone. Drawing it here
-    // needs the form schema on the client, which is why the open decision is to ship the
-    // resolved schema in the SSR bootstrap and render from that.
-    //
-    // Returning null is the honest placeholder while that is decided: it is what already
-    // happens, now written down. This block type must not ship until this case draws the
-    // same form the server did.
     case 'contact-form':
-      return null
+      return <ConsumerContactForm formKey={block.data.formKey} blockId={block.id} />
   }
+}
+
+/**
+ * Contact form (#1030), drawn from the schema the *server* resolved and shipped in the SSR
+ * bootstrap.
+ *
+ * Why not fetch it here: this SPA replaces the server-rendered markup on mount (see the
+ * comment above `#root` in templates/public/record-detail.php). If the client asked the
+ * issuing product again it could get a different answer than the crawler saw. Rendering both
+ * from one resolved payload makes "the crawlable form and the hydrated form agree" structural
+ * rather than hopeful — and costs no extra request.
+ *
+ * The form posts to `submitPath`, which the server put in the bootstrap: the records-side
+ * proxy. A form posting straight at the issuing product would need the connect-token in the
+ * browser, which is the thing this whole design exists to prevent.
+ */
+function ConsumerContactForm({ formKey, blockId }: { formKey: string; blockId: string }) {
+  const { t } = useTranslation()
+  const schema = readContactFormSchema(formKey)
+
+  if (schema === null) {
+    // Matches the server's fail-visible notice: an empty region would read as "this page has
+    // no form" and the author would never learn the key was wrong.
+    return (
+      <div className="block block--contact-form contact-form--unavailable">
+        <p>{t('public.blocks.contactForm.unavailable')}</p>
+      </div>
+    )
+  }
+
+  const fieldId = (key: string) => `contact-${blockId}-${key}`
+
+  return (
+    <form className="block block--contact-form" method="post" action={schema.submitPath}>
+      <input type="hidden" name="form_key" value={schema.formKey} />
+      {schema.fields.map((field) => (
+        <p className="contact-form__field" key={field.key}>
+          <label htmlFor={fieldId(field.key)}>{field.label}</label>
+          <ContactFormControl field={field} id={fieldId(field.key)} />
+        </p>
+      ))}
+      {schema.consentRequired ? (
+        <p className="contact-form__field contact-form__field--consent">
+          <label>
+            <input type="checkbox" name="consent" value="1" required />{' '}
+            {schema.consentLabel ?? <span lang="en">I agree to the processing of my message.</span>}
+          </label>
+        </p>
+      ) : null}
+      <p className="contact-form__actions">
+        <button type="submit">{schema.submitLabel ?? <span lang="en">Send</span>}</button>
+      </p>
+    </form>
+  )
+}
+
+function ContactFormControl({ field, id }: { field: PublicContactFormFieldDto; id: string }) {
+  if (field.type === 'textarea') {
+    return <textarea id={id} name={field.key} rows={6} required={field.required} />
+  }
+
+  if (field.type === 'select') {
+    return (
+      <select id={id} name={field.key} required={field.required} defaultValue="">
+        {/* A required select whose first option is already chosen can never fail validation. */}
+        {field.required ? <option value="" disabled /> : null}
+        {field.options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    )
+  }
+
+  const type = ['email', 'tel', 'url'].includes(field.type) ? field.type : 'text'
+
+  return <input type={type} id={id} name={field.key} required={field.required} />
 }
 
 /**

--- a/frontend/src/shared/ui/blocks/BlocksRenderer.tsx
+++ b/frontend/src/shared/ui/blocks/BlocksRenderer.tsx
@@ -82,6 +82,20 @@ function ConsumerBlock({ block }: { block: Block }) {
       return <div className="spacer" data-spacer-size={block.data.size} aria-hidden="true" />
     case 'divider':
       return <hr className="divider" />
+    // contact-form (#1030): deliberately not drawn here *yet*.
+    //
+    // The form is rendered server-side so it is crawlable and works without JS. But this
+    // SPA replaces the SSR markup on mount (see the comment above `#root` in
+    // templates/public/record-detail.php), so leaving this case empty means the form
+    // disappears for everyone who has JavaScript — i.e. almost everyone. Drawing it here
+    // needs the form schema on the client, which is why the open decision is to ship the
+    // resolved schema in the SSR bootstrap and render from that.
+    //
+    // Returning null is the honest placeholder while that is decided: it is what already
+    // happens, now written down. This block type must not ship until this case draws the
+    // same form the server did.
+    case 'contact-form':
+      return null
   }
 }
 

--- a/src/BlocksField/BlockTypes.php
+++ b/src/BlocksField/BlockTypes.php
@@ -9,7 +9,11 @@ namespace NeNeRecords\BlocksField;
  * an admin inspector form, and a `data` shape validated by
  * {@see BlocksDocumentValidator}. Curated typed blocks (Gutenberg-style column),
  * NOT a free-form page builder. S1 ships `text` and `callout`, S2 adds `hero`,
- * S4 adds `gallery`, S5 adds `chart`.
+ * S4 adds `gallery`, S5 adds `chart`, and records-embed 案1 adds `contact-form` (#1030).
+ *
+ * Adding a type here is safe for existing documents: unknown types are rejected on
+ * write ({@see BlocksDocumentValidator}) and dropped on read, so no stored document
+ * changes meaning when the list grows.
  */
 final class BlockTypes
 {
@@ -24,6 +28,7 @@ final class BlockTypes
         'columns',
         'spacer',
         'divider',
+        'contact-form',
     ];
 
     public static function isValid(string $type): bool

--- a/src/BlocksField/BlocksDocumentValidator.php
+++ b/src/BlocksField/BlocksDocumentValidator.php
@@ -52,6 +52,19 @@ final class BlocksDocumentValidator
 
     private const SPACER_SIZES = ['sm', 'md', 'lg'];
 
+    /**
+     * Display variants of the contact-form block (#1030). Only `inline` ships in the first
+     * version: it renders as pure SSR, while `modal` and `chat` would need a CSP nonce and
+     * client JS. Adding a variant later is additive — an old document naming a variant this
+     * list does not know is rejected on write, never silently downgraded.
+     *
+     * @var list<string>
+     */
+    private const CONTACT_FORM_VARIANTS = ['inline'];
+
+    /** contact's `public_form_key` — an opaque handle, not a secret. */
+    private const MAX_FORM_KEY_LEN = 64;
+
     private const MAX_GALLERY_ITEMS = 50;
     private const MAX_SERIES_POINTS = 60;
     private const MAX_SERIES_LABEL_LEN = 120;
@@ -145,6 +158,7 @@ final class BlocksDocumentValidator
             'group' => $this->validateGroupData($path, $data, $count, $errors),
             'columns' => $this->validateColumnsData($path, $data, $count, $errors),
             'spacer' => $this->validateSpacerData($path, $data, $errors),
+            'contact-form' => $this->validateContactFormData($path, $data, $errors),
             default => null,
         };
     }
@@ -234,6 +248,51 @@ final class BlocksDocumentValidator
         $size = $data['size'] ?? null;
         if (!is_string($size) || !in_array($size, self::SPACER_SIZES, true)) {
             $errors[] = new ValidationError("{$path}.data.size", 'Spacer size must be one of: ' . implode(', ', self::SPACER_SIZES) . '.', 'invalid');
+        }
+    }
+
+    /**
+     * `{ formKey, variant? }` — the author names a form that lives in another product; records
+     * fetches its schema server-side and renders the fields.
+     *
+     * The key is checked for shape only. Whether the form exists is not knowable here (it is
+     * contact's data, and this validator must not make a network call on save), so an author
+     * typo surfaces at render time as a visible failure rather than a silent blank — the same
+     * fail-visible rule the submission proxy follows (#1031).
+     *
+     * @param array<array-key, mixed> $data
+     * @param list<ValidationError>   $errors
+     */
+    private function validateContactFormData(string $path, array $data, array &$errors): void
+    {
+        $formKey = $data['formKey'] ?? null;
+
+        if (!is_string($formKey) || $formKey === '' || strlen($formKey) > self::MAX_FORM_KEY_LEN) {
+            $errors[] = new ValidationError(
+                "{$path}.data.formKey",
+                'Contact form block requires a form key (max ' . self::MAX_FORM_KEY_LEN . ' chars).',
+                'invalid',
+            );
+        } elseif (preg_match('/^[A-Za-z0-9_-]+$/', $formKey) !== 1) {
+            // The key is interpolated into a URL path when the schema is fetched. Restricting
+            // it here means the fetch cannot be talked into addressing something else.
+            $errors[] = new ValidationError(
+                "{$path}.data.formKey",
+                'Contact form key may only contain letters, digits, hyphen and underscore.',
+                'invalid',
+            );
+        }
+
+        $variant = $data['variant'] ?? null;
+
+        // Absent means `inline`. Storing the default explicitly is allowed but not required,
+        // so a document written before a second variant existed stays valid.
+        if ($variant !== null && (!is_string($variant) || !in_array($variant, self::CONTACT_FORM_VARIANTS, true))) {
+            $errors[] = new ValidationError(
+                "{$path}.data.variant",
+                'Contact form variant must be one of: ' . implode(', ', self::CONTACT_FORM_VARIANTS) . '.',
+                'invalid',
+            );
         }
     }
 

--- a/src/PublicRecord/ContactFormField.php
+++ b/src/PublicRecord/ContactFormField.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+/**
+ * One field of a contact form, as described by the issuing product's public schema.
+ *
+ * Deliberately a narrow subset of what contact may return: records renders inputs, it does
+ * not re-implement contact's form model. Anything records cannot render is ignored rather
+ * than guessed at.
+ */
+final readonly class ContactFormField
+{
+    /**
+     * @param list<string> $options values for `select`; empty for every other type
+     */
+    public function __construct(
+        public string $key,
+        public string $label,
+        public string $type,
+        public bool $required,
+        public array $options = [],
+    ) {
+    }
+}

--- a/src/PublicRecord/ContactFormSchema.php
+++ b/src/PublicRecord/ContactFormSchema.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+final readonly class ContactFormSchema
+{
+    /**
+     * @param list<ContactFormField> $fields
+     */
+    public function __construct(
+        public string $formKey,
+        public array $fields,
+        public bool $consentRequired = false,
+        public ?string $submitLabel = null,
+    ) {
+    }
+}

--- a/src/PublicRecord/ContactFormSchema.php
+++ b/src/PublicRecord/ContactFormSchema.php
@@ -7,6 +7,10 @@ namespace NeNeRecords\PublicRecord;
 final readonly class ContactFormSchema
 {
     /**
+     * Wording that belongs to the issuing product, not to records: the consent sentence is
+     * that product's legal text, and the submit label is its copy. records only falls back to
+     * English when the schema omits them — see the SSR i18n gap tracked in #1034.
+     *
      * @param list<ContactFormField> $fields
      */
     public function __construct(
@@ -14,6 +18,7 @@ final readonly class ContactFormSchema
         public array $fields,
         public bool $consentRequired = false,
         public ?string $submitLabel = null,
+        public ?string $consentLabel = null,
     ) {
     }
 }

--- a/src/PublicRecord/ContactFormSchemaProviderInterface.php
+++ b/src/PublicRecord/ContactFormSchemaProviderInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+/**
+ * Supplies the field definitions of a contact form, fetched from the issuing product.
+ *
+ * Returns null for every failure — unknown key, network error, malformed response. The
+ * renderer turns null into a *visible* notice rather than an empty region, so a mistyped
+ * form key looks broken to the author instead of quietly rendering nothing (#1030 / #1031
+ * fail-visible rule).
+ */
+interface ContactFormSchemaProviderInterface
+{
+    public function schemaFor(string $formKey): ?ContactFormSchema;
+}

--- a/src/PublicRecord/ContactSubmissionProxyRoute.php
+++ b/src/PublicRecord/ContactSubmissionProxyRoute.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+/**
+ * The single place the submission endpoint path is written down.
+ *
+ * The SSR form posts here, and the proxy that will answer it (#1031) registers here. Keeping
+ * it in one constant is what lets a test pin "the rendered form posts to records, never to
+ * contact directly" without restating the path — a form that posted straight to the issuing
+ * product would expose the connect-token to the browser, which is the whole thing this
+ * design exists to prevent.
+ */
+final class ContactSubmissionProxyRoute
+{
+    public const PATH = '/api/v1/public/contact-submissions';
+}

--- a/src/PublicRecord/GetPublicRecordViewUseCase.php
+++ b/src/PublicRecord/GetPublicRecordViewUseCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NeNeRecords\PublicRecord;
 
+use NeNeRecords\BlocksField\BlocksField;
+use NeNeRecords\BlocksField\BlocksFieldRepositoryInterface;
 use NeNeRecords\BoolField\BoolField;
 use NeNeRecords\BoolField\BoolFieldRepositoryInterface;
 use NeNeRecords\DateTimeField\DateTimeField;
@@ -46,6 +48,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
         private EntityRelationRepositoryInterface $entityRelations,
         private ListPublicSettingsUseCaseInterface $publicSettings,
         private PublicRecordHierarchyBuilder $hierarchyBuilder,
+        private ?BlocksFieldRepositoryInterface $blocksFields = null,
     ) {
     }
 
@@ -102,6 +105,11 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
         $dateTimeFieldRows = in_array('datetime', $dataTypes, true)
             ? $this->dateTimeFields->findByEntityId($entityId, self::FIELD_VALUE_LIMIT, 0)
             : [];
+        // Blocks are read only so the SSR template can render the block types that must exist
+        // before JavaScript does (#1030). The SPA keeps loading them from /api/v1/blocks-fields.
+        $blocksFieldRows = ($this->blocksFields !== null && in_array('blocks', $dataTypes, true))
+            ? $this->blocksFields->findByEntityId($entityId, self::FIELD_VALUE_LIMIT, 0)
+            : [];
 
         $allEntityTypes = $this->entityTypes->findAll(self::ENTITY_TYPE_LIMIT, 0);
         $entityTypeSlugById = [];
@@ -143,6 +151,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
             $enumFieldRows,
             $boolFieldRows,
             $dateTimeFieldRows,
+            $blocksFieldRows,
             $entityId,
             $entityTypeSlugById,
             $relationTextFieldsByEntityTypeId,
@@ -284,6 +293,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
      * @param list<EnumField> $enumFieldRows
      * @param list<BoolField> $boolFieldRows
      * @param list<DateTimeField> $dateTimeFieldRows
+     * @param list<BlocksField> $blocksFieldRows
      * @param array<int, string> $entityTypeSlugById
      * @param array<int, list<TextField>> $relationTextFieldsByEntityTypeId
      * @param array<string, list<ListEntityRelationItem>> $relationsByFieldKey
@@ -296,6 +306,7 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
         array $enumFieldRows,
         array $boolFieldRows,
         array $dateTimeFieldRows,
+        array $blocksFieldRows,
         int $entityId,
         array $entityTypeSlugById,
         array $relationTextFieldsByEntityTypeId,
@@ -352,6 +363,9 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
                 fieldKey: $fieldDef->fieldKey,
                 dataType: $fieldDef->dataType,
                 displayValue: PublicFieldDisplayFormatter::format($fieldDef->dataType, $raw),
+                blocksDocument: $fieldDef->dataType === 'blocks'
+                    ? $this->findBlocksDocument($blocksFieldRows, $fieldDef->fieldKey)
+                    : null,
             );
         }
 
@@ -494,6 +508,23 @@ final readonly class GetPublicRecordViewUseCase implements GetPublicRecordViewUs
 
     /** @param list<BoolField> $rows */
     private function findBoolValue(array $rows, string $fieldKey): ?bool
+    {
+        foreach ($rows as $row) {
+            if ($row->fieldKey === $fieldKey) {
+                return $row->value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The stored blocks document for a field, or null when the record has no value for it.
+     * Unlike the other finders this returns the raw JSON: the SSR renderer parses it itself.
+     *
+     * @param list<BlocksField> $rows
+     */
+    private function findBlocksDocument(array $rows, string $fieldKey): ?string
     {
         foreach ($rows as $row) {
             if ($row->fieldKey === $fieldKey) {

--- a/src/PublicRecord/HttpContactFormSchemaProvider.php
+++ b/src/PublicRecord/HttpContactFormSchemaProvider.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use NeNeRecords\Http\SsrfGuard;
+use Throwable;
+
+/**
+ * Fetches a contact form's public schema from the issuing product over HTTP.
+ *
+ * The endpoint is unauthenticated by design (`GET {base}/public/forms/{key}/schema`) — the
+ * form key is a handle, not a secret, so **no connect-token is sent here**. The token belongs
+ * to the submission path (#1031) and nowhere else; keeping the read path credential-free
+ * means a schema fetch can never be the thing that leaks it.
+ *
+ * The base URL comes from the operator (`NENE_RECORDS_CONTACT_BASE_URL`), not from tenant
+ * data, but it is still SSRF-guarded and connection-pinned: a misconfigured deployment
+ * should fail rather than let a public page drive requests at internal addresses.
+ *
+ * Every failure returns null, which the renderer turns into a visible notice. This is called
+ * while rendering a public page, so the timeout is deliberately short — a slow sibling must
+ * not hold a page open.
+ */
+final readonly class HttpContactFormSchemaProvider implements ContactFormSchemaProviderInterface
+{
+    private const TIMEOUT_SECONDS = 3;
+
+    /** Bounds the response we are willing to parse; a real schema is a few kilobytes. */
+    private const MAX_BODY_BYTES = 262144;
+
+    public function __construct(
+        private ?string $baseUrl,
+        private SsrfGuard $ssrfGuard = new SsrfGuard(),
+    ) {
+    }
+
+    public function schemaFor(string $formKey): ?ContactFormSchema
+    {
+        $base = $this->baseUrl === null ? '' : rtrim(trim($this->baseUrl), '/');
+
+        // Not configured is a normal state (most tenants never place a contact block), and it
+        // must not throw out of a page render.
+        if ($base === '' || preg_match('/^[A-Za-z0-9_-]+$/', $formKey) !== 1) {
+            return null;
+        }
+
+        try {
+            $body = $this->get($base . '/public/forms/' . $formKey . '/schema');
+        } catch (Throwable) {
+            return null;
+        }
+
+        if ($body === null) {
+            return null;
+        }
+
+        $decoded = json_decode($body, true);
+
+        return is_array($decoded) ? $this->toSchema($formKey, $decoded) : null;
+    }
+
+    private function get(string $url): ?string
+    {
+        $inspection = $this->ssrfGuard->inspect($url);
+
+        if (!$inspection->allowed) {
+            return null;
+        }
+
+        $handle = curl_init($url);
+
+        if ($handle === false) {
+            return null;
+        }
+
+        curl_setopt_array($handle, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => self::TIMEOUT_SECONDS,
+            CURLOPT_CONNECTTIMEOUT => self::TIMEOUT_SECONDS,
+            CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+            CURLOPT_HTTPHEADER => ['Accept: application/json', 'User-Agent: NeNeRecords-ContactEmbed/1.0'],
+            CURLOPT_RESOLVE => $this->pinnedAddresses($url, $inspection->addresses),
+        ]);
+
+        $result = curl_exec($handle);
+        $status = (int) curl_getinfo($handle, CURLINFO_RESPONSE_CODE);
+        curl_close($handle);
+
+        if (!is_string($result) || $status < 200 || $status >= 300) {
+            return null;
+        }
+
+        return strlen($result) > self::MAX_BODY_BYTES ? null : $result;
+    }
+
+    /**
+     * @param array<array-key, mixed> $payload
+     */
+    private function toSchema(string $formKey, array $payload): ?ContactFormSchema
+    {
+        $rawFields = $payload['fields'] ?? null;
+
+        if (!is_array($rawFields)) {
+            return null;
+        }
+
+        $fields = [];
+
+        foreach ($rawFields as $rawField) {
+            if (!is_array($rawField)) {
+                continue;
+            }
+
+            $key = $rawField['key'] ?? null;
+
+            if (!is_string($key) || $key === '') {
+                continue;
+            }
+
+            $label = $rawField['label'] ?? null;
+            $type = $rawField['type'] ?? null;
+
+            $fields[] = new ContactFormField(
+                key: $key,
+                label: is_string($label) && $label !== '' ? $label : $key,
+                type: is_string($type) ? $type : 'text',
+                required: (bool) ($rawField['required'] ?? false),
+                options: $this->stringList($rawField['options'] ?? null),
+            );
+        }
+
+        $submitLabel = $payload['submitLabel'] ?? null;
+
+        return new ContactFormSchema(
+            formKey: $formKey,
+            fields: $fields,
+            consentRequired: (bool) ($payload['consentRequired'] ?? false),
+            submitLabel: is_string($submitLabel) && $submitLabel !== '' ? $submitLabel : null,
+        );
+    }
+
+    /** @return list<string> */
+    private function stringList(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $strings = [];
+
+        foreach ($value as $item) {
+            if (is_string($item)) {
+                $strings[] = $item;
+            }
+        }
+
+        return $strings;
+    }
+
+    /**
+     * @param list<string> $addresses
+     *
+     * @return list<string> CURLOPT_RESOLVE entries "host:port:ip"
+     */
+    private function pinnedAddresses(string $url, array $addresses): array
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+
+        if (!is_string($host) || $host === '') {
+            return [];
+        }
+
+        $host = trim($host, '[]');
+        $port = parse_url($url, PHP_URL_PORT);
+
+        if (!is_int($port)) {
+            $scheme = parse_url($url, PHP_URL_SCHEME);
+            $port = is_string($scheme) && strtolower($scheme) === 'https' ? 443 : 80;
+        }
+
+        $entries = [];
+
+        foreach ($addresses as $ip) {
+            $entries[] = $host . ':' . $port . ':' . $ip;
+        }
+
+        return $entries;
+    }
+}

--- a/src/PublicRecord/HttpContactFormSchemaProvider.php
+++ b/src/PublicRecord/HttpContactFormSchemaProvider.php
@@ -133,12 +133,14 @@ final readonly class HttpContactFormSchemaProvider implements ContactFormSchemaP
         }
 
         $submitLabel = $payload['submitLabel'] ?? null;
+        $consentLabel = $payload['consentLabel'] ?? null;
 
         return new ContactFormSchema(
             formKey: $formKey,
             fields: $fields,
             consentRequired: (bool) ($payload['consentRequired'] ?? false),
             submitLabel: is_string($submitLabel) && $submitLabel !== '' ? $submitLabel : null,
+            consentLabel: is_string($consentLabel) && $consentLabel !== '' ? $consentLabel : null,
         );
     }
 

--- a/src/PublicRecord/PublicRecordServiceProvider.php
+++ b/src/PublicRecord/PublicRecordServiceProvider.php
@@ -12,6 +12,7 @@ use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\View\HtmlResponseFactory;
 use Nene2\View\NativePhpViewRenderer;
+use NeNeRecords\BlocksField\BlocksFieldRepositoryInterface;
 use NeNeRecords\BoolField\BoolFieldRepositoryInterface;
 use NeNeRecords\DateTimeField\DateTimeFieldRepositoryInterface;
 use NeNeRecords\Entity\EntityRepositoryInterface;
@@ -100,6 +101,7 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                     $entityRelations = $container->get(EntityRelationRepositoryInterface::class);
                     $publicSettings = $container->get(ListPublicSettingsUseCaseInterface::class);
                     $hierarchyBuilder = $container->get(PublicRecordHierarchyBuilder::class);
+                    $blocksFields = $container->get(BlocksFieldRepositoryInterface::class);
 
                     if (!$entityTypes instanceof EntityTypeRepositoryInterface) {
                         throw new LogicException('Entity type repository service is invalid.');
@@ -107,6 +109,10 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
 
                     if (!$entities instanceof EntityRepositoryInterface) {
                         throw new LogicException('Entity repository service is invalid.');
+                    }
+
+                    if (!$blocksFields instanceof BlocksFieldRepositoryInterface) {
+                        throw new LogicException('Blocks field repository service is invalid.');
                     }
 
                     if (!$hierarchyBuilder instanceof PublicRecordHierarchyBuilder) {
@@ -157,6 +163,7 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                         $entityRelations,
                         $publicSettings,
                         $hierarchyBuilder,
+                        $blocksFields,
                     );
                 },
             )
@@ -244,6 +251,30 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                 },
             )
             ->set(
+                ContactFormSchemaProviderInterface::class,
+                static function (ContainerInterface $container): ContactFormSchemaProviderInterface {
+                    // Operator-supplied, not tenant-supplied: one contact deployment serves the
+                    // whole records instance. Unset is a normal state — most tenants never place
+                    // a contact block — and the provider then reports "no schema", which the
+                    // renderer shows as a visible notice rather than an empty page region.
+                    $baseUrl = getenv('NENE_RECORDS_CONTACT_BASE_URL');
+
+                    return new HttpContactFormSchemaProvider(is_string($baseUrl) ? $baseUrl : null);
+                },
+            )
+            ->set(
+                SsrBlocksRenderer::class,
+                static function (ContainerInterface $container): SsrBlocksRenderer {
+                    $schemas = $container->get(ContactFormSchemaProviderInterface::class);
+
+                    if (!$schemas instanceof ContactFormSchemaProviderInterface) {
+                        throw new LogicException('Contact form schema provider service is invalid.');
+                    }
+
+                    return new SsrBlocksRenderer($schemas);
+                },
+            )
+            ->set(
                 RenderPublicRecordViewHandler::class,
                 static function (ContainerInterface $container): RenderPublicRecordViewHandler {
                     $useCase = $container->get(GetPublicRecordViewUseCaseInterface::class);
@@ -254,6 +285,7 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                     $responseFactory = $container->get(ResponseFactoryInterface::class);
                     $frontPage = $container->get(FrontPageSetting::class);
                     $listWidgets = $container->get(ListWidgetsUseCaseInterface::class);
+                    $blocksRenderer = $container->get(SsrBlocksRenderer::class);
 
                     if (!$useCase instanceof GetPublicRecordViewUseCaseInterface) {
                         throw new LogicException('GetPublicRecordView use case service is invalid.');
@@ -287,6 +319,10 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                         throw new LogicException('ListWidgets use case service is invalid.');
                     }
 
+                    if (!$blocksRenderer instanceof SsrBlocksRenderer) {
+                        throw new LogicException('SSR blocks renderer service is invalid.');
+                    }
+
                     return new RenderPublicRecordViewHandler(
                         $useCase,
                         $publicSettings,
@@ -298,6 +334,7 @@ final readonly class PublicRecordServiceProvider implements ServiceProviderInter
                         $frontPage,
                         $listWidgets,
                         \NeNeRecords\Http\BasePath::fromEnv(),
+                        $blocksRenderer,
                     );
                 },
             )

--- a/src/PublicRecord/PublicRecordViewDisplayField.php
+++ b/src/PublicRecord/PublicRecordViewDisplayField.php
@@ -8,12 +8,20 @@ final readonly class PublicRecordViewDisplayField
 {
     /**
      * @param list<array{label: string, href: string}> $relationLinks
+     * @param string|null                              $blocksDocument the raw blocks document, for
+     *                                                                 `blocks` fields only. Carried
+     *                                                                 beside `displayValue` rather
+     *                                                                 than inside it so the JSON API
+     *                                                                 keeps returning exactly what it
+     *                                                                 returned before (#1030); only the
+     *                                                                 SSR template reads this.
      */
     public function __construct(
         public string $fieldKey,
         public string $dataType,
         public string $displayValue,
         public array $relationLinks = [],
+        public ?string $blocksDocument = null,
     ) {
     }
 }

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -43,11 +43,31 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
      * OrgResolverMiddleware on `nene2.base_prefix`. '' = root single-tenant.
      */
     /**
+     * Merges every field's resolved contact-form schemas into one map for the bootstrap.
+     *
+     * @param array<string, SsrBlocksRenderResult> $blocks
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function contactFormSchemas(array $blocks): array
+    {
+        $schemas = [];
+
+        foreach ($blocks as $result) {
+            foreach ($result->contactForms as $formKey => $schema) {
+                $schemas[$formKey] = $schema;
+            }
+        }
+
+        return $schemas;
+    }
+
+    /**
      * @param list<PublicRecordViewDisplayField> $displayFields
      *
-     * @return array<string, string> field key => server-rendered HTML ('' when nothing in the
-     *                               document is server-renderable, which is the case for every
-     *                               document written before #1030)
+     * @return array<string, SsrBlocksRenderResult> field key => render result (empty HTML when
+     *                               nothing in the document is server-renderable, which is the
+     *                               case for every document written before #1030)
      */
     private function renderBlocks(array $displayFields): array
     {
@@ -55,15 +75,18 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
             return [];
         }
 
-        $html = [];
+        $rendered = [];
 
         foreach ($displayFields as $field) {
             if ($field->dataType === 'blocks' && $field->blocksDocument !== null) {
-                $html[$field->fieldKey] = $this->blocksRenderer->render($field->blocksDocument, $field->fieldKey);
+                $rendered[$field->fieldKey] = $this->blocksRenderer->render(
+                    $field->blocksDocument,
+                    $field->fieldKey,
+                );
             }
         }
 
-        return $html;
+        return $rendered;
     }
 
     private function effectiveBase(ServerRequestInterface $request): string
@@ -220,8 +243,19 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
             ? $output->metaDescription
             : $defaultMetaDescription;
 
+        // Rendered once, then used twice: the HTML goes into the template and the schemas that
+        // produced it go into the bootstrap, so the SPA draws the same form from the same data
+        // instead of asking the issuing product again (#1030).
+        $blocks = $this->renderBlocks($output->displayFields);
+        $bootstrap = $output->bootstrap;
+        $contactForms = $this->contactFormSchemas($blocks);
+
+        if ($contactForms !== []) {
+            $bootstrap['contactForms'] = $contactForms;
+        }
+
         $bootstrapJson = json_encode(
-            $output->bootstrap,
+            $bootstrap,
             JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE,
         );
 
@@ -260,7 +294,10 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
             // Pre-rendered once per field: the renderer may reach the issuing product over the
             // network, so the template must not be able to trigger it twice by evaluating the
             // same expression in a condition and again in the body.
-            'blocksHtmlByFieldKey' => $this->renderBlocks($output->displayFields),
+            'blocksHtmlByFieldKey' => array_map(
+                static fn (SsrBlocksRenderResult $result): string => $result->html,
+                $blocks,
+            ),
             'chapterNav' => $output->chapterNav,
             // The front page is a site root, not a node in the path hierarchy: drop the
             // breadcrumb trail + its BreadcrumbList JSON-LD (the template hides both when empty).

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -33,6 +33,7 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
         private ListWidgetsUseCaseInterface $listWidgets,
         /** Sub-directory install prefix (`APP_BASE_PATH`); '' = served at root. */
         private string $basePath = '',
+        private ?SsrBlocksRenderer $blocksRenderer = null,
     ) {
     }
 
@@ -41,6 +42,30 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
      * plus the per-request tenant prefix in directory mode (`/org1`), set by
      * OrgResolverMiddleware on `nene2.base_prefix`. '' = root single-tenant.
      */
+    /**
+     * @param list<PublicRecordViewDisplayField> $displayFields
+     *
+     * @return array<string, string> field key => server-rendered HTML ('' when nothing in the
+     *                               document is server-renderable, which is the case for every
+     *                               document written before #1030)
+     */
+    private function renderBlocks(array $displayFields): array
+    {
+        if ($this->blocksRenderer === null) {
+            return [];
+        }
+
+        $html = [];
+
+        foreach ($displayFields as $field) {
+            if ($field->dataType === 'blocks' && $field->blocksDocument !== null) {
+                $html[$field->fieldKey] = $this->blocksRenderer->render($field->blocksDocument);
+            }
+        }
+
+        return $html;
+    }
+
     private function effectiveBase(ServerRequestInterface $request): string
     {
         return $this->basePath . (string) $request->getAttribute('nene2.base_prefix', '');
@@ -232,6 +257,10 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
             'entityTypeName' => $output->entityTypeName,
             'entityId' => $output->entityId,
             'displayFields' => $output->displayFields,
+            // Pre-rendered once per field: the renderer may reach the issuing product over the
+            // network, so the template must not be able to trigger it twice by evaluating the
+            // same expression in a condition and again in the body.
+            'blocksHtmlByFieldKey' => $this->renderBlocks($output->displayFields),
             'chapterNav' => $output->chapterNav,
             // The front page is a site root, not a node in the path hierarchy: drop the
             // breadcrumb trail + its BreadcrumbList JSON-LD (the template hides both when empty).

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -59,7 +59,7 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
 
         foreach ($displayFields as $field) {
             if ($field->dataType === 'blocks' && $field->blocksDocument !== null) {
-                $html[$field->fieldKey] = $this->blocksRenderer->render($field->blocksDocument);
+                $html[$field->fieldKey] = $this->blocksRenderer->render($field->blocksDocument, $field->fieldKey);
             }
         }
 

--- a/src/PublicRecord/SsrBlocksRenderResult.php
+++ b/src/PublicRecord/SsrBlocksRenderResult.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+/**
+ * What one blocks document produced on the server: the HTML, plus the public schemas that
+ * were resolved to produce it.
+ *
+ * The schemas travel with the HTML because the SPA replaces the server-rendered markup on
+ * mount (see `#root` in templates/public/record-detail.php). If the client fetched them
+ * again it could get a different answer than the crawler saw; handing it the *same* resolved
+ * data makes "SSR and SPA render the same form" a structural property rather than a hope —
+ * and costs no extra request (#1030).
+ */
+final readonly class SsrBlocksRenderResult
+{
+    /**
+     * @param array<string, array<string, mixed>> $contactForms form key => public schema, as it
+     *                                                          goes into the SSR bootstrap
+     */
+    public function __construct(
+        public string $html,
+        public array $contactForms = [],
+    ) {
+    }
+}

--- a/src/PublicRecord/SsrBlocksRenderer.php
+++ b/src/PublicRecord/SsrBlocksRenderer.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+/**
+ * Renders the *server-renderable* block types of a blocks document into HTML.
+ *
+ * ## Why this is an allow-list and not a port of the client renderer
+ *
+ * Blocks are rendered by React (`BlocksRenderer.tsx`) once the SPA hydrates. Re-implementing
+ * all nine types here would create two renderers to keep in step forever. Instead this class
+ * knows exactly the types that must exist *before* JavaScript runs — today only
+ * `contact-form`, which has to be crawlable and has to work with JS off — and emits nothing
+ * for every other type.
+ *
+ * That "nothing" is the safety property: for a document made of the existing types this
+ * renderer returns an empty string, so the public HTML of every record written so far is
+ * byte-identical to what it was before this class existed. `SsrBlocksRendererTest` pins that,
+ * together with a positive control showing a contact-form document *does* change.
+ *
+ * Everything emitted here is escaped. No block type may produce caller-supplied markup.
+ */
+final readonly class SsrBlocksRenderer
+{
+    private const MAX_BLOCKS = 200;
+
+    public function __construct(
+        private ContactFormSchemaProviderInterface $schemas,
+    ) {
+    }
+
+    /**
+     * @param string $documentJson the stored blocks document; anything unparseable renders empty
+     */
+    public function render(string $documentJson): string
+    {
+        if (trim($documentJson) === '') {
+            return '';
+        }
+
+        $decoded = json_decode($documentJson, true);
+
+        if (!is_array($decoded) || !array_is_list($decoded)) {
+            return '';
+        }
+
+        $html = '';
+        $rendered = 0;
+
+        foreach ($decoded as $block) {
+            if ($rendered >= self::MAX_BLOCKS) {
+                break;
+            }
+
+            ++$rendered;
+
+            if (!is_array($block)) {
+                continue;
+            }
+
+            $type = $block['type'] ?? null;
+            $data = $block['data'] ?? null;
+
+            if (!is_string($type) || !is_array($data)) {
+                continue;
+            }
+
+            // This match *is* the allow-list. Every type not named here is rendered by the
+            // client renderer after hydration, and emitting nothing for it is what keeps the
+            // server-rendered HTML of every pre-#1030 document unchanged.
+            $html .= match ($type) {
+                'contact-form' => $this->renderContactForm($data),
+                default => '',
+            };
+        }
+
+        return $html;
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    private function renderContactForm(array $data): string
+    {
+        $formKey = $data['formKey'] ?? null;
+
+        if (!is_string($formKey) || $formKey === '') {
+            return '';
+        }
+
+        $schema = $this->schemas->schemaFor($formKey);
+
+        if ($schema === null) {
+            // Fail-visible: an author who mistyped the key, or an outage at the issuing
+            // product, must be able to see that something is wrong. An empty region would
+            // look like a page that simply has no form.
+            return '<div class="block block--contact-form contact-form--unavailable">'
+                . '<p>This form is temporarily unavailable.</p>'
+                . '</div>';
+        }
+
+        $fields = '';
+
+        foreach ($schema->fields as $field) {
+            $fields .= $this->renderField($field);
+        }
+
+        if ($schema->consentRequired) {
+            $fields .= '<p class="contact-form__field contact-form__field--consent">'
+                . '<label><input type="checkbox" name="consent" value="1" required> '
+                . 'I agree to the processing of my message.'
+                . '</label></p>';
+        }
+
+        $submitLabel = $schema->submitLabel !== null && trim($schema->submitLabel) !== ''
+            ? $schema->submitLabel
+            : 'Send';
+
+        // The action is always the records-side proxy. Posting straight at the issuing
+        // product would mean handing the browser the connect-token.
+        return '<form class="block block--contact-form" method="post" action="'
+            . $this->escape(ContactSubmissionProxyRoute::PATH) . '">'
+            . '<input type="hidden" name="form_key" value="' . $this->escape($schema->formKey) . '">'
+            . $fields
+            . '<p class="contact-form__actions"><button type="submit">' . $this->escape($submitLabel) . '</button></p>'
+            . '</form>';
+    }
+
+    private function renderField(ContactFormField $field): string
+    {
+        $id = 'contact-field-' . $this->escape($field->key);
+        $required = $field->required ? ' required' : '';
+        $label = '<label for="' . $id . '">' . $this->escape($field->label) . '</label>';
+
+        $control = match ($field->type) {
+            'textarea' => '<textarea id="' . $id . '" name="' . $this->escape($field->key) . '" rows="6"' . $required . '></textarea>',
+            'select' => $this->renderSelect($field, $id, $required),
+            'email', 'tel', 'url' => '<input type="' . $this->escape($field->type) . '" id="' . $id
+                . '" name="' . $this->escape($field->key) . '"' . $required . '>',
+            // Anything records does not know how to render becomes a plain text input rather
+            // than being dropped: a field the author expects to collect must still collect.
+            default => '<input type="text" id="' . $id . '" name="' . $this->escape($field->key) . '"' . $required . '>',
+        };
+
+        return '<p class="contact-form__field">' . $label . $control . '</p>';
+    }
+
+    private function renderSelect(ContactFormField $field, string $id, string $required): string
+    {
+        $options = '';
+
+        foreach ($field->options as $option) {
+            $options .= '<option value="' . $this->escape($option) . '">' . $this->escape($option) . '</option>';
+        }
+
+        return '<select id="' . $id . '" name="' . $this->escape($field->key) . '"' . $required . '>' . $options . '</select>';
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+}

--- a/src/PublicRecord/SsrBlocksRenderer.php
+++ b/src/PublicRecord/SsrBlocksRenderer.php
@@ -36,19 +36,20 @@ final readonly class SsrBlocksRenderer
      * @param string $scope        disambiguates generated element ids when more than one blocks
      *                             field is rendered on a page — pass the field key
      */
-    public function render(string $documentJson, string $scope = ''): string
+    public function render(string $documentJson, string $scope = ''): SsrBlocksRenderResult
     {
         if (trim($documentJson) === '') {
-            return '';
+            return new SsrBlocksRenderResult('');
         }
 
         $decoded = json_decode($documentJson, true);
 
         if (!is_array($decoded) || !array_is_list($decoded)) {
-            return '';
+            return new SsrBlocksRenderResult('');
         }
 
         $html = '';
+        $contactForms = [];
         $scanned = 0;
 
         foreach ($decoded as $index => $block) {
@@ -72,13 +73,65 @@ final readonly class SsrBlocksRenderer
             // This match *is* the allow-list. Every type not named here is rendered by the
             // client renderer after hydration, and emitting nothing for it is what keeps the
             // server-rendered HTML of every pre-#1030 document unchanged.
-            $html .= match ($type) {
-                'contact-form' => $this->renderContactForm($data, $this->idPrefix($scope, $block, $index)),
-                default => '',
-            };
+            if ($type === 'contact-form') {
+                $schema = $this->resolveSchema($data);
+
+                if ($schema !== null) {
+                    $contactForms[$schema->formKey] = $this->schemaToArray($schema);
+                }
+
+                $html .= $this->renderContactForm($data, $this->idPrefix($scope, $block, $index), $schema);
+
+                continue;
+            }
+
+            // Every other type is rendered by the client renderer after hydration. Emitting
+            // nothing for it is what keeps the server-rendered HTML of every pre-#1030
+            // document unchanged.
         }
 
-        return $html;
+        return new SsrBlocksRenderResult($html, $contactForms);
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    private function resolveSchema(array $data): ?ContactFormSchema
+    {
+        $formKey = $data['formKey'] ?? null;
+
+        if (!is_string($formKey) || $formKey === '') {
+            return null;
+        }
+
+        return $this->schemas->schemaFor($formKey);
+    }
+
+    /**
+     * The shape the SPA reads out of the bootstrap. Only what is needed to draw the form —
+     * this is contact's public schema, and nothing else from records is added to it.
+     *
+     * @return array<string, mixed>
+     */
+    private function schemaToArray(ContactFormSchema $schema): array
+    {
+        return [
+            'formKey' => $schema->formKey,
+            'submitPath' => ContactSubmissionProxyRoute::PATH,
+            'consentRequired' => $schema->consentRequired,
+            'consentLabel' => $schema->consentLabel,
+            'submitLabel' => $schema->submitLabel,
+            'fields' => array_map(
+                static fn (ContactFormField $field): array => [
+                    'key' => $field->key,
+                    'label' => $field->label,
+                    'type' => $field->type,
+                    'required' => $field->required,
+                    'options' => $field->options,
+                ],
+                $schema->fields,
+            ),
+        ];
     }
 
     /**
@@ -107,15 +160,13 @@ final readonly class SsrBlocksRenderer
     /**
      * @param array<array-key, mixed> $data
      */
-    private function renderContactForm(array $data, string $idPrefix): string
+    private function renderContactForm(array $data, string $idPrefix, ?ContactFormSchema $schema): string
     {
         $formKey = $data['formKey'] ?? null;
 
         if (!is_string($formKey) || $formKey === '') {
             return '';
         }
-
-        $schema = $this->schemas->schemaFor($formKey);
 
         if ($schema === null) {
             // Fail-visible: an author who mistyped the key, or an outage at the issuing

--- a/src/PublicRecord/SsrBlocksRenderer.php
+++ b/src/PublicRecord/SsrBlocksRenderer.php
@@ -33,8 +33,10 @@ final readonly class SsrBlocksRenderer
 
     /**
      * @param string $documentJson the stored blocks document; anything unparseable renders empty
+     * @param string $scope        disambiguates generated element ids when more than one blocks
+     *                             field is rendered on a page — pass the field key
      */
-    public function render(string $documentJson): string
+    public function render(string $documentJson, string $scope = ''): string
     {
         if (trim($documentJson) === '') {
             return '';
@@ -47,14 +49,14 @@ final readonly class SsrBlocksRenderer
         }
 
         $html = '';
-        $rendered = 0;
+        $scanned = 0;
 
-        foreach ($decoded as $block) {
-            if ($rendered >= self::MAX_BLOCKS) {
+        foreach ($decoded as $index => $block) {
+            if ($scanned >= self::MAX_BLOCKS) {
                 break;
             }
 
-            ++$rendered;
+            ++$scanned;
 
             if (!is_array($block)) {
                 continue;
@@ -71,7 +73,7 @@ final readonly class SsrBlocksRenderer
             // client renderer after hydration, and emitting nothing for it is what keeps the
             // server-rendered HTML of every pre-#1030 document unchanged.
             $html .= match ($type) {
-                'contact-form' => $this->renderContactForm($data),
+                'contact-form' => $this->renderContactForm($data, $this->idPrefix($scope, $block, $index)),
                 default => '',
             };
         }
@@ -80,9 +82,32 @@ final readonly class SsrBlocksRenderer
     }
 
     /**
+     * Element ids have to be unique across the whole page, not just within one form: two
+     * contact blocks, or a second blocks field using the same field keys, would otherwise
+     * produce duplicate ids and silently break every `<label for>` association.
+     *
+     * @param array<array-key, mixed> $block
+     */
+    private function idPrefix(string $scope, array $block, int|string $index): string
+    {
+        $blockId = $block['id'] ?? null;
+        $unique = is_string($blockId) && $blockId !== '' ? $blockId : (string) $index;
+
+        return $this->slug($scope) . '-' . $this->slug($unique);
+    }
+
+    /** Reduces a caller-supplied string to characters that are safe in an id attribute. */
+    private function slug(string $value): string
+    {
+        $slug = preg_replace('/[^A-Za-z0-9_-]/', '', $value);
+
+        return is_string($slug) && $slug !== '' ? $slug : '0';
+    }
+
+    /**
      * @param array<array-key, mixed> $data
      */
-    private function renderContactForm(array $data): string
+    private function renderContactForm(array $data, string $idPrefix): string
     {
         $formKey = $data['formKey'] ?? null;
 
@@ -97,26 +122,25 @@ final readonly class SsrBlocksRenderer
             // product, must be able to see that something is wrong. An empty region would
             // look like a page that simply has no form.
             return '<div class="block block--contact-form contact-form--unavailable">'
-                . '<p>This form is temporarily unavailable.</p>'
+                . '<p lang="en">This form is temporarily unavailable.</p>'
                 . '</div>';
         }
 
         $fields = '';
 
         foreach ($schema->fields as $field) {
-            $fields .= $this->renderField($field);
+            $fields .= $this->renderField($field, $idPrefix);
         }
 
         if ($schema->consentRequired) {
+            // The consent sentence is the issuing product's legal text. records only supplies
+            // a fallback, and marks it `lang="en"` so the markup does not claim to be in the
+            // page's language when it is not (SSR i18n gap: #1034).
             $fields .= '<p class="contact-form__field contact-form__field--consent">'
                 . '<label><input type="checkbox" name="consent" value="1" required> '
-                . 'I agree to the processing of my message.'
+                . $this->wording($schema->consentLabel, 'I agree to the processing of my message.')
                 . '</label></p>';
         }
-
-        $submitLabel = $schema->submitLabel !== null && trim($schema->submitLabel) !== ''
-            ? $schema->submitLabel
-            : 'Send';
 
         // The action is always the records-side proxy. Posting straight at the issuing
         // product would mean handing the browser the connect-token.
@@ -124,13 +148,15 @@ final readonly class SsrBlocksRenderer
             . $this->escape(ContactSubmissionProxyRoute::PATH) . '">'
             . '<input type="hidden" name="form_key" value="' . $this->escape($schema->formKey) . '">'
             . $fields
-            . '<p class="contact-form__actions"><button type="submit">' . $this->escape($submitLabel) . '</button></p>'
+            . '<p class="contact-form__actions"><button type="submit">'
+            . $this->wording($schema->submitLabel, 'Send')
+            . '</button></p>'
             . '</form>';
     }
 
-    private function renderField(ContactFormField $field): string
+    private function renderField(ContactFormField $field, string $idPrefix): string
     {
-        $id = 'contact-field-' . $this->escape($field->key);
+        $id = 'contact-' . $idPrefix . '-' . $this->slug($field->key);
         $required = $field->required ? ' required' : '';
         $label = '<label for="' . $id . '">' . $this->escape($field->label) . '</label>';
 
@@ -149,13 +175,30 @@ final readonly class SsrBlocksRenderer
 
     private function renderSelect(ContactFormField $field, string $id, string $required): string
     {
-        $options = '';
+        // A required `<select>` whose first option is already selected can never fail
+        // validation — the browser considers it filled in. An empty placeholder first is what
+        // makes `required` mean anything.
+        $options = $field->required ? '<option value="" selected disabled></option>' : '';
 
         foreach ($field->options as $option) {
             $options .= '<option value="' . $this->escape($option) . '">' . $this->escape($option) . '</option>';
         }
 
         return '<select id="' . $id . '" name="' . $this->escape($field->key) . '"' . $required . '>' . $options . '</select>';
+    }
+
+    /**
+     * Wording records did not author. When the issuing product supplies it, it is rendered as
+     * given; the English fallback is tagged so assistive tech and crawlers are not told it is
+     * in the page's language.
+     */
+    private function wording(?string $supplied, string $englishFallback): string
+    {
+        if ($supplied !== null && trim($supplied) !== '') {
+            return $this->escape($supplied);
+        }
+
+        return '<span lang="en">' . $this->escape($englishFallback) . '</span>';
     }
 
     private function escape(string $value): string

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -213,6 +213,16 @@ if ($ogImageUrl !== null) {
           <section class="bundle-seo">
             <div class="markdown-body"><?= $renderBundleSeo($field->displayValue) ?></div>
           </section>
+        <?php /* Blocks that must exist before JavaScript does (#1030). The condition is
+                 "produced any HTML", not "is a blocks field": a document made only of the
+                 client-rendered types yields '' and falls through to the branch below, so
+                 its server-rendered output is exactly what it was before this branch
+                 existed. The HTML is built by SsrBlocksRenderer, which escapes everything
+                 it emits and never passes through caller-supplied markup. */ ?>
+        <?php elseif ($field->dataType === 'blocks' && ($blocksHtmlByFieldKey[$field->fieldKey] ?? '') !== ''): ?>
+          <section class="blocks-ssr">
+            <?= $blocksHtmlByFieldKey[$field->fieldKey] ?>
+          </section>
         <?php else: ?>
           <section>
             <h2><?= $e($field->fieldKey) ?></h2>

--- a/tests/BlocksField/BlocksDocumentValidatorTest.php
+++ b/tests/BlocksField/BlocksDocumentValidatorTest.php
@@ -350,4 +350,60 @@ final class BlocksDocumentValidatorTest extends TestCase
         $this->expectException(ValidationException::class);
         $this->validator->validate('[{"id":"s","type":"spacer","data":{"size":"huge"}}]');
     }
+
+    // ── contact-form (#1030) ──────────────────────────────────────────────────
+
+    public function testAcceptsContactFormWithAndWithoutVariant(): void
+    {
+        // The variant is optional and defaults to inline, so a document written before a
+        // second variant exists stays valid once one is added.
+        $this->validator->validate('[{"id":"c","type":"contact-form","data":{"formKey":"ayane-contact"}}]');
+        $this->validator->validate('[{"id":"c","type":"contact-form","data":{"formKey":"ayane_contact-1","variant":"inline"}}]');
+        $this->addToAssertionCount(1);
+    }
+
+    public function testRejectsContactFormWithoutFormKey(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('[{"id":"c","type":"contact-form","data":{"variant":"inline"}}]');
+    }
+
+    public function testRejectsContactFormWithEmptyFormKey(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('[{"id":"c","type":"contact-form","data":{"formKey":""}}]');
+    }
+
+    public function testRejectsFormKeyThatCouldRedirectTheSchemaFetch(): void
+    {
+        // The key is interpolated into a URL path when the schema is fetched, so path
+        // traversal and absolute URLs must not survive validation.
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('[{"id":"c","type":"contact-form","data":{"formKey":"../../admin/secrets"}}]');
+    }
+
+    public function testRejectsUnshippedVariant(): void
+    {
+        // modal / chat are deliberately not in the first version (they need a CSP nonce and
+        // client JS). Naming one must fail loudly rather than silently render inline.
+        $this->expectException(ValidationException::class);
+        $this->validator->validate('[{"id":"c","type":"contact-form","data":{"formKey":"k","variant":"modal"}}]');
+    }
+
+    public function testContactFormIsALeafSoItMayLiveInsideAGroup(): void
+    {
+        $this->validator->validate(json_encode([
+            [
+                'id' => 'g',
+                'type' => 'group',
+                'data' => [
+                    'tone' => 'card',
+                    'children' => [
+                        ['id' => 'c', 'type' => 'contact-form', 'data' => ['formKey' => 'ayane-contact']],
+                    ],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR));
+        $this->addToAssertionCount(1);
+    }
 }

--- a/tests/PublicRecord/PublicRecordHttpTest.php
+++ b/tests/PublicRecord/PublicRecordHttpTest.php
@@ -13,11 +13,15 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\View\HtmlResponseFactory;
 use Nene2\View\NativePhpViewRenderer;
+use NeNeRecords\BlocksField\BlocksField;
 use NeNeRecords\Entity\Entity;
 use NeNeRecords\Entity\EntityStatus;
 use NeNeRecords\EntityType\EntityType;
 use NeNeRecords\EntityType\SeoPageKind;
 use NeNeRecords\FieldDef\FieldDef;
+use NeNeRecords\PublicRecord\ContactFormField;
+use NeNeRecords\PublicRecord\ContactFormSchema;
+use NeNeRecords\PublicRecord\ContactFormSchemaProviderInterface;
 use NeNeRecords\PublicRecord\FrontPageSetting;
 use NeNeRecords\PublicRecord\GenerateSitemapUseCase;
 use NeNeRecords\PublicRecord\GetPublicRecordHierarchyHandler;
@@ -34,8 +38,10 @@ use NeNeRecords\PublicRecord\RenderPublicRecordViewHandler;
 use NeNeRecords\PublicRecord\RenderRobotsHandler;
 use NeNeRecords\PublicRecord\RenderSitemapHandler;
 use NeNeRecords\PublicRecord\ResolvePublicPermalinkHandler;
+use NeNeRecords\PublicRecord\SsrBlocksRenderer;
 use NeNeRecords\Setting\ListPublicSettingsUseCase;
 use NeNeRecords\Setting\SettingDef;
+use NeNeRecords\Tests\BlocksField\InMemoryBlocksFieldRepository;
 use NeNeRecords\Tests\BoolField\InMemoryBoolFieldRepository;
 use NeNeRecords\Tests\DateTimeField\InMemoryDateTimeFieldRepository;
 use NeNeRecords\Tests\Entity\InMemoryEntityRepository;
@@ -83,6 +89,8 @@ final class PublicRecordHttpTest extends TestCase
         ?string $entity10Layout = null,
         string $typeDefaultLayout = 'standard',
         SeoPageKind $seoPageKind = SeoPageKind::Article,
+        ?string $blocksDocument = null,
+        ?ContactFormSchema $contactFormSchema = null,
     ): RequestHandlerInterface {
         $entityTypes = new InMemoryEntityTypeRepository([
             // Declared Article on purpose: most tests here assert the dated-entry
@@ -169,6 +177,13 @@ final class PublicRecordHttpTest extends TestCase
         ]);
         $publicSettings = new ListPublicSettingsUseCase(new InMemorySettingRepository($settingDefs), $mediaRepository, $frontPage);
 
+        $blocksFields = new InMemoryBlocksFieldRepository();
+
+        if ($blocksDocument !== null) {
+            $fieldDefs->save(new FieldDef(entityTypeId: 1, fieldKey: 'sections', dataType: 'blocks', id: 90));
+            $blocksFields->save(new BlocksField(10, 'sections', $blocksDocument));
+        }
+
         $useCase = new GetPublicRecordViewUseCase(
             $entityTypes,
             $entities,
@@ -181,6 +196,7 @@ final class PublicRecordHttpTest extends TestCase
             new InMemoryEntityRelationRepository(),
             $publicSettings,
             new PublicRecordHierarchyBuilder($entities, $textFields),
+            $blocksFields,
         );
 
         $jsonResponse = new JsonResponseFactory($this->factory, $this->factory);
@@ -205,7 +221,16 @@ final class PublicRecordHttpTest extends TestCase
             machineApiKey: null,
         );
 
-        $renderHandler = new RenderPublicRecordViewHandler($useCase, $publicSettings, $htmlResponse, $config, $projectRoot, $this->factory, new PublicHtmlSanitizer(), $frontPage, new ListWidgetsUseCase(new InMemoryWidgetRepository()), $basePath);
+        $renderHandler = new RenderPublicRecordViewHandler($useCase, $publicSettings, $htmlResponse, $config, $projectRoot, $this->factory, new PublicHtmlSanitizer(), $frontPage, new ListWidgetsUseCase(new InMemoryWidgetRepository()), $basePath, new SsrBlocksRenderer(new class ($contactFormSchema) implements ContactFormSchemaProviderInterface {
+            public function __construct(private readonly ?ContactFormSchema $schema)
+            {
+            }
+
+            public function schemaFor(string $formKey): ?ContactFormSchema
+            {
+                return $this->schema;
+            }
+        }));
         $this->renderHandler = $renderHandler;
         $customPermalink = new RenderCustomPermalinkHandler($entities, $entityTypes, $renderHandler);
         $registrar = new PublicRecordRouteRegistrar(
@@ -1047,6 +1072,56 @@ final class PublicRecordHttpTest extends TestCase
         )->getBody();
 
         self::assertSame('bare', $this->bootstrapOf($html)['entityTypes']['items'][0]['default_layout']);
+    }
+
+    // ── blocks SSR (#1030) ────────────────────────────────────────────────────
+
+    /**
+     * hub 検収条件1, at the level that actually ships. A record whose blocks document is made
+     * only of the pre-#1030 types must still render the labelled "—" row and no block markup:
+     * the template branch is entered on "the renderer produced HTML", not on "this is a blocks
+     * field", so an unchanged document takes the same path it always took.
+     *
+     * This asserts the rendered markup, not a byte diff against a build without the feature —
+     * that stronger claim is pinned one level down, where `SsrBlocksRenderer` returns '' for
+     * exactly this document (`SsrBlocksRendererTest`).
+     */
+    public function testLegacyBlocksDocumentRendersNoServerSideBlockMarkup(): void
+    {
+        $legacy = '[{"id":"t","type":"text","data":{"markdown":"hello"}},{"id":"d","type":"divider","data":{}}]';
+
+        $html = (string) $this->buildApplication(false, $this->projectRoot, blocksDocument: $legacy)
+            ->handle($this->factory->createServerRequest('GET', 'https://example.test/article/hello-world'))
+            ->getBody();
+
+        self::assertStringNotContainsString('blocks-ssr', $html);
+        self::assertStringNotContainsString('<form', $html);
+        self::assertStringContainsString('<h2>sections</h2>', $html);
+        self::assertStringContainsString('<p>—</p>', $html);
+    }
+
+    /** The positive control: a contact-form document does change the page. */
+    public function testContactFormBlockIsRenderedIntoTheCrawlableHtml(): void
+    {
+        $document = '[{"id":"c","type":"contact-form","data":{"formKey":"ayane-contact","variant":"inline"}}]';
+        $schema = new ContactFormSchema('ayane-contact', [
+            new ContactFormField('email', 'Email', 'email', true),
+            new ContactFormField('message', 'Message', 'textarea', true),
+        ]);
+
+        $html = (string) $this->buildApplication(
+            false,
+            $this->projectRoot,
+            blocksDocument: $document,
+            contactFormSchema: $schema,
+        )->handle($this->factory->createServerRequest('GET', 'https://example.test/article/hello-world'))->getBody();
+
+        self::assertStringContainsString('class="blocks-ssr"', $html);
+        self::assertStringContainsString('action="/api/v1/public/contact-submissions"', $html);
+        self::assertStringContainsString('type="email"', $html);
+        self::assertStringContainsString('<textarea', $html);
+        // The form is crawlable and JS-free, so the labelled "—" fallback must be gone.
+        self::assertStringNotContainsString('<h2>sections</h2>', $html);
     }
 
     /** @return array<string, mixed> the SSR bootstrap payload the SPA hydrates from */

--- a/tests/PublicRecord/SsrBlocksRendererTest.php
+++ b/tests/PublicRecord/SsrBlocksRendererTest.php
@@ -32,7 +32,7 @@ final class SsrBlocksRendererTest extends TestCase
      */
     public function testExistingBlockTypesRenderNothingOnTheServer(): void
     {
-        self::assertSame('', $this->renderer()->render(self::LEGACY_DOCUMENT));
+        self::assertSame('', $this->renderer()->render(self::LEGACY_DOCUMENT)->html);
     }
 
     /**
@@ -41,7 +41,7 @@ final class SsrBlocksRendererTest extends TestCase
      */
     public function testAContactFormDocumentDoesChangeTheOutput(): void
     {
-        $html = $this->renderer()->render('[{"id":"c","type":"contact-form","data":{"formKey":"ayane-contact"}}]');
+        $html = $this->renderer()->render('[{"id":"c","type":"contact-form","data":{"formKey":"ayane-contact"}}]')->html;
 
         self::assertNotSame('', $html);
         self::assertStringContainsString('<form', $html);
@@ -53,7 +53,7 @@ final class SsrBlocksRendererTest extends TestCase
      */
     public function testFormPostsToTheRecordsProxyAndLeaksNothing(): void
     {
-        $html = $this->renderer()->render('[{"id":"c","type":"contact-form","data":{"formKey":"ayane-contact"}}]');
+        $html = $this->renderer()->render('[{"id":"c","type":"contact-form","data":{"formKey":"ayane-contact"}}]')->html;
 
         self::assertStringContainsString('action="' . ContactSubmissionProxyRoute::PATH . '"', $html);
         self::assertStringContainsString('method="post"', $html);
@@ -68,7 +68,7 @@ final class SsrBlocksRendererTest extends TestCase
 
     public function testRendersOneControlPerSchemaFieldWithTypesAndRequiredness(): void
     {
-        $html = $this->renderer()->render('[{"id":"c","type":"contact-form","data":{"formKey":"ayane-contact"}}]');
+        $html = $this->renderer()->render('[{"id":"c","type":"contact-form","data":{"formKey":"ayane-contact"}}]')->html;
 
         self::assertStringContainsString('name="name"', $html);
         self::assertStringContainsString('type="email"', $html);
@@ -83,7 +83,7 @@ final class SsrBlocksRendererTest extends TestCase
             new ContactFormField('nickname', 'Nickname', 'colour-picker', false),
         ]));
 
-        $html = $renderer->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]');
+        $html = $renderer->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]')->html;
 
         self::assertStringContainsString('name="nickname"', $html);
         self::assertStringContainsString('type="text"', $html);
@@ -95,7 +95,7 @@ final class SsrBlocksRendererTest extends TestCase
             new ContactFormField('evil" onfocus="alert(1)', '<script>alert(1)</script>', 'text', false),
         ], submitLabel: '"><script>x</script>'));
 
-        $html = $renderer->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]');
+        $html = $renderer->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]')->html;
 
         self::assertStringNotContainsString('<script>', $html);
         self::assertStringNotContainsString('onfocus="alert(1)"', $html);
@@ -111,7 +111,7 @@ final class SsrBlocksRendererTest extends TestCase
             }
         });
 
-        $html = $renderer->render('[{"id":"c","type":"contact-form","data":{"formKey":"typo"}}]');
+        $html = $renderer->render('[{"id":"c","type":"contact-form","data":{"formKey":"typo"}}]')->html;
 
         // An empty region would look like a page that simply has no form; the author would
         // never learn the key was wrong.
@@ -121,9 +121,9 @@ final class SsrBlocksRendererTest extends TestCase
 
     public function testConsentCheckboxAppearsOnlyWhenTheFormRequiresIt(): void
     {
-        $without = $this->renderer()->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]');
+        $without = $this->renderer()->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]')->html;
         $with = $this->renderer(new ContactFormSchema('k', [], consentRequired: true))
-            ->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]');
+            ->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]')->html;
 
         self::assertStringNotContainsString('name="consent"', $without);
         self::assertStringContainsString('name="consent"', $with);
@@ -132,13 +132,13 @@ final class SsrBlocksRendererTest extends TestCase
     public function testMalformedOrEmptyDocumentsRenderNothing(): void
     {
         foreach (['', '   ', 'not json', '{"not":"a list"}', '[42]', '[{"type":"contact-form"}]'] as $document) {
-            self::assertSame('', $this->renderer()->render($document), 'Document: ' . $document);
+            self::assertSame('', $this->renderer()->render($document)->html, 'Document: ' . $document);
         }
     }
 
     public function testBlockWithoutAFormKeyRendersNothing(): void
     {
-        self::assertSame('', $this->renderer()->render('[{"id":"c","type":"contact-form","data":{"variant":"inline"}}]'));
+        self::assertSame('', $this->renderer()->render('[{"id":"c","type":"contact-form","data":{"variant":"inline"}}]')->html);
     }
 
     public function testTwoFormsOnOnePageDoNotShareElementIds(): void
@@ -150,7 +150,7 @@ final class SsrBlocksRendererTest extends TestCase
 
         $html = $this->renderer(new ContactFormSchema('k', [
             new ContactFormField('email', 'Email', 'email', true),
-        ]))->render($document, 'sections');
+        ]))->render($document, 'sections')->html;
 
         preg_match_all('/id="([^"]+)"/', $html, $matches);
         $ids = $matches[1];
@@ -166,8 +166,8 @@ final class SsrBlocksRendererTest extends TestCase
             new ContactFormField('email', 'Email', 'email', true),
         ]));
 
-        $first = $renderer->render($document, 'sections');
-        $second = $renderer->render($document, 'footer');
+        $first = $renderer->render($document, 'sections')->html;
+        $second = $renderer->render($document, 'footer')->html;
 
         self::assertNotSame(
             $this->firstId($first),
@@ -180,7 +180,7 @@ final class SsrBlocksRendererTest extends TestCase
     {
         $html = $this->renderer(new ContactFormSchema('k', [
             new ContactFormField('bad" onfocus="alert(1)', 'Bad', 'text', false),
-        ]))->render('[{"id":"a\" onload=\"x","type":"contact-form","data":{"formKey":"k"}}]', 'sc"ope');
+        ]))->render('[{"id":"a\" onload=\"x","type":"contact-form","data":{"formKey":"k"}}]', 'sc"ope')->html;
 
         // The escaped text `onfocus=` may legitimately appear inside an attribute *value*;
         // what must never appear is a real attribute break, i.e. an unescaped quote followed
@@ -201,7 +201,7 @@ final class SsrBlocksRendererTest extends TestCase
         // the control as filled in and `required` never fires.
         $html = $this->renderer(new ContactFormSchema('k', [
             new ContactFormField('topic', 'Topic', 'select', true, ['Sales', 'Support']),
-        ]))->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]');
+        ]))->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]')->html;
 
         self::assertStringContainsString('<option value="" selected disabled></option>', $html);
     }
@@ -210,7 +210,7 @@ final class SsrBlocksRendererTest extends TestCase
     {
         $html = $this->renderer(new ContactFormSchema('k', [
             new ContactFormField('topic', 'Topic', 'select', false, ['Sales']),
-        ]))->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]');
+        ]))->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]')->html;
 
         self::assertStringNotContainsString('<option value="" selected disabled>', $html);
     }
@@ -220,7 +220,7 @@ final class SsrBlocksRendererTest extends TestCase
         // The consent sentence is contact's legal text and the button is its copy; records
         // must not overwrite either with English.
         $html = $this->renderer(new ContactFormSchema('k', [], consentRequired: true, submitLabel: '送信する', consentLabel: '個人情報の取り扱いに同意します'))
-            ->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]');
+            ->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]')->html;
 
         self::assertStringContainsString('送信する', $html);
         self::assertStringContainsString('個人情報の取り扱いに同意します', $html);
@@ -232,10 +232,83 @@ final class SsrBlocksRendererTest extends TestCase
         // records has no SSR message catalogue yet (#1034). Until it does, the fallback must
         // not claim to be in the page's language — crawlers read this markup.
         $html = $this->renderer(new ContactFormSchema('k', [], consentRequired: true))
-            ->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]');
+            ->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]')->html;
 
         self::assertStringContainsString('<span lang="en">Send</span>', $html);
         self::assertStringContainsString('lang="en">I agree', $html);
+    }
+
+    // ── bootstrap 同梱（hub 裁定 (c)・2026-07-30）────────────────────────────
+
+    /**
+     * hub pin 1: only the resolved *public* schema travels in the bootstrap. No token, no
+     * internal URL, no reference to the connect-token module — same shelf as the #1029 pins.
+     */
+    public function testBootstrapCarriesOnlyThePublicSchema(): void
+    {
+        $result = $this->renderer(new ContactFormSchema('ayane-contact', [
+            new ContactFormField('email', 'Email', 'email', true),
+        ], consentRequired: true, submitLabel: '送信', consentLabel: '同意します'))
+            ->render('[{"id":"c","type":"contact-form","data":{"formKey":"ayane-contact"}}]');
+
+        self::assertArrayHasKey('ayane-contact', $result->contactForms);
+
+        $encoded = (string) json_encode($result->contactForms);
+
+        foreach (['token', 'Authorization', 'Bearer', 'ConnectToken', 'org_connect_tokens', 'http://', 'https://'] as $forbidden) {
+            self::assertStringNotContainsString($forbidden, $encoded, $forbidden . ' must not reach the bootstrap.');
+        }
+
+        // What it *does* carry: enough to draw the identical form, and the proxy path so the
+        // client cannot invent a different destination.
+        $schema = $result->contactForms['ayane-contact'];
+        self::assertSame(ContactSubmissionProxyRoute::PATH, $schema['submitPath']);
+        self::assertSame('送信', $schema['submitLabel']);
+        self::assertSame([['key' => 'email', 'label' => 'Email', 'type' => 'email', 'required' => true, 'options' => []]], $schema['fields']);
+    }
+
+    /**
+     * The point of (c): the schema handed to the client is the same one the server drew from,
+     * so the crawlable form and the hydrated form cannot disagree. Asserted by resolving once
+     * and checking every field of the HTML is described by the bootstrap entry.
+     */
+    public function testBootstrapDescribesExactlyWhatTheServerRendered(): void
+    {
+        $result = $this->renderer(new ContactFormSchema('k', [
+            new ContactFormField('email', 'Email', 'email', true),
+            new ContactFormField('message', 'Message', 'textarea', false),
+        ]))->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]');
+
+        preg_match_all('/name="([^"]+)"/', $result->html, $matches);
+        $rendered = array_values(array_diff($matches[1], ['form_key']));
+
+        $described = array_map(
+            static fn (array $field): string => (string) $field['key'],
+            $result->contactForms['k']['fields'],
+        );
+
+        self::assertSame($described, $rendered);
+    }
+
+    public function testAFormThatCouldNotBeResolvedContributesNothingToTheBootstrap(): void
+    {
+        $renderer = new SsrBlocksRenderer(new class () implements ContactFormSchemaProviderInterface {
+            public function schemaFor(string $formKey): ?ContactFormSchema
+            {
+                return null;
+            }
+        });
+
+        $result = $renderer->render('[{"id":"c","type":"contact-form","data":{"formKey":"typo"}}]');
+
+        // The visible failure notice is server-only; there is nothing for the client to draw.
+        self::assertSame([], $result->contactForms);
+        self::assertStringContainsString('contact-form--unavailable', $result->html);
+    }
+
+    public function testLegacyDocumentsAddNothingToTheBootstrap(): void
+    {
+        self::assertSame([], $this->renderer()->render(self::LEGACY_DOCUMENT)->contactForms);
     }
 
     private function firstId(string $html): string

--- a/tests/PublicRecord/SsrBlocksRendererTest.php
+++ b/tests/PublicRecord/SsrBlocksRendererTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use NeNeRecords\PublicRecord\ContactFormField;
+use NeNeRecords\PublicRecord\ContactFormSchema;
+use NeNeRecords\PublicRecord\ContactFormSchemaProviderInterface;
+use NeNeRecords\PublicRecord\ContactSubmissionProxyRoute;
+use NeNeRecords\PublicRecord\SsrBlocksRenderer;
+use PHPUnit\Framework\TestCase;
+
+final class SsrBlocksRendererTest extends TestCase
+{
+    /**
+     * A document made only of the block types that existed before #1030. Used as the
+     * unchanged-output control below.
+     */
+    private const LEGACY_DOCUMENT = <<<'JSON'
+        [
+          {"id":"t","type":"text","data":{"markdown":"hello"}},
+          {"id":"c","type":"callout","data":{"kind":"info","body":"note"}},
+          {"id":"s","type":"spacer","data":{"size":"md"}},
+          {"id":"d","type":"divider","data":{}},
+          {"id":"g","type":"group","data":{"tone":"card","children":[{"id":"t2","type":"text","data":{"markdown":"inner"}}]}}
+        ]
+        JSON;
+
+    /**
+     * hub 検収条件1: existing documents must render exactly as before — asserted, not claimed.
+     */
+    public function testExistingBlockTypesRenderNothingOnTheServer(): void
+    {
+        self::assertSame('', $this->renderer()->render(self::LEGACY_DOCUMENT));
+    }
+
+    /**
+     * The positive control for the test above. Without this, "renders nothing" would also
+     * pass if the renderer were broken and rendered nothing at all, ever.
+     */
+    public function testAContactFormDocumentDoesChangeTheOutput(): void
+    {
+        $html = $this->renderer()->render('[{"id":"c","type":"contact-form","data":{"formKey":"ayane-contact"}}]');
+
+        self::assertNotSame('', $html);
+        self::assertStringContainsString('<form', $html);
+    }
+
+    /**
+     * hub 検収条件2: the no-JS form posts at the records-side proxy, never at the issuing
+     * product — a direct post would mean handing the browser the connect-token.
+     */
+    public function testFormPostsToTheRecordsProxyAndLeaksNothing(): void
+    {
+        $html = $this->renderer()->render('[{"id":"c","type":"contact-form","data":{"formKey":"ayane-contact"}}]');
+
+        self::assertStringContainsString('action="' . ContactSubmissionProxyRoute::PATH . '"', $html);
+        self::assertStringContainsString('method="post"', $html);
+
+        // Nothing that points at contact, and nothing token-shaped, may appear in public HTML.
+        self::assertStringNotContainsString('http://', $html);
+        self::assertStringNotContainsString('https://', $html);
+        self::assertStringNotContainsString('Authorization', $html);
+        self::assertStringNotContainsString('Bearer', $html);
+        self::assertStringNotContainsString('token', $html);
+    }
+
+    public function testRendersOneControlPerSchemaFieldWithTypesAndRequiredness(): void
+    {
+        $html = $this->renderer()->render('[{"id":"c","type":"contact-form","data":{"formKey":"ayane-contact"}}]');
+
+        self::assertStringContainsString('name="name"', $html);
+        self::assertStringContainsString('type="email"', $html);
+        self::assertStringContainsString('<textarea', $html);
+        self::assertStringContainsString('required', $html);
+        self::assertStringContainsString('value="ayane-contact"', $html);
+    }
+
+    public function testUnknownFieldTypeBecomesATextInputRatherThanDisappearing(): void
+    {
+        $renderer = $this->renderer(new ContactFormSchema('k', [
+            new ContactFormField('nickname', 'Nickname', 'colour-picker', false),
+        ]));
+
+        $html = $renderer->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]');
+
+        self::assertStringContainsString('name="nickname"', $html);
+        self::assertStringContainsString('type="text"', $html);
+    }
+
+    public function testSchemaValuesAreEscapedIntoAttributesAndText(): void
+    {
+        $renderer = $this->renderer(new ContactFormSchema('k', [
+            new ContactFormField('evil" onfocus="alert(1)', '<script>alert(1)</script>', 'text', false),
+        ], submitLabel: '"><script>x</script>'));
+
+        $html = $renderer->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]');
+
+        self::assertStringNotContainsString('<script>', $html);
+        self::assertStringNotContainsString('onfocus="alert(1)"', $html);
+        self::assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testMissingSchemaFailsVisiblyInsteadOfRenderingNothing(): void
+    {
+        $renderer = new SsrBlocksRenderer(new class () implements ContactFormSchemaProviderInterface {
+            public function schemaFor(string $formKey): ?ContactFormSchema
+            {
+                return null;
+            }
+        });
+
+        $html = $renderer->render('[{"id":"c","type":"contact-form","data":{"formKey":"typo"}}]');
+
+        // An empty region would look like a page that simply has no form; the author would
+        // never learn the key was wrong.
+        self::assertStringContainsString('contact-form--unavailable', $html);
+        self::assertStringNotContainsString('<form', $html);
+    }
+
+    public function testConsentCheckboxAppearsOnlyWhenTheFormRequiresIt(): void
+    {
+        $without = $this->renderer()->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]');
+        $with = $this->renderer(new ContactFormSchema('k', [], consentRequired: true))
+            ->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]');
+
+        self::assertStringNotContainsString('name="consent"', $without);
+        self::assertStringContainsString('name="consent"', $with);
+    }
+
+    public function testMalformedOrEmptyDocumentsRenderNothing(): void
+    {
+        foreach (['', '   ', 'not json', '{"not":"a list"}', '[42]', '[{"type":"contact-form"}]'] as $document) {
+            self::assertSame('', $this->renderer()->render($document), 'Document: ' . $document);
+        }
+    }
+
+    public function testBlockWithoutAFormKeyRendersNothing(): void
+    {
+        self::assertSame('', $this->renderer()->render('[{"id":"c","type":"contact-form","data":{"variant":"inline"}}]'));
+    }
+
+    private function renderer(?ContactFormSchema $schema = null): SsrBlocksRenderer
+    {
+        $resolved = $schema ?? new ContactFormSchema('ayane-contact', [
+            new ContactFormField('name', 'Your name', 'text', true),
+            new ContactFormField('email', 'Email', 'email', true),
+            new ContactFormField('message', 'Message', 'textarea', true),
+        ]);
+
+        return new SsrBlocksRenderer(new class ($resolved) implements ContactFormSchemaProviderInterface {
+            public function __construct(private readonly ContactFormSchema $schema)
+            {
+            }
+
+            public function schemaFor(string $formKey): ContactFormSchema
+            {
+                return $this->schema;
+            }
+        });
+    }
+}

--- a/tests/PublicRecord/SsrBlocksRendererTest.php
+++ b/tests/PublicRecord/SsrBlocksRendererTest.php
@@ -141,6 +141,113 @@ final class SsrBlocksRendererTest extends TestCase
         self::assertSame('', $this->renderer()->render('[{"id":"c","type":"contact-form","data":{"variant":"inline"}}]'));
     }
 
+    public function testTwoFormsOnOnePageDoNotShareElementIds(): void
+    {
+        // Duplicate ids break every `<label for>` association silently — clicking a label
+        // focuses the first match, which is in the other form.
+        $document = '[{"id":"one","type":"contact-form","data":{"formKey":"k"}},'
+            . '{"id":"two","type":"contact-form","data":{"formKey":"k"}}]';
+
+        $html = $this->renderer(new ContactFormSchema('k', [
+            new ContactFormField('email', 'Email', 'email', true),
+        ]))->render($document, 'sections');
+
+        preg_match_all('/id="([^"]+)"/', $html, $matches);
+        $ids = $matches[1];
+
+        self::assertCount(2, $ids);
+        self::assertSame($ids, array_unique($ids), 'Generated element ids must be unique on a page.');
+    }
+
+    public function testTwoBlocksFieldsOnOnePageDoNotShareElementIds(): void
+    {
+        $document = '[{"id":"one","type":"contact-form","data":{"formKey":"k"}}]';
+        $renderer = $this->renderer(new ContactFormSchema('k', [
+            new ContactFormField('email', 'Email', 'email', true),
+        ]));
+
+        $first = $renderer->render($document, 'sections');
+        $second = $renderer->render($document, 'footer');
+
+        self::assertNotSame(
+            $this->firstId($first),
+            $this->firstId($second),
+            'The scope must disambiguate ids across blocks fields.',
+        );
+    }
+
+    public function testIdsBuiltFromCallerSuppliedStringsStaySafe(): void
+    {
+        $html = $this->renderer(new ContactFormSchema('k', [
+            new ContactFormField('bad" onfocus="alert(1)', 'Bad', 'text', false),
+        ]))->render('[{"id":"a\" onload=\"x","type":"contact-form","data":{"formKey":"k"}}]', 'sc"ope');
+
+        // The escaped text `onfocus=` may legitimately appear inside an attribute *value*;
+        // what must never appear is a real attribute break, i.e. an unescaped quote followed
+        // by a handler. Assert on the dangerous shape, not on the substring.
+        self::assertDoesNotMatchRegularExpression('/"\s+on[a-z]+\s*=/i', $html);
+
+        preg_match_all('/id="([^"]*)"/', $html, $matches);
+        self::assertNotSame([], $matches[1]);
+
+        foreach ($matches[1] as $id) {
+            self::assertMatchesRegularExpression('/^[A-Za-z0-9_-]+$/', $id, 'Generated ids must be attribute-safe.');
+        }
+    }
+
+    public function testRequiredSelectGetsAnEmptyFirstOptionSoRequiredMeansSomething(): void
+    {
+        // Without a placeholder the first option is already selected, so the browser treats
+        // the control as filled in and `required` never fires.
+        $html = $this->renderer(new ContactFormSchema('k', [
+            new ContactFormField('topic', 'Topic', 'select', true, ['Sales', 'Support']),
+        ]))->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]');
+
+        self::assertStringContainsString('<option value="" selected disabled></option>', $html);
+    }
+
+    public function testOptionalSelectHasNoPlaceholderOption(): void
+    {
+        $html = $this->renderer(new ContactFormSchema('k', [
+            new ContactFormField('topic', 'Topic', 'select', false, ['Sales']),
+        ]))->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]');
+
+        self::assertStringNotContainsString('<option value="" selected disabled>', $html);
+    }
+
+    public function testWordingSuppliedByTheIssuingProductIsUsedVerbatim(): void
+    {
+        // The consent sentence is contact's legal text and the button is its copy; records
+        // must not overwrite either with English.
+        $html = $this->renderer(new ContactFormSchema('k', [], consentRequired: true, submitLabel: '送信する', consentLabel: '個人情報の取り扱いに同意します'))
+            ->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]');
+
+        self::assertStringContainsString('送信する', $html);
+        self::assertStringContainsString('個人情報の取り扱いに同意します', $html);
+        self::assertStringNotContainsString('lang="en"', $html);
+    }
+
+    public function testEnglishFallbackWordingIsTaggedAsEnglish(): void
+    {
+        // records has no SSR message catalogue yet (#1034). Until it does, the fallback must
+        // not claim to be in the page's language — crawlers read this markup.
+        $html = $this->renderer(new ContactFormSchema('k', [], consentRequired: true))
+            ->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]');
+
+        self::assertStringContainsString('<span lang="en">Send</span>', $html);
+        self::assertStringContainsString('lang="en">I agree', $html);
+    }
+
+    private function firstId(string $html): string
+    {
+        preg_match_all('/id="([^"]+)"/', $html, $matches);
+        $ids = $matches[1];
+
+        self::assertNotSame([], $ids, 'The rendered form must carry at least one element id.');
+
+        return $ids[0];
+    }
+
     private function renderer(?ContactFormSchema $schema = null): SsrBlocksRenderer
     {
         $resolved = $schema ?? new ContactFormSchema('ayane-contact', [


### PR DESCRIPTION
> **Draft**: PHP 側のみ。**TS レジストリが入るまでマージしない**（理由は §残作業）。

## 着手して分かったこと（issue の前提と実測が違った）

issue #1030 は「SSR 描画（inline・純 SSR）」を要件にしていますが、**records に PHP 側のブロック描画は
存在しませんでした**:

- `GetPublicRecordViewUseCase` の `match ($fieldDef->dataType)` に **blocks の腕が無い**
- 結果 SSR は `<h2>フィールド名</h2><p>—</p>` を出すだけ＝**クローラと no-JS には blocks が見えていない**
- 実際の描画は React `BlocksRenderer.tsx`（362行）だけ

つまりこれは「ブロック型を1つ足す」作業ではなく **blocks の SSR 描画という新機能**です。
hub 承認済みの方針: **全型の PHP レンダラは作らない**（TSX 362行の二重実装＝永久に2箇所同期する負債）。
代わりに **描ける型だけの allowlist レンダラ**を作り、初号消費者を contact-form にしました。

## 変更

- **`BlockTypes` ＋ `BlocksDocumentValidator`**: `contact-form` を追加。
  `formKey` は URL パスへ差し込むので文字集合を絞る（`../` や絶対 URL は検証を通らない）。
  `variant` は省略可＝`inline`、未知の variant は**弾く**（黙って inline に落とさない）。
- **`SsrBlocksRenderer`**: `match` そのものが allowlist で、**知らない型は何も出さない**。
  これが安全性の本体——既存ドキュメントの SSR 出力が変わらない理由がここ。
- **テンプレート分岐の条件は「blocks フィールドか」ではなく「HTML が出たか」**。
  出なければ従来の `<h2>キー</h2><p>—</p>` にそのまま落ちる。
- **`blocksDocument` は `displayValue` の中でなく隣**に持たせた → JSON API の返す内容は1文字も変わらない。
- **スキーマ取得にトークンを送らない**。フォームキーは秘密ではなく、トークンは送信経路（#1031）だけの
  持ち物。読み取り経路を資格情報ゼロにしておけば、そこが漏洩点になりようがない。SSRF ガード＋接続ピン留め＋
  3秒タイムアウト（公開ページの描画中に叩くため）。
- **取得失敗は fail-visible**（「一時的に利用できません」）。空領域だと著者はキーの打ち間違いに永久に
  気づけない。

## hub 検収条件2つ（どちらも実装済み）

| 条件 | どこで pin したか |
|---|---|
| ① 既存ドキュメントの SSR 出力が変わらない（**陽性対照つき**） | `SsrBlocksRendererTest`（renderer が `''` を返す＋contact-form 文書では**変わる**ことも同じテストで）／`PublicRecordHttpTest`（実 SSR HTML に block markup が出ず `<p>—</p>` に落ちる） |
| ② no-JS フォームの action が #1031 proxy 固定 | `action` が `ContactSubmissionProxyRoute::PATH` であること＋**contact 直 URL・`token`・`Authorization`・`Bearer` が公開 HTML に出ない**ことを同じテストで（#1032 pin ④ と同じ棚）。属性は `ENT_QUOTES` でエスケープし、悪意ある label/key/submitLabel を入れた回帰テストつき |

## 残作業（このブランチで続ける・**マージ前提条件**）

TS 側: `blocks-document.ts`（型/coerce/serialize/validate）・`block-catalog.ts`・`BlockInspector`・
`BlocksFieldEditor`（2つの switch）・`BlocksRenderer`・i18n **6言語**・`public-site.css`。

🔴 **単独マージ不可の理由**: `parseBlocksDocument` は未知の型を握り潰す設計なので、TS に
`contact-form` が無いまま出すと **hydrate 後にフォームが消える**（クローラには見えるが人間には消える）。

## 検証

`composer check` 緑 — PHPUnit **1592** / PHPStan L8 / CS / OpenAPI valid / conformance OK / MCP valid。

🤖 Generated with [Claude Code](https://claude.com/claude-code)