### PR TITLE
fix(frontend): findBy* の待ちが testTimeout の予算を使い切らない設定を直す（#1035）

### DIFF
--- a/frontend/tests/setup/vitest.setup.ts
+++ b/frontend/tests/setup/vitest.setup.ts
@@ -1,4 +1,15 @@
 import '@testing-library/jest-dom/vitest'
+import { configure } from '@testing-library/react'
+
+// `findBy*` / `waitFor` の待ち時間（asyncUtilTimeout）は testing-library の既定が 1000ms で、
+// vitest の testTimeout（既定 5000ms・本リポは vitest.config.ts で 15000ms）とは**別の予算**。
+// 既定のままだと、テストに残り時間があるのに非同期ヘルパだけが先に諦める。
+// 実際 #1035 では高負荷時（environment 175s）に初回レンダリングが 1 秒以内に落ち着かず、
+// 予算を 4 秒残したまま `findByRole` が失敗して Stop hook ゲートを 3 回誤発火させた。
+// 通常時のこのスイートは 1 テスト 200〜500ms 程度なので 5000ms は 10 倍前後の余裕。
+// testTimeout はこれより十分上に置く（そうしないと findBy の読みやすい失敗メッセージが出る前に
+// テスト全体がタイムアウトする）。
+configure({ asyncUtilTimeout: 5000 })
 
 // jsdom does not implement ResizeObserver. Components that observe element size
 // (e.g. the public header's nav fit-probe) construct one on mount; provide an

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -17,6 +17,9 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./tests/setup/vitest.setup.ts'],
+    // asyncUtilTimeout（5000ms・tests/setup/vitest.setup.ts）より十分上に置く。
+    // 同値以下だと、findBy* が読みやすい失敗を返す前にテスト全体がタイムアウトしてしまう。
+    testTimeout: 15000,
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'tests/**/*.test.ts', 'tests/**/*.test.tsx'],
   },
 })


### PR DESCRIPTION
## 根因

testing-library の `asyncUtilTimeout`（`findBy*` / `waitFor` の待ち）と、
vitest の `testTimeout`（テスト全体）は **別の予算**だった。

| 設定 | 変更前 | 変更後 |
| --- | ---: | ---: |
| `asyncUtilTimeout` | **1000ms**（既定・上書きなし） | **5000ms** |
| `testTimeout` | **5000ms**（既定・未設定） | **15000ms** |

**テストに 5000ms の予算があるのに、`findByRole` は 1000ms で諦めていた。**
高負荷時（実測: environment **175.24s** / import 103.84s）に初回レンダリングが1秒以内に
落ち着かず、**予算を4秒残したまま**失敗する。これが「負荷時に断続的」の正体。

## なぜ全体設定にしたか

個別の `findByRole(..., { timeout })` ではなく `configure()` で揃えた。
**`findBy*` を使うテストは 11 ファイル**あり、同じ理由でいつ落ちてもおかしくないため。

`testTimeout` を 15000ms に上げたのは、asyncUtilTimeout より**十分上に置く**必要があるから。
同値以下だと、`findBy*` が読みやすい失敗メッセージを返す前にテスト全体がタイムアウトしてしまう。

## 🔬 検証 — 「緑になった」は効いた証拠にならないので陽性対照を取った

この flaky は**高負荷でしか出ない**ので、通常実行が緑でも「直った」ことにはならない
（Stop hook pilot の観測でも、**同一ハッシュが数分の間に緑→赤**になっている）。

そこで **設定が実際にこのテストの挙動を支配しているか**を陽性対照で確かめた:

| 条件 | 結果 |
| --- | --- |
| `asyncUtilTimeout: 1`（意図的に極小） | 🔴 当該ファイルの **14 テストが全て失敗** |
| `asyncUtilTimeout: 5000`（本設定） | 🟢 14 passed |
| フル `npm run check` | 🟢 **exit 0**（119 files / **666 tests**） |

＝ `configure()` は無視されておらず、**この待ち時間がこのテストの成否を実際に決めている**。
1ms で全滅する以上、1000ms → 5000ms の引き上げは同じ経路に効く。

## 背景（Stop hook pilot）

本件は pilot 期間中の **ブロック4回のうち3回**の原因だった。
観測報告は `_work/reports/2026-08-05-stop-hook-pilot-observation-records.md`。

hub 裁定により **「標準化の前に #1035 を直す」**が条件付き承認され、本 PR はその実施。
S/N 比 0 のゲート（＝赤が一度も実在の欠陥を指していない状態）を放置すると、
**「このゲートの赤は無視してよい」という学習を人間に教える**ため。

Closes #1035