### PR TITLE
ci(frontend): check に本番 build を配線する — 射程はバンドル解決性であって CSS ではない（#1052）

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -29,6 +29,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # npm run check = type-check + lint + format + test + validate:themes + knip
+      # + build（本番バンドル・#1052）+ build-storybook。
+      #
+      # 🔴 build の射程を誤読しないこと（#1052 で実測・2026-08-05 @ 44ee92c）:
+      # build は **CSS を守らない**。prettier 正規形に整形した不正 CSS（`color:;`）を
+      # theme/index.css に注入した実測では format rc=0・build rc=0 で全通過した。
+      # records には stylelint が無いので、CSS の妥当性ゲートは build を足しても増えない。
+      #
+      # build が実際に塞ぐのは **本番バンドル経路の解決性**。src/main.tsx から到達する
+      # .ts/.tsx 600 本のうち 573 本（95%）は story のどれからも到達せず、そこに
+      # 解決不能な import があっても type-check / lint / format / test / validate:themes /
+      # knip / build-storybook は 7つ全て rc=0 で素通りする（陽性対照の実測・#1052 参照）。
       - name: Run checks
         run: npm run check
 

--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -940,10 +940,20 @@ Recommended scripts:
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "knip": "knip",
-    "check": "npm run type-check && npm run lint && npm run format && npm run test && npm run build-storybook"
+    "check": "npm run type-check && npm run lint && npm run format && npm run test && npm run knip && npm run build && npm run build-storybook"
   }
 }
 ```
+
+`check` must include **`build`** (the production bundle). `tsc` type-checks modules but never
+verifies that CSS/asset imports resolve to real files — they are typed by `vite/client`'s
+wildcard declarations — so a renamed or deleted asset breaks only `vite build`. In this repo
+573 of the 600 `.ts`/`.tsx` files reachable from `src/main.tsx` (**95%**) are never loaded by any
+story, so `build-storybook` cannot stand in for it (measured 2026-08-05, [#1052](https://github.com/hideyukiMORI/nene-records/issues/1052)).
+
+🔴 Do not over-read the scope: **`build` does not guard CSS.** Prettier-formatted invalid CSS
+(`color:;`) passes both `format` and `build`. CSS validity needs stylelint, which this repo does
+not have.
 
 CI on frontend PRs:
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,7 @@
     "codegen": "openapi-typescript ../docs/openapi/openapi.yaml -o src/shared/api/schema.gen.ts",
     "check:fast": "npm run type-check && npm run lint && npm run format && npm run test && npm run validate:themes",
     "knip": "knip",
-    "check": "npm run type-check && npm run lint && npm run format && npm run test && npm run validate:themes && npm run knip && npm run build-storybook",
+    "check": "npm run type-check && npm run lint && npm run format && npm run test && npm run validate:themes && npm run knip && npm run build && npm run build-storybook",
     "prepare": "husky",
     "gen:base-tokens": "node scripts/generate-base-theme-tokens.mjs",
     "audit": "audit-ci --config audit-ci.jsonc"


### PR DESCRIPTION
## 目的

`npm run check` にも Frontend CI にも **`vite build`（本番バンドル）が無く**、
本番バンドル経路の解決性がどこでも検査されていなかった。board 行70（横断調査
「front check/CI のビルドゲート穴」・正本 nene2-fleet-tooling#210）の **records 配布ぶん**。
A1（hooks→model）完了により解禁済み。

## 変更

| ファイル | 内容 |
| --- | --- |
| `frontend/package.json` | `check` の `knip` と `build-storybook` の間に **`npm run build`** を挿入 |
| `.github/workflows/frontend-ci.yml` | 射程の注記をコメントで同梱（CI に独立ステップは足さない＝Q3 裁定どおり `check` へ集約） |
| `docs/development/frontend-standards.md` | 推奨 `check` に `build` を追加＋「build は CSS を守らない」注記 |

## 🔬 検証 — 陽性対照で「このゲートが何を捕まえるか」を実測した

本番グラフにだけ載る `src/app/providers.tsx`（story からも test からも到達しない）へ
`import '@/app/__probe-does-not-exist.css'` を1行注入し、各ゲートを**個別に**走らせた。

| ゲート | 修正前 rc | 修正後の `check` |
| --- | ---: | --- |
| `type-check` | 0 | |
| `lint` | 0 | |
| `format` | 0 | |
| `test` | 0 | |
| `validate:themes` | 0 | |
| `knip` | 0 | |
| `build-storybook` | 0 | |
| **`build`** | 🔴 **1** | ← ここで落ちる |
| **`npm run check` 全体** | 🟢 **0（素通り）** | 🔴 **1** |

**修正前は現行 check の7ゲートすべてが緑のまま本番バンドルだけが壊れていた。修正後は同じ probe が check で止まる。**
`tsc` が捕まえないのは、CSS/アセットが `vite/client` のワイルドカード宣言で型付けされ、
**実ファイルの存在を型検査が見ない**から（＝ CSS やアセットの改名・削除がこの穴の現実的な入口）。

### storybook では代替できない（実測）

`.storybook/main.ts` の glob は `../src/shared/ui/**/*.stories.@(tsx|mdx)`（**story 7本**）。

| 集合 | .ts/.tsx |
| --- | ---: |
| `src/main.tsx` から到達（本番バンドルのグラフ） | **600** |
| story ＋ `preview.tsx` から到達 | **35** |
| **本番にだけ載る（storybook が一度も読まない）** | **573 ＝ 95%** |

### 🔴 射程を誤読しないための対照（vault #352 の訂正を records でも再現）

**`build` は CSS を守らない。**

| 注入した内容 | `format`(prettier) | `build` |
| --- | ---: | ---: |
| 不正 CSS `color:;`（prettier 正規形） | **0** | **0** |
| 同上（整形前） | 1 ※**書式**差分としての検出で、CSS の妥当性検査ではない | 0 |
| 閉じない `@media`（パース不能） | 2 | 1 |

＝ 構文として壊れていない限り**不正な CSS は現行 check を全通過する**。
records には stylelint が無く CSS の妥当性ゲートは実質ゼロだが、それは **build を足しても増えない**（本 PR の射程外・別途 hub 判断待ち）。

### コスト

| | 実測 |
| --- | ---: |
| `npm run check` 修正前 | **1分20.5秒** |
| `npm run check` 修正後 | **1分29.7秒**（+9.2秒 ≒ +11%） |
| 全体 | 🟢 exit 0（119 files / **666 tests** / `built in 1.38s` / Storybook build completed） |

## チェックリスト

- [x] `npm run check --prefix frontend` 緑（exit 0・上表）
- [x] 陽性対照（probe あり）で `check` が **rc=1** になることを確認
- [x] 陰性対照（probe なし・修正後）で `check` が **rc=0** のままであることを確認
- [ ] `composer check` … **未実行**（この環境で Docker エンジンが停止中。PHP は1行も触っていないので Backend CI に委ねる）
- [x] ブランチは最新 main（`44ee92c`）から作成＝strict=true でも BEHIND にならない

Closes #1052
