### PR TITLE
fix(security-harness): probe.sh の F-01 期待値を #827 後の仕様へ揃える（#1054）

### DIFF
--- a/docs/security/harness/README.md
+++ b/docs/security/harness/README.md
@@ -22,7 +22,11 @@ bash docs/security/harness/probe.sh
 2. Installs two orgs (`default`, `ayane`) each with an admin, logs in, and seeds a webhook (with a secret)
    and a draft entity.
 3. Runs the attack battery and asserts the expected result for each case:
-   - unauthenticated GET on admin routes → **401** (F-01)
+   - unauthenticated GET on sensitive routes (secrets / bulk export / org metrics / connect-tokens) → **401** (F-01)
+   - unauthenticated GET on the **public read surface** (entity-types / entities / text-fields / tags) → **200**.
+     This is a positive control, not an oversight: the first cut of #824 blanket-protected every GET and
+     bounced every visitor of the public site to `/login` (#826). #827 restored these deliberately, so the
+     harness asserts they stay open — re-tightening them fails loudly instead of shipping as a "fix".
    - cross-tenant cookie / JWT-bearer replay → **403** (F-02)
    - CSRF (cookie mutation without `X-Requested-With`) → **403**
    - superadmin route as non-superadmin → **403**, unauthenticated → **401** (#797)

--- a/docs/security/harness/probe.sh
+++ b/docs/security/harness/probe.sh
@@ -45,9 +45,22 @@ curl -s -c "$WORK/other.txt" -o /dev/null -X POST "$B/api/v1/auth/login" -H 'Con
 curl -s -b "$WORK/match.txt" -o /dev/null -X POST "$B/api/v1/webhooks" -H 'Content-Type: application/json' -H 'X-Requested-With: 1' \
   -d '{"url":"https://x.example/h","events":["entity.created"],"secret":"whsec_TEST","is_active":true}'
 
-echo "== F-01: unauthenticated admin GET must be 401 =="
-for p in /api/v1/webhooks /api/v1/entities /api/v1/entities/export /api/v1/text-fields /api/v1/notification-channels; do
+echo "== F-01: unauthenticated GET on sensitive routes must be 401 =="
+# The ADMIN_ONLY_PREFIXES of AdminApiAuthMiddleware: secrets, bulk export, org metrics,
+# and the credentials another product issued to this tenant (#1029).
+for p in /api/v1/webhooks /api/v1/notification-channels /api/v1/connect-tokens \
+         /api/v1/entities/export /api/v1/dashboard /api/v1/settings /api/v1/users; do
   check "unauth GET $p" 401 "$(code "$B$p")"
+done
+
+echo "== F-01 positive control: the public read surface must STAY open =="
+# 🔴 Do not "fix" these to 401. The first cut of #824 blanket-protected every GET and
+# took the public consumer site down with it (#826) — every visitor was bounced to
+# /login. #827 restored these deliberately: the site renders from them unauthenticated.
+# They are asserted here so that re-tightening the read surface fails loudly instead of
+# shipping as a "security improvement".
+for p in /api/v1/entity-types /api/v1/entities /api/v1/text-fields /api/v1/tags; do
+  check "unauth GET $p stays open" 200 "$(code "$B$p")"
 done
 check "public GET /api/v1/public/settings stays open" 200 "$(code "$B/api/v1/public/settings")"
 check "GET /health stays open" 200 "$(code "$B/health")"


### PR DESCRIPTION
## 目的

`docs/security/harness/probe.sh` の F-01 期待値が **#827 以前のまま**で、
現行 main に対して走らせると **2件 fail** していた。この harness は
`docs/security/2026-07-13-assessment.md` が指す**自己診断ツール**＝第三者が最初に走らせる場所なので、
「走らせると赤が出る／赤の意味が仕様と逆」は診断の信頼性を直接損なう。

発見経路: F-01/02/03 開示の前提チェック1（稼働インスタンス実査・board 行72）。

## 変更

| ファイル | 内容 |
| --- | --- |
| `docs/security/harness/probe.sh` | F-01 の 401 群を `ADMIN_ONLY_PREFIXES` の実態へ／公開 read 4本を **200 の陽性対照**として追加 |
| `docs/security/harness/README.md` | 手順3 の記述を同じ形へ（「なぜ 200 なのか」＝#826 の経緯つき） |

**401 を期待する群**（`ADMIN_ONLY_PREFIXES` に揃えた）:
`webhooks` / `notification-channels` / **`connect-tokens`（#1029 で追加・harness に未反映だった）** /
`entities/export` / `dashboard` / `settings` / `users`

**200 を期待する群**（新設・公開 read サーフェス）:
`entity-types` / `entities` / `text-fields` / `tags`

> 🔴 この4本を「401 に直す」のは**退行**です。#824 の初手が GET を一律封鎖して公開サイトを落とし
> （#826・全訪問者が `/login` へバウンス）、#827 で意図的に開け直したもの。
> 陽性対照として書いておくことで、**再び締めたら赤になる**。

## 🔬 検証 — 隔離インスタンスで実際に走らせた（2026-08-05）

harness 自身の隔離環境（compose project `nene-records-sectest` / app :18092 / mysql :13318・実行後 `down -v`）。

| 条件 | 結果 |
| --- | --- |
| **修正前**（`HEAD` の probe.sh） | 🔴 F-01 で **2 failed**（`/api/v1/entities` と `/api/v1/text-fields` が expected 401, got 200） |
| **修正後**（本 PR） | 🟢 **22 passed, 0 failed** |

＝ 「期待値が仕様と逆」であることを**推測でなく実行で確認**し、修正後に緑になることも実行で確認した。

本番でも同じ値を実測済み（未認証 GET・browser UA・稼働インスタンス実査）:
`entity-types` / `entities` / `text-fields` / `tags` は apex・aozora とも **200**、
`connect-tokens` / `dashboard` は **401**。

## チェックリスト

- [x] `bash docs/security/harness/probe.sh` 緑（**22 passed, 0 failed**）
- [x] 修正前が赤になることを実行で確認（2 failed）
- [x] 隔離環境の後片付け確認（`sectest` のコンテナ・ボリュームとも残骸ゼロ）
- [x] 本番への影響なし（harness はローカル隔離インスタンスのみ・本番には向けていない）
- [ ] `composer check` / `npm run check` … **未実行**（変更は shell と md のみ・PHP/TS は不変）

Closes #1054
