### PR TITLE
fix(tenancy): org 不在のホストが HTML で 200 を返すのを止める（#1057）

### DIFF
--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -154,6 +154,19 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
     /** Container key for the shared RequestScopedHolder<int> that carries org_id. */
     public const ORG_ID_HOLDER = 'nene-records.org_id_holder';
 
+    /**
+     * Container key for the shared RequestScopedHolder<bool> that carries a *definite
+     * negative* from org resolution: the request named an organization and that
+     * organization does not exist (or is inactive).
+     *
+     * Distinct from "org_id was never set", which also covers configuration gaps
+     * (`org-not-resolved`) — those must keep working so an unconfigured install can
+     * still reach `/admin`. Written by OrgResolverMiddleware, read by
+     * SingleOriginKernel so the single-origin edge layers don't answer for a tenant
+     * that isn't there (#1057).
+     */
+    public const ORG_MISSING_HOLDER = 'nene-records.org_missing_holder';
+
     public function register(ContainerBuilder $builder): void
     {
         // Register the shared org_id holder so all repos and OrgResolverMiddleware share the same instance.
@@ -161,6 +174,15 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             self::ORG_ID_HOLDER,
             static function (): RequestScopedHolder {
                 /** @var RequestScopedHolder<int> */
+                return new RequestScopedHolder();
+            },
+        );
+
+        // Shared "this host names an org that isn't serviceable" flag (#1057).
+        $builder->set(
+            self::ORG_MISSING_HOLDER,
+            static function (): RequestScopedHolder {
+                /** @var RequestScopedHolder<bool> */
                 return new RequestScopedHolder();
             },
         );

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -332,6 +332,14 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     }
                     /** @var RequestScopedHolder<int> $orgIdHolder */
 
+                    // "This host names an org that isn't serviceable" flag (#1057):
+                    // shared with SingleOriginKernel so the edge layers stop answering.
+                    $orgMissingHolder = $container->get(ApplicationServiceProvider::ORG_MISSING_HOLDER);
+                    if (!$orgMissingHolder instanceof RequestScopedHolder) {
+                        throw new LogicException('Org missing holder service is invalid.');
+                    }
+                    /** @var RequestScopedHolder<bool> $orgMissingHolder */
+
                     // DB の system_config から解決モードを読む（env フォールバック付き）。
                     // system_config は migration で tenant_* を空文字 '' で seed するため、`??`
                     // だと空文字（非 null）が env フォールバックを覆い隠す。`?:` で「空なら env」
@@ -363,7 +371,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     $wwwBaseDomain = $resolvedDomain === 'localhost' ? '' : $resolvedDomain;
                     $authMiddleware[] = new WwwRedirectMiddleware($responseFactory, $orgIdHolder, $wwwBaseDomain);
 
-                    $authMiddleware[] = new OrgResolverMiddleware($orgIdHolder, $orgRepo, $problemDetails, $strategy);
+                    $authMiddleware[] = new OrgResolverMiddleware($orgIdHolder, $orgRepo, $problemDetails, $strategy, $orgMissingHolder);
 
                     // Per-org maintenance mode (#813): gate the public surface for anonymous
                     // visitors when the resolved org's `maintenance_mode` setting is on. Placed

--- a/src/Http/SingleOriginKernel.php
+++ b/src/Http/SingleOriginKernel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeNeRecords\Http;
 
+use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\PublicRecord\RenderPublicHomeHandler;
 use NeNeRecords\PublicRecord\RenderPublicTypeArchiveHandler;
 use NeNeRecords\UrlRedirect\UrlRedirectResolver;
@@ -32,6 +33,10 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final readonly class SingleOriginKernel implements RequestHandlerInterface
 {
+    /**
+     * @param RequestScopedHolder<bool> $orgMissing raised by OrgResolverMiddleware when
+     *        the request named an organization that does not exist (or is inactive)
+     */
     public function __construct(
         private RequestHandlerInterface $application,
         private CustomPermalinkResolver $customPermalink,
@@ -39,12 +44,28 @@ final readonly class SingleOriginKernel implements RequestHandlerInterface
         private RenderPublicTypeArchiveHandler $typeArchive,
         private RenderPublicHomeHandler $frontPage,
         private SpaShellFallback $shell,
+        private RequestScopedHolder $orgMissing,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $response = $this->application->handle($request);
+
+        // Every layer below answers *for a tenant* — the permalink / 301 / archive
+        // lookups are org-scoped, and the shell is a tenant's page. When org
+        // resolution produced a definite negative, there is no tenant to answer for,
+        // so the pipeline's 404 (or the 403 for an inactive org) is the final answer.
+        //
+        // Without this the shell turned that 404 into a 200 for `/` and for every
+        // client-routed surface (`/login`, `/admin/...`, `/search`), so a decommissioned
+        // host stayed "up" in HTML while `/api/*` correctly 404'd — the shape that
+        // monitoring is least able to catch, and one that reappears every time an org
+        // is retired, independently of whether its DNS record is removed (#1057).
+        if ($this->orgMissing->isSet() && $this->orgMissing->get() === true) {
+            return $response;
+        }
+
         $response = $this->customPermalink->apply($request, $response);
         $response = $this->redirects->apply($request, $response);
         // Entity type archive SSR (#877): `/posts` etc. were SPA-only, so crawlers got

--- a/src/Http/SingleOriginServiceProvider.php
+++ b/src/Http/SingleOriginServiceProvider.php
@@ -7,6 +7,8 @@ namespace NeNeRecords\Http;
 use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\RequestScopedHolder;
+use NeNeRecords\ApplicationServiceProvider;
 use NeNeRecords\PublicRecord\RenderPublicHomeHandler;
 use NeNeRecords\PublicRecord\RenderPublicTypeArchiveHandler;
 use NeNeRecords\Setting\ListPublicSettingsUseCaseInterface;
@@ -89,6 +91,7 @@ final readonly class SingleOriginServiceProvider implements ServiceProviderInter
                     $typeArchive = $c->get(RenderPublicTypeArchiveHandler::class);
                     $frontPage = $c->get(RenderPublicHomeHandler::class);
                     $shell = $c->get(SpaShellFallback::class);
+                    $orgMissing = $c->get(ApplicationServiceProvider::ORG_MISSING_HOLDER);
 
                     if (!$application instanceof RequestHandlerInterface) {
                         throw new LogicException('Application request handler service is invalid.');
@@ -108,6 +111,10 @@ final readonly class SingleOriginServiceProvider implements ServiceProviderInter
                     if (!$shell instanceof SpaShellFallback) {
                         throw new LogicException('SPA shell fallback service is invalid.');
                     }
+                    if (!$orgMissing instanceof RequestScopedHolder) {
+                        throw new LogicException('Org missing holder service is invalid.');
+                    }
+                    /** @var RequestScopedHolder<bool> $orgMissing */
 
                     return new SingleOriginKernel(
                         $application,
@@ -116,6 +123,7 @@ final readonly class SingleOriginServiceProvider implements ServiceProviderInter
                         $typeArchive,
                         $frontPage,
                         $shell,
+                        $orgMissing,
                     );
                 },
             );

--- a/src/Organization/Resolution/OrgResolverMiddleware.php
+++ b/src/Organization/Resolution/OrgResolverMiddleware.php
@@ -25,7 +25,8 @@ use Psr\Http\Server\RequestHandlerInterface;
  *  1. strategy->resolve() → slug or custom domain identifier
  *  2. OrganizationRepository::findBySlug() → Organization
  *  3. If not found by slug, try findByCustomDomain() (for CustomDomainStrategy)
- *  4. 404 if still not found
+ *  4. 404 if still not found — and raise the `$orgMissing` flag so the single-origin
+ *     edge layers stop turning that 404 into a 200 SPA shell (#1057)
  */
 final readonly class OrgResolverMiddleware implements MiddlewareInterface
 {
@@ -49,13 +50,19 @@ final readonly class OrgResolverMiddleware implements MiddlewareInterface
     ];
 
     /**
-     * @param RequestScopedHolder<int> $orgId
+     * @param RequestScopedHolder<int>  $orgId
+     * @param RequestScopedHolder<bool> $orgMissing marks a *definite negative*: the
+     *        request named an organization and no serviceable one exists for it. The
+     *        single-origin edge layers read this so they don't answer for a tenant
+     *        that isn't there (#1057). Deliberately NOT raised for `org-not-resolved`
+     *        (a configuration gap) — see process().
      */
     public function __construct(
         private RequestScopedHolder $orgId,
         private OrganizationRepositoryInterface $repository,
         private ProblemDetailsResponseFactory $problemDetails,
         private OrgResolutionStrategyInterface $strategy,
+        private RequestScopedHolder $orgMissing,
     ) {
     }
 
@@ -87,6 +94,11 @@ final readonly class OrgResolverMiddleware implements MiddlewareInterface
                 return $handler->handle($request->withAttribute('nene2.apex', true));
             }
 
+            // NOT flagged as "org missing": this is a configuration gap (e.g. no
+            // ORG_SLUG yet), not a dead tenant. Flagging it would stop the SPA shell
+            // from serving `/admin` and `/login` on an install that hasn't been
+            // configured yet — i.e. it would lock the operator out of the surface
+            // they need to fix it (#1057).
             return $this->problemDetails->create(
                 $request,
                 'org-not-resolved',
@@ -101,6 +113,8 @@ final readonly class OrgResolverMiddleware implements MiddlewareInterface
             ?? $this->repository->findByCustomDomain($identifier);
 
         if ($org === null) {
+            $this->orgMissing->set(true);
+
             return $this->problemDetails->create(
                 $request,
                 'org-not-found',
@@ -111,6 +125,8 @@ final readonly class OrgResolverMiddleware implements MiddlewareInterface
         }
 
         if (!$org->isActive) {
+            $this->orgMissing->set(true);
+
             return $this->problemDetails->create(
                 $request,
                 'org-inactive',

--- a/tests/Http/SingleOriginKernelTest.php
+++ b/tests/Http/SingleOriginKernelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeNeRecords\Tests\Http;
 
 use DateTimeImmutable;
+use Nene2\Http\RequestScopedHolder;
 use NeNeRecords\Entity\Entity;
 use NeNeRecords\Entity\EntityStatus;
 use NeNeRecords\EntityType\EntityType;
@@ -37,12 +38,17 @@ final class SingleOriginKernelTest extends TestCase
     private Psr17Factory $factory;
     private InMemoryUrlRedirectRepository $redirects;
     private string $shellPath;
+    /** @var RequestScopedHolder<bool> */
+    private RequestScopedHolder $orgMissing;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->factory = new Psr17Factory();
         $this->redirects = new InMemoryUrlRedirectRepository();
+        /** @var RequestScopedHolder<bool> $orgMissing */
+        $orgMissing = new RequestScopedHolder();
+        $this->orgMissing = $orgMissing;
 
         $shellPath = tempnam(sys_get_temp_dir(), 'shell_');
         self::assertNotFalse($shellPath);
@@ -88,6 +94,7 @@ final class SingleOriginKernelTest extends TestCase
             $typeArchive ?? $this->typeArchive(),
             $frontPage ?? $this->frontPage(false),
             new SpaShellFallback($this->shellPath, $this->factory, $this->factory),
+            $this->orgMissing,
         );
     }
 
@@ -577,6 +584,96 @@ final class SingleOriginKernelTest extends TestCase
         $response = $this->kernel($this->appReturning(404))->handle($request);
 
         self::assertSame(404, $response->getStatusCode());
+    }
+
+    // ── Decommissioned tenant (#1057) ────────────────────────────────────────
+    //
+    // `ayane.nene-records.com` kept answering `GET /` with 200 + the SPA shell for
+    // three weeks after its org was deleted, while `GET /api/health` correctly 404'd
+    // `org-not-found`. The 404 was real — SpaShellFallback repainted it, because `/`
+    // and every SPA_APP_ROUTES surface are served at 200 by design for a *live*
+    // tenant and the shell had no way to know there wasn't one.
+    //
+    // One test per surface: `/` and the client-routed routes reach 200 through two
+    // different branches of that status expression, so a partial revert must fail
+    // something here.
+
+    public function testMissingOrgKeepsTheHardNotFoundAtRoot(): void
+    {
+        $this->orgMissing->set(true);
+
+        $request = $this->factory
+            ->createServerRequest('GET', 'https://dead-tenant.test/')
+            ->withHeader('Accept', 'text/html');
+
+        $response = $this->kernel($this->appReturning(404))->handle($request);
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertStringNotContainsString('id="root"', (string) $response->getBody());
+    }
+
+    public function testMissingOrgKeepsTheHardNotFoundOnClientRoutedSurfaces(): void
+    {
+        // These are the paths SPA_APP_ROUTES serves at 200 for a live tenant. A
+        // decommissioned host must not offer a login form.
+        foreach (['/login', '/admin/dashboard', '/search', '/signup'] as $path) {
+            $this->orgMissing->reset();
+            $this->orgMissing->set(true);
+
+            $response = $this->kernel($this->appReturning(404))->handle(
+                $this->factory->createServerRequest('GET', 'https://dead-tenant.test' . $path)
+                    ->withHeader('Accept', 'text/html'),
+            );
+
+            self::assertSame(404, $response->getStatusCode(), $path . ' must stay a hard 404');
+            self::assertStringNotContainsString('id="root"', (string) $response->getBody(), $path);
+        }
+    }
+
+    public function testMissingOrgSkipsTheOrgScopedEdgeLayers(): void
+    {
+        // The 301 map, custom permalinks, the type archive and the front page are all
+        // org-scoped lookups. With no tenant there is nothing to look them up in, so
+        // they must not run at all — not merely fail to match.
+        $this->redirects->save('/2024/01/hello-world', '/posts/1');
+        $this->orgMissing->set(true);
+
+        $response = $this->kernel($this->appReturning(404), $this->permalinkResolverTagging())->handle(
+            $this->factory->createServerRequest('GET', 'https://dead-tenant.test/2024/01/hello-world')
+                ->withHeader('Accept', 'text/html'),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertSame('', $response->getHeaderLine('Location'));
+        self::assertSame('', $response->getHeaderLine('X-Test-Permalink'));
+    }
+
+    public function testMissingOrgLeavesTheInactiveTenantForbiddenIntact(): void
+    {
+        // An inactive org answers 403 (org-inactive) and also raises the flag. The
+        // kernel must hand that response back untouched rather than swallow it.
+        $this->orgMissing->set(true);
+
+        $response = $this->kernel($this->appReturning(403))->handle(
+            $this->factory->createServerRequest('GET', 'https://suspended.test/')
+                ->withHeader('Accept', 'text/html'),
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function testUnflaggedRequestsStillGetTheShell(): void
+    {
+        // The guard reads a *definite negative*. An unconfigured deployment
+        // (`org-not-resolved`, flag never raised) keeps reaching /admin so the
+        // operator can finish setting it up.
+        $response = $this->kernel($this->appReturning(404))->handle(
+            $this->factory->createServerRequest('GET', 'https://unconfigured.test/admin/dashboard')
+                ->withHeader('Accept', 'text/html'),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('id="root"', (string) $response->getBody());
     }
 
     /** A permalink resolver that claims every 404 path, tagging the response. */

--- a/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
+++ b/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
@@ -31,6 +31,8 @@ final class OrgResolverMiddlewareTest extends TestCase
         $factory = new Psr17Factory();
         /** @var RequestScopedHolder<int> $orgId */
         $orgId = new RequestScopedHolder();
+        /** @var RequestScopedHolder<bool> $orgMissing */
+        $orgMissing = new RequestScopedHolder();
 
         $middleware = new OrgResolverMiddleware(
             $orgId,
@@ -42,6 +44,7 @@ final class OrgResolverMiddlewareTest extends TestCase
                     return null;
                 }
             },
+            $orgMissing,
         );
 
         $response = $middleware->process(
@@ -60,6 +63,8 @@ final class OrgResolverMiddlewareTest extends TestCase
 
         self::assertSame(200, $response->getStatusCode());
         self::assertSame(0, $orgId->get());
+        // A bypass route never names a tenant, so it is not a *missing* one (#1057).
+        self::assertFalse($orgMissing->isSet());
     }
 
     /**
@@ -72,6 +77,8 @@ final class OrgResolverMiddlewareTest extends TestCase
         $factory = new Psr17Factory();
         /** @var RequestScopedHolder<int> $orgId */
         $orgId = new RequestScopedHolder();
+        /** @var RequestScopedHolder<bool> $orgMissing */
+        $orgMissing = new RequestScopedHolder();
         $repository = new InMemoryOrganizationRepository();
         $repository->save(new Organization('My Shop', 'myshop', 'free', true));
 
@@ -80,6 +87,7 @@ final class OrgResolverMiddlewareTest extends TestCase
             $repository,
             new ProblemDetailsResponseFactory($factory, $factory),
             new PathPrefixResolutionStrategy(),
+            $orgMissing,
         );
 
         $capture = new class ($factory) implements RequestHandlerInterface {
@@ -108,6 +116,7 @@ final class OrgResolverMiddlewareTest extends TestCase
         // …and re-exposed for URL generation, alongside the resolved org.
         self::assertSame('/myshop', $capture->seen->getAttribute('nene2.base_prefix'));
         self::assertSame('myshop', $capture->seen->getAttribute('nene2.org.slug'));
+        self::assertFalse($orgMissing->isSet());
     }
 
     /**
@@ -119,12 +128,15 @@ final class OrgResolverMiddlewareTest extends TestCase
         $factory = new Psr17Factory();
         /** @var RequestScopedHolder<int> $orgId */
         $orgId = new RequestScopedHolder();
+        /** @var RequestScopedHolder<bool> $orgMissing */
+        $orgMissing = new RequestScopedHolder();
 
         $middleware = new OrgResolverMiddleware(
             $orgId,
             new InMemoryOrganizationRepository(),
             new ProblemDetailsResponseFactory($factory, $factory),
             new SubdomainResolutionStrategy('nene-records.com'),
+            $orgMissing,
         );
 
         $capture = new class ($factory) implements RequestHandlerInterface {
@@ -151,6 +163,8 @@ final class OrgResolverMiddlewareTest extends TestCase
         self::assertSame(0, $orgId->get()); // no-tenant sentinel
         self::assertNotNull($capture->seen);
         self::assertTrue($capture->seen->getAttribute('nene2.apex'));
+        // The apex is a real surface (landing / signup), not a missing tenant (#1057).
+        self::assertFalse($orgMissing->isSet());
     }
 
     public function testSubdomainUnknownTenantStill404s(): void
@@ -158,12 +172,15 @@ final class OrgResolverMiddlewareTest extends TestCase
         $factory = new Psr17Factory();
         /** @var RequestScopedHolder<int> $orgId */
         $orgId = new RequestScopedHolder();
+        /** @var RequestScopedHolder<bool> $orgMissing */
+        $orgMissing = new RequestScopedHolder();
 
         $middleware = new OrgResolverMiddleware(
             $orgId,
             new InMemoryOrganizationRepository(), // empty → "nope" not found
             new ProblemDetailsResponseFactory($factory, $factory),
             new SubdomainResolutionStrategy('nene-records.com'),
+            $orgMissing,
         );
 
         $response = $middleware->process(
@@ -181,5 +198,93 @@ final class OrgResolverMiddlewareTest extends TestCase
         );
 
         self::assertSame(404, $response->getStatusCode());
+        // #1057: the definite negative the single-origin edge layers read, so the
+        // 404 is not repainted as a 200 SPA shell for `/` and `/login`.
+        self::assertTrue($orgMissing->isSet());
+        self::assertTrue($orgMissing->get());
+    }
+
+    /**
+     * #1057: an inactive org is equally unserviceable. Its 403 never reaches the SPA
+     * shell today (the shell only fills 404s), but the flag must be consistent so a
+     * later change to that status — #973 proposes 404 — cannot silently reintroduce
+     * a 200 for a suspended tenant.
+     */
+    public function testInactiveTenantIsFlaggedAsUnserviceable(): void
+    {
+        $factory = new Psr17Factory();
+        /** @var RequestScopedHolder<int> $orgId */
+        $orgId = new RequestScopedHolder();
+        /** @var RequestScopedHolder<bool> $orgMissing */
+        $orgMissing = new RequestScopedHolder();
+        $repository = new InMemoryOrganizationRepository();
+        $repository->save(new Organization('Suspended', 'suspended', 'free', false));
+
+        $middleware = new OrgResolverMiddleware(
+            $orgId,
+            $repository,
+            new ProblemDetailsResponseFactory($factory, $factory),
+            new SubdomainResolutionStrategy('nene-records.com'),
+            $orgMissing,
+        );
+
+        $response = $middleware->process(
+            $factory->createServerRequest('GET', 'https://suspended.nene-records.com/'),
+            $this->passThrough($factory),
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertTrue($orgMissing->get());
+    }
+
+    /**
+     * #1057: a configuration gap is NOT a missing tenant. `org-not-resolved` means the
+     * deployment has no ORG_SLUG yet — flagging it would stop the SPA shell serving
+     * `/admin` and `/login`, locking the operator out of the surface they need to fix
+     * it. The 404 stays, the flag does not.
+     */
+    public function testUnconfiguredDeploymentIsNotFlaggedAsMissingOrg(): void
+    {
+        $factory = new Psr17Factory();
+        /** @var RequestScopedHolder<int> $orgId */
+        $orgId = new RequestScopedHolder();
+        /** @var RequestScopedHolder<bool> $orgMissing */
+        $orgMissing = new RequestScopedHolder();
+
+        $middleware = new OrgResolverMiddleware(
+            $orgId,
+            new InMemoryOrganizationRepository(),
+            new ProblemDetailsResponseFactory($factory, $factory),
+            new class () implements OrgResolutionStrategyInterface {
+                public function resolve(ServerRequestInterface $request): ?string
+                {
+                    return null; // e.g. EnvResolutionStrategy with no ORG_SLUG
+                }
+            },
+            $orgMissing,
+        );
+
+        $response = $middleware->process(
+            $factory->createServerRequest('GET', 'https://example.test/admin/dashboard'),
+            $this->passThrough($factory),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertFalse($orgMissing->isSet());
+    }
+
+    /** A handler that answers 200 for anything that gets past the middleware. */
+    private function passThrough(Psr17Factory $factory): RequestHandlerInterface
+    {
+        return new readonly class ($factory) implements RequestHandlerInterface {
+            public function __construct(private Psr17Factory $factory)
+            {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->factory->createResponse(200);
+            }
+        };
     }
 }


### PR DESCRIPTION
## 目的

org を廃止したホストが **HTML では 200 を返し続ける**のを止める（work order 玉2・due 2026-08-16）。

`ayane.nene-records.com` は 07-18 に org 廃止済みだが、hub 実測（08-09）で:

| 経路 | before | after |
|---|---|---|
| `GET /`（`Accept: text/html`） | 🔴 **200** SPA シェル 1,661B | 🟢 **404** |
| `GET /login` `/admin/x` `/search` | 🔴 **200** SPA シェル | 🟢 **404** |
| `GET /api/health` | ✅ 404 `org-not-found` | ✅ 404（不変） |

**「HTML なら 200」は死活監視が最も引っかかる形**で、07-31 の第32回検収で実際に偽緑を作っている。

## 変更点

### 原因は org 解決ではなくエッジ層だった

`OrgResolverMiddleware` は org 不在時に**正しく 404 を返せていた**。それを外側の
`SpaShellFallback` が塗り替えていた（`src/Http/SpaShellFallback.php:114`）:

```php
$status = ($response->getStatusCode() === 404 && $path !== '/' && preg_match(self::SPA_APP_ROUTES, $path) !== 1)
    ? 404 : 200;
```

`/` は第2項で、`/login` `/admin/...` `/search` `/signup` は第3項で 200 に落ちる。
`/api/...` だけ `PASSTHROUGH` で素通りしていた——**API だけ正しく見えていた理由がこれ**。
シェル層は「org が存在しない」と「ルータが知らないパス」を**区別する手段を持っていなかった**。

### 直し方

org 解決の**確定的な否定**（解決子は取れたが org が無い／非活性）を運ぶ request-scoped
フラグを `OrgResolverMiddleware` が立て、`SingleOriginKernel` が読む。立っていれば
エッジ層5段（custom permalink → 301 マップ → type archive → front page → SPA シェル）を
**全て素通り**し、パイプラインの答えをそのまま返す。

- `org_id` holder と同じ既存パターン。`SingleOriginKernel` の docblock が元から
  「エッジ層は同一リクエスト内の request-scoped な org コンテキストを読む」と明言している
- シェル層だけでなく**カーネルで止める**のが正。permalink / 301 / archive / front page も
  全て org スコープの DB 参照で、テナントが居ないなら**引く先が無い**（マッチしないのではなく、走らせない）

### 意図的に対象外にしたもの

🔴 **`org-not-resolved`（`ORG_SLUG` 未設定などの設定不備）にはフラグを立てない。**
ここまで塞ぐと**未設定のインストールが `/admin` と `/login` に到達できなくなり、
直すための面から締め出される**。塞ぐのは `org-not-found` と `org-inactive` に限る。

🟡 **非活性 org（403）にもフラグは立てる。** 現状 403 はシェルに届かない（シェルは 404 しか
埋めない）が、**#973 が提案する 404 化で「停止中テナントの 200」が黙って復活しない**ようにするため。

🟡 **ステータスは 404 のまま**（410 にしない）。org 行が消えている以上、アプリからは
「元々無い」と「消えた」を区別できず、410 を名乗る根拠が無い。

### DNS 削除との関係

**代替関係ではない。** 生存条件は Caddy の `*.nene-records.com` ワイルドカード＋on-demand TLS
なので DNS を消せばこのホストは落ちるが、**次に org を廃止したとき同じ形が生まれる**。
本 PR は根治側、DNS 削除（board 行110・`@hide`）は個別対処側で、**両方要る**。

## 検証

```
composer check   # 🟢 1643 tests / 4964 assertions・PHPStan level 8・CS-Fixer・OpenAPI・MCP catalog
npm run check --prefix frontend   # 🟢（フロント無変更・退行が無いことの確認）
```

### 回帰テストが「直る前は落ちる」ことの確認

作業中に**未適用の `src/` に対してテストを走らせる事故**が起き、結果的に before 状態の
実測になった。新規テストのうち

- `testMissingOrgKeepsTheHardNotFoundAtRoot`（200 ≠ 404）
- `testMissingOrgKeepsTheHardNotFoundOnClientRoutedSurfaces`（`/login` で 200 ≠ 404）
- `testMissingOrgSkipsTheOrgScopedEdgeLayers`（200 ≠ 404）
- `testSubdomainUnknownTenantStill404s` のフラグ表明（false ≠ true）

が**実際に落ちた**。空振りテストではない。

### 追加したテスト

| テスト | 守るもの |
|---|---|
| `SingleOriginKernelTest::testMissingOrgKeepsTheHardNotFoundAtRoot` | `/` の 200 |
| `〃::testMissingOrgKeepsTheHardNotFoundOnClientRoutedSurfaces` | `SPA_APP_ROUTES` 4面の 200（`/` とは別分岐なので別テスト） |
| `〃::testMissingOrgSkipsTheOrgScopedEdgeLayers` | 301 / permalink が走らないこと |
| `〃::testMissingOrgLeavesTheInactiveTenantForbiddenIntact` | 403 を飲み込まない |
| `〃::testUnflaggedRequestsStillGetTheShell` | 未設定インストールの `/admin` 到達性 |
| `OrgResolverMiddlewareTest::testInactiveTenantIsFlaggedAsUnserviceable` | #973 の将来変更への保険 |
| `〃::testUnconfiguredDeploymentIsNotFlaggedAsMissingOrg` | 設定不備を dead tenant 扱いしない |
| 既存3テストに `assertFalse($orgMissing->isSet())` を追加 | bypass / apex / 正常解決で誤発火しない |

### 本番反映後に確認すること（施主 GO 後）

```bash
curl -sS -o /dev/null -w '%{http_code}\n' -H 'Accept: text/html' https://ayane.nene-records.com/        # 404 を期待
curl -sS -o /dev/null -w '%{http_code}\n' -H 'Accept: text/html' https://ayane.nene-records.com/login   # 404 を期待
curl -sS -o /dev/null -w '%{http_code}\n' -H 'Accept: text/html' https://records.nene-suite.com/        # 200 のまま（退行が無いこと）
```

🔴 **plain curl は公開サイトについて嘘をつく**ので `Accept: text/html` を必ず付ける。
🔴 **opcache があるので、本番で before/after を測るならアプリコンテナを再起動してから**。

## チェックリスト

- [x] Issue 紐付け（#1057）
- [x] `composer check` 緑
- [x] `npm run check --prefix frontend` 緑
- [x] 回帰テストが修正前には落ちることを実測
- [x] 正常テナントの挙動が変わらないことをテストで固定
- [ ] **マージは施主 GO 待ち**（hub 一報済み）

Closes #1057
