### PR TITLE
ci: Frontend CI に週次 schedule ハーネスを追加

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -8,6 +8,28 @@ on:
     branches:
       - main
 
+  # 週次 schedule（フリート横断配布・第1波）。
+  # 🔴 既知の限界: public リポの scheduled workflow は 60 日間リポジトリ活動が
+  # 無いと GitHub 側で自動的に無効化される（公式ドキュメント）。休眠が続くと
+  # 「配ったのに動いていない」が静かに起きる。復旧にはこの workflow を re-enable
+  # するか、何らかのコミットで活動を起こす必要がある。
+  schedule:
+    - cron: '25 0 * * 1' # 月曜 00:25 UTC = 09:25 JST（フリート内で艦ごとに分をずらして同時発火を回避）
+
+  # 手動トリガー（simulate_failure で通知経路を検証できる）
+  workflow_dispatch:
+    inputs:
+      simulate_failure:
+        description: '意図的に check を失敗させ、失敗通知の経路を検証する'
+        type: boolean
+        default: false
+
+# event_name を含めないと、schedule / workflow_dispatch の実行が push の実行に
+# cancel-in-progress で巻き込まれて消える（設定は正しく見えるのに走らない）。
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
   frontend-check:
     runs-on: ubuntu-latest
@@ -25,6 +47,10 @@ jobs:
           node-version: '22'
           cache: npm
           cache-dependency-path: frontend/package-lock.json
+
+      - name: Simulate failure (validation only)
+        if: inputs.simulate_failure
+        run: exit 1
 
       - name: Install dependencies
         run: npm ci
@@ -48,3 +74,28 @@ jobs:
       # allowlist に無い high/critical は fail。config = frontend/audit-ci.jsonc
       - name: Audit (fail on high/critical)
         run: npm run audit
+
+  notify-failure:
+    name: Open an issue when the scheduled run fails
+    if: failure() && (github.event_name == 'schedule' || inputs.simulate_failure)
+    needs: [frontend-check]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      ISSUE_TITLE: '🔴 週次 CI（schedule）が失敗しています — nene-records'
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Create or update the failure issue
+        run: |
+          set -euo pipefail
+          existing="$(gh issue list --state open --limit 100 --json number,title \
+            | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
+          body="週次の schedule 実行が失敗しました。 実行: ${RUN_URL}"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$body"
+          fi


### PR DESCRIPTION
## 何を足したか

フリート横断の週次 CI ハーネス配布（第1波）。正典: `_work/handoff-nene2-python-2026-08-12-schedule-rollout-note.md`。

- **本体 CI の選定**: `frontend-ci.yml` を「本体の CI」として選んだ。理由は依存監査（`npm run audit` = `audit-ci --config audit-ci.jsonc`）を含んでいるのがこの workflow だからで、`backend-ci.yml` には composer audit 等の依存監査ステップが無い。
- **デプロイ workflow の除外**: 本リポの `.github/workflows/` には CI 用の2ファイル（`backend-ci.yml` / `frontend-ci.yml`）しか存在せず、デプロイ用 workflow 自体が無い。`docs/deployment.md` によれば本番デプロイは `docker compose` ベースの手動運用であり GitHub Actions 経由ではないため、「週次で本番デプロイが走る」事故は構造的に起こり得ない。
- **3点セット**: `schedule`（`25 0 * * 1`）／`workflow_dispatch`（`simulate_failure` 入力つき）／`concurrency`（group に `github.event_name` を含める）。
- **踏み台**: `frontend-check` ジョブ先頭に `Simulate failure (validation only)` ステップ（`if: inputs.simulate_failure` / `run: exit 1`）。
- **notify-failure ジョブ**: 正典からそのまま転記。`needs: [frontend-check]`（本リポの実ジョブ名に差し替え）。`GH_REPO` を渡し、`ISSUE_TITLE` に艦名（nene-records）を入れた。

## 割り当て cron

`25 0 * * 1`（月曜 00:25 UTC = 09:25 JST）。フリート内で艦ごとに分をずらして同時発火を回避（既使用: 00=origin/fleet-tooling, 30=nene2-python, 40=records-commercial, 05=clear, 10=deal, 15=field, 20=payout）。

## 60日自動無効化の限界

public リポの scheduled workflow は GitHub 側の仕様で、60日間リポジトリ活動が無いと自動的に無効化される。休眠が続くと「配ったのに動いていない」が静かに起きうる。workflow ファイル内にコメントで明記済み。リポジトリの外から見る横断ポーリングは別途 hub 側で検討中。

## 変更していないもの

既存のジョブ本体・テスト・アプリコード・デプロイ設定・`backend-ci.yml` には一切触れていない。

## 検証（マージ後に実施予定）

- [ ] `workflow_dispatch`（通常）→ 緑
- [ ] `workflow_dispatch -f simulate_failure=true` → 失敗し Issue が新規起票される
- [ ] 検証用 Issue に意図的失敗である旨を明記して close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>