### PR TITLE
chore(deps): league/commonmark を 2.10.0 へ lock only で更新し、backend CI に composer audit を追加

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
+      - name: composer audit
+        run: composer audit --no-interaction
+
       - name: Prepare environment
         run: cp .env.example .env
 

--- a/composer.lock
+++ b/composer.lock
@@ -754,7 +754,7 @@
             "dist": {
                 "type": "path",
                 "url": "../NENE2",
-                "reference": "54cb3b5e2596d09396b8bc4b1a7030f80ff22931"
+                "reference": "a678bf8f1d6a958014b74b7b2a91267d97794d83"
             },
             "require": {
                 "monolog/monolog": "^3.0",
@@ -775,6 +775,7 @@
                 "symfony/yaml": "^8.0"
             },
             "suggest": {
+                "robmorgan/phinx": "Required by Nene2\\Install\\DatabaseSchemaApplier. A consumer that uses it MUST add phinx to its require (NOT require-dev) — it is here only as a dev dependency, so a --no-dev production build would omit it and installs would fatally fail when applying migrations.",
                 "symfony/yaml": "Required to run validate-mcp-tools.php from a consumer project (add to your require-dev)"
             },
             "type": "library",
@@ -822,8 +823,17 @@
                 "mcp": [
                     "php tools/validate-mcp-tools.php"
                 ],
+                "conformance": [
+                    "php tools/conformance.php --fleet"
+                ],
                 "version:check": [
                     "php tools/validate-version.php"
+                ],
+                "i18n:check": [
+                    "php tools/i18n-freshness.php"
+                ],
+                "i18n:baseline": [
+                    "php tools/i18n-freshness.php --write-baseline"
                 ],
                 "migrations:status": [
                     "phinx status -c phinx.php"
@@ -843,6 +853,7 @@
                     "@cs",
                     "@openapi",
                     "@mcp",
+                    "@conformance",
                     "@version:check"
                 ]
             },
@@ -856,16 +867,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.2",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
                 "shasum": ""
             },
             "require": {
@@ -887,8 +898,8 @@
                 "github/gfm": "0.29.0",
                 "michelf/php-markdown": "^1.4 || ^2.0",
                 "nyholm/psr7": "^1.5",
-                "phpstan/phpstan": "^1.8.2",
-                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "phpstan/phpstan": "^2.0.0",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0 || ^12.0.0 || ^13.0.0",
                 "scrutinizer/ocular": "^1.8.1",
                 "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
                 "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
@@ -902,7 +913,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.9-dev"
+                    "dev-main": "2.11-dev"
                 }
             },
             "autoload": {
@@ -959,7 +970,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-19T13:16:38+00:00"
+            "time": "2026-08-11T16:06:25+00:00"
         },
         {
             "name": "league/config",
@@ -1481,16 +1492,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.4",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
-                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "url": "https://api.github.com/repos/nette/utils/zipball/b043439dbdf954e6c28b5ea7e34b0100f83165e0",
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0",
                 "shasum": ""
             },
             "require": {
@@ -1510,7 +1521,7 @@
             },
             "suggest": {
                 "ext-gd": "to use Image",
-                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-iconv": "to use Strings::chr(), ord() and reverse()",
                 "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
                 "ext-json": "to use Nette\\Utils\\Json",
                 "ext-mbstring": "to use Strings::lower() etc...",
@@ -1566,9 +1577,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.4"
+                "source": "https://github.com/nette/utils/tree/v4.1.5"
             },
-            "time": "2026-05-11T20:49:54+00:00"
+            "time": "2026-07-17T23:02:45+00:00"
         },
         {
             "name": "nyholm/psr7",
@@ -2568,16 +2579,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -2615,7 +2626,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -2635,7 +2646,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:52:40+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/event-dispatcher",


### PR DESCRIPTION
## 背景

2026-08-06 付で `league/commonmark` の advisory が6件公開された（`composer audit` 実測）:

| Severity | Advisory ID | Title | Affected |
|---|---|---|---|
| high | PKSA-cqd6-fg4n-nxpf | DoS via colliding heading slugs | `>=2.0.0,<2.9.0` |
| high | PKSA-1q6p-sqkj-8mmj | DoS via duplicate footnote definitions | `>=1.5.0,<2.9.0` |
| high | PKSA-mc58-w91n-f5gv | DoS via adjacent inline attribute blocks | `>=1.5.0,<2.9.0` |
| high | PKSA-t21r-vtr5-3mdz (CVE-2026-71488) | Quadratic-time DoS parsing crafted Markdown | `>=0.6.0,<2.9.0` |
| medium | PKSA-5mzr-szzf-z6cn | DoS via deeply nested XML output | `>=2.0.0,<2.9.0` |
| medium | PKSA-scnn-p8mm-jbft (CVE-2026-71478) | AttributesExtension href/src filter bypass via control bytes | `>=1.5.0,<=2.8.3` |

`composer.json` の `"league/commonmark": "^2.7"` は直接依存で、最新の 2.10.0 は caret 範囲内。
そのため `composer.lock` のみで解消できた（`composer.json` は無変更）。

## 変更

1. `composer update league/commonmark --with-dependencies --no-interaction` を実行し、
   `composer.lock` を更新（2.8.2 → 2.10.0）。`composer.json` に差分なし。
   - 併せて commonmark の推移依存（`nette/utils`・`symfony/deprecation-contracts`）と、
     path repository で管理している `hideyukimori/nene2`（`../NENE2` の dev-main HEAD）の
     ロック参照も更新された。後者は path repository の性質上、lock 再生成のたびに
     ローカルの現在 HEAD が反映されるための副作用で、今回の意図した変更ではない。
   - `composer audit` は 6件 → **0件**を確認。
2. `.github/workflows/backend-ci.yml` の `composer install` の直後に、独立した
   `composer audit` ステップを追加。既存ステップの中身は変更していない
   （`composer check` スクリプトには埋め込まず、CI ログ上で単独の結果として見えるようにした）。
   - フリート16リポで PHP 側の依存脆弱性監査が CI に配線されていなかったため
     （npm 側は `audit-ci` で導入済み・#1038）、この艦を起点に追加する。

Closes #1061

## 検証

- [x] `git diff --name-only`（変更前）が `composer.lock` のみだったことを確認 → CI ステップ追加のため最終的に `.github/workflows/backend-ci.yml` も含む2ファイル
- [x] `composer audit --format=plain`: 更新前 6件 → 更新後 0件
- [x] `.github/workflows/backend-ci.yml` の YAML 構文チェック OK
- [ ] CI 全緑を確認後、マージ

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)