### PR TITLE
feat(public): trusted-embed を本文の任意位置へ置けるようにする（#937）

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -7001,7 +7001,11 @@ components:
           enum: [recent-posts, menu, toc, search, tag-cloud, popular-posts, calendar, trusted-embed]
         region:
           type: string
-          enum: [header, sidebar, aside, footer]
+          enum: [header, sidebar, aside, footer, inline]
+          description: >-
+            Layout region the widget is placed into. `inline` is not a place on the
+            page: the widget renders only where an `html` field's body references it
+            with a `<div data-nene-embed="<id>"></div>` marker (#937).
         display_order:
           type: integer
           minimum: 0
@@ -7041,7 +7045,11 @@ components:
           enum: [recent-posts, menu, toc, search, tag-cloud, popular-posts, calendar, trusted-embed]
         region:
           type: string
-          enum: [header, sidebar, aside, footer]
+          enum: [header, sidebar, aside, footer, inline]
+          description: >-
+            Layout region the widget is placed into. `inline` is not a place on the
+            page: the widget renders only where an `html` field's body references it
+            with a `<div data-nene-embed="<id>"></div>` marker (#937).
         display_order:
           type: integer
           minimum: 0

--- a/docs/security/trusted-embed.md
+++ b/docs/security/trusted-embed.md
@@ -86,6 +86,15 @@ re-validated settings — never from anything in the authored HTML. Authored mar
 choose *where* an embed goes; it can never choose *what* it is. A raw `<script>` in an
 `html` field is still stripped unconditionally, exactly as before.
 
+**Where the `div`-only rule actually lives.** On the SSR side the sanitizer enforces it
+(`allowAttribute(..., ['div'])`). On the SPA side it does **not**: DOMPurify keeps
+`data-*` on any element by default (`ALLOW_DATA_ATTR`), so the `data-nene-embed` entry
+in its `ADD_ATTR` list is currently a **no-op** — it only becomes load-bearing if that
+default is ever turned off. What holds the two sides together today is the *consumer*:
+`InlineTrustedEmbedHtml` checks the element itself (`tagName === 'DIV'`, no children)
+before it will place anything. If you change either sanitizer, that check — not the
+sanitizer config — is what keeps SSR and SPA agreeing on what a marker is.
+
 ## SRI runbook — keep the integrity hash in sync with the script
 
 Subresource Integrity pins the embed to an exact file. **If the self-owned script

--- a/docs/security/trusted-embed.md
+++ b/docs/security/trusted-embed.md
@@ -8,6 +8,8 @@ operational rules that keep it safe. Introduced across two phases:
 - **Phase 2** — the first-party `trusted-embed` widget emits the actual
   `<script src integrity crossorigin="anonymous" async>`, gated by the allowlist,
   on both the SSR shell and the SPA.
+- **Phase 3** (#937) — the same vetted embed can be placed at an **arbitrary point
+  inside a page's content**, via an inert marker, without relaxing the sanitizer.
 
 The content sanitizer is **never** relaxed: user-authored HTML still cannot carry a
 `<script>`. Embeds only come from this typed, admin-vetted path.
@@ -45,6 +47,44 @@ third, separate layer.
 
 Any failure ⇒ the embed is **not rendered** (and, on save, the admin gets a
 field-level error). A misconfiguration fails closed.
+
+## Placement: chrome regions vs inline (#937)
+
+A `trusted-embed` widget renders in one of two ways, decided by its **region**:
+
+| Region | Where it renders |
+|---|---|
+| `header` / `sidebar` / `aside` / `footer` | In that part of the site chrome, like any other widget. |
+| `inline` | **Nowhere on its own.** Only where a page's content references it by marker. |
+
+To place an embed inside the body of an `html` field, park the widget in the
+`inline` region and write the marker where you want it:
+
+```html
+<p>…copy…</p>
+<div data-nene-embed="12"></div>
+<p>…more copy…</p>
+```
+
+`12` is the widget's id (shown in the admin widget board). The rules are strict and
+identical on the SSR and SPA paths — a marker that breaks any of them renders nothing:
+
+- the marker must be a **`div`**, and it must be **empty** (`<div …></div>`);
+- the referenced widget must exist, be a `trusted-embed`, and be in the **`inline`**
+  region (a region-placed widget already renders in its region — honouring a marker
+  for it would load the same script twice);
+- its settings must pass every rule in *What is validated* above, allowlist included;
+- the same widget is emitted **at most once** per document, even if the marker is
+  repeated.
+
+### Why this is not a hole in the sanitizer
+
+The only concession is that the `data-nene-embed` **attribute** survives sanitizing on
+`div`. That attribute is inert: it carries no URL, no integrity hash and no code. The
+`<script>` itself is rebuilt **after** sanitizing, from the widget's stored,
+re-validated settings — never from anything in the authored HTML. Authored markup can
+choose *where* an embed goes; it can never choose *what* it is. A raw `<script>` in an
+`html` field is still stripped unconditionally, exactly as before.
 
 ## SRI runbook — keep the integrity hash in sync with the script
 

--- a/frontend/src/features/manage-widgets/ui/WidgetRegionBoard.tsx
+++ b/frontend/src/features/manage-widgets/ui/WidgetRegionBoard.tsx
@@ -29,6 +29,10 @@ const REGION_FLOW: Record<WidgetRegion, 'row' | 'col'> = {
   sidebar: 'col',
   aside: 'col',
   footer: 'col',
+  // `inline` is not a column on the page (#937): it is a holding area whose
+  // widgets render wherever an html field's marker calls them. It still lists
+  // and reorders like a stacked region here.
+  inline: 'col',
 }
 
 export function WidgetRegionBoard({
@@ -113,7 +117,11 @@ export function WidgetRegionBoard({
     const list = byRegion(region)
     const flow = REGION_FLOW[region]
     const cond =
-      region === 'sidebar' || region === 'aside' ? t(`admin.layout.cond.${region}`) : null
+      region === 'sidebar' || region === 'aside'
+        ? t(`admin.layout.cond.${region}`)
+        : region === 'inline'
+          ? t('admin.widgets.board.inlineNote')
+          : null
 
     const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
       if (!dnd || getDragPayload() === null) return
@@ -235,6 +243,8 @@ export function WidgetRegionBoard({
       </div>
 
       {renderRegion('footer')}
+
+      {renderRegion('inline')}
     </Stack>
   )
 }

--- a/frontend/src/features/public-view-entity-record/ui/PublicRecordFieldList.tsx
+++ b/frontend/src/features/public-view-entity-record/ui/PublicRecordFieldList.tsx
@@ -1,7 +1,8 @@
 import type { Entity } from '@/entities/entity'
 import { parseBundleDocument } from '@/shared/lib/bundle-document'
 import { isMarkdownBodyField } from '@/shared/lib/is-markdown-body-field'
-import { SandboxedBundle, SanitizedHtml, Text } from '@/shared/ui'
+import { InlineTrustedEmbedHtml } from '@/features/render-widgets'
+import { SandboxedBundle, Text } from '@/shared/ui'
 import { BlocksRenderer } from '@/shared/ui/blocks'
 import { PublicMarkdownContent } from '@/shared/ui/markdown'
 import type { PublicFieldRow } from '../model/use-public-view-entity-record-page'
@@ -60,7 +61,7 @@ export function PublicRecordFieldList({
         if (row.dataType === 'html') {
           return (
             <div key={row.fieldKey} className="prose">
-              <SanitizedHtml html={row.displayValue === '—' ? '' : row.displayValue} />
+              <InlineTrustedEmbedHtml html={row.displayValue === '—' ? '' : row.displayValue} />
             </div>
           )
         }

--- a/frontend/src/features/render-widgets/index.ts
+++ b/frontend/src/features/render-widgets/index.ts
@@ -1,2 +1,4 @@
+export { InlineTrustedEmbedHtml } from './ui/InlineTrustedEmbedHtml'
+export type { InlineTrustedEmbedHtmlProps } from './ui/InlineTrustedEmbedHtml'
 export { SiteWidgetBody, SiteWidgets } from './ui/SiteWidgets'
 export { PageContentContext, usePageContent } from './page-content-context'

--- a/frontend/src/features/render-widgets/ui/InlineTrustedEmbedHtml.test.tsx
+++ b/frontend/src/features/render-widgets/ui/InlineTrustedEmbedHtml.test.tsx
@@ -1,0 +1,157 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PublicSettingItem } from '@/entities/setting'
+import type { Widget } from '@/entities/widget'
+
+// Control the org's public settings + widgets (the two sources the placement
+// resolves against) without the network. The parsing/validation stays real.
+let settingsItems: PublicSettingItem[] = []
+let widgetItems: Widget[] = []
+
+vi.mock('@/entities/setting', async (importActual) => {
+  const actual = await importActual<typeof import('@/entities/setting')>()
+  return { ...actual, usePublicSettings: () => ({ data: { items: settingsItems } }) }
+})
+vi.mock('@/entities/widget', async (importActual) => {
+  const actual = await importActual<typeof import('@/entities/widget')>()
+  return { ...actual, usePublicWidgets: () => ({ data: { items: widgetItems } }) }
+})
+
+const { InlineTrustedEmbedHtml } = await import('./InlineTrustedEmbedHtml')
+
+afterEach(cleanup)
+
+const ORIGIN = 'https://widgets.example.com'
+
+const VALID: Record<string, unknown> = {
+  origin: ORIGIN,
+  src: `${ORIGIN}/form.js`,
+  integrity: 'sha384-abcDEF123+/=',
+}
+
+function setAllowlist(origins: string[]): void {
+  settingsItems = [{ settingKey: 'embed_allowlist', value: JSON.stringify(origins) }]
+}
+
+function setWidgets(...widgets: Partial<Widget>[]): void {
+  widgetItems = widgets.map((w, i) => ({
+    id: i + 1,
+    widgetType: 'trusted-embed',
+    region: 'inline',
+    displayOrder: 0,
+    title: null,
+    settings: VALID,
+    createdAt: '',
+    updatedAt: '',
+    ...w,
+  }))
+}
+
+const marker = (id = 1): string => `<div data-nene-embed="${String(id)}"></div>`
+
+describe('InlineTrustedEmbedHtml', () => {
+  it('injects the validated script at the marker position', () => {
+    setAllowlist([ORIGIN])
+    setWidgets({ id: 1 })
+    const { container } = render(<InlineTrustedEmbedHtml html={`<p>a</p>${marker()}<p>b</p>`} />)
+
+    const script = container.querySelector('[data-nene-embed="1"] script')
+    expect(script).not.toBeNull()
+    expect(script?.getAttribute('src')).toBe(`${ORIGIN}/form.js`)
+    expect(script?.getAttribute('integrity')).toBe('sha384-abcDEF123+/=')
+    expect(script?.getAttribute('crossorigin')).toBe('anonymous')
+    expect(script?.hasAttribute('async')).toBe(true)
+    // The surrounding prose is untouched.
+    expect(container.querySelectorAll('p')).toHaveLength(2)
+  })
+
+  it('emits the data-* attributes from the widget settings', () => {
+    setAllowlist([ORIGIN])
+    setWidgets({ id: 1, settings: { ...VALID, attributes: { 'data-form': 'ayane-contact' } } })
+    const { container } = render(<InlineTrustedEmbedHtml html={marker()} />)
+
+    expect(container.querySelector('script')?.getAttribute('data-form')).toBe('ayane-contact')
+  })
+
+  it('renders no script when the origin is not on the allowlist', () => {
+    setAllowlist(['https://other.example.org'])
+    setWidgets({ id: 1 })
+    const { container } = render(<InlineTrustedEmbedHtml html={marker()} />)
+
+    expect(container.querySelector('script')).toBeNull()
+  })
+
+  it('renders no script when the allowlist is empty', () => {
+    setAllowlist([])
+    setWidgets({ id: 1 })
+    const { container } = render(<InlineTrustedEmbedHtml html={marker()} />)
+
+    expect(container.querySelector('script')).toBeNull()
+  })
+
+  it('renders no script when the marker points at an unknown widget', () => {
+    setAllowlist([ORIGIN])
+    setWidgets({ id: 1 })
+    const { container } = render(<InlineTrustedEmbedHtml html={marker(99)} />)
+
+    expect(container.querySelector('script')).toBeNull()
+  })
+
+  it('does not honour a marker for a region-placed widget', () => {
+    // It already renders in its region; honouring the marker would double-load.
+    setAllowlist([ORIGIN])
+    setWidgets({ id: 1, region: 'footer' })
+    const { container } = render(<InlineTrustedEmbedHtml html={marker()} />)
+
+    expect(container.querySelector('script')).toBeNull()
+  })
+
+  it('renders no script when the SRI is missing', () => {
+    setAllowlist([ORIGIN])
+    const noSri: Record<string, unknown> = { ...VALID }
+    delete noSri['integrity']
+    setWidgets({ id: 1, settings: noSri })
+    const { container } = render(<InlineTrustedEmbedHtml html={marker()} />)
+
+    expect(container.querySelector('script')).toBeNull()
+  })
+
+  it('renders no script for a cross-origin src', () => {
+    setAllowlist([ORIGIN])
+    setWidgets({ id: 1, settings: { ...VALID, src: 'https://evil.example.com/form.js' } })
+    const { container } = render(<InlineTrustedEmbedHtml html={marker()} />)
+
+    expect(container.querySelector('script')).toBeNull()
+  })
+
+  it('emits the same widget only once even when the marker is repeated', () => {
+    setAllowlist([ORIGIN])
+    setWidgets({ id: 1 })
+    const { container } = render(<InlineTrustedEmbedHtml html={`${marker()}<p>x</p>${marker()}`} />)
+
+    expect(container.querySelectorAll('script')).toHaveLength(1)
+  })
+
+  it('ignores a marker that is not an empty div (SSR parity)', () => {
+    setAllowlist([ORIGIN])
+    setWidgets({ id: 1 })
+    const { container } = render(
+      <InlineTrustedEmbedHtml
+        html={'<div data-nene-embed="1">x</div><span data-nene-embed="1"></span>'}
+      />,
+    )
+
+    expect(container.querySelector('script')).toBeNull()
+  })
+
+  it('still strips an authored script tag from the body', () => {
+    setAllowlist([ORIGIN])
+    setWidgets({ id: 1 })
+    const { container } = render(
+      <InlineTrustedEmbedHtml html={`<script src="${ORIGIN}/form.js"></script><p>a</p>`} />,
+    )
+
+    expect(container.querySelector('script')).toBeNull()
+    expect(container.querySelector('p')?.textContent).toBe('a')
+  })
+})

--- a/frontend/src/features/render-widgets/ui/InlineTrustedEmbedHtml.tsx
+++ b/frontend/src/features/render-widgets/ui/InlineTrustedEmbedHtml.tsx
@@ -98,12 +98,15 @@ export function InlineTrustedEmbedHtml({ html, className }: InlineTrustedEmbedHt
       if (emitted.has(id)) {
         continue
       }
-      emitted.add(id)
 
       const embed = embeds.get(id)
       if (embed === undefined) {
         continue
       }
+
+      // Marked only once it actually resolved, so `emitted` means "emitted" and
+      // not "seen" — matching the SSR pass.
+      emitted.add(id)
 
       const script = document.createElement('script')
       // Content attributes, so the values are exactly what the browser's SRI +

--- a/frontend/src/features/render-widgets/ui/InlineTrustedEmbedHtml.tsx
+++ b/frontend/src/features/render-widgets/ui/InlineTrustedEmbedHtml.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { publicSettingsToMap, usePublicSettings } from '@/entities/setting'
+import { usePublicWidgets } from '@/entities/widget'
+import { INLINE_REGION } from '@/shared/lib/resolve-layout'
+import { SanitizedHtml } from '@/shared/ui'
+import {
+  type ResolvedTrustedEmbed,
+  parseEmbedAllowlist,
+  resolveTrustedEmbed,
+} from '../lib/trusted-embed'
+
+export interface InlineTrustedEmbedHtmlProps {
+  html: string
+  className?: string
+}
+
+/** `data-nene-embed="<id>"` — the inert marker, mirroring `TrustedEmbedPlacements::ATTRIBUTE`. */
+const MARKER_ATTRIBUTE = 'data-nene-embed'
+
+/** Widget ids are positive integers; anything else is not a placement. */
+const MARKER_ID_PATTERN = /^\d{1,18}$/
+
+/**
+ * The live SPA twin of `TrustedEmbedPlacements` (#937): renders an `html` field's
+ * sanitized body and turns each inline marker inside it —
+ * `<div data-nene-embed="12"></div>` — into the actual validated
+ * `<script src integrity crossorigin="anonymous" async>`, at that exact spot.
+ *
+ * This is the twin of the SSR path, and the two must agree rule for rule (the
+ * #891 family of bugs is what happens when they drift). Both:
+ *
+ * - honour the marker on **`div` only**, and only when it is **empty**;
+ * - resolve it to a `trusted-embed` widget in the **`inline` region** (a
+ *   region-placed widget already renders in its region — honouring a marker for
+ *   it would load the same script twice);
+ * - re-validate the widget's stored settings against the org's `embed_allowlist`
+ *   (origin allowlisted, `src` same-origin, SRI present, `data-*` only) and
+ *   render **nothing** if any rule fails;
+ * - emit a given widget **at most once** per document.
+ *
+ * As in `TrustedEmbedWidget`, nothing is ever built from the authored HTML: the
+ * markup only chooses *where*, the widget's re-validated settings decide *what*.
+ * React does not execute a `<script>` rendered in JSX, so the tag is created
+ * imperatively — which is also why the server-rendered copy is inert
+ * (`<noscript>`) and cannot double-load.
+ */
+export function InlineTrustedEmbedHtml({ html, className }: InlineTrustedEmbedHtmlProps) {
+  const { data: settings } = usePublicSettings()
+  const { data: widgets } = usePublicWidgets()
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // id → resolved embed, for inline-region trusted-embed widgets that pass every
+  // rule. Built once per settings/widgets change; the effect only places them.
+  const embeds = useMemo(() => {
+    const resolved = new Map<number, ResolvedTrustedEmbed>()
+    if (settings === undefined || widgets === undefined) {
+      return resolved
+    }
+    const allowlist = parseEmbedAllowlist(publicSettingsToMap(settings.items))
+    if (allowlist.length === 0) {
+      return resolved
+    }
+    for (const widget of widgets.items) {
+      if (widget.widgetType !== 'trusted-embed' || widget.region !== INLINE_REGION) {
+        continue
+      }
+      const embed = resolveTrustedEmbed(widget.settings, allowlist)
+      if (embed !== null) {
+        resolved.set(widget.id, embed)
+      }
+    }
+    return resolved
+  }, [settings, widgets])
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (container === null || embeds.size === 0) {
+      return
+    }
+
+    const injected: HTMLScriptElement[] = []
+    const emitted = new Set<number>()
+
+    for (const marker of container.querySelectorAll(`[${MARKER_ATTRIBUTE}]`)) {
+      // Twin rules with the SSR pass: `div` only, and empty only. DOMPurify keeps
+      // `data-*` on any element, so this check — not the sanitizer — is what makes
+      // the two sides agree on what counts as a placement.
+      if (marker.tagName !== 'DIV' || marker.childNodes.length > 0) {
+        continue
+      }
+
+      const raw = marker.getAttribute(MARKER_ATTRIBUTE) ?? ''
+      if (!MARKER_ID_PATTERN.test(raw)) {
+        continue
+      }
+
+      const id = Number(raw)
+      if (emitted.has(id)) {
+        continue
+      }
+      emitted.add(id)
+
+      const embed = embeds.get(id)
+      if (embed === undefined) {
+        continue
+      }
+
+      const script = document.createElement('script')
+      // Content attributes, so the values are exactly what the browser's SRI +
+      // CORS checks read (and what SSR emits), independent of IDL reflection.
+      script.setAttribute('src', embed.src)
+      script.setAttribute('integrity', embed.integrity)
+      script.setAttribute('crossorigin', 'anonymous')
+      script.setAttribute('async', '')
+      script.async = true
+      for (const [name, value] of Object.entries(embed.attributes)) {
+        script.setAttribute(name, value)
+      }
+      marker.appendChild(script)
+      injected.push(script)
+    }
+
+    return () => {
+      for (const script of injected) {
+        script.remove()
+      }
+    }
+  }, [embeds, html])
+
+  return (
+    <div ref={containerRef}>
+      <SanitizedHtml html={html} {...(className !== undefined ? { className } : {})} />
+    </div>
+  )
+}

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -2816,8 +2816,11 @@ export interface components {
             id: number;
             /** @enum {string} */
             widget_type: "recent-posts" | "menu" | "toc" | "search" | "tag-cloud" | "popular-posts" | "calendar" | "trusted-embed";
-            /** @enum {string} */
-            region: "header" | "sidebar" | "aside" | "footer";
+            /**
+             * @description Layout region the widget is placed into. `inline` is not a place on the page: the widget renders only where an `html` field's body references it with a `<div data-nene-embed="<id>"></div>` marker (#937).
+             * @enum {string}
+             */
+            region: "header" | "sidebar" | "aside" | "footer" | "inline";
             display_order: number;
             title: string | null;
             /** @description Widget-type-specific configuration. */
@@ -2835,8 +2838,11 @@ export interface components {
         CreateWidgetRequest: {
             /** @enum {string} */
             widget_type: "recent-posts" | "menu" | "toc" | "search" | "tag-cloud" | "popular-posts" | "calendar" | "trusted-embed";
-            /** @enum {string} */
-            region: "header" | "sidebar" | "aside" | "footer";
+            /**
+             * @description Layout region the widget is placed into. `inline` is not a place on the page: the widget renders only where an `html` field's body references it with a `<div data-nene-embed="<id>"></div>` marker (#937).
+             * @enum {string}
+             */
+            region: "header" | "sidebar" | "aside" | "footer" | "inline";
             /** @default 0 */
             display_order: number;
             title?: string | null;

--- a/frontend/src/shared/i18n/messages/de.ts
+++ b/frontend/src/shared/i18n/messages/de.ts
@@ -443,6 +443,8 @@ export const de = {
     'Widgets im Hauptbereich werden auf der öffentlichen Website nicht dargestellt.',
   'admin.widgets.board.addHere': '+ Hier hinzufügen',
   'admin.widgets.board.empty': 'Noch keine Widgets in diesem Bereich.',
+  'admin.widgets.board.inlineNote':
+    'Im Inhalt platziert. Ein Widget hier wird allein nicht gerendert — nur dort, wo ein html-Feld <div data-nene-embed="ID"></div> angibt.',
   'widgets.recentPosts.unconfigured': 'Kein Inhaltstyp konfiguriert.',
   'widgets.recentPosts.empty': 'Noch keine Beiträge.',
   'widgets.menu.empty': 'Noch keine Menüeinträge.',
@@ -1088,6 +1090,7 @@ export const de = {
   'admin.region.sidebar': 'Seitenleiste',
   'admin.region.aside': 'Randspalte',
   'admin.region.footer': 'Fußzeile',
+  'admin.region.inline': 'Im Inhalt (inline)',
   'admin.fieldDefs.displayOrder': 'Anzeigereihenfolge',
   'admin.entityStatus.publish': 'Veröffentlichen',
   'admin.entityStatus.publishedAt': 'Veröffentlicht {{date}}',

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -449,6 +449,8 @@ export const en = {
   'admin.widgets.board.mainNote': 'Widgets placed in main are not rendered on the public site.',
   'admin.widgets.board.addHere': '+ Add here',
   'admin.widgets.board.empty': 'No widgets in this region yet.',
+  'admin.widgets.board.inlineNote':
+    'Placed inside content. A widget here renders nowhere on its own — only where an html field says <div data-nene-embed="ID"></div>.',
   'widgets.recentPosts.unconfigured': 'No content type configured.',
   'widgets.recentPosts.empty': 'No posts yet.',
   'widgets.menu.empty': 'No menu items yet.',
@@ -1102,6 +1104,7 @@ export const en = {
   'admin.region.sidebar': 'Sidebar',
   'admin.region.aside': 'Aside',
   'admin.region.footer': 'Footer',
+  'admin.region.inline': 'In content (inline)',
   'admin.fieldDefs.displayOrder': 'Display order',
   'admin.entityStatus.publish': 'Publish',
   'admin.entityStatus.publishedAt': 'Published {{date}}',

--- a/frontend/src/shared/i18n/messages/fr.ts
+++ b/frontend/src/shared/i18n/messages/fr.ts
@@ -446,6 +446,8 @@ export const fr = {
     'Les widgets placés dans la zone principale ne sont pas rendus sur le site public.',
   'admin.widgets.board.addHere': '+ Ajouter ici',
   'admin.widgets.board.empty': 'Aucun widget dans cette région pour le moment.',
+  'admin.widgets.board.inlineNote':
+    'Placé dans le contenu. Un widget ici ne s\'affiche pas seul — uniquement là où un champ html indique <div data-nene-embed="ID"></div>.',
   'widgets.recentPosts.unconfigured': 'Aucun type de contenu configuré.',
   'widgets.recentPosts.empty': 'Aucun article pour le moment.',
   'widgets.menu.empty': 'Aucun élément de menu pour le moment.',
@@ -1111,6 +1113,7 @@ export const fr = {
   'admin.region.sidebar': 'Barre latérale',
   'admin.region.aside': 'Aparté',
   'admin.region.footer': 'Pied de page',
+  'admin.region.inline': 'Dans le contenu (en ligne)',
   'admin.fieldDefs.displayOrder': "Ordre d'affichage",
   'admin.entityStatus.publish': 'Publier',
   'admin.entityStatus.publishedAt': 'Publié le {{date}}',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -442,6 +442,8 @@ export const ja = {
   'admin.widgets.board.mainNote': 'main に置いたウィジェットは公開サイトでは描画されません。',
   'admin.widgets.board.addHere': '＋ ここに追加',
   'admin.widgets.board.empty': 'この領域にウィジェットはまだありません。',
+  'admin.widgets.board.inlineNote':
+    '本文内に置く領域。ここのウィジェットは単独では描画されず、html フィールドに <div data-nene-embed="ID"></div> と書いた位置にだけ出ます。',
   'widgets.recentPosts.unconfigured': 'コンテンツタイプが未設定です。',
   'widgets.recentPosts.empty': '投稿がまだありません。',
   'widgets.menu.empty': 'メニュー項目がまだありません。',
@@ -1101,6 +1103,7 @@ export const ja = {
   'admin.region.sidebar': 'サイドバー',
   'admin.region.aside': 'アサイド',
   'admin.region.footer': 'フッター',
+  'admin.region.inline': '本文内（インライン）',
   'admin.fieldDefs.displayOrder': '表示順',
   'admin.entityStatus.publish': '公開',
   'admin.entityStatus.publishedAt': '{{date}} に公開',

--- a/frontend/src/shared/i18n/messages/pt-BR.ts
+++ b/frontend/src/shared/i18n/messages/pt-BR.ts
@@ -443,6 +443,8 @@ export const ptBR = {
     'Widgets colocados na área principal não são renderizados no site público.',
   'admin.widgets.board.addHere': '+ Adicionar aqui',
   'admin.widgets.board.empty': 'Nenhum widget nesta região ainda.',
+  'admin.widgets.board.inlineNote':
+    'Colocado dentro do conteúdo. Um widget aqui não é renderizado sozinho — apenas onde um campo html indica <div data-nene-embed="ID"></div>.',
   'widgets.recentPosts.unconfigured': 'Nenhum tipo de conteúdo configurado.',
   'widgets.recentPosts.empty': 'Nenhum post ainda.',
   'widgets.menu.empty': 'Nenhum item de menu ainda.',
@@ -1101,6 +1103,7 @@ export const ptBR = {
   'admin.region.sidebar': 'Barra lateral',
   'admin.region.aside': 'Lateral',
   'admin.region.footer': 'Rodapé',
+  'admin.region.inline': 'No conteúdo (inline)',
   'admin.fieldDefs.displayOrder': 'Ordem de exibição',
   'admin.entityStatus.publish': 'Publicar',
   'admin.entityStatus.publishedAt': 'Publicado {{date}}',

--- a/frontend/src/shared/i18n/messages/zh-Hans.ts
+++ b/frontend/src/shared/i18n/messages/zh-Hans.ts
@@ -419,6 +419,8 @@ export const zhHans = {
   'admin.widgets.board.mainNote': '放在主栏的小部件不会在公共站点上渲染。',
   'admin.widgets.board.addHere': '＋ 在此添加',
   'admin.widgets.board.empty': '此区域还没有小部件。',
+  'admin.widgets.board.inlineNote':
+    '放在正文中。此处的挂件不会单独渲染——只在 html 字段写有 <div data-nene-embed="ID"></div> 的位置出现。',
   'widgets.recentPosts.unconfigured': '未配置内容类型。',
   'widgets.recentPosts.empty': '还没有文章。',
   'widgets.menu.empty': '还没有菜单项。',
@@ -1055,6 +1057,7 @@ export const zhHans = {
   'admin.region.sidebar': '侧边栏',
   'admin.region.aside': '边栏',
   'admin.region.footer': '页脚',
+  'admin.region.inline': '正文内（内联）',
   'admin.fieldDefs.displayOrder': '显示顺序',
   'admin.entityStatus.publish': '发布',
   'admin.entityStatus.publishedAt': '已于 {{date}} 发布',

--- a/frontend/src/shared/lib/resolve-layout.ts
+++ b/frontend/src/shared/lib/resolve-layout.ts
@@ -34,9 +34,25 @@ export const DEFAULT_REGION: ContentRegion = 'main'
  * regions, widgets place into the site chrome (header/footer) and side columns;
  * `main` is record content, not a widget target.
  */
-export type WidgetRegion = 'header' | 'sidebar' | 'aside' | 'footer'
+export type WidgetRegion = 'header' | 'sidebar' | 'aside' | 'footer' | 'inline'
 
-export const WIDGET_REGIONS: readonly WidgetRegion[] = ['header', 'sidebar', 'aside', 'footer']
+export const WIDGET_REGIONS: readonly WidgetRegion[] = [
+  'header',
+  'sidebar',
+  'aside',
+  'footer',
+  'inline',
+]
+
+/**
+ * `inline` is the one region that is not a place on the page (#937, mirrors
+ * `WidgetRegions::INLINE`): a widget parked there renders nowhere on its own and
+ * appears only where an `html` field's body references it with a
+ * `<div data-nene-embed="<id>"></div>` marker. Layout code must therefore never
+ * treat it as a column — the helpers below build from explicit column lists, and
+ * `SiteWidgets` filters by exact region, so it is excluded by construction.
+ */
+export const INLINE_REGION = 'inline' as const
 
 /** Regions each layout renders, in order (mirrors PublicLayouts::regions). */
 const LAYOUT_REGIONS: Record<PublicLayoutKey, readonly ContentRegion[]> = {

--- a/frontend/src/shared/ui/html/SanitizedHtml.tsx
+++ b/frontend/src/shared/ui/html/SanitizedHtml.tsx
@@ -17,8 +17,13 @@ export interface SanitizedHtmlProps {
  * an SSR/SPA parity break (#891 family). The reverse-tabnabbing surface that
  * justified stripping is closed by the hook below instead, which forces
  * `rel="noopener noreferrer"` onto every anchor that carries a `target`.
+ *
+ * `data-nene-embed` is listed for the same parity reason (#937): it is the inert
+ * marker that says *where* a vetted trusted-embed goes. It carries no URL and no
+ * script — `InlineTrustedEmbedHtml` is what turns a marker into a tag, and only
+ * from the widget's stored, re-validated settings.
  */
-const SANITIZE_CONFIG = { FORBID_TAGS: ['style'], ADD_ATTR: ['target'] }
+const SANITIZE_CONFIG = { FORBID_TAGS: ['style'], ADD_ATTR: ['target', 'data-nene-embed'] }
 
 DOMPurify.addHook('afterSanitizeAttributes', (node) => {
   if (node.tagName === 'A' && node.getAttribute('target') !== null) {

--- a/src/PublicRecord/PublicHtmlSanitizer.php
+++ b/src/PublicRecord/PublicHtmlSanitizer.php
@@ -27,6 +27,13 @@ final readonly class PublicHtmlSanitizer
             ->allowRelativeLinks()
             ->allowRelativeMedias()
             ->allowAttribute('style', '*')
+            // Inert placement marker for trusted embeds (#937): `data-nene-embed`
+            // survives on `div` so an author can say *where* a vetted embed goes.
+            // It carries no URL and no script — the tag itself is rebuilt from the
+            // widget's stored settings after this pass (see TrustedEmbedPlacements),
+            // so this is a positioning hook, never an execution path. `<script>`
+            // in an html field remains stripped unconditionally.
+            ->allowAttribute(TrustedEmbedPlacements::ATTRIBUTE, ['div'])
             // A full custom page body (a `bare`/custom page authored as one html
             // field) routinely exceeds Symfony's 20 KB default, which would
             // silently truncate the crawlable SSR mid-page. Raise the cap to a

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -184,12 +184,13 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
         // configured we skip the widget query entirely, so a page with no embed
         // configured does exactly what it did before — no extra work, no output.
         $embedAllowlist = EmbedAllowlist::fromSettings($settings);
+        $embedWidgets = [];
         $embedScripts = '';
         if (!$embedAllowlist->isEmpty()) {
-            $embedScripts = TrustedEmbedScripts::render(
-                $this->listWidgets->execute()->items,
-                $embedAllowlist,
-            );
+            // Fetched once and reused by both embed paths: the chrome regions
+            // (here) and inline markers inside html fields (renderHtml below).
+            $embedWidgets = $this->listWidgets->execute()->items;
+            $embedScripts = TrustedEmbedScripts::render($embedWidgets, $embedAllowlist);
         }
 
         // First-party floating CTA (#982): a fixed chrome button rendered verbatim into
@@ -343,7 +344,11 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
             'renderMarkdown' => static fn (string $markdown): string => PublicMarkdownRenderer::toSafeHtml($markdown),
             // html-typed fields (e.g. WXR-imported content): sanitize server-side so the
             // crawlable SSR shows the same trusted markup the SPA renders via DOMPurify.
-            'renderHtml' => fn (string $rawHtml): string => $this->htmlSanitizer->sanitize($rawHtml),
+            'renderHtml' => fn (string $rawHtml): string => TrustedEmbedPlacements::apply(
+                $this->htmlSanitizer->sanitize($rawHtml),
+                $embedWidgets,
+                $embedAllowlist,
+            ),
             // A bundle's crawlable twin (#311): render its seoText markdown server-side
             // (the sandboxed iframe itself is SPA-only / invisible to crawlers).
             'renderBundleSeo' => static fn (string $raw): string => PublicMarkdownRenderer::toSafeHtml(BundleDocumentValidator::seoTextOf($raw)),

--- a/src/PublicRecord/TrustedEmbedPlacements.php
+++ b/src/PublicRecord/TrustedEmbedPlacements.php
@@ -55,8 +55,12 @@ final class TrustedEmbedPlacements
 
     /**
      * An empty `div` carrying `data-nene-embed="<digits>"` among its attributes.
-     * `[^>]*` cannot run past the tag because the sanitizer escapes `>` inside
-     * attribute values to `&gt;` (verified) — so the match can never span tags.
+     *
+     * The match cannot span tags, and that holds **independently of what the
+     * sanitizer does**: `[^>]*` stops at the first `>` by construction, so the
+     * attribute run can never escape the tag it started in. Nothing here relies
+     * on how attribute values happen to be escaped upstream — swapping the
+     * sanitizer cannot invalidate this pattern.
      */
     private const MARKER_PATTERN =
         '#<div\b([^>]*\s)?' . self::ATTRIBUTE . '="(\d{1,18})"([^>]*)>\s*</div>#i';
@@ -89,11 +93,18 @@ final class TrustedEmbedPlacements
                 if (isset($emitted[$id])) {
                     return '';
                 }
-                $emitted[$id] = true;
 
                 $spec = self::resolve($id, $widgets, $allowlist);
+                if ($spec === null) {
+                    return '';
+                }
 
-                return $spec === null ? '' : TrustedEmbedScripts::inlineTagFor($spec);
+                // Marked only once it actually resolved, so `$emitted` means
+                // "emitted" and not "seen": a marker that fails to resolve stays
+                // a fresh decision for every later occurrence of the same id.
+                $emitted[$id] = true;
+
+                return TrustedEmbedScripts::inlineTagFor($spec);
             },
             $sanitizedHtml,
         );

--- a/src/PublicRecord/TrustedEmbedPlacements.php
+++ b/src/PublicRecord/TrustedEmbedPlacements.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use NeNeRecords\Http\EmbedAllowlist;
+use NeNeRecords\Widget\TrustedEmbedSettings;
+use NeNeRecords\Widget\Widget;
+use NeNeRecords\Widget\WidgetRegions;
+
+/**
+ * Inline placement for `trusted-embed` widgets (#937): lets an author drop a
+ * vetted embed at an **arbitrary point inside an `html` field's body**, instead
+ * of only into the site chrome regions {@see TrustedEmbedScripts} covers.
+ *
+ * The author writes a marker — nothing else:
+ *
+ * ```html
+ * <div data-nene-embed="12"></div>
+ * ```
+ *
+ * where `12` is the id of a `trusted-embed` widget in the
+ * {@see WidgetRegions::INLINE} region. The marker is *inert content*: it carries
+ * no script, no URL and no integrity hash, so it is safe to author, safe to
+ * import, and safe to leave in place when the widget is deleted.
+ *
+ * 🔑 **The sanitizer is not widened for scripts.** `<script>` in an `html` field
+ * is still stripped unconditionally by {@see PublicHtmlSanitizer} (and DOMPurify
+ * on the SPA side). The only concession is that the `data-nene-embed` attribute
+ * survives on `div` — an inert hook, not an execution path. Substitution happens
+ * **after** sanitizing, and the emitted tag is rebuilt by
+ * {@see TrustedEmbedScripts::tagFor()} from the widget's *stored, re-validated*
+ * settings — never from anything in the authored HTML. That is the same
+ * generation discipline as #802: raw input can choose *where* an embed goes, but
+ * never *what* it is.
+ *
+ * Every marker is resolved fail-closed. The marker is replaced with the empty
+ * string — leaving no trace and emitting no script — when the referenced widget
+ * does not exist, is not a `trusted-embed`, is not in the `inline` region, has
+ * malformed settings, or has an origin absent from the org's `embed_allowlist`.
+ * The same widget is emitted at most once per document even if referenced twice,
+ * so a duplicated marker cannot double-load the script.
+ *
+ * A marker with content inside it (`<div data-nene-embed="1">x</div>`) is
+ * deliberately **not** matched: only an empty marker is a placement. This keeps
+ * the substitution a single, well-defined token replacement with no nesting
+ * ambiguity, and leaves the rest of the document byte-for-byte untouched (no
+ * DOM round-trip, so established bespoke pages cannot be reflowed by this pass).
+ */
+final class TrustedEmbedPlacements
+{
+    /** The inert marker attribute; allowed on `div` only (see PublicHtmlSanitizer). */
+    public const ATTRIBUTE = 'data-nene-embed';
+
+    /**
+     * An empty `div` carrying `data-nene-embed="<digits>"` among its attributes.
+     * `[^>]*` cannot run past the tag because the sanitizer escapes `>` inside
+     * attribute values to `&gt;` (verified) — so the match can never span tags.
+     */
+    private const MARKER_PATTERN =
+        '#<div\b([^>]*\s)?' . self::ATTRIBUTE . '="(\d{1,18})"([^>]*)>\s*</div>#i';
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * Replace every inline marker in already-sanitized HTML with its validated
+     * embed tag. Returns the input unchanged when it holds no marker, when the
+     * org has no allowlist, or when no widget resolves.
+     *
+     * @param list<Widget> $widgets all of the org's widgets (any type / region)
+     */
+    public static function apply(string $sanitizedHtml, array $widgets, EmbedAllowlist $allowlist): string
+    {
+        if (!str_contains($sanitizedHtml, self::ATTRIBUTE)) {
+            return $sanitizedHtml;
+        }
+
+        $emitted = [];
+
+        $replaced = preg_replace_callback(
+            self::MARKER_PATTERN,
+            static function (array $m) use ($widgets, $allowlist, &$emitted): string {
+                $id = (int) $m[2];
+
+                // Emit a given widget at most once per document.
+                if (isset($emitted[$id])) {
+                    return '';
+                }
+                $emitted[$id] = true;
+
+                $spec = self::resolve($id, $widgets, $allowlist);
+
+                return $spec === null ? '' : TrustedEmbedScripts::inlineTagFor($spec);
+            },
+            $sanitizedHtml,
+        );
+
+        // preg_replace_callback returns null only on a PCRE failure (e.g. backtrack
+        // limit on pathological input). Fail closed to the sanitized input rather
+        // than emitting a half-substituted document.
+        return $replaced ?? $sanitizedHtml;
+    }
+
+    /**
+     * The validated spec of the inline `trusted-embed` widget with this id, or
+     * `null` when it does not resolve under every #802 rule.
+     *
+     * @param list<Widget> $widgets
+     */
+    private static function resolve(int $id, array $widgets, EmbedAllowlist $allowlist): ?TrustedEmbedSettings
+    {
+        if ($allowlist->isEmpty()) {
+            return null;
+        }
+
+        foreach ($widgets as $widget) {
+            if ($widget->id !== $id) {
+                continue;
+            }
+            if ($widget->widgetType !== 'trusted-embed') {
+                return null;
+            }
+            // Only widgets parked in the inline region are placeable by marker;
+            // a region-placed widget already renders in its region, and honouring
+            // a marker for it would double-load the script.
+            if ($widget->region !== WidgetRegions::INLINE) {
+                return null;
+            }
+
+            $spec = TrustedEmbedSettings::tryParse($widget->settings);
+            if ($spec === null) {
+                return null;
+            }
+
+            // Independent allowlist gate (the CSP is the other layer) — identical
+            // to the region path in TrustedEmbedScripts.
+            return in_array($spec->origin, $allowlist->origins(), true) ? $spec : null;
+        }
+
+        return null;
+    }
+}

--- a/src/PublicRecord/TrustedEmbedScripts.php
+++ b/src/PublicRecord/TrustedEmbedScripts.php
@@ -7,6 +7,7 @@ namespace NeNeRecords\PublicRecord;
 use NeNeRecords\Http\EmbedAllowlist;
 use NeNeRecords\Widget\TrustedEmbedSettings;
 use NeNeRecords\Widget\Widget;
+use NeNeRecords\Widget\WidgetRegions;
 
 /**
  * First-party server-side renderer for `trusted-embed` widgets (#802): turns a
@@ -61,6 +62,13 @@ final class TrustedEmbedScripts
                 continue;
             }
 
+            // Inline-region widgets are placed by a marker inside the content
+            // (#937, TrustedEmbedPlacements), not into the chrome. Emitting them
+            // here too would load the same script twice.
+            if ($widget->region === WidgetRegions::INLINE) {
+                continue;
+            }
+
             $spec = TrustedEmbedSettings::tryParse($widget->settings);
             if ($spec === null) {
                 continue;
@@ -81,6 +89,17 @@ final class TrustedEmbedScripts
         // Inert shell copy: present for parity + crawlable markup, never a second
         // execution (the SPA is the live runtime — see class docblock).
         return '<noscript data-nene-trusted-embed>' . implode('', $tags) . '</noscript>';
+    }
+
+    /**
+     * One validated embed, wrapped for inline placement inside an `html` field's
+     * body (#937). Same tag and the same inert `<noscript>` shell as the chrome
+     * path above — for the same reason: the SPA owns the live runtime, so the
+     * server-rendered copy must never be the one that executes.
+     */
+    public static function inlineTagFor(TrustedEmbedSettings $spec): string
+    {
+        return '<noscript data-nene-trusted-embed>' . self::tag($spec) . '</noscript>';
     }
 
     private static function tag(TrustedEmbedSettings $spec): string

--- a/src/Widget/WidgetRegions.php
+++ b/src/Widget/WidgetRegions.php
@@ -10,11 +10,20 @@ namespace NeNeRecords\Widget;
  * chrome and side columns: `header` and `footer` are site-wide bars, `sidebar`
  * and `aside` are the secondary columns of multi-column record layouts. `main`
  * is reserved for record content and is not a widget target.
+ *
+ * {@see INLINE} is the one region that is not a place on the page: a widget
+ * parked there renders **nowhere** on its own, and appears only where an `html`
+ * field's body references it by marker (#937 — see
+ * {@see \NeNeRecords\PublicRecord\TrustedEmbedPlacements}). It is what lets an
+ * embed sit at an arbitrary point in the content instead of in the chrome.
  */
 final class WidgetRegions
 {
+    /** Not a place on the page: rendered only where content references it by marker (#937). */
+    public const INLINE = 'inline';
+
     /** @var list<string> */
-    private const REGIONS = ['header', 'sidebar', 'aside', 'footer'];
+    private const REGIONS = ['header', 'sidebar', 'aside', 'footer', self::INLINE];
 
     public static function isValid(string $region): bool
     {

--- a/tests/PublicRecord/TrustedEmbedPlacementsTest.php
+++ b/tests/PublicRecord/TrustedEmbedPlacementsTest.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use NeNeRecords\Http\EmbedAllowlist;
+use NeNeRecords\PublicRecord\PublicHtmlSanitizer;
+use NeNeRecords\PublicRecord\TrustedEmbedPlacements;
+use NeNeRecords\Widget\Widget;
+use PHPUnit\Framework\TestCase;
+
+final class TrustedEmbedPlacementsTest extends TestCase
+{
+    private const ORIGIN = 'https://widgets.example.com';
+
+    /** @param array<string, mixed> $settings */
+    private function widget(
+        int $id,
+        string $type = 'trusted-embed',
+        string $region = 'inline',
+        ?array $settings = null,
+    ): Widget {
+        return new Widget(
+            id: $id,
+            widgetType: $type,
+            region: $region,
+            displayOrder: 0,
+            title: null,
+            settings: $settings ?? $this->validSettings(),
+            createdAt: '',
+            updatedAt: '',
+        );
+    }
+
+    /** @return array<string, mixed> */
+    private function validSettings(): array
+    {
+        return [
+            'origin' => self::ORIGIN,
+            'src' => self::ORIGIN . '/form.js',
+            'integrity' => 'sha384-abcDEF123+/=',
+        ];
+    }
+
+    private function allowlist(string $origin = self::ORIGIN): EmbedAllowlist
+    {
+        return EmbedAllowlist::fromSettings(['embed_allowlist' => json_encode([$origin], JSON_THROW_ON_ERROR)]);
+    }
+
+    private function marker(int $id = 1): string
+    {
+        return '<div data-nene-embed="' . $id . '"></div>';
+    }
+
+    // ---------------------------------------------------------------- happy path
+
+    public function testMarkerIsReplacedWithTheValidatedTag(): void
+    {
+        $html = TrustedEmbedPlacements::apply(
+            '<p>before</p>' . $this->marker() . '<p>after</p>',
+            [$this->widget(1)],
+            $this->allowlist(),
+        );
+
+        self::assertStringContainsString('<p>before</p>', $html);
+        self::assertStringContainsString('<p>after</p>', $html);
+        self::assertStringContainsString('<noscript data-nene-trusted-embed>', $html);
+        self::assertStringContainsString('src="' . self::ORIGIN . '/form.js"', $html);
+        self::assertStringContainsString('integrity="sha384-abcDEF123+/="', $html);
+        self::assertStringContainsString('crossorigin="anonymous"', $html);
+        self::assertStringNotContainsString('data-nene-embed', $html);
+    }
+
+    public function testTagIsEmittedAtTheMarkerPositionNotAppended(): void
+    {
+        $html = TrustedEmbedPlacements::apply(
+            '<p>a</p>' . $this->marker() . '<p>b</p>',
+            [$this->widget(1)],
+            $this->allowlist(),
+        );
+
+        self::assertLessThan(strpos($html, '<p>b</p>') ?: 0, strpos($html, '<script') ?: 0);
+        self::assertGreaterThan(strpos($html, '<p>a</p>') ?: 0, strpos($html, '<script') ?: 0);
+    }
+
+    public function testMarkerWithOtherAttributesStillResolves(): void
+    {
+        $html = TrustedEmbedPlacements::apply(
+            '<div style="text-align:center" data-nene-embed="1"></div>',
+            [$this->widget(1)],
+            $this->allowlist(),
+        );
+
+        self::assertStringContainsString('<script', $html);
+    }
+
+    public function testDataAttributesFromSettingsAreEmitted(): void
+    {
+        $settings = $this->validSettings();
+        $settings['attributes'] = ['data-form' => 'ayane-contact', 'data-trigger' => 'button'];
+
+        $html = TrustedEmbedPlacements::apply(
+            $this->marker(),
+            [$this->widget(1, settings: $settings)],
+            $this->allowlist(),
+        );
+
+        self::assertStringContainsString('data-form="ayane-contact"', $html);
+        self::assertStringContainsString('data-trigger="button"', $html);
+    }
+
+    // ---------------------------------------------------------------- fail closed
+
+    public function testUnknownWidgetIdRemovesTheMarker(): void
+    {
+        $html = TrustedEmbedPlacements::apply(
+            '<p>a</p>' . $this->marker(99) . '<p>b</p>',
+            [$this->widget(1)],
+            $this->allowlist(),
+        );
+
+        self::assertSame('<p>a</p><p>b</p>', $html);
+    }
+
+    public function testEmptyAllowlistRemovesTheMarker(): void
+    {
+        self::assertSame(
+            '',
+            TrustedEmbedPlacements::apply($this->marker(), [$this->widget(1)], EmbedAllowlist::empty()),
+        );
+    }
+
+    public function testOriginOutsideTheAllowlistRemovesTheMarker(): void
+    {
+        self::assertSame(
+            '',
+            TrustedEmbedPlacements::apply(
+                $this->marker(),
+                [$this->widget(1)],
+                $this->allowlist('https://other.example.com'),
+            ),
+        );
+    }
+
+    public function testNonTrustedEmbedWidgetRemovesTheMarker(): void
+    {
+        self::assertSame(
+            '',
+            TrustedEmbedPlacements::apply(
+                $this->marker(),
+                [$this->widget(1, type: 'recent-posts', settings: ['limit' => 5])],
+                $this->allowlist(),
+            ),
+        );
+    }
+
+    public function testRegionPlacedWidgetIsNotPlaceableByMarker(): void
+    {
+        // It already renders in its region; honouring the marker would double-load.
+        self::assertSame(
+            '',
+            TrustedEmbedPlacements::apply(
+                $this->marker(),
+                [$this->widget(1, region: 'footer')],
+                $this->allowlist(),
+            ),
+        );
+    }
+
+    public function testMalformedSettingsRemoveTheMarker(): void
+    {
+        $settings = $this->validSettings();
+        unset($settings['integrity']);
+
+        self::assertSame(
+            '',
+            TrustedEmbedPlacements::apply($this->marker(), [$this->widget(1, settings: $settings)], $this->allowlist()),
+        );
+    }
+
+    public function testCrossOriginSrcRemovesTheMarker(): void
+    {
+        $settings = $this->validSettings();
+        $settings['src'] = 'https://evil.example.com/form.js';
+
+        self::assertSame(
+            '',
+            TrustedEmbedPlacements::apply($this->marker(), [$this->widget(1, settings: $settings)], $this->allowlist()),
+        );
+    }
+
+    // ---------------------------------------------------------------- shape rules
+
+    public function testTheSameWidgetIsEmittedOnlyOncePerDocument(): void
+    {
+        $html = TrustedEmbedPlacements::apply(
+            $this->marker() . '<p>x</p>' . $this->marker(),
+            [$this->widget(1)],
+            $this->allowlist(),
+        );
+
+        self::assertSame(1, substr_count($html, '<script'));
+    }
+
+    public function testMarkerWithContentIsNotAPlacement(): void
+    {
+        $input = '<div data-nene-embed="1">x</div>';
+
+        self::assertSame($input, TrustedEmbedPlacements::apply($input, [$this->widget(1)], $this->allowlist()));
+    }
+
+    public function testHtmlWithoutAnyMarkerIsReturnedByteForByte(): void
+    {
+        $input = '<p>plain <em>body</em></p><img src="/a.png" alt="a">';
+
+        self::assertSame($input, TrustedEmbedPlacements::apply($input, [$this->widget(1)], $this->allowlist()));
+    }
+
+    public function testMarkerInsideAnAttributeValueIsNotSubstituted(): void
+    {
+        // The sanitizer escapes `<` inside attribute values, so a marker written
+        // there is inert text — it must not become a script.
+        $input = '<p title="&lt;div data-nene-embed=&quot;1&quot;&gt;&lt;/div&gt;">t</p>';
+
+        self::assertSame($input, TrustedEmbedPlacements::apply($input, [$this->widget(1)], $this->allowlist()));
+    }
+
+    // ---------------------------------------------------------------- with the sanitizer
+
+    public function testSanitizerKeepsTheMarkerButStillStripsScripts(): void
+    {
+        $sanitized = (new PublicHtmlSanitizer())->sanitize(
+            '<p>a</p>' . $this->marker() . '<script>alert(1)</script><p onclick="x()">b</p>',
+        );
+
+        self::assertStringContainsString('data-nene-embed="1"', $sanitized);
+        self::assertStringNotContainsString('alert(1)', $sanitized);
+        self::assertStringNotContainsString('onclick', $sanitized);
+
+        $html = TrustedEmbedPlacements::apply($sanitized, [$this->widget(1)], $this->allowlist());
+
+        self::assertStringContainsString('<script src="' . self::ORIGIN . '/form.js"', $html);
+        self::assertStringNotContainsString('alert(1)', $html);
+    }
+
+    public function testMarkerAttributeIsNotHonouredOnOtherElements(): void
+    {
+        $sanitized = (new PublicHtmlSanitizer())->sanitize('<span data-nene-embed="1"></span>');
+
+        self::assertStringNotContainsString('data-nene-embed', $sanitized);
+        self::assertStringNotContainsString(
+            '<script',
+            TrustedEmbedPlacements::apply($sanitized, [$this->widget(1)], $this->allowlist()),
+        );
+    }
+
+    public function testAuthoredScriptTagIsStillStrippedEvenWithAnAllowlistedSrc(): void
+    {
+        // The concession is the marker attribute — never a raw <script> in content.
+        $sanitized = (new PublicHtmlSanitizer())->sanitize(
+            '<script src="' . self::ORIGIN . '/form.js" integrity="sha384-abcDEF123+/=" crossorigin="anonymous"></script>',
+        );
+
+        self::assertSame('', trim($sanitized));
+    }
+}

--- a/tests/PublicRecord/TrustedEmbedScriptsTest.php
+++ b/tests/PublicRecord/TrustedEmbedScriptsTest.php
@@ -12,12 +12,12 @@ use PHPUnit\Framework\TestCase;
 final class TrustedEmbedScriptsTest extends TestCase
 {
     /** @param array<string, mixed> $settings */
-    private function widget(string $type, array $settings): Widget
+    private function widget(string $type, array $settings, string $region = 'footer'): Widget
     {
         return new Widget(
             id: 1,
             widgetType: $type,
-            region: 'footer',
+            region: $region,
             displayOrder: 0,
             title: null,
             settings: $settings,
@@ -39,6 +39,15 @@ final class TrustedEmbedScriptsTest extends TestCase
             'src' => 'https://widgets.example.com/form.js',
             'integrity' => 'sha384-abcDEF123+/=',
         ];
+    }
+
+    public function testInlineRegionWidgetIsNotRenderedIntoTheChrome(): void
+    {
+        // #937: an inline widget is placed by a marker inside the content
+        // (TrustedEmbedPlacements). Rendering it here too would load it twice.
+        $widgets = [$this->widget('trusted-embed', $this->validSettings(), 'inline')];
+
+        self::assertSame('', TrustedEmbedScripts::render($widgets, $this->allowlist()));
     }
 
     public function testEmptyAllowlistRendersNothing(): void


### PR DESCRIPTION
## 目的

検証済みの `trusted-embed` を、サイトの chrome（header/sidebar/aside/footer）だけでなく
**`html` フィールド本文の任意の位置**へ置けるようにする。AYANE の実需（「ayane.co.jp みたいに
モーダルで問い合わせフォームを出したい」）から出た製品要求。

hub 裁定の**案β**（2026-08-15）に沿う。**案α（`crossorigin`/SRI を必須にしない）は却下済み**で、
本 PR は**サニタイザに穴を開けない**。

> ⚠️ #937 の**本文**にある「確定入力値」（`embed.281342b5743e.js`）は現存せず 404。
> 実装は issue のコメント末尾と `_work/reports/2026-08-15-937-step5-trusted-embed.md` を正とした。
> なお本 PR のコードは org 非依存で、AYANE の実値は widget 設定として投入する運用になる。

## 変更

新しい region `inline` を追加した。これはページ上の場所ではなく「本文から呼ばれたときだけ出る」
置き場で、単独では描画されない。本文側には無害なマーカーだけを書く:

```html
<p>…copy…</p>
<div data-nene-embed="12"></div>
<p>…more copy…</p>
```

サニタイズの**後**に、この位置へ widget の保管済み設定から再構築したタグを差し込む。
著者の markup が決められるのは「どこに出すか」だけで、「何を出すか」は決して決められない
（#802 と同じ生成規律）。

| 追加/変更 | 中身 |
| --- | --- |
| `TrustedEmbedPlacements`（新規） | SSR 側の置換。DOM 往復をしないので本文は byte-for-byte 不変 |
| `InlineTrustedEmbedHtml`（新規） | SPA 側の双子。マウント後に script を imperative 注入 |
| `WidgetRegions::INLINE` / TS `WidgetRegion` | `inline` を追加（admin のウィジェットボードにも枠と説明を追加） |
| `PublicHtmlSanitizer` / `SanitizedHtml` | マーカー属性 `data-nene-embed` を許可 |
| `docs/openapi/openapi.yaml` | region enum に `inline`（型は再生成済み） |
| `docs/security/trusted-embed.md` | placement 節（なぜ穴ではないかを含む） |

## 🔴 信頼モデルを緩めていないこと（レビュー観点）

通したのは **`data-nene-embed` 属性を `div` にだけ残すこと**のみ。この属性は URL も integrity も
コードも持たない。本文中の生の `<script>` は従来どおり**無条件で除去**される
（allowlist 済みの src を書いた script すら消えることをテストで固定した:
`testAuthoredScriptTagIsStillStrippedEvenWithAnAllowlistedSrc`）。

### 二重ロードの防止

- chrome 経路（`TrustedEmbedScripts`）は `inline` の widget を **skip** する
- **region 配置済みの widget はマーカーからは解決しない**（既に region で描画されているため）
- 同一 widget は1文書につき**1回だけ**（マーカーを重複させても増えない）

### SSR / SPA の双子性（#891 系の再発防止）

両経路が**同じ規則**で判定する。どれか1つでも外れれば**何も描画しない**（fail closed）:

| 規則 | SSR | SPA |
| --- | --- | --- |
| `div` のみ / 空のマーカーのみ | ✅ | ✅ |
| `inline` region の `trusted-embed` のみ | ✅ | ✅ |
| allowlist・origin・same-origin `src`・SRI・`data-*` の再検証 | ✅ | ✅ |
| 同一 widget は1回だけ | ✅ | ✅ |

🔑 DOMPurify は既定で `data-*` を**どの要素にも**残すので、SPA 側は要素名の判定を自前で持ち、
**サニタイザの既定値に依存せず** SSR と一致させている。

## 検証

- `composer check` **緑** — PHPUnit **1662 tests / 4997 assertions**・PHPStan level 8 エラー0・
  CS-Fixer 差分なし・OpenAPI valid・conformance OK・MCP valid
- `npm run check --prefix frontend` **緑** — type-check / lint / prettier / **677 tests (120 files)** /
  themes / knip / build / storybook
- 追加テスト **PHP 19本・TS 11本**。**陰性対照つき**（unknown id・allowlist 外 origin・空 allowlist・
  非 trusted-embed・region 配置済み・SRI 欠落・クロスオリジン src・非空マーカー・span マーカー・
  マーカー重複）を**両側で同一判定**になるところまで固定した

### 測れていないこと

**E2E（実フォームの描画と着信）は `https://ayane.co.jp` からしか測れない。** フォーム API
`/public/forms/{key}/…` が form 単位の `allowed_origins` で守られており、localhost / stg /
`records.nene-suite.com` では schema の fetch が CORS で落ちる（#937 受け入れ条件 追補のとおり）。
ローカルで「`embed.js` は 200 なのにフォームが出ない」のは**正常**で、placement の不具合ではない。

本 PR の射程は「**検証済みタグを任意位置に出すところまで**」で、そこは双子テストで成立を確認している。

## チェックリスト

- [x] Issue 駆動（#937）
- [x] `composer check` 緑
- [x] `npm run check --prefix frontend` 緑
- [x] OpenAPI 更新＋型再生成
- [x] ドキュメント更新（`docs/security/trusted-embed.md`）
- [x] SSR/SPA parity テスト
- [ ] **マージと本番反映は施主の直接 GO 待ち**（承認の二本立て）

Closes #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)
