### PR TITLE
docs: 版数表記を実測へ揃え、リリース手順に自リポ同期を足す（#1039）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Flexible entity platform — lighter and more typed than WordPress post meta. Ad
 
 ## Current Status
 
-M1 – M16 complete plus the post-#536 wave (crawlable SSR / WXR migration / public i18n / production SaaS + Tier A zip installer, v0.5.2 released). In production as a subdomain multi-tenant SaaS. The moving frontier is intentionally not tracked here — the top of the private current.md (`nene-origin/internal-docs/records/todo/`) is the source of truth.
+M1 – M16 complete plus the post-#536 wave (crawlable SSR / WXR migration / public i18n / production SaaS + Tier A zip installer, v0.5.3 released). In production as a subdomain multi-tenant SaaS. The moving frontier is intentionally not tracked here — the top of the private current.md (`nene-origin/internal-docs/records/todo/`) is the source of truth.
 
 ## Verification
 
@@ -101,7 +101,9 @@ composer migrations:rollback  # rollback last batch
 1. `VERSION` をバンプする（版の単一ソース。`/machine/health` も同じ値を報告する・#586）。
 2. `bash tools/build-release.sh <version>` で配布 zip を作る（→ `dist/nene-records-<version>.zip`。詳細は `docs/install-tier-a.md`）。
 3. zip と `.sha256` を GitHub Release に添付して公開する（Latest・target=main）。
-4. Release 公開後、プロフィール README（github.com/hideyukiMORI/hideyukiMORI）の版数・状況表を同期する（At a glance / Platform products / What shipped recently の該当行）。
+4. **自リポの版数表記を同期する** — `CLAUDE.md` の Current Status と `README.md` の版数・本番反映日。
+   🔴 ここが抜けていたため v0.5.2 → v0.5.3 で1版ずれたまま出荷した（#1039）。**`VERSION` を上げた PR の中で同時に直す。**
+5. Release 公開後、プロフィール README（github.com/hideyukiMORI/hideyukiMORI）の版数・状況表を同期する（At a glance / Platform products / What shipped recently の該当行）。
 
 ## OpenAPI → TypeScript types
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ AI clients (MCP)        ──┘
 | Public-site hardening | Superadmin-only console, CSP trusted-embed allowlist (Phase 1), org-level maintenance mode | ✅ merged (#797, #802 Phase 1, #813) |
 | Public-site hardening (remaining) | Trusted-embed Phase 2 (widget primitive) / Phase 3 (media); maintenance-mode admin UI toggle | 🔄 open (#802, #814) |
 
-NeNe Records runs in production as a subdomain multi-tenant SaaS and ships as a self-contained **Tier A zip installer** for shared hosting (current release **v0.5.2**, deployed to production 2026-07-13). Open follow-up work is tracked privately in `nene-origin/internal-docs/records/todo/current.md`; see [`docs/roadmap.md`](./docs/roadmap.md) for direction.
+NeNe Records runs in production as a subdomain multi-tenant SaaS and ships as a self-contained **Tier A zip installer** for shared hosting (current release **v0.5.3**, deployed to production 2026-07-22). Open follow-up work is tracked privately in `nene-origin/internal-docs/records/todo/current.md`; see [`docs/roadmap.md`](./docs/roadmap.md) for direction.
 
 | Area | State |
 | --- | --- |


### PR DESCRIPTION
`VERSION` は 0.5.3 なのに CLAUDE.md と README.md が v0.5.2 のまま止まっていた。
CLAUDE.md は AI エージェントが最初に読む入口、README.md は外部から最初に見える面で、
どちらも「今どの版か」を1行で名乗る場所なので、ずれると現在地認識と公開面の名乗りが
同時にずれる。

実測して直した:

- VERSION が 0.5.3 になったのは 2df8f93（2026-07-17 23:37:02）
- v0.5.3 の GitHub Release は 2026-07-17T14:38:31Z（Latest）
- 本番（ConoHa）の配備ツリーは VERSION 0.5.3 で稼働中
- 本番反映日は 2026-07-22 — pre_deploy バックアップの痕跡が VERSION バンプ直前 07-17 02:19、
  直後 2026-07-22 01:26 であることから特定した。同じ方法で既存の記述「v0.5.2 / 2026-07-13」も
  再現できる（v0.5.2 は 07-09 リリース・痕跡 07-13 01:48）ので、手法は元の記述と一致している

再発防止として Release 節に手順4「自リポの版数表記を同期する」を追加した。従来は手順4
（プロフィール README の同期）だけがあり、自リポ側を同期する手順が無かった。今回のずれは
その穴からそのまま出ているので、VERSION を上げた PR の中で同時に直すことを明記した。

射程外として残したもの: docs/roadmap.md の「Tier A zip インストーラ（v0.5.0〜v0.5.2）」は
Issue の対象に入っていないため触っていない。docs/security/ 配下の 0.5.2 は「試験時点の版」
なので正しく凍結された記述であり、直してはいけない。

ドキュメントのみの変更でコードは触っていない（gates は CI に委ねる）。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EVNPuKeeHDpEZ2pAoSPNdW
