### PR TITLE
chore(deps): fast-uri を 3.1.7 へ lock only で更新する（#1067）

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6741,9 +6741,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
audit-ci が fast-uri の high 4件（GHSA-5jgf-p345-68v8 / GHSA-f65p-4m7j-42xc /
GHSA-fph4-wmhf-6fwf / GHSA-jqff-g426-hqxp）を検出し、main の frontend CI が赤に
なっていた。この状態ではすべての PR がゲートで落ちる。

実測:

- 解決版は 3.1.5、脆弱範囲は 3.0.0 - 3.1.5
- 依存元は ajv の `fast-uri: ^3.0.1`（推移依存・直接依存ではない）
- 3.x 系の修正版 3.1.7 は `^3.0.1` を満たすので package.json の変更が要らない
- 直前の緑は 08-31 の schedule 実行 ⇒ その後に出た advisory であって、
  こちらが持ち込んだものではない

`npm update fast-uri` で lock を 3.1.5 → 3.1.7 にし、
`npx audit-ci --config audit-ci.jsonc` が `Passed npm security audit.`（rc=0）を
返すことを手元で確認した。

allowlist には入れていない。audit-ci.jsonc の allowlist は #1050 以降 空で
「high は例外なし運用」と明記されており、今回は fix が実在して要求範囲内で取れるので
抑止する理由がない。

検出の経緯: #1039（.md 2ファイルだけの変更・PR #1065）で frontend-check が落ちた。
docs のみの変更なので無関係と決めつけずログを読んで判明した。ゲートは正しく働いている。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EVNPuKeeHDpEZ2pAoSPNdW
