### PR TITLE
fix(public): 発行元スキーマの honeypot 型を描画も転送もしない（#1066）

### DIFF
--- a/src/ContactSubmission/SubmitContactFormHandler.php
+++ b/src/ContactSubmission/SubmitContactFormHandler.php
@@ -270,7 +270,11 @@ final readonly class SubmitContactFormHandler
         $declared = [];
 
         foreach ($schema->fields as $field) {
-            $declared[$field->key] = true;
+            // Declared but never rendered (#1066), so it is accepted like a control field and
+            // dropped rather than forwarded: the issuing product discards honeypot values on
+            // ingest anyway, and refusing the whole submission would punish a browser that still
+            // holds a page rendered before the fix.
+            $declared[$field->key] = $field->isHoneypot() ? 'drop' : true;
         }
 
         $values = [];
@@ -284,6 +288,10 @@ final readonly class SubmitContactFormHandler
 
             if (!isset($declared[$key])) {
                 return null;
+            }
+
+            if ($declared[$key] === 'drop') {
+                continue;
             }
 
             $values[$key] = is_string($value) ? $value : '';

--- a/src/PublicRecord/ContactFormField.php
+++ b/src/PublicRecord/ContactFormField.php
@@ -14,6 +14,16 @@ namespace NeNeRecords\PublicRecord;
 final readonly class ContactFormField
 {
     /**
+     * The issuing product's own bot trap. It is the one declared type records must actively
+     * refuse to render: the `default` arm of the renderer turns unknown types into a plain
+     * text input so an author's field still collects, and for a honeypot that is exactly wrong
+     * — a visible, empty-labelled box that people fill in and the issuing product then discards
+     * without an error (#1066). records runs its own hidden honeypot instead
+     * (`SubmitContactFormHandler::HONEYPOT_FIELD`).
+     */
+    public const TYPE_HONEYPOT = 'honeypot';
+
+    /**
      * @param list<string> $options values for `select`; empty for every other type
      */
     public function __construct(
@@ -23,5 +33,10 @@ final readonly class ContactFormField
         public bool $required,
         public array $options = [],
     ) {
+    }
+
+    public function isHoneypot(): bool
+    {
+        return $this->type === self::TYPE_HONEYPOT;
     }
 }

--- a/src/PublicRecord/SsrBlocksRenderer.php
+++ b/src/PublicRecord/SsrBlocksRenderer.php
@@ -221,6 +221,14 @@ final readonly class SsrBlocksRenderer
 
     private function renderField(ContactFormField $field, string $idPrefix): string
     {
+        // The issuing product's honeypot is declared so records *knows about* it, not so records
+        // shows it. Falling through to `default` would print a visible, empty-labelled text box
+        // whose contents the issuing product then drops without an error (#1066). records has its
+        // own hidden trap above; this one stays unrendered.
+        if ($field->isHoneypot()) {
+            return '';
+        }
+
         $id = 'contact-' . $idPrefix . '-' . $this->slug($field->key);
         $required = $field->required ? ' required' : '';
         $label = '<label for="' . $id . '">' . $this->escape($field->label) . '</label>';

--- a/tests/ContactSubmission/SubmitContactFormHandlerTest.php
+++ b/tests/ContactSubmission/SubmitContactFormHandlerTest.php
@@ -260,6 +260,32 @@ final class SubmitContactFormHandlerTest extends TestCase
         self::assertTrue($this->logger->has('info', 'honeypot'), 'A silent drop makes "it never arrived" unanswerable.');
     }
 
+    /**
+     * #1066: the issuing product's honeypot is declared by the schema, so it must not trip the
+     * "key outside the schema" refusal — a browser still holding a page rendered before the fix
+     * would otherwise have its submission thrown away. It is accepted and dropped instead, the
+     * way a control field is: the issuing product discards honeypot values on ingest anyway.
+     */
+    public function testIssuingProductHoneypotIsAcceptedButNeverForwarded(): void
+    {
+        $handler = (new SubmitContactFormHandlerFactory($this))->build(schema: new ContactFormSchema('k', [
+            new ContactFormField('email', 'Email', 'email', true),
+            new ContactFormField('website', '', ContactFormField::TYPE_HONEYPOT, false),
+        ]));
+
+        $response = $handler->handle($this->request([
+            'form_key' => 'k',
+            'email' => 'a@example.test',
+            'website' => 'https://spam.example',
+        ]));
+
+        self::assertSame(303, $response->getStatusCode());
+        self::assertSame([['email' => 'a@example.test']], array_map(
+            static fn (array $sent): array => $sent['values'],
+            $this->sender->sent,
+        ), 'The schema-declared honeypot must not reach the issuing product.');
+    }
+
     // ── redirect safety ───────────────────────────────────────────────────────
 
     /**

--- a/tests/PublicRecord/SsrBlocksRendererTest.php
+++ b/tests/PublicRecord/SsrBlocksRendererTest.php
@@ -90,6 +90,34 @@ final class SsrBlocksRendererTest extends TestCase
         self::assertStringContainsString('type="text"', $html);
     }
 
+    /**
+     * #1066: the issuing product declares its own honeypot so records *knows about* it, not so
+     * records shows it. Before the fix it fell through to the `default` arm above and printed a
+     * visible, empty-labelled text box whose contents the issuing product then discarded without
+     * an error.
+     *
+     * Both halves matter: deleting every honeypot would also satisfy the first assertion, so the
+     * second pins that records' own hidden trap survives.
+     */
+    public function testIssuingProductHoneypotIsNotRenderedButRecordsOwnTrapStillIs(): void
+    {
+        $renderer = $this->renderer(new ContactFormSchema('k', [
+            new ContactFormField('message', 'Message', 'textarea', true),
+            new ContactFormField('website', '', ContactFormField::TYPE_HONEYPOT, false),
+        ]));
+
+        $html = $renderer->render('[{"id":"c","type":"contact-form","data":{"formKey":"k"}}]')->html;
+
+        // Nothing a person could see or type into. `name="website"` is not a substring of
+        // `name="website_url"`, so this does not accidentally assert against records' own trap.
+        self::assertStringNotContainsString('name="website"', $html);
+        self::assertStringNotContainsString('contact-c-website"', $html);
+
+        // records' own hidden trap is still emitted, and the real fields still render.
+        self::assertStringContainsString('name="' . SubmitContactFormHandler::HONEYPOT_FIELD . '"', $html);
+        self::assertStringContainsString('name="message"', $html);
+    }
+
     public function testSchemaValuesAreEscapedIntoAttributesAndText(): void
     {
         $renderer = $this->renderer(new ContactFormSchema('k', [


### PR DESCRIPTION
contact が返す `field_type: honeypot` のフィールドを、records の SSR が利用者に見える
空ラベルのテキスト入力として描画していた。`SsrBlocksRenderer::renderField()` の match に
honeypot の枝が無く、`default`（知らない型は素のテキスト入力にする）へ落ちていたため。

default 自体は意図した設計で、著者が集めるつもりのフィールドを落とさないためにある。
honeypot はその既定と正面から衝突する唯一の型だった——「知らない型」ではなく
「知っていて出してはいけない型」なので、型知識を ContactFormField へ集約して分けた。

実測（2026-09-05・ayane 本番のスキーマ）:

  GET https://contact.ayane.co.jp/public/forms/ayane-contact/schema
  key='website'  type='honeypot'  required=False  label={'ja': ''}

このまま配備すると「ご相談内容」の下に空ラベルの入力欄が出る。実害は4つ:

- 利用者にラベルの無い入力欄が見える
- 空ラベルの入力欄で a11y 違反
- 入力しても field_values に載って上流へ行き、contact の IngestSubmissionHandler が
  FieldType::Honeypot を continue で捨てる＝書いた内容がエラーも出さずに消える
- 見えている以上、honeypot としても機能しない

変更:

- ContactFormField に TYPE_HONEYPOT と isHoneypot() を追加（型知識の置き場を1つにする）
- SsrBlocksRenderer::renderField() で honeypot 型は空文字を返す
- SubmitContactFormHandler::collectDeclaredValues() で honeypot 型のキーは制御フィールドと
  同じ扱いにして field_values から落とす。スキーマ宣言済みなので「スキーマ外のキー」による
  全体拒否には落とさない——fix 前に描画されたページをまだ開いているブラウザを罰しないため

リグレッションテスト2本を追加した。振る舞いだけを戻した陰性対照で、両方が本物の
assertion 失敗になることを確認済み（定数の未定義による fatal ではなく、失敗出力に
`<label for="contact-0-c-website"></label><input type="text" ... name="website">` という
バグの現物が出ることまで確認した）。SSR 側のテストは「honeypot が消えたこと」だけでなく
「records 自身の website_url トラップが残っていること」も同時に固定している——
両方消しても前半だけなら通ってしまうため。

records 自身の bot 防御（website_url honeypot ＋ IP/フォームの二重 throttle）は #1031 の波で
既に入っており、本件はそちらの不足ではない。

board id:079（08-26 指示書・案1 を ayane へ適用）のブロッカー。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EVNPuKeeHDpEZ2pAoSPNdW
