### PR TITLE
feat(release): 配布 zip に tools/export-org.php を同梱する（#972）

### DIFF
--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -48,6 +48,9 @@ mkdir -p "$STAGE/tools"
 cp "$ROOT/tools/hosting-precheck.php" "$STAGE/tools/"
 cp "$ROOT/tools/install.php" "$STAGE/tools/"
 cp "$ROOT/tools/import-org.php" "$STAGE/tools/"
+# export は import と対で移送経路の半分。同梱しないと Tier A インスタンスは供給された
+# 経路でバックアップ・移送・stg refresh ができない（#972）。
+cp "$ROOT/tools/export-org.php" "$STAGE/tools/"
 cp "$ROOT/tools/webhook-worker.php" "$STAGE/tools/"
 cp "$ROOT/.env.example" "$STAGE/.env.example"
 cp "$ROOT/phinx.php" "$STAGE/phinx.php"


### PR DESCRIPTION
export は import と対で移送経路の半分なのに、zip の同梱 allowlist に export-org.php が
無かった。帰結として Tier A インスタンスは供給された経路で export できず、共有ホスティング
上の本番からのバックアップ・移送・stg refresh が製品の枠内で成立していなかった。

2026-07-18 の AYANE stg 構築で発見され、そのときはリポの v0.5.3 タグから export-org.php を
本番 tools/ へ手で追加配置して回避していた。次リリースで直す約束のまま残っていたもの。

実測で確かめた（前後の対照）:

  v0.5.3 の配布 zip（2026-07-17 に実際に出荷した dist/nene-records-0.5.3.zip）
    tools/ = 5ファイル・export-org.php **無し**
  本コミット後にビルドした zip
    tools/ = 6ファイル・export-org.php **有り**（4,341 bytes）

出荷済みの成果物そのものを陰性対照に使えたので、「同梱リストに1行足した」ではなく
「配布物が実際に変わった」ところまで確認できている。

board id:079（08-26 指示書・案1 を ayane へ適用）で v0.5.4 を切る前段として、指示書の
「#972 の現状を先に読む・未了なら本件と合流」に従って合流させた。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EVNPuKeeHDpEZ2pAoSPNdW
