### PR TITLE
feat(appearance): org 単位でファビコンを登録して公開サイトに適用する（#1073）

### DIFF
--- a/database/migrations/20260906000000_add_favicon_setting.php
+++ b/database/migrations/20260906000000_add_favicon_setting.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * org 単位のファビコン `favicon_media_id`（#1073）。
+ *
+ * これが無かったため、製品既定と違うファビコンを出したい設置は
+ * `templates/public/record-detail.php` と `type-archive.php` の `<link rel="icon">` を
+ * **サーバ上で直接書き換える**しか手が無かった。ayane.co.jp が実際にそうなっており、
+ * その改変は git のどのコミットにも存在しないため、配備のたびに製品既定へ黙って戻り、
+ * 戻った事実もどこにも記録されなかった（2026-09-05 実測）。
+ *
+ * 値は org スコープの**メディア URL**（`logo_media_id` / `default_og_image` と同形式）。
+ * 公開 SSR が {@see \NeNeRecords\PublicRecord\PublicFaviconLinks} 経由で解決する。
+ * SVG は原本のまま、ラスタは `icon32` / `icon180` / `icon192` の派生に解決される。
+ *
+ * 既定は空文字（＝製品既定のファビコンを出す＝現状維持）。べき等（既存はスキップ）。
+ * `setting_defs` は org スコープなので組織ごとに insert。
+ */
+final class AddFaviconSetting extends AbstractMigration
+{
+    private const SETTING_KEY = 'favicon_media_id';
+
+    public function up(): void
+    {
+        if (!$this->hasTable('organizations') || !$this->hasTable('setting_defs')) {
+            return;
+        }
+
+        $pdo = $this->getAdapter()->getConnection();
+        $now = date('Y-m-d H:i:s');
+
+        $orgs = $pdo->query('SELECT id FROM organizations ORDER BY id ASC')->fetchAll(PDO::FETCH_COLUMN);
+
+        $check = $pdo->prepare('SELECT id FROM setting_defs WHERE organization_id = ? AND setting_key = ?');
+        $insert = $pdo->prepare(
+            'INSERT INTO setting_defs (organization_id, setting_key, data_type, default_value, is_public, label, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        );
+
+        foreach ($orgs as $orgIdRaw) {
+            $orgId = (int) $orgIdRaw;
+            $check->execute([$orgId, self::SETTING_KEY]);
+            if ($check->fetch() !== false) {
+                continue;
+            }
+            $insert->execute([
+                $orgId,
+                self::SETTING_KEY,
+                'media',
+                '',
+                1,
+                'Favicon',
+                $now,
+                $now,
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        if (!$this->hasTable('setting_defs')) {
+            return;
+        }
+
+        $this->execute("DELETE FROM setting_defs WHERE setting_key = '" . self::SETTING_KEY . "'");
+    }
+}

--- a/src/Media/MediaImagePresets.php
+++ b/src/Media/MediaImagePresets.php
@@ -20,6 +20,12 @@ final class MediaImagePresets
         // Social card width (og:image / twitter:image). Aspect is preserved
         // (width-constrained), which social platforms crop/letterbox as needed.
         'og' => 1200,
+        // Favicon sizes (#1073). Named rather than free-form for the same reason as the rest
+        // of this list: the closed set is what stops arbitrary-size generation being used as a
+        // disk/CPU DoS. 180 is the apple-touch-icon size; 192 covers the web app manifest.
+        'icon32' => 32,
+        'icon180' => 180,
+        'icon192' => 192,
     ];
 
     public static function isValid(string $name): bool

--- a/src/PublicRecord/PublicFaviconLinks.php
+++ b/src/PublicRecord/PublicFaviconLinks.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\PublicRecord;
+
+use NeNeRecords\Http\BasePath;
+use NeNeRecords\Media\MediaDerivativeUrl;
+
+/**
+ * The `<link rel="icon">` block for the crawlable SSR shell (#1073).
+ *
+ * Before this existed the block was hardcoded to the product's own icons, so an installation
+ * that wanted its own favicon had no choice but to edit `templates/public/*.php` on the server.
+ * ayane.co.jp did exactly that, and the edit lived in no commit — every deploy silently
+ * reverted the site to the NeNe Records icon and nothing recorded that it had happened.
+ * The org setting replaces that edit, so the templates can ship unmodified.
+ *
+ * Shape mirrors {@see \NeNeRecords\PublicRecord\WebAnalyticsHeadSnippet} and
+ * {@see \NeNeRecords\PublicRecord\FloatingCtaHtml}: the renderer builds a string, the template
+ * echoes it. "No config, no change" — an org that has set nothing keeps the product default.
+ */
+final readonly class PublicFaviconLinks
+{
+    public const SETTING_KEY = 'favicon_media_id';
+
+    /**
+     * Shipped in `dist/assets/favicon` and moved under `public_html/assets/` by the Tier A
+     * build. Paths are base-relative so they resolve against `<base>` on any deep path (#986).
+     */
+    private const PRODUCT_DEFAULT = <<<'HTML'
+        <link rel="icon" href="assets/favicon/favicon.svg" type="image/svg+xml" />
+            <link rel="icon" href="assets/favicon/favicon-32.png" sizes="32x32" />
+            <link rel="icon" href="assets/favicon/favicon-16.png" sizes="16x16" />
+            <link rel="apple-touch-icon" href="assets/favicon/apple-touch-icon.png" />
+            <link rel="manifest" href="assets/favicon/site.webmanifest" />
+        HTML;
+
+    /**
+     * Media URLs are root-relative (`/media/...`), which — unlike the product default's
+     * base-relative paths — ignore `<base href>`. So a subdirectory install needs the base
+     * prefixed explicitly, the same way og:image does.
+     *
+     * @param array<string, string> $settings   public settings, `settingKey => effectiveValue`
+     * @param string                $basePath   effective base path, '' at the domain root
+     */
+    public static function render(array $settings, string $basePath = ''): string
+    {
+        $url = trim($settings[self::SETTING_KEY] ?? '');
+
+        if ($url === '') {
+            return self::PRODUCT_DEFAULT;
+        }
+
+        // SVG is served as uploaded: it is resolution-independent, so rasterising it through
+        // the derivative pipeline would only lose quality. `MediaDerivativeUrl` agrees — `.svg`
+        // is deliberately absent from its image extensions and it returns null for one.
+        if (preg_match('/\.svg$/i', $url) === 1) {
+            return '<link rel="icon" href="' . self::escape(self::href($url, $basePath)) . '" type="image/svg+xml" />';
+        }
+
+        $small = MediaDerivativeUrl::forPreset($url, 'icon32');
+        $apple = MediaDerivativeUrl::forPreset($url, 'icon180');
+        $large = MediaDerivativeUrl::forPreset($url, 'icon192');
+
+        // Not a media-library image (an external URL, a PDF, a typo). Falling back to the
+        // product icon beats emitting a link that 404s — a broken favicon is the one thing
+        // this feature exists to prevent.
+        if ($small === null || $apple === null || $large === null) {
+            return self::PRODUCT_DEFAULT;
+        }
+
+        return '<link rel="icon" href="' . self::escape(self::href($small, $basePath)) . '" sizes="32x32" />' . "\n"
+            . '    <link rel="icon" href="' . self::escape(self::href($large, $basePath)) . '" sizes="192x192" />' . "\n"
+            . '    <link rel="apple-touch-icon" href="' . self::escape(self::href($apple, $basePath)) . '" />';
+    }
+
+    /** Absolute URLs pass through; root-relative media paths get the install's base. */
+    private static function href(string $path, string $basePath): string
+    {
+        return str_starts_with($path, 'http') ? $path : BasePath::prefix($basePath, $path);
+    }
+
+    private static function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+}

--- a/src/PublicRecord/RenderPublicRecordViewHandler.php
+++ b/src/PublicRecord/RenderPublicRecordViewHandler.php
@@ -322,6 +322,8 @@ final readonly class RenderPublicRecordViewHandler implements PublicRecordViewRe
             'siteName' => $siteName,
             'metaDescription' => $metaDescription,
             'analyticsHead' => $analyticsHead,
+            // Org favicon when set, product default otherwise (#1073).
+            'faviconLinks' => PublicFaviconLinks::render($settings, $effectiveBase),
             // Validated trusted-embed <script> tags for the crawlable shell (#802);
             // '' when the org has no allowlist / no trusted-embed widgets.
             'embedScripts' => $embedScripts,

--- a/src/PublicRecord/RenderPublicTypeArchiveRenderer.php
+++ b/src/PublicRecord/RenderPublicTypeArchiveRenderer.php
@@ -108,6 +108,8 @@ final readonly class RenderPublicTypeArchiveRenderer implements PublicTypeArchiv
             'metaDescription' => $metaDescription,
             'ogImageUrl' => $ogImageUrl,
             'analyticsHead' => $analyticsHead,
+            // Org favicon when set, product default otherwise (#1073).
+            'faviconLinks' => PublicFaviconLinks::render($settings, $effectiveBase),
             // Server-generated floating CTA chrome (#982); '' when disabled / no match.
             'floatingCta' => $floatingCta,
             // The first page is the archive's canonical address; deeper pages carry

--- a/src/Setting/PdoDefaultSettingDefsSeeder.php
+++ b/src/Setting/PdoDefaultSettingDefsSeeder.php
@@ -36,6 +36,7 @@ final readonly class PdoDefaultSettingDefsSeeder implements DefaultSettingDefsSe
         ['setting_key' => 'theme_overrides', 'data_type' => 'text', 'default_value' => '{}', 'is_public' => 1, 'label' => 'Theme customizations'],
         ['setting_key' => 'logo_media_id', 'data_type' => 'media', 'default_value' => '', 'is_public' => 1, 'label' => 'Logo'],
         ['setting_key' => 'default_og_image', 'data_type' => 'media', 'default_value' => '', 'is_public' => 1, 'label' => 'Default social image (og:image)'],
+        ['setting_key' => 'favicon_media_id', 'data_type' => 'media', 'default_value' => '', 'is_public' => 1, 'label' => 'Favicon'],
         ['setting_key' => 'copyright_text', 'data_type' => 'text', 'default_value' => '© {year} {site}', 'is_public' => 1, 'label' => 'Copyright'],
         ['setting_key' => 'layout_config', 'data_type' => 'text', 'default_value' => '{"home":{"columns":2,"mainPos":"left","swap":false},"record":{"columns":3,"mainPos":"left","swap":false}}', 'is_public' => 1, 'label' => 'Layout'],
         ['setting_key' => 'excerpt_source', 'data_type' => 'text', 'default_value' => 'auto', 'is_public' => 0, 'label' => 'Excerpt source (auto / body / meta)'],

--- a/templates/public/record-detail.php
+++ b/templates/public/record-detail.php
@@ -5,14 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <?php /* Runtime base path: anchors the SPA (router/API derive it from <base>). #zip-install S2 */ ?>
     <base href="<?= $e($basePath . '/') ?>" />
-    <?php /* Favicon: the crawlable SSR shell must declare it so Google/browsers use the
-             real icon instead of an auto-generated letter monogram (#986). Base-relative
-             paths resolve against <base> on any deep path; assets ship in dist/assets/favicon. */ ?>
-    <link rel="icon" href="assets/favicon/favicon.svg" type="image/svg+xml" />
-    <link rel="icon" href="assets/favicon/favicon-32.png" sizes="32x32" />
-    <link rel="icon" href="assets/favicon/favicon-16.png" sizes="16x16" />
-    <link rel="apple-touch-icon" href="assets/favicon/apple-touch-icon.png" />
-    <link rel="manifest" href="assets/favicon/site.webmanifest" />
+    <?php /* Favicon: org setting when set, product default otherwise (#1073).
+             Built server-side so the crawlable shell declares the real icon (#986). */ ?>
+    <?= $faviconLinks ?>
     <?php /* GA4 / GTM + Consent Mode v2 — pre-built, nonce'd, '' when analytics is off. */ ?>
     <?= $analyticsHead ?>
     <?php if ($metaDescription !== ''): ?>

--- a/templates/public/type-archive.php
+++ b/templates/public/type-archive.php
@@ -5,13 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <?php /* Runtime base path: anchors the SPA (router/API derive it from <base>). #zip-install S2 */ ?>
     <base href="<?= $e($basePath . '/') ?>" />
-    <?php /* Favicon: declared in the crawlable SSR shell so Google/browsers use the real
-             icon instead of an auto-generated letter monogram (#986). Base-relative. */ ?>
-    <link rel="icon" href="assets/favicon/favicon.svg" type="image/svg+xml" />
-    <link rel="icon" href="assets/favicon/favicon-32.png" sizes="32x32" />
-    <link rel="icon" href="assets/favicon/favicon-16.png" sizes="16x16" />
-    <link rel="apple-touch-icon" href="assets/favicon/apple-touch-icon.png" />
-    <link rel="manifest" href="assets/favicon/site.webmanifest" />
+    <?php /* Favicon: org setting when set, product default otherwise (#1073).
+             Built server-side so the crawlable shell declares the real icon (#986). */ ?>
+    <?= $faviconLinks ?>
     <?= $analyticsHead ?>
     <?php if ($metaDescription !== ''): ?>
       <meta name="description" content="<?= $e($metaDescription) ?>" />

--- a/tests/PublicRecord/PublicFaviconLinksTest.php
+++ b/tests/PublicRecord/PublicFaviconLinksTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeNeRecords\Tests\PublicRecord;
+
+use NeNeRecords\PublicRecord\PublicFaviconLinks;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The org favicon (#1073).
+ *
+ * The feature exists because an installation that wanted its own icon previously had to edit
+ * `templates/public/*.php` on the server, and that edit — living in no commit — was reverted
+ * by every deploy without leaving a trace. So the test that matters most is the fallback one:
+ * an org that sets nothing must keep behaving exactly as before.
+ */
+final class PublicFaviconLinksTest extends TestCase
+{
+    public function testUnsetOrgKeepsTheProductDefault(): void
+    {
+        foreach ([[], ['favicon_media_id' => ''], ['favicon_media_id' => '   ']] as $settings) {
+            $html = PublicFaviconLinks::render($settings);
+
+            self::assertStringContainsString('assets/favicon/favicon.svg', $html);
+            self::assertStringContainsString('assets/favicon/apple-touch-icon.png', $html);
+            self::assertStringContainsString('site.webmanifest', $html);
+        }
+    }
+
+    /**
+     * SVG is resolution-independent, so pushing it through the raster derivative pipeline would
+     * only lose quality. `MediaDerivativeUrl` agrees — `.svg` is absent from its image extensions.
+     */
+    public function testSvgIsServedAsUploadedWithoutADerivative(): void
+    {
+        $html = PublicFaviconLinks::render([
+            'favicon_media_id' => 'https://example.test/media/2026/09/brand.svg',
+        ]);
+
+        self::assertSame(
+            '<link rel="icon" href="https://example.test/media/2026/09/brand.svg" type="image/svg+xml" />',
+            $html,
+        );
+        self::assertStringNotContainsString('/icon32/', $html);
+        self::assertStringNotContainsString('assets/favicon/', $html);
+    }
+
+    public function testRasterResolvesToTheIconDerivatives(): void
+    {
+        $html = PublicFaviconLinks::render([
+            'favicon_media_id' => 'https://example.test/media/2026/09/brand.png',
+        ]);
+
+        self::assertStringContainsString('href="https://example.test/media/icon32/2026/09/brand.png" sizes="32x32"', $html);
+        self::assertStringContainsString('href="https://example.test/media/icon192/2026/09/brand.png" sizes="192x192"', $html);
+        self::assertStringContainsString('rel="apple-touch-icon" href="https://example.test/media/icon180/2026/09/brand.png"', $html);
+
+        // The product default must be gone, or the browser would pick whichever came first.
+        self::assertStringNotContainsString('assets/favicon/', $html);
+    }
+
+    /**
+     * A value that is not a media-library image (an external URL, a PDF, a typo) must not
+     * produce a link that 404s — a broken favicon is the thing this feature prevents.
+     */
+    public function testUnresolvableValueFallsBackToTheProductDefault(): void
+    {
+        foreach ([
+            'https://example.test/not-media/brand.png',
+            'https://example.test/media/2026/09/brochure.pdf',
+            'nonsense',
+        ] as $value) {
+            $html = PublicFaviconLinks::render(['favicon_media_id' => $value]);
+
+            self::assertStringContainsString('assets/favicon/favicon.svg', $html, $value);
+        }
+    }
+
+    /**
+     * Media URLs are root-relative, so unlike the product default's base-relative paths they
+     * ignore `<base href>`. A subdirectory install must get the base prefixed explicitly or
+     * every icon 404s — the same reasoning og:image already follows.
+     */
+    public function testSubdirectoryInstallGetsTheBasePrefixed(): void
+    {
+        $html = PublicFaviconLinks::render(['favicon_media_id' => '/media/2026/06/card.png'], '/sub');
+
+        self::assertStringContainsString('href="/sub/media/icon32/2026/06/card.png"', $html);
+        self::assertStringContainsString('href="/sub/media/icon180/2026/06/card.png"', $html);
+
+        // At the domain root the path is emitted unchanged.
+        $root = PublicFaviconLinks::render(['favicon_media_id' => '/media/2026/06/card.png']);
+        self::assertStringContainsString('href="/media/icon32/2026/06/card.png"', $root);
+    }
+
+    public function testValueIsEscapedIntoTheAttribute(): void
+    {
+        $html = PublicFaviconLinks::render([
+            'favicon_media_id' => 'https://example.test/media/2026/09/a" onload="alert(1).svg',
+        ]);
+
+        self::assertStringNotContainsString('onload="alert(1)"', $html);
+        self::assertStringContainsString('&quot;', $html);
+    }
+}

--- a/tests/PublicRecord/RenderPublicTypeArchiveRendererTest.php
+++ b/tests/PublicRecord/RenderPublicTypeArchiveRendererTest.php
@@ -122,4 +122,24 @@ final class RenderPublicTypeArchiveRendererTest extends TestCase
         self::assertStringContainsString('<link rel="icon" href="assets/favicon/favicon.svg" type="image/svg+xml" />', $html);
         self::assertStringContainsString('<link rel="manifest" href="assets/favicon/site.webmanifest" />', $html);
     }
+
+    /**
+     * #1073 end to end: the org setting must actually reach the rendered <head>. The unit test
+     * on {@see \NeNeRecords\PublicRecord\PublicFaviconLinks} would still pass if the template
+     * variable were misspelled, so this asserts through the real renderer.
+     */
+    public function testOrgFaviconSettingReachesTheRenderedHead(): void
+    {
+        $html = $this->renderArchive([
+            new SettingDef('site_name', 'text', 'NeNe Records', true, 'Site name'),
+            new SettingDef('favicon_media_id', 'media', '7', true, 'Favicon'),
+        ]);
+
+        self::assertStringContainsString('href="/media/icon32/2026/06/card.png" sizes="32x32"', $html);
+        self::assertStringContainsString('rel="apple-touch-icon" href="/media/icon180/2026/06/card.png"', $html);
+
+        // The product default must be replaced, not appended — two rel="icon" blocks would let
+        // the browser pick whichever came first.
+        self::assertStringNotContainsString('assets/favicon/favicon.svg', $html);
+    }
 }


### PR DESCRIPTION
これが無かったため、製品既定と違うファビコンを出したい設置は templates/public/ の
<link rel="icon"> をサーバ上で直接書き換えるしか手が無かった。ayane.co.jp が実際に
そうなっており、その改変は git のどのコミットにも存在しないため、配備のたびに製品既定へ
黙って戻り、戻った事実もどこにも記録されない状態だった（2026-09-05 実測。ayane 本番の
src/ + templates/ 全 1,156 ファイルを md5 で全履歴と突き合わせた結果、どのコミットとも
一致しないのはこの2枚だけで、どちらも改変内容は favicon の参照先だった）。

施主の指摘「ayane は ayane の都合で書き換えているのだから records のものと明確に切り分け
ないとダメ」を受け、設置固有の書き換えを製品機能に吸収する。

新機構は足していない。既存の形をそのまま使う:

- 設定 def は data_type => 'media'。logo_media_id / default_og_image と同型で、
  管理画面は data_type を見てメディアピッカーを出す汎用実装なので**フロント変更は不要**
- 値はメディア id。ListPublicSettingsUseCase が URL へ解決する
- 派生は MediaImagePresets の閉じた集合に icon32 / icon180 / icon192 を追加。
  閉じているのは任意サイズ生成を DoS に使わせないためなので、名前付きで足すのが正規の作法
- SVG は原本のまま配る。resolution-independent なのでラスタ化は劣化にしかならず、
  MediaDerivativeUrl も .svg を画像拡張子から意図的に外して null を返す

未設定の org は従来どおり製品既定のファビコンを出す（後方互換）。

## 途中で自分のテストが間違っていた（2回）

1. end-to-end テストで media 型の値に URL を渡していた。実際の保存値はメディア id で、
   ListPublicSettingsUseCase が URL へ解決する。実装ではなくテストの前提が誤っていた。
2. 出力を絶対 URL と想定していたが、実際はルート相対だった。ここで、ルート相対の
   /media/... は <base href> を無視するので**サブディレクトリ設置では 404 する**ことに
   気づいた。og:image と同じく BasePath::prefix() を通す修正を入れ、
   サブディレクトリのケースをテストで固定した。

⇒ end-to-end テストを書いていなければ、単体テストは全部緑のままサブディレクトリ設置で
   壊れていた。テンプレート変数名の typo も単体テストでは捕まらない。

検証: composer check 緑（PHPUnit 1,670 / PHPStan level 8 エラー0 / CS-Fixer / OpenAPI / MCP）。
既存の PublicRecordHttpTest / RenderPublicTypeArchiveRendererTest が favicon の出力を
assert しており、テンプレート変数を壊すと落ちることを陰性対照で確認済み。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EVNPuKeeHDpEZ2pAoSPNdW
